### PR TITLE
Include a two-handed weapon's forced-unequip in the Equip menu preview

### DIFF
--- a/changelog.d/rpg2k-equip-menu-two-handed-preview.fixed.md
+++ b/changelog.d/rpg2k-equip-menu-two-handed-preview.fixed.md
@@ -1,0 +1,9 @@
+- **The Equip menu's candidate stat-comparison arrow now accounts for a
+  two-handed weapon's forced-unequip side effect on the other hand, instead
+  of only diffing the two items landing in the browsed slot.** Confirmed
+  against EasyRPG Player's source: equipping (or already wielding) a
+  two-handed weapon forces the paired weapon/shield slot empty, and the
+  stat preview must include that slot's own loss. The preview previously
+  computed a different formula than what actually happens when the item is
+  equipped, sometimes showing an Up arrow for a swap that is a net stat
+  loss once the forced-off item is accounted for.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6015,6 +6015,40 @@ not yet verified:
   the RPG2003 `compare_operator` read for both `==`/`>` against RPG2000's
   unconditional `>=` — the first two confirmed to fail against the pre-fix
   code before the fix.
+- ✅ **The Equip menu's candidate stat-comparison arrow now accounts for a
+  両手持ち (two-handed) weapon's forced-unequip side effect on the other
+  hand, instead of only diffing the two items landing in the browsed slot.**
+  Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
+  UpdateStatusWindow` (`src/scene_equip.cpp`) builds the projected full stat
+  totals, then subtracts the *other* hand's own item too whenever either it
+  or the candidate is 両手持ち (`other_old_item->two_handed ||
+  current_item->two_handed`) — since equipping either one forces the
+  opposite slot empty, exactly the side effect `Actor#equip_item`/
+  `#free_two_handed_slot` (fixed earlier this session) already applies when
+  the swap actually happens. `Scene::EquipMenu#build_cand_window`
+  (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) instead diffed only
+  `item_stat_sum(candidate) - item_stat_sum(currently_worn)` for the one
+  slot being browsed, with no reference to the other hand at all — the
+  preview and the actual equip application had quietly diverged into two
+  different formulas. Concretely: weapon slot holds a Sword (Atk +20),
+  shield slot a Shield (Def +25); browsing the weapon slot's candidates with
+  a Claymore (Atk +40, 両手持ち) highlighted, the *true* net change is +40
+  Atk − 20 Atk − 25 Def = **−5** (the shield gets knocked off), which should
+  draw the Down arrow — the old preview computed a naive 40 − 20 = **+20**
+  and drew Up, the directionally wrong verdict, not merely an imprecise
+  number. Fixed with a new `#equip_delta(id)` (subsuming the old inline
+  `item_stat_sum(id) - equipped_sum` at the one call site) that also
+  subtracts the other hand's `item_stat_sum` whenever `Actor#two_handed?`
+  says either side is 両手持ち, gated on `id != 0` since EasyRPG's own
+  `current_item &&` guard means Remove never triggers the side effect
+  (dropping this slot's item never forces anything off the *other* hand).
+  Only the weapon/shield pair can ever trigger it (`#other_hand_item` mirrors
+  `#free_two_handed_slot`'s own slot gate); armor/helmet/accessory previews
+  are unaffected. Covered by three new `scripts/rpg2k_scene_check.rb`
+  checks — the weapon-slot Claymore trace above (Up → Down once the side
+  effect is included), the symmetric shield-slot case, and Remove's own
+  no-side-effect exemption — the first two confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -299,6 +299,37 @@ class RPG2k
         '-'
       end
 
+      # The other hand's own current item id when browsing the weapon (0) or
+      # shield (1) slot -- the only two slots a 両手持ち weapon can force off
+      # -- or nil for any other slot. Mirrors `Actor#free_two_handed_slot`'s
+      # own `slot == WEAPON_SLOT || slot == SHIELD_SLOT` gate.
+      def other_hand_item
+        case @slot_index
+        when Game::Actor::WEAPON_SLOT then actor.equipment[Game::Actor::SHIELD_SLOT]
+        when Game::Actor::SHIELD_SLOT then actor.equipment[Game::Actor::WEAPON_SLOT]
+        end
+      end
+
+      # The candidate's real net stat-point delta against what is equipped
+      # now -- not just the two items landing in *this* slot. Confirmed
+      # against EasyRPG's actual C++ source: `Scene_Equip::
+      # UpdateStatusWindow` (`src/scene_equip.cpp`) also subtracts the
+      # *other* hand's item when either it or the candidate is a 両手持ち
+      # weapon (`Actor#two_handed?`), since equipping either one forces the
+      # opposite slot empty -- the exact side effect `Actor#equip_item` /
+      # `#free_two_handed_slot` already applies for real, which this preview
+      # ignored (id 0, "Remove", never triggers it either way, matching
+      # EasyRPG's own `current_item &&` guard -- removing an item never
+      # forces anything off the other hand).
+      def equip_delta(id)
+        delta = item_stat_sum(id) - item_stat_sum(actor.equipment[@slot_index])
+        other = other_hand_item
+        if id != 0 && other && (actor.two_handed?(other) || actor.two_handed?(id))
+          delta -= item_stat_sum(other)
+        end
+        delta
+      end
+
       def build_cand_window
         @cand_window.dispose if @cand_window
         rows = candidates
@@ -310,14 +341,13 @@ class RPG2k
         @cand_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
-        equipped_sum = item_stat_sum(actor.equipment[@slot_index])
         rows.each_with_index do |(id, count), i|
           if id == 0
             c.draw_text 0, i * LINE_H, inner_w, LINE_H, "(Remove)"
           else
             c.draw_text 0, i * LINE_H, inner_w - 80, LINE_H, item_name(id)
             c.draw_text inner_w - 80, i * LINE_H, 40, LINE_H,
-                        equip_compare_arrow(item_stat_sum(id) - equipped_sum)
+                        equip_compare_arrow(equip_delta(id))
             c.draw_text inner_w - 40, i * LINE_H, 40, LINE_H, ":#{count}"
           end
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12309,6 +12309,10 @@ class MenuStubActor
   def equipment_fixed?; !!@equipment_fixed_flag; end
   attr_accessor :cursed_slot
   def slot_cursed?(slot); @cursed_slot == slot; end
+  # No item in this bare fixture is ever 両手持ち (two-handed) -- a check
+  # exercising that needs its own richer stub, same as the item/skill tables
+  # below.
+  def two_handed?(_item_id); false; end
 end
 
 class MenuStubParty
@@ -14003,6 +14007,82 @@ check 'Scene::EquipMenu: the candidate arrow sums all four stat deltas against t
   eq '^', texts[2], 'a candidate with strictly more combined points draws Up'
   eq 'v', texts[5], 'one with strictly fewer draws Down'
   eq '-', texts[8], 'an exact match draws Same, not counted per-stat'
+end
+
+# An actor whose weapon-slot Claymore (id 2) is 両手持ち; MenuStubActor's own
+# stub always answers false, so a check exercising the forced-unequip side
+# effect needs this richer one instead.
+class TwoHandedActor < MenuStubActor
+  TWO_HANDED_IDS = [2].freeze
+  def two_handed?(item_id); TWO_HANDED_IDS.include?(item_id); end
+end
+
+class TwoHandedEquipParty < MenuStubParty
+  ITEMS = {
+    1 => OpenStruct.new(name: 'Sword', atk_points1: 20),    # worn, weapon slot
+    2 => OpenStruct.new(name: 'Claymore', atk_points1: 40), # 両手持ち candidate
+    5 => OpenStruct.new(name: 'Shield', def_points1: 25)    # worn, shield slot
+  }.freeze
+  def initialize
+    super
+    @actors = [TwoHandedActor.new]
+  end
+  def db_item(id); ITEMS[id]; end
+  def equip_candidates(_slot, _actor = nil); [[2, 1]]; end
+end
+
+check 'Scene::EquipMenu: a 両手持ち candidate also drops the other hand\'s ' \
+      'stat bonus from the preview, matching what actually equipping it does' do
+  # Confirmed against EasyRPG's actual C++ source: Scene_Equip::
+  # UpdateStatusWindow (src/scene_equip.cpp) also subtracts the *other*
+  # hand's item when either it or the candidate is 両手持ち, since equipping
+  # either one forces the opposite slot empty -- the exact side effect
+  # Actor#equip_item / #free_two_handed_slot already applies for real. A
+  # preview that only diffs the two items landing in the browsed slot would
+  # show the Claymore's own +20 Atk (40 - 20) and draw Up, even though the
+  # true net (+20 Atk, -25 Def from the forced-off Shield) is -5.
+  state = Game::State.new(TwoHandedEquipParty.new, 1, 0, 0)
+  actor = state.party.actors.first
+  actor.equipment[0] = 1 # weapon slot: Sword, atk 20
+  actor.equipment[1] = 5 # shield slot: Shield, def 25
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  scene.instance_variable_set(:@mode, :items)
+  scene.send(:build_cand_window)
+  texts = window_texts(scene.instance_variable_get(:@cand_window))
+  # Row 0 is "(Remove)"; the one candidate (Claymore) follows it, arrow at 2.
+  eq 'v', texts[2],
+     'net -5 (claymore +40 atk, sword -20 atk, forced-off shield -25 def), ' \
+     'not a naive +20 that ignores the shield the claymore forces off'
+end
+
+check "Scene::EquipMenu: browsing the shield slot with a 両手持ち weapon " \
+      'already worn shows the same forced-unequip side effect' do
+  # Symmetric case: any candidate landing in the shield slot forces the
+  # weapon slot's own 両手持ち weapon off, even an ordinary (non-two-handed)
+  # shield candidate -- EasyRPG's guard is `other_old_item->two_handed ||
+  # current_item->two_handed`, either side qualifies.
+  state = Game::State.new(TwoHandedEquipParty.new, 1, 0, 0)
+  actor = state.party.actors.first
+  actor.equipment[0] = 2 # weapon slot: Claymore (two-handed), atk 40
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  scene.instance_variable_set(:@slot_index, Game::Actor::SHIELD_SLOT)
+  scene.instance_variable_set(:@mode, :items)
+  # An ordinary (non-two-handed) shield candidate landing in the shield slot.
+  eq(-15, scene.send(:equip_delta, 5),
+     'the shield itself (+25 def) against nothing (empty slot), minus the ' \
+     "forced-off claymore's own -40 atk: 25 - 0 - 40 = -15")
+end
+
+check "Scene::EquipMenu: Remove never triggers the 両手持ち forced-unequip " \
+      'side effect' do
+  # EasyRPG's own guard is `current_item && ...` -- id 0 (Remove) has no
+  # candidate item at all, so the other hand is never touched by removing
+  # this slot's own item.
+  state = Game::State.new(TwoHandedEquipParty.new, 1, 0, 0)
+  actor = state.party.actors.first
+  actor.equipment[0] = 2 # weapon slot: Claymore (two-handed), atk 40
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  eq(-40, scene.send(:equip_delta, 0), 'just the claymore\'s own -40 atk, no extra subtraction')
 end
 
 # A party whose weapon slot equips a dangling item id (a database shrink


### PR DESCRIPTION
## Summary
- The Equip menu's candidate stat-comparison arrow now accounts for a 両手持ち (two-handed) weapon's forced-unequip side effect on the other hand, instead of only diffing the two items landing in the browsed slot.
- Confirmed against EasyRPG's actual C++ source: `Scene_Equip::UpdateStatusWindow` (`src/scene_equip.cpp`) builds the projected full stat totals, then subtracts the *other* hand's own item too whenever either it or the candidate is 両手持ち (`other_old_item->two_handed || current_item->two_handed`) — since equipping either one forces the opposite slot empty, exactly the side effect `Actor#equip_item`/`#free_two_handed_slot` (fixed earlier this session) already applies when the swap actually happens.
- `Scene::EquipMenu#build_cand_window` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) instead diffed only `item_stat_sum(candidate) - item_stat_sum(currently_worn)` for the one slot being browsed, with no reference to the other hand at all — the preview and the actual equip application had quietly diverged into two different formulas.
- Concretely: weapon slot holds a Sword (Atk +20), shield slot a Shield (Def +25); browsing the weapon slot's candidates with a Claymore (Atk +40, 両手持ち) highlighted, the *true* net change is +40 Atk − 20 Atk − 25 Def = **−5** (the shield gets knocked off), which should draw the Down arrow — the old preview computed a naive 40 − 20 = **+20** and drew Up, the directionally wrong verdict, not merely an imprecise number.
- Fixed with a new `#equip_delta(id)` (subsuming the old inline diff at the one call site) that also subtracts the other hand's `item_stat_sum` whenever `Actor#two_handed?` says either side is 両手持ち, gated on `id != 0` since EasyRPG's own `current_item &&` guard means Remove never triggers the side effect. Only the weapon/shield pair can ever trigger it (`#other_hand_item` mirrors `#free_two_handed_slot`'s own slot gate); armor/helmet/accessory previews are unaffected.

## Test plan
- [x] Three new `scripts/rpg2k_scene_check.rb` checks — the weapon-slot Claymore trace above (Up → Down once the side effect is included), the symmetric shield-slot case, and Remove's own no-side-effect exemption — the first two confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_scene_check.rb` — 620 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 896 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_