### PR TITLE
Sync the battle screen's actor sprites/status window with a mid-fight roster change

### DIFF
--- a/changelog.d/battle-mid-fight-party-roster-sync-rendering.fixed.md
+++ b/changelog.d/battle-mid-fight-party-roster-sync-rendering.fixed.md
@@ -1,0 +1,17 @@
+- **Battle**: a party member added or removed mid-fight by a `Change Party
+  Member` battle event now actually appears or disappears on the battle
+  screen the instant it happens, instead of the status window and RPG2003's
+  actor battle sprites staying pinned to whoever was in the party when the
+  fight opened. `Interpreter#do_change_party` notifies the open battle
+  screen the moment a real membership change happens (mirroring EasyRPG's
+  `Game_Party::AddActor`/`RemoveActor` calling `Scene_Battle_Rpg2k::
+  OnPartyChanged` synchronously); the screen builds or disposes that one
+  actor's sprite, updates `@battle_ui[:allies]`, and redraws the status
+  window immediately -- covering the RPG2003 gauge-card layout
+  (`battle_type` 2) the same way as the plain text rows, since both already
+  read from the same roster. A member who leaves and rejoins the same fight
+  is drawn with a freshly built sprite (never a disposed-and-reused one)
+  while reusing the same `Combatant` the mechanics keep for them (ADR 0050),
+  so their accumulated battle-only state still survives the round trip.
+  This is the rendering follow-up ADR 0050 (mid-battle party roster sync)
+  deliberately deferred; see ADR 0051.

--- a/docs/adr/0051-mid-battle-party-roster-sync-rendering.md
+++ b/docs/adr/0051-mid-battle-party-roster-sync-rendering.md
@@ -1,0 +1,110 @@
+# 51. Mid-battle party roster sync: rendering
+
+Date: 2026-08-15
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0050 fixed the mechanic: `Game::Battle#sync_allies_from_party` re-derives
+the fight's real ally roster from the live `Game::Party` at each round
+boundary and before every action, so a `Change Party Member` battle event
+correctly adds/removes combatants from turn order and targeting. That step
+deliberately left the screen untouched: `@battle_ui[:allies]`, the battle
+status window, and RPG2003's actor battle sprites (added by the
+alternate-battle-screen initiative, ADR 0043/0044-era work, `Scene::Map
+#build_actor_sprites`/`#build_actor_sprite`) still showed whoever was in the
+party when the fight opened, for the fight's whole duration.
+
+Checked against EasyRPG Player's real source rather than assumed:
+`Scene_Battle_Rpg2k::OnPartyChanged(Game_Actor*, bool added)`
+(`src/scene_battle_rpg2k.cpp`) builds or tears down that one actor's
+`Sprite_Actor` and is called **synchronously**, at the exact moment the party
+changes, from `Game_Party::AddActor`/`RemoveActor` (`src/game_party.cpp`) via
+`Scene::Find(Scene::Battle)`. This codebase's render layer is event-driven,
+not polled — `#refresh_battle_status` already runs reactively at specific
+moments (opening the battle, selecting a command, opening the options
+window) — but nothing fired when a battle-event page's `Change Party Member`
+command actually mutated the party mid-fight, so the render layer had no
+signal that anything had happened at all.
+
+## Decision
+
+- `Interpreter` gains `attr_accessor :battle_screen`, set on `@battle_ui
+  [:events]` in `Scene::Map#open_battle` right alongside the existing
+  `@battle_ui[:events].battle = @battle_ui[:battle]` — the same kind of
+  reference `.battle` already gives a battle-event page's interpreter back
+  into the fight's own domain object, just one level up, into the screen
+  that owns it. `@battle_ui[:events]` is the only interpreter that ever runs
+  commands while `@battle_ui` exists (the foreground/parallel interpreters
+  are held off by `event_busy?`/`parallels_paused?` for as long as a battle
+  is open), so this is never set on any other interpreter, and reads nil
+  (a no-op) everywhere but a running battle-event page — the same scope
+  `.battle` already has.
+- `Interpreter#do_change_party` detects a genuine membership flip (comparing
+  `party.include_actor?` before/after — `#add_actor`/`#remove_actor` both
+  silently no-op on a full party, an unknown roster id, or a redundant
+  add/remove) and calls `@battle_screen.on_battle_party_changed(actor,
+  added)`, mirroring EasyRPG's `Game_Party::AddActor`/`RemoveActor` calling
+  `OnPartyChanged` at the exact point of mutation, not on some later poll.
+- `Scene::Map#on_battle_party_changed` builds (`#add_battle_actor_sprite`) or
+  disposes (`#remove_battle_actor_sprite`) that one actor's sprite, updates
+  `@battle_ui[:allies]`, and calls `#refresh_battle_status` immediately —
+  covering both the plain text status rows and, since `#refresh_battle_status`
+  already dispatches on `#gauge_battle_layout?`, the RPG2003 gauge card too,
+  with no separate code path needed.
+- `Game::Battle`'s own roster (`@battle_ui[:battle].allies`) is never
+  written to by the removal path, and `Game::Battle.new` is now handed
+  `allies.dup` rather than the same array `@battle_ui[:allies]` holds. Ruby
+  arrays are mutable objects — without the dup, deleting a departed member
+  from the render-facing array (so their sprite/status row actually
+  disappears) would delete it from `Game::Battle`'s own bookkeeping array
+  too, and the *next* `#sync_allies_from_party` call would no longer find
+  their existing `Combatant` on a rejoin, silently rebuilding a fresh one
+  and losing the accumulated battle-only state ADR 0050 specifically set out
+  to preserve. The two arrays start with the same `Combatant` *objects* (a
+  lookup through either one sees the same battle-only state) but are free to
+  diverge in which objects they each hold. The one exception is a genuinely
+  new participant: `#add_battle_actor_sprite` pushes their fresh `Combatant`
+  onto `@battle_ui[:battle].allies` too (mirroring the exact line
+  `#sync_allies_from_party` would run on its own next call), so the
+  mechanics and the screen are never tracking two different `Combatant`
+  objects for the same actor.
+- Every actor sprite's Z is re-derived from its current index in
+  `@battle_ui[:allies]` (`#reset_actor_battler_z`, using the existing
+  `#actor_sprite_z(i) = 200 + i` formula unchanged) after every add and
+  remove, not just assigned once for the newly (dis)appearing sprite. An add
+  or remove elsewhere in the roster shifts every later member's index, and
+  without a full recompute, a survivor can be left at a stale Z that a later
+  insertion recomputes independently — e.g. removing index 1 of 3 leaves
+  index 2's sprite at its old Z (202); adding a new member back in at the
+  new index 2 would then compute the same Z 202, and the two sprites would
+  collide. Matches EasyRPG's own `ResetAllBattlerZ()`, called for the same
+  reason right after `OnPartyChanged` adds a sprite.
+
+## Consequences
+
+The battle screen now matches the roster `Game::Battle` has been playing
+against since ADR 0050: a member added mid-fight gets their sprite and status
+row the instant the `Change Party Member` command runs, not on some later
+incidental redraw; a member removed mid-fight has their own sprite disposed
+and their row dropped, with every other member's sprite object left
+untouched; and a member who leaves and rejoins the same fight is drawn with a
+freshly built sprite (never a disposed-and-reused one) while reusing the
+exact same `Combatant` the mechanics already keep for them, so no duplicate
+render-side bookkeeping accumulates across repeated swaps within one fight.
+
+`Game::Battle`'s own mechanics (`#sync_allies_from_party`, `#out_of_play?`,
+`Combatant#member`) are untouched — this step only consumes the roster state
+ADR 0050 already keeps correct.
+
+Covered by six new checks in `scripts/rpg2k_scene_check.rb`: an add and a
+remove driven through a real `Change Party Member` battle-event page (the
+production path, not a direct method call); the gauge-card status panel
+(`battle_type` 2) picking up an add the same as the plain text rows; a
+leave-then-rejoin within the same fight reusing the same `Combatant` and its
+accumulated state while never reusing a disposed `Sprite` object or leaking
+a duplicate; and the Z-recompute specifically preventing the stale-Z
+collision described above across a remove-then-add cycle.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -242,6 +242,14 @@ module Game
     # what makes the battle-only commands no-ops outside a battle — exactly as
     # they are in RPG_RT, where the editor cannot even place them there.
     attr_accessor :battle
+    # The Scene::Map hosting the running fight `@battle` belongs to, set
+    # alongside it. Lets #do_change_party notify the battle screen the moment
+    # a Change Party Member command actually adds/removes a member, mirroring
+    # EasyRPG's `Game_Party::AddActor`/`RemoveActor` calling
+    # `Scene::Battle::OnPartyChanged` synchronously rather than leaving the
+    # screen to notice on some later redraw. nil outside battle (same scope as
+    # `@battle`), so the notification is a no-op there.
+    attr_accessor :battle_screen
     # Answers tile queries for Store Terrain / Event ID: responds to
     # `terrain_id(x, y)` and `event_id_at(x, y)`. Set by the owning scene; nil
     # makes those commands store 0 (the map is not queryable without it).
@@ -1793,13 +1801,23 @@ module Game
     # (loaded from the leader's CharSet) has to be reloaded here too. Without
     # this a companion swap left the map showing whichever leader's graphic
     # happened to be cached, which for Nepheshel's 5205 Change Party Member
-    # commands is most of the game.
+    # commands is most of the game. When this runs from a battle-event page
+    # (@battle_screen set, see its own comment), also pushes the change to
+    # the open battle screen's actor sprites and status window immediately.
     def do_change_party(cmd)
-      actor = cmd.param(1) == 0 ? cmd.param(2) : variables[cmd.param(2)]
-      if cmd.param(0) == 0
-        party.add_actor(actor)
-      else
-        party.remove_actor(actor)
+      id = cmd.param(1) == 0 ? cmd.param(2) : variables[cmd.param(2)]
+      added = cmd.param(0) == 0
+      was_member = party.include_actor?(id)
+      added ? party.add_actor(id) : party.remove_actor(id)
+      # #add_actor/#remove_actor silently no-op on a full party, an unknown
+      # roster id, or a redundant add/remove of an already-(non)member -- only
+      # a genuine membership flip needs to reach the battle screen. Reads the
+      # actor back from the roster (not @actors, which no longer holds it
+      # after a remove) since #on_battle_party_changed needs the same
+      # Game::Actor either way.
+      if @battle_screen && party.include_actor?(id) != was_member
+        actor = party.roster[id]
+        @battle_screen.on_battle_party_changed(actor, added) if actor
       end
       @actor_graphic_changed = true
       check_game_over

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4466,7 +4466,20 @@ class RPG2k
                        # from `opt`, the cursor row inside it whenever it is
                        # open (set fresh by #open_battle_options each time).
                        options_shown: false, opt: 0,
-                       battle: Game::Battle.new(allies, foes, @rng,
+                       # `allies.dup`, not `allies` itself: `@battle_ui[:allies]`
+                       # below stays the exact same array Game::Battle is
+                       # handed here would otherwise *be* -- Ruby arrays are
+                       # mutable objects, so without the dup, deleting a
+                       # departed member from the render-facing
+                       # `@battle_ui[:allies]` (#remove_battle_actor_sprite)
+                       # would delete it from Game::Battle's own bookkeeping
+                       # array too, breaking the rejoin-reuses-the-same-
+                       # Combatant guarantee #sync_allies_from_party depends
+                       # on (ADR 0050). The two arrays start with the same
+                       # Combatant *objects* (so a lookup through either one
+                       # sees the same battle-only state) but are free to
+                       # diverge in which objects they each hold.
+                       battle: Game::Battle.new(allies.dup, foes, @rng,
                                                 situations, true, true, true,
                                                 req[:first_strike] ? true : false,
                                                 properties,
@@ -4489,14 +4502,16 @@ class RPG2k
                                                 # from it every round/action
                                                 # rather than staying pinned to
                                                 # the `allies` snapshot taken
-                                                # just above. `@battle_ui[:allies]`
-                                                # itself is untouched here --
-                                                # still that one-shot snapshot
-                                                # -- so the status window/actor
-                                                # sprites do not yet reflect a
-                                                # mid-fight swap; that is
-                                                # rendering work left for a
-                                                # follow-up.
+                                                # just above. The screen itself
+                                                # (`@battle_ui[:allies]`, the
+                                                # status window, actor sprites)
+                                                # follows the same change the
+                                                # instant it happens instead --
+                                                # see #on_battle_party_changed,
+                                                # reached from
+                                                # Interpreter#do_change_party
+                                                # via `@battle_ui[:events].
+                                                # battle_screen` below.
                                                 party: @state.party),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
@@ -4523,6 +4538,14 @@ class RPG2k
                        # it needs no seeding beyond starting at 0 every fight.
                        frame: 0 }
         @battle_ui[:events].battle = @battle_ui[:battle]
+        # Lets a Change Party Member command run from a battle event page
+        # (Interpreter#do_change_party) reach back into this screen the
+        # moment it fires -- see #on_battle_party_changed. `@battle_ui[:events]`
+        # is the one interpreter ever running commands while a battle is open
+        # (the foreground/parallel interpreters are held off by `event_busy?`/
+        # `parallels_paused?` for as long as `@battle_ui` exists), so this is
+        # never set on any other interpreter.
+        @battle_ui[:events].battle_screen = self
         # A battle page can Call Common Event (1005), so it needs the same
         # resolver the encounter's own owning interpreter runs against --
         # the foreground by default, or a Parallel Process's own interpreter
@@ -4802,6 +4825,81 @@ class RPG2k
         spr.y = actor.respond_to?(:battle_y) ? (actor.battle_y || 0) : 0
         spr.z = actor_sprite_z(i)
         spr
+      end
+
+      # Interpreter#do_change_party's hook (via `@battle_ui[:events].
+      # battle_screen`, set in #open_battle) for a Change Party Member battle
+      # event that actually added or removed a member -- mirrors EasyRPG's
+      # `Game_Party::AddActor`/`RemoveActor` calling
+      # `Scene_Battle_Rpg2k::OnPartyChanged` synchronously, right when the
+      # party changes, rather than leaving the screen to notice on some later
+      # redraw. `actor` is the `Game::Actor` (from `Game::Party#roster`, so it
+      # resolves the same whether they are still a member or just left).
+      # `Game::Battle`'s own roster (`@battle_ui[:battle]`) is left alone --
+      # its `sync_allies_from_party`/`out_of_play?`/`member` bookkeeping
+      # (ADR 0050) already reads correctly from the live party on its own
+      # schedule; this only updates what's drawn.
+      def on_battle_party_changed(actor, added)
+        return unless @battle_ui
+        added ? add_battle_actor_sprite(actor) : remove_battle_actor_sprite(actor)
+        refresh_battle_status
+      end
+      public :on_battle_party_changed
+
+      # An actor just (re)joined the fight: reuse their existing `Combatant`
+      # if `Game::Battle` already has one (they left and are rejoining this
+      # same fight, so the reused object keeps its accumulated battle-only
+      # state -- the same reuse-on-rejoin guarantee ADR 0050 gives the
+      # mechanics), or build a fresh one exactly the way
+      # `Game::Battle#sync_allies_from_party` would on its own next sync --
+      # pushed onto `@battle_ui[:battle].allies` (not just returned) so that
+      # later sync finds it already there and reuses it too, rather than the
+      # render layer and the battle ending up tracking two different
+      # `Combatant` objects for the same actor.
+      def add_battle_actor_sprite(actor)
+        battle = @battle_ui[:battle]
+        combatant = battle.ally_by_actor_id(actor.id)
+        unless combatant
+          combatant = Game::Battle.from_actor(actor)
+          battle.allies.push(combatant)
+        end
+        return if @battle_ui[:allies].any? { |c| c.equal?(combatant) }
+        @battle_ui[:allies].push(combatant)
+        return unless @battle_ui[:actor_sprites]
+        i = @battle_ui[:allies].length - 1
+        @battle_ui[:actor_sprites].push(combatant.dead? ? nil : build_actor_sprite(combatant.actor, i))
+        reset_actor_battler_z
+      end
+
+      # An actor just left the fight: drop their `Combatant` from the
+      # render-facing `@battle_ui[:allies]` (not from `Game::Battle`'s own
+      # roster -- see #on_battle_party_changed) and dispose their specific
+      # sprite, leaving every other actor's sprite untouched. A rejoin later
+      # builds a brand new sprite (#add_battle_actor_sprite always calls
+      # #build_actor_sprite fresh); this never leaves a disposed `Sprite`
+      # sitting in the collection for that to reuse.
+      def remove_battle_actor_sprite(actor)
+        idx = @battle_ui[:allies].index { |c| c.actor && c.actor.id == actor.id }
+        return unless idx
+        @battle_ui[:allies].delete_at(idx)
+        sprites = @battle_ui[:actor_sprites]
+        return unless sprites
+        dispose_battle_sprite(sprites.delete_at(idx))
+        reset_actor_battler_z
+      end
+
+      # Re-derive every surviving actor sprite's Z from its current index in
+      # `@battle_ui[:allies]` (#actor_sprite_z). An add or remove elsewhere in
+      # the roster shifts everyone after it, so without this, two sprites can
+      # end up sharing a Z once enough adds/removes have happened -- e.g.
+      # remove index 1 of 3 (leaving index 2's sprite still at its old Z 202),
+      # then add a new member at the new index 2, which would also compute Z
+      # 202. Matches EasyRPG's own `ResetAllBattlerZ()`, called for the same
+      # reason right after `OnPartyChanged` adds a sprite.
+      def reset_actor_battler_z
+        sprites = @battle_ui[:actor_sprites]
+        return unless sprites
+        sprites.each_with_index { |spr, i| spr.z = actor_sprite_z(i) if spr }
       end
 
       # The BattleCharSet bitmap for an actor pose's `battler_name`, cached

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -134,7 +134,11 @@ module RGSS
     # the map layers share one and the overlays do not.
     attr_reader :viewport
     def initialize(viewport = nil, *); @viewport = viewport; end
-    def dispose; end
+    # Tracked (not just a no-op) so the mid-battle roster-sync rendering
+    # checks can assert a departed actor's specific sprite was actually
+    # disposed, and that a rejoin never hands back an already-disposed one.
+    def dispose; @disposed = true; end
+    def disposed?; !!@disposed; end
     # #flash/#update, as the target-scope Battle Animation flash
     # (Scene::Map#fire_target_flash/#update_enemy_flashes) uses them: mirrors
     # the real native contract (mruby-rgss/src/lib.cxx's spr_flash/spr_update)
@@ -2224,8 +2228,8 @@ class BattleStubActor
                  battle_commands: nil, battle_command_table: {},
                  level: 1, level_up_at: nil, learn_table: [],
                  battler_animation_id: nil, battle_x: 0, battle_y: 0,
-                 faceset_name: nil, faceset_index: 0)
-    @exp = 0; @id = id; @name = 'Hero'
+                 faceset_name: nil, faceset_index: 0, name: 'Hero')
+    @exp = 0; @id = id; @name = name
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
     @mp = mp; @max_mp = mp; @int = int; @skills = skills
     @rename_skill = rename_skill; @skill_name = skill_name; @states = states
@@ -2285,7 +2289,7 @@ class BattleStubActor
 end
 
 class BattleStubParty
-  attr_reader :actors, :gold
+  attr_reader :actors, :gold, :roster
   attr_accessor :leader
   # `rpg2003` stands in for the real `Game::Party#rpg2003?` (`Scene::Map
   # #flying_offset` reads it off `@state.party`, not the database directly, so
@@ -2304,10 +2308,18 @@ class BattleStubParty
   # #gauge_battle_layout? the same way -- distinct from `alternate_layout`,
   # which is also true for the plain sprite-only layout (battle_type 1); a
   # check exercising the gauge card status panel sets this one instead/as well.
+  # `actors:`/`roster_actors:` back the mid-battle roster-sync rendering
+  # checks (Interpreter#do_change_party -> Scene::Map#on_battle_party_changed):
+  # `actors:` overrides the single-`actor` default as the starting party,
+  # `roster_actors:` names actors known but not (yet) a member, mirroring a
+  # real Game::Party's roster always knowing an actor #add_actor can bring
+  # in. Every check predating this stays on the plain `[actor]`/roster-of-one
+  # shape.
   def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil, skill_db: nil,
                  enemy_group: Hash.new(true), alternate_layout: false,
-                 automatic_placement: false, gauge_layout: false)
-    @actors = [actor]
+                 automatic_placement: false, gauge_layout: false,
+                 actors: nil, roster_actors: nil)
+    @actors = actors || [actor]
     @gold = 0
     @leader = nil
     @rpg2003 = rpg2003
@@ -2318,6 +2330,8 @@ class BattleStubParty
     @alternate_layout = alternate_layout
     @automatic_placement = automatic_placement
     @gauge_layout = gauge_layout
+    @roster = {}
+    (@actors + (roster_actors || [])).each { |a| @roster[a.id] = a }
   end
   def gain_gold(n); @gold += n; end
   def any_alive?; @actors.any? { |a| !a.dead? }; end
@@ -2326,6 +2340,18 @@ class BattleStubParty
   def alternate_battle_layout?; @alternate_layout; end
   def automatic_battle_placement?; @automatic_placement; end
   def gauge_battle_layout?; @gauge_layout; end
+  # Interpreter#do_change_party's own interface (#add_actor/#remove_actor/
+  # #include_actor?), mirroring Game::Party's real semantics closely enough
+  # for these checks: add is a no-op for an already-present or unknown-roster
+  # id, remove drops whichever actor (if any) currently holds that id.
+  def include_actor?(id); @actors.any? { |a| a.id == id }; end
+  def add_actor(id)
+    return if include_actor?(id)
+    a = @roster[id]
+    return unless a
+    @actors.push(a)
+  end
+  def remove_actor(id); @actors.reject! { |a| a.id == id }; end
   # A troop victory drop (Game::Troop#drops -> Scene::Map#battle_result_lines)
   # both grants the item and names it in the result window -- mirrors
   # ShopStubParty's own #gain_item, plus a #db_item lookup against whatever
@@ -10047,11 +10073,12 @@ end
 # check predating the gauge-card status panel used; a check exercising a
 # non-default battle-screen presentation (BattleStubParty's `gauge_layout:`)
 # passes its own instead.
-def battle_scene_with_pages(pages, party: BattleStubParty.new)
+def battle_scene_with_pages(pages, party: BattleStubParty.new, battleranimations: nil)
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic)
-  scene = new_scene({ 1 => event(2, 2, auto) }, troop_pages: pages)
+  scene = new_scene({ 1 => event(2, 2, auto) }, troop_pages: pages,
+                    battleranimations: battleranimations)
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, party)
   [scene, st]
@@ -11019,8 +11046,8 @@ end
 # Open a battle and run it up to the command phase, answering [scene, ui].
 # Dismisses the once-per-battle automatic options window (a C press on its
 # default cursor row 0, "Battle") along the way -- see #battle_to_command.
-def battle_at_command(pages = nil, party: BattleStubParty.new)
-  scene, = battle_scene_with_pages(pages, party: party)
+def battle_at_command(pages = nil, party: BattleStubParty.new, battleranimations: nil)
+  scene, = battle_scene_with_pages(pages, party: party, battleranimations: battleranimations)
   ui = nil
   10.times do
     ui = scene.instance_variable_get(:@battle_ui)
@@ -11625,6 +11652,181 @@ check 'DrawNumberSystem2 leading-zero cascade matches EasyRPG exactly (7, 42, 10
   eq [[8, 1], [16, 0], [24, 0]], glyphs.call(100),
      'a hundreds digit that carries down still draws its own zero tens/ones cells'
   eq [[8, 9], [16, 9], [24, 9]], glyphs.call(999), 'three 9s, still no (blank) thousands cell'
+end
+
+# -- mid-battle party roster sync: the screen (step 2 of the roster-sync ------
+# initiative; step 1, ADR 0050, fixed the mechanic -- Game::Battle now
+# re-derives its own turn order/targeting from the live party every round/
+# action) --------------------------------------------------------------------
+#
+# Interpreter#do_change_party notifies the open battle screen the moment a
+# Change Party Member battle event actually adds or removes a member (see
+# Scene::Map#on_battle_party_changed, reached via `@battle_ui[:events].
+# battle_screen`) -- these checks drive it through a real battle-event page,
+# the same path production code takes, except where noted.
+
+check 'a Change Party Member add on a battle page builds that actor\'s sprite ' \
+      'immediately and updates the status window' do
+  ic = Game::Interpreter::Cmd
+  hero = BattleStubActor.new(id: 1, name: 'Hero', battler_animation_id: 5)
+  ally = BattleStubActor.new(id: 2, name: 'Ally', battler_animation_id: 5, hp: 50)
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose(battler_name: 'Party', battler_index: 0) }) }
+  party = BattleStubParty.new(hero, alternate_layout: true, roster_actors: [ally])
+  pages = { 1 => troop_page([ECmd.new(ic::CHANGE_PARTY, [0, 0, 2])]) } # add actor 2
+  scene, ui = battle_at_command(pages, party: party, battleranimations: anims)
+
+  eq 2, ui[:allies].length, 'the newcomer joined @battle_ui[:allies] the instant the page ran'
+  newcomer = ui[:allies].find { |c| c.actor && c.actor.id == 2 }
+  ok newcomer, 'as their own Combatant'
+  eq 50, newcomer.hp
+
+  sprites = ui[:actor_sprites]
+  eq 2, sprites.length, 'a sprite slot for the newcomer too'
+  ok sprites[0] && sprites[1], "both members' idle-pose sprites were built"
+
+  texts = window_texts(ui[:status_win])
+  ok texts.include?('Hero') && texts.include?('Ally'), 'both members show in the status window'
+end
+
+check 'a Change Party Member remove on a battle page disposes only that ' \
+      'actor\'s sprite, and drops just them from @battle_ui[:allies]/the status window' do
+  ic = Game::Interpreter::Cmd
+  hero = BattleStubActor.new(id: 1, name: 'Hero', battler_animation_id: 5)
+  ally = BattleStubActor.new(id: 2, name: 'Ally', battler_animation_id: 5)
+  third = BattleStubActor.new(id: 3, name: 'Third', battler_animation_id: 5)
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose(battler_name: 'Party', battler_index: 0) }) }
+  party = BattleStubParty.new(actors: [hero, ally, third], alternate_layout: true)
+  pages = { 1 => troop_page([ECmd.new(ic::CHANGE_PARTY, [1, 0, 2])]) } # remove actor 2
+  scene, = battle_scene_with_pages(pages, party: party, battleranimations: anims)
+
+  # Capture the pristine, pre-page sprite objects: #build_actor_sprites runs
+  # synchronously inside #open_battle, before the turn-0 page's own command
+  # ever gets a chance to run (it waits out the encounter-narration banner
+  # first -- see #drive_battle_encounter_message).
+  ui = nil
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui
+  end
+  ok ui, 'the battle opened'
+  eq :encounter_message, ui[:phase], 'still narrating -- the page has not run its command yet'
+  eq 3, ui[:allies].length, 'all three start in @battle_ui[:allies]'
+  hero_sprite, ally_sprite, third_sprite = ui[:actor_sprites]
+  ok hero_sprite && ally_sprite && third_sprite, 'all three built a sprite up front'
+
+  30.times do
+    RGSS::Input.triggered = [RGSS::Input::C] if ui[:phase] == :battle_options
+    scene.update
+    RGSS::Input.triggered = []
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui[:phase] == :command
+  end
+  eq :command, ui[:phase], 'the page ran (and handed control back) along the way'
+
+  eq 2, ui[:allies].length, 'the removed member dropped out of @battle_ui[:allies]'
+  ok ui[:allies].none? { |c| c.actor && c.actor.id == 2 }
+  ok ui[:allies].any? { |c| c.actor && c.actor.id == 1 }
+  ok ui[:allies].any? { |c| c.actor && c.actor.id == 3 }
+
+  eq 2, ui[:actor_sprites].length
+  ok ui[:actor_sprites].include?(hero_sprite), "Hero's original sprite object is untouched"
+  ok ui[:actor_sprites].include?(third_sprite), "Third's original sprite object is untouched"
+  ok !ui[:actor_sprites].include?(ally_sprite), "the removed actor's sprite slot is gone"
+  ok ally_sprite.disposed?, "the removed actor's specific sprite was disposed"
+  ok !hero_sprite.disposed?, "a bystander's sprite was never disposed"
+  ok !third_sprite.disposed?, "a bystander's sprite was never disposed"
+
+  texts = window_texts(ui[:status_win])
+  ok !texts.include?('Ally'), 'the removed member dropped off the status window'
+  ok texts.include?('Hero') && texts.include?('Third'), 'the remaining members still show'
+end
+
+check 'a Change Party Member add reaches the gauge-card status panel ' \
+      '(battle_type 2) too, not just the plain text row' do
+  ic = Game::Interpreter::Cmd
+  hero = BattleStubActor.new(id: 1, name: 'Hero', hp: 100, mp: 20, faceset_name: 'HeroFace')
+  ally = BattleStubActor.new(id: 2, name: 'Ally', hp: 80, mp: 10, faceset_name: 'AllyFace')
+  party = BattleStubParty.new(hero, gauge_layout: true, roster_actors: [ally])
+  pages = { 1 => troop_page([ECmd.new(ic::CHANGE_PARTY, [0, 0, 2])]) } # add actor 2
+  scene, = battle_scene_with_pages(pages, party: party)
+  # Set before the fight ever opens, so #on_battle_party_changed's own
+  # #refresh_battle_status call (triggered by the page below) already draws
+  # the gauge card, not just a later manually-forced redraw.
+  scene.db.system.system2_name = 'BattleStatus'
+
+  ui = nil
+  30.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
+    scene.update
+    RGSS::Input.triggered = []
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :command
+  end
+  eq :command, ui[:phase]
+  eq 2, ui[:allies].length, 'both members reached the gauge-card roster'
+
+  faces = ui[:status_win].contents.blt_calls.select do |call|
+    call[2].respond_to?(:load_name) && call[2].load_name.to_s.start_with?('FaceSet/')
+  end
+  eq [[0, 24], [80, 24]], faces.map { |call| call[0, 2] },
+     'a face column at x = 80*i for each member -- the newcomer got their own at i=1'
+end
+
+check 'leaving and rejoining the same fight reuses the same Combatant (and ' \
+      'its accumulated battle-only state) but always rebuilds a fresh sprite -- ' \
+      'never a leaked duplicate, never a disposed-and-reused one' do
+  hero = BattleStubActor.new(id: 1, name: 'Hero', battler_animation_id: 5)
+  ally = BattleStubActor.new(id: 2, name: 'Ally', battler_animation_id: 5)
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose(battler_name: 'Party', battler_index: 0) }) }
+  party = BattleStubParty.new(actors: [hero, ally], alternate_layout: true)
+  scene, ui = battle_at_command(nil, party: party, battleranimations: anims)
+
+  eq 2, ui[:allies].length
+  original_combatant = ui[:allies].find { |c| c.actor.id == 2 }
+  original_sprite = ui[:actor_sprites][ui[:allies].index(original_combatant)]
+  ok original_combatant && original_sprite
+
+  original_combatant.states = [5] # an accumulated battle-only status
+  scene.send(:on_battle_party_changed, ally, false) # leaves
+  eq 1, ui[:allies].length, 'dropped from the render roster'
+  ok !ui[:actor_sprites].include?(original_sprite)
+  ok original_sprite.disposed?, 'their sprite was disposed on the way out'
+
+  scene.send(:on_battle_party_changed, ally, true) # rejoins the same fight
+  eq 2, ui[:allies].length, 'back in the render roster, not duplicated'
+  eq 1, ui[:allies].count { |c| c.actor && c.actor.id == 2 }, 'no leaked duplicate Combatant'
+  rejoined_combatant = ui[:allies].find { |c| c.actor.id == 2 }
+  ok rejoined_combatant.equal?(original_combatant), 'the exact same Combatant object is reused'
+  eq [5], rejoined_combatant.states, 'their accumulated battle-only state survived the round trip'
+
+  new_sprite = ui[:actor_sprites][ui[:allies].index(rejoined_combatant)]
+  ok new_sprite, 'a sprite was rebuilt for the rejoin'
+  ok !new_sprite.equal?(original_sprite), 'a fresh Sprite object, never the disposed one'
+  eq 2, ui[:actor_sprites].compact.length, 'no leaked extra sprite either'
+end
+
+check 'actor sprite Z stays collision-free across a remove-then-add cycle, ' \
+      'matching EasyRPG\'s ResetAllBattlerZ' do
+  hero = BattleStubActor.new(id: 1, name: 'Hero', battler_animation_id: 5)
+  ally = BattleStubActor.new(id: 2, name: 'Ally', battler_animation_id: 5)
+  third = BattleStubActor.new(id: 3, name: 'Third', battler_animation_id: 5)
+  newcomer = BattleStubActor.new(id: 4, name: 'New', battler_animation_id: 5)
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose(battler_name: 'Party', battler_index: 0) }) }
+  party = BattleStubParty.new(actors: [hero, ally, third], alternate_layout: true,
+                              roster_actors: [newcomer])
+  scene, ui = battle_at_command(nil, party: party, battleranimations: anims)
+  eq [200, 201, 202], ui[:actor_sprites].map(&:z), 'starting Z per index (#actor_sprite_z)'
+
+  scene.send(:on_battle_party_changed, ally, false) # remove the middle member
+  eq [200, 201], ui[:actor_sprites].map(&:z),
+     "Third's Z was recomputed for its new index (1), not left stale at 202"
+
+  scene.send(:on_battle_party_changed, newcomer, true) # a brand new member joins
+  zs = ui[:actor_sprites].map(&:z)
+  eq [200, 201, 202], zs
+  eq zs.uniq.length, zs.length, 'no two actor sprites end up sharing a Z'
 end
 
 # -- the battle log in the game's own words ------------------------------------


### PR DESCRIPTION
## Summary

Step 2 of the mid-battle party roster sync initiative. Step 1 (#861, ADR 0050) fixed the mechanic: `Game::Battle#sync_allies_from_party` re-derives the fight's real ally roster from the live `Game::Party` at each round boundary and before every action, so a `Change Party Member` battle event correctly joins/leaves turn order and targeting. That step deliberately left rendering untouched — `@battle_ui[:allies]`, the battle status window, and RPG2003's actor battle sprites (step 3 of the alternate-battle-screen initiative, #850) still showed whoever was in the party when the fight opened, for the fight's whole duration.

This step makes the screen match the now-correct mechanical roster, mirroring EasyRPG's real `Scene_Battle_Rpg2k::OnPartyChanged`, called synchronously from `Game_Party::AddActor`/`RemoveActor` at the exact moment the party changes:

- `Interpreter` gains `attr_accessor :battle_screen` (the same kind of reference `.battle` already gives a battle-event page's interpreter, one level up) — set on `@battle_ui[:events]` in `Scene::Map#open_battle`.
- `Interpreter#do_change_party` detects a genuine membership flip and notifies `@battle_screen.on_battle_party_changed(actor, added)` right when the party actually changes.
- `Scene::Map#on_battle_party_changed` builds (`#add_battle_actor_sprite`) or disposes (`#remove_battle_actor_sprite`) that one actor's sprite, updates `@battle_ui[:allies]`, and calls `#refresh_battle_status` immediately — covering both the plain text status rows and the RPG2003 gauge-card layout (`battle_type` 2), since both already read from the same roster.
- `Game::Battle.new` now receives `allies.dup` rather than the same array `@battle_ui[:allies]` holds, so the render layer can drop a departed member from what's drawn without deleting it from `Game::Battle`'s own bookkeeping array — which would otherwise break the rejoin-reuses-the-same-`Combatant` guarantee ADR 0050 relies on. The one exception: a genuinely new participant's fresh `Combatant` is pushed onto `Game::Battle`'s own array too, so mechanics and rendering never track two different objects for the same actor.
- Every actor sprite's Z is recomputed from its current roster index after every add/remove (`#reset_actor_battler_z`), matching EasyRPG's own `ResetAllBattlerZ()` — otherwise a remove-then-add cycle can leave two sprites sharing a Z.

`Game::Battle`'s own mechanics (`sync_allies_from_party`, `out_of_play?`, `member`) are untouched — this step only consumes the already-correct roster state.

See ADR 0051 for the full design writeup.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 893 checks pass (unchanged)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 615 checks pass, including 6 new ones covering: add/remove via a real `Change Party Member` battle-event page, the gauge-card status panel reflecting an add, a leave-then-rejoin reusing the same `Combatant`/state without leaking or reusing a disposed sprite, and a Z-collision regression across a remove-then-add cycle
- [x] Native rebuild (`scripts/native-build-without-nix.bash`, builds `rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LPmBuSzRswZPGh6bQGfyKC)_