### PR TITLE
Revert a skippable Move Route step's turn on a blocked move/diagonal

### DIFF
--- a/changelog.d/rpg2k-move-route-skip-revert-turn.fixed.md
+++ b/changelog.d/rpg2k-move-route-skip-revert-turn.fixed.md
@@ -1,0 +1,9 @@
+- **A blocked Move Route step on a skippable ("Ignore If Can't Move") route
+  no longer leaves the character visibly turned toward the obstruction —
+  the failed turn now reverts entirely before the route advances.**
+  Confirmed against EasyRPG Player's source: a skippable route's failed
+  move reverts both direction and facing to what they were before the
+  attempt, so a skipped step has no visible effect at all. This engine
+  turned the character to face the obstacle unconditionally and never
+  reverted it, so a skippable route's character stayed turned toward every
+  obstacle it brushed past, even ones it visibly walked around.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5916,6 +5916,38 @@ not yet verified:
   new `scripts/rpg2k_scene_check.rb` check pinning a `\s[20]\.` pause to
   exactly 20 frames (16 + 4, the maximum stretch), confirmed to fail against
   the pre-fix code before the fix (`expected 20, got 16`).
+- ✅ **A blocked Move Route step on a *skippable* ("Ignore If Can't Move")
+  route no longer leaves the character visibly turned toward the
+  obstruction — the failed turn now reverts entirely before the route
+  advances, matching a *non*-skippable route (which still turns, since it
+  keeps retrying the same step facing the obstacle).** Confirmed against
+  EasyRPG's actual C++ source: `Game_Character::UpdateMoveRoute`
+  (`src/game_character.cpp`) turns toward the attempted direction
+  unconditionally, but once the move fails and `current_route.skippable` is
+  set, it calls `SetDirection(prev_direction); SetFacing(prev_facing);`
+  before moving on to the next command — a skipped step has no visible
+  effect at all, not even a flinch toward the wall. `Game::MoveRoute#do_move`
+  (`mruby-rpg2k/mrblib/game.rb`) called `character.face(dir)`
+  unconditionally on a blocked move and never reverted it, so a skippable
+  route's character stayed turned toward every obstacle its route ever
+  brushed past, even ones it visibly walked around — directly observable
+  (sprite orientation) and capable of skewing a later `MOVE_FORWARD` or a
+  page condition's own direction check. `#do_diagonal` had the identical gap
+  for a blocked diagonal step. `#do_jump`/`#land_jump` needed no equivalent
+  fix: unlike EasyRPG's jump-block scan (which turns the character as it
+  walks the block's own face/move sub-commands before the landing check),
+  this port's jump-block scan only accumulates a local direction/offset and
+  never touches the character's own facing until a *successful* landing
+  (`Character#jump`), so a blocked jump already left the character
+  untouched, the same end state EasyRPG's revert achieves by a different
+  route. Fixed by saving the pre-turn direction in both `#do_move` and
+  `#do_diagonal` and restoring it (`character.direction = prev_dir`) in the
+  skippable-blocked branch only. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks — a blocked skippable cardinal move
+  reverting to its starting direction (contrasted with a non-skippable move
+  on the identical setup, which still turns) and a blocked skippable
+  diagonal doing the same — both confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5219,14 +5219,27 @@ module Game
     # party fires it exactly like an autonomous move already does.
     def do_move(character, world, dir)
       return [:turned, true] if dir.nil?
+      prev_dir = character.direction
       if character.through || world.passable?(character, dir)
         character.move(dir)
         [:moved, true]
       else
-        character.face(dir) # an obstructed move still turns to face it
+        character.face(dir) # an obstructed move still turns to face it --
         nx, ny = Character.step_tile(character.x, character.y, dir)
         status = world.hero_position == [nx, ny] ? :touched_hero : :blocked
-        @skippable ? [status, true] : [status, false]
+        if @skippable
+          # ...unless the route can skip past the block, in which case
+          # EasyRPG's UpdateMoveRoute (src/game_character.cpp) reverts the
+          # turn entirely (`SetDirection(prev_direction);
+          # SetFacing(prev_facing);`) before advancing to the next command --
+          # a skipped step has no visible effect at all, not even a flinch
+          # toward the obstacle. A non-skippable route keeps the turn (the
+          # same command retries next frame, still facing the obstacle).
+          character.direction = prev_dir
+          [status, true]
+        else
+          [status, false]
+        end
       end
     end
 
@@ -5331,6 +5344,7 @@ module Game
 
     def do_diagonal(character, world, id)
       horizontal, vertical = DIAGONAL[id]
+      prev_dir = character.direction
       character.face(vertical)
       passable = character.through ||
                  (world.passable?(character, horizontal) &&
@@ -5338,8 +5352,13 @@ module Game
       if passable
         character.move_diagonal(horizontal, vertical)
         [:moved, true]
+      elsif @skippable
+        # Same skippable-block reversion #do_move applies -- a diagonal that
+        # can't move leaves no visible turn behind on a skippable route.
+        character.direction = prev_dir
+        [:blocked, true]
       else
-        @skippable ? [:blocked, true] : [:blocked, false]
+        [:blocked, false]
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -235,6 +235,27 @@ check 'a blocked skippable move advances past the obstruction' do
   eq [0, 1], [c.x, c.y]
 end
 
+check 'a blocked skippable move reverts the turn it made; a non-skippable ' \
+      'one keeps facing the obstacle' do
+  # Confirmed against EasyRPG's actual C++ source: Game_Character::
+  # UpdateMoveRoute (src/game_character.cpp) turns toward the attempted
+  # direction unconditionally, but on a *skippable* route a failed move
+  # reverts that turn entirely (`SetDirection(prev_direction);
+  # SetFacing(prev_facing);`) before advancing -- the skipped step leaves no
+  # visible flinch toward the obstacle. A non-skippable route's own turn
+  # stands, since the same command retries next frame still facing it.
+  skip = R.new([mc(R::MOVE_RIGHT)], repeat: false, skippable: true)
+  c = Game::Character.new(0, 0, 2) # starts facing Down
+  w = FakeWorld.new(blocked: [[1, 0]])
+  eq :blocked, skip.step(c, w)
+  eq 2, c.direction, 'reverted to Down, not left turned toward the wall (6)'
+
+  non_skip = R.new([mc(R::MOVE_RIGHT)], repeat: false, skippable: false)
+  c2 = Game::Character.new(0, 0, 2)
+  eq :blocked, non_skip.step(c2, w)
+  eq 6, c2.direction, 'still turns to face the obstacle it keeps retrying'
+end
+
 check 'a move blocked specifically by the hero reports :touched_hero, not ' \
       'plain :blocked, with the same retry rule' do
   # yado.tk (docs/TODO.md "Running a hero-targeted Parallel-Process Set Move
@@ -467,6 +488,14 @@ check 'diagonal move needs both cardinals and faces vertical' do
   c2 = Game::Character.new(2, 2)
   eq :blocked, route2.step(c2, FakeWorld.new(blocked: [[3, 2]])) # east blocked
   eq [2, 2], [c2.x, c2.y]
+  eq 8, c2.direction, 'non-skippable still turns to face the vertical component'
+
+  # Skippable reverts that turn entirely, the same rule an ordinary blocked
+  # move follows (see #do_move's own revert check above).
+  route3 = R.new([mc(R::MOVE_UPRIGHT)], skippable: true)
+  c3 = Game::Character.new(2, 2, 2) # starts facing Down
+  eq :blocked, route3.step(c3, FakeWorld.new(blocked: [[3, 2]]))
+  eq 2, c3.direction, 'reverted to Down, not left turned toward the wall (8)'
 end
 
 check 'move forward steps in the current facing' do


### PR DESCRIPTION
## Summary
- A blocked Move Route step on a *skippable* ("Ignore If Can't Move") route no longer leaves the character visibly turned toward the obstruction — the failed turn now reverts entirely before the route advances, matching a *non*-skippable route (which still turns, since it keeps retrying the same step facing the obstacle).
- Confirmed against EasyRPG's actual C++ source: `Game_Character::UpdateMoveRoute` (`src/game_character.cpp`) turns toward the attempted direction unconditionally, but once the move fails and `current_route.skippable` is set, it calls `SetDirection(prev_direction); SetFacing(prev_facing);` before moving on to the next command — a skipped step has no visible effect at all, not even a flinch toward the wall.
- `Game::MoveRoute#do_move` (`mruby-rpg2k/mrblib/game.rb`) called `character.face(dir)` unconditionally on a blocked move and never reverted it, so a skippable route's character stayed turned toward every obstacle its route ever brushed past, even ones it visibly walked around — directly observable (sprite orientation) and capable of skewing a later `MOVE_FORWARD` or a page condition's own direction check. `#do_diagonal` had the identical gap for a blocked diagonal step.
- `#do_jump`/`#land_jump` needed no equivalent fix: unlike EasyRPG's jump-block scan (which turns the character as it walks the block's own face/move sub-commands before the landing check), this port's jump-block scan only accumulates a local direction/offset and never touches the character's own facing until a *successful* landing (`Character#jump`), so a blocked jump already left the character untouched, the same end state EasyRPG's revert achieves by a different route.
- Fixed by saving the pre-turn direction in both `#do_move` and `#do_diagonal` and restoring it (`character.direction = prev_dir`) in the skippable-blocked branch only.

## Test plan
- [x] Two new `scripts/rpg2k_logic_check.rb` checks — a blocked skippable cardinal move reverting to its starting direction (contrasted with a non-skippable move on the identical setup, which still turns) and a blocked skippable diagonal doing the same — both confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_logic_check.rb` — 894 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 610 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_