### PR TITLE
Fix RPG2003 Flash Screen Begin/End continuous strobe mode

### DIFF
--- a/changelog.d/rpg2k-flash-screen-continuous-mode.fixed.md
+++ b/changelog.d/rpg2k-flash-screen-continuous-mode.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003's Flash Screen command now supports its Begin/End continuous-strobe
+  mode**, instead of always running the RPG2000 one-shot fade. Confirmed
+  against EasyRPG Player's source: a 7th command parameter, present only on
+  RPG2003 command lists, dispatches between a one-shot flash, an indefinitely
+  repeating strobe that re-arms to peak strength every time it would settle,
+  and an explicit stop. This build never read that parameter, so every
+  Begin/End flash silently ran as a single fade-and-stop.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6049,6 +6049,40 @@ not yet verified:
   effect is included), the symmetric shield-slot case, and Remove's own
   no-side-effect exemption — the first two confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **RPG2003's Flash Screen command (11040) now supports its Begin/End
+  continuous-strobe mode, instead of always running the RPG2000 one-shot
+  fade.** Confirmed against EasyRPG's actual C++ source: `CommandFlashScreen`
+  (`src/game_interpreter.cpp`) reads a 7th parameter — present only on an
+  RPG2003 command list of more than 6 parameters
+  (`com.parameters.size() <= 6 || !Player::IsRPG2k3Commands()` always falls
+  back to mode 0) — and dispatches on it: `0` → `Game_Screen::FlashOnce`
+  (the existing one-shot fade this build already had), `1` →
+  `Game_Screen::FlashBegin` (arms an indefinitely repeating strobe), `2` →
+  `Game_Screen::FlashEnd` (stops one immediately). `Flash::Update`
+  (`src/flash.h`) re-arms a Begin strobe at its peak strength the instant it
+  would otherwise settle to zero, over and over, until an explicit End —
+  this build's `Interpreter#do_flash_screen`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) never read `cmd.param(6)` at all, so
+  every RPG2003 Begin/End flash silently ran as a single fade-and-stop, and
+  no amount of waiting brought the strobe back. Only mode 0 ever waits —
+  EasyRPG's own `CommandFlashScreen` never calls `SetupWait` for modes 1/2,
+  matching how a Begin strobe never actually "finishes" for the interpreter
+  to resume on. Fixed by giving `Game::Screen` (`mruby-rpg2k/mrblib/game.rb`)
+  a `@flash_continuous` flag: `#flash_begin` is `#flash` plus setting it,
+  `#flash_end` zeroes the flash and clears it, and `#update_flash` re-arms to
+  `@flash_power`/`@flash_total` the instant `@flash_frames` would settle at
+  zero while the flag holds — the existing one-shot decay curve is untouched
+  otherwise. `#do_flash_screen` now dispatches on `cmd.param(6)`, gated on
+  `@state.party.rpg2003? && cmd.parameters.size > 6` to match EasyRPG's
+  fallback exactly. Covered by four new checks — a `Game::Screen`-level test
+  (`scripts/rpg2k_logic_check.rb`) proving a Begin strobe decays to zero then
+  re-arms to peak and repeats until `#flash_end` stops it, an
+  interpreter-level Begin test proving the command itself never pauses and
+  the re-arm happens after one real period, an interpreter-level End test
+  proving it stops an in-flight strobe immediately, and a fallback test
+  proving a non-RPG2003 party ignores a stray 7th parameter and always
+  settles — the `Game::Screen` test and the two interpreter dispatch tests
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6413,6 +6413,7 @@ module Game
       @flash_strength = 0 # current strength, fading to 0 over the duration
       @flash_frames = 0 # frames left in the current flash (0 = faded out)
       @flash_total = 0
+      @flash_continuous = false # RPG2003 Begin/End strobe: re-arms at 0 instead of settling
       @pan_x = 0        # current pan offset in pixels (added to the camera)
       @pan_y = 0
       @pan_tx = 0       # target pan offset the current pan/reset scrolls toward
@@ -6544,8 +6545,12 @@ module Game
     end
 
     # Begin a flash of colour (r, g, b) at peak strength `power`, fading linearly
-    # to 0 over `frames` frames (frames <= 0 clears any flash immediately).
+    # to 0 over `frames` frames (frames <= 0 clears any flash immediately). A
+    # one-shot flash (RPG2003's Flash Screen mode 0, or the pre-2003 command
+    # shape) — matches EasyRPG's `Game_Screen::FlashOnce`, which always clears
+    # any in-progress strobe.
     def flash(r, g, b, power, frames)
+      @flash_continuous = false
       @flash_r = r
       @flash_g = g
       @flash_b = b
@@ -6558,6 +6563,22 @@ module Game
         @flash_frames = frames
         @flash_strength = power
       end
+    end
+
+    # RPG2003 Flash Screen mode 1: like #flash, but the strobe re-arms to peak
+    # strength every time it fades out, indefinitely, until #flash_end (or a
+    # fresh one-shot #flash) stops it — matches `Game_Screen::FlashBegin`.
+    def flash_begin(r, g, b, power, frames)
+      flash(r, g, b, power, frames)
+      @flash_continuous = true
+    end
+
+    # RPG2003 Flash Screen mode 2: stop a #flash_begin strobe immediately,
+    # settled at no flash — matches `Game_Screen::FlashEnd`.
+    def flash_end
+      @flash_continuous = false
+      @flash_frames = 0
+      @flash_strength = 0
     end
 
     # Erase Screen: take the screen to black in the given Game::Transition style,
@@ -6699,8 +6720,15 @@ module Game
     def update_flash
       return if @flash_frames <= 0
       @flash_frames -= 1
-      # Strength fades linearly from the peak power to 0 across the duration.
-      @flash_strength = @flash_total > 0 ? @flash_power * @flash_frames / @flash_total : 0
+      if @flash_frames <= 0 && @flash_continuous
+        # A Begin strobe never settles: re-arm at peak strength for another
+        # full duration, matching `Flash::Update`'s own continuous re-arm.
+        @flash_frames = @flash_total
+        @flash_strength = @flash_power
+      else
+        # Strength fades linearly from the peak power to 0 across the duration.
+        @flash_strength = @flash_total > 0 ? @flash_power * @flash_frames / @flash_total : 0
+      end
     end
 
     # Step the pan offset toward its target, landing exactly on the last frame.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2965,13 +2965,29 @@ module Game
     # peak strength param3, fading out over param4 tenths of a second. When param5
     # (the wait flag) is set, pause until it fades — the owning scene advances
     # Game::Screen each frame and resumes us once no screen effect is animating.
+    # RPG2003 extends the command with a param6 mode byte (0 one-shot / 1 begin a
+    # repeating strobe / 2 end one), matching EasyRPG's `CommandFlashScreen`
+    # (src/game_interpreter.cpp): a command list carrying no 7th parameter (an
+    # RPG2000 project, or an RPG2003 one never given the extended layout) always
+    # falls back to a plain one-shot flash, mode 0. Only mode 0 ever waits — Begin
+    # and End never suspend the interpreter, since the strobe runs indefinitely.
     def do_flash_screen(cmd)
-      frames = cmd.param(4) * FRAMES_PER_TENTH
-      @state.screen.flash(cmd.param(0), cmd.param(1), cmd.param(2),
-                          cmd.param(3), frames)
-      return unless cmd.param(5) != 0 && @state.screen.flashing?
-      @wait_kind = :screen
-      @waiting = true
+      mode = @state.party.rpg2003? && cmd.parameters.size > 6 ? cmd.param(6) : 0
+      case mode
+      when 1
+        frames = cmd.param(4) * FRAMES_PER_TENTH
+        @state.screen.flash_begin(cmd.param(0), cmd.param(1), cmd.param(2),
+                                  cmd.param(3), frames)
+      when 2
+        @state.screen.flash_end
+      else
+        frames = cmd.param(4) * FRAMES_PER_TENTH
+        @state.screen.flash(cmd.param(0), cmd.param(1), cmd.param(2),
+                            cmd.param(3), frames)
+        return unless cmd.param(5) != 0 && @state.screen.flashing?
+        @wait_kind = :screen
+        @waiting = true
+      end
     end
 
     # Pan Screen: param0 selects the operation — 0 lock the camera in place, 1

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1034,6 +1034,25 @@ check 'Screen flash with zero duration is inert' do
   eq 0, s.flash_color[3]
 end
 
+check 'Screen flash_begin re-arms to peak strength indefinitely until flash_end' do
+  s = Game::Screen.new
+  s.flash_begin(0, 255, 0, 40, 4) # colour, peak strength 40, over 4 frames
+  ok s.flashing?
+  eq 40, s.flash_color[3], 'peaks at full strength when it starts'
+  s.update; eq 30, s.flash_color[3]
+  s.update; eq 20, s.flash_color[3]
+  s.update; eq 10, s.flash_color[3]
+  s.update
+  eq 40, s.flash_color[3], 're-armed to peak strength instead of settling at 0'
+  ok s.flashing?, 'still flashing after re-arming'
+  s.update; eq 30, s.flash_color[3], 'decaying again from the fresh peak'
+  s.flash_end
+  ok !s.flashing?, 'flash_end stops the strobe immediately'
+  eq 0, s.flash_color[3]
+  s.update # further updates are a no-op once ended
+  eq 0, s.flash_color[3]
+end
+
 check 'Screen busy? reflects tint, shake or flash activity' do
   s = Game::Screen.new
   ok !s.busy?
@@ -2070,6 +2089,54 @@ check 'Flash Screen with a wait pauses until the flash fades out' do
   it.update
   eq true, st.switches[2], 'resumed once the flash faded'
   eq 0, st.screen.flash_color[3]
+end
+
+check 'RPG2003 Flash Screen mode 1 (Begin) strobes indefinitely and never pauses' do
+  st = new_state(rpg2003: true)
+  it = Game::Interpreter.new(st)
+  # red, peak strength 20, 2 tenths (12 frames), wait 0, mode 1 (Begin).
+  it.start([FakeCmd.new(IC::FLASH_SCREEN, [255, 0, 0, 20, 2, 0, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Begin never pauses the interpreter'
+  eq true, st.switches[1], 'the command after Begin still ran'
+  ok st.screen.flashing?
+  eq 20, st.screen.flash_color[3]
+  11.times { st.screen.update }
+  ok st.screen.flash_color[3] < 20, 'decaying before the period ends'
+  st.screen.update # the 12th update: the period lapses
+  eq 20, st.screen.flash_color[3], 're-armed to peak instead of settling at 0'
+  ok st.screen.flashing?, 'still strobing after one full period'
+end
+
+check 'RPG2003 Flash Screen mode 2 (End) stops a Begin strobe immediately' do
+  st = new_state(rpg2003: true)
+  st.screen.flash_begin(255, 0, 0, 20, 12)
+  ok st.screen.flashing?
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::FLASH_SCREEN, [0, 0, 0, 0, 0, 0, 2]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'End never pauses the interpreter'
+  eq true, st.switches[1], 'the command after End still ran'
+  ok !st.screen.flashing?, 'End stops the strobe'
+  eq 0, st.screen.flash_color[3]
+  st.screen.update # further updates are a no-op once ended
+  ok !st.screen.flashing?
+end
+
+check 'A pre-RPG2003 or short-parameter Flash Screen command always falls back to mode 0' do
+  st = new_state(rpg2003: false)
+  it = Game::Interpreter.new(st)
+  # A 7-parameter command list, but not an RPG2003 project: EasyRPG's
+  # `CommandFlashScreen` fallback (`com.parameters.size() <= 6 ||
+  # !Player::IsRPG2k3Commands()`) always wins, so param6's "1" is ignored.
+  it.start([FakeCmd.new(IC::FLASH_SCREEN, [255, 0, 0, 20, 2, 0, 1])])
+  it.update
+  ok st.screen.flashing?
+  12.times { st.screen.update }
+  eq 0, st.screen.flash_color[3], 'settled to zero, not re-armed -- mode 0, not Begin'
+  ok !st.screen.flashing?
 end
 
 check 'Pan Screen lock / unlock are instant and never pause' do


### PR DESCRIPTION
## Summary
- RPG2003's Flash Screen command (11040) carries a 7th parameter (mode: 0 one-shot / 1 Begin / 2 End) that `Interpreter#do_flash_screen` never read, so every RPG2003 Begin/End flash silently ran as a single one-shot fade instead of an indefinitely repeating strobe.
- Confirmed against EasyRPG Player's actual source: `CommandFlashScreen` (`src/game_interpreter.cpp`) dispatches on that 7th parameter — gated on `com.parameters.size() > 6 && Player::IsRPG2k3Commands()`, matching this codebase's own `@state.party.rpg2003? && cmd.parameters.size > 6` convention (mirroring `do_key_input`'s existing edition/param-count gate) — into `Game_Screen::FlashOnce`/`FlashBegin`/`FlashEnd`. `Flash::Update` (`src/flash.h`) re-arms a Begin strobe to peak strength the instant it would otherwise settle to zero, repeating until an explicit End.
- `Game::Screen` (`mruby-rpg2k/mrblib/game.rb`) gains a `@flash_continuous` flag: `#flash_begin` is `#flash` plus setting it, `#flash_end` zeroes the flash and clears it, and `#update_flash` re-arms to peak strength/full duration instead of settling when the flag holds — the existing one-shot decay curve is untouched otherwise. `#do_flash_screen` (`mruby-rpg2k/mrblib/interpreter.rb`) now dispatches on `cmd.param(6)`. Only mode 0 ever waits, matching EasyRPG (`SetupWait` is never called for modes 1/2).

## Test plan
- New `scripts/rpg2k_logic_check.rb` checks: a `Game::Screen`-level test proving a Begin strobe decays to zero then re-arms to peak and repeats until `#flash_end` stops it; an interpreter-level Begin test proving the command never pauses and the re-arm happens after one real period; an interpreter-level End test proving it stops an in-flight strobe immediately; a fallback test proving a non-RPG2003 party ignores a stray 7th parameter.
- The `Game::Screen` test and both interpreter dispatch tests confirmed to fail against the pre-fix code (`NoMethodError`/wrong re-arm value) before the fix, via `git stash`.
- All four CRuby suites pass (907 + 620 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_