### PR TITLE
Apply elemental attribute resistance to healing/recovery skills

### DIFF
--- a/changelog.d/heal-skill-attribute-resistance.fixed.md
+++ b/changelog.d/heal-skill-attribute-resistance.fixed.md
@@ -1,0 +1,10 @@
+- **Battle**: a healing/recovery skill's elemental `attributes:` are now
+  threaded through and applied to its recovery amount, the same way an attack
+  skill's already were. `Game::Party#battle_skill_command`'s recovery branch
+  now carries the skill's own `attributes:`, and `Game::Battle#apply_skill_hit`
+  scales the HP/SP recovery by the target's attribute resistance before
+  variance, matching EasyRPG Player's `Algo::CalcSkillEffect` (`Attribute::
+  ApplyAttributeSkillMultiplier` runs unconditionally, with no heal-vs-damage
+  gate). This is what a database uses to make a character harder/easier to
+  heal via a tagged heal plus a custom resistance, or to build a
+  caster-excluding MP-restore skill via 0% self-resistance.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4597,6 +4597,17 @@ module Game
           physical_rate: (sk.physical_rate || 0) * 10 }
       else
         { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0,
+          # EasyRPG's `Algo::CalcSkillEffect` runs `Attribute::
+          # ApplyAttributeSkillMultiplier` unconditionally -- there is no
+          # heal-vs-damage branch gating it -- so a recovery skill tagged
+          # with an elemental attribute scales by the target's resistance
+          # exactly like an attack skill's `attributes:` above. This is what
+          # lets a database tag a heal with a custom attribute and set a
+          # character's own resistance to it to make them harder/easier to
+          # heal, or build a caster-excluding MP-restore via 0% self-resistance
+          # (confirmed against algo.cpp directly and independently by
+          # @2000_battle_bot/デフォ戦bot trivia on this exact trick).
+          attributes: skill_attributes(sk),
           variance: skill_variance(sk), attr_shift: shift, attr_ids: shift_ids,
           stat_mod_keys: stat_keys,
           # The raw, un-gated effect a buff-only skill (affect_hp clear,
@@ -10361,6 +10372,12 @@ module Game
         # 0 throughout, but the modifier still applies off the skill's own
         # base effect.
         stat_amount = cmd[:stat_effect] || 0
+        # Elemental scaling applies to a recovery's own effect exactly the way
+        # it applies to an attack's (see #battle_skill_command's ally branch
+        # comment above) -- EasyRPG's `CalcSkillEffect` order is attribute
+        # multiplier first, then variance last, for either sign of effect.
+        hp = apply_attr_multiplier(hp, cmd[:attributes], target)
+        mp = apply_attr_multiplier(mp, cmd[:attributes], target)
         if @variance && cmd[:variance] && cmd[:variance] > 0
           hp = varied(hp, cmd[:variance])
           mp = varied(mp, cmd[:variance])

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9716,6 +9716,69 @@ check 'battle_skill_command carries the skill variance on its heal branch too' d
   eq 7, c[:variance], 'the heal branch reports the skill row variance, not 0'
 end
 
+check 'battle_skill_command carries the skill elemental attributes on its heal branch too, ' \
+     'and a target that partly resists them heals for less than the raw base' do
+  # EasyRPG's `Algo::CalcSkillEffect` runs `Attribute::
+  # ApplyAttributeSkillMultiplier` unconditionally -- no heal-vs-damage branch
+  # gates it -- so a healing skill tagged with an elemental attribute (a real
+  # RPG2000/2003 database trick: tag a heal with a custom attribute and set a
+  # character's own resistance to it to make them harder/easier to heal) scales
+  # its recovery by the target's resistance exactly like an attack skill's own
+  # `attributes:` already does. Verified directly against EasyRPG Player's
+  # `src/algo.cpp` and independently by @2000_battle_bot/デフォ戦bot trivia.
+  skills = { 8 => fake_skill(name: 'Cure', scope: 3, power: 30, hp: true,
+                             attribute_effects: [false, false, true]) } # element 3
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  ally = combatant('Ally', 0, 0, 5, 1000)
+  ally.hp = 1
+  ally.attr_ranks = { 3 => 3 } # rank D = 50% -- partly resists this heal
+  bat = Game::Battle.new([caster, ally], [combatant('Foe', 0, 0, 1, 1)],
+                        Game::Rng.new(1)) # 3-arg: variance off
+  c = st.party.battle_skill_command(st.party.db_skill(8), caster, ally)
+  eq [3], c[:attributes], "the recovery branch now carries the skill's own attributes"
+  bat.command_skill(caster, ally, name: 'Cure', cost: c[:cost], hp: c[:hp],
+                    mp: c[:mp], variance: c[:variance], attributes: c[:attributes])
+  bat.begin_round
+  e = bat.step_action
+  eq 15, e[:recover_hp], "30 * 50% resistance -- not the raw base 30"
+end
+
+check 'battle: a healing skill tagged with an attribute the target is fully immune to ' \
+     '(0% rank) heals for the attribute-adjusted amount, not the raw base' do
+  # Rank E is 0% on the default attribute table -- the same "0% self-resistance"
+  # trick a caster-excluding MP-restore skill relies on.
+  mage = combatant_mp('Mage', 10, 0, 20, 100, 30)
+  ally = combatant('Ally', 40, 0, 5, 100)
+  ally.hp = 1
+  ally.attr_ranks = { 3 => 4 } # rank E = 0% -- fully immune to this heal
+  bat = Game::Battle.new([mage, ally], [combatant('Foe', 0, 0, 1, 1)],
+                        Game::Rng.new(1)) # variance off
+  bat.command_skill(mage, ally, name: 'Cure', cost: 0, hp: 30, attributes: [3])
+  bat.begin_round
+  e = bat.step_action
+  eq 0, e[:recover_hp], '30 scaled by 0% resistance -- the attribute-adjusted amount, not raw 30'
+end
+
+check 'battle: a healing skill with no attributes tagged heals the raw base amount, unchanged ' \
+     '(regression against the elemental-heal fix above)' do
+  skills = { 8 => fake_skill(name: 'Heal', scope: 3, power: 30, hp: true) } # no attribute_effects
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  ally = combatant('Ally', 0, 0, 5, 1000)
+  ally.hp = 1
+  ally.attr_ranks = { 3 => 4 } # would zero an attribute-3 heal -- irrelevant here, the skill is untagged
+  bat = Game::Battle.new([caster, ally], [combatant('Foe', 0, 0, 1, 1)],
+                        Game::Rng.new(1)) # 3-arg: variance off
+  c = st.party.battle_skill_command(st.party.db_skill(8), caster, ally)
+  eq [], c[:attributes], 'an untagged skill still carries an empty attributes list'
+  bat.command_skill(caster, ally, name: 'Heal', cost: c[:cost], hp: c[:hp],
+                    mp: c[:mp], variance: c[:variance], attributes: c[:attributes])
+  bat.begin_round
+  e = bat.step_action
+  eq 30, e[:recover_hp], 'the raw base, exactly as before this fix'
+end
+
 check 'Battle: a stronger party wins, a weaker one is defeated' do
   hero = combatant('Hero', 40, 20, 20, 200)
   slime = combatant('Slime', 8, 4, 5, 30)
@@ -9942,11 +10005,11 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
        stat_mod_keys: [], cured: [], stat_effect: 24,
        physical_rate: 0 }, # purely magical -> 0
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
-  eq({ cost: 5, hp: 32, mp: 0, variance: 4, attr_shift: nil, attr_ids: [],
+  eq({ cost: 5, hp: 32, mp: 0, attributes: [], variance: 4, attr_shift: nil, attr_ids: [],
        stat_mod_keys: [], stat_effect: 32, cured: [], inflict: [], chance: 100 },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))
   # Cure affects HP and SP: effect = 10 + 40*12/40 = 22
-  eq({ cost: 4, hp: 22, mp: 22, variance: 4, attr_shift: nil, attr_ids: [],
+  eq({ cost: 4, hp: 22, mp: 22, attributes: [], variance: 4, attr_shift: nil, attr_ids: [],
        stat_mod_keys: [], stat_effect: 22, cured: [], inflict: [], chance: 100 },
      st.party.battle_skill_command(st.party.db_skill(9), caster, nil))
 end


### PR DESCRIPTION
## Summary

- `Game::Party#battle_skill_command`'s ally-scope/recovery branch never read the skill's own `attributes:` (`skill_attributes(sk)`) into its recovery amount, and `Game::Battle#apply_skill_hit`'s heal branch applied the raw effect with no `apply_attr_multiplier` call at all — unlike the attack branch, which already threads `attributes: skill_attributes(sk)` through to `apply_attr_multiplier`.
- Verified against EasyRPG Player's real C++ source (`src/algo.cpp`, `Algo::CalcSkillEffect`): `effect = Attribute::ApplyAttributeSkillMultiplier(effect, target, skill);` runs **unconditionally**, with no heal-vs-damage branch gating it. A healing skill tagged with an elemental attribute (a real RPG2000/2003 database trick — e.g. tagging a heal with a custom attribute and setting a character's own resistance to that attribute to make them harder/easier to heal, or building a caster-excluding MP-restore skill via 0% self-resistance) should have its recovery scaled by the target's resistance exactly like a damage skill's effect is. This also matches independent デフォ戦bot community trivia describing the same trick.
- Fix: thread `attributes: skill_attributes(sk)` through the recovery branch of `battle_skill_command` the same way the attack branch already does, and scale `hp`/`mp` by `apply_attr_multiplier` (before variance, matching `CalcSkillEffect`'s attribute-then-variance order) in `apply_skill_hit`'s heal branch, mirroring the attack branch's existing call. The attack branch itself is unchanged.

## Test plan

- [x] Added checks to `scripts/rpg2k_logic_check.rb`: a healing skill tagged with an attribute the target partly resists (rank D, 50%) heals for less than its base effect; a healing skill tagged with an attribute the target is fully immune to (rank E, 0%) heals for the attribute-adjusted amount (0), not the raw base; a healing skill with no attributes tagged still heals the raw base amount (regression). Confirmed all three fail against the pre-fix code.
- [x] Fixed an existing exact-hash check (`battle_skill_command yields attack damage, ally heal and self recovery`) that needed the new `attributes: []` key added to its expected heal-branch hashes.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 897 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 617 checks passed.
- [x] Native rebuild: `scripts/native-build-without-nix.bash` compiled cleanly and `ninja rpg_maker_clone` reports up to date / linked successfully (the script's own trailing "boot checks against real downloaded game data" step is unrelated — it just needs `scripts/download-*.bash` game data this container doesn't have).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V4xcbSuB9RXZix5uSPTDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4xcbSuB9RXZix5uSPTDHu)_