### PR TITLE
Battle Conditional Branch: implement actor "can use battle command" test

### DIFF
--- a/changelog.d/battle-conditional-branch-actor-can-act.fixed.md
+++ b/changelog.d/battle-conditional-branch-actor-can-act.fixed.md
@@ -1,0 +1,21 @@
+- **The battle-page Conditional Branch's "actor can use a battle command"
+  sub-test (opcode 13310, `param0 == 2`, `param2 == 3`) is now implemented**,
+  instead of always reporting false. Verified against EasyRPG Player's real
+  source (`src/game_interpreter_battle.cpp`'s actor case,
+  `result = actor->CanAct();`, and `Game_Battler::CanAct` in
+  `src/game_battler.cpp`): the ally can use a battle command unless it
+  currently carries a "do nothing" restriction (asleep/paralysed-type
+  states). Deliberately narrower than `Game::Battle#command_restricted?`
+  (`mruby-rpg2k/mrblib/game.rb`), which also flags a Berserk (`attack_enemy`)
+  or Confusion (`attack_ally`) restriction — those answer "does this ally get
+  a normal command menu," a different question, and a battler under only one
+  of them still "can act" by RPG_RT's own `CanAct` definition, just on a
+  forced target. `Game::Battle#do_nothing_restricted?`, which already backed
+  half of `#command_restricted?`, is now exposed publicly for
+  `Game::Interpreter#battle_actor_condition` to call. The sibling "named"
+  sub-test (`param2 == 1`) stays unimplemented (false): EasyRPG's real actor
+  case never sub-dispatches on a second parameter at all, so there is no
+  known "named" behaviour to match. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks, including one that fails against a
+  naive `command_restricted?`-based implementation to pin the Berserk/
+  Confusion distinction.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8876,6 +8876,11 @@ module Game
     def do_nothing_restricted?(b)
       (b.states || []).any? { |id| state_field(state_def(id), :restriction) == RESTRICTION_DO_NOTHING }
     end
+    # Called from Game::Interpreter#battle_actor_condition (the battle-page
+    # Conditional Branch's "can use battle command" actor test, EasyRPG's
+    # `Game_Battler::CanAct`) -- exposed the same way #choose_auto_battle_command
+    # is, well outside this otherwise-private section.
+    public :do_nothing_restricted?
 
     # The state definition for `id` from the lookup, or nil (no lookup / unknown).
     def state_def(id); @states ? @states[id] : nil; end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2448,7 +2448,9 @@ module Game
     #   4 the currently-targeted troop member is param1
     #   5 actor param1's chosen command is param2
     # Tests 4 and 5 read live battle-UI state the runtime does not model; they
-    # report false rather than guessing, so the else branch runs.
+    # report false rather than guessing, so the else branch runs. Actor
+    # sub-test 3 ("can use battle command") is implemented; sub-test 1
+    # ("named") is not -- see #battle_actor_condition for why.
     def do_conditional_battle(cmd)
       return if eval_battle_condition(cmd)
       skip_to([Cmd::ELSE_BRANCH_B, Cmd::END_BRANCH_B], cmd.indent)
@@ -2469,15 +2471,31 @@ module Game
       end
     end
 
-    # An actor sub-condition: is the actor in this fight, and is it afflicted by
-    # the given status? The name / usable-command tests need data the battle
-    # context does not carry, so they report false.
+    # An actor sub-condition: is the actor in this fight, is it afflicted by
+    # the given status, and can it currently be handed a battle command?
+    #
+    # Sub-test 3 mirrors EasyRPG's `Game_Battler::CanAct` (via
+    # `Game_Interpreter_Battle::CommandConditionalBranchBattle`'s actor case):
+    # true unless the ally carries a "do nothing" restriction (asleep /
+    # paralysed). A Berserk (attack_enemy) or Confusion (attack_ally)
+    # restriction does NOT fail this test -- such an ally still "can act", it
+    # just acts on a forced target instead of the chosen command, which is why
+    # this calls Game::Battle's do_nothing-only check rather than its broader
+    # #command_restricted? (which also flags Berserk/Confusion because it
+    # answers a different question: "does this ally get a normal command
+    # menu").
+    #
+    # Sub-test 1 ("named") has no real counterpart to implement: EasyRPG's
+    # actual actor case never sub-dispatches on a second parameter at all --
+    # it unconditionally resolves to CanAct() using only the actor id. There
+    # is no known "named" behavior to match, so it reports false.
     def battle_actor_condition(cmd)
       ally = @battle && @battle.ally_by_actor_id(cmd.param(1))
       return false unless ally
       case cmd.param(2)
-      when 0 then true                       # is in the party
-      when 2 then ally.state?(cmd.param(3))  # is afflicted by a status
+      when 0 then true                                  # is in the party
+      when 2 then ally.state?(cmd.param(3))              # is afflicted by a status
+      when 3 then !@battle.do_nothing_restricted?(ally)  # can use a battle command
       else false
       end
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13283,6 +13283,60 @@ check 'the battle Conditional Branch tests switches, variables and battlers' do
   eq 2, st.variables[1], 'an actor not in the fight fails'
 end
 
+# デフォ戦bot trivia, verified against EasyRPG's real
+# Game_Interpreter_Battle::CommandConditionalBranchBattle / Game_Battler::CanAct
+# (src/game_interpreter_battle.cpp, src/game_battler.cpp): actor sub-test 3
+# ("can use battle command") is true unless the ally carries a "do nothing"
+# restriction (asleep/paralysed) -- it does NOT fail for a Berserk
+# (attack_enemy) or Confusion (attack_ally) restriction, since such an ally
+# still "can act," it just acts on a forced target. That is a strictly
+# narrower check than Game::Battle#command_restricted? (which flags
+# Berserk/Confusion too, since it answers "does this ally get a normal
+# command menu" -- a different question); a naive implementation built on
+# #command_restricted? instead of the do_nothing-only check would wrongly
+# report the berserked/confused ally below as unable to use a battle command.
+check 'battle Conditional Branch actor sub-test 3 (can use battle command) matches CanAct, not command_restricted?' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0),  # do-nothing (asleep/paralysed)
+             7 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0),  # attack-enemy (berserk)
+             6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0) } # attack-ally (confusion)
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.actor = FakeSourceActor.new(1)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  branch = lambda do |params|
+    [FakeCmd.new(IC::CONDITIONAL_B, params, indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+     FakeCmd.new(IC::ELSE_BRANCH_B, [], indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+     FakeCmd.new(IC::END_BRANCH_B, [], indent: 0)]
+  end
+
+  it.start(branch.call([2, 1, 3]))
+  it.update
+  eq 1, st.variables[1], 'an unrestricted ally can use a battle command'
+
+  hero.states = [8]
+  it.start(branch.call([2, 1, 3]))
+  it.update
+  eq 2, st.variables[1], 'a do-nothing restricted (asleep/paralysed) ally cannot'
+
+  hero.states = [7]
+  ok b.command_restricted?(hero), 'sanity: command_restricted? flags the berserked ally...'
+  it.start(branch.call([2, 1, 3]))
+  it.update
+  eq 1, st.variables[1],
+     '...but the berserked ally still "can act" (CanAct), so sub-test 3 stays true'
+
+  hero.states = [6]
+  ok b.command_restricted?(hero), 'sanity: command_restricted? flags the confused ally too...'
+  it.start(branch.call([2, 1, 3]))
+  it.update
+  eq 1, st.variables[1], '...yet a confused ally likewise still "can act"'
+end
+
 check 'troop-member numbering stays stable when a middle member dies or is hidden' do
   # docs/TODO.md's render-order fix left this "still open": does killing or
   # hiding troop member 1 (the middle of three) shift member 2 down into


### PR DESCRIPTION
## Summary

- The battle-page Conditional Branch's actor sub-test 3 ("can use battle command", opcode 13310, `param0 == 2`, `param2 == 3`) always fell through to `false`. It is now implemented against EasyRPG Player's real behaviour: true unless the ally currently carries a "do nothing" restriction (asleep/paralysed-type states) — `src/game_interpreter_battle.cpp`'s actor case resolves to `actor->CanAct()`, and `Game_Battler::CanAct` (`src/game_battler.cpp`) scans only for `Restriction_do_nothing`.
- This is deliberately **not** `Game::Battle#command_restricted?`, which also flags Berserk (`attack_enemy`) / Confusion (`attack_ally`). Those restrictions answer a different question ("does this ally get a normal command menu") — a berserked or confused ally still "can act" by `CanAct`'s definition, it just acts on a forced target. `Game::Battle#do_nothing_restricted?` (already backing half of `#command_restricted?`) is now exposed publicly, the same way `#choose_auto_battle_command` already is, so the interpreter can call it directly.
- Sub-test 1 ("named") is **not** implemented. I cloned and read EasyRPG Player's actual `Game_Interpreter_Battle::CommandConditionalBranchBattle` to verify it before guessing, and its real actor case never sub-dispatches on a second parameter at all — `param0 == 2` resolves unconditionally to `CanAct()` using only the actor id. There's no known "named" behavior to match, so it stays `false` with a comment explaining why, matching this codebase's existing honest-about-gaps convention (rather than fabricating semantics for a test that doesn't appear to exist in the real engine).

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: an unrestricted ally reads as able to use a battle command; an asleep/paralysed ally reads as unable to; a berserk-only or confusion-only ally still reads as **able** to (the specific distinction from `command_restricted?`). Confirmed the new check fails against the pre-fix code, and also fails against a naive `command_restricted?`-based implementation, before finalizing.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 897 checks pass.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 617 checks pass.
- [x] `scripts/native-build-without-nix.bash` (full native build + render probe) succeeds; `ninja rpg_maker_clone` afterward reports up to date.
- [x] Changelog fragment added (`changelog.d/battle-conditional-branch-actor-can-act.fixed.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YPNevKhsgCkWqK4uxftp9

---
_Generated by [Claude Code](https://claude.ai/code/session_015YPNevKhsgCkWqK4uxftp9)_