### PR TITLE
Read Timer2 and compare_operator in a map event page's own condition

### DIFF
--- a/changelog.d/rpg2k-event-page-timer2-compare-operator.fixed.md
+++ b/changelog.d/rpg2k-event-page-timer2-compare-operator.fixed.md
@@ -1,0 +1,10 @@
+- **A map event page's RPG2003-only Timer2 condition is now consulted, and
+  its variable condition now reads RPG2003's own comparison operator
+  instead of always testing `>=`.** Confirmed against EasyRPG Player's
+  source: RPG2003 lets a page condition compare a variable with `==`, `<=`,
+  `>`, `<`, or `!=`, not only `>=`, and adds a second Timer condition
+  alongside the original. Both fields were already parsed from the
+  database but never consulted. Fixing the variable comparison also
+  surfaced and corrected a wrong schema default that would have flipped
+  every untouched RPG2003 page's variable condition from `>=` to `==` once
+  read.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5975,6 +5975,46 @@ not yet verified:
   an end-to-end frame count showing the Airship's own tile-crossing slide is
   exactly half the length of the on-foot one — both confirmed to fail
   against the pre-fix code before the fix.
+- ✅ **A map event page's RPG2003-only Timer2 (0x40) condition is now
+  consulted, and its variable condition now reads RPG2003's own
+  `compare_operator` instead of always testing `>=`.** Confirmed against
+  EasyRPG's actual C++ source: `Game_Event::AreConditionsMet`
+  (`src/game_event.cpp`) checks `page.condition.flags.timer2 &&
+  Player::IsRPG2k3Commands()` against `GetTimerSeconds(Timer2)` — the
+  identical "counted down to *_sec or below" rule `TIMER` (Timer1) already
+  used, just against a different timer and edition-gated — and separately
+  branches the `VARIABLE` condition on `Player::IsRPG2k()`: RPG2000 always
+  hardcodes `>=`, but RPG2003 reads `compare_operator` (0..5: `==, >=, <=,
+  >, <, !=`) through `Game_Interpreter_Shared::CheckOperator`. `Game::
+  EventPage` (`mruby-rpg2k/mrblib/game.rb`) had no `TIMER2` constant at all
+  and its own doc comment said the bit "stays out of scope"; its `VARIABLE`
+  branch hardcoded `>=` for every edition, with no `compare_operator`
+  branch whatsoever. Both fields were already parsed by the schema
+  (`mruby-lcf/mrblib/schema.rb`'s `MAP_EVENT_PAGE_CONDITION`, fields 9-10)
+  but never consumed — the same "parsed but never read" pattern behind
+  several other fixes this session. A third bug surfaced while fixing the
+  second: liblcf's own generated `eventpagecondition.h` declares
+  `int32_t compare_operator = 1;` (`Comparison_greater_equal`), but this
+  port's schema declared its default as `0` (`Comparison_equal`) — since an
+  absent chunk field decodes to its schema default, reading
+  `compare_operator` with the wrong default would have silently turned
+  every RPG2003 map's *untouched* variable condition (the common case —
+  the field only differs from its default when a page author explicitly
+  picks a comparison other than the editor's own ">=") from `>=` into `==`,
+  a regression the fix had to correct before the new read could ship safely.
+  Fixed by adding `EventPage::TIMER2`, threading `Game::State#timer2_seconds`
+  (mirroring `#timer_seconds`, both reading `#timer(id)`) through
+  `EventPage.active?`/`.select` and their two `Scene::Map` call sites, and
+  branching the `VARIABLE` check on `party.rpg2003?` the same way EasyRPG
+  branches on `Player::IsRPG2k()` — plus correcting the schema default from
+  `0` to `1`. `Game::BattlePage` (troop/battle-event pages) needed no
+  equivalent change: EasyRPG's own `TroopPageCondition` carries no
+  `compare_operator` field at all, so its hardcoded `>=` was already
+  correct. Covered by three new `scripts/rpg2k_logic_check.rb` checks — the
+  Timer2 threshold/edition-gate (mirroring the existing Timer1 check), and
+  the RPG2003 `compare_operator` read for both `==`/`>` against RPG2000's
+  unconditional `>=` — the first two confirmed to fail against the pre-fix
+  code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -932,10 +932,18 @@ module LCF
       8 => { name: :timer_sec, type: :int, default: 0 },
       # RPG2003-only: a second timer condition (flags bit 0x40, gated on
       # Player::IsRPG2k3Commands() in EasyRPG) and the variable comparison
-      # operator (0 = >=). The RPG2000 runtime always compares with >=, so these
-      # are carried for schema completeness rather than consumed by EventPage.
+      # operator, both now read by Game::EventPage -- see its own TIMER2 /
+      # compare_operator handling there.
       9 => { name: :timer2_sec, type: :int, default: 0 },
-      10 => { name: :compare_operator, type: :int, default: 0 },
+      # 0 == 1 >= 2 <= 3 > 4 < 5 != (liblcf's EventPageCondition::Comparison
+      # enum). Default 1 (>=), not 0 (==): liblcf's generated
+      # eventpagecondition.h declares `int32_t compare_operator = 1;`, and an
+      # absent chunk field reads as its schema default -- an RPG2000 database
+      # (which never writes this RPG2003-only field at all) or an RPG2003
+      # page whose editor dropdown was left at its own default both need the
+      # ordinary ">=" reading, not "==", once EventPage actually consults
+      # this field.
+      10 => { name: :compare_operator, type: :int, default: 1 },
     }
 
     MOVE_ROUTE = {

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5419,24 +5419,54 @@ module Game
     # flags bits (chunk 1 of the page condition). Bit order confirmed against
     # liblcf's generated EventPageCondition::Flags declaration (switch_a,
     # switch_b, variable, item, actor, timer, timer2): TIMER is bit 5 (0x20),
-    # a genuine RPG2000 page condition, not an RPG2003 extension. The next bit,
-    # timer2 (0x40), *is* RPG2003-only (EasyRPG's AreConditionsMet gates it on
-    # Player::IsRPG2k3Commands()) and stays out of scope here -- see
-    # schema.rb's MAP_EVENT_PAGE_CONDITION comment.
+    # a genuine RPG2000 page condition, not an RPG2003 extension. The next
+    # bit, TIMER2 (0x40), *is* RPG2003-only -- EasyRPG's AreConditionsMet
+    # (src/game_event.cpp) gates it on `Player::IsRPG2k3Commands()`.
     SWITCH_A = 0x01
     SWITCH_B = 0x02
     VARIABLE = 0x04
     ITEM     = 0x08
     ACTOR    = 0x10
     TIMER    = 0x20
+    TIMER2   = 0x40
 
-    def self.active?(cond, switches, variables, party, timer_seconds = 0)
+    # `EventPageCondition::Comparison` (liblcf): the variable condition's own
+    # RPG2003 operator, read only once `#active?`'s RPG2003 branch below
+    # confirms it's in this valid 0..5 range -- an out-of-range value (never
+    # written by a real editor, but not schema-clamped either) falls through
+    # to "condition not checked", matching EasyRPG's own
+    # `compare_operator >= 0 && compare_operator <= 5` guard exactly.
+    def self.compare(a, b, op)
+      case op
+      when 0 then a == b
+      when 1 then a >= b
+      when 2 then a <= b
+      when 3 then a > b
+      when 4 then a < b
+      when 5 then a != b
+      end
+    end
+
+    def self.active?(cond, switches, variables, party, timer_seconds = 0, timer2_seconds = 0)
       return true if cond.nil?
       flags = cond.flags || 0
       return false if (flags & SWITCH_A) != 0 && !switches[cond.switch_a_id]
       return false if (flags & SWITCH_B) != 0 && !switches[cond.switch_b_id]
       if (flags & VARIABLE) != 0
-        return false if variables[cond.variable_id] < cond.variable_value
+        # RPG2000 always compares with plain >=; RPG2003 reads the page's own
+        # operator instead (EasyRPG's AreConditionsMet: `Player::IsRPG2k()`
+        # branches to the hardcoded >=, everything else to `CheckOperator`
+        # against `compare_operator`) -- these are genuinely different rules,
+        # not the same comparison with an edition-gated constant.
+        rpg2003 = party && party.respond_to?(:rpg2003?) && party.rpg2003?
+        if rpg2003
+          op = cond.compare_operator
+          if op && op >= 0 && op <= 5
+            return false unless compare(variables[cond.variable_id], cond.variable_value, op)
+          end
+        else
+          return false if variables[cond.variable_id] < cond.variable_value
+        end
       end
       if (flags & ITEM) != 0
         return false unless party && party.has_item?(cond.item_id)
@@ -5450,15 +5480,21 @@ module Game
       if (flags & TIMER) != 0
         return false if timer_seconds > cond.timer_sec
       end
+      # TIMER2 is the identical rule against Timer2's own remaining seconds,
+      # RPG2003-only (EasyRPG's `Player::IsRPG2k3Commands()` gate).
+      if (flags & TIMER2) != 0 && party && party.respond_to?(:rpg2003?) && party.rpg2003?
+        return false if timer2_seconds > cond.timer2_sec
+      end
       true
     end
 
     # Return [id, page] of the active page for an event, or nil when none apply.
-    def self.select(pages, switches, variables, party, timer_seconds = 0)
+    def self.select(pages, switches, variables, party, timer_seconds = 0, timer2_seconds = 0)
       return nil if pages.nil?
       chosen = nil
       pages.each do |id, page|
-        chosen = [id, page] if active?(page.condition, switches, variables, party, timer_seconds)
+        chosen = [id, page] if active?(page.condition, switches, variables, party,
+                                        timer_seconds, timer2_seconds)
       end
       chosen
     end
@@ -11025,6 +11061,10 @@ module Game
     # so these keep reading and writing it by name.
     def timer_seconds; timer(0).seconds; end
     def timer_display_text; timer(0).display_text; end
+
+    # Timer2's own remaining seconds -- RPG2003's map-event page TIMER2
+    # condition reads this, not #timer_seconds (Timer1's).
+    def timer2_seconds; timer(1).seconds; end
     def timer_frames; timer(0).frames; end
     def timer_frames=(v); timer(0).frames = v; end
     def timer_running; timer(0).running; end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1030,7 +1030,7 @@ class RPG2k
           next if @erased_events[id] # an Erase Event lasts the whole visit
           selected = Game::EventPage.select(ev.pages, @state.switches,
                                             @state.variables, @state.party,
-                                            @state.timer_seconds)
+                                            @state.timer_seconds, @state.timer2_seconds)
           next unless selected
           page = selected[1]
           @events.push(build_event(id, ev, page, restore_route_index: restore_route_index))
@@ -2588,7 +2588,7 @@ class RPG2k
           next if changed || @erased_events[id]
           selected = Game::EventPage.select(src.pages, @state.switches,
                                             @state.variables, @state.party,
-                                            @state.timer_seconds)
+                                            @state.timer_seconds, @state.timer2_seconds)
           page = selected && selected[1]
           e = live[id]
           changed = true unless page.equal?(e && e[:page])

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -12722,22 +12722,29 @@ FakePage = Struct.new(:condition, :event)
 
 # A map event page condition (LMU chunk 1 of MAP_EVENT_PAGE_CONDITION). Only
 # the fields a given check enables in `flags` are read, so the rest can stay
-# at their editor defaults.
+# at their editor defaults. `compare_operator` defaults to 1 (>=), matching
+# liblcf's own generated default (`eventpagecondition.h`: `int32_t
+# compare_operator = 1;`) -- the value an untouched field decodes to.
 FakeEventCond = Struct.new(:flags, :switch_a_id, :switch_b_id, :variable_id,
-                            :variable_value, :item_id, :actor_id, :timer_sec)
+                            :variable_value, :item_id, :actor_id, :timer_sec,
+                            :timer2_sec, :compare_operator)
 def event_cond(flags, opts = {})
   c = FakeEventCond.new(flags)
   c.variable_value = 0
   c.timer_sec = 0
+  c.timer2_sec = 0
+  c.compare_operator = 1
   opts.each { |k, v| c.send("#{k}=", v) }
   c
 end
 
-# A minimal party stand-in for EventPage::ITEM / ::ACTOR: just enough to
-# answer has_item?/include_actor? from plain arrays.
-FakeEventPageParty = Struct.new(:items, :actor_ids) do
+# A minimal party stand-in for EventPage::ITEM / ::ACTOR / the RPG2003-only
+# compare_operator / TIMER2 branches: just enough to answer has_item?/
+# include_actor?/rpg2003? from plain values.
+FakeEventPageParty = Struct.new(:items, :actor_ids, :rpg2003) do
   def has_item?(id); items.include?(id); end
   def include_actor?(id); actor_ids.include?(id); end
+  def rpg2003?; !!rpg2003; end
 end
 
 check 'Game::EventPage.active? tests switch, variable, item and actor conditions' do
@@ -12794,6 +12801,68 @@ check 'Game::EventPage.active? tests the Timer (0x20) condition against Timer1 s
   sw[4] = true
   eq true, Game::EventPage.active?(combo, sw, vars, party, 10)
   eq false, Game::EventPage.active?(combo, sw, vars, party, 60), 'switch alone is not enough'
+end
+
+check 'Game::EventPage.active? tests the Timer2 (0x40) condition, RPG2003 only' do
+  # Confirmed against EasyRPG's actual C++ source: Game_Event::
+  # AreConditionsMet (src/game_event.cpp) gates Timer2 on
+  # Player::IsRPG2k3Commands() -- an RPG2000 database ignores the bit
+  # entirely, even if it happens to be set. Same "counted down to timer2_sec
+  # or below" rule as Timer1, against Timer2's own seconds (the method's
+  # 6th argument), never Timer1's.
+  st = new_state
+  sw = st.switches
+  vars = st.variables
+  cond = event_cond(Game::EventPage::TIMER2, timer2_sec: 30)
+
+  rpg2003 = FakeEventPageParty.new([], [], true)
+  eq false, Game::EventPage.active?(cond, sw, vars, rpg2003, 0, 60), 'well above the threshold'
+  eq false, Game::EventPage.active?(cond, sw, vars, rpg2003, 0, 31), 'one second above the threshold'
+  eq true, Game::EventPage.active?(cond, sw, vars, rpg2003, 0, 30), 'exactly at the threshold: <=, not <'
+  eq true, Game::EventPage.active?(cond, sw, vars, rpg2003, 0, 0), 'timer fully elapsed'
+  # Timer1's own seconds (arg 5) plays no part in a pure Timer2 condition.
+  eq true, Game::EventPage.active?(cond, sw, vars, rpg2003, 999, 0)
+
+  rpg2000 = FakeEventPageParty.new([], [], false)
+  eq true, Game::EventPage.active?(cond, sw, vars, rpg2000, 0, 999),
+     'RPG2000 ignores the Timer2 bit entirely, however far from the threshold Timer2 sits'
+end
+
+check "Game::EventPage.active?'s variable condition reads RPG2003's own " \
+      'compare_operator instead of a hardcoded >=' do
+  # Confirmed against EasyRPG's actual C++ source: AreConditionsMet branches
+  # on Player::IsRPG2k() -- RPG2000 always compares >=, but everything else
+  # (RPG2003) reads condition.compare_operator through CheckOperator
+  # (src/game_interpreter_shared.h): 0 == 1 >= 2 <= 3 > 4 < 5 !=. These are
+  # genuinely different rules per edition, not a shared comparison with an
+  # edition-gated constant.
+  st = new_state
+  sw = st.switches
+  vars = st.variables
+  vars[2] = 5
+
+  rpg2003 = FakeEventPageParty.new([], [], true)
+  eq_cond = event_cond(Game::EventPage::VARIABLE, variable_id: 2,
+                        variable_value: 5, compare_operator: 0) # ==
+  eq true, Game::EventPage.active?(eq_cond, sw, vars, rpg2003), 'var 2 (5) == 5'
+  vars[2] = 6
+  eq false, Game::EventPage.active?(eq_cond, sw, vars, rpg2003),
+     'RPG2003 == does not also accept >, unlike a hardcoded >='
+
+  vars[2] = 5
+  gt_cond = event_cond(Game::EventPage::VARIABLE, variable_id: 2,
+                        variable_value: 5, compare_operator: 3) # >
+  eq false, Game::EventPage.active?(gt_cond, sw, vars, rpg2003), 'var 2 (5) is not > 5'
+  vars[2] = 6
+  eq true, Game::EventPage.active?(gt_cond, sw, vars, rpg2003)
+
+  # RPG2000 always compares >=, regardless of what compare_operator (an
+  # RPG2003-only field) happens to hold -- here it would read as == and
+  # reject the equal case if RPG2000 consulted it, which it must not.
+  vars[2] = 5
+  rpg2000 = FakeEventPageParty.new([], [], false)
+  eq true, Game::EventPage.active?(eq_cond, sw, vars, rpg2000),
+     'RPG2000 ignores compare_operator entirely and stays >='
 end
 
 check 'Game::EventPage.select picks the last page whose conditions (including Timer) hold' do


### PR DESCRIPTION
## Summary
- A map event page's RPG2003-only Timer2 (0x40) condition is now consulted, and its variable condition now reads RPG2003's own `compare_operator` instead of always testing `>=`.
- Confirmed against EasyRPG's actual C++ source: `Game_Event::AreConditionsMet` (`src/game_event.cpp`) checks `page.condition.flags.timer2 && Player::IsRPG2k3Commands()` against `GetTimerSeconds(Timer2)` — the identical "counted down to `*_sec` or below" rule `TIMER` (Timer1) already used, just against a different timer and edition-gated — and separately branches the `VARIABLE` condition on `Player::IsRPG2k()`: RPG2000 always hardcodes `>=`, but RPG2003 reads `compare_operator` (0..5: `==, >=, <=, >, <, !=`) through `Game_Interpreter_Shared::CheckOperator`.
- `Game::EventPage` (`mruby-rpg2k/mrblib/game.rb`) had no `TIMER2` constant at all and its own doc comment said the bit "stays out of scope"; its `VARIABLE` branch hardcoded `>=` for every edition, with no `compare_operator` branch whatsoever. Both fields were already parsed by the schema (`mruby-lcf/mrblib/schema.rb`'s `MAP_EVENT_PAGE_CONDITION`, fields 9-10) but never consumed — the same "parsed but never read" pattern behind several other fixes this session.
- A third bug surfaced while fixing the second: liblcf's own generated `eventpagecondition.h` declares `int32_t compare_operator = 1;` (`Comparison_greater_equal`), but this port's schema declared its default as `0` (`Comparison_equal`) — since an absent chunk field decodes to its schema default, reading `compare_operator` with the wrong default would have silently turned every RPG2003 map's *untouched* variable condition (the common case) from `>=` into `==`, a regression the fix had to correct before the new read could ship safely.
- Fixed by adding `EventPage::TIMER2`, threading `Game::State#timer2_seconds` (mirroring `#timer_seconds`, both reading `#timer(id)`) through `EventPage.active?`/`.select` and their two `Scene::Map` call sites, and branching the `VARIABLE` check on `party.rpg2003?` the same way EasyRPG branches on `Player::IsRPG2k()` — plus correcting the schema default from `0` to `1`.
- `Game::BattlePage` (troop/battle-event pages) needed no equivalent change: EasyRPG's own `TroopPageCondition` carries no `compare_operator` field at all, so its hardcoded `>=` was already correct.

## Test plan
- [x] Three new `scripts/rpg2k_logic_check.rb` checks — the Timer2 threshold/edition-gate (mirroring the existing Timer1 check), and the RPG2003 `compare_operator` read for both `==`/`>` against RPG2000's unconditional `>=` — the first two confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_logic_check.rb` — 896 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 617 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] `ninja test` (native mruby test suite, including `mruby-lcf`'s own asserts) — 8/8 passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_