### PR TITLE
Stop clamping an enemy Transformation's HP/SP to the new form's max

### DIFF
--- a/changelog.d/rpg2k-enemy-transform-hp-carryover.fixed.md
+++ b/changelog.d/rpg2k-enemy-transform-hp-carryover.fixed.md
@@ -1,0 +1,7 @@
+- **An enemy Transformation no longer heals it back up to the new form's max
+  HP/SP.** Confirmed against EasyRPG Player's source: `Game_Enemy::Transform`
+  only repoints the monster's database row and refreshes its sprite — it
+  never touches current HP/SP. This build force-clamped both down to the new
+  form's maximum, silently full-healing a boss whenever its "true form"
+  transformation had a lower max HP than its current HP, breaking the
+  classic "damage carries across a phase transformation" boss design.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6123,6 +6123,36 @@ not yet verified:
   wearer, and RPG2003 `reverse_state_effect` on defensive gear carrying no
   resistance meaning — the first two confirmed to fail against the pre-fix
   code before the fix.
+- ✅ **An enemy Transformation (action kind 2) no longer clamps its current
+  HP/SP down to the new form's maximum — they now carry over completely
+  unchanged, as real RPG_RT does.** Confirmed against EasyRPG's actual C++
+  source: `Game_Enemy::Transform` (`src/game_enemy.cpp`) only ever repoints
+  the `enemy` database row and refreshes the battle sprite — `hp`/`sp` are
+  set to their max exactly once, in the constructor, on the enemy's very
+  first spawn (`Game_Enemy::Game_Enemy`), never again inside `Transform`
+  itself. `Game_BattleAlgorithm::Transform::ApplyCustomEffect`
+  (`src/game_battlealgorithm.cpp`) calls `Game_Enemy::Transform` and nothing
+  else — it never calls `SetAffectedHp`/`SetAffectedSp`, so the generic
+  post-effect `ApplyHpEffect`/`ApplySpEffect` pass every action runs through
+  afterward is a no-op for it (`GetAffectedHp() == 0` short-circuits before
+  `ChangeHp`/`SetHp`, the only place that ever clamps to `GetMaxHp()`, is
+  reached). `Game::Battle#enemy_transform_action`
+  (`mruby-rpg2k/mrblib/game.rb`) instead force-clamped `b.hp`/`b.mp` down to
+  the new form's max whenever the prior value exceeded it — the comment
+  above it even claimed this matched `Game_Enemy::Transform`, which the
+  actual source contradicts outright. This breaks the classic "damage
+  carries across a phase transformation" boss design: a monster with
+  `max_hp = 1000` sitting at 950 HP that transforms into a "true form" with
+  `max_hp = 100` should still take 950 cumulative damage to finish off (its
+  `GetHp()` legitimately exceeding its own `GetMaxHp()` until something else
+  changes it) — this build instead silently full-healed it down to the new
+  100 cap, making the "true form" reveal trivially one-shot-able. Fixed by
+  simply removing the two clamp lines; `max_hp`/`max_mp` still update to the
+  new form's values exactly as before, only the current `hp`/`mp` fields are
+  left untouched. Covered by a new `scripts/rpg2k_logic_check.rb` check
+  transforming a 950-HP/40-SP monster into a 100-max-HP/10-max-SP form and
+  asserting both current values survive exactly, confirmed to fail against
+  the pre-fix code (`expected 950, got 100`) before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9531,17 +9531,28 @@ module Game
     end
 
     # A transformation (kind 2): the monster becomes another database enemy,
-    # taking on its name, stats and battle graphic (and its action pattern) while
-    # keeping its place in the fight. Current HP / SP carry over clamped to the
-    # new maxima, matching RPG_RT's Game_Enemy::Transform.
+    # taking on its name, stats and battle graphic (and its action pattern)
+    # while keeping its place in the fight. Current HP / SP carry over
+    # completely unchanged, *not* reclamped to the new maxima -- EasyRPG's
+    # `Game_Enemy::Transform` (`src/game_enemy.cpp`) only ever repoints the
+    # `enemy` database row and refreshes the sprite; it never touches `hp`/
+    # `sp` at all (those are set to the max only once, in the constructor, on
+    # the enemy's very first spawn). `Transform`'s own battle-algorithm
+    # (`Game_BattleAlgorithm::Transform::ApplyCustomEffect`,
+    # `src/game_battlealgorithm.cpp`) never calls `SetAffectedHp`/
+    # `SetAffectedSp` either, so the generic post-effect `ApplyHpEffect`/
+    # `ApplySpEffect` pass skip it outright (`GetAffectedHp() == 0` is a
+    # no-op). A boss can therefore legitimately carry HP above a later,
+    # lower-max "true form" until something else changes it -- a classic
+    # "damage carries across a transformation" design this build's own
+    # clamp made impossible by silently full-healing every downward
+    # transform.
     def enemy_transform_action(b, act)
       into = @ai && @ai.enemy(act.enemy_id)
       return enemy_fallback_attack(b) unless into
       b.name = into.name
       b.atk = into.atk; b.def = into.def; b.agi = into.agi; b.spi = into.spi
       b.max_hp = into.max_hp; b.max_mp = into.max_sp
-      b.hp = b.hp > into.max_hp ? into.max_hp : b.hp
-      b.mp = (b.mp || 0) > into.max_sp ? into.max_sp : b.mp
       b.crit_chance = Battle.crit_chance_of(into)
       b.attr_ranks = Battle.attr_ranks_of(into)
       b.state_ranks = Battle.state_ranks_of(into)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14499,6 +14499,36 @@ check 'a transformation into an unknown enemy degrades to an attack' do
   eq 20, e[:damage]
 end
 
+# A "true form" boss trick -- transforming into a form with a *smaller* max
+# HP/SP than the current values must not full-heal-then-clamp them down.
+# EasyRPG's `Game_Enemy::Transform` (src/game_enemy.cpp) only ever repoints
+# the `enemy` database row and refreshes the sprite; it never touches hp/sp
+# at all (those are set to the max exactly once, in the constructor, on the
+# enemy's very first spawn). `Game_BattleAlgorithm::Transform`'s own
+# `ApplyCustomEffect` never calls `SetAffectedHp`/`SetAffectedSp` either, so
+# the generic post-effect pass (`GetAffectedHp() == 0`) is a no-op for it.
+check 'a transformation carries current HP/SP over unchanged, not reclamped to the new maxima' do
+  row = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                   :agility, :exp, :gold).new('Weak Slime', 100, 10, 5, 2, 2,
+                                              5, 0, 0)
+  db = Struct.new(:enemy).new({ 1 => row })
+  ai = Game::EnemyAi.new(db, new_state)
+  # def 80 makes the hero's own preceding basic-attack turn (it goes first,
+  # being faster) land for 0 damage, so the transform's own hp/sp handling is
+  # what this check is isolating -- the pre-existing default-hero attack step
+  # in #enemy_entry is otherwise unavoidable.
+  foe = combatant('Slime King', 90, 80, 5, 950) # 950 current HP
+  foe.max_hp = 1000 # ...out of a 1000 max, about to drop to a 100-max form
+  foe.mp = 40
+  foe.max_mp = 50
+  e = enemy_entry([enemy_action(kind: 2, enemy_id: 1)], ai, foe: foe)
+  eq true, e[:transform]
+  eq 100, foe.max_hp, "the new form's own max"
+  eq 950, foe.hp, 'current HP carries over completely unchanged, above the new max'
+  eq 10, foe.max_mp
+  eq 40, foe.mp, 'current SP carries over unchanged too'
+end
+
 # -- the database path ---------------------------------------------------------
 
 check 'Game::Enemy decodes its action pattern off the database row' do


### PR DESCRIPTION
## Summary
- `Game::Battle#enemy_transform_action` (`mruby-rpg2k/mrblib/game.rb`) force-clamped a transforming enemy's current `hp`/`mp` down to the new form's maximum whenever the prior value exceeded it — and its own comment claimed this matched `Game_Enemy::Transform`, which the actual EasyRPG source contradicts.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Enemy::Transform` (`src/game_enemy.cpp`) only ever repoints the `enemy` database row and refreshes the battle sprite. `hp`/`sp` are set to their max exactly once, in the constructor, on the enemy's very first spawn — never again inside `Transform` itself. `Game_BattleAlgorithm::Transform::ApplyCustomEffect` (`src/game_battlealgorithm.cpp`) calls `Game_Enemy::Transform` and nothing else — it never calls `SetAffectedHp`/`SetAffectedSp`, so the generic post-effect `ApplyHpEffect`/`ApplySpEffect` pass every action runs afterward is a no-op for it.
- This breaks the classic "damage carries across a phase transformation" boss design: a monster with `max_hp = 1000` sitting at 950 HP that transforms into a "true form" with `max_hp = 100` should still take 950 cumulative damage to finish off — this build instead silently full-healed it down to the new 100 cap, making the "true form" reveal trivially one-shot-able.
- Fixed by simply removing the two clamp lines; `max_hp`/`max_mp` still update to the new form's values exactly as before, only the current `hp`/`mp` fields are left untouched.

## Test plan
- New `scripts/rpg2k_logic_check.rb` check transforming a 950-HP/40-SP monster into a 100-max-HP/10-max-SP form and asserting both current values survive exactly, confirmed to fail against the pre-fix code (`expected 950, got 100`) before the fix, via `git stash`.
- All four CRuby suites pass (912 + 628 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_