### PR TITLE
Double the party's slide speed while aboard the Airship

### DIFF
--- a/changelog.d/rpg2k-airship-double-speed.fixed.md
+++ b/changelog.d/rpg2k-airship-double-speed.fixed.md
@@ -1,0 +1,6 @@
+- **Boarding the Airship now doubles the party's per-frame walking speed,
+  instead of moving at the same rate as on foot (or in a Boat/Ship, which
+  are correctly unchanged).** Confirmed against EasyRPG Player's source: the
+  Airship carries a distinct, doubled move speed from Boat/Ship, which both
+  keep the player's own default walking rate. An Airship ride previously
+  crossed the map at exactly walking pace.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5948,6 +5948,33 @@ not yet verified:
   on the identical setup, which still turns) and a blocked skippable
   diagonal doing the same — both confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **Boarding the Airship now doubles the party's per-frame walking speed,
+  instead of moving at the same rate as on foot (or in a Boat/Ship, which
+  are correctly unchanged).** Confirmed against EasyRPG's actual C++ source:
+  `Game_Vehicle`'s constructor (`src/game_vehicle.cpp`) gives Boat and Ship
+  `MoveSpeed_normal` — identical to the player's own on-foot default — but
+  the Airship `MoveSpeed_double`, twice the per-frame step;
+  `Game_Player::GetOnVehicle`/`GetOffVehicle` (`src/game_player.cpp`) stash
+  and restore the player's pre-board speed around whichever value applies.
+  `Scene::Map#advance_player_slide` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  instead advanced the party's pixel slide by a flat `SPEED` constant every
+  frame with zero reference to `@state.boarded` — an Airship ride crossed
+  the map at exactly walking pace, when real RPG2003 makes it noticeably
+  faster. This engine has no general per-character move-speed model to save
+  and restore the way EasyRPG's `preboard_move_speed` does — the Speed
+  Up/Down move-route commands only ever touch an NPC/forced-route
+  `Character` mirror, never the player's own walking rate — so rebuilding
+  that whole mechanism was out of scope; instead, a new
+  `#player_slide_speed` derives the doubled rate straight from
+  `@state.boarded` each frame (`SPEED * 2` only while `:airship`, plain
+  `SPEED` for on-foot/Boat/Ship alike), reverting for free the instant
+  `#disembark_vehicle` clears the flag, with the same practical effect as
+  EasyRPG's stash-and-restore for the one vehicle where it's actually
+  observable. Covered by two new `scripts/rpg2k_scene_check.rb` checks — a
+  direct check of `#player_slide_speed` across all four riding states, and
+  an end-to-end frame count showing the Airship's own tile-crossing slide is
+  exactly half the length of the on-foot one — both confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3361,6 +3361,21 @@ class RPG2k
         @player_forced_step = true
       end
 
+      # The party's own per-frame slide rate: SPEED on foot, in a Boat, or in a
+      # Ship (EasyRPG's Game_Vehicle constructor, src/game_vehicle.cpp, gives
+      # both `MoveSpeed_normal`, identical to the player's own default), but
+      # doubled while aboard the Airship (`MoveSpeed_double`). Boarding stashes
+      # no separate "preboard speed" the way EasyRPG's Game_Player does --
+      # unlike EasyRPG, this engine has no general per-character move-speed
+      # model to save and restore (Speed Up/Down move-route commands only
+      # ever touch an NPC/forced-route Character mirror, never the player's
+      # own walking rate), so the airship's speedup is derived straight from
+      # `@state.boarded` each frame instead, reverting for free the instant
+      # #disembark_vehicle clears it.
+      def player_slide_speed
+        @state.boarded == :airship ? SPEED * 2 : SPEED
+      end
+
       # Advance the party's pixel slide by one frame, landing it on the
       # destination tile when the slide completes. Returns true while a slide is
       # still in progress.
@@ -3371,7 +3386,7 @@ class RPG2k
       # for a landing that never came.
       def advance_player_slide
         return false unless @moving
-        @move_count += SPEED
+        @move_count += player_slide_speed
         if @move_count >= TILE
           @state.x = @dest_x
           @state.y = @dest_y

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6854,6 +6854,64 @@ check 'the airship lands in place where the terrain allows it' do
   eq [0, 0], [air.x, air.y], 'the airship stayed where it landed'
 end
 
+check 'boarding the airship doubles the party\'s per-frame slide speed; boat/ship do not' do
+  # Confirmed against EasyRPG's actual C++ source: Game_Vehicle's constructor
+  # (src/game_vehicle.cpp) gives Boat/Ship `MoveSpeed_normal` -- identical to
+  # the player's own on-foot default -- but the Airship `MoveSpeed_double`,
+  # twice the per-frame step. #player_slide_speed is the port target.
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  speed = RPG2k::Scene::Map::SPEED
+  eq speed, scene.send(:player_slide_speed), 'on foot: the ordinary speed'
+  st.boarded = :boat
+  eq speed, scene.send(:player_slide_speed), 'boat: the ordinary speed too'
+  st.boarded = :ship
+  eq speed, scene.send(:player_slide_speed), 'ship: the ordinary speed too'
+  st.boarded = :airship
+  eq speed * 2, scene.send(:player_slide_speed), 'airship: double the ordinary speed'
+end
+
+check 'the airship crosses a tile in half the frames walking on foot takes' do
+  on_foot = new_scene({}, player: [0, 0])
+  RGSS::Input.dir_value = 6 # east
+  frames_on_foot = 0
+  st_foot = on_foot.instance_variable_get(:@state)
+  until st_foot.x == 1
+    on_foot.update
+    frames_on_foot += 1
+    break if frames_on_foot > 30
+  end
+  RGSS::Input.dir_value = 0
+  ok st_foot.x == 1, 'walked the tile'
+
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 0
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded
+
+  RGSS::Input.dir_value = 6
+  frames_flying = 0
+  until st.x == 1
+    scene.update
+    frames_flying += 1
+    break if frames_flying > 30
+  end
+  RGSS::Input.dir_value = 0
+  ok st.x == 1, 'flew the tile'
+  # One frame registers the input and starts the slide (the same on foot or
+  # flying -- this fixed frame doesn't scale with speed); the remaining
+  # frames cover the tile's 16px at SPEED px/frame walking, or 2*SPEED
+  # flying, so the *slide* portion halves even though the totals don't.
+  eq 1 + (frames_on_foot - 1) / 2, frames_flying,
+     "the airship's slide is exactly half the length of the on-foot one"
+end
+
 check 'the airship cannot land on a tile a map event occupies unless it has Through Mode on' do
   # yado.tk: an airship can never land on a tile a map event occupies,
   # regardless of terrain. Flying itself ignores events entirely


### PR DESCRIPTION
## Summary
- Boarding the Airship now doubles the party's per-frame walking speed, instead of moving at the same rate as on foot (or in a Boat/Ship, which are correctly unchanged).
- Confirmed against EasyRPG's actual C++ source: `Game_Vehicle`'s constructor (`src/game_vehicle.cpp`) gives Boat and Ship `MoveSpeed_normal` — identical to the player's own on-foot default — but the Airship `MoveSpeed_double`, twice the per-frame step; `Game_Player::GetOnVehicle`/`GetOffVehicle` (`src/game_player.cpp`) stash and restore the player's pre-board speed around whichever value applies.
- `Scene::Map#advance_player_slide` (`mruby-rpg2k/mrblib/scene/map.rb`) instead advanced the party's pixel slide by a flat `SPEED` constant every frame with zero reference to `@state.boarded` — an Airship ride crossed the map at exactly walking pace, when real RPG2003 makes it noticeably faster.
- This engine has no general per-character move-speed model to save and restore the way EasyRPG's `preboard_move_speed` does — the Speed Up/Down move-route commands only ever touch an NPC/forced-route `Character` mirror, never the player's own walking rate — so rebuilding that whole mechanism was out of scope; instead, a new `#player_slide_speed` derives the doubled rate straight from `@state.boarded` each frame (`SPEED * 2` only while `:airship`, plain `SPEED` for on-foot/Boat/Ship alike), reverting for free the instant `#disembark_vehicle` clears the flag, with the same practical effect as EasyRPG's stash-and-restore for the one vehicle where it's actually observable.

## Test plan
- [x] Two new `scripts/rpg2k_scene_check.rb` checks — a direct check of `#player_slide_speed` across all four riding states, and an end-to-end frame count showing the Airship's own tile-crossing slide is exactly half the length of the on-foot one — both confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_scene_check.rb` — 612 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 894 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_