### PR TITLE
Sync Game::Battle's ally roster from the live party mid-fight

### DIFF
--- a/changelog.d/battle-mid-fight-party-roster-sync.fixed.md
+++ b/changelog.d/battle-mid-fight-party-roster-sync.fixed.md
@@ -1,0 +1,18 @@
+- **Battle**: a party member added or removed mid-fight by a `Change Party
+  Member` battle event now actually joins or leaves the fight's own roster.
+  `Game::Battle` previously snapshotted `@allies` once at battle start and
+  never re-read `Game::Party`, so a swapped-in member never got a turn and a
+  swapped-out member kept acting and being targeted for the rest of the
+  fight. `Game::Battle.new` now takes an optional `party:` (the live
+  `Game::Party`, passed by `Scene::Map#open_battle`); with it, the roster is
+  re-derived from the live party before every action, a rejoining member
+  reuses their existing `Combatant` (so battle-only states/stat modifiers
+  survive the round trip rather than resetting) rather than getting a fresh
+  one, and a turn already queued when its owner leaves is dropped rather
+  than resolving, matching EasyRPG's `Scene_Battle_Rpg2k::
+  ProcessSceneActionBattle` (`battler->Exists()`) once checked directly
+  against its real source. Every existing `Game::Battle.new` fixture (no
+  `party:` argument) is unaffected. This step covers the core mechanic only
+  (roster/turn-order/targeting) — the battle screen's status window and actor
+  sprites still show the roster as it was when the fight opened; that's
+  rendering work for a follow-up. See ADR 0050.

--- a/docs/adr/0050-mid-battle-party-roster-sync.md
+++ b/docs/adr/0050-mid-battle-party-roster-sync.md
@@ -1,0 +1,142 @@
+# 50. Mid-battle party roster sync
+
+Date: 2026-08-15
+
+## Status
+
+Accepted
+
+## Context
+
+`Game::Battle`'s ally roster (`@allies`) is built once, at battle start:
+`Scene::Map#open_battle` snapshots `@state.party.actors.map { |a|
+Game::Battle.from_actor(a) }` and hands the array to `Game::Battle.new`.
+Nothing about the fight ever looks at `Game::Party` again after that.
+
+A battle-event `Change Party Member` command
+(`Interpreter#do_change_party`) mutates the live `Game::Party#actors`
+(`#add_actor`/`#remove_actor`) at any point during a fight — a troop page
+can run one after any acting battler's turn. Neither call reaches the
+running battle: a member swapped in never gets a turn, and a member swapped
+out keeps acting and keeps being a valid target for the rest of the fight.
+Found via four independent community デフォ戦bot trivia items describing
+this exact class of bug.
+
+Checked against EasyRPG's real source rather than trusted from the trivia
+alone:
+
+- `Game_Party::AddActor`/`RemoveActor` (`src/game_party.cpp`) call
+  `Scene::Find(Scene::Battle)` and, if a battle scene is running,
+  `scene->OnPartyChanged(actor, added)`.
+- `Game_Party::GetBattlers` is read **live** wherever the engine needs the
+  current roster (e.g. `Game_Battle::UpdateAtbGauges`,
+  `src/game_battle.cpp`) — there is no separate cached battle-roster array
+  in EasyRPG at all. Per-battle ephemeral state (ATB gauge, equipment-derived
+  combat flags) lives directly on the persistent `Game_Actor`, which is
+  *why* EasyRPG needs no sync step: reading the party fresh always reflects
+  the truth.
+- `Game_Battler::Exists()` (`game_battler.h`) is
+  `!IsHidden() && !IsDead() && IsInParty()`, and
+  `Scene_Battle_Rpg2k::ProcessSceneActionBattle`'s `ePreAction` substate
+  rechecks it **immediately before running each already-queued action**,
+  discarding the ones that fail
+  (`while (!battle_actions.empty() && !battle_actions.front()->Exists())
+  RemoveCurrentAction();`). `battle_actions` (the turn queue) itself is
+  built once per round, from the live party, by `SelectNextActor`/
+  `CreateEnemyActions`, ahead of `CreateExecutionOrder`'s agility sort.
+
+That last point **corrects** an initial reading of the trivia this fix was
+scoped from. The trivia's own account ("if a character isn't in the party
+at turn start... they don't act that round" / "swap out then back in still
+lets their queued command execute") reads as: membership is read once, at
+round start, and a queued-but-not-yet-run action is immune to a mid-round
+departure. The first half holds up against `SelectNextActor`/
+`CreateEnemyActions`. The second does not: `Exists()`'s `IsInParty()` term
+is rechecked right before *every* queued action runs, not just once per
+round, so a member who leaves after their action was queued but before
+their turn comes up loses that turn. Only a turn that has already resolved
+is unaffected (nothing rewinds the log) — which is the part of the trivia
+that happens to still be true, just for a narrower reason than stated.
+
+This codebase's own `Game::Battle::Combatant` is a deliberately different
+design from EasyRPG's live-actor model — see the class's own comment — an
+ephemeral per-fight snapshot so battle-only modifiers (`atk_mod`/`def_mod`/
+`spi_mod`/`agi_mod`, `attr_ranks` shifts, inflicted `states`) never write
+back to the persistent `Game::Actor` and reset cleanly every fight (ADR
+0033 and the state-halving/doubling work). That design is real and
+already battle-tested, and this fix does not change it: it must not
+silently discard and rebuild a `Combatant` for an actor who leaves and
+rejoins the *same* fight, or their accumulated battle-only state would
+incorrectly reset mid-fight.
+
+## Decision
+
+- `Game::Battle.new` gains an optional `party:` keyword (default `nil`) — a
+  live `Game::Party` reference. `Scene::Map#open_battle` passes
+  `@state.party`; every existing fixture / spec battle (nothing passes
+  `party:`) is unaffected, since `@allies` behaves exactly as before when
+  it is nil. This keeps the constructor's existing test-fixture-friendly
+  shape intact rather than threading party access through some other
+  mechanism.
+- `Combatant` gains one field, `member` (nil/true = "yes", the default so
+  nothing existing changes), tracking "currently a member of the live
+  party" — distinct from "has ever appeared in this fight", the same way
+  `hidden` already tracks "off currently" distinct from "left the troop
+  entirely" for enemies. `#out_of_play?` now folds this in alongside
+  `dead?`/`hidden`, so every existing `turn_order`/`side_targets`/`alive?`/
+  etc. call site that already filters `out_of_play?` stops queueing or
+  targeting a departed member for free, with no call site of its own to
+  update.
+- `Battle#sync_allies_from_party` (private) re-derives `@allies` from the
+  live party: a member with no `Combatant` yet gets a fresh one
+  (`.from_actor`) — matching EasyRPG's live-read semantics for a genuinely
+  new participant, no accumulated modifiers; a member who already has one
+  (they left *this* fight and are rejoining) reuses that exact object
+  rather than rebuilding it, so accumulated battle-only state survives. A
+  `Combatant` whose actor has left the live party is kept in `@allies` (not
+  removed) — a later rejoin needs to find it, and `#apply_to_party` still
+  needs to write its final state back to the actor at battle end — but
+  flagged `member = false`.
+- The sync runs in two places, mirroring the two EasyRPG call sites found
+  above: once per round in `#refill_queue` (decides who is queueable this
+  round, ahead of `#turn_order`), and again in both `#step`/`#step_action`
+  right after popping the next queued battler (mirrors `ePreAction`'s
+  per-action `Exists()` recheck) — so a battler removed after their action
+  was queued, but before it runs, has that action dropped rather than
+  resolved.
+
+## Consequences
+
+The mechanical roster is now correct: a member added mid-fight joins the
+next round they're present for and can act and be targeted; a member
+removed mid-fight stops being queued and stops being targetable, and loses
+a turn still only queued (not yet run) at the moment they leave, while a
+turn that already resolved before they left stands; a member who leaves and
+rejoins the same fight keeps their accumulated battle-only state (states,
+`atk_mod`/etc.) rather than it resetting, because the same `Combatant`
+object is reused rather than rebuilt.
+
+Deliberately out of scope for this step, and left for a follow-up:
+`Scene::Map`'s battle-screen rendering. `@battle_ui[:allies]`, the actor
+status window and actor sprites are still the one-shot snapshot taken when
+the fight opened — the mechanical fix above does not touch them, so a
+mid-fight swap is now correct in how the fight plays out but the screen
+still shows the original cast until that follow-up lands.
+
+Threading `party:` through turned out not to be architecturally awkward:
+`Game::Battle` already receives everything else it needs (rng, states,
+attributes, ai) as optional constructor arguments from `Scene::Map#open_battle`,
+so `party:` is one more of the same shape, and the two per-round/per-action
+sync call sites were natural extensions of `#refill_queue` (which already
+runs once per round) and `#step`/`#step_action` (which already special-case
+a dead battler the same way).
+
+Covered by three new checks in `scripts/rpg2k_logic_check.rb`: an actor
+added mid-fight joins the next round's turn order and can act; an actor
+removed mid-round loses a turn only queued (not yet resolved) at the moment
+they leave, then stops being queued or targetable in the following round;
+an actor who leaves and rejoins the same fight keeps an accumulated state
+and stat modifier on the *same* `Combatant` object. Every pre-existing
+`Game::Battle.new` fixture across `scripts/rpg2k_logic_check.rb` (dozens,
+none passing `party:`) and `scripts/rpg2k_scene_check.rb`'s own
+`Scene::Map#open_battle`-driven battles continue to pass unchanged.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7801,7 +7801,26 @@ module Game
                            # Combatant leaves it nil (read as empty by
                            # #atk_states -- monsters equip nothing in real
                            # RPG_RT either).
-                           :atk_states) do
+                           :atk_states,
+                           # Whether this ally's actor is currently a member of
+                           # the live Game::Party, kept in sync by
+                           # Battle#sync_allies_from_party for a fight
+                           # constructed with `party:` (mid-battle roster
+                           # sync). nil/true means "yes" -- every Combatant
+                           # built without going through that path (every
+                           # existing fixture, and an enemy, which never has
+                           # this field touched at all) is a member for free,
+                           # matching the unconditional-membership behaviour
+                           # this class had before the field existed. Distinct
+                           # from #out_of_play?'s other two causes
+                           # (dead?/hidden): a not-a-member Combatant has not
+                           # left *the fight* the way a felled or fled battler
+                           # has -- it is deliberately kept in @allies (not
+                           # removed) so a later rejoin finds and reuses this
+                           # exact object rather than rebuilding a fresh one
+                           # and losing its accumulated battle-only state (see
+                           # this Struct's own class comment).
+                           :member) do
       def dead?; hp <= 0; end
 
       # Swings per basic attack: 2 with a 二刀流 weapon, 1 otherwise. Struct
@@ -7827,8 +7846,16 @@ module Game
       # A troop member the editor placed but flagged invisible has not entered
       # the fight yet: it does not act, cannot be targeted and does not keep the
       # battle going. Show Hidden Monster (13150) clears the flag and brings it
-      # in. Distinct from `dead?`, which is purely about HP.
-      def out_of_play?; dead? || hidden ? true : false; end
+      # in. Distinct from `dead?`, which is purely about HP. An ally whose
+      # actor has left the live party (#member? false, mid-battle roster sync)
+      # is out of play the same way -- not queued, not targetable -- without
+      # being dropped from @allies the way dead?/hidden never are either.
+      def out_of_play?; dead? || hidden || !member? ? true : false; end
+      # See the `member` field's own comment: nil (never touched by
+      # mid-battle roster sync, or synced back true on a rejoin) reads as "yes,
+      # a member" -- only an explicit `false` (this actor's Combatant exists
+      # but has left the live party) reads otherwise.
+      def member?; member == false ? false : true; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
       def int; spi; end
@@ -7996,9 +8023,16 @@ module Game
     # actions its pattern lists, but a skill or transformation it cannot resolve
     # falls back to a plain attack — which is exactly the old behaviour, so every
     # existing fixture keeps its results.
+    # `party` is an optional live Game::Party reference (Scene::Map#open_battle
+    # passes `@state.party`) that opts this fight into re-deriving @allies from
+    # the *live* roster around every acting battler -- see
+    # #sync_allies_from_party. Omitted (every existing fixture / spec battle
+    # that builds `allies` once and hands it to .new directly), @allies is
+    # exactly what the constructor was given and never changes membership on
+    # its own, unchanged from before this parameter existed.
     def initialize(allies, enemies, rng = nil, states = nil, variance = false,
                    criticals = false, accuracy = false, first_strike = false,
-                   attributes = nil, ai = nil, rpg2003: false)
+                   attributes = nil, ai = nil, rpg2003: false, party: nil)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
@@ -8010,6 +8044,7 @@ module Game
       @attributes = attributes
       @ai = ai
       @rpg2003 = rpg2003 ? true : false
+      @party = party
       @rounds = 0
       @result = nil
       @escaped = false # set once the party successfully flees (#attempt_escape)
@@ -8189,7 +8224,8 @@ module Game
         refill_queue if @queue.empty?
         return nil if @queue.empty? # hit MAX_ROUNDS
         b = @queue.shift
-        next if b.dead?
+        sync_allies_from_party if @party # see #step_action's own comment on why
+        next if b.dead? || !b.member?
         # The battler's own turn starts here, whether or not it ends up able to
         # act — RPG_RT bumps the per-battler counter as the turn begins, not
         # once the action lands (EasyRPG's Scene_Battle::NextTurn).
@@ -8679,12 +8715,29 @@ module Game
     # Returns nil once the round's queue is exhausted or the battle is decided —
     # the caller then clears commands with #end_round and either shows the result
     # or asks for the next round. Unlike #step it never starts a new round.
+    #
+    # `sync_allies_from_party` (mid-battle roster sync) runs again right here,
+    # not only once at #refill_queue -- ported from EasyRPG's
+    # `Scene_Battle_Rpg2k::ProcessSceneActionBattle`, whose `ePreAction`
+    # substate rechecks `battler->Exists()` (`!IsHidden() && !IsDead() &&
+    # IsInParty()`, `game_battler.h`) immediately before running *each* queued
+    # action and discards the ones that fail
+    # (`while (!battle_actions.empty() && !battle_actions.front()->Exists())
+    # RemoveCurrentAction();`, `scene_battle_rpg2k.cpp`) -- confirmed against
+    # that real source specifically because this codebase's own community-
+    # trivia writeup claimed the opposite ("swap out then back in still lets
+    # the queued command execute"). It does not: a party member who leaves
+    # *after* their action was queued this round but *before* their turn comes
+    # up loses that turn, exactly like a battler who dies first already did
+    # here (`next if b.dead?`, unchanged) -- only a turn that has already
+    # resolved is unaffected, since nothing here ever reaches back into `@log`.
     def step_action
       return @pending.shift unless @pending.empty? # drain a buffered all-target hit
       loop do
         return nil if finished? || @queue.empty?
         b = @queue.shift
-        next if b.dead?
+        sync_allies_from_party if @party
+        next if b.dead? || !b.member?
         # Afflicted states act at the start of the battler's turn: slip damage
         # (which cannot itself knock it out -- see apply_turn_states) and, if it
         # cannot act (asleep / paralysed), its turn is skipped.
@@ -8874,10 +8927,55 @@ module Game
     def refill_queue
       @rounds += 1
       return if @rounds > MAX_ROUNDS
+      # Mid-battle roster sync: who is queueable *this* round is decided right
+      # here, once, before #turn_order runs -- see #sync_allies_from_party.
+      # EasyRPG builds its own equivalent queue (`battle_actions`) the same
+      # way: `Scene_Battle_Rpg2k::SelectNextActor`/`CreateEnemyActions` walk
+      # the *current* `Main_Data::game_party`/`game_enemyparty` once per round,
+      # ahead of `CreateExecutionOrder`'s sort -- a member not present in the
+      # party at that moment is not in `battle_actions` and does not act this
+      # round, even if they swap in moments later. (#step_action re-syncs
+      # again before every single action for the other half of the rule --
+      # see its own comment.)
+      sync_allies_from_party if @party
       @queue = turn_order
       # A pre-emptive first strike catches the enemies off guard: they skip the
       # opening round, so only the party acts in round 1.
       @queue = @queue.reject { |b| side_of(b) == :enemy } if @first_strike && @rounds == 1
+    end
+
+    # Re-derive @allies from the live Game::Party (`party:` on #initialize) --
+    # see #refill_queue and #step_action, the two call sites, and the
+    # Combatant `member` field's own comment for what this flag means.
+    #
+    # A live party member with no Combatant here yet (never present in this
+    # fight before) gets a fresh one via .from_actor and joins @allies --
+    # EasyRPG has no separate battle roster to preserve at all (its
+    # `Game_Party::GetBattlers` is a live read every time, straight off the
+    # persistent `Game_Actor`), so a genuinely new participant starting with
+    # no accumulated battle-only modifiers (atk_mod/attr_ranks/states/...)
+    # matches that live-read semantics exactly. A live member who already has
+    # a Combatant (they left *this* fight earlier and are rejoining) reuses
+    # that exact object instead -- rebuilding it would silently reset
+    # whatever battle-only state it had accumulated, which is precisely what
+    # this class's own ephemeral-snapshot design (see the Combatant class
+    # comment) exists to avoid ever happening to a member who never left.
+    #
+    # A Combatant whose actor is no longer live is kept in @allies (so a later
+    # rejoin still finds it, and #apply_to_party still writes its final state
+    # back to the actor at battle end) but flagged not-a-member, which
+    # #out_of_play? now folds in alongside dead?/hidden -- every existing
+    # #turn_order/#side_targets/#alive?/etc. site that already filters
+    # out_of_play? stops queueing or targeting it for free, with no call site
+    # of its own to update.
+    def sync_allies_from_party
+      live_ids = {}
+      @party.actors.each { |a| live_ids[a.id] = true }
+      @allies.each { |c| c.member = false if c.actor && !live_ids[c.actor.id] }
+      @party.actors.each do |a|
+        existing = @allies.find { |c| c.actor && c.actor.id == a.id }
+        existing ? (existing.member = true) : @allies.push(self.class.from_actor(a))
+      end
     end
 
     # Battlers ordered by a per-round randomised Agility roll (highest first)

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4478,7 +4478,26 @@ class RPG2k
                                                 # (see #apply_attr_multiplier)
                                                 # is handled differently per
                                                 # edition.
-                                                rpg2003: db.respond_to?(:rpg2003?) && db.rpg2003?),
+                                                rpg2003: db.respond_to?(:rpg2003?) && db.rpg2003?,
+                                                # Mid-battle roster sync
+                                                # (Game::Battle#sync_allies_from_party):
+                                                # a Change Party Member command
+                                                # run from a battle event page
+                                                # mutates this same live
+                                                # Game::Party, and the battle
+                                                # re-derives its own @allies
+                                                # from it every round/action
+                                                # rather than staying pinned to
+                                                # the `allies` snapshot taken
+                                                # just above. `@battle_ui[:allies]`
+                                                # itself is untouched here --
+                                                # still that one-shot snapshot
+                                                # -- so the status window/actor
+                                                # sprites do not yet reflect a
+                                                # mid-fight swap; that is
+                                                # rendering work left for a
+                                                # follow-up.
+                                                party: @state.party),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10272,6 +10272,127 @@ check 'attribute defence shift applies to the target rank, capped at ' \
   eq 3, foe.attr_ranks[1], 'capped one step better than base (C -> D)'
 end
 
+# -- Battle mid-battle roster sync ---------------------------------------------
+#
+# Game::Battle's @allies is a one-shot snapshot unless constructed with
+# `party:` (a live Game::Party) -- see Battle#sync_allies_from_party and
+# Scene::Map#open_battle, its one production call site. These checks build
+# `party:` battles directly, the way #open_battle does, rather than going
+# through the scene.
+#
+# All three foes below are a 0-attack, 100000-HP punching bag, so a fight
+# never ends and the exact same two allies stay alive across every round --
+# the point of these checks is roster membership, not combat outcome.
+def roster_sync_db
+  FakeActorDB.new({
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8, agi: 100),
+    2 => FakePlayerRow.new('Companion', '', 0, 5, max_hp: 80, max_mp: 20, atk: 8, def: 6, agi: 1),
+  }, [1, 2])
+end
+
+def watcher; combatant('Watcher', 0, 0, 1, 100_000); end
+
+check 'battle: an actor added to the live party mid-fight joins the next round' do
+  db = roster_sync_db
+  party = Game::Party.new(db) # only the Hero (id 1) starts in the party
+  party.remove_actor(2)
+  bat = Game::Battle.new(party.actors.map { |a| Game::Battle.from_actor(a) }, [watcher],
+                         Game::Rng.new(1), nil, false, false, false, false, nil, nil,
+                         party: party)
+
+  bat.begin_round
+  ok bat.ally_by_actor_id(2).nil?, 'no Combatant at all before ever joining this fight'
+  entries = []
+  loop { e = bat.step_action; break unless e; entries << e }
+  bat.end_round
+  ok entries.none? { |e| e[:attacker] == 'Companion' }, 'not queued -- not a member yet'
+
+  party.add_actor(2)
+  bat.begin_round # round 2: #refill_queue re-syncs @allies from the live party
+  newcomer = bat.ally_by_actor_id(2)
+  ok newcomer, '#sync_allies_from_party built a fresh Combatant for them'
+  eq true, newcomer.member?
+
+  entries = []
+  loop { e = bat.step_action; break unless e; entries << e }
+  bat.end_round
+  ok entries.any? { |e| e[:attacker] == 'Companion' },
+     'takes a turn in the very round they joined'
+end
+
+# Corrects an initial reading of this fix's own community-trivia source
+# ("swap out then back in still lets the queued command execute"), checked
+# directly against EasyRPG's real `Scene_Battle_Rpg2k::ProcessSceneActionBattle`:
+# its `ePreAction` substate rechecks `battler->Exists()` (which folds in
+# `IsInParty()`, `game_battler.h`) immediately before running *each* queued
+# action and drops the ones that fail, not only the ones for the *next*
+# round's queue. #step_action ports that same recheck (see its own comment) --
+# a turn already resolved before the removal stands (nothing rewinds `@log`),
+# but a turn still only *queued* when its owner leaves is dropped, exactly
+# like a battler who died first already was.
+check 'battle: an actor removed mid-round loses a not-yet-resolved queued turn' do
+  db = roster_sync_db
+  party = Game::Party.new(db) # both start in the party; Hero's agi 100 guarantees they act first
+  bat = Game::Battle.new(party.actors.map { |a| Game::Battle.from_actor(a) }, [watcher],
+                         Game::Rng.new(1), nil, false, false, false, false, nil, nil,
+                         party: party)
+
+  bat.begin_round
+  first = bat.step_action
+  eq 'Hero', first[:attacker], 'the highest-agility ally goes first, deterministically'
+  ok first[:damage] > 0, 'the attack already landed'
+
+  # A battle-event page runs after Hero's turn (Game::Battle#pending_empty?'s
+  # own comment: a page is checked once per acting battler) and fires a
+  # Change Party Member removing the Companion, whose own turn is still
+  # sitting in the queue, not yet resolved.
+  party.remove_actor(2)
+
+  entries = []
+  loop { e = bat.step_action; break unless e; entries << e }
+  bat.end_round
+  ok entries.none? { |e| e[:attacker] == 'Companion' },
+     'the queued-but-not-yet-run turn is dropped, not resolved'
+
+  companion = bat.ally_by_actor_id(2)
+  ok companion, 'the Combatant is kept in @allies, not discarded'
+  eq false, companion.member?
+  ok companion.out_of_play?
+
+  bat.begin_round # round 2
+  entries2 = []
+  loop { e = bat.step_action; break unless e; entries2 << e }
+  bat.end_round
+  ok entries2.none? { |e| e[:attacker] == 'Companion' }, 'not queued for a round begun after they left'
+  ok entries2.none? { |e| e[:target] == 'Companion' }, 'not a valid target either, once out of play'
+end
+
+check 'battle: leaving and rejoining the same fight keeps accumulated battle-only state' do
+  db = roster_sync_db
+  party = Game::Party.new(db)
+  bat = Game::Battle.new(party.actors.map { |a| Game::Battle.from_actor(a) }, [watcher],
+                         Game::Rng.new(1), nil, false, false, false, false, nil, nil,
+                         party: party)
+
+  companion = bat.ally_by_actor_id(2)
+  companion.states = [5]  # an active battle-only status
+  companion.atk_mod = 7   # an accumulated per-battle stat modifier (e.g. from a skill)
+
+  party.remove_actor(2)
+  bat.begin_round # sync: flagged not-a-member, Combatant otherwise untouched
+  ok !companion.member?
+  eq [5], companion.states
+  eq 7, companion.atk_mod
+
+  party.add_actor(2)
+  bat.begin_round # sync: rejoins -- the same object is reused, not rebuilt
+  rejoined = bat.ally_by_actor_id(2)
+  ok rejoined.equal?(companion), 'the exact same Combatant comes back, not a fresh one'
+  eq true, rejoined.member?
+  eq [5], rejoined.states, 'the state they left with is still active'
+  eq 7, rejoined.atk_mod, 'the accumulated stat modifier survived the round trip'
+end
+
 # -- Ability-value change (schema fields 33-36: affect_attack/defense/spirit/
 # agility) -- a skill's own per-battle ATK/DEF/SPI/AGI modifier, distinct from
 # both attribute-defence rank shifting (above) and a *state*'s halve/double


### PR DESCRIPTION
## Summary

- `Game::Battle`'s ally roster (`@allies`) was a one-shot snapshot taken at battle start (`Scene::Map#open_battle`). A `Change Party Member` battle event (`Interpreter#do_change_party`, mutating `Game::Party#add_actor`/`#remove_actor`) never reached the running battle: a member swapped in never got a turn, and a member swapped out kept acting and stayed a valid target for the rest of the fight. Found via four independent community デフォ戦bot trivia items describing this exact bug class.
- `Game::Battle.new` gains an optional `party:` keyword (a live `Game::Party`); `Scene::Map#open_battle` now passes `@state.party`. With it, `@allies` is re-derived from the live party once per round (`#refill_queue`, decides who's queueable) and again before every single action (`#step`/`#step_action`, mirrors EasyRPG's per-action recheck — see below). Without it (every existing fixture / spec battle), nothing changes.
- `Combatant` gained one field, `member`, tracked the same way `hidden` already tracks an enemy that fled: distinct from "has ever appeared in this fight". `#out_of_play?` now folds it in alongside `dead?`/`hidden`, so every existing `turn_order`/`side_targets`/`alive?`/etc. call site that already filters `out_of_play?` stops queueing or targeting a departed member for free.
- A member who leaves and rejoins the *same* fight reuses their existing `Combatant` rather than getting a fresh one, so accumulated battle-only state (inflicted states, `atk_mod`/`def_mod`/`spi_mod`/`agi_mod`, `attr_ranks` shifts) survives the round trip — this codebase's `Combatant` is a deliberate ephemeral-snapshot design (see its own class comment / ADR 0033), not something to silently reset on a swap.

## A correction, found verifying against EasyRPG's real source

The task this was scoped from included a specific timing claim reverse-engineered from the trivia: "a member already queued whose party membership changes mid-round keeps their queued turn regardless." I was asked to confirm or correct that against EasyRPG's actual `CreateExecutionOrder`/turn-queue code. I did, and it's wrong:

- `Game_Battler::Exists()` (`game_battler.h`) is `!IsHidden() && !IsDead() && IsInParty()`.
- `Scene_Battle_Rpg2k::ProcessSceneActionBattle`'s `ePreAction` substate rechecks `Exists()` **immediately before running each already-queued action** and drops the ones that fail: `while (!battle_actions.empty() && !battle_actions.front()->Exists()) RemoveCurrentAction();`.

So a member who leaves *after* their action was queued this round but *before* their turn comes up **loses that turn** — it does not still resolve. Only a turn that has already resolved is unaffected (nothing rewinds the log), which is the part of the trivia that happens to hold, just for a narrower reason than stated. `#step`/`#step_action` now port this exact recheck. See ADR 0050 for the full source citations (`Game_Party::AddActor`/`RemoveActor` calling `scene->OnPartyChanged`, `Game_Party::GetBattlers` being a live read with no cached roster at all, `SelectNextActor`/`CreateEnemyActions` building the round's queue from the live party ahead of `CreateExecutionOrder`'s sort).

## Scope

Per the task, this is the core mechanic only: roster membership, turn-order, targeting. **Rendering is explicitly out of scope and left for a follow-up** — `@battle_ui[:allies]`, the battle status window and actor sprites are still `Scene::Map`'s one-shot snapshot from when the fight opened, so a mid-fight swap is now mechanically correct but the screen doesn't yet show it.

Threading `party:` through was not architecturally awkward: `Game::Battle` already takes everything else (rng, states, attributes, ai) as optional constructor arguments from `Scene::Map#open_battle`, so this is one more of the same shape, and the two sync call sites were natural extensions of methods (`#refill_queue`, `#step`/`#step_action`) that already ran once per round / already special-cased a dead battler the same way.

## Test plan

- [x] Three new checks in `scripts/rpg2k_logic_check.rb`: an actor added mid-fight joins the next round and can act; an actor removed mid-round loses a turn only queued (not yet resolved) at the moment they leave, then stops being queued/targetable next round; an actor who leaves and rejoins the same fight keeps accumulated state/modifiers on the *same* `Combatant` object.
- [x] Every pre-existing `Game::Battle.new` fixture (dozens across `scripts/rpg2k_logic_check.rb`, none passing `party:`) is unaffected — `ruby scripts/rpg2k_logic_check.rb` passes (893 checks).
- [x] `ruby scripts/rpg2k_scene_check.rb` passes (610 checks), including `Scene::Map#open_battle`-driven battles now constructed with `party:`.
- [x] Native rebuild: `scripts/native-build-without-nix.bash` then `ninja rpg_maker_clone` (up to date / no work to do on the second run).
- [x] `ctest` in `build/`: 7/8 pass; `exe_open` fails, but that's this sandbox missing the `Nepheshel206beta` sample game data entirely (`data/` only has `mv-sample`/`mz-sample` here) — unrelated to this change and reproducible on `master`.
- ADR 0050 records the design and the EasyRPG source citations; changelog fragment added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Redf3LY8hUd1p6pADFmFHt)_