### PR TITLE
fix(rpg2k): let F9 debug menu open during battle in Test Play

### DIFF
--- a/changelog.d/f9-debug-menu-during-battle.fixed.md
+++ b/changelog.d/f9-debug-menu-during-battle.fixed.md
@@ -1,0 +1,10 @@
+- **The F9 debug menu now opens during battle in Test Play.** RPG_RT's
+  switch/variable editor was reachable from the field map only —
+  `Scene::Map#try_open_debug_menu` was called solely from the main loop's
+  non-busy branch, and `#event_busy?` is unconditionally true for as long as
+  `@battle_ui` is set, so F9 silently did nothing for the entire duration of
+  any fight. Per community RPG_RT trivia ("これは戦闘中でも行える" — this
+  also works during battle), a battle no longer blocks it: `#drive_battle`
+  now also polls for F9 each frame. Every other busy condition (a message
+  window, an interpreter mid-wait) still gates the ordinary field-map case
+  exactly as before.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3627,9 +3627,16 @@ class RPG2k
       # the field map only (not while an event holds the interpreter) and only
       # during Test Play -- a released game (RPG2k#test_play false) never sees
       # F9 open anything, same as every other test-play-gated tool (see
-      # changelog.d/test-play-gated-debug-tooling.added.md).
+      # changelog.d/test-play-gated-debug-tooling.added.md). A battle does NOT
+      # block it, per community RPG_RT trivia (@2000_battle_bot /
+      # デフォ戦bot): "テストプレイ中にＦ９キーを押せば スイッチ・変数の値を
+      # 好きに変えられる。これは戦闘中でも行える。" -- so `@battle_ui` alone is
+      # excluded from the busy check here (see #drive_battle's own call),
+      # while every other #event_busy? condition (a message window, an
+      # interpreter mid-wait) still gates the ordinary field-map case exactly
+      # as before.
       def try_open_debug_menu
-        return if event_busy?
+        return if event_busy? && @battle_ui.nil?
         return unless @parent.test_play
         return unless Input.trigger?(Input::F9)
         @parent.push Scene::DebugMenu.new(@parent, @state)
@@ -4444,6 +4451,11 @@ class RPG2k
         when :result      then drive_battle_result
         when :event       then drive_battle_event
         end
+        # F9 opens the debug menu mid-fight too (see #try_open_debug_menu) --
+        # the ordinary field-map call site only ever runs once #event_busy? is
+        # fully clear, which a battle never is, so this is the one place that
+        # reaches the check while @battle_ui is up.
+        try_open_debug_menu
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle failed: #{e.message}"
         owner = (@battle_ui && @battle_ui[:owner]) || it

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15194,6 +15194,49 @@ check 'F9 does nothing outside Test Play' do
   ok scene.parent.pushed.empty?, 'a released game never sees F9 open anything'
 end
 
+# yado.tk / community RPG_RT trivia (@2000_battle_bot / デフォ戦bot):
+# "テストプレイ中にＦ９キーを押せば スイッチ・変数の値を好きに変えられる。
+# これは戦闘中でも行える。" -- F9 during Test Play works during battle too,
+# unlike every other #event_busy? condition (see #try_open_debug_menu).
+check 'F9 opens the debug menu during Test Play even with a battle open' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) }, test_play: true)
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  10.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+  end
+  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+
+  RGSS::Input.triggered = [RGSS::Input::F9]
+  scene.update
+  pushed = scene.parent.pushed
+  eq 1, pushed.size, 'F9 pushed exactly one scene, mid-battle'
+  ok pushed.first.is_a?(RPG2k::Scene::DebugMenu), 'the pushed scene is the debug menu'
+  ok scene.instance_variable_get(:@battle_ui), 'the battle stays open behind the debug menu'
+end
+
+check 'F9 does nothing during a battle outside Test Play' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) }) # test_play defaults false
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  10.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+  end
+  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+
+  RGSS::Input.triggered = [RGSS::Input::F9]
+  scene.update
+  ok scene.parent.pushed.empty?, 'a released game never sees F9 open anything, mid-battle either'
+end
+
 check 'the debug menu toggles a switch on C and flips to Variable on Left/Right' do
   st = menu_state
   st.switches[1] = false


### PR DESCRIPTION
## Summary

- `Scene::Map#try_open_debug_menu` (the F9 switch/variable editor, gated on Test Play) was only ever called from the main update loop's non-busy branch, and `#event_busy?` is unconditionally true for the entire duration of any battle (`@battle_ui` set) — so F9 silently did nothing during any fight.
- Per community RPG_RT trivia (`@2000_battle_bot` / デフォ戦bot): "テストプレイ中にＦ９キーを押せば スイッチ・変数の値を好きに変えられる。これは戦闘中でも行える。" — battle specifically does not block F9 in real RPG_RT.
- `#drive_battle` (the single per-frame battle-update entry point, shared by both a foreground- and a Parallel-Process-owned battle) now also polls for F9 each frame, and `try_open_debug_menu`'s own busy guard excludes `@battle_ui` from the check. Every other `#event_busy?` condition (a message window, an interpreter mid-wait) still gates the ordinary field-map case exactly as before — only the battle-open condition specifically confirmed by the trivia is bypassed.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` passes (903 checks)
- [x] `ruby scripts/rpg2k_scene_check.rb` passes (622 checks), including two new checks mirroring the existing F9 checks' shape: F9 opens `Scene::DebugMenu` mid-battle with Test Play on, and does nothing mid-battle with Test Play off
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYWtnVmHjBqaLLt19aNCrw)_