### PR TITLE
Fix battle-only states to clear at battle end

### DIFF
--- a/changelog.d/battle-only-state-lifecycle.fixed.md
+++ b/changelog.d/battle-only-state-lifecycle.fixed.md
@@ -1,0 +1,21 @@
+- **Battle-only states (situation table `type` 0, the default) now clear at
+  battle end instead of surviving onto the field party.** `Game::Battle
+  #apply_to_party` (`mruby-rpg2k/mrblib/game.rb`) copied every combatant's
+  `states` back onto its persistent `Game::Actor` unconditionally, so a state
+  the database flagged "battle only" survived past battle end exactly as
+  much as one flagged "also on map" (`type` 1) — a status the player could
+  never have cured outside battle then sat on the field roster indefinitely.
+  Verified against EasyRPG Player's actual C++ source:
+  `Game_Battler::RemoveBattleStates` (`src/game_battler.cpp`), called from
+  `Game_Battle::Quit()`, removes exactly the states whose own
+  `lcf::rpg::State::Persistence` is `Persistence_ends` (0) and leaves
+  `Persistence_persists` (1) alone — this codebase's own `schema.rb` decodes
+  the same field, under the name `type`, with the matching comment ("0:
+  battle only, 1: also on map"), but nothing in the runtime ever consulted
+  it. Fixed with a new `Game::Battle::STATE_PERSISTS_ON_MAP` constant and a
+  `#surviving_states` filter applied inside `#apply_to_party`, reusing the
+  existing `#state_def`/`#state_field` lookup pattern (a state whose row
+  can't be found is dropped rather than guessed at, matching this file's
+  usual dangling-reference handling). Covered by new
+  `scripts/rpg2k_logic_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8128,6 +8128,14 @@ module Game
     RESTRICTION_ATTACK_ENEMY = 2
     RESTRICTION_ATTACK_ALLY  = 3
 
+    # A state's own `type` field (situation table element 2): 0 (the schema
+    # default) is battle-only, cleared at battle end; 1 also persists onto
+    # the map. Matches liblcf's `Persistence` enum (`Persistence_ends` = 0,
+    # `Persistence_persists` = 1) verified against its generated state.h --
+    # EasyRPG's Game_Battler::RemoveBattleStates (State::RemoveAllBattle),
+    # called from Game_Battle::Quit(), strips exactly the `ends` states.
+    STATE_PERSISTS_ON_MAP = 1
+
     # True once one side has been wiped out, or the party has fled — the battle
     # is decided.
     def finished?; @escaped || !alive?(@allies) || !alive?(@enemies); end
@@ -8260,10 +8268,19 @@ module Game
     # combatant reduced to 0 comes out knocked out (戦闘不能). Combatants without a
     # source actor -- enemies, or bare test snapshots -- are skipped. States are
     # written before HP so `set_hp` gets the last word on the death state.
+    #
+    # A battle-only state (situation.type 0, the default -- see
+    # STATE_PERSISTS_ON_MAP) never makes it into that write-back: EasyRPG
+    # strips those at battle end (Game_Battler::RemoveBattleStates) before the
+    # map ever sees them, so carrying one through here would let a status the
+    # player could not have cured outside battle sit on the field party
+    # indefinitely. A state whose row can't be found is dropped the same way
+    # rather than guessed at, matching this file's usual dangling-reference
+    # handling.
     def apply_to_party
       @allies.each do |c|
         next unless c.actor
-        c.actor.states = c.states if c.states && c.actor.respond_to?(:states=)
+        c.actor.states = surviving_states(c.states) if c.states && c.actor.respond_to?(:states=)
         c.actor.set_hp(c.hp)
         c.actor.mp = Game.clamp(c.mp, 0, c.actor.max_mp) if c.mp
       end
@@ -8879,6 +8896,12 @@ module Game
 
     # The state definition for `id` from the lookup, or nil (no lookup / unknown).
     def state_def(id); @states ? @states[id] : nil; end
+
+    # `ids` filtered down to the ones that outlive battle -- see
+    # STATE_PERSISTS_ON_MAP and #apply_to_party's own comment.
+    def surviving_states(ids)
+      (ids || []).select { |id| state_field(state_def(id), :type) == STATE_PERSISTS_ON_MAP }
+    end
 
     # Which side a combatant is on. Only a party member carries the live
     # Game::Actor it was snapshotted from, so that is the test. Recorded on a log

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3131,7 +3131,14 @@ FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           # equipment from the field for as long as it lasts
                           # (Game::Actor#equipment_fixed?/#state_cursed?).
                           # Appended last, same reason again.
-                          :cursed)
+                          :cursed,
+                          # ... and the situation table's own `type` field
+                          # (element 2): 0 (the schema default) is battle-only,
+                          # cleared at battle end by Battle#apply_to_party; 1
+                          # also persists onto the map. Appended last, same
+                          # reason again -- nil reads as 0/battle-only via
+                          # #state_field, the schema's own default.
+                          :type)
 # A state row carrying only the fields a check names, with the rest at the
 # database defaults — notably reduce_hit_ratio 100, which is "does not blind".
 def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
@@ -3145,7 +3152,8 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                affect_spirit: false, affect_agility: false,
                hp_change_type: Game::States::CHANGE_TYPE_LOSE,
                sp_change_type: Game::States::CHANGE_TYPE_LOSE,
-               avoid_attacks: false, reflect_magic: false, cursed: false)
+               avoid_attacks: false, reflect_magic: false, cursed: false,
+               type: 0)
   FakeStateDef.new(restriction, hp_val, hp_max, sp_val, sp_max, hold_turn,
                    auto_release, release_by_attack, reduce_hit_ratio,
                    restrict_skill, restrict_skill_level,
@@ -3155,7 +3163,7 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                    affect_type, affect_attack, affect_defense,
                    affect_spirit, affect_agility,
                    hp_change_type, sp_change_type, avoid_attacks, reflect_magic,
-                   cursed)
+                   cursed, type)
 end
 # An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
@@ -11028,7 +11036,11 @@ check 'a battle item cures the target status; states carry out via apply_to_part
   ally.add_state(3); ally.add_state(9)         # afflicted entering the fight
   c = Game::Battle.from_actor(ally)
   eq true, c.state?(3)                          # the status walked into battle
-  bat = Game::Battle.new([c], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  # State 9 flagged `type: 1` (persists on the map) so it's still there to
+  # assert on after #apply_to_party -- state 3 doesn't need a row since it's
+  # cured mid-battle, well before write-back ever looks at it.
+  states = { 9 => fake_state(type: 1) }
+  bat = Game::Battle.new([c], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1), states)
   bat.command_item(c, c, item_id: 5, name: 'Antidote',
                    **st.party.battle_item_command(st.party.db_item(5), c))
   bat.run_round
@@ -11046,12 +11058,46 @@ check 'battle carries an actor status through unchanged when nothing cures it' d
   hc = Game::Battle.from_actor(hero)
   eq true, hc.state?(5)
   hc.hp = 40                                    # took some damage on the way
-  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  states = { 5 => fake_state(type: 1) }         # flagged to persist on the map
+  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1), states)
   bat.apply_to_party
   eq 40, hero.hp
   eq true, hero.state?(5)                       # the status survived the battle
 end
 
+check 'Battle#apply_to_party drops a battle-only state (type 0, the default)' do
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hc = Game::Battle.from_actor(hero)
+  hc.states = [3] # inflicted mid-fight, never on the actor before this
+  states = { 3 => fake_state(type: 0) } # 0 == battle only, the schema default
+  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1), states)
+  bat.apply_to_party
+  eq false, hero.state?(3), 'a battle-only state never carries onto the field party'
+end
+
+check 'Battle#apply_to_party keeps a state explicitly flagged type 1 (persists)' do
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hc = Game::Battle.from_actor(hero)
+  hc.states = [3]
+  states = { 3 => fake_state(type: 1) } # 1 == also persists on the map
+  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1), states)
+  bat.apply_to_party
+  eq true, hero.state?(3), 'a state flagged to persist carries onto the field party'
+end
+
+check 'Battle#apply_to_party drops a state whose row is missing rather than guessing' do
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hc = Game::Battle.from_actor(hero)
+  hc.states = [3, 99] # 99: dangling id, no row in the lookup table at all
+  states = { 3 => fake_state(type: 1) }
+  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1), states)
+  bat.apply_to_party
+  eq true, hero.state?(3)
+  eq false, hero.state?(99), 'the dangling id is dropped silently, not guessed at'
+end
 
 check 'battle poison slips HP each turn (fixed val + percent of max)' do
   states = { 2 => FakeStateDef.new(0, 5, 10, 0, 0) } # 5 + 10% of max HP / turn


### PR DESCRIPTION
## Summary

- `Game::Battle#apply_to_party` (`mruby-rpg2k/mrblib/game.rb`) wrote every combatant's `states` back onto its persistent `Game::Actor` unconditionally at battle end, so a state the database flagged **battle only** (the `situation` table's own `type` field, 0 — the default) survived past battle end exactly as much as one flagged **also on map** (`type` 1). The `type` field was already parsed by `schema.rb` but never consulted anywhere in the runtime.
- Verified against EasyRPG Player's real C++ source: `Game_Battler::RemoveBattleStates` (`src/game_battler.cpp`), called from `Game_Battle::Quit()`, removes exactly the states whose `lcf::rpg::State::Persistence` is `Persistence_ends` (0) and leaves `Persistence_persists` (1) alone.
- Added a `Game::Battle::STATE_PERSISTS_ON_MAP` constant and a `#surviving_states` filter applied inside `#apply_to_party`, reusing the existing `#state_def`/`#state_field` lookup pattern already used elsewhere in the same file (e.g. for `:restriction`). A state whose row can't be found is dropped rather than guessed at, matching this file's usual dangling-reference handling.
- Two pre-existing `scripts/rpg2k_logic_check.rb` fixtures assumed a state with no matching row survives `#apply_to_party` unchanged; a real RPG2000 database would flag such a state `type` 0 (battle only) by default, so they were updated to pass an explicit `type: 1` (persists) state definition where the check's actual intent is to verify write-back of an *unrelated, untouched* status.

## Test plan

- [x] Added `scripts/rpg2k_logic_check.rb` checks: a battle-only state (`type` 0, the default) does not survive `#apply_to_party`; a state explicitly flagged `type` 1 (persists) does survive; a state with a dangling/missing id is dropped rather than guessed at. Confirmed the battle-only-state check fails against the pre-fix code.
- [x] `ruby scripts/rpg2k_logic_check.rb` passes (899 checks).
- [x] `ruby scripts/rpg2k_scene_check.rb` passes (617 checks).
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds.
- [x] Added a changelog fragment (`changelog.d/battle-only-state-lifecycle.fixed.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FH4YMsh9wsvMc6wDrjJcDa)_