### PR TITLE
Let defensive equipment resist status-effect infliction

### DIFF
--- a/changelog.d/rpg2k-state-resist-equipment.fixed.md
+++ b/changelog.d/rpg2k-state-resist-equipment.fixed.md
@@ -1,0 +1,9 @@
+- **Defensive equipment (shield/armor/helmet/accessory) can now resist a
+  status effect from landing at all**, on top of a target's existing A-E
+  susceptibility rank. Confirmed against EasyRPG Player's source
+  (`Game_Actor::GetStateProbability`): an item flagging a state in its own
+  `state_set` reduces that state's chance to land by its `state_chance`
+  percent, taking the single strongest piece of resistance worn rather than
+  stacking every equipped item. This build parsed those fields but never
+  read them defensively, so a "Poison resist" accessory or similar item had
+  no effect on its wearer.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6083,6 +6083,46 @@ not yet verified:
   proving a non-RPG2003 party ignores a stray 7th parameter and always
   settles — the `Game::Screen` test and the two interpreter dispatch tests
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **An ally's equipped shield/armor/helmet/accessory can now resist a
+  status effect from landing at all, instead of only its A-E susceptibility
+  rank ever mattering.** Confirmed against EasyRPG's actual C++ source:
+  `Game_Actor::GetStateProbability` (`src/game_actor.cpp`) scans every
+  equipped item (weapon excluded) for one that flags the state in its own
+  `state_set` and — for RPG2000, or an RPG2003 item without
+  `reverse_state_effect` set — folds `100 - item->state_chance` into the
+  result as a multiplier, taking the *strongest* single piece across all
+  four defensive slots rather than summing them ("takes the armor of the
+  character with the most resistance for that particular state"), applied
+  on top of the existing `GetStateRate(rank)` result. Both of its real call
+  sites (`src/game_battlealgorithm.cpp`, skill/item infliction and
+  weapon-granted infliction alike) route every state roll through it. This
+  codebase's `Game::Battle#state_susceptibility` (`mruby-rpg2k/mrblib/
+  game.rb`) already modelled the A-E rank half correctly but never read a
+  defensive item's `state_set`/`state_chance` fields at all — despite both
+  being parsed by the schema and already consumed on the *offense* side
+  (`Actor#weapon_states`, weapon-only) — so an ordinary "50% Poison
+  resistance" accessory or "90% Paralysis ward" helmet had zero effect on
+  its wearer. Concretely: an actor with no rank override for Poison (rank-C
+  default, 60%) wearing an accessory that flags Poison at `state_chance: 50`
+  faces a Poison Sting at 100% occurrence — real RPG_RT/EasyRPG lands it
+  `60 * (100-50)/100 = 30%` of the time; this build landed it the full `60%`,
+  the accessory silently doing nothing. Fixed with a new `Actor
+  #state_resist_mul(sid)` (mirroring `#weapon_states`' own equipment-scan
+  shape, but gated on the four defensive types — `Party::ITEM_SHIELD/
+  _ARMOR/_HELMET/_ACCESSORY` — instead of the weapon slot, and excluding an
+  RPG2003 `reverse_state_effect` item exactly as EasyRPG's own
+  `!(Player::IsRPG2k3() && item->reverse_state_effect)` guard does, since
+  that flag has no meaning on defensive gear's `state_set`), multiplied into
+  `#state_susceptibility`'s existing rank-based result whenever the target
+  is an ally (an enemy Combatant carries no `actor`, matching
+  `Game_Enemy::GetStateProbability`'s own equipment-free formula). Covered
+  by four new `scripts/rpg2k_logic_check.rb` checks — the Poison-accessory
+  trace above (bare vs. equipped), the strongest-of-several-pieces rule (a
+  50% and a 90% resist item together yield 90%'s multiplier, not both
+  stacked), a weapon's own `state_set` granting no resistance to its
+  wearer, and RPG2003 `reverse_state_effect` on defensive gear carrying no
+  resistance meaning — the first two confirmed to fail against the pre-fix
+  code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1881,6 +1881,37 @@ module Game
       { inflict: inflict, heal: heal }
     end
 
+    # The strongest defensive resistance the actor's equipped shield / armor /
+    # helmet / accessory (never a weapon) offers against state `sid` landing,
+    # as a percent multiplier (100 = no resistance). Ports EasyRPG's
+    # `Game_Actor::GetStateProbability` (`src/game_actor.cpp`): an item that
+    # flags `sid` in its own `state_set` contributes `100 - state_chance`, and
+    # the *lowest* (strongest) contribution across every equipped defensive
+    # item wins -- "takes the armor of the character with the most resistance
+    # for that particular state", not a sum of every piece worn. An RPG2003
+    # item with `reverse_state_effect` set plays no part here (that flag turns
+    # a *weapon's* own states into cures, per #weapon_states -- it has no
+    # meaning on defensive gear's state_set), matching EasyRPG's own
+    # `!(Player::IsRPG2k3() && item->reverse_state_effect)` guard.
+    def state_resist_mul(sid)
+      mul = 100
+      return mul unless @db.respond_to?(:item)
+      is2k3 = rpg2003?
+      @equipment.each do |iid|
+        next if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next unless it && it.respond_to?(:type) &&
+                    [Party::ITEM_SHIELD, Party::ITEM_ARMOR, Party::ITEM_HELMET,
+                     Party::ITEM_ACCESSORY].include?(it.type)
+        next if is2k3 && it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+        set = it.respond_to?(:state_set) ? it.state_set : nil
+        next unless set && set[sid - 1] && set[sid - 1] != 0
+        chance = it.respond_to?(:state_chance) ? (it.state_chance || 0) : 0
+        mul = 100 - chance if 100 - chance < mul
+      end
+      mul
+    end
+
     # The actor's basic-attack base hit rate (percent): the highest `hit` among
     # the equipped weapons (item field 17), or the RPG2000 unarmed default of 90
     # when nothing is equipped or the row omits it. Feeds the battle's to-hit
@@ -10572,15 +10603,28 @@ module Game
     # directly (RPG2000 has no separate instant-death mechanic), and yado.tk
     # documents its infliction chance as governed solely by the skill's own
     # occurrence-rate operand, never reduced by the target's A-E resistance rank.
+    # An ally's own defensive equipment can scale the A-E result down further
+    # still -- see Actor#state_resist_mul.
     def state_susceptibility(target, sid)
       return 100 if sid == Game::Actor::DEATH_STATE
       ranks = target.state_ranks
       return 100 if ranks.nil? || ranks.empty?
-      default_rank = ally?(target) ? 2 : 1
+      is_ally = ally?(target)
+      default_rank = is_ally ? 2 : 1
       rank = ranks[sid] || default_rank
       rank = 0 if rank < 0
       rank = 4 if rank > 4
-      state_rate(sid, rank)
+      pct = state_rate(sid, rank)
+      # An ally's equipped shield/armor/helmet/accessory can further resist a
+      # state landing on top of its A-E rank -- see Actor#state_resist_mul.
+      # Enemies equip nothing, matching Game_Enemy::GetStateProbability's own
+      # rank-only formula (no equipment scan at all). `respond_to?` tolerates
+      # a bare test double standing in for `actor` (#ally? only cares that the
+      # field is non-nil), read as full resistance (100, a no-op multiplier).
+      if is_ally && target.actor.respond_to?(:state_resist_mul)
+        pct = pct * target.actor.state_resist_mul(sid) / 100
+      end
+      pct
     end
 
     # Inflict a skill command's `inflict` states on `target`, each landing only if

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8742,6 +8742,77 @@ check "an enemy's own missing state-rank entry defaults to B (80%), an actor's t
   eq 100, bat.send(:state_susceptibility, slime, 2), "state 2 is explicitly rank A (100%) for the enemy too"
 end
 
+# Ports EasyRPG's `Game_Actor::GetStateProbability` (src/game_actor.cpp): a
+# shield/armor/helmet/accessory that flags a state in its own `state_set`
+# resists it landing at all, by `100 - state_chance` percent, on top of the
+# target's A-E rank. `Game_Enemy::GetStateProbability` never scans equipment
+# at all (monsters equip nothing), so only an ally is affected.
+check "an ally's defensive equipment resists a state landing, on top of its A-E rank" do
+  items = { 5 => fake_item(type: 5, state_set: [0, 0, 1], state_chance: 50) } # accessory
+  st = skill_party({}, items)
+  a = st.party.actor_by_id(1)
+  bare = Game::Battle.from_actor(a)
+  bare.state_ranks = { 99 => 0 } # a fixture row models no ranks -- force the non-empty path
+  foe = combatant('Foe', 0, 0, 5, 999)
+  bat = Game::Battle.new([bare], [foe], Game::Rng.new(1))
+  eq 60, bat.send(:state_susceptibility, bare, 3),
+     'no resist gear equipped yet -- the plain rank-C default (60%)'
+
+  a.equip([0, 0, 0, 0, 5]) # the accessory, in the accessory slot
+  worn = Game::Battle.from_actor(a)
+  worn.state_ranks = { 99 => 0 }
+  bat2 = Game::Battle.new([worn], [foe], Game::Rng.new(1))
+  eq 30, bat2.send(:state_susceptibility, worn, 3),
+     '60% rank-C base * (100 - 50)% resist = 30%'
+end
+
+check "the strongest of several equipped resistances wins, not their sum or the weakest" do
+  items = {
+    5 => fake_item(type: 5, state_set: [0, 0, 1], state_chance: 50), # accessory, 50% resist
+    6 => fake_item(type: 4, state_set: [0, 0, 1], state_chance: 90), # helmet, 90% resist (stronger)
+  }
+  st = skill_party({}, items)
+  a = st.party.actor_by_id(1)
+  a.equip([0, 0, 0, 6, 5])
+  hero = Game::Battle.from_actor(a)
+  hero.state_ranks = { 99 => 0 }
+  foe = combatant('Foe', 0, 0, 5, 999)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  eq 6, bat.send(:state_susceptibility, hero, 3),
+     '60% rank-C base * (100 - 90)% -- the strongest single piece, not 50+90 stacked'
+end
+
+check "a weapon's own state_set/state_chance is offense only -- it grants no resistance" do
+  items = { 5 => fake_item(type: 1, state_set: [0, 0, 1], state_chance: 90) } # weapon
+  st = skill_party({}, items)
+  a = st.party.actor_by_id(1)
+  a.equip([5, 0, 0, 0, 0])
+  hero = Game::Battle.from_actor(a)
+  hero.state_ranks = { 99 => 0 }
+  foe = combatant('Foe', 0, 0, 5, 999)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  eq 60, bat.send(:state_susceptibility, hero, 3),
+     "a weapon's own state_set never counts toward the wearer's own resistance"
+end
+
+check "on RPG2003, a defensive item's reverse_state_effect flag grants no resistance either" do
+  # reverse_state_effect only ever means something on a *weapon's own* states
+  # (flips inflict to heal, #weapon_states) or a curative item; it has no
+  # meaning on defensive gear's state_set, matching EasyRPG's own
+  # `!(Player::IsRPG2k3() && item->reverse_state_effect)` guard excluding it.
+  items = { 5 => fake_item(type: 5, state_set: [0, 0, 1], state_chance: 50,
+                            reverse_state: true) }
+  st = skill_party({}, items, rpg2003: true)
+  a = st.party.actor_by_id(1)
+  a.equip([0, 0, 0, 0, 5])
+  hero = Game::Battle.from_actor(a)
+  hero.state_ranks = { 99 => 0 }
+  foe = combatant('Foe', 0, 0, 5, 999)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  eq 60, bat.send(:state_susceptibility, hero, 3),
+     'reverse_state_effect on defensive gear is not a resistance flip'
+end
+
 check 'Battle.attack_damage is half attack less a quarter defence, floored at 0' do
   eq 18, Game::Battle.attack_damage(40, 8),  '20 - 2'
   eq 0,  Game::Battle.attack_damage(2, 40),  'floored at 0, not 1 (a genuine no-damage hit)'


### PR DESCRIPTION
## Summary
- `Game::Battle#state_susceptibility` (`mruby-rpg2k/mrblib/game.rb`) only ever consulted a target's A-E susceptibility rank; a shield/armor/helmet/accessory's own `state_set`/`state_chance` fields are parsed by the schema and already consumed on the *offense* side (`Actor#weapon_states`, weapon-only), but never read defensively — so an ordinary "50% Poison resistance" accessory or "90% Paralysis ward" helmet had zero effect on its wearer.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Actor::GetStateProbability` (`src/game_actor.cpp`) scans every equipped item (weapon excluded) for one flagging the state in its own `state_set` and — for RPG2000, or an RPG2003 item without `reverse_state_effect` set — folds `100 - item->state_chance` into the result, taking the *strongest* single piece of resistance across all four defensive slots rather than summing them ("takes the armor of the character with the most resistance for that particular state"). Both real call sites (`src/game_battlealgorithm.cpp`, skill/item infliction and weapon-granted infliction alike) route every state roll through it.
- Fixed with a new `Actor#state_resist_mul(sid)` (mirroring `#weapon_states`' own equipment-scan shape, but gated on the four defensive item types instead of the weapon slot, and excluding an RPG2003 `reverse_state_effect` item exactly as EasyRPG's own guard does), multiplied into `#state_susceptibility`'s existing rank-based result whenever the target is an ally — an enemy Combatant carries no `actor`, matching `Game_Enemy::GetStateProbability`'s own equipment-free formula.

## Test plan
- Four new `scripts/rpg2k_logic_check.rb` checks: a Poison-accessory trace (bare vs. equipped: 60% → 30%), the strongest-of-several-pieces rule (a 50% and a 90% resist item together yield 90%'s multiplier, not both stacked), a weapon's own `state_set` granting no resistance to its wearer, and RPG2003 `reverse_state_effect` on defensive gear carrying no resistance meaning.
- The first two confirmed to fail against the pre-fix code (`expected 30, got 60` / `expected 6, got 60`) before the fix, via `git stash`.
- All four CRuby suites pass (911 + 628 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_