### PR TITLE
Wire battle-animation screen_shaking timings into Game::Screen#shake

### DIFF
--- a/changelog.d/battle-animation-screen-shake.added.md
+++ b/changelog.d/battle-animation-screen-shake.added.md
@@ -1,0 +1,22 @@
+- **A Battle Animation's per-frame `screen_shaking` timing now actually
+  shakes**, instead of being decoded and silently dropped. The LCF
+  `animation_timing` schema (`mruby-lcf/mrblib/schema.rb`) decodes database
+  field 8 as `screen_shaking` (0 none / 1 target / 2 screen), but
+  `Scene::Map#fire_animation_flashes` — the loop that already wires up the
+  sibling `flash_scope` field — never read it. Verified against EasyRPG
+  Player's actual C++ source, `BattleAnimation::ProcessAnimationTiming`
+  (`src/battle_animation.cpp`, fetched verbatim): both cases fire a fixed
+  `(power 3, speed 5, frames 32)` triple regardless of the timing's own data.
+  `screen_shaking` 2 reuses this codebase's existing `Game::Screen#shake` —
+  the exact mechanism the Shake Screen event command (11050) already
+  drives — with that same triple. `screen_shaking` 1 shakes just the
+  animation's own target: a new `Scene::Map#fire_target_shake`/
+  `#update_enemy_shakes` ports the same `Shake::NextPosition` sine-wave step
+  `Game::Screen#update_shake` already uses to a single battler sprite's own x,
+  mirroring EasyRPG's `BattleAnimationBattle`/`BattleAnimationBattler::
+  ShakeTargets`; a map-triggered Show Battle Animation's target case is left a
+  genuine no-op, matching `BattleAnimationMap::ShakeTargets`'s own empty
+  method body in the real source rather than treating it as an oversight to
+  fill in. Covered by six new `scripts/rpg2k_scene_check.rb` checks (screen
+  and target scope in both the battle-round and map-triggered paths, plus the
+  default-0 and no-resolvable-target regression cases).

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4432,6 +4432,7 @@ class RPG2k
         return unless @battle_ui[:owner].equal?(it)
         update_enemy_flashes
         update_enemy_positions
+        update_enemy_shakes
         case @battle_ui[:phase]
         when :encounter_message then drive_battle_encounter_message
         when :battle_options then drive_battle_options
@@ -7739,6 +7740,21 @@ class RPG2k
       # left untouched by the `ANIM_CELL_FRAMES` fix's own comment ("independent
       # constants").
       ANIM_FLASH_FRAMES = 11
+      # A frame's `screen_shaking` timing (LCF field 8: 0 none / 1 target / 2
+      # screen) fires a fixed (power, speed, frames) triple regardless of the
+      # timing's own data -- verified against EasyRPG Player's actual C++
+      # source, `BattleAnimation::ProcessAnimationTiming` (src/battle_animation.cpp,
+      # fetched verbatim): both the `ScreenShake_screen` (`screen->
+      # ShakeOnce(3, 5, 32)`) and `ScreenShake_target` (`ShakeTargets(3, 5,
+      # 32)`) cases share this exact triple, which their own comment calls
+      # "not proven accurate" but the only real-RPG_RT numbers documented
+      # anywhere. `frames` is already in real (60fps) frames, not tenths of a
+      # second -- their comment derives it as "16 animation frames (32 real
+      # frames)" -- so it needs no `FRAMES_PER_TENTH` conversion, unlike the
+      # Shake Screen event command's own param2 (#do_shake_screen).
+      ANIM_SHAKE_POWER = 3
+      ANIM_SHAKE_SPEED = 5
+      ANIM_SHAKE_FRAMES = 32
       # RPG2000 battle-animation cells: a 96x96 grid, 5 cells across the sheet.
       ANIM_CELL = 96
       ANIM_SHEET_COLS = 5
@@ -8208,9 +8224,11 @@ class RPG2k
 
       # Fire the current frame's timings request: flash_scope 2 (whole screen,
       # already implemented) or flash_scope 1 (the animation's own target --
-      # #fire_target_flash in battle, #fire_map_target_flash on the map).
-      # RPG2000 stores the colour / power as 0..31, scaled up to the 0..255
-      # range every flash path uses.
+      # #fire_target_flash in battle, #fire_map_target_flash on the map), plus
+      # screen_shaking 2 (whole screen) / 1 (the animation's own target --
+      # #fire_target_shake in battle only, see there for why the map path is a
+      # genuine no-op rather than a gap). RPG2000 stores the flash colour /
+      # power as 0..31, scaled up to the 0..255 range every flash path uses.
       def fire_animation_flashes(ma)
         ma[:timings].each do |t|
           next unless (t.frame || 0) == ma[:frame_i]
@@ -8230,6 +8248,23 @@ class RPG2k
             # every real frame, the exact same shape as #ma[:screen_flash_hold]
             # just above.
             ma[:target_flash_hold] = ANIM_FLASH_FRAMES
+          end
+          case (t.screen_shaking || 0)
+          when 2
+            # The exact mechanism the Shake Screen event command (11050,
+            # #do_shake_screen) already drives -- same Game::Screen#shake
+            # call, same (power, speed, frames) argument order -- just with
+            # EasyRPG's own fixed triple instead of a command's own params.
+            # A timed shake decays on its own via Game::Screen#update
+            # (already driven every frame), so unlike the flash paths above
+            # this needs no per-frame re-assertion hold.
+            @state.screen.shake(ANIM_SHAKE_POWER, ANIM_SHAKE_SPEED, ANIM_SHAKE_FRAMES)
+          when 1
+            # BattleAnimationMap::ShakeTargets (the map-triggered Show Battle
+            # Animation path) is a genuine empty no-op in EasyRPG's real
+            # source, not a dropped feature -- so this only ever fires in
+            # battle, matching #fire_target_shake's own battle-only scope.
+            fire_target_shake(ma[:target_index]) if ma[:battle]
           end
         end
       end
@@ -8254,6 +8289,71 @@ class RPG2k
         spr.flash(Color.new((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
                             (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8),
                   ANIM_FLASH_FRAMES)
+      end
+
+      # The screen_shaking-1 counterpart to #fire_target_flash: arms a timed
+      # shake of just the animation's own target sprite, mirroring EasyRPG's
+      # actual C++ source verbatim -- both `BattleAnimationBattle::
+      # ShakeTargets` and `BattleAnimationBattler::ShakeTargets`
+      # (src/battle_animation.cpp) shake every one of the animation's own
+      # battler targets with `battler->ShakeOnce(str, spd, time)`, the exact
+      # same triple `ProcessAnimationTiming` already fires for the screen
+      # case. This codebase's front-view battle has no per-sprite native
+      # shake primitive the way Sprite#flash exists for the colour pulse, so
+      # the state is tracked in a plain `@battle_ui[:enemy_shake]` hash
+      # (paralleling `enemy_sprites` by index) and stepped by
+      # #update_enemy_shakes every frame -- the same `Shake::NextPosition`
+      # sine-wave port Game::Screen#update_shake already drives for the
+      # whole-screen case, just applied to one sprite's own x. RPG2000's
+      # battle is front-view, so an ally-targeted entry has no sprite to
+      # shake (target_index is nil there, the same gap #fire_target_flash's
+      # own comment already documents) -- a silent no-op, not an error.
+      def fire_target_shake(target_index)
+        sprites = @battle_ui && @battle_ui[:enemy_sprites]
+        return unless target_index && sprites && sprites[target_index]
+        @battle_ui[:enemy_shake] ||= []
+        @battle_ui[:enemy_shake][target_index] =
+          { power: ANIM_SHAKE_POWER, speed: ANIM_SHAKE_SPEED, frames: ANIM_SHAKE_FRAMES, offset: 0 }
+      end
+
+      # Advance every in-flight #fire_target_shake state by one frame --
+      # called from #drive_battle every frame, right alongside
+      # #update_enemy_flashes/#update_enemy_positions. A direct port of
+      # Game::Screen#update_shake's own step (see there for the EasyRPG
+      # `Shake::NextPosition`/`Shake::Update` provenance), just keyed per
+      # troop-member index instead of a single screen-wide state, and applied
+      # to that member's own sprite x (recomputed from its live database
+      # position the same way #update_enemy_positions already recomputes y
+      # for a levitating member, so a sprite rebuilt mid-shake --
+      # #reveal_battle_monster, #remove_fled_monster -- is never left
+      # offset from a stale base). A slot with nothing active costs nothing.
+      def update_enemy_shakes
+        shakes = @battle_ui[:enemy_shake]
+        return unless shakes
+        sprites = @battle_ui[:enemy_sprites]
+        troop = @battle_ui[:troop]
+        shakes.each_index do |i|
+          st = shakes[i]
+          next unless st
+          spr = sprites && sprites[i]
+          member = troop && troop.members[i]
+          unless spr && member
+            shakes[i] = nil
+            next
+          end
+          st[:frames] -= 1
+          if st[:frames] <= 0
+            st[:offset] = 0
+            shakes[i] = nil
+          else
+            amplitude = 1 + 2 * st[:power]
+            phase = (st[:frames] * 4 * (st[:speed] + 2)) % 256
+            newpos = (amplitude * Math.sin(phase * Math::PI / 128) * -1).to_i
+            cutoff = (st[:speed] * amplitude) / 8 + 1
+            st[:offset] = Game.clamp(newpos, st[:offset] - cutoff, st[:offset] + cutoff)
+          end
+          spr.x = member.x - spr.bitmap.width / 2 + st[:offset]
+        end
       end
 
       # The map-triggered counterpart to #fire_target_flash: a flash_scope-1

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7306,6 +7306,47 @@ check "a map-triggered Show Battle Animation's target-scope flash pulses the pla
   ok st.switches[6], 'the event resumed after the animation'
 end
 
+# screen_shaking (LCF database field 8 on an animation timing: 0 none / 1
+# target / 2 screen, decoded by mruby-lcf/mrblib/schema.rb) was decoded but
+# never read by #fire_animation_flashes at all. Verified against EasyRPG
+# Player's actual C++ source, `BattleAnimation::ProcessAnimationTiming`
+# (src/battle_animation.cpp, fetched verbatim): screen_shaking 2 fires
+# `screen->ShakeOnce(3, 5, 32)` from the shared base class, with no
+# `ma[:battle]` gate the way the target case just below needs one -- so a
+# map-triggered Show Battle Animation shakes the whole screen exactly the
+# same way a battle-round one does (see the battle-round check further down),
+# reusing the exact Game::Screen#shake call/argument order the Shake Screen
+# event command (11050, #do_shake_screen) already drives rather than
+# inventing a second shake mechanism. A hand-built timing (rather than a
+# fixture animation) isolates it the same way the flash_scope-1 check above
+# does.
+check 'a map-context screen-scope animation shake triggers the same Game::Screen#shake state as Shake Screen' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  ok !st.screen.shaking?, 'not shaking to start with'
+  timing = OpenStruct.new(frame: 0, screen_shaking: 2)
+  ma = { frame_i: 0, timings: [timing] } # no :battle key -- the map path
+  scene.send(:fire_animation_flashes, ma)
+  ok st.screen.shaking?, 'the screen shake started on the map path too'
+end
+
+# screen_shaking 1 ("target") on a map-triggered Show Battle Animation is a
+# genuine no-op, not a dropped feature: EasyRPG's own `BattleAnimationMap::
+# ShakeTargets` (src/battle_animation.cpp, fetched verbatim) is an empty
+# method body -- `void BattleAnimationMap::ShakeTargets(int, int, int) {}` --
+# unlike `BattleAnimationBattle`/`BattleAnimationBattler`'s real per-battler
+# shake (see the battle-round check further down). #fire_animation_flashes
+# only calls #fire_target_shake when `ma[:battle]`, matching that real split
+# rather than treating the map path as an oversight to fill in.
+check 'a map-context target-scope animation shake is a real no-op, matching BattleAnimationMap::ShakeTargets' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  timing = OpenStruct.new(frame: 0, screen_shaking: 1)
+  ma = { frame_i: 0, timings: [timing] } # no :battle key -- the map path
+  scene.send(:fire_animation_flashes, ma) # must not raise
+  ok !st.screen.shaking?, 'never touches the whole-screen shake either'
+end
+
 # The same timing aimed at a named map event instead pulses *that* event's own
 # flash, not the player's -- #map_animation_flash_target resolves a plain
 # event id the same way #animation_target_pixel already does for centring the
@@ -11164,6 +11205,79 @@ check 'a target-scope animation flash pulses the hit enemy, not the screen or a 
   # the flash fades out and clears after its own duration -- not left stuck on.
   anim_flash_frames.times { scene.send(:update_enemy_flashes) }
   eq nil, spr.flash_color, 'the flash faded out after its duration'
+end
+
+# screen_shaking 2 ("screen") on a battle-round animation. Verified against
+# EasyRPG Player's actual C++ source, `BattleAnimation::ProcessAnimationTiming`
+# (src/battle_animation.cpp, fetched verbatim): `screen->ShakeOnce(3, 5, 32)`
+# -- the exact same Game::Screen#shake call and (power, speed, frames)
+# argument order the Shake Screen event command (11050) already drives (see
+# the 'Shake Screen with a wait...' check above), so this reuses it rather
+# than inventing a second shake mechanism.
+check 'a screen-scope animation shake triggers the same Game::Screen#shake state as Shake Screen' do
+  scene, = battle_at_command
+  st = scene.instance_variable_get(:@state)
+  ok !st.screen.shaking?, 'not shaking to start with'
+  timing = OpenStruct.new(frame: 0, screen_shaking: 2)
+  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
+  scene.send(:fire_animation_flashes, ma)
+  ok st.screen.shaking?, 'the screen shake started'
+  RPG2k::Scene::Map::ANIM_SHAKE_FRAMES.times { st.screen.update }
+  ok !st.screen.shaking?, "settled after EasyRPG's own fixed 32-frame duration"
+end
+
+# The default (0, "none") screen_shaking must stay a regression-safe no-op --
+# #fire_animation_flashes already runs unconditionally on every timing, so a
+# frame with no screen_shaking data at all (the schema default) must never
+# start a shake nobody asked for.
+check 'a screen_shaking-0 (default) timing triggers no shake' do
+  scene, = battle_at_command
+  st = scene.instance_variable_get(:@state)
+  timing = OpenStruct.new(frame: 0, flash_scope: 0, screen_shaking: 0)
+  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
+  scene.send(:fire_animation_flashes, ma)
+  ok !st.screen.shaking?, 'screen_shaking 0 (the schema default) never touches the screen shake'
+end
+
+# screen_shaking 1 ("target"): EasyRPG's own `BattleAnimationBattle::
+# ShakeTargets`/`BattleAnimationBattler::ShakeTargets` (src/battle_animation.cpp,
+# fetched verbatim) shake every one of the animation's own battler targets
+# with the same (3, 5, 32) triple as the screen case, via `battler->
+# ShakeOnce(...)` -- #fire_target_shake/#update_enemy_shakes port that to this
+# codebase's own per-sprite x, since there is no native per-sprite shake
+# primitive the way Sprite#flash exists for the colour pulse.
+check 'a target-scope animation shake jitters the hit enemy sprite, not a bystander, and settles back' do
+  scene, ui = battle_at_command
+  spr = ui[:enemy_sprites][0]
+  bystander = ui[:enemy_sprites][1]
+  base_x = spr.x
+  bystander_x = bystander.x
+  timing = OpenStruct.new(frame: 0, screen_shaking: 1)
+  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
+  scene.send(:fire_animation_flashes, ma)
+  moved = false
+  RPG2k::Scene::Map::ANIM_SHAKE_FRAMES.times do
+    scene.send(:update_enemy_shakes)
+    moved ||= spr.x != base_x
+  end
+  ok moved, "the targeted enemy sprite's x moved off its base position at some point during the shake"
+  eq base_x, spr.x, 'settled back to its base x once the shake duration elapsed'
+  eq bystander_x, bystander.x, 'the untargeted bystander sprite was never touched'
+  st = scene.instance_variable_get(:@state)
+  ok !st.screen.shaking?, 'screen_shaking 1 never touches the whole-screen shake, unlike screen_shaking 2'
+end
+
+# An ally-targeted entry (RPG2000's battle is front-view: no sprite for a
+# party member, so target_index is nil there -- see #battle_animation_pixel)
+# has nothing to shake; #fire_target_shake must not raise reaching for a
+# nonexistent sprite, the same shape #fire_target_flash's own no-target check
+# above already covers.
+check 'a target-scope shake with no resolvable target sprite is a silent no-op' do
+  scene, = battle_at_command
+  timing = OpenStruct.new(frame: 0, screen_shaking: 1)
+  ma = { frame_i: 0, battle: true, target_index: nil, timings: [timing] }
+  scene.send(:fire_animation_flashes, ma) # must not raise
+  ok true, 'no exception targeting nothing'
 end
 
 # ANIM_FLASH_FRAMES itself, pinned against EasyRPG's actual C++ source rather


### PR DESCRIPTION
## Summary

- `mruby-lcf/mrblib/schema.rb` decodes each battle-animation frame's timing
  `screen_shaking` field (LCF field 8: 0 none / 1 target / 2 screen), but
  `Scene::Map#fire_animation_flashes` — the same loop that already wires up
  the sibling `flash_scope` field — never read it, so a shake-carrying
  animation frame was silently dropped.
- Verified against EasyRPG Player's real source,
  `BattleAnimation::ProcessAnimationTiming` (`src/battle_animation.cpp`,
  fetched verbatim): both cases fire a fixed `(power 3, speed 5, frames 32)`
  triple regardless of the timing's own data.
  - `screen_shaking` 2 ("screen") reuses this codebase's existing
    `Game::Screen#shake` — the exact mechanism the Shake Screen event command
    (11050, `#do_shake_screen`) already drives, with the same argument order
    — instead of inventing a second shake mechanism.
  - `screen_shaking` 1 ("target") shakes just the animation's own battler
    sprite in battle: new `Scene::Map#fire_target_shake`/
    `#update_enemy_shakes` port the same `Shake::NextPosition` sine-wave step
    `Game::Screen#update_shake` already uses to a single enemy sprite's own
    x, mirroring EasyRPG's `BattleAnimationBattle`/`BattleAnimationBattler::
    ShakeTargets`. A map-triggered Show Battle Animation's target case stays
    a genuine no-op, matching `BattleAnimationMap::ShakeTargets`'s own empty
    method body in the real source rather than treating it as an oversight
    to fill in.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` passes (903 checks)
- [x] `ruby scripts/rpg2k_scene_check.rb` passes (626 checks, including 6 new
      ones covering screen/target scope in both the battle-round and
      map-triggered paths, plus the default-0 and no-resolvable-target
      regression cases)
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds; `--rgss_effect_probe`
      render check passes
- [x] `pre-commit` (clang-format/whitespace/EOF hooks) passes on the changed
      files


---
_Generated by [Claude Code](https://claude.ai/code/session_01SZvCFmrLW8DDJJ13mThdpU)_