### PR TITLE
Fix browser startup crash by downgrading SAFE_HEAP alignment checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,22 @@ if(EMSCRIPTEN)
     # corruption early instead of as an opaque trap.
     "-sEXCEPTION_STACK_TRACES=1"
     "-sASSERTIONS=2"
-    "-sSAFE_HEAP=1"
+    # SAFE_HEAP=2, not 1: mode 2 keeps the out-of-bounds and null heap-access
+    # checks and downgrades the alignment check to a one-shot warning. Mode 1
+    # aborts on it, and that killed the page at startup -- "Aborted(alignment
+    # fault)" out of JS_CallInternal, before any game code ran. The unaligned
+    # access is quickjs's: a JSFunctionBytecode's constant pool is laid out
+    # directly behind the struct (cpool_offset = sizeof(*b)), and that struct is
+    # 92 bytes on wasm32 -- 4-byte aligned, being all 32-bit fields -- so the
+    # JSValue array behind it starts 4 bytes off its natural 8-byte alignment.
+    # Every OP_fclosure/OP_push_const load from it trips the check, so any
+    # script holding a nested function does, our own host preamble
+    # (mruby-mvjs/src/mvjs.cxx) included. Only mode 1's strictness is lost:
+    # unaligned accesses are legal in wasm, and mode 1 rejects them so that a
+    # build stays valid through wasm2js as well, which this page never uses. A
+    # single "warning: alignment fault" line in a page log is that check, and is
+    # expected rather than a symptom.
+    "-sSAFE_HEAP=2"
     "-sSTACK_OVERFLOW_CHECK=2"
     # The shell page needs FS + ccall for the runtime loader, and its two
     # KEEPALIVE entry points kept in the JS exports past dead-code elimination:

--- a/changelog.d/wasm-safe-heap-alignment.fixed.md
+++ b/changelog.d/wasm-safe-heap-alignment.fixed.md
@@ -1,0 +1,9 @@
+- The browser build no longer aborts at startup with
+  `RuntimeError: Aborted(alignment fault)`. Emscripten's `-sSAFE_HEAP=1` also
+  checks access alignment, which quickjs trips as soon as it runs a script
+  containing a nested function: a `JSFunctionBytecode`'s constant pool is
+  allocated directly behind the struct, so on wasm32 the `JSValue` array starts
+  4 bytes off its natural 8-byte alignment. The page now links with
+  `-sSAFE_HEAP=2`, which keeps the out-of-bounds and null heap-access checks and
+  drops only the alignment check — unaligned accesses are legal in wasm, and the
+  build never goes through wasm2js.


### PR DESCRIPTION
## Summary
This change fixes a startup crash in the browser build where Emscripten's strict heap safety checks were rejecting unaligned memory accesses made by quickjs. The fix downgrades from `-sSAFE_HEAP=1` to `-sSAFE_HEAP=2` to keep critical safety checks while allowing the unaligned accesses that are legal in WebAssembly.

## Changes
- **CMakeLists.txt**: Changed Emscripten flag from `-sSAFE_HEAP=1` to `-sSAFE_HEAP=2`
  - Mode 1 enforces strict alignment checks and aborts on violations
  - Mode 2 keeps out-of-bounds and null pointer checks but downgrades alignment violations to warnings
  - This resolves the `Aborted(alignment fault)` error that occurred at startup

## Implementation Details
The root cause is in quickjs's memory layout: `JSFunctionBytecode` structs have their constant pool (`JSValue` array) allocated directly behind the struct. On wasm32, the struct is 92 bytes (4-byte aligned due to all 32-bit fields), so the 8-byte-aligned `JSValue` array starts 4 bytes off its natural alignment. This triggers alignment checks on every `OP_fclosure` and `OP_push_const` operation.

Since unaligned accesses are legal in WebAssembly (unlike in wasm2js, which this build doesn't use), the stricter alignment enforcement in mode 1 is unnecessary. Mode 2 provides the best balance: it maintains protection against actual memory safety issues (out-of-bounds and null pointer accesses) while allowing the unaligned accesses that quickjs requires.

https://claude.ai/code/session_01BLewLvz2DmcwwyVMCNf9wc