### PR TITLE
Stamp bridged stderr lines with their script source location

### DIFF
--- a/changelog.d/log-bridge-script-location.changed.md
+++ b/changelog.d/log-bridge-script-location.changed.md
@@ -1,0 +1,11 @@
+- `$stderr` lines bridged from Ruby into ng-log (`RGSS::ErrorReport`, see
+  `include/terminal.hxx`'s "Stderr log bridge" section) are now stamped with
+  the *script* location that logged them — e.g. `Scene_Map:120` — instead of
+  every bridged line pointing at the same C++ statement in
+  `src/log_bridge.cxx`. `RGSS.__log_bridge_write` (`mruby-rgss/src/lib.cxx`)
+  walks the interpreter's call stack to find it, skipping the log bridge's own
+  plumbing (`RGSS::ErrorReport`'s tee and `RGSS.warn_once`/`.warn_stub`) so the
+  reported frame is the real logging site. A native caller with no script
+  location (the non-Ruby diagnostics covered by
+  `native-stderr-log-bridge.changed.md`, or bytecode built without debug info)
+  falls back to the previous behaviour.

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -124,7 +124,21 @@ void terminal_append_console(std::string& s);
 // mrbtest, the PSP and Wio Terminal targets -- leave it null, so the forward
 // is a harmless no-op and $stderr keeps behaving exactly as before there.
 
-using log_bridge_hook_fn = void (*)(const char* msg, size_t len);
+// Each forwarded line carries the source location it came from, because
+// without one every bridged line reaches ng-log from the same C++ statement in
+// src/log_bridge.cxx -- so the whole runtime log used to be stamped
+// "log_bridge.cxx:12" and said nothing about which script logged what.  For a
+// line written from Ruby the binding answers the *script* location
+// (mruby-rgss/src/lib.cxx walks the interpreter's call stack for it), so a
+// warning from a game's own Scene_Map section is stamped with that section and
+// line, exactly as a C++ LOG() is stamped with its file and line.  `file` is
+// null when the location is unknown -- a native caller that passed none, or a
+// build whose bytecode carries no debug info -- and the hook then falls back to
+// its own call site.
+using log_bridge_hook_fn = void (*)(const char* msg,
+                                    size_t len,
+                                    const char* file,
+                                    int line);
 
 // Install (or clear, with nullptr) the hook every forwarded line reaches.
 // Called once at start-up, before the mruby interpreter runs any Ruby code;
@@ -132,8 +146,14 @@ using log_bridge_hook_fn = void (*)(const char* msg, size_t len);
 void log_bridge_set_hook(log_bridge_hook_fn hook);
 
 // Forward one already-buffered line (no trailing newline) to the installed
-// hook, if any.  Safe to call unconditionally.
-void log_bridge_write(const char* msg, size_t len);
+// hook, if any.  Safe to call unconditionally.  `file`/`line` are the source
+// location the line came from (see above); the default means "unknown", which
+// is what every native caller passes.  `file` need only stay alive for the
+// duration of the call.
+void log_bridge_write(const char* msg,
+                      size_t len,
+                      const char* file = nullptr,
+                      int line = 0);
 
 // Convenience for the native (non-Ruby) diagnostics in mruby-rgss/mruby-mvjs
 // that used to be a bare `fprintf(stderr, ...)`: writes `msg` to the real

--- a/mruby-rgss/mrblib/error_report.rb
+++ b/mruby-rgss/mrblib/error_report.rb
@@ -15,7 +15,9 @@ module RGSS
   # forwards it to ng-log via the hook the executable installs (see
   # include/terminal.hxx's "Stderr log bridge" section) -- so the same warning
   # that lands in a crash report also respects ng-log's severity filtering and
-  # shows up in the on-screen terminal log console. That call is guarded by
+  # shows up in the on-screen terminal log console, stamped with the script
+  # location it was written at (the binding reads that off the call stack,
+  # skipping the tee's own frames below). That call is guarded by
   # `respond_to?`: this file otherwise has no mruby dependency, which is what
   # lets scripts/error_report_check.rb exercise it on plain CRuby (see that
   # script and mruby-rgss/test/test.rb, which both cover this design). `$stderr`
@@ -74,10 +76,21 @@ module RGSS
     @lines = []
     @partial = ""
     @installed = false
+    @last_location = nil
 
     class << self
       # The recorded lines, oldest first, newline-free.
       attr_reader :lines
+
+      # The script location the log bridge attributed to the last line it
+      # forwarded, as "file:line" — the location the engine's log stamps that
+      # line with (RGSS.__log_bridge_write answers it; see
+      # include/terminal.hxx's "Stderr log bridge" section). nil where nothing
+      # has been forwarded, or where the binding is absent (CRuby) or could not
+      # tell (bytecode built without debug info). Nothing in the runtime reads
+      # it; it is how the location can be checked from Ruby, where the forward
+      # itself is invisible.
+      attr_reader :last_location
     end
 
     # Tee $stderr through the ring buffer. Called once at start-up (from
@@ -116,10 +129,26 @@ module RGSS
     # Record raw log output. Writes arrive in arbitrary chunks (a `puts` is one
     # call, a `print` per fragment is many), so text is buffered until a newline
     # completes a line.
+    #
+    # A plain index loop rather than `each { |line| push(line) }` on purpose:
+    # `each`'s block is its own call frame (Array#each is core Ruby, not a C
+    # primitive), which sat between `push` and whatever called `record` on
+    # every single bridged line. RGSS.__log_bridge_write's script_location walk
+    # (mruby-rgss/src/lib.cxx) skips frames it recognises as this file's own
+    # plumbing to find the real logging site, and that extra frame is core
+    # mruby's own file (mrblib/array.rb) rather than error_report.rb, so the
+    # walk stopped there and every bridged line got attributed to Array#each
+    # instead of the script that logged. A `while` loop compiles with no new
+    # call frame, so the frame right above `push` is `record`, and the one
+    # above that is `record`'s real caller, exactly as intended.
     def self.record(text)
       parts = (@partial + text.to_s).split("\n", -1)
       @partial = parts.pop || ""
-      parts.each { |line| push(line) }
+      i = 0
+      while i < parts.size
+        push(parts[i])
+        i += 1
+      end
       nil
     end
 
@@ -139,6 +168,7 @@ module RGSS
     def self.clear
       @lines = []
       @partial = ""
+      @last_location = nil
       nil
     end
 
@@ -146,7 +176,9 @@ module RGSS
       line = line[0, MAX_LINE_CHARS] + "..." if line.size > MAX_LINE_CHARS
       @lines << line
       @lines.shift while @lines.size > MAX_LINES
-      RGSS.__log_bridge_write(line) if RGSS.respond_to?(:__log_bridge_write)
+      if RGSS.respond_to?(:__log_bridge_write)
+        @last_location = RGSS.__log_bridge_write(line)
+      end
       nil
     end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2,7 +2,13 @@
 #include <mruby/array.h>
 #include <mruby/class.h>
 #include <mruby/data.h>
+// debug.h/irep.h/proc.h: the log bridge reads the script location of the frame
+// that logged out of the running proc's irep debug info (see
+// script_location below).
+#include <mruby/debug.h>
 #include <mruby/hash.h>
+#include <mruby/irep.h>
+#include <mruby/proc.h>
 #include <mruby/string.h>
 #include <mruby/value.h>
 #include <mruby/variable.h>
@@ -80,7 +86,10 @@ void rgss_tts_define(mrb_state* M, RClass* rgss);
 // $stderr line to the executable's ng-log hook (a no-op on mrbtest, PSP and
 // Wio Terminal, which never install one -- see include/terminal.hxx's
 // "Stderr log bridge" section, docs/adr/0005).
-void log_bridge_write(const char* msg, size_t len);
+void log_bridge_write(const char* msg,
+                      size_t len,
+                      const char* file = nullptr,
+                      int line = 0);
 // Also defined in log_bridge.cxx: writes to the real stderr (unconditionally)
 // and forwards through log_bridge_write. Used by the native (non-Ruby)
 // diagnostics below that used to be a bare fprintf(stderr, ...).
@@ -6118,15 +6127,92 @@ static mrb_value mouse_pressed_m(mrb_state* M, mrb_value) {
   return mrb_bool_value(rgss_mouse_pressed() != 0);
 }
 
+// Where a bridged log line was written: the Ruby file and line, or file =
+// nullptr when the call stack cannot say.
+struct ScriptLocation {
+  const char* file;
+  int line;
+};
+
+// True for a frame that only *carried* the message rather than writing it.
+// RGSS::ErrorReport's tee (Tee#write / #puts / .record / .push, all of
+// error_report.rb) sits between every logging site and this binding, and
+// RGSS.warn_once / .warn_stub are the engine's own forwarders on top of it --
+// stamping the log with any of them would just name the plumbing on every
+// line, which is the same uselessness as naming log_bridge.cxx.
+static bool log_forwarder_frame(mrb_state* M,
+                                const mrb_callinfo* ci,
+                                const char* file) {
+  const char* base = file;
+  for (const char* p = file; *p != '\0'; ++p) {
+    if (*p == '/' || *p == '\\')
+      base = p + 1;
+  }
+  if (std::strcmp(base, "error_report.rb") == 0)
+    return true;
+  if (ci->mid == 0)
+    return false;
+  const char* mid = mrb_sym_name(M, ci->mid);
+  return mid != nullptr && (std::strcmp(mid, "warn_once") == 0 ||
+                            std::strcmp(mid, "warn_stub") == 0);
+}
+
+// The script location the innermost non-forwarder Ruby frame is at. Walks the
+// interpreter's call stack the way mruby's own backtrace does (see
+// pack_backtrace in 3rd/mruby/src/backtrace.c): each frame's proc carries the
+// irep it runs, and the irep's debug info maps the frame's program counter to
+// a file and line. Frames with no debug info are skipped rather than reported
+// as unknown, so a build compiled without -g (or a C function in the middle of
+// the stack) falls back to the next frame that can answer, and only a stack
+// that can answer nowhere gives up.
+static bool script_location(mrb_state* M, ScriptLocation* out) {
+  for (const mrb_callinfo* ci = M->c->ci; ci >= M->c->cibase; --ci) {
+    const struct RProc* proc = ci->proc;
+    if (proc == nullptr || MRB_PROC_CFUNC_P(proc))
+      continue;
+    const mrb_irep* irep = proc->body.irep;
+    if (irep == nullptr || irep->debug_info == nullptr || ci->pc == nullptr)
+      continue;
+    // ci->pc is the *next* instruction to run, so the call being made is the
+    // one before it -- the same -1 mruby's backtrace applies.
+    const uint32_t idx = static_cast<uint32_t>(ci->pc - 1 - irep->iseq);
+    int32_t line = -1;
+    const char* file = nullptr;
+    if (!mrb_debug_get_position(M, irep, idx, &line, &file))
+      continue;
+    if (file == nullptr || line < 0)
+      continue;
+    if (log_forwarder_frame(M, ci, file))
+      continue;
+    out->file = file;
+    out->line = static_cast<int>(line);
+    return true;
+  }
+  out->file = nullptr;
+  out->line = 0;
+  return false;
+}
+
 // RGSS.__log_bridge_write(line) -- called by RGSS::ErrorReport.push
 // (mruby-rgss/mrblib/error_report.rb) for every $stderr line it buffers. See
 // include/terminal.hxx's "Stderr log bridge" section.
+//
+// The line is forwarded together with the script location it was written at,
+// so the engine's log names the script that logged ("Scene_Map:120") instead
+// of stamping every bridged line with this bridge's own C++ call site. Returns
+// that location as "file:line", or nil when the stack could not say -- what
+// RGSS::ErrorReport.last_location exposes, and what the mrbtest build (which
+// installs no hook, so nothing else about the forward is observable) checks.
 static mrb_value log_bridge_write_m(mrb_state* M, mrb_value) {
   const char* msg;
   mrb_int len;
   mrb_get_args(M, "s", &msg, &len);
-  log_bridge_write(msg, static_cast<size_t>(len));
-  return mrb_nil_value();
+  ScriptLocation loc = {nullptr, 0};
+  script_location(M, &loc);
+  log_bridge_write(msg, static_cast<size_t>(len), loc.file, loc.line);
+  if (loc.file == nullptr)
+    return mrb_nil_value();
+  return mrb_format(M, "%s:%d", loc.file, loc.line);
 }
 
 // RGSS.window_title = "..." -- the running game's own title, set by each

--- a/mruby-rgss/src/log_bridge.cxx
+++ b/mruby-rgss/src/log_bridge.cxx
@@ -11,9 +11,9 @@ void log_bridge_set_hook(log_bridge_hook_fn hook) {
   g_hook = hook;
 }
 
-void log_bridge_write(const char* msg, size_t len) {
+void log_bridge_write(const char* msg, size_t len, const char* file, int line) {
   if (g_hook != nullptr)
-    g_hook(msg, len);
+    g_hook(msg, len, file, line);
 }
 
 void log_bridge_write_stderr(const char* msg) {

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1763,6 +1763,24 @@ assert "RGSS::ErrorReport::Tee forwards every write and records it" do
   RGSS::ErrorReport.clear
 end
 
+assert "RGSS::ErrorReport stamps a bridged line with the script's location" do
+  # Every line the bridge forwards used to reach ng-log from the same C++
+  # statement, so the whole runtime log was stamped "log_bridge.cxx:12" and said
+  # nothing about which script logged what. RGSS.__log_bridge_write now reads
+  # the location off the interpreter's call stack, skipping the tee's own frames
+  # (record/push, both error_report.rb) -- so what it answers is *this* file and
+  # the line that logged. mrbtest installs no ng-log hook, so the location it
+  # reports is the only observable half of the forward here.
+  RGSS::ErrorReport.clear
+  expected_line = __LINE__ + 1
+  RGSS::ErrorReport.record("[RGSS] location probe\n")
+  loc = RGSS::ErrorReport.last_location
+  assert_kind_of String, loc
+  assert_true loc.include?("test.rb:"), "attributed to #{loc}"
+  assert_equal expected_line, loc.split(":").last.to_i
+  RGSS::ErrorReport.clear
+end
+
 assert "RGSS::ErrorReport.probe! raises after logging its marker line" do
   # The engine's --error_dump_probe drives this to check a real report keeps the
   # exception, its backtrace and the captured log; assert here that the probe

--- a/src/log_bridge.cxx
+++ b/src/log_bridge.cxx
@@ -8,8 +8,22 @@
 
 namespace {
 
-void forward_to_nglog(const char* msg, size_t len) {
-  LOG(WARNING) << std::string_view(msg, len);
+// `file`/`line` are where the message really came from -- the Ruby script
+// location for a line written by a game's own script or by the engine's Ruby
+// half (see include/terminal.hxx's "Stderr log bridge" section).  Handing them
+// to nglog::LogMessage, rather than using LOG(WARNING) here, is what makes the
+// log (and the on-screen console fed by src/log_console.cxx) say
+// "Scene_Map:120" instead of stamping every bridged line with this file and
+// this line number.  A null `file` means the caller had no location to give --
+// the native log_bridge_write_stderr diagnostics, or bytecode built without
+// debug info -- and those keep the old behaviour of pointing here.
+void forward_to_nglog(const char* msg, size_t len, const char* file, int line) {
+  if (file == nullptr) {
+    LOG(WARNING) << std::string_view(msg, len);
+    return;
+  }
+  nglog::LogMessage(file, line, nglog::NGLOG_WARNING).stream()
+      << std::string_view(msg, len);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Enhanced the log bridge to attribute `$stderr` lines forwarded from Ruby to ng-log with their actual script source location (e.g., `Scene_Map:120`) instead of always pointing to the same C++ statement in `log_bridge.cxx`.

## Key Changes

- **Call stack introspection**: Added `script_location()` function in `mruby-rgss/src/lib.cxx` that walks the mruby interpreter's call stack to extract the script file and line number from the innermost non-forwarder frame's irep debug info.

- **Forwarder frame detection**: Implemented `log_forwarder_frame()` to identify and skip internal plumbing frames (`error_report.rb`, `RGSS.warn_once`, `RGSS.warn_stub`) so the reported location is the actual logging site, not the bridge's own machinery.

- **Updated log bridge signature**: Extended `log_bridge_write()` and the `log_bridge_hook_fn` callback to accept optional `file` and `line` parameters, allowing source location information to flow through to ng-log.

- **Ruby binding enhancement**: Modified `log_bridge_write_m()` to extract script location and return it as `"file:line"` string (or `nil` if unavailable), exposed via `RGSS::ErrorReport.last_location`.

- **Error report improvements**: 
  - Added `@last_location` tracking to `RGSS::ErrorReport`
  - Changed `record()` from `each` block to explicit `while` loop to avoid introducing an extra call frame that would interfere with stack walking
  - Updated `push()` to capture and store the location returned by the bridge

- **ng-log integration**: Modified `forward_to_nglog()` in `src/log_bridge.cxx` to use `nglog::LogMessage` with the provided file/line when available, falling back to `LOG(WARNING)` for native callers without location info.

## Implementation Details

- The script location walk mirrors mruby's own backtrace implementation, using `mrb_debug_get_position()` to map instruction pointers to source locations
- Frames without debug info are skipped rather than reported as unknown, allowing fallback to the next available frame
- Native callers and builds without debug symbols gracefully fall back to the previous behavior (pointing to `log_bridge.cxx`)
- The `file` pointer only needs to remain valid for the duration of the hook call

https://claude.ai/code/session_01W6TX1ha639yVtE1QEegrRj