### PR TITLE
Stretch a \. message pause with the active \s[n] typing speed

### DIFF
--- a/changelog.d/rpg2k-message-pause-speed.fixed.md
+++ b/changelog.d/rpg2k-message-pause-speed.fixed.md
@@ -1,0 +1,7 @@
+- **A `\.` (quarter-second) message pause now stretches with the `\s[n]`
+  typing speed in effect when it's reached, instead of always holding a
+  flat 16 frames.** Confirmed against EasyRPG Player's source: a message
+  typing speed of 17-20 stretches the quarter-pause by 1-4 extra frames —
+  RPG_RT's own developers flagged this as a likely bug, but it's the real,
+  observable behavior. The full-second `\|` pause is unaffected and stays
+  flat regardless of typing speed.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5897,6 +5897,25 @@ not yet verified:
   `no_terrain_damage` gear that blocks ordinary damage, and a healing tile
   never flashing the screen — the first two confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **A `\.` (quarter-second) message pause now stretches with the `\s[n]`
+  typing speed in effect when it's reached, instead of always holding a flat
+  16 frames.** Confirmed against EasyRPG's actual C++ source
+  (`src/window_message.cpp`, `case '.'`, whose own comment calls it "a
+  bug(??)"): `SetWaitForNonPrintable(16 + Utils::Clamp(speed - 16, 0, 4))`,
+  where `speed` is whatever `\s[n]` (1..20) is active at that point in the
+  text — a speed of 17..20 stretches the pause by 1..4 extra frames. `\|`
+  (the full-second pause) carries no such term and stays a flat 61 in both
+  engines. `Scene::Map#drive_message_pause` used a bare `MSG_PAUSE_QUARTER`
+  constant (16) with no reference to the current speed at all, even though
+  the engine already tracks everything needed to compute it correctly:
+  `Game::TextReveal#speed_at(pos)` resolves the `\s[n]` in effect at any
+  revealed-character position, and each pause already carries its own `at:`
+  position. Fixed by having `#drive_message_pause` call
+  `reveal.speed_at(pause[:at])` and add EasyRPG's own clamp term for the
+  `:quarter` pause kind only, leaving `:full`/`:key` untouched. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check pinning a `\s[20]\.` pause to
+  exactly 20 frames (16 + 4, the maximum stretch), confirmed to fail against
+  the pre-fix code before the fix (`expected 20, got 16`).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8947,6 +8947,14 @@ class RPG2k
       # 61 frames" -- src/window_message.cpp, `case '.'` / `case '|'`), the
       # same "the natural reading is wrong" shape this codebase already
       # tracks for other RPG_RT quirks (e.g. the item-drain clamp order).
+      #
+      # `\.` alone has a second quirk on top: EasyRPG's own comment calls it
+      # "a bug(??)" -- `SetWaitForNonPrintable(16 + Utils::Clamp(speed - 16,
+      # 0, 4))`, where `speed` is whatever `\s[n]` (1..20) is in effect when
+      # the `\.` is reached, not a fixed 16. A speed of 17..20 stretches the
+      # quarter-pause by 1..4 extra frames; `\|`'s own 61-frame hold carries
+      # no such term (`case '|'` is a bare literal, no `speed` reference at
+      # all) and stays flat regardless of speed.
       MSG_PAUSE_QUARTER = 16
       MSG_PAUSE_FULL = 61
 
@@ -8997,14 +9005,21 @@ class RPG2k
       end
 
       # Hold the reveal at a pacing code: `\!` waits for a button, `\.` / `\|`
-      # count down a fixed number of frames (a button skips the wait).
+      # count down a fixed number of frames (a button skips the wait). A `\.`
+      # pause's own length depends on the `\s[n]` typing speed in effect at
+      # that point in the text (see #speed_at and MSG_PAUSE_QUARTER's own
+      # comment); `\|` never varies.
       def drive_message_pause(reveal, pause, pressed)
         if pause[:kind] == :key
           reveal.release_pause if pressed
           return
         end
-        @message[:pause_frames] ||=
-          pause[:kind] == :full ? MSG_PAUSE_FULL : MSG_PAUSE_QUARTER
+        @message[:pause_frames] ||= if pause[:kind] == :full
+                                       MSG_PAUSE_FULL
+                                     else
+                                       speed = reveal.speed_at(pause[:at])
+                                       MSG_PAUSE_QUARTER + Game.clamp(speed - 16, 0, 4)
+                                     end
         @message[:pause_frames] -= 1
         if pressed || @message[:pause_frames] <= 0
           @message[:pause_frames] = nil

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3448,6 +3448,35 @@ check 'a \\. pause holds the reveal for RPG_RT\'s real 16 frames, not the docume
   eq 16, held, 'RPG_RT holds a \\. pause for 16 frames, not the documented 15'
 end
 
+check 'a \\. pause at typing speed 20 holds for 20 frames, not a flat 16' do
+  # EasyRPG's own comment calls this "a bug(??)": `SetWaitForNonPrintable(16
+  # + Utils::Clamp(speed - 16, 0, 4))`, where `speed` is whatever `\s[n]`
+  # (1..20) is in effect when the `\.` is reached, not a fixed 16. Speed 20
+  # stretches the quarter-pause by its full +4 (`clamp(20-16, 0, 4) = 4`).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: '\\s[20]a\\.b')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  frames = 0
+  until reveal.pending_pause
+    scene.update
+    frames += 1
+    break if frames > 30
+  end
+  ok reveal.pending_pause, 'the \\. pause is reached'
+  held = 0
+  until reveal.pending_pause.nil?
+    scene.update
+    held += 1
+    break if held > 30
+  end
+  eq 20, held, 'speed 20 stretches the quarter-pause to 20 frames (16 + 4), not a flat 16'
+end
+
 check 'a \\| pause holds the reveal for RPG_RT\'s real 61 frames, not the documented 60' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- A `\.` (quarter-second) message pause now stretches with the `\s[n]` typing speed in effect when it's reached, instead of always holding a flat 16 frames.
- Confirmed against EasyRPG's actual C++ source (`src/window_message.cpp`, `case '.'`, whose own comment calls it "a bug(??)"): `SetWaitForNonPrintable(16 + Utils::Clamp(speed - 16, 0, 4))`, where `speed` is whatever `\s[n]` (1..20) is active at that point in the text — a speed of 17..20 stretches the pause by 1..4 extra frames. `\|` (the full-second pause) carries no such term and stays a flat 61 in both engines.
- `Scene::Map#drive_message_pause` used a bare `MSG_PAUSE_QUARTER` constant (16) with no reference to the current speed at all, even though the engine already tracks everything needed to compute it correctly: `Game::TextReveal#speed_at(pos)` resolves the `\s[n]` in effect at any revealed-character position, and each pause already carries its own `at:` position.
- Fixed by having `#drive_message_pause` call `reveal.speed_at(pause[:at])` and add EasyRPG's own clamp term for the `:quarter` pause kind only, leaving `:full`/`:key` untouched.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check pinning a `\s[20]\.` pause to exactly 20 frames (16 + 4, the maximum stretch), confirmed to fail against the pre-fix code before the fix (`expected 20, got 16`)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 610 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 890 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_