### PR TITLE
Heal instead of no-op on a terrain tile with negative damage

### DIFF
--- a/changelog.d/rpg2k-terrain-healing-tile.fixed.md
+++ b/changelog.d/rpg2k-terrain-healing-tile.fixed.md
@@ -1,0 +1,7 @@
+- **A terrain tile with a negative `damage` value now heals the party each
+  step instead of doing nothing, bypassing 地形ダメージ無効 (terrain-damage
+  immunity) gear entirely while doing it.** Confirmed against EasyRPG
+  Player's source: a terrain row carries one plain signed damage field, and
+  a negative value applies to every party member unconditionally, healing
+  rather than hurting — the immunity gear only blocks positive damage. A
+  healing tile also never flashes the screen, unlike a damaging one.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5868,6 +5868,35 @@ not yet verified:
   own weapon's state, never both), and an actual three-swing basic Attack
   landing all three hits rather than being capped at two — all three
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **A terrain row's negative `damage` field now heals the party each step
+  instead of doing nothing, and bypasses 地形ダメージ無効 gear entirely while
+  doing it.** RPG2000/2003 terrain rows carry one plain signed `damage`
+  field with no separate heal flag. Confirmed against EasyRPG's actual C++
+  source: `Game_Player::Move`'s terrain block (`src/game_player.cpp`) guards
+  its per-actor loop with `terrain->damage < 0 ||
+  !hero->PreventsTerrainDamage()` — a negative value applies to *every*
+  party member unconditionally — then calls `ChangeHp(-terrain->damage,
+  ...)` either way, so `-(-3) = +3` heals. `red_flash` is only set for
+  *positive* damage (`if (terrain->damage > 0) red_flash = true`), so a heal
+  never flashes the screen or counts as "damaged" for the RPG2003 footstep
+  SE's `on_damage_se` gate. `Game::Party#apply_terrain_damage` instead
+  returned `[]` immediately for any non-positive amount, and even a version
+  that removed that early return would still have wrongly gated a heal on
+  the immunity flag — so a "recovery floor" terrain did nothing to anyone,
+  gear or no gear. A real definition exists in this data: Nepheshel's own
+  database defines terrain #8 "回復床" (Recovery floor, `damage = -1`),
+  though — like the original 2000-era 地形ダメージ terrains ADR 0034 fixed —
+  it goes unplaced on every one of Nepheshel's maps, the same "authored,
+  never shipped" pattern. Fixed by changing `#apply_terrain_damage`'s early
+  return to `amount != 0` and its immunity check to `amount > 0 &&
+  actor.prevents_terrain_damage?`, and by having `Scene::Map#note_party_step`
+  gate the screen flash and the footstep SE's "damaged" flag on the
+  terrain's `damage` sign rather than merely on whether anyone was touched.
+  Covered by three new `scripts/rpg2k_scene_check.rb` checks — a negative-
+  damage terrain healing every tile walked, that healing bypassing
+  `no_terrain_damage` gear that blocks ordinary damage, and a healing tile
+  never flashing the screen — the first two confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2963,14 +2963,25 @@ module Game
     # mtf-meido-action on its Safety Boots, against damage floors of 1 HP a step
     # (Nepheshel's ダメージ床 set, mtf's Poison Swamp).
     #
-    # Returns the actors that actually lost HP, so the scene can flash only when
-    # there is something to report.
+    # Returns the actors actually touched (damaged *or* healed), so the scene
+    # can flash only when there is something to report.
+    #
+    # A negative `amount` is a *healing* tile (RPG2000/2003 terrain rows carry
+    # one plain signed damage field, no separate heal flag) -- confirmed
+    # against EasyRPG's actual C++ source: `Game_Player::Move`'s terrain block
+    # (`src/game_player.cpp`) guards the per-actor loop with `terrain->damage
+    # < 0 || !hero->PreventsTerrainDamage()`, so a negative value heals *every*
+    # party member unconditionally, bypassing `no_terrain_damage` gear
+    # entirely -- only positive damage respects that immunity. `ChangeHp` is
+    # still called with `-terrain->damage` either way (`-(-1) = +1`, a heal),
+    # so the existing `-amount` formula already produces the right sign; only
+    # which branch the immunity check gates needed to change.
     def apply_terrain_damage(amount)
-      return [] unless amount && amount > 0
+      return [] unless amount && amount != 0
       hit = []
       @actors.each do |actor|
         next if actor.nil? || actor.dead?
-        next if actor.prevents_terrain_damage?
+        next if amount > 0 && actor.prevents_terrain_damage?
         actor.change_hp(-amount, false)
         hit << actor
       end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -9059,13 +9059,19 @@ class RPG2k
         hit = @state.party.apply_map_step_damage(state_table, steps)
         # RPG2000's 地形ダメージ on top of it: the terrain the tile just stepped
         # onto belongs to may take HP off everyone not wearing gear that blocks
-        # it. Read after the status slip and flashed together, since both are the
-        # same "your HP just fell and the map has nowhere to say so" moment.
+        # it -- or, for a terrain with a negative `damage` (a healing tile),
+        # add HP to everyone regardless of that gear (#apply_terrain_damage's
+        # own doc comment). Read after the status slip and flashed together,
+        # since both are the same "your HP just fell and the map has nowhere
+        # to say so" moment -- except a heal never flashes red or counts as
+        # "damaged" for the footstep SE below, matching EasyRPG's own
+        # `Game_Player::Move`, which only sets `red_flash` for positive damage.
         row = terrain_row_at(@state.x, @state.y)
         terrain_hit = terrain_step_damage(row)
-        hit = hit + terrain_hit
-        play_terrain_footstep_se(row, !terrain_hit.empty?)
-        return if hit.empty?
+        terrain_damaged = !terrain_hit.empty? && row && row.respond_to?(:damage) &&
+                          row.damage && row.damage > 0
+        play_terrain_footstep_se(row, terrain_damaged)
+        return if hit.empty? && !terrain_damaged
         @state.screen.flash(*STEP_DAMAGE_FLASH)
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13704,6 +13704,41 @@ check 'harmless ground takes nothing' do
   eq 100, hero.hp
 end
 
+check 'a negative terrain damage heals every tile instead of hurting' do
+  # Confirmed against EasyRPG's actual C++ source: Game_Player::Move applies
+  # `hero->ChangeHp(-terrain->damage, ...)` regardless of sign, so a terrain
+  # row with a negative `damage` field (a "recovery floor") heals rather than
+  # hurts -- `-(-3) = +3`. Party#apply_terrain_damage's own doc comment is the
+  # port target.
+  hero = SlipActor.new([], 70)
+  scene = new_scene({}, player: [0, 0], members: [hero], terrain_damage: -3)
+  walk(scene, 1)
+  eq 73, hero.hp, 'the first tile already heals'
+  walk(scene, 2)
+  eq 79, hero.hp, 'and so does every one after it'
+end
+
+check '地形ダメージ無効 gear does NOT block a healing tile -- only a damaging one' do
+  # EasyRPG's own gate is `terrain->damage < 0 || !hero->PreventsTerrainDamage()`
+  # -- a negative damage value short-circuits the immunity check entirely, so
+  # gear that blocks a damage floor does not also block a recovery floor.
+  hero = SlipActor.new([], 70)
+  hero.prevents_terrain_damage = true
+  scene = new_scene({}, player: [0, 0], members: [hero], terrain_damage: -3)
+  walk(scene, 2)
+  eq 76, hero.hp, "the immunity gear didn't stop the heal"
+end
+
+check 'a healing tile never flashes the screen, unlike a damaging one' do
+  # EasyRPG's Game_Player::Move only sets `red_flash` for positive `damage`
+  # (`if (terrain->damage > 0) red_flash = true`) -- a heal never flashes.
+  hero = SlipActor.new([], 70)
+  scene = new_scene({}, player: [0, 0], members: [hero], terrain_damage: -3)
+  walk(scene, 1)
+  st = scene.instance_variable_get(:@state)
+  ok !st.screen.flashing?, 'no flash for a heal, even though HP changed'
+end
+
 # -- footstep SE (RPG2003 歩行音, ADR 0034 follow-up) --------------------------
 #
 # EasyRPG's Game_Player::Move plays terrain->footstep behind a


### PR DESCRIPTION
## Summary
- A terrain row's negative `damage` field now heals the party each step instead of doing nothing, and bypasses 地形ダメージ無効 (terrain-damage immunity) gear entirely while doing it.
- RPG2000/2003 terrain rows carry one plain signed `damage` field with no separate heal flag. Confirmed against EasyRPG's actual C++ source: `Game_Player::Move`'s terrain block (`src/game_player.cpp`) guards its per-actor loop with `terrain->damage < 0 || !hero->PreventsTerrainDamage()` — a negative value applies to *every* party member unconditionally — then calls `ChangeHp(-terrain->damage, ...)` either way, so `-(-3) = +3` heals.
- `red_flash` is only set for *positive* damage (`if (terrain->damage > 0) red_flash = true`), so a heal never flashes the screen or counts as "damaged" for the RPG2003 footstep SE's `on_damage_se` gate.
- `Game::Party#apply_terrain_damage` instead returned `[]` immediately for any non-positive amount, and even a version that removed that early return would still have wrongly gated a heal on the immunity flag — so a "recovery floor" terrain did nothing to anyone, gear or no gear.
- A real definition exists in this data: Nepheshel's own database defines terrain #8 "回復床" (Recovery floor, `damage = -1`), though — like the original 2000-era 地形ダメージ terrains ADR 0034 fixed — it goes unplaced on every one of Nepheshel's maps, the same "authored, never shipped" pattern.
- Fixed by changing `#apply_terrain_damage`'s early return to `amount != 0` and its immunity check to `amount > 0 && actor.prevents_terrain_damage?`, and by having `Scene::Map#note_party_step` gate the screen flash and the footstep SE's "damaged" flag on the terrain's `damage` sign rather than merely on whether anyone was touched.

## Test plan
- [x] Three new `scripts/rpg2k_scene_check.rb` checks — a negative-damage terrain healing every tile walked, that healing bypassing `no_terrain_damage` gear that blocks ordinary damage, and a healing tile never flashing the screen — the first two confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_scene_check.rb` — 609 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 887 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_