### PR TITLE
Refactor battle system as standalone Scene::Battle

### DIFF
--- a/changelog.d/rpg2k-battle-scene.changed.md
+++ b/changelog.d/rpg2k-battle-scene.changed.md
@@ -1,0 +1,10 @@
+- **rpg2k: the turn-based fight is now its own `Scene::Battle`**, not a mode
+  of `Scene::Map`. The command/target/skill/item windows, troop and party
+  sprites, round animation, battle-event pages and result screen all moved
+  out of `mruby-rpg2k/mrblib/scene/map.rb` into a new
+  `mruby-rpg2k/mrblib/scene/battle.rb`; `Scene::Map` now constructs and drives
+  a `Scene::Battle` instance for the duration of an encounter instead of
+  threading a `@battle_ui` hash through its own methods. Purely an
+  architectural change — no mechanic, timing or on-screen behaviour differs;
+  see ADR 0052 for the design and `scripts/rpg2k_scene_check.rb` (628 checks)
+  / `scripts/rpg2k_logic_check.rb` (907 checks) for the unchanged coverage.

--- a/docs/adr/0052-battle-as-its-own-scene.md
+++ b/docs/adr/0052-battle-as-its-own-scene.md
@@ -1,0 +1,119 @@
+# 52. Battle as its own Scene, not a mode of Scene::Map
+
+Date: 2026-08-15
+
+## Status
+
+Accepted
+
+## Context
+
+RPG2000's turn-based fight used to be a *mode* of `Scene::Map` rather than a
+scene in its own right. A `@battle_ui` hash living on the map scene carried
+the fight's entire live state (phase, the `Game::Battle` model, combatant
+snapshots, cursors, windows, sprites), and roughly a hundred `drive_battle_*`
+/ `battle_*` methods sat in the middle of `mruby-rpg2k/mrblib/scene/map.rb`
+right alongside the field-map's own event/movement/rendering code — about
+3,000 of the file's ~10,600 lines. `Scene::Map#update`'s own `:battle` wait
+branch called `#drive_battle`, which built and drove the fight inline; there
+was no `Scene::Battle` a Battle Processing (Enemy Encounter) command could
+push the way `Scene::Menu`/`Scene::Title`/etc. are pushed onto `RPG2k
+#@scenes` elsewhere in this codebase.
+
+That worked (every mechanic RPG_RT's real `Scene_Battle` has was faithfully
+ported), but it meant:
+
+- The single largest file in the engine kept growing in a section that has
+  nothing to do with map rendering, event stepping or movement — the two
+  concerns were interleaved by accident of history, not by any real coupling.
+- Every battle-only helper was reachable (and callable) from any of Scene
+  ::Map's other ~350 methods, with nothing marking the boundary; a mistaken
+  cross-call between "the fight" and "the field map" would have compiled and
+  run without any signal it had happened.
+- The fight could never be reached except through `Scene::Map`'s own
+  `@battle_ui` gate — there was no independent object a future caller (a
+  scripted/debug battle, a battle-only test harness, a different call site
+  entirely) could construct and drive on its own.
+
+RPG_RT itself keeps the two as genuinely separate scenes (`Scene_Map` /
+`Scene_Battle`, EasyRPG Player's own `src/scene_battle.cpp`); this ADR brings
+the port's own structure in line with that, without changing any observable
+behaviour.
+
+## Decision
+
+- New `RPG2k::Scene::Battle < Scene::Base`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) owns everything the fight itself is
+  made of: the phase machine (`#update`), the command / target / skill / item
+  / ally-target windows, the troop and party sprites, the per-action round
+  animation, the troop's own battle-event pages, and the result screen. Its
+  live state is the same hash the old `@battle_ui` was (`@ui`, `attr_reader
+  :ui`), just owned by the fight's own object instead of the map's.
+- `Scene::Map` keeps a single `@battle` ivar (a `Scene::Battle` instance, or
+  `nil` between encounters) instead of `@battle_ui`. `#drive_battle` is still
+  `Scene::Map`'s own method — Battle Processing can be issued from the
+  foreground event or from a Parallel Process's own interpreter, and only
+  `Scene::Map` sees every interpreter that could raise the wait — but it now
+  only decides *whether* a fight should open or keep running, constructing a
+  `Scene::Battle` and calling its `#start` the first frame, then handing every
+  later frame to that instance's own `#update` for as long as the calling
+  interpreter still owns it (the same block-and-retry shape already used for
+  `:message`/`:choice`/`:number`). `Scene::Map#close_battle` disposes the
+  fight's windows/sprites (`Scene::Battle#dispose`) and drops the reference;
+  every other truthy `@battle_ui` check on the map side (rendering the battle
+  backdrop instead of the map, hiding pictures, pausing a non-`in_battle`
+  timer, gating `#parallels_paused?`/`#event_busy?`) became the equivalent
+  `@battle`/`@battle.nil?` check unchanged.
+- `Scene::Battle` is *not* pushed onto `RPG2k#@scenes` the way
+  `Scene::Menu`/`Scene::Title` are. `Scene::Map#update` still runs every frame
+  a fight is open — the map keeps ticking the screen tint, pictures, timers,
+  weather and the owner Parallel Process exactly as before, all of which the
+  existing comments document at length as deliberately *not* pausing for a
+  battle — so a real scene-stack push (which would leave `Scene::Map#update`
+  uncalled while `Scene::Battle` sits on top, the way it already *is*
+  uncalled while `Scene::Menu` is up) would have had to duplicate all of that
+  onto the new scene to preserve it. Composition (`Scene::Map` owns and
+  drives a `Scene::Battle` instance every frame) gets the same object
+  separation with zero behavioural risk; a real stack push is a larger,
+  separate change this ADR does not make.
+- What a fight still needs from the surrounding map — graphic caches shared
+  across encounters (a monster/backdrop/battler decoded in one fight stays
+  warm for the next), the RNG the map's own event/move-route code already
+  shares with the party, the windowskin (reloaded by a mid-fight Change
+  System Graphic), and the animation player a round's skill/item animation
+  shares with the map's own Show Battle Animation command — is reached back
+  through `@map` (`Scene::Battle#initialize(map, req, owner)`), against a set
+  of readers and methods `Scene::Map` now exposes publicly for exactly this
+  (grouped under the "Services Scene::Battle calls back into" heading next to
+  `#dispose`, plus a second `public :...` list once the rest are defined).
+  The two map-triggered/battle-round twins of the same mechanism
+  (`#fire_target_flash`/`#fire_map_target_flash`,
+  `#fire_target_shake`/(no map twin — a documented EasyRPG no-op),
+  `#clear_target_flash`/`#clear_map_target_flash`) split the same way: the
+  battle-only half moved to `Scene::Battle`, the map-only half stayed, and
+  `Scene::Map#fire_animation_flashes`/`#hold_animation_target_flash` dispatch
+  to `@battle.fire_target_flash`/`@battle.fire_target_shake`/
+  `@battle.clear_target_flash` on the `ma[:battle]` branch.
+
+## Consequences
+
+`mruby-rpg2k/mrblib/scene/map.rb` shrank from ~10,600 to ~7,700 lines;
+`mruby-rpg2k/mrblib/scene/battle.rb` is a new ~3,000-line file. No mechanic
+changed — `scripts/rpg2k_scene_check.rb`'s 628 checks (rewritten to reach the
+fight's state via `scene.instance_variable_get(:@battle)`/`.ui` and the
+`battle_ui(scene)`/`fake_battle(scene, ui)` helpers that back it, and to send
+battle-only methods to that object instead of the map scene) and
+`scripts/rpg2k_logic_check.rb`'s 907 all still pass unchanged in what they
+assert. `Interpreter#battle_screen` — the hook `Change Party Member` battle
+events use to push a roster change onto the render layer (ADR 0050/0051) —
+now naturally resolves to the `Scene::Battle` instance instead of the whole
+map scene, which is the hook's real target and was previously reached only
+because the map scene *was* the battle screen.
+
+The one gap this does not close: `Scene::Battle` still cannot be reached or
+driven except through `Scene::Map#drive_battle` opening one. A future battle-
+only test harness or a scripted/debug encounter that wants to drive a fight
+without a full map scene behind it is easier to build now (`Scene::Battle
+.new(map, req, owner)` takes a narrow, already-public dependency list) but
+still needs *some* `Scene::Map`-shaped object to hand it — closing that gap
+further is follow-up work, not part of this change.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -58,7 +58,7 @@ frame — with `map.layers` alone at 22.7ms (66.5% of work) and ~350,000
 allocations/second. Those are the numbers the rest of this page reasons about,
 and they are what the tile cache and `Bitmap#copy_blt` removed.
 
-Note that `map.layers` and `map.chars` are inside the `if @battle_ui` gate in
+Note that `map.layers` and `map.chars` are inside the `if @battle` gate in
 `#render`, so they stop being recorded during a fight — the map is not drawn
 there at all. A profile of a battle-heavy run will show a different shape.
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3234,7 +3234,7 @@ module Game
     # `#alternate_battle_layout?` above, which is also true for the plain
     # sprite-only layout (1). The party status panel reads this to know when
     # to replace its text status window with the gauge card layout (see
-    # scene/map.rb's `#refresh_battle_status`); an alternative-layout (1)
+    # scene/battle.rb's `#refresh_battle_status`); an alternative-layout (1)
     # database, or one with no `#battlecommands` table at all, reads false.
     def gauge_battle_layout?
       return false unless @db.respond_to?(:battlecommands)
@@ -3246,7 +3246,7 @@ module Game
     # chunk 29 field 2 -- 0 manual, 1 automatic; see schema.rb). Manual is
     # `Game::Actor#battle_x`/`#battle_y` read as literal screen coordinates;
     # automatic computes a grid formula this runtime does not implement yet
-    # (see the alternate-battle-sprite renderer in scene/map.rb), so callers
+    # (see the alternate-battle-sprite renderer in scene/battle.rb), so callers
     # use this to know when to fall back to the raw coordinates and log a
     # diagnostic instead of guessing at the formula. A bare test fixture with
     # no `#battlecommands` table, or an RPG2000 database (which never sets
@@ -8049,7 +8049,7 @@ module Game
     # A heavily-armoured target can shrug off a weak attacker's blow entirely
     # (a genuine "no damage" hit, not a guaranteed minimum scratch); `#deal_attack`
     # already builds an ordinary attack-shaped log entry regardless of the
-    # resulting damage value, and `#battle_result_line` (`scene/map.rb`) already
+    # resulting damage value, and `#battle_result_line` (`scene/battle.rb`) already
     # renders a 0 as the "undamaged" term line rather than a damage number, so
     # this needed no companion change beyond the floor itself.
     def self.attack_damage(atk, dfn)

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -242,7 +242,7 @@ module Game
     # what makes the battle-only commands no-ops outside a battle — exactly as
     # they are in RPG_RT, where the editor cannot even place them there.
     attr_accessor :battle
-    # The Scene::Map hosting the running fight `@battle` belongs to, set
+    # The Scene::Battle running the fight `@battle` belongs to, set
     # alongside it. Lets #do_change_party notify the battle screen the moment
     # a Change Party Member command actually adds/removes a member, mirroring
     # EasyRPG's `Game_Party::AddActor`/`RemoveActor` calling

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1,0 +1,3030 @@
+class RPG2k
+  module Scene
+    # RPG2000's turn-based fight.
+    #
+    # RPG_RT runs an encounter as a scene of its own: `Scene_Battle` takes the
+    # screen over from `Scene_Map` for as long as the fight lasts, which is why
+    # its backdrop is all there is behind the troop and why no part of the map
+    # is drawn beside it (EasyRPG Player's `src/scene_battle.cpp`). This port
+    # used to run the same screen *inline on the map* instead, as a mode gated
+    # on a `@battle_ui` hash living on Scene::Map -- some three thousand lines
+    # of phase machine, windows, sprites, round animation and battle-event
+    # pages sitting in the middle of the map scene, reachable only through that
+    # one hash, and impossible to open from anywhere but a map.
+    #
+    # The fight is this scene now. Everything the fight itself is made of lives
+    # here: the phase machine (#update), the command / skill / item / target
+    # windows, the troop and party sprites, the per-action round animation, the
+    # troop's own battle-event pages and the result screen.
+    #
+    # Scene::Map still owns the frame around it -- it keeps driving the screen
+    # effects, pictures, timers and animations a fight can still show, and it
+    # owns the interpreters whose Battle Processing command opened this fight
+    # in the first place -- so it constructs this scene, hands it every frame
+    # for as long as the fight is open (see Scene::Map#drive_battle) and tears
+    # it down again (Scene::Map#close_battle). What stays the map's, and is
+    # reached back into through `@map`, is listed under the "Services
+    # Scene::Battle calls back into" heading at the end of scene/map.rb: the
+    # graphic caches shared across encounters, the BGM stack that has to bring
+    # the field track back afterwards, the battle-animation player a round's
+    # skill / item animations share with the map's own Show Battle Animation
+    # command, the Game Over teardown and the F9 debug menu.
+    class Battle < Base
+      SCREEN_W = RPG2k::WIDTH
+      SCREEN_H = RPG2k::HEIGHT
+
+      # `req` is the Battle Processing request that opened this fight
+      # (`{ troop_id:, first_strike:, defeat_game_over:, ... }`), `owner` the
+      # interpreter that raised it -- the map's foreground event by default, or
+      # a Parallel Process's own interpreter for a fight it opened itself. The
+      # owner is the one this scene hands its outcome back to (#finish), and
+      # the one Scene::Map checks a frame against before handing it over, so
+      # two interpreters racing for the single battle slot cannot drive each
+      # other's fight.
+      #
+      # Nothing is built here: #start opens the fight (SE, BGM, troop, sprites,
+      # the encounter banner) once the map has this scene in hand, since
+      # opening one can immediately finish it again -- an empty or all-KO'd
+      # party settles to a defeat on the spot -- and that has to be able to
+      # reach back through the map.
+      def initialize(map, req, owner)
+        super map.parent
+        @map = map
+        @state = map.state
+        @rng = map.rng
+        @req = req
+        @owner = owner
+        # Graphic caches belong to the map visit, not to one encounter, so a
+        # monster / backdrop / battler sheet decoded in one fight is still
+        # warm for the next one on the same map (see Scene::Map's own
+        # #cached_bitmap comment).
+        @monster_cache = map.monster_cache
+        @backdrop_cache = map.backdrop_cache
+        @battlecharset_cache = map.battlecharset_cache
+        @system2_cache = map.system2_cache
+      end
+
+      # `ui` is the fight's whole live state: phase, the Game::Battle model,
+      # the combatant snapshots, cursors, windows and sprites. Read by
+      # Scene::Map for the handful of things a running fight changes about the
+      # map's own frame (a timer without the "run in battle" flag pauses, the
+      # message window skips its open animation, the map layers are hidden).
+      attr_reader :ui, :owner, :map
+
+      # The map's windowskin rather than a copy taken at construction: a
+      # Change System Graphic (10680) run from a battle event page reloads it
+      # mid-fight (Scene::Map#reload_windowskin), and every window opened from
+      # here on has to pick the new one up.
+      def windowskin
+        @map.windowskin
+      end
+
+      # Memoize a named graphic load, exactly like Scene::Map's own
+      # #cached_bitmap (see there) -- duplicated rather than reached through
+      # `@map.` since it touches nothing Map-specific, only the cache hash
+      # (one of @monster_cache, @backdrop_cache, @battlecharset_cache,
+      # @system2_cache, all shared with Scene::Map -- see #initialize) and
+      # the key its own caller already resolved.
+      def cached_bitmap(cache, key)
+        return cache[key] if cache.key?(key)
+        cache[key] = yield
+      end
+
+      # Advance the fight one frame: the flash/position/shake ticks every
+      # in-play troop sprite needs regardless of phase, then dispatch on the
+      # current phase to whichever `drive_battle_*` handler drives it (a
+      # command menu, a target cursor, the skill/item sub-menus, the round
+      # animation, the result screen, a running battle-event page, ...).
+      #
+      # Called from Scene::Map#drive_battle every frame this fight is the one
+      # its calling interpreter owns (see there) -- never re-entered for a
+      # *different* interpreter's own Battle Processing command while this
+      # fight has the single battle slot, the same block-and-retry shape
+      # Scene::Map already gives :message/:choice/:number.
+      def update
+        update_enemy_flashes
+        update_enemy_positions
+        update_enemy_shakes
+        case @ui[:phase]
+        when :encounter_message then drive_battle_encounter_message
+        when :battle_options then drive_battle_options
+        when :command     then drive_battle_command
+        when :target      then drive_battle_target
+        when :skill       then drive_battle_skill
+        when :item        then drive_battle_item
+        when :ally_target then drive_battle_ally_target
+        when :animate     then drive_battle_animate
+        when :result      then drive_battle_result
+        when :event       then drive_battle_event
+        end
+        # F9 opens the debug menu mid-fight too -- the ordinary field-map call
+        # site only ever runs once #event_busy? is fully clear, which a battle
+        # never is, so this is the one place that reaches the check while a
+        # fight is open.
+        @map.try_open_debug_menu
+      end
+
+      def start
+        # RPG_RT's own `Scene_Battle` constructor (src/scene_battle.cpp) plays
+        # the database's Battle Start system SE (`SFX_BeginBattle`) as its very
+        # first act, unconditionally and before even the battle BGM swap --
+        # `#play_system_se`/`SFX_BATTLE` already exist (Scene::Base's shared
+        # system-SE table, `DB_SE_FIELD`), but nothing here ever called them for
+        # this slot: Escape/dodge/damage/death/item all already fire at their
+        # own moments (SFX_ESCAPE/SFX_DODGE/SFX_ENEMY_DAMAGE/SFX_ACTOR_DAMAGE/
+        # SFX_ENEMY_DEATH/SFX_ITEM), only the battle-open moment itself was
+        # silent.
+        # Fires for every encounter this scene ever opens through -- a foreground
+        # Enemy Encounter command, one issued from a Parallel Process, and a
+        # random/wandering-monster encounter -- since #start is their one
+        # shared entry point.
+        play_system_se(SFX_BATTLE)
+        @map.play_battle_bgm
+        troop = Game::Troop.new(db, @req[:troop_id])
+        allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
+        foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
+        # The database's state table drives per-turn afflictions (poison slip,
+        # sleep skip) in battle.
+        situations = db.respond_to?(:situation) ? db.situation : nil
+        properties = db.respond_to?(:property) ? db.property : nil
+        @ui = { phase: :command, troop: troop,
+                       # Whether the Battle/Auto Battle/Escape options window
+                       # has already shown its once-per-battle automatic
+                       # appearance (see #enter_command_phase) -- distinct
+                       # from `opt`, the cursor row inside it whenever it is
+                       # open (set fresh by #start_options each time).
+                       options_shown: false, opt: 0,
+                       # `allies.dup`, not `allies` itself: `@ui[:allies]`
+                       # below stays the exact same array Game::Battle is
+                       # handed here would otherwise *be* -- Ruby arrays are
+                       # mutable objects, so without the dup, deleting a
+                       # departed member from the render-facing
+                       # `@ui[:allies]` (#remove_battle_actor_sprite)
+                       # would delete it from Game::Battle's own bookkeeping
+                       # array too, breaking the rejoin-reuses-the-same-
+                       # Combatant guarantee #sync_allies_from_party depends
+                       # on (ADR 0050). The two arrays start with the same
+                       # Combatant *objects* (so a lookup through either one
+                       # sees the same battle-only state) but are free to
+                       # diverge in which objects they each hold.
+                       battle: Game::Battle.new(allies.dup, foes, @rng,
+                                                situations, true, true, true,
+                                                @req[:first_strike] ? true : false,
+                                                properties,
+                                                # Lets the troop run its 行動パターン:
+                                                # skills, transformations and the
+                                                # switch / party-level conditions.
+                                                Game::EnemyAi.new(db, @state),
+                                                # A negative attribute rank rate
+                                                # (see #apply_attr_multiplier)
+                                                # is handled differently per
+                                                # edition.
+                                                rpg2003: db.respond_to?(:rpg2003?) && db.rpg2003?,
+                                                # Mid-battle roster sync
+                                                # (Game::Battle#sync_allies_from_party):
+                                                # a Change Party Member command
+                                                # run from a battle event page
+                                                # mutates this same live
+                                                # Game::Party, and the battle
+                                                # re-derives its own @allies
+                                                # from it every round/action
+                                                # rather than staying pinned to
+                                                # the `allies` snapshot taken
+                                                # just above. The screen itself
+                                                # (`@ui[:allies]`, the
+                                                # status window, actor sprites)
+                                                # follows the same change the
+                                                # instant it happens instead --
+                                                # see #on_battle_party_changed,
+                                                # reached from
+                                                # Interpreter#do_change_party
+                                                # via `@ui[:events].
+                                                # battle_screen` below.
+                                                party: @state.party),
+                       allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
+                       skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
+                       skills: [], items: [],
+                       status_win: nil, cmd_win: nil, target_win: nil,
+                       skill_win: nil, item_win: nil, ally_win: nil,
+                       action_win: nil, anim_timer: 0,
+                       back_sprite: nil, enemy_sprites: nil,
+                       result_win: nil, result: nil,
+                       # The troop's battle-event pages: their own interpreter,
+                       # the message window they draw into, and which pages have
+                       # already fired this turn (RPG2000 runs a page once per
+                       # turn its condition holds, so this resets each round).
+                       events: Game::Interpreter.new(@state), event_win: nil,
+                       pages_run: {},
+                       # Whether the just-drained #step_action entry finished
+                       # its battler's whole action (see #drive_battle_animate),
+                       # and which phase a running battle-event page resumes to
+                       # once it finishes (see #run_battle_events).
+                       battler_boundary: false, event_return_phase: :command,
+                       # Frames elapsed since this battle opened -- cosmetic
+                       # only (drives a levitating enemy's bob, #flying_offset),
+                       # never read for any combat/save-affecting purpose, so
+                       # it needs no seeding beyond starting at 0 every fight.
+                       frame: 0 }
+        @ui[:events].battle = @ui[:battle]
+        # Lets a Change Party Member command run from a battle event page
+        # (Interpreter#do_change_party) reach back into this screen the
+        # moment it fires -- see #on_battle_party_changed. `@ui[:events]`
+        # is the one interpreter ever running commands while a battle is open
+        # (the foreground/parallel interpreters are held off by `event_busy?`/
+        # `parallels_paused?` for as long as `@ui` exists), so this is
+        # never set on any other interpreter.
+        @ui[:events].battle_screen = self
+        # A battle page can Call Common Event (1005), so it needs the same
+        # resolver the encounter's own owning interpreter runs against --
+        # the foreground by default, or a Parallel Process's own interpreter
+        # for a fight it opened itself (see `owner` above).
+        @ui[:events].resolver = @owner.resolver
+        build_battle_sprites
+        build_actor_sprites
+        refresh_battle_status
+        # RPG_RT's own `Scene_Battle_Rpg2k::ProcessSceneActionStart`
+        # (EasyRPG Player's `src/scene_battle_rpg2k.cpp`) narrates the
+        # encounter before the party is ever asked for a command: one
+        # `terms.encounter` line per visible (non-`hidden`) troop member
+        # -- `Game_EnemyParty::GetActiveBattlers`, "not dead or hidden" --
+        # each built by concatenating the enemy's own name in front of the
+        # term (`Window_BattleMessage::PushWithSubject`'s stock, non-
+        # Maniac-Patch branch: `subject + message`, no placeholder), then,
+        # if this encounter is a first-strike ambush
+        # (`req[:first_strike]`, already threaded through to `Game::Battle`
+        # above for the actual mechanic), a final fixed `terms.
+        # special_combat` line with no name substitution -- pushed
+        # *in addition to*, not instead of, the per-enemy lines, exactly as
+        # real RPG_RT orders them. Nothing shows when the troop is entirely
+        # hidden and the fight is not a first strike, matching
+        # `if (!visible_enemies.empty()) SetWait(...)` gating the whole
+        # substate there.
+        lines = battle_encounter_lines(troop, @req)
+        if lines.empty?
+          return if run_battle_events
+          settle_already_finished_battle || enter_command_phase
+        else
+          show_battle_banner(lines)
+          @ui[:phase] = :encounter_message
+          @ui[:anim_timer] = BATTLE_ENCOUNTER_MSG_FRAMES
+        end
+      end
+
+      # The encounter narration lines built above -- see #start's own
+      # comment for the real-RPG_RT sourcing. Returns [] when there is
+      # nothing to say (every troop member hidden, no first strike).
+      def battle_encounter_lines(troop, req)
+        lines = troop.members.reject(&:hidden).map do |enemy|
+          "#{enemy.name}#{term(:encounter, ' appeared!')}"
+        end
+        lines << term(:special_combat, 'You get the first strike!') if req[:first_strike]
+        lines
+      end
+
+      # How long the encounter banner lingers before the command phase opens.
+      # Real RPG_RT paces this per-line with wordwrap and per-page wait
+      # timers (`SetWait(4, 4)` / `SetWait(8, 8)` / `SetWait(30, 70)`); this
+      # screen has no per-page message window (see #battle_result_lines'
+      # own comment on the same simplification), so the whole banner -- every
+      # line at once -- holds for one flat beat instead, matching only
+      # RPG_RT's own minimum `SetWait(4, 4)` gate rather than the full
+      # per-line reading pause -- long enough to register as its own frame
+      # of input-free banner before the command menu takes over the same
+      # screen rect.
+      BATTLE_ENCOUNTER_MSG_FRAMES = 4
+
+      # Drive the encounter-message phase: hold the banner for
+      # `BATTLE_ENCOUNTER_MSG_FRAMES`, then drop it and fall into the same
+      # turn-0-battle-event / command-phase flow #start used to reach
+      # directly.
+      def drive_battle_encounter_message
+        if @ui[:anim_timer] > 0
+          @ui[:anim_timer] -= 1
+          return
+        end
+        close_battle_action
+        @ui[:phase] = :command
+        return if run_battle_events
+        settle_already_finished_battle || enter_command_phase
+      end
+
+      # An encounter can start already decided — an empty party (every member
+      # removed via Change Party Member) or one left all-KO'd from a prior
+      # fight, with no revive in between, both read as no living ally at all.
+      # `#draw_battle_command`'s `current_actor` (`living_allies[actor_i]`) is
+      # nil either way, so it already declines to open a command window
+      # (`return unless actor`) rather than crash — but nothing then moved the
+      # battle on, since a round only ever starts once the player picks a
+      # command for *some* actor. The command phase sat frozen forever, never
+      # reaching the `battle.finished?` check `#finish_round_animation`/
+      # `#leave_battle_event_phase` run after every other round, instead of
+      # yado.tk's documented "battling with an empty party is instant defeat"
+      # (worded the same way for an all-KO'd one). `Game::Battle#end_round`
+      # is what actually computes `#result` (`alive?(@allies) ? :victory :
+      # :defeat`); calling it here settles the same way an ordinary round
+      # ending would, with nothing to clear (`@allies.each` no-ops on an empty
+      # or already-KO'd roster). Returns whether it fired, so `#start`
+      # only falls back to the normal command window when there is actually
+      # someone to command.
+      def settle_already_finished_battle
+        battle = @ui[:battle]
+        return false unless battle.finished?
+        battle.end_round
+        enter_battle_result(battle.result)
+        true
+      end
+
+      # A troop member's sprite depth for its add-order index `i` (0-based).
+      # RPG2000 numbers troop members by add-order and renders the
+      # **lower**-numbered member closer to the camera (yado.tk); the native
+      # renderer draws the *highest*-z sprite on top (see `gfx_update`'s own
+      # "leaving the greatest z on top"), so index 0 needs the highest z here
+      # -- the reverse of the add-order index itself.
+      def battler_z(i)
+        100 + (@ui[:troop].members.size - 1 - i)
+      end
+
+      # Vertical pixel bob for a levitating (`Game::Enemy#levitate`) troop
+      # member, or 0 for everyone else. yado.tk only ever says the "airborne"
+      # flag "changes its Y position on screen" with no magnitude or edition
+      # given; EasyRPG's own `Game_Enemy::GetFlyingOffset` supplies both
+      # missing facts and, more importantly, the edition gate the yado.tk
+      # source never mentioned at all: `if (!Player::IsRPG2k3() || !IsFlying())
+      # return 0;` -- "2k does not support flying, albeit mentioned in the
+      # help file" (their comment). So a genuine RPG2000 database's own
+      # `levitate` flag has no on-screen effect whatsoever, real RPG_RT bug and
+      # all; only an RPG2003 one draws the +/-4px, 256-frame-period sine bob
+      # (`round(sin(2*PI*frame/256) * 4)`, their `frame` a per-battler counter
+      # incremented once per battle frame) computed here from this scene's own
+      # per-battle `@ui[:frame]` instead -- a single shared phase for
+      # every levitating member rather than EasyRPG's per-battler-randomized
+      # start offset, since nothing in either wiki mirror (both unreachable
+      # this session) describes members desyncing from one another, only that
+      # each one "changes its Y position".
+      FLYING_AMPLITUDE = 4
+      FLYING_PERIOD = 256
+      def flying_offset(member)
+        return 0 unless member.levitate && @state.party.rpg2003?
+        frame = @ui[:frame] || 0
+        (Math.sin(2 * Math::PI * frame / FLYING_PERIOD.to_f) * FLYING_AMPLITUDE).round
+      end
+
+      # A troop member's on-screen y, centred on its database position and
+      # nudged by #flying_offset -- shared by every site that (re)builds an
+      # enemy sprite so the three stay in lockstep with the per-frame update
+      # (#update_enemy_positions) that keeps a levitating one bobbing after.
+      def battler_y(member, bmp)
+        member.y - bmp.height / 2 + flying_offset(member)
+      end
+
+      # A troop member's sprite opacity: 160/255 (~63%) for one flagged
+      # "Appear Transparent" (`Game::Enemy#transparent`, database field 10),
+      # 255 (fully opaque) for everyone else -- verified against EasyRPG
+      # Player's actual C++ source, `Sprite_Enemy::Draw`'s `alpha = 160 * alpha
+      # / 255` (`src/sprite_enemy.cpp`), with `alpha` at its 255 baseline since
+      # this codebase has no death-fade/explode sprite animation to scale it
+      # from. Purely cosmetic, no accuracy/evasion effect, same as
+      # #flying_offset -- shared by every site that (re)builds an enemy sprite
+      # so all three agree.
+      TRANSPARENT_ENEMY_OPACITY = 160
+      def battler_opacity(member)
+        member.transparent ? TRANSPARENT_ENEMY_OPACITY : 255
+      end
+
+      # RPG2000 is a front-view battle: the enemy troop is drawn as sprites over a
+      # battle background, while the party is represented by the status window (not
+      # sprites). Build the backdrop and one sprite per visible troop member,
+      # centred on its database position. Hidden (invisible) members get no sprite
+      # until a battle event reveals them — a mechanism still to come.
+      def build_battle_sprites
+        build_battle_back(encounter_backdrop)
+        @ui[:enemy_sprites] = @ui[:troop].members.each_with_index.map do |enemy, i|
+          next nil if enemy.hidden
+          bmp = battler_bitmap(enemy)
+          spr = Sprite.new
+          spr.bitmap = bmp
+          spr.x = enemy.x - bmp.width / 2
+          spr.y = battler_y(enemy, bmp)
+          spr.z = battler_z(i)
+          spr.opacity = battler_opacity(enemy)
+          spr
+        end
+        # The battler (graphic name + hue) each sprite was drawn from, so a
+        # transformation mid-fight is noticed and redrawn (see
+        # #refresh_battle_sprites) -- matching EasyRPG's own
+        # `Sprite_Enemy::Refresh`, which rebuilds on either changing.
+        @ui[:sprite_names] = @ui[:foes].map { |f| f.battler_name }
+        @ui[:sprite_hues] = @ui[:foes].map { |f| f.battler_hue || 0 }
+        refresh_battle_sprites
+      end
+
+      # RPG2003's alternative/gauge battle layouts draw each living party
+      # member as a sprite too (unlike RPG2000's status-window-only layout --
+      # see Game::Party#alternate_battle_layout?), sourced from the
+      # database's Battler Animation table (chunk 32, db.battleranimations --
+      # decoded in a prior change, nothing read it until now). Scoped to the
+      # plain Idle pose only (Pose id 0): no active state, not defending --
+      # EasyRPG's Sprite_Actor::DoIdleAnimation (src/sprite_actor.cpp) swaps
+      # in a Defend or state-mapped pose in those two cases, which is
+      # follow-up work for a later change, not this one. A dead party member
+      # gets no sprite (mirrors a hidden troop member never getting one
+      # either in #build_battle_sprites above); the party status window keeps
+      # showing everyone regardless, so a member left spriteless here (dead,
+      # or any of the gaps #build_actor_sprite itself documents) is never
+      # invisible to the player. A traditional-layout database (or a bare
+      # test fixture whose party doesn't even answer #alternate_battle_layout?)
+      # builds nothing, matching current behaviour exactly.
+      def build_actor_sprites
+        @ui[:actor_sprites] = nil
+        return unless @state.party.respond_to?(:alternate_battle_layout?) &&
+                      @state.party.alternate_battle_layout?
+        @ui[:actor_sprites] = @ui[:allies].each_with_index.map do |ally, i|
+          next nil if ally.dead?
+          build_actor_sprite(ally.actor, i)
+        end
+      end
+
+      # Idle pose id within a `db.battleranimations` entry's `poses` table
+      # (lcf::rpg::BattlerAnimation::Pose_Idle -- schema.rb's own comment on
+      # chunk 32 lists the full 12-pose order).
+      ACTOR_IDLE_POSE = 0
+      # `poses[id].animation_type` values: 0 a BattleCharSet sprite sheet
+      # (implemented below), 1 a full Battle/<name> (CBA) animation sequence
+      # played in place of a static sprite (not implemented here -- see
+      # #build_actor_sprite).
+      ACTOR_POSE_TYPE_BATTLE = 1
+      # A BattleCharSet sheet is framed in fixed 48x48 cells, one row per
+      # `battler_index` (EasyRPG's Sprite_Actor::OnBattlercharsetReady --
+      # `SetSrcRect(Rect(0, battler_index * 48, 48, 48))`).
+      ACTOR_CHARSET_CELL = 48
+      # Clear of both the enemy troop's own z range (#battler_z's 100 +
+      # troop_size-1 span) and the animation overlay's z 150, so an actor
+      # sprite never fights either for draw order; still well below every UI
+      # window (z >= 300).
+      def actor_sprite_z(i)
+        200 + i
+      end
+
+      # A living party member's Idle-pose sprite, or nil when this step
+      # cannot draw one: `actor.battler_animation_id` names no
+      # `db.battleranimations` entry (Game::Actor#battler_animation_id
+      # already logs that diagnostic itself), the resolved entry defines no
+      # Idle pose at all (silent -- an entry legitimately covering only some
+      # of the 12 poses is normal authoring, not a dangling reference), or
+      # the pose uses the `animation_type == 1` battle/CBA format this step
+      # does not implement (logged below, matching this codebase's "reported
+      # gap, not silently invented" convention for unimplemented behaviour).
+      #
+      # Position is the raw database `battle_x`/`battle_y`
+      # (Game_Actor::GetOriginalPosition) -- confirmed against EasyRPG's
+      # actual C++ source this is only what `battlecommands.placement`
+      # manual (0) uses; automatic (1) instead computes a real grid formula
+      # (`CalculateBaseGridPosition`, src/game_battle.cpp) this step does not
+      # implement either, so that case also just logs and falls back to the
+      # same raw coordinates rather than guessing at the formula.
+      def build_actor_sprite(actor, i)
+        anim_id = actor.respond_to?(:battler_animation_id) ? (actor.battler_animation_id || 0) : 0
+        table = db.respond_to?(:battleranimations) ? db.battleranimations : nil
+        entry = (table && anim_id > 0) ? table[anim_id] : nil
+        return nil unless entry
+        pose = entry.respond_to?(:poses) && entry.poses ? entry.poses[ACTOR_IDLE_POSE] : nil
+        return nil unless pose
+
+        if pose.animation_type == ACTOR_POSE_TYPE_BATTLE
+          $stderr.puts "[RPG2k] actor ##{actor.id}: idle pose uses a battle-animation (CBA) " \
+                       "sheet, not a BattleCharSet -- not yet implemented, sprite not drawn"
+          return nil
+        end
+
+        bmp = actor_battlecharset_bitmap(pose.battler_name)
+        return nil unless bmp
+
+        if @state.party.respond_to?(:automatic_battle_placement?) &&
+           @state.party.automatic_battle_placement?
+          $stderr.puts "[RPG2k] actor ##{actor.id}: automatic battler placement not yet " \
+                       "implemented, using the database's manual battle_x/battle_y"
+        end
+
+        spr = Sprite.new
+        spr.bitmap = bmp
+        spr.src_rect = Rect.new(0, (pose.battler_index || 0) * ACTOR_CHARSET_CELL,
+                                ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL)
+        spr.x = actor.respond_to?(:battle_x) ? (actor.battle_x || 0) : 0
+        spr.y = actor.respond_to?(:battle_y) ? (actor.battle_y || 0) : 0
+        spr.z = actor_sprite_z(i)
+        spr
+      end
+
+      # Interpreter#do_change_party's hook (via `@ui[:events].
+      # battle_screen`, set in #start) for a Change Party Member battle
+      # event that actually added or removed a member -- mirrors EasyRPG's
+      # `Game_Party::AddActor`/`RemoveActor` calling
+      # `Scene_Battle_Rpg2k::OnPartyChanged` synchronously, right when the
+      # party changes, rather than leaving the screen to notice on some later
+      # redraw. `actor` is the `Game::Actor` (from `Game::Party#roster`, so it
+      # resolves the same whether they are still a member or just left).
+      # `Game::Battle`'s own roster (`@ui[:battle]`) is left alone --
+      # its `sync_allies_from_party`/`out_of_play?`/`member` bookkeeping
+      # (ADR 0050) already reads correctly from the live party on its own
+      # schedule; this only updates what's drawn.
+      def on_battle_party_changed(actor, added)
+        return unless @ui
+        added ? add_battle_actor_sprite(actor) : remove_battle_actor_sprite(actor)
+        refresh_battle_status
+      end
+      public :on_battle_party_changed
+
+      # An actor just (re)joined the fight: reuse their existing `Combatant`
+      # if `Game::Battle` already has one (they left and are rejoining this
+      # same fight, so the reused object keeps its accumulated battle-only
+      # state -- the same reuse-on-rejoin guarantee ADR 0050 gives the
+      # mechanics), or build a fresh one exactly the way
+      # `Game::Battle#sync_allies_from_party` would on its own next sync --
+      # pushed onto `@ui[:battle].allies` (not just returned) so that
+      # later sync finds it already there and reuses it too, rather than the
+      # render layer and the battle ending up tracking two different
+      # `Combatant` objects for the same actor.
+      def add_battle_actor_sprite(actor)
+        battle = @ui[:battle]
+        combatant = battle.ally_by_actor_id(actor.id)
+        unless combatant
+          combatant = Game::Battle.from_actor(actor)
+          battle.allies.push(combatant)
+        end
+        return if @ui[:allies].any? { |c| c.equal?(combatant) }
+        @ui[:allies].push(combatant)
+        return unless @ui[:actor_sprites]
+        i = @ui[:allies].length - 1
+        @ui[:actor_sprites].push(combatant.dead? ? nil : build_actor_sprite(combatant.actor, i))
+        reset_actor_battler_z
+      end
+
+      # An actor just left the fight: drop their `Combatant` from the
+      # render-facing `@ui[:allies]` (not from `Game::Battle`'s own
+      # roster -- see #on_battle_party_changed) and dispose their specific
+      # sprite, leaving every other actor's sprite untouched. A rejoin later
+      # builds a brand new sprite (#add_battle_actor_sprite always calls
+      # #build_actor_sprite fresh); this never leaves a disposed `Sprite`
+      # sitting in the collection for that to reuse.
+      def remove_battle_actor_sprite(actor)
+        idx = @ui[:allies].index { |c| c.actor && c.actor.id == actor.id }
+        return unless idx
+        @ui[:allies].delete_at(idx)
+        sprites = @ui[:actor_sprites]
+        return unless sprites
+        dispose_battle_sprite(sprites.delete_at(idx))
+        reset_actor_battler_z
+      end
+
+      # Re-derive every surviving actor sprite's Z from its current index in
+      # `@ui[:allies]` (#actor_sprite_z). An add or remove elsewhere in
+      # the roster shifts everyone after it, so without this, two sprites can
+      # end up sharing a Z once enough adds/removes have happened -- e.g.
+      # remove index 1 of 3 (leaving index 2's sprite still at its old Z 202),
+      # then add a new member at the new index 2, which would also compute Z
+      # 202. Matches EasyRPG's own `ResetAllBattlerZ()`, called for the same
+      # reason right after `OnPartyChanged` adds a sprite.
+      def reset_actor_battler_z
+        sprites = @ui[:actor_sprites]
+        return unless sprites
+        sprites.each_with_index { |spr, i| spr.z = actor_sprite_z(i) if spr }
+      end
+
+      # The BattleCharSet bitmap for an actor pose's `battler_name`, cached
+      # like every other named battle graphic (see #cached_bitmap) and
+      # colour-keyed the same way CharSet/Monster are. A missing/empty name
+      # or a failed load draws the same solid placeholder block
+      # #battler_bitmap falls back to for a missing enemy graphic (see
+      # #placeholder_battler), sized to one BattleCharSet cell so the
+      # src_rect crop in #build_actor_sprite still makes sense against it.
+      def actor_battlecharset_bitmap(name)
+        key = (name && !name.empty?) ? name : nil
+        cached_bitmap(@battlecharset_cache, key) do
+          if key
+            begin
+              Bitmap.new("BattleCharSet/#{name}", true)
+            rescue StandardError => e
+              $stderr.puts "[RPG2k] actor battler '#{name}' load failed: #{e.message}"
+              actor_placeholder_battler
+            end
+          else
+            actor_placeholder_battler
+          end
+        end
+      end
+
+      def actor_placeholder_battler
+        bmp = Bitmap.new(ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL)
+        bmp.fill_rect 0, 0, ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL, Color.new(180, 60, 60, 255)
+        bmp
+      end
+
+      # Where a battle-event page's message panel sits — above the action banner,
+      # so a page talking mid-round does not fight it for the same row.
+      BATTLE_EVENT_MSG_Y = 8
+
+      # The backdrop this encounter fights over: whatever Game::Backdrop resolves
+      # for the current map, given the terrain the party is standing on. '' when
+      # nothing names one, which draws the flat field.
+      def encounter_backdrop
+        Game::Backdrop.name_for(@state.map_id, @map.map_properties,
+                                @map.terrain_backdrop(@state.x, @state.y))
+      end
+
+      def build_battle_back(name = nil)
+        bmp = battle_back_bitmap(name)
+        spr = Sprite.new
+        spr.bitmap = bmp
+        spr.z = 5
+        @ui[:back_sprite] = spr
+      end
+
+      # The battle backdrop: the Backdrop/<name> image a Change Battle Background
+      # command (or the encounter) named, falling back to the flat colour field
+      # when there is no name or the file is missing — the same fallback the map
+      # uses for a missing chipset. Cached by name (see #cached_bitmap) so
+      # re-entering the same encounter, or a battle event that swaps back to a
+      # backdrop already shown this visit, does not re-decode it.
+      def battle_back_bitmap(name)
+        key = (name && !name.empty?) ? name : nil
+        cached_bitmap(@backdrop_cache, key) do
+          if key
+            begin
+              Bitmap.new("Backdrop/#{key}")
+            rescue StandardError => e
+              $stderr.puts "[RPG2k] battle backdrop '#{key}' failed to load: #{e.message}"
+              flat_battle_back
+            end
+          else
+            flat_battle_back
+          end
+        end
+      end
+
+      def flat_battle_back
+        bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(16, 16, 32, 255)
+        bmp
+      end
+
+      # Change Battle Background (13210): swap the backdrop mid-fight, releasing
+      # the sprite and bitmap the old one held.
+      def rebuild_battle_back(name)
+        dispose_battle_sprite(@ui[:back_sprite])
+        @ui[:back_sprite] = nil
+        build_battle_back(name)
+      end
+
+      # The battler graphic for `enemy` (Monster/<battler_name>, colour-keyed), or
+      # a solid placeholder block when it has no graphic or the file is missing —
+      # the same fallback strategy the map uses for a missing chipset. Cached by
+      # name+hue (see #cached_bitmap) so a monster reused across troop slots, or a
+      # transformation that returns to a battler already shown this visit, is
+      # decoded (and hue-rotated) once. The hue rotation (database field 3, see
+      # `Game::Enemy#battler_hue`) is applied to this decode alone, never to a
+      # cached bitmap already shared by a same-named, differently-hued sibling —
+      # `Bitmap#hue_change` (`mruby-rgss/src/lib.cxx`) mutates in place, so the
+      # cache key must fold hue in rather than rotate a shared entry.
+      def battler_bitmap(enemy)
+        name = enemy.battler_name
+        hue = enemy.respond_to?(:battler_hue) ? (enemy.battler_hue || 0) : 0
+        key = (name && !name.empty?) ? "#{name}\0#{hue}" : nil
+        cached_bitmap(@monster_cache, key) do
+          if key
+            begin
+              bmp = Bitmap.new("Monster/#{name}", true)
+              bmp.hue_change(hue) if hue != 0
+              bmp
+            rescue StandardError => e
+              $stderr.puts "[RPG2k] battler load failed for #{enemy.name}: #{e.message}"
+              placeholder_battler
+            end
+          else
+            placeholder_battler
+          end
+        end
+      end
+
+      def placeholder_battler
+        bmp = Bitmap.new(32, 32)
+        bmp.fill_rect 0, 0, 32, 32, Color.new(180, 60, 60, 255)
+        bmp
+      end
+
+      # Decay any in-flight target-scope Battle Animation flash (#fire_target_flash)
+      # by one frame. RGSS's native Sprite#flash bakes its colour into the
+      # composite and fades it linearly, but only when driven by an explicit
+      # Sprite#update each frame (mruby-rgss/src/lib.cxx) -- the same contract
+      # #update_map_tone already drives on @map_viewport/@upper_viewport, just
+      # for the per-enemy sprites instead of a viewport tone. A sprite with no
+      # flash in flight costs nothing here (native #update no-ops).
+      def update_enemy_flashes
+        (@ui[:enemy_sprites] || []).each { |s| s.update if s }
+      end
+
+      # Advance the per-battle frame counter #flying_offset reads and re-seat
+      # any levitating troop member's sprite at its new bob height. A no-op
+      # (bar the counter tick) for a plain RPG2000 fight or a troop with no
+      # `levitate` member: #flying_offset already reads 0 for both, so the
+      # assignment below is just re-writing the same y already set.
+      def update_enemy_positions
+        @ui[:frame] = (@ui[:frame] || 0) + 1
+        sprites = @ui[:enemy_sprites]
+        return unless sprites
+        @ui[:troop].members.each_with_index do |member, i|
+          spr = sprites[i]
+          next unless spr && member.levitate
+          spr.y = battler_y(member, spr.bitmap)
+        end
+      end
+
+      # Show a living enemy's sprite, hide a defeated one — called after each
+      # animated action so a downed enemy vanishes from the field.
+      def refresh_battle_sprites
+        sprites = @ui[:enemy_sprites]
+        return unless sprites
+        # A transformation swaps a monster's graphic mid-fight, so redraw any
+        # combatant no longer wearing the battler its sprite was built from
+        # before deciding what is visible.
+        names = (@ui[:sprite_names] ||= [])
+        hues = (@ui[:sprite_hues] ||= [])
+        @ui[:foes].each_with_index do |foe, i|
+          changed = names[i] != foe.battler_name || hues[i] != (foe.battler_hue || 0)
+          rebuild_battler_sprite(i, foe) if sprites[i] && changed
+        end
+        @ui[:foes].each_with_index do |foe, i|
+          spr = sprites[i]
+          # Out of play, not merely dead: a monster that has fled (its own Escape
+          # action, or a page's Force Flee) or one still flagged invisible is off
+          # the field and must not be drawn — the same test #living_foes uses to
+          # keep it out of the target cursor.
+          spr.visible = !foe.out_of_play? if spr
+        end
+      end
+
+      # Redraw troop slot `i` with `foe`'s current battler graphic, keeping its
+      # place and depth, and release the sprite and bitmap the old one held.
+      def rebuild_battler_sprite(i, foe)
+        sprites = @ui[:enemy_sprites]
+        member = @ui[:troop].members[i]
+        return unless member
+        old = sprites[i]
+        bmp = battler_bitmap(foe)
+        spr = Sprite.new
+        spr.bitmap = bmp
+        spr.x = member.x - bmp.width / 2
+        spr.y = battler_y(member, bmp)
+        spr.z = battler_z(i)
+        spr.opacity = battler_opacity(member)
+        spr.visible = !foe.out_of_play?
+        sprites[i] = spr
+        dispose_battle_sprite(old)
+        @ui[:sprite_names][i] = foe.battler_name
+        @ui[:sprite_hues][i] = foe.battler_hue || 0
+      end
+
+      def living_allies; @ui[:allies].reject(&:dead?); end
+
+      # Living allies selectable as a manually-chosen Battle Item target right
+      # now: `#living_allies` narrowed by the pending item's own 使用可能キャラ
+      # (`actor_set`) restriction when there is one -- the same per-recipient
+      # gate `Game::Party#use_medicine` already applies in the field menu
+      # (`Game::Party#item_usable_by?`), which this picker had never
+      # consulted at all, so a party member the item cannot affect used to be
+      # offered as a choice anyway rather than not appearing in the first
+      # place. A pending skill is untouched -- actor_set only gates
+      # equipment/items, never skills. `@state.party` not answering
+      # `item_usable_by?` (a battle test's stub party, which never models
+      # equipment restrictions) degrades to "unrestricted", the same default
+      # the real method itself falls back to for an item with no actor_set at
+      # all.
+      def battle_ally_targets
+        allies = living_allies
+        return allies unless pending_kind == :item
+        return allies unless @state.party.respond_to?(:item_usable_by?)
+        it = @ui[:pending] && @ui[:pending][:it]
+        return allies unless it
+        allies.select { |a| a.actor.nil? || @state.party.item_usable_by?(it, a.actor.id) }
+      end
+      # Targetable foes: alive *and* in play, so a troop member still flagged
+      # invisible never appears in the target cursor.
+      def living_foes;   @ui[:foes].reject(&:out_of_play?); end
+      def current_actor; living_allies[@ui[:actor_i]]; end
+
+      # The real Game::Actor behind the current battler (the snapshots are built
+      # from the party in order), so the Skill menu can read its known skills.
+      def current_actor_row
+        idx = @ui[:allies].index(current_actor)
+        idx ? @state.party.actors[idx] : nil
+      end
+
+      # The per-actor commands, in menu order (the cursor row is 1 + index,
+      # below the actor-name header): each a `{ label:, action: }` pair, drawn
+      # by `#battle_commands` below and dispatched by `#select_battle_command`.
+      #
+      # An acting actor whose own RPG2003 battle-command list
+      # (`Game::Actor#battle_commands`, edited by Change Battle Commands (1009)
+      # or a class change) resolves to at least one usable entry drives the
+      # menu; otherwise this falls back to the fixed **Attack, Skill, Defend,
+      # Item** four — EasyRPG's `Scene_Battle_Rpg2k::CreateBattleCommandWindow`
+      # builds that exact array (`command_attack`, `command_skill`,
+      # `command_defend`, `command_item`), not the Item-before-Defend order
+      # this used to assume, read from the database's battle-command terms with
+      # the standard RPG2k labels as fallback. The Skill slot is not memoized:
+      # it substitutes the acting actor's own RPG2000 rename
+      # (`#skill_command_label` below) when the database sets one, so it can
+      # change from one actor's turn to the next.
+      def battle_command_rows
+        actor = current_actor_row
+        custom = actor && custom_battle_commands(actor)
+        return custom if custom
+
+        [
+          { label: term(:battle_attack, 'Attack'), action: :attack },
+          { label: skill_command_label, action: :skill },
+          { label: term(:battle_defend, 'Defend'), action: :defend },
+          { label: term(:battle_item, 'Item'), action: :item }
+        ]
+      end
+
+      # `actor`'s own RPG2003 battle-command list resolved to menu rows, or nil
+      # when there is nothing usable in it (no data at all -- an RPG2000
+      # database, or a class/actor row that never set field 80, both of which
+      # `Game::Actor#battle_commands` itself already reports as `[0]`, Row
+      # alone -- or every entry turned out unsupported), so the caller falls
+      # back to the fixed four.
+      #
+      # Each id is either 0 (Row -- not a menu row here any more than in
+      # EasyRPG's own `Game_Actor::GetBattleCommands`, whose comment marks it
+      # "not impl" and skips it the same way), -1 (an empty padding slot,
+      # likewise skipped), or a positive ref into the database's own
+      # Battle-Commands table (`Game::Actor#battle_command_row`) naming one
+      # entry's `name` + `type`. Only the four types this engine actually
+      # drives -- Attack, (sub)Skill, Defense, Item -- become a row; Escape
+      # (the first actor's own Cancel already offers it) and Special (no
+      # handler modelled anywhere in this engine) are skipped, same as an
+      # unresolvable ref (a project whose database has no Battle-Commands
+      # table decoded, or an id it doesn't define).
+      def custom_battle_commands(actor)
+        return nil unless actor.respond_to?(:battle_commands)
+        cmds = actor.battle_commands
+        return nil unless cmds
+        rows = cmds.each_with_object([]) do |cmd_id, out|
+          next if cmd_id.nil? || cmd_id <= 0 # Row / empty slot
+
+          row = actor.battle_command_row(cmd_id)
+          next unless row
+
+          case row.type
+          when Game::Actor::BATTLE_COMMAND_ATTACK
+            out << { label: nonblank(row.name, term(:battle_attack, 'Attack')), action: :attack }
+          when Game::Actor::BATTLE_COMMAND_SKILL, Game::Actor::BATTLE_COMMAND_SUBSKILL
+            out << { label: nonblank(row.name, skill_command_label), action: :skill }
+          when Game::Actor::BATTLE_COMMAND_DEFENSE
+            out << { label: nonblank(row.name, term(:battle_defend, 'Defend')), action: :defend }
+          when Game::Actor::BATTLE_COMMAND_ITEM
+            out << { label: nonblank(row.name, term(:battle_item, 'Item')), action: :item }
+          end
+          # Escape / Special: no menu row (see the method comment above).
+        end
+        rows.empty? ? nil : rows
+      end
+
+      def battle_commands
+        battle_command_rows.map { |c| c[:label] }
+      end
+
+      # The Skill command's own label. RPG2000's Actor sheet has a "custom
+      # battle command" checkbox + name field (database fields 66/67,
+      # `Game::Actor#rename_skill?` / `#skill_command_name`) that renames just
+      # this one slot — EasyRPG's own `Game_Actor::GetSkillName`: `rename_skill
+      # ? skill_name : Data::terms.command_skill`. Parsed by the schema and
+      # never read anywhere in this gem before now, so a game that set it (e.g.
+      # renaming Skill to "Magic") showed the generic term regardless.
+      def skill_command_label
+        actor = current_actor_row
+        if actor && actor.respond_to?(:rename_skill?) && actor.rename_skill?
+          nonblank(actor.skill_command_name, term(:battle_skill, 'Skill'))
+        else
+          term(:battle_skill, 'Skill')
+        end
+      end
+
+      # Per-actor command menu: Attack, Skill, Defend or Item.
+      def drive_battle_command
+        if Input.trigger?(Input::DOWN)
+          @ui[:cmd] += 1
+          @ui[:cmd] %= battle_commands.length
+          draw_battle_command
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::UP)
+          @ui[:cmd] -= 1
+          @ui[:cmd] %= battle_commands.length
+          draw_battle_command
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C)
+          select_battle_command
+        elsif Input.trigger?(Input::B)
+          # `ProcessSceneActionCommand`'s own B/Cancel branch plays Cancel
+          # unconditionally, *before* deciding where it lands: `...Cancel...;
+          # --actor_index; SelectPreviousActor();`. `SelectPreviousActor()`
+          # itself is what branches on whether an earlier commandable ally
+          # is left to re-command.
+          play_system_se(SFX_CANCEL)
+          prev_i = prev_commandable_actor_index
+          if prev_i.nil?
+            # `SelectPreviousActor()`'s `allies[0] == active_actor` branch:
+            # the actor whose command list is open is already the first
+            # commandable member, so this reopens the Battle/Auto Battle/
+            # Escape options window (`SetState(State_SelectOption)`) rather
+            # than attempting Escape directly.
+            open_battle_options
+          else
+            # Re-commanding the previous actor is the ordinary case.
+            @ui[:actor_i] = prev_i # re-command the previous commandable member
+            @ui[:cmd] = 0
+            draw_battle_command
+          end
+        end
+      end
+
+      # The Battle/Auto Battle/Escape options window's own menu rows, in
+      # display order (top to bottom, matching real RPG2k's
+      # `battle_options`/`Window_Command` build). `battle_fight`/
+      # `battle_auto`/`battle_escape` are the database's Term fields
+      # 101/102/103 -- decoded by the schema but never read before this.
+      def battle_option_rows
+        [
+          { label: term(:battle_fight, 'Fight'), action: :battle },
+          { label: term(:battle_auto, 'Auto Battle'), action: :auto_battle },
+          { label: term(:battle_escape, 'Escape'), action: :escape }
+        ]
+      end
+
+      # Whether any living ally could actually be handed a manual command
+      # this round -- EasyRPG's own `IsAnyControllable()` guard inside
+      # `ProcessSceneActionFightAutoEscape`, which skips the options window
+      # entirely (straight to actor selection) when the whole party is
+      # asleep/paralysed/similarly restricted or already flagged for auto
+      # battle, since neither Battle nor Auto Battle would have anything left
+      # to act on. `Game_Actor::IsControllable()` is exactly this pair of
+      # checks: `GetSignificantRestriction() == Restriction_normal &&
+      # !GetAutoBattle()`.
+      def any_commandable_ally?
+        battle = @ui[:battle]
+        living_allies.any? { |a| !battle.command_restricted?(a) && !force_ai_actor?(a) }
+      end
+
+      # The command phase's first entry for this battle only -- opens the
+      # options window once, automatically, the way `ProcessSceneActionStart`'s
+      # final substate does unconditionally after the encounter/turn-0-event
+      # messages resolve (`battle_message_window->Clear();
+      # SetState(State_SelectOption);`). Every later re-entry into the command
+      # phase this battle (round 2+, back from a between-rounds battle event
+      # page) goes straight to the ordinary per-actor command window instead --
+      # the window's *other* trigger, B/Cancel on the first commandable actor,
+      # is wired separately in #drive_battle_command and is not gated by this
+      # flag, matching `SelectPreviousActor()`'s own unconditional re-entry.
+      def enter_command_phase
+        if @ui[:options_shown] || !any_commandable_ally?
+          @ui[:options_shown] = true
+          open_next_command
+        else
+          @ui[:options_shown] = true
+          open_battle_options
+        end
+      end
+
+      def open_battle_options
+        @ui[:phase] = :battle_options
+        @ui[:opt] = 0
+        draw_battle_options
+      end
+
+      # The options window's cursor menu -- Up/Down move the cursor, C
+      # confirms the highlighted row. B/Cancel is a deliberate no-op: this is
+      # the state machine's own root here (matching
+      # `ProcessSceneActionFightAutoEscape`'s `eWaitForInput` substate, which
+      # has no cancel handling at all -- there is no parent state to cancel
+      # back to).
+      def drive_battle_options
+        rows = battle_option_rows
+        if Input.trigger?(Input::DOWN)
+          @ui[:opt] += 1
+          @ui[:opt] %= rows.length
+          draw_battle_options
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::UP)
+          @ui[:opt] -= 1
+          @ui[:opt] %= rows.length
+          draw_battle_options
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C)
+          select_battle_option
+        end
+      end
+
+      # Act on the highlighted options-window row. Battle dismisses the
+      # window and falls through to the ordinary per-actor command menu,
+      # exactly where the battle already was before the window opened. Auto
+      # Battle hands the whole round to `#queue_auto_battle_round`. Escape
+      # reuses `#try_battle_escape` verbatim -- the same Decision-vs-Buzzer
+      # gate on `allow_escape` this engine's old direct-B-press shortcut
+      # already had, just triggered from the window instead.
+      def select_battle_option
+        case battle_option_rows[@ui[:opt]][:action]
+        when :battle
+          play_system_se(SFX_DECISION)
+          @ui[:phase] = :command
+          # `open_next_command`, not a direct `draw_battle_command` -- the
+          # window opening never advanced `actor_i` past a restricted/
+          # Forced-AI leading actor (matching real RPG_RT's own
+          # `SelectNextActor` doing that skip itself once `State_SelectActor`
+          # is entered from here, not before).
+          open_next_command
+        when :auto_battle
+          play_system_se(SFX_DECISION)
+          queue_auto_battle_round
+        when :escape
+          if @req[:allow_escape]
+            play_system_se(SFX_DECISION)
+            try_battle_escape
+          else
+            play_system_se(SFX_BUZZER)
+          end
+        end
+      end
+
+      # "Auto Battle": every commandable living ally gets
+      # `Game::Battle#choose_auto_battle_command`'s AI pick queued for the
+      # round instead of the manual per-actor command menu -- the same
+      # engine `#skip_restricted_actors` already calls per-actor for a
+      # 強制AI-flagged ally (see `#force_ai_actor?`), just applied to the
+      # whole party at once rather than one actor. A restricted ally
+      # (asleep/paralysed/forced) is left alone exactly as the ordinary
+      # command phase already leaves it -- its round action is decided
+      # elsewhere, not by a queued command.
+      def queue_auto_battle_round
+        battle = @ui[:battle]
+        living_allies.each do |a|
+          next if battle.command_restricted?(a)
+          battle.choose_auto_battle_command(a)
+        end
+        @ui[:actor_i] = living_allies.length
+        @ui[:phase] = :command
+        open_next_command
+      end
+
+      # Escape command (cancel on the first actor's menu): roll the party's
+      # agility-based escape chance. On success show the result window (the
+      # database's own `escape_success` wording, like a victory or defeat) and
+      # flee once it is dismissed; on a failed roll the party forfeits the
+      # round — every member skips and only the enemies act, bannered with
+      # `escape_failure` the same way a landed hit is — and the next attempt is
+      # likelier (Game::Battle#attempt_escape).
+      def try_battle_escape
+        battle = @ui[:battle]
+        if battle.attempt_escape
+          # A dedicated Escape SE, not Decision -- confirmed against
+          # EasyRPG's own ProcessSceneActionEscape: the success branch plays
+          # `GetSystemSE(SFX_Escape)` right before ending the battle. A
+          # failed attempt plays no SE at all there, just the message.
+          play_system_se(SFX_ESCAPE)
+          enter_battle_result(:escape)
+        else
+          $stderr.puts '[RPG2k battle] escape failed'
+          show_battle_banner([term(:escape_failure, "Couldn't escape!")])
+          living_allies.each { |a| battle.command_skip(a) }
+          start_round_animation
+        end
+      end
+
+      # Act on the highlighted command: Attack / Skill open a selection, Defend
+      # is committed at once. Dispatches by `#battle_command_rows`' own
+      # `action` for the highlighted row rather than a fixed row index, so a
+      # customized, reordered or shortened list (`#custom_battle_commands`)
+      # still routes to the right handler regardless of where each command
+      # landed.
+      # Which SE each command plays on confirm -- Decision immediately for
+      # Attack/Defend (`Scene_Battle::AttackSelected`/`DefendSelected` both
+      # play it as their own first statement, before doing anything else),
+      # Skill/Item deferred to #start_skill/#start_item since
+      # RPG_RT's own Decision-on-opening-the-submenu and Buzzer-on-nothing-
+      # to-pick are both conditional on that submenu's own state there.
+      def select_battle_command
+        case battle_command_rows[@ui[:cmd]][:action]
+        when :attack
+          play_system_se(SFX_DECISION)
+          @ui[:pending] = { kind: :attack }
+          @ui[:target_i] = 0
+          @ui[:phase] = :target
+          draw_battle_target
+        when :skill then open_battle_skill
+        when :defend
+          play_system_se(SFX_DECISION)
+          @ui[:battle].command_defend(current_actor)
+          advance_actor
+        when :item then open_battle_item
+        end
+      end
+
+      # Enemy target-selection menu: pick which living enemy the Attack (or an
+      # enemy-scope Skill) hits.
+      def drive_battle_target
+        foes = living_foes
+        if Input.trigger?(Input::DOWN) && !foes.empty?
+          @ui[:target_i] += 1
+          @ui[:target_i] %= foes.length
+          draw_battle_target
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::UP) && !foes.empty?
+          @ui[:target_i] -= 1
+          @ui[:target_i] %= foes.length
+          draw_battle_target
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C)
+          play_system_se(SFX_DECISION)
+          target = foes[@ui[:target_i]]
+          close_battle_target
+          if pending_kind == :skill
+            apply_pending_skill(target)
+          else
+            @ui[:battle].command_attack(current_actor, target)
+            @ui[:pending] = nil
+            @ui[:phase] = :command
+            advance_actor
+          end
+        elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
+          close_battle_target
+          if pending_kind == :skill
+            @ui[:phase] = :skill
+            draw_battle_skill
+          else
+            @ui[:pending] = nil
+            @ui[:phase] = :command
+            draw_battle_command
+          end
+        end
+      end
+
+      def pending_kind; @ui[:pending] && @ui[:pending][:kind]; end
+
+      # -- Skill sub-menu ------------------------------------------------------
+
+      # Open the current actor's battle-skill list (nothing to open if they know
+      # no battle-usable skill).
+      def open_battle_skill
+        actor = current_actor_row
+        list = actor ? @state.party.battle_skills(actor, current_actor) : []
+        # A status that seals skills (封印 / Silence) takes them off the menu
+        # rather than letting the actor pick one that would be refused.
+        battle = @ui[:battle]
+        battler = current_actor
+        if battle && battler
+          list = list.reject do |sid, _cost|
+            battle.skill_sealed?(battler, @state.party.db_skill(sid))
+          end
+        end
+        @ui[:skills] = list
+        # RPG_RT always plays Decision opening this list, and Buzzer only
+        # once a confirm inside it finds nothing usable
+        # (`Scene_Battle::SkillSelected`'s own `!skill || !CheckEnable`
+        # check) -- this engine instead never opens an empty list at all, so
+        # Buzzer plays here, at the one point that same "nothing to pick"
+        # outcome is actually known.
+        if @ui[:skills].empty?
+          play_system_se(SFX_BUZZER)
+          return
+        end
+        play_system_se(SFX_DECISION)
+        @ui[:skill_i] = 0
+        @ui[:phase] = :skill
+        draw_battle_skill
+      end
+
+      def drive_battle_skill
+        skills = @ui[:skills]
+        if Input.trigger?(Input::DOWN) && !skills.empty?
+          @ui[:skill_i] += 1
+          @ui[:skill_i] %= skills.length
+          draw_battle_skill
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::UP) && !skills.empty?
+          @ui[:skill_i] -= 1
+          @ui[:skill_i] %= skills.length
+          draw_battle_skill
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C)
+          confirm_battle_skill
+        elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
+          close_battle_skill
+          @ui[:phase] = :command
+          draw_battle_command
+        end
+      end
+
+      # Choose the highlighted skill: if the caster cannot afford its SP, this
+      # is RPG_RT's own Buzzer case (`SkillSelected`'s `CheckEnable` covers
+      # affordability); otherwise Decision, then route to enemy / ally target
+      # selection (or cast at once on a self-scope skill).
+      def confirm_battle_skill
+        sid, cost = @ui[:skills][@ui[:skill_i]]
+        if current_actor.mp < cost # can't afford: stay on the list
+          play_system_se(SFX_BUZZER)
+          return
+        end
+        play_system_se(SFX_DECISION)
+        sk = @state.party.db_skill(sid)
+        @ui[:pending] = { kind: :skill, sk: sk, sid: sid }
+        close_battle_skill
+        case @state.party.battle_skill_target(sk)
+        when :self
+          apply_pending_skill(current_actor)
+        when :enemy
+          @ui[:target_i] = 0
+          @ui[:phase] = :target
+          draw_battle_target
+        when :all_enemy
+          apply_pending_skill_all(living_foes)
+        when :all_ally
+          apply_pending_skill_all(living_allies)
+        else # :ally
+          @ui[:ally_i] = 0
+          @ui[:phase] = :ally_target
+          draw_battle_ally_target
+        end
+      end
+
+      # Commit the pending skill on `target` (SP cost / effect from the model),
+      # then move to the next actor.
+      def apply_pending_skill(target)
+        sk = @ui[:pending][:sk]
+        sid = @ui[:pending][:sid]
+        c = @state.party.battle_skill_command(sk, current_actor, target)
+        @ui[:battle].command_skill(current_actor, target,
+                                          name: sk.name, skill_id: sid,
+                                          absorb: c[:absorb] ? true : false,
+                                          # Left as `c[:attack]` verbatim (not coerced to a
+                                          # boolean): a stub `battle_skill_command` in the test
+                                          # suite that omits the key entirely needs `nil` to
+                                          # reach #apply_skill_hit so its own sign-of-hp
+                                          # fallback still applies, matching this build's real
+                                          # Game::Party#battle_skill_command before this key
+                                          # existed at all.
+                                          attack: c[:attack],
+                                          cost: c[:cost],
+                                          hp: c[:hp], mp: c[:mp],
+                                          inflict: c[:inflict], chance: c[:chance],
+                                          variance: c[:variance] || 0,
+                                          attributes: c[:attributes],
+                                          attr_shift: c[:attr_shift],
+                                          attr_ids: c[:attr_ids],
+                                          stat_mod_keys: c[:stat_mod_keys],
+                                          stat_effect: c[:stat_effect] || 0,
+                                          cured: c[:cured])
+        @ui[:pending] = nil
+        @ui[:phase] = :command
+        advance_actor
+      end
+
+      # Commit the pending all-target skill on every `targets` combatant (all
+      # living enemies for an attack skill, all living allies for a heal): build
+      # one per-target effect from the model (attack damage varies with each
+      # target's defence) and queue them as a single volley. The shared SP cost /
+      # infliction ride along once.
+      def apply_pending_skill_all(targets)
+        sk = @ui[:pending][:sk]
+        sid = @ui[:pending][:sid]
+        meta = @state.party.battle_skill_command(sk, current_actor, targets.first)
+        effects = targets.map do |t|
+          c = @state.party.battle_skill_command(sk, current_actor, t)
+          { target: t, hp: c[:hp], mp: c[:mp] }
+        end
+        @ui[:battle].command_skill_all(current_actor, effects,
+                                              name: sk.name, skill_id: sid,
+                                              absorb: meta[:absorb] ? true : false,
+                                              attack: meta[:attack], # see #apply_pending_skill's comment
+                                              cost: meta[:cost],
+                                              inflict: meta[:inflict], chance: meta[:chance],
+                                              variance: meta[:variance] || 0,
+                                              attributes: meta[:attributes],
+                                              attr_shift: meta[:attr_shift],
+                                              attr_ids: meta[:attr_ids],
+                                              stat_mod_keys: meta[:stat_mod_keys],
+                                              stat_effect: meta[:stat_effect] || 0,
+                                              cured: meta[:cured])
+        @ui[:pending] = nil
+        @ui[:phase] = :command
+        advance_actor
+      end
+
+      # -- Item sub-menu -------------------------------------------------------
+
+      # Open the party's battle-usable items (nothing to open if the bag holds
+      # none).
+      def open_battle_item
+        @ui[:items] = @state.party.battle_items
+        # See #start_skill's identical comment -- the same Decision/
+        # Buzzer split, ported from `Scene_Battle::ItemSelected`.
+        if @ui[:items].empty?
+          play_system_se(SFX_BUZZER)
+          return
+        end
+        play_system_se(SFX_DECISION)
+        @ui[:item_i] = 0
+        @ui[:phase] = :item
+        draw_battle_item
+      end
+
+      def drive_battle_item
+        items = @ui[:items]
+        if Input.trigger?(Input::DOWN) && !items.empty?
+          @ui[:item_i] += 1
+          @ui[:item_i] %= items.length
+          draw_battle_item
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::UP) && !items.empty?
+          @ui[:item_i] -= 1
+          @ui[:item_i] %= items.length
+          draw_battle_item
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C)
+          play_system_se(SFX_DECISION)
+          item_id, _count = @ui[:items][@ui[:item_i]]
+          it = @state.party.db_item(item_id)
+          @ui[:pending] = { kind: :item, item_id: item_id, it: it }
+          close_battle_item
+          if @state.party.switch_item?(item_id)
+            apply_pending_switch_item
+          elsif @state.party.item_all_allies?(it)
+            apply_pending_item_all(living_allies)
+          else
+            @ui[:ally_i] = 0
+            @ui[:phase] = :ally_target
+            draw_battle_ally_target
+          end
+        elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
+          close_battle_item
+          @ui[:phase] = :command
+          draw_battle_command
+        end
+      end
+
+      # -- Ally target (heal skill / medicine) --------------------------------
+
+      def drive_battle_ally_target
+        allies = battle_ally_targets
+        if Input.trigger?(Input::DOWN) && !allies.empty?
+          @ui[:ally_i] += 1
+          @ui[:ally_i] %= allies.length
+          draw_battle_ally_target
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::UP) && !allies.empty?
+          @ui[:ally_i] -= 1
+          @ui[:ally_i] %= allies.length
+          draw_battle_ally_target
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C) && !allies.empty?
+          # `Scene_Battle::AllySelected` was not itself fetched verbatim,
+          # but it is one of the same family of "Selected" callbacks as
+          # Attack/Defend/Item/Skill above, every one of which plays
+          # Decision as its own first statement before acting.
+          play_system_se(SFX_DECISION)
+          target = allies[@ui[:ally_i]]
+          close_battle_ally_target
+          if pending_kind == :skill
+            apply_pending_skill(target)
+          else
+            apply_pending_item(target)
+          end
+        elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
+          close_battle_ally_target
+          if pending_kind == :skill
+            @ui[:phase] = :skill
+            draw_battle_skill
+          else
+            @ui[:phase] = :item
+            draw_battle_item
+          end
+        end
+      end
+
+      # Commit a switch item: it has no target at all -- the same as the field
+      # menu's own switch item (Scene::ItemMenu#apply_switch_item) skips
+      # straight past target selection -- so this queues immediately off
+      # #drive_battle_item's Confirm, with `current_actor` standing in for
+      # `command_item`'s `target:` (never read for a switch effect; a switch
+      # item's hp/mp are always 0, so it does not touch its HP/MP either).
+      # `switch_id` rides the log entry the same way `item_id` does, so
+      # #drive_battle_animate can flip it -- and only then, deferred to when
+      # the action actually lands, exactly like the bag deduction it sits
+      # beside there.
+      def apply_pending_switch_item
+        pending = @ui[:pending]
+        @ui[:battle].command_item(current_actor, current_actor,
+                                         item_id: pending[:item_id],
+                                         name: pending[:it].name,
+                                         switch_id: pending[:it].switch_id)
+        @ui[:pending] = nil
+        @ui[:phase] = :command
+        advance_actor
+      end
+
+      # Commit the pending item on `target` (recovery from the model; the bag is
+      # consumed later, when the action lands), then move to the next actor.
+      def apply_pending_item(target)
+        pending = @ui[:pending]
+        c = @state.party.battle_item_command(pending[:it], target)
+        @ui[:battle].command_item(current_actor, target,
+                                         item_id: pending[:item_id],
+                                         name: pending[:it].name,
+                                         hp: c[:hp], mp: c[:mp], cured: c[:cured])
+        @ui[:pending] = nil
+        @ui[:phase] = :command
+        advance_actor
+      end
+
+      # Commit an all-party item on every living ally: one per-member recovery
+      # from the model, queued as a single volley that consumes one item.
+      def apply_pending_item_all(targets)
+        pending = @ui[:pending]
+        effects = targets.map do |t|
+          c = @state.party.battle_item_command(pending[:it], t)
+          { target: t, hp: c[:hp], mp: c[:mp] }
+        end
+        cured = @state.party.battle_item_command(pending[:it], targets.first)[:cured]
+        @ui[:battle].command_item_all(current_actor, effects,
+                                             item_id: pending[:item_id],
+                                             name: pending[:it].name, cured: cured)
+        @ui[:pending] = nil
+        @ui[:phase] = :command
+        advance_actor
+      end
+
+      # Move to the next living party member, or start playing out the round once
+      # every member has a command.
+      def advance_actor
+        @ui[:actor_i] += 1
+        @ui[:cmd] = 0
+        open_next_command
+      end
+
+      # Advance `actor_i` past any living ally the round already decides
+      # for automatically -- a "do nothing" or forced attack-ally/
+      # attack-enemy restriction, see `Game::Battle#command_restricted?` --
+      # then either open the next actually-commandable ally's menu or, if
+      # every remaining living ally is restricted, start the round right
+      # away exactly as running out of allies after the last command
+      # already does. Without this, an asleep/paralysed/confused/berserk
+      # ally still got the ordinary Attack/Skill/Defend/Item prompt, and a
+      # party entirely under such states (e.g. everyone put to sleep by an
+      # enemy's spell) froze the command phase forever waiting on choices
+      # that could never change the outcome -- the "unrecoverable
+      # input-blocking state lock" case flagged as still open next to the
+      # empty/all-KO'd-party fix above.
+      def open_next_command
+        skip_restricted_actors
+        if @ui[:actor_i] >= living_allies.length
+          start_round_animation
+        else
+          draw_battle_command
+        end
+      end
+
+      # Also auto-commands (rather than merely skipping) a 強制AI-flagged ally
+      # that isn't otherwise restricted: `Game::Actor#force_ai?` -- checked
+      # only once `#command_restricted?` has already answered false, matching
+      # `Scene_Battle_Rpg2k::SelectNextActor`'s own real check order (CanAct
+      # -> forced attack-ally/attack-enemy restriction -> auto_battle) -- gets
+      # `Game::Battle#choose_auto_battle_command` to queue its action right
+      # here instead of ever drawing the manual command window for it.
+      def skip_restricted_actors
+        battle = @ui[:battle]
+        allies = living_allies
+        i = @ui[:actor_i]
+        loop do
+          a = allies[i]
+          break unless a
+          if battle.command_restricted?(a)
+            i += 1
+          elsif force_ai_actor?(a)
+            battle.choose_auto_battle_command(a)
+            i += 1
+          else
+            break
+          end
+        end
+        @ui[:actor_i] = i
+      end
+
+      def force_ai_actor?(combatant)
+        combatant.actor && combatant.actor.respond_to?(:force_ai?) && combatant.actor.force_ai?
+      end
+
+      # The index of the previous living ally free to receive a manual
+      # command, walking backward from just before the current one and
+      # skipping any restricted ally the same way `#skip_restricted_actors`
+      # does going forward -- nil once nothing earlier is left to
+      # re-command, matching EasyRPG's `SelectPreviousActor` recursing back
+      # to the Fight/Auto/Escape menu once it would land on the very first
+      # ally.
+      def prev_commandable_actor_index
+        battle = @ui[:battle]
+        allies = living_allies
+        i = @ui[:actor_i] - 1
+        i -= 1 while i >= 0 && (battle.command_restricted?(allies[i]) || force_ai_actor?(allies[i]))
+        i >= 0 ? i : nil
+      end
+
+      # Frames each attack of the round lingers on screen before the next lands —
+      # a beat long enough to read the hit and see the HP tick, at ~1/3s / 60fps.
+      BATTLE_ANIM_FRAMES = 20
+
+      # Begin animating the commanded round: dismiss the command menu and prime
+      # the battle's per-action queue. From here #drive_battle_animate lands one
+      # attack per BATTLE_ANIM_FRAMES until the round's queue empties.
+      def start_round_animation
+        if @ui[:cmd_win]
+          @ui[:cmd_win].dispose
+          @ui[:cmd_win] = nil
+        end
+        @ui[:battle].begin_round
+        @ui[:phase] = :animate
+        @ui[:anim_timer] = 0 # land the first attack next frame
+      end
+
+      # One attack per BATTLE_ANIM_FRAMES: land the next action (mutating a single
+      # battler's HP), tick the HP display, and banner the hit. When the round's
+      # queue empties, settle it and either show the result or re-open commands —
+      # so the round plays out action by action rather than all at once.
+      def drive_battle_animate
+        # A skill or item that names a battle animation plays it over the target
+        # before the round moves on, so the round is paced by the animation
+        # rather than by the fixed banner timer.
+        if battle_animation_playing?
+          @map.step_map_animation
+          return
+        end
+        if @ui[:anim_timer] > 0
+          @ui[:anim_timer] -= 1
+          return
+        end
+        # A battle page is checked once per *acting battler*, not once per
+        # round -- EasyRPG's CheckBattleEndAndScheduleEvents runs "before each
+        # battler acts and also right after the last battler acts" (the
+        # latter half is #finish_round_animation's own check, already in
+        # place). The boundary between two battlers' actions is exactly where
+        # the previous #step_action call left nothing buffered (a dual-wield
+        # swing or an all-target Skill/Item queues several hits from *one*
+        # battler; the check belongs between battlers, not between hits).
+        if @ui[:battler_boundary]
+          @ui[:battler_boundary] = false
+          return if run_battle_events(:animate)
+        end
+        entry = @ui[:battle].step_action
+        if entry
+          # An Item action spends one *use* from the real bag when it lands (so
+          # backing out during the command phase never spends it), which only
+          # costs a copy once the item's 使用回数 runs out -- the same
+          # Game::Party#consume_item_use the field menu goes through, so a
+          # multi-use bomb or a 特殊効果 weapon behaves identically in a fight.
+          # A switch item flips its switch at the same moment -- the state table
+          # is the scene's, same as the field menu's own Scene::ItemMenu, and
+          # this is the only place a queued switch-item action ever reaches it.
+          @state.party.consume_item_use(entry[:item_id]) if entry[:item_id]
+          @state.switches[entry[:switch_id]] = true if entry[:switch_id]
+          log_round([entry])
+          refresh_battle_status
+          refresh_battle_sprites
+          show_battle_action(entry)
+          play_battle_action_se(entry)
+          # When an animation plays, it is the wait; otherwise the banner timer
+          # is, exactly as before.
+          @ui[:anim_timer] =
+            start_battle_animation(entry) ? 0 : BATTLE_ANIM_FRAMES
+          @ui[:battler_boundary] = @ui[:battle].pending_empty?
+        else
+          finish_round_animation
+        end
+      end
+
+      def battle_animation_playing?
+        !@map.map_animation.nil? && @map.map_animation[:battle]
+      end
+
+      # Play the animation this action names, over its target. RPG2000 keeps the
+      # animation on the **skill** and on the **item**, not on the action -- 557
+      # skill rows and 170 item rows across the test beds name one, and none of
+      # them played. Returns true when one started.
+      #
+      # A plain attack now plays one too: Game::Battle#deal_attack resolves
+      # the attacking actor's own weapon/unarmed animation (Actor#
+      # attack_animation_id) and carries it on the log entry as
+      # `attack_animation_id`, which #battle_animation_id below reads once
+      # neither a skill nor an item claims the entry.
+      def start_battle_animation(entry)
+        id = battle_animation_id(entry)
+        return false unless id && id > 0
+        tx, ty, height = battle_animation_pixel(entry)
+        anim = @map.build_animation(id, tx, ty, true, target_index: entry[:target_index],
+                               target_height: height)
+        return false unless anim
+        @map.map_animation = anim
+        @map.fire_animation_flashes(anim) # frame 0 flashes, as the map path does
+        true
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle animation failed: #{e.message}"
+        false
+      end
+
+      def battle_animation_id(entry)
+        row =
+          if entry[:skill_id] && db.respond_to?(:skill) && db.skill
+            db.skill[entry[:skill_id]]
+          elsif entry[:item_id] && db.respond_to?(:item) && db.item
+            db.item[entry[:item_id]]
+          end
+        return row.animation_id if row && row.respond_to?(:animation_id)
+        # Neither a skill nor an item: a plain Attack, whose own animation
+        # Game::Battle#deal_attack already resolved onto the log entry.
+        entry[:attack_animation_id]
+      end
+
+      # Where it plays: over the targeted enemy's sprite. RPG2000 draws no sprite
+      # for a party member -- its battle is first-person -- so an action aimed at
+      # one plays over the middle of the screen instead of nowhere. The third
+      # element is the sprite's own pixel height, for #animation_position_offset
+      # to split into head/feet thirds -- nil for the screen-centre fallback,
+      # which has no sprite to measure and so never moves off it.
+      def battle_animation_pixel(entry)
+        i = entry[:target_index]
+        sprites = @ui[:enemy_sprites]
+        spr = i && sprites ? sprites[i] : nil
+        bmp = spr && spr.bitmap
+        return [SCREEN_W / 2, SCREEN_H / 2, nil] unless bmp
+        [spr.x + bmp.width / 2, spr.y + bmp.height / 2, bmp.height]
+      end
+
+      # Show Battle Animation (13260), the battle-page form of the map's own
+      # 11210: it needs this round's own positioning (#battle_animation_pixel,
+      # the targeted enemy's live sprite -- or the ally-side screen-centre
+      # fallback) and Character Flash mechanism (#fire_target_flash, an
+      # `@ui[:enemy_sprites]` entry), the same two `battle_animation_id`/
+      # `entry`-shaped inputs #start_battle_animation already builds from a
+      # round's own log entry -- just keyed off `req[:target]` (the command's
+      # own troop-member param) directly instead of an entry's
+      # `target_index`, since a battle page names its target explicitly
+      # rather than inheriting it from whichever action just landed. Called
+      # from Scene::Map#start_map_animation, which every battle-page-issued
+      # Show Battle Animation request (`req[:battle]`) dispatches to.
+      def start_battle_page_animation(req)
+        tx, ty, height = battle_animation_pixel(target_index: req[:target])
+        @map.build_animation(req[:animation], tx, ty, true, target_index: req[:target],
+                             target_height: height)
+      end
+
+      # Close out an animated round: clear the commands, drop the action banner,
+      # and branch to the result window or the next command phase.
+      def finish_round_animation
+        battle = @ui[:battle]
+        battle.end_round
+        close_battle_action
+        if battle.finished?
+          enter_battle_result(battle.result)
+        else
+          @ui[:actor_i] = 0
+          @ui[:cmd] = 0
+          @ui[:phase] = :command
+          # A new turn re-arms every page: RPG2000 fires a battle page once per
+          # turn in which its condition holds, not once per battle.
+          @ui[:pages_run] = {}
+          open_next_command unless run_battle_events
+        end
+      end
+
+      # -- battle-event pages --------------------------------------------------
+
+      # Start the next troop battle-event page whose condition holds and that has
+      # not yet fired this turn, switching to the :event phase. Returns whether a
+      # page was started, so the caller knows whether to draw the command window
+      # or hand the frame to the event. A troop that scripts nothing, or whose
+      # pages have all fired, simply returns false.
+      #
+      # `return_phase` is where #leave_battle_event_phase resumes once the page
+      # (and any chained page after it) finishes: `:command` for the between-
+      # rounds check (the default -- the normal case, opening the next round's
+      # command menu), `:animate` for the between-battlers check
+      # (#drive_battle_animate), which needs to pick back up mid-round rather
+      # than restart the command phase.
+      def run_battle_events(return_phase = :command)
+        ui = @ui
+        return false unless ui && ui[:troop].pages
+        matched = Game::BattlePage.select_all(ui[:troop].pages, @state.switches,
+                                              @state.variables, ui[:battle])
+        entry = matched.find { |(id, _)| !ui[:pages_run][id] }
+        return false unless entry
+        ui[:pages_run][entry[0]] = true
+        cmds = entry[1].event
+        return run_battle_events(return_phase) if cmds.nil? || cmds.empty? # empty page: try the next
+        ui[:events].battle = ui[:battle]
+        ui[:events].start(cmds)
+        ui[:event_return_phase] = return_phase
+        ui[:phase] = :event
+        true
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle event page failed: #{e.message}"
+        false
+      end
+
+      # Advance the running battle-event page one frame. Battle pages use the
+      # ordinary command set (messages, switches, variables, audio) on top of the
+      # battle-only commands, so the interpreter is driven the same way the map
+      # drives an event — only the UI it may reach for is narrower.
+      def drive_battle_event
+        it = @ui[:events]
+        apply_battle_event_requests(it)
+        return if finish_terminated_battle
+        if it.waiting?
+          drive_battle_event_wait(it)
+        elsif it.running?
+          it.update
+        else
+          leave_battle_event_phase
+        end
+      end
+
+      def drive_battle_event_wait(it)
+        case it.wait_kind
+        when :message, :choice then drive_battle_event_message(it)
+        when :animation then @map.drive_map_animation(it)
+        when :wait
+          @ui[:event_timer] ||= @map.frames_from_tenths(it.wait_frames)
+          if @ui[:event_timer] <= 0
+            @ui[:event_timer] = nil
+            it.resume
+          else
+            @ui[:event_timer] -= 1
+          end
+        else
+          # A battle page cannot open the map's teleport / shop / menu UI; those
+          # requests are released so the page runs on rather than wedging here.
+          it.resume
+        end
+      end
+
+      # Show the page's message lines in a battle text panel and dismiss it on a
+      # button press. A [Show Choices] in a battle page is displayed the same way
+      # and takes the first option, which is what the runtime can answer without
+      # a battle choice widget.
+      def drive_battle_event_message(it)
+        unless @ui[:event_win]
+          lines = it.wait_kind == :choice ? it.choice_labels : it.message_lines
+          @ui[:event_win] =
+            battle_text_window(lines || [], BATTLE_EVENT_MSG_Y, 340)
+          return # shown this frame; take the button from the next one
+        end
+        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        choice = it.wait_kind == :choice
+        close_battle_event_window
+        choice ? it.choose(0) : it.resume
+      end
+
+      def close_battle_event_window
+        return unless @ui && @ui[:event_win]
+        @ui[:event_win].dispose
+        @ui[:event_win] = nil
+      end
+
+      # Apply the requests a battle page queued: revealed troop members get the
+      # sprite they never had, and a Change Battle Background rebuilds the
+      # backdrop.
+      #
+      # The status panel is rebuilt unconditionally afterwards. A battle page's
+      # Change Monster HP / MP / Condition commands write straight to the live
+      # combatants rather than queueing a request, so nothing here would have
+      # told the panel it is stale — a page that poisoned the boss changed the
+      # fight but not the screen until the next action happened to redraw it.
+      def apply_battle_event_requests(it)
+        it.take_revealed_monsters.each { |i| reveal_battle_monster(i) }
+        fled = it.take_fled_monsters
+        fled.each { |i| remove_fled_monster(i) }
+        play_escape_se unless fled.empty?
+        name = it.take_battle_background
+        rebuild_battle_back(name) unless name.nil?
+        refresh_battle_status
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle event request failed: #{e.message}"
+        nil
+      end
+
+      # Show Hidden Monster: clear the member's hidden flag and build the sprite
+      # build_battle_sprites skipped, so it appears mid-fight.
+      def reveal_battle_monster(index)
+        member = @ui[:troop].members[index]
+        return unless member && member.hidden
+        member.hidden = false
+        # Bring the combatant into the fight as well, not just the sprite: until
+        # now it took no turn and could not be targeted (Combatant#out_of_play?).
+        foe = @ui[:battle].enemy(index)
+        foe.hidden = false if foe
+        bmp = battler_bitmap(member)
+        spr = Sprite.new
+        spr.bitmap = bmp
+        spr.x = member.x - bmp.width / 2
+        spr.y = battler_y(member, bmp)
+        spr.z = battler_z(index)
+        spr.opacity = battler_opacity(member)
+        dispose_battle_sprite(@ui[:enemy_sprites][index])
+        @ui[:enemy_sprites][index] = spr
+      end
+
+      # Force Flee: the troop member ran, so drop its sprite. Game::Battle has
+      # already hidden the combatant (which takes it out of play without counting
+      # as a kill), and the troop member's own flag is set so a later rebuild does
+      # not draw it again.
+      def remove_fled_monster(index)
+        member = @ui[:troop].members[index]
+        member.hidden = true if member
+        dispose_battle_sprite(@ui[:enemy_sprites][index])
+        @ui[:enemy_sprites][index] = nil
+      end
+
+      # The escape sound RPG_RT plays when a Force Flee sends enemies running.
+      def play_escape_se
+        play_system_se(SFX_ESCAPE)
+      end
+
+      # Terminate Battle: leave the fight with no victory / defeat processing.
+      # Returns whether the battle was ended, so the caller stops driving it.
+      def finish_terminated_battle
+        return false unless @ui[:battle].terminated?
+        close_battle_event_window
+        finish_battle(:abort)
+        true
+      end
+
+      # The running page finished: fire the next matching page (chained pages
+      # keep the same return_phase, so a battler-boundary check that opens
+      # several pages in a row still resumes mid-round rather than jumping to
+      # the command phase partway through), or hand the turn back — to the
+      # result window when the page decided the fight, to the mid-round
+      # animation loop when this page was a between-battlers check, otherwise
+      # to the party's command phase (a between-rounds check, the default).
+      def leave_battle_event_phase
+        close_battle_event_window
+        return_phase = @ui[:event_return_phase] || :command
+        return if run_battle_events(return_phase)
+        battle = @ui[:battle]
+        if battle.finished?
+          enter_battle_result(battle.result)
+        elsif return_phase == :animate
+          @ui[:phase] = :animate
+        else
+          @ui[:phase] = :command
+          enter_command_phase
+        end
+      end
+
+      def enter_battle_result(result)
+        @ui[:result] = result
+        @map.play_victory_bgm if result == :victory
+        lines = battle_result_lines(result, @ui[:troop])
+        [@ui[:status_win], @ui[:cmd_win]].each { |w| w.dispose if w }
+        @ui[:status_win] = nil
+        @ui[:cmd_win] = nil
+        open_battle_result(lines)
+        @ui[:phase] = :result
+      end
+
+      def drive_battle_result
+        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        finish_battle(@ui[:result])
+      end
+
+      # Close the battle and hand the outcome back to the event. A defeat in an
+      # encounter whose defeat mode is "game over" (rather than a [Defeat]
+      # handler) ends the game instead of resuming the event; every other outcome
+      # — victory, escape, or a defeat with a custom handler — resumes it. Hands
+      # the outcome to whichever interpreter actually opened this fight
+      # (`@owner` -- the foreground by default, or a Parallel
+      # Process's own interpreter, see Scene::Map#drive_battle), captured before
+      # #dispose clears @ui out from under it (via Scene::Map#close_battle,
+      # which drops the map's own @battle reference too).
+      def finish_battle(result)
+        # Persist the party's post-battle HP (and any knock-outs) before leaving
+        # the fight, so damage taken sticks and a downed member stays down.
+        @ui[:battle].apply_to_party
+        # Capture the fight's own round count (Game::Battle#turn, its live
+        # @rounds counter) before #dispose discards the Battle object --
+        # this is RPG2000's "turns passed in latest battle" (Game::State
+        # #last_battle_turns, LCF inventory chunk 109 field 41).
+        @state.last_battle_turns = @ui[:battle].turn
+        # A defeat in "game over" mode (no custom [Defeat] handler) with the whole
+        # party knocked out ends the game; every other outcome resumes the event.
+        game_over = result == :defeat && @req[:defeat_game_over] &&
+                    @state.party.all_dead?
+        owner = @owner
+        @map.close_battle
+        if game_over
+          @map.perform_game_over(owner)
+        else
+          @map.restore_pre_battle_bgm
+          owner.resume_battle(result)
+        end
+      end
+
+      def log_round(entries)
+        entries.each do |e|
+          battle_action_lines(e).each { |l| $stderr.puts "[RPG2k battle] #{l}" }
+        end
+      end
+
+      # What an action says, in the game's own words. RPG2000 keeps the sentences
+      # in the 用語 table as *predicates* — 「の攻撃！」, 「のダメージを与えた！」 —
+      # and RPG_RT prints the battler's name in front of each. Both test beds
+      # fill 126 of the 127 fields in, so a log that invents its own English is
+      # ignoring text the author wrote.
+      #
+      # RPG_RT says it in more than one line: what the battler did, then what it
+      # did to the target. This returns them in that order, and falls back to the
+      # composed English for any field the database leaves blank — an
+      # English-release table with half the battle terms empty still reads.
+      def battle_action_body(e)
+        # An item announces itself with the `use_item` term, still unread, and
+        # "does nothing" is worded by the state that caused it rather than by a
+        # term — both keep the composed wording. A skill has its own two
+        # sentences and takes the branch below.
+        return [battle_action_line(e)] if e[:nothing]
+        return battle_skill_body(e) if e[:skill_id]
+        return battle_item_body(e) if e[:item_id]
+        return [battle_action_line(e)] if e[:recover] || e[:skill]
+        t = db.respond_to?(:term) ? db.term : nil
+        want_start = battle_start_field(e)
+        want_result = battle_result_wanted?(e)
+        want_crit = e[:critical] ? true : false
+        start = want_start && battle_start_line(t, e, want_start)
+        result = want_result && battle_result_line(t, e)
+        crit = want_crit &&
+               Game::States::BattleText.critical(t, e[:target_ally] ? true : false)
+        # All or nothing per entry: a half-translated line ("スライムの攻撃！"
+        # with no damage sentence under it) reads worse than the composed
+        # English, so a blank term drops the whole entry back to the fallback
+        # — which already carries the crit note itself (`battle_action_line`'s
+        # ' (critical!)' suffix), so a blank `actor_critical` / `enemy_critical`
+        # loses nothing by falling back whole.
+        return [battle_action_line(e)] if (want_start && !start) ||
+                                          (want_result && !result) ||
+                                          (want_crit && !crit)
+        lines = []
+        lines << start if start
+        lines << crit if crit
+        lines << result if result
+        lines.empty? ? [battle_action_line(e)] : lines
+      end
+
+      # A skill's own two sentences, then what it did. `using_message1` follows
+      # the caster's name and `using_message2` stands alone as a second line, so
+      # a spell reads 「リトは炎を放った！」 / 「あたりが真っ赤に染まる！」 before
+      # 「スライムに 42 のダメージを与えた！」.
+      #
+      # A skill that achieved nothing takes its own failure sentence instead of a
+      # damage line — the skill row's `failure_message` picks which of the three
+      # 用語 failure lines (or the dodge line) says so.
+      #
+      # A skill row that sets no sentence at all keeps the composed wording, for
+      # the same reason a blank term does: the bare damage line would lose the
+      # only thing naming what was cast.
+      def battle_skill_body(e)
+        bt = Game::States::BattleText
+        row = db.respond_to?(:skill) && db.skill ? db.skill[e[:skill_id]] : nil
+        caster = (e[:recover] ? e[:actor] : e[:attacker]).to_s
+        lines = bt.skill_start(row, caster)
+        return [battle_action_line(e)] if lines.empty?
+        t = db.respond_to?(:term) ? db.term : nil
+        rest = battle_skill_result(t, row, e)
+        return [battle_action_line(e)] unless rest
+        lines + rest
+      rescue StandardError => ex
+        $stderr.puts "[RPG2k] skill message lookup failed: #{ex.message}"
+        [battle_action_line(e)]
+      end
+
+      # What the skill did: the damage / dodge line for an attack, nothing extra
+      # for a recovery that worked, and the failure sentence for one that did
+      # not. nil when a needed sentence is missing, so the caller falls back
+      # whole rather than printing half of one.
+      def battle_skill_result(t, row, e)
+        bt = Game::States::BattleText
+        return [] if e[:target].nil?
+        if skill_achieved_nothing?(e)
+          line = bt.skill_failure(t, row, e[:target].to_s)
+          return line ? [line] : nil
+        end
+        return battle_recovery_lines(t, e) if e[:recover]
+        line = battle_result_line(t, e)
+        return nil unless line
+        [line] + battle_absorb_lines(t, e)
+      end
+
+      # What a 吸収 skill took from its target, after the damage line. [] when
+      # the skill drained nothing or the database has no wording -- unlike the
+      # damage line this one is additive, so a missing term drops the extra
+      # sentence rather than the whole entry.
+      def battle_absorb_lines(t, e)
+        amount = e[:absorbed_hp] || 0
+        return [] unless amount > 0
+        line = Game::States::BattleText.absorbed(
+          t, e[:target].to_s, amount, :hp, e[:target_ally] ? true : false
+        )
+        line ? [line] : []
+      end
+
+      # An item borrows the `use_item` term rather than carrying a sentence of
+      # its own -- 「リトはポーションを使った！」 is the only line RPG2000 builds
+      # from two names -- and then says what it restored.
+      def battle_item_body(e)
+        bt = Game::States::BattleText
+        t = db.respond_to?(:term) ? db.term : nil
+        start = bt.item_start(t, e[:actor].to_s, e[:source].to_s)
+        return [battle_action_line(e)] unless start
+        rest =
+          if e[:switch_id]
+            # A switch item always "does something" (flips its switch), even
+            # though it restores no HP/MP and cures nothing -- unlike a
+            # medicine it never "achieves nothing", so it is just the "used
+            # it!" line alone, the same silent flip the field menu shows.
+            []
+          elsif skill_achieved_nothing?(e)
+            # An item that did nothing has no `failure_message` to choose with,
+            # so RPG2000 has no sentence for it: the composed line still says
+            # more than the bare "used it" would.
+            nil
+          else
+            battle_recovery_lines(t, e)
+          end
+        return [battle_action_line(e)] unless rest
+        [start] + rest
+      rescue StandardError => ex
+        $stderr.puts "[RPG2k] item message lookup failed: #{ex.message}"
+        [battle_action_line(e)]
+      end
+
+      # What a heal restored: one line per pool it filled, in the game's own
+      # words (「リトのＨＰが 30 回復した！」). [] when it restored nothing but
+      # cured something -- the state sentences carry that -- and nil when the
+      # database has no wording, so the caller falls back whole.
+      def battle_recovery_lines(t, e)
+        bt = Game::States::BattleText
+        name = e[:target].to_s
+        lines = []
+        [[:hp, e[:recover_hp]], [:mp, e[:recover_mp]]].each do |pool, amount|
+          next unless amount && amount > 0
+          line = bt.recovered(t, name, amount, pool)
+          return nil unless line
+          lines << line
+        end
+        lines
+      end
+
+      # A skill with nothing to show for itself: a heal that restored no HP or SP
+      # and cured nothing, or an attack that was dodged.
+      def skill_achieved_nothing?(e)
+        return true if e[:missed]
+        return false unless e[:recover]
+        (e[:recover_hp] || 0) <= 0 && (e[:recover_mp] || 0) <= 0 &&
+          (e[:cured] || []).empty? && (e[:inflicted] || []).empty?
+      end
+
+      # Which term words this entry's "so-and-so did a thing" line, or nil when
+      # RPG2000 has none for it — a skill or an item names itself instead (its
+      # own `using_message` is a separate field, still unread), and "does
+      # nothing" is a state's own sentence rather than a term.
+      def battle_start_field(e)
+        return nil if e[:recover] || e[:skill] || e[:nothing]
+        return :enemy_transform if e[:transform]
+        return :defending if e[:defend]
+        return :observing if e[:observe]
+        return :focus if e[:charge]
+        return :enemy_escape if e[:fled]
+        return :autodestruction if e[:autodestruct]
+        :attacking
+      end
+
+      def battle_start_line(t, e, field)
+        Game::States::BattleText.action(t, e[:attacker].to_s, field)
+      end
+
+      # Does this entry report on a target at all? A Defend, a flee or an
+      # autodestruct that found nobody has no one to report on.
+      def battle_result_wanted?(e)
+        return false if e[:recover] || e[:target].nil?
+        e[:missed] || !e[:damage].nil? ? true : false
+      end
+
+      # What it did to that target: a miss, a blow that got through for nothing,
+      # or the damage.
+      def battle_result_line(t, e)
+        bt = Game::States::BattleText
+        name = e[:target].to_s
+        ally = e[:target_ally] ? true : false
+        return bt.dodge(t, name) if e[:missed]
+        return bt.damage(t, name, e[:damage], ally) if e[:damage] > 0
+        bt.undamaged(t, name, ally)
+      end
+
+      # A one-line description of a battle log entry, for the on-screen banner and
+      # the console trace. A recovery (heal skill / medicine) reads as a restore;
+      # a skill attack names the skill; a plain attack is "A hits B for N".
+      #
+      # This is the fallback now: it words an entry whose terms the database left
+      # blank. `battle_action_body` prefers the game's own sentences.
+      def battle_action_line(e)
+        if e[:recover]
+          parts = []
+          parts << "#{e[:recover_hp]} HP" if e[:recover_hp] && e[:recover_hp] > 0
+          parts << "#{e[:recover_mp]} MP" if e[:recover_mp] && e[:recover_mp] > 0
+          body = if !parts.empty? then "+#{parts.join(' / ')}"
+                 elsif e[:switch_id] then 'switch on'
+                 else 'no effect'
+                 end
+          "#{e[:actor]}'s #{e[:source]}: #{e[:target]} #{body}"
+        elsif e[:missed]
+          "#{e[:attacker]} misses #{e[:target]}"
+        elsif e[:transform]
+          "#{e[:attacker]} transforms!"
+        elsif e[:defend]
+          "#{e[:attacker]} defends"
+        elsif e[:observe]
+          "#{e[:attacker]} watches closely"
+        elsif e[:charge]
+          "#{e[:attacker]} gathers strength"
+        elsif e[:fled]
+          "#{e[:attacker]} flees!"
+        elsif e[:nothing]
+          "#{e[:attacker]} does nothing"
+        else
+          hits = if e[:autodestruct] then ' blows itself up on'
+                 elsif e[:skill] then "'s #{e[:skill]} hits"
+                 else ' hits'
+                 end
+          line = "#{e[:attacker]}#{hits} #{e[:target]} for #{e[:damage]}"
+          line += ' (critical!)' if e[:critical]
+          line += ' (charged)' if e[:charged]
+          line
+        end
+      end
+
+      # Everything the action announces: what it did, then the conditions it
+      # changed. `log_round` traces all of it and `show_battle_action` banners
+      # all of it, so the console and the screen never disagree.
+      def battle_action_lines(entry)
+        battle_action_body(entry) + battle_state_lines(entry)
+      end
+
+      # The result window's text: the outcome, and on a win the EXP / gold gained
+      # (granted here). RPG2000 shows this after the fight before returning to the
+      # map. The headline is the database's own wording -- the 用語 table's
+      # `victory` / `defeat` fields, the same table (and the same "falls back to
+      # composed English when the database leaves it blank" rule)
+      # Game::States::BattleText already reads every per-action line from.
+      # The EXP / gold / item lines are composed from their own terms too now
+      # (`exp_received`, the `gold_received_a` / `_b` pair, `item_received`),
+      # confirmed against EasyRPG Player's actual C++ source rather than
+      # guessed at: `PartyMessage::GetExperienceGainedMessage` /
+      # `GetGoldReceivedMessage` / `GetItemReceivedMessage`
+      # (`src/game_message_terms.cpp`), stock-RPG2000 (non-`Feature::
+      # HasPlaceholders`, non-Maniac-Patch) branch -- `exp << terms.
+      # exp_received` (no separating space outside the RPG2k3-English
+      # release), `terms.gold_recieved_a << " " << money << terms.gold <<
+      # terms.gold_recieved_b`, `item_name << terms.item_recieved`. These
+      # three term fields were parsed by the schema and never read anywhere
+      # in `mruby-rpg2k` before now, so a game that customised them (a
+      # translation, a non-English original) showed this codebase's
+      # hardcoded English regardless.
+      #
+      # A level-up (and any skill the growth table teaches at it) is
+      # announced too now, the missing half of the same gap: EasyRPG's
+      # `Scene_Battle_Rpg2k::ProcessSceneActionVictory`
+      # (`src/scene_battle_rpg2k.cpp`) builds the EXP/gold/item summary as one
+      # page, then calls `Game_Actor::ChangeExp` once per active ally right
+      # after it, which is exactly `Game::Interpreter#do_change_exp`'s own
+      # gain_exp-then-announce shape (`queue_level_up_messages`,
+      # `mrblib/interpreter.rb`) -- so each actor's level/skill snapshot is
+      # taken here the same way, right before its own `#gain_exp`. Unlike
+      # that interpreter path (still the documented "plain English line for
+      # now" simplification), this screen already reads real database terms
+      # for every other line, so `#battle_level_up_message` /
+      # `#battle_skill_learned_message` below do too, built from EasyRPG's
+      # `ActorMessage::GetLevelUpMessage` / `GetLearningMessage`
+      # (`src/game_message_terms.cpp`), stock-RPG2000/CP932 branch: `name <<
+      # "は" << terms.level << " " << new_level << " " << terms.level_up` and
+      # `skill.name << terms.skill_learned` (no actor name -- it always
+      # follows that actor's own level-up line, same as here). RPG_RT shows
+      # these on their own page per actor rather than inline with the EXP
+      # tally; this screen has no per-page window, only one flat line list
+      # for the whole result, so they are appended to that list instead, in
+      # the same after-the-tally order the real sequence uses.
+      def battle_result_lines(result, troop)
+        return [term(:escape_success, 'Escaped!')] if result == :escape
+        return [term(:defeat, 'The party was defeated...')] unless result == :victory
+        exp = troop.total_exp
+        gold = troop.total_gold
+        @state.party.gain_gold(gold)
+        lines = [term(:victory, 'Victory!')]
+        lines << "#{exp}#{term(:exp_received, ' EXP gained.')}" if exp > 0
+        if gold > 0
+          lines << "#{term(:gold_received_a, 'Found')} #{gold}#{term(:gold, 'G')}" \
+                   "#{term(:gold_received_b, '.')}"
+        end
+        # Each defeated enemy may drop its treasure item (rolled on the battle's
+        # own RNG); grant it to the bag and name it in the result window.
+        troop.drops(@ui[:battle].rng).each do |iid|
+          @state.party.gain_item(iid, 1)
+          it = @state.party.db_item(iid)
+          name = it ? it.name : "item #{iid}"
+          lines << "#{name}#{term(:item_received, ' obtained.')}"
+        end
+        @state.party.actors.each do |a|
+          before_level = a.respond_to?(:level) ? a.level : nil
+          before_skills = a.respond_to?(:skills) ? a.skills.dup : []
+          a.gain_exp(exp)
+          lines.concat(battle_level_up_lines(a, before_level, before_skills)) if before_level
+        end
+        lines
+      end
+
+      # Level-up (and, for each level, any growth-table skill it teaches)
+      # lines for one actor's post-battle EXP gain, mirroring
+      # `Game::Interpreter#queue_level_up_messages`'s own before/after skill
+      # comparison: `before_skills` is that actor's skill list snapshotted
+      # right before `#gain_exp`, so a skill already known (an earlier
+      # explicit Change Skill teach) is told apart from one this exact gain
+      # just taught. Returns [] when the level did not rise.
+      def battle_level_up_lines(actor, before_level, before_skills)
+        return [] if actor.level <= before_level
+        lines = []
+        ((before_level + 1)..actor.level).each do |lv|
+          lines << battle_level_up_message(actor, lv)
+          next unless actor.respond_to?(:learn_table)
+          actor.learn_table.each do |sid, at|
+            next unless at == lv && !before_skills.include?(sid)
+            sk = @state.party.db_skill(sid)
+            lines << battle_skill_learned_message(actor, sk) if sk
+          end
+        end
+        lines
+      end
+
+      # The one line a level-up announces, built from the database's own
+      # `level`/`level_up` terms the way EasyRPG's stock/CP932
+      # `GetLevelUpMessage` branch does (see `#battle_result_lines`'s own
+      # comment) -- falls back to composed English, matching every other
+      # line on this screen, only when the database leaves `level_up` blank
+      # (a raw `level_up` term with no `level` term set still gets the
+      # 'Lv' stand-in rather than losing the whole line to English).
+      def battle_level_up_message(actor, level)
+        up = term(:level_up, nil)
+        return "#{actor.name} is now level #{level}!" unless up
+        "#{actor.name}は#{term(:level, 'Lv')} #{level} #{up}"
+      end
+
+      # The one line a newly-learned skill announces, immediately following
+      # its level's own line above -- EasyRPG's stock/CP932
+      # `GetLearningMessage` branch names only the skill, never the actor,
+      # since it always trails that actor's own level-up line the way it
+      # does here too. Falls back to composed English (which does name the
+      # actor, since a database leaving `skill_learned` blank gets no
+      # level-up line's context to lean on either) when the term is blank.
+      def battle_skill_learned_message(actor, sk)
+        learned = term(:skill_learned, nil)
+        return "#{actor.name} learned #{sk.name}!" unless learned
+        "#{sk.name}#{learned}"
+      end
+
+      # RPG_RT's battle windows share one fixed panel: a 320x80 strip along the
+      # bottom edge with 16px rows -- not the content-fitted, 14px-row windows
+      # this screen used to draw. EasyRPG's Scene_Battle_Rpg2k / Scene_Battle
+      # construct status_window / command_window / target_window / item_window /
+      # skill_window / battle_message_window all at
+      # `(x, screen_height - 80, w, 80)`, and Window_Selectable's own
+      # `menu_item_height` (16, matching this screen's message-window
+      # `MSG_LINE_H`) is what actually spaces their rows.
+      BATTLE_LINE_H = 16
+      BATTLE_PANEL_Y = SCREEN_H - 80
+      BATTLE_PANEL_H = 80
+      # The actor-command window is a fixed 76px (`option_command_mov` in
+      # EasyRPG), docked to the right edge; the status window takes the rest of
+      # the row (`MENU_WIDTH - option_command_mov`).
+      BATTLE_CMD_W = 76
+      BATTLE_STATUS_W = SCREEN_W - BATTLE_CMD_W
+      # The enemy target list (`CreateBattleTargetWindow`) is a fixed 136px, and
+      # only ever covers the status window's footprint -- the command window
+      # stays on screen beside it.
+      BATTLE_TARGET_W = 136
+      # How many rows show at once before a longer list (an 8-monster troop, a
+      # long skill list) scrolls: the panel's fixed 64px content area (80 minus
+      # the 8px border on each side) divided by the 16px row height.
+      BATTLE_VISIBLE_ROWS = 4
+
+      # Column origins within the status panel's contents, in the order RPG_RT's
+      # battle status window uses them: who, what condition they are in, then the
+      # gauges. The condition column is why this window is laid out in columns at
+      # all — a state is drawn in its *own* palette colour, which a single
+      # `draw_text` of a whole line cannot do. (EasyRPG's
+      # `Window_BattleStatus::Refresh`, RPG2k branch: name at 4, state at 86,
+      # HP at 142, SP at 202 for a party with no maxima over 999.)
+      STATUS_NAME_X  = 4
+      STATUS_STATE_X = 86
+      STATUS_HP_X    = 142
+      STATUS_MP_X    = 202
+
+      # Rebuild the status panel: the party's HP and SP, each with the one
+      # condition RPG_RT shows — the significant state, or the database's
+      # "normal" term when there is none — so a status inflicted by a skill or
+      # by a battle page's Change Monster Condition is visible rather than only
+      # simulated. RPG2000 is front-view: the enemy troop is never listed here
+      # (EasyRPG's Scene_Battle_Rpg2k builds exactly one Window_BattleStatus,
+      # defaulted to `enemy: false`) -- it is represented only by its battler
+      # sprites and, when targeted, by the target window's name list. The row
+      # of whichever actor is currently being commanded gets the cursor,
+      # mirroring `status_window->SetIndex` in EasyRPG's `SelectNextActor`.
+      #
+      # `battle_type` 2 (gauge, `#gauge_battle_layout?`) replaces this whole
+      # panel with RPG2003's face/bar "gauge card" layout instead
+      # (`#battle_status_gauge_window`) -- `battle_type` 1 (alternative) is
+      # unchanged, and still builds the same text rows this always has, since
+      # only 2 asks for the card presentation (EasyRPG's own
+      # `Window_BattleStatus::Refresh`/`RefreshGauge` branch the same way, on
+      # `battle_type == BattleType_gauge` specifically, not on "not
+      # traditional"). Falls back to the text rows when the gauge window
+      # cannot be built (no System2 graphic, or a failed load) rather than
+      # leaving the panel blank.
+      def refresh_battle_status
+        @ui[:status_win].dispose if @ui[:status_win]
+        win = battle_status_gauge_window(@ui[:allies]) if gauge_battle_layout?
+        @ui[:status_win] = win || begin
+          rows = @ui[:allies].map { |a| battle_status_row(a) }
+          # No row highlighted while the options window is open -- matching
+          # `status_window->SetIndex(-1)` in `ProcessSceneActionFightAutoEscape`'s
+          # own `eMoveWindow` substate; nobody is "the acting actor" until
+          # Battle or Auto Battle is chosen.
+          idx = @ui[:phase] == :battle_options ? nil : @ui[:allies].index(current_actor)
+          battle_status_window(rows, idx)
+        end
+      end
+
+      # Whether the database's `battlecommands.battle_type` is specifically 2
+      # (gauge) -- distinct from `Game::Party#alternate_battle_layout?`, which
+      # is also true for the plain sprite-only layout (1) and still uses the
+      # unchanged text status window for that case. A bare test fixture (or
+      # any database `#alternate_battle_layout?` itself already reads false
+      # for) reads false here too.
+      def gauge_battle_layout?
+        @state.party.respond_to?(:gauge_battle_layout?) && @state.party.gauge_battle_layout?
+      end
+
+      # One party member's row as [text, x, colour index] segments: name,
+      # condition, then the HP / SP gauges.
+      def battle_status_row(b)
+        hp = b.hp < 0 ? 0 : b.hp
+        [[b.name, STATUS_NAME_X, 0], battle_state_segment(b),
+         ["HP #{hp}/#{b.max_hp}", STATUS_HP_X, 0],
+         ["MP #{b.mp}/#{b.max_mp}", STATUS_MP_X, 0]]
+      end
+
+      # The condition column, as a status-panel segment: the same reading the
+      # field windows draw (Scene::Base#state_display), placed in its column.
+      def battle_state_segment(b)
+        text, color = state_display(b.states)
+        [text, STATUS_STATE_X, color]
+      end
+
+      # `Window_BattleStatus`'s own default `actor_face_height` (24) -- the
+      # small-window variant (14) is `battlecommands.window_size`, which
+      # schema.rb has not decoded yet (see this change's changelog entry), so
+      # every gauge card always uses the large-window offset.
+      ACTOR_FACE_HEIGHT = 24
+
+      # The gauge card layout (`battle_type` 2): one 80px-wide card per party
+      # member -- face, HP/SP bars and digit-glyph numbers, drawn straight
+      # from the database's own System2 graphic -- ported column-for-column
+      # from EasyRPG's real `Window_BattleStatus::Refresh`/`RefreshGauge`
+      # (the `!enemy && battle_type == BattleType_gauge` branch of each).
+      # Borderless like RPG_RT's own gauge window (`Window#transparent=` --
+      # EasyRPG's constructor sets `border_x = border_y = 0` and
+      # `SetOpacity(0)` for this same case, "simulate a borderless window...
+      # makes the implementation on scene-side easier"), and never gets a
+      # cursor rect: `UpdateCursorRect` returns an empty rect unconditionally
+      # for this battle_type, so no row is ever highlighted here, unlike the
+      # text status window's acting-actor cursor. The ATB/wait gauge row
+      # `RefreshGauge` also draws (`DrawGaugeSystem2(..., GetAtbGauge,
+      # GetMaxAtbGauge, 2)`) is skipped -- this runtime has no ATB/wait-timer
+      # subsystem to read a value from. Returns nil (so `#refresh_battle_status`
+      # falls back to the plain text rows) when the database names no System2
+      # graphic, or names one that fails to load -- there is no sensible
+      # placeholder gauge sprite sheet the way there's a placeholder colour
+      # block for a missing battler graphic.
+      def battle_status_gauge_window(allies)
+        system2 = battle_system2_bitmap
+        return nil unless system2
+        inner_w = BATTLE_STATUS_W - Window::BORDER * 2
+        inner_h = BATTLE_PANEL_H - Window::BORDER * 2
+        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
+        win.z = 300
+        win.transparent = true
+        c = Bitmap.new(inner_w, inner_h)
+        allies.each_with_index { |ally, i| draw_battle_gauge_card(c, system2, ally, i) }
+        win.contents = c
+        win
+      end
+
+      # One party member's gauge card at column `i`. `ally` is a
+      # `Game::Battle::Combatant` (`Game::Battle.from_actor`) -- its `.actor`
+      # is the underlying `Game::Actor`, the only place `faceset_name`/
+      # `faceset_index` (chunk 11 fields 15/16, including any Change Actor
+      # Face override) live. Ported from `RefreshGauge`'s own gauge-card
+      # block: the face, then the bar's left cap / stretched centre / right
+      # cap at `System2` (0,32,16,48)/(16,32,16,48)/(32,32,16,48), then the
+      # HP row (`which` 0) and SP row (`which` 1) fills and numbers -- the
+      # exact x/y arithmetic (`32 + 80*i`, `40 + 80*i`, `y + 12 + 4`) is
+      # copied from the real source rather than re-derived.
+      def draw_battle_gauge_card(c, system2, ally, i)
+        draw_battle_gauge_face(c, ally.actor, i)
+        x = 32 + i * 80
+        y = ACTOR_FACE_HEIGHT
+        c.blt x, y, system2, Rect.new(0, 32, 16, 48)
+        x += 16
+        fill_x = x
+        c.stretch_blt Rect.new(x, y, 25, 48), system2, Rect.new(16, 32, 16, 48)
+        x += 25
+        c.blt x, y, system2, Rect.new(32, 32, 16, 48)
+        hp = ally.hp < 0 ? 0 : ally.hp
+        draw_gauge_system2(c, system2, fill_x, y, hp, ally.max_hp, 0)
+        draw_gauge_system2(c, system2, fill_x, y + 16, ally.mp, ally.max_mp, 1)
+        num_x = 40 + 80 * i
+        draw_number_system2(c, system2, num_x, y, hp)
+        draw_number_system2(c, system2, num_x, y + 12 + 4, ally.mp)
+      end
+
+      # The card's face portrait -- the same 48x48 FaceSet crop
+      # `#load_face_bitmap`/`FACE_SIZE` already draw for the name-entry and
+      # message-face screens, just placed at this card's column instead of
+      # its own window. Draws nothing (leaving the card's bars/numbers alone)
+      # for an actor with no faceset set, or a faceset file that fails to
+      # load, the same "a missing portrait shows nothing" rule
+      # `#load_face`/`#draw_kana_face` already use -- and, matching every
+      # other optional actor field this screen reads (`battler_animation_id`,
+      # `battle_x`/`battle_y`), `#respond_to?`-guarded so a bare test fixture
+      # actor with no faceset fields at all still draws the rest of the card.
+      def draw_battle_gauge_face(c, actor, i)
+        return unless actor && actor.respond_to?(:faceset_name)
+        face = @map.load_face_bitmap(actor.faceset_name)
+        return unless face
+        index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
+        src = Rect.new((index % 4) * Map::FACE_SIZE,
+                       (index / 4) * Map::FACE_SIZE,
+                       Map::FACE_SIZE, Map::FACE_SIZE)
+        c.blt 80 * i, ACTOR_FACE_HEIGHT, face, src
+      end
+
+      # The HP (`which` 0) or SP (`which` 1) bar fill: a `25 * cur / max`
+      # wide stretch of the fill tile at `System2` `(48, 32 + 16*which, 16,
+      # 16)` -- except an exactly-full gauge (`cur == max`) reads the
+      # visually distinct "full" fill tile 16px over, at `(64, ...)`,
+      # instead of the normal partial-fill one. Ported from
+      # `Window_BattleStatus::DrawGaugeSystem2` exactly, including its
+      # `max == 0` no-draw guard (a stat with no pool at all, e.g. an actor
+      # with 0 max SP, draws no fill for that row).
+      def draw_gauge_system2(c, system2, x, y, cur, max, which)
+        return if max == 0
+        gauge_x = cur == max ? 16 : 0
+        width = 25 * cur / max
+        c.stretch_blt Rect.new(x, y, width, 16), system2,
+                     Rect.new(48 + gauge_x, 32 + 16 * which, 16, 16)
+      end
+
+      # Right-aligned up-to-4-digit number in 8x16 glyph cells (`System2`
+      # `(digit * 8, 80, 8, 16)`), leading zeros suppressed rather than drawn
+      # -- ported from `Window_BattleStatus::DrawNumberSystem2` exactly,
+      # including its exact leading-zero cascade: a thousands (or hundreds)
+      # digit that comes out to 0 still lets the *next* digit down draw via
+      # its own `handle_zero` carry, so 100 draws all three digits ("100")
+      # while 7 draws only the ones cell (three blank cells then "7") and 42
+      # draws the tens+ones cells ("42", blank above).
+      def draw_number_system2(c, system2, x, y, value)
+        handle_zero = false
+        if value >= 1000
+          c.blt x, y, system2, Rect.new((value / 1000) * 8, 80, 8, 16)
+          value %= 1000
+          handle_zero = true if value < 100
+        end
+        if handle_zero || value >= 100
+          handle_zero = false
+          c.blt x + 8, y, system2, Rect.new((value / 100) * 8, 80, 8, 16)
+          value %= 100
+          handle_zero = true if value < 10
+        end
+        if handle_zero || value >= 10
+          c.blt x + 16, y, system2, Rect.new((value / 10) * 8, 80, 8, 16)
+          value %= 10
+        end
+        c.blt x + 24, y, system2, Rect.new(value * 8, 80, 8, 16)
+      end
+
+      # The RPG2003 System2 graphic (gauge fill/caps and the digit glyphs the
+      # gauge card draws numbers with) -- one cache entry, keyed by name like
+      # every other named battle graphic (`#cached_bitmap`), since a project
+      # only ever declares the one in `system.system2_name` (chunk 22 field
+      # 20, schema.rb). A blank name or a failed load returns nil (and logs,
+      # for the latter) so `#battle_status_gauge_window` falls back to the
+      # plain text status row instead of crashing -- unlike
+      # `#battler_bitmap`/`#actor_battlecharset_bitmap`, there is no sensible
+      # placeholder gauge sprite sheet to draw in its place.
+      def battle_system2_bitmap
+        name = db.system.respond_to?(:system2_name) ? db.system.system2_name : nil
+        return nil unless name && !name.empty?
+        cached_bitmap(@system2_cache, name) do
+          begin
+            Bitmap.new("System2/#{name}", true)
+          rescue StandardError => e
+            $stderr.puts "[RPG2k] System2 graphic '#{name}' load failed: #{e.message}"
+            nil
+          end
+        end
+      end
+
+      # The current actor's command menu — Attack / Skill / Defend / Item, with
+      # a cursor. RPG_RT does not put the actor's name in this window at all
+      # (EasyRPG's `CreateBattleCommandWindow` builds it once from the four
+      # command terms in that order): the acting actor is shown by the cursor
+      # `#refresh_battle_status` puts on their row in the status window instead
+      # (EasyRPG's `status_window->SetIndex(actor_index)`). The Skill slot's own
+      # label can still change per actor (`#skill_command_label`), the same way
+      # EasyRPG's `RefreshCommandWindow` calls `SetItemText` on that one row
+      # after the window is built rather than rebuilding the whole thing.
+      def draw_battle_command
+        actor = current_actor
+        return unless actor
+        @ui[:cmd_win].dispose if @ui[:cmd_win]
+        labels = battle_commands
+        win = Window.new(BATTLE_STATUS_W, BATTLE_PANEL_Y, BATTLE_CMD_W, BATTLE_PANEL_H)
+        win.z = 320
+        win.windowskin = windowskin
+        inner_w = BATTLE_CMD_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        labels.each_with_index do |label, i|
+          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
+        end
+        win.contents = c
+        win.cursor_rect =
+          Rect.new(0, @ui[:cmd] * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
+        @ui[:cmd_win] = win
+        refresh_battle_status
+      end
+
+      # The Battle/Auto Battle/Escape options window -- the same panel and
+      # rect the per-actor command window uses (only one of the two is ever
+      # on screen at a time), just with `#battle_option_rows`' three entries
+      # instead of the usual four.
+      def draw_battle_options
+        @ui[:cmd_win].dispose if @ui[:cmd_win]
+        labels = battle_option_rows.map { |r| r[:label] }
+        win = Window.new(BATTLE_STATUS_W, BATTLE_PANEL_Y, BATTLE_CMD_W, BATTLE_PANEL_H)
+        win.z = 320
+        win.windowskin = windowskin
+        inner_w = BATTLE_CMD_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        labels.each_with_index do |label, i|
+          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
+        end
+        win.contents = c
+        win.cursor_rect =
+          Rect.new(0, @ui[:opt] * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
+        @ui[:cmd_win] = win
+        refresh_battle_status
+      end
+
+      # The target-selection menu — the living enemies, with a cursor. Fixed at
+      # `CreateBattleTargetWindow`'s own rect: it covers the status window's
+      # footprint (not the command window's, which stays on screen beside it).
+      def draw_battle_target
+        foes = living_foes
+        @ui[:target_win].dispose if @ui[:target_win]
+        @ui[:target_win] =
+          battle_list_window(0, BATTLE_TARGET_W, foes.map(&:name),
+                             @ui[:target_i], 330)
+      end
+
+      def close_battle_target
+        return unless @ui[:target_win]
+        @ui[:target_win].dispose
+        @ui[:target_win] = nil
+      end
+
+      # A bottom-anchored list window of `labels` with the cursor on `sel`, at
+      # left edge `x` and width `w`, fixed to the panel's own height (80px, the
+      # shape every RPG_RT battle list window shares) — the shared shape of the
+      # Skill / Item / target / ally-target menus. A list longer than
+      # `BATTLE_VISIBLE_ROWS` scrolls, keeping `sel` in view, the way
+      # `Window_Selectable`'s own scrolling does for an oversized troop or
+      # skill list.
+      def battle_list_window(x, w, labels, sel, z)
+        rows = BATTLE_VISIBLE_ROWS
+        scroll = labels.length > rows ? [[sel - rows + 1, 0].max, labels.length - rows].min : 0
+        win = Window.new(x, BATTLE_PANEL_Y, w, BATTLE_PANEL_H)
+        win.z = z
+        win.windowskin = windowskin
+        inner_w = w - Window::BORDER * 2
+        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        labels.each_with_index do |label, i|
+          next if i < scroll || i >= scroll + rows
+          c.draw_text 0, (i - scroll) * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
+        end
+        win.contents = c
+        unless labels.empty?
+          win.cursor_rect = Rect.new(0, (sel - scroll) * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
+        end
+        win
+      end
+
+      # The current actor's battle skills as "Name  cost", with a cursor. Full
+      # width, same rect as the item menu — RPG_RT's skill and item windows
+      # cover both the status and command windows while open (EasyRPG's
+      # `skill_window` / `item_window`, `(0, screen_height - 80, MENU_WIDTH,
+      # 80)`).
+      def draw_battle_skill
+        @ui[:skill_win].dispose if @ui[:skill_win]
+        labels = @ui[:skills].map do |sid, cost|
+          sk = @state.party.db_skill(sid)
+          "#{sk ? sk.name : "Skill #{sid}"}  #{cost}"
+        end
+        @ui[:skill_win] = battle_list_window(0, SCREEN_W, labels, @ui[:skill_i], 325)
+      end
+
+      def close_battle_skill
+        return unless @ui[:skill_win]
+        @ui[:skill_win].dispose
+        @ui[:skill_win] = nil
+      end
+
+      # The party's battle items as "Name  xN", with a cursor.
+      def draw_battle_item
+        @ui[:item_win].dispose if @ui[:item_win]
+        labels = @ui[:items].map do |id, count|
+          it = @state.party.db_item(id)
+          "#{it ? it.name : "Item #{id}"}  x#{count}"
+        end
+        @ui[:item_win] = battle_list_window(0, SCREEN_W, labels, @ui[:item_i], 325)
+      end
+
+      def close_battle_item
+        return unless @ui[:item_win]
+        @ui[:item_win].dispose
+        @ui[:item_win] = nil
+      end
+
+      # The living party members selectable as a heal target ("Name HP h/mh"),
+      # with a cursor -- narrowed by #battle_ally_targets when a pending item's
+      # actor_set excludes some of them. RPG_RT reuses the status window itself
+      # for this (`status_window->SetChoiceMode`); this screen still draws a
+      # separate window, but at the status window's own rect and footprint so
+      # it reads the same way -- covering the party's HP display, leaving the
+      # command window in view beside it.
+      def draw_battle_ally_target
+        @ui[:ally_win].dispose if @ui[:ally_win]
+        labels = battle_ally_targets.map do |a|
+          "#{a.name}  #{a.hp < 0 ? 0 : a.hp}/#{a.max_hp}"
+        end
+        @ui[:ally_win] =
+          battle_list_window(0, BATTLE_STATUS_W, labels, @ui[:ally_i], 335)
+      end
+
+      def close_battle_ally_target
+        return unless @ui[:ally_win]
+        @ui[:ally_win].dispose
+        @ui[:ally_win] = nil
+      end
+
+      # Banner the attack that just landed ("Hero hits Slime for 12", "…
+      # defeated!") low on the screen while the round animates, so each action
+      # reads on screen as well as its HP tick. Replaced by the next action's
+      # banner and dropped when the round settles.
+      def show_battle_action(entry)
+        show_battle_banner(battle_action_lines(entry))
+      end
+
+      # The low action banner itself, shared by a landed hit (#show_battle_action)
+      # and a failed Escape attempt: both are transient status text over the
+      # still-running fight, replaced by whatever banners next and dropped when
+      # the round settles.
+      def show_battle_banner(lines)
+        @ui[:action_win].dispose if @ui[:action_win]
+        @ui[:action_win] = battle_panel_window(lines, 340)
+      end
+
+      # The system SFX a landed action plays, alongside its banner. Each check
+      # is independent rather than an elsif chain -- RPG_RT plays its own cue
+      # for each thing that happened to the same hit, not one sound standing in
+      # for all of them: a killing blow plays the damage sound and then the
+      # death cry, and an item that lands a hit plays the item's own cue
+      # alongside the hit's (EasyRPG's Scene_Battle_Rpg2k fires
+      # SFX_EnemyDamage / SFX_AllyDamage and, on top of a kill, SFX_EnemyKill,
+      # as separate calls rather than one replacing another).
+      def play_battle_action_se(entry)
+        # `attacker_ally` only rides on a plain Attack's own entry (never a
+        # skill/item hit -- see Battle#deal_attack), and is `false` rather
+        # than absent for an enemy's swing, so this fires before the hit's
+        # own resolution SE, matching RPG_RT playing it at the very start of
+        # the action.
+        play_system_se(SFX_ENEMY_ATTACK) if entry[:attacker_ally] == false
+        play_system_se(SFX_DODGE) if entry[:missed]
+        if entry[:damage] && entry[:damage] > 0
+          play_system_se(entry[:target_ally] ? SFX_ACTOR_DAMAGE : SFX_ENEMY_DAMAGE)
+        end
+        play_system_se(SFX_ENEMY_DEATH) if entry[:defeated] && !entry[:target_ally]
+        play_system_se(SFX_ITEM) if entry[:item_id]
+      end
+
+      # The conditions the action just landed or lifted, one sentence each under
+      # the action's own line — RPG_RT announces every one of them, and until now
+      # a skill that poisoned its target said only how much damage it did.
+      #
+      # The sentences come from the state row itself (`message_actor` /
+      # `message_enemy` for one landing, `message_recovery` for one lifting),
+      # which is where the game's own wording lives. An English-release database
+      # leaves them blank, so a plain composition stands in.
+      def battle_state_lines(entry)
+        table = db.respond_to?(:situation) ? db.situation : nil
+        name = entry[:target].to_s
+        ally = entry[:target_ally] ? true : false
+        lines = []
+        (entry[:inflicted] || []).each do |id|
+          lines << (Game::States.inflict_message(id, table, name, ally) ||
+                    "#{name} is #{state_label(id, table)}")
+        end
+        # A state the target already carried when the skill tried to inflict it
+        # again. RPG_RT announces it rather than going quiet, in the state's own
+        # words ("はすでに毒に冒されている！"), and reports it as a *success*.
+        (entry[:already] || []).each do |id|
+          lines << (Game::States.already_message(id, table, name) ||
+                    "#{name} is already #{state_label(id, table)}")
+        end
+        # `cured` is a medicine or a cure skill lifting a state; `woke` is a blow
+        # shaking one off (a state's `release_by_attack`). Both are the state
+        # lifting, which has one wording whichever side it happened to.
+        ((entry[:cured] || []) + (entry[:woke] || [])).each do |id|
+          lines << (Game::States.recovery_message(id, table, name) ||
+                    "#{name} recovers from #{state_label(id, table)}")
+        end
+        # Being downed is state 1 landing, and RPG_RT announces it with that
+        # state's own sentence — which is worded from the *speaker's* side, so a
+        # Japanese game says "ゼロは倒れた！" of a party member and "スライムを
+        # 倒した！" of an enemy. The simulation reports it as a flag on the hit
+        # rather than through `inflicted`, so it is read from there.
+        if entry[:defeated]
+          lines << (Game::States.inflict_message(Game::States::DEATH_ID, table,
+                                                 name, ally) ||
+                    "#{name} is defeated!")
+        end
+        terms = db.respond_to?(:term) ? db.term : nil
+        (entry[:stat_changed] || {}).each do |key, delta|
+          term_name = STAT_CHANGE_TERM[key]
+          next unless term_name && delta && delta != 0
+          lines << (Game::States::BattleText.parameter_change(terms, name, delta, term_name) ||
+                    "#{name}'s #{term_name} #{delta > 0 ? 'rose' : 'fell'} by #{delta.abs}")
+        end
+        attr_ids = entry[:attr_shifted] || []
+        unless attr_ids.empty?
+          positive = (entry[:attr_shift_dir] || 1) > 0
+          props = db.respond_to?(:property) ? db.property : nil
+          attr_ids.each do |aid|
+            row = props ? props[aid] : nil
+            attr_name = row && row.respond_to?(:name) ? row.name : "attribute #{aid}"
+            lines << (Game::States::BattleText.attribute_shift(terms, name, positive, attr_name) ||
+                      "#{name}'s resistance to #{attr_name} #{positive ? 'rose' : 'fell'}")
+          end
+        end
+        lines
+      end
+
+      # The 用語 field naming each ATK/DEF/SPI(mind)/AGI stat itself (as
+      # opposed to `Game::Battle::STAT_MOD_FIELD`, which names the Combatant
+      # accessor that holds the modifier) -- what #battle_state_lines passes
+      # `BattleText.parameter_change` as `points`.
+      STAT_CHANGE_TERM = { atk: :attack, def: :defense, spi: :mind, agi: :agility }.freeze
+
+      def state_label(id, table)
+        Game::States.name(id, table) || "state #{id}"
+      end
+
+      def close_battle_action
+        return unless @ui[:action_win]
+        @ui[:action_win].dispose
+        @ui[:action_win] = nil
+      end
+
+      def open_battle_result(lines)
+        @ui[:result_win] = battle_panel_window(lines, 320)
+      end
+
+      # RPG_RT's battle message window (the per-action banner, the result
+      # panel) is a fixed 320x80 strip at the bottom of the screen -- the same
+      # rect as the status/command windows it visually replaces while it is up
+      # (EasyRPG's `Window_BattleMessage`, `(0, screen_height - 80, MENU_WIDTH,
+      # 80)`) -- not a panel sized to fit its text.
+      def battle_panel_window(lines, z)
+        inner_w = SCREEN_W - Window::BORDER * 2
+        win = Window.new(0, BATTLE_PANEL_Y, SCREEN_W, BATTLE_PANEL_H)
+        win.z = z
+        win.windowskin = windowskin
+        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        lines.each_with_index do |line, i|
+          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, line
+        end
+        win.contents = c
+        win
+      end
+
+      # A text panel of `lines` at vertical position `y` and depth `z`, sized to
+      # fit its content -- used for the battle-event page message window, which
+      # this screen deliberately keeps off the bottom panel's rect (see
+      # `BATTLE_EVENT_MSG_Y`) so a page talking mid-round does not fight the
+      # action banner for the same row.
+      def battle_text_window(lines, y, z)
+        inner_w = SCREEN_W - 20 - Window::BORDER * 2
+        inner_h = [lines.length, 1].max * BATTLE_LINE_H
+        win = Window.new(10, y, SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        win.z = z
+        win.windowskin = windowskin
+        c = Bitmap.new(inner_w, inner_h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        lines.each_with_index do |line, i|
+          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, line
+        end
+        win.contents = c
+        win
+      end
+
+      # The party status panel: each row is a list of [text, x, colour index]
+      # segments rather than one string, so a row can mix colours. Drawn through
+      # `draw_system_text`, which fills the glyphs from the System graphic's own
+      # palette swatch (and falls back to flat white text when the project ships
+      # no windowskin) — the way RPG_RT colours a state name. Fixed at the
+      # bottom-left of the panel (`Window_BattleStatus`'s own rect), with a
+      # cursor on `cursor_idx`'s row when the acting actor is one of these rows.
+      def battle_status_window(rows, cursor_idx = nil)
+        inner_w = BATTLE_STATUS_W - Window::BORDER * 2
+        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
+        win.z = 300
+        win.windowskin = windowskin
+        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        rows.each_with_index do |segments, i|
+          segments.each do |text, x, color|
+            draw_system_text c, x, i * BATTLE_LINE_H, inner_w - x,
+                             BATTLE_LINE_H, text.to_s, windowskin, color
+          end
+        end
+        win.contents = c
+        if cursor_idx
+          win.cursor_rect = Rect.new(0, cursor_idx * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
+        end
+        win
+      end
+
+      def dispose
+        return unless @ui
+        [@ui[:status_win], @ui[:cmd_win],
+         @ui[:target_win], @ui[:skill_win],
+         @ui[:item_win], @ui[:ally_win],
+         @ui[:action_win], @ui[:result_win],
+         @ui[:event_win]].each { |w| w.dispose if w }
+        dispose_battle_sprite(@ui[:back_sprite])
+        (@ui[:enemy_sprites] || []).each { |s| dispose_battle_sprite(s) }
+        (@ui[:actor_sprites] || []).each { |s| dispose_battle_sprite(s) }
+        @ui = nil
+      end
+
+      # Dispose a battle sprite. Its bitmap (the backdrop or a battler, see
+      # #battle_back_bitmap / #battler_bitmap) is a shared @backdrop_cache or
+      # @monster_cache entry that may still be referenced elsewhere (another
+      # troop slot, a later encounter reusing the same graphic this visit),
+      # so only the sprite itself is freed here.
+      def dispose_battle_sprite(spr)
+        return unless spr
+        spr.dispose
+      end
+
+      # The battle-round half of #hold_animation_target_flash's forced clear:
+      # the same RGSS Sprite#flash primitive #fire_target_flash arms a flash
+      # with, called with a zero duration (flash_count 0 reads as "not
+      # flashing," mruby-rgss/src/lib.cxx's own spr_flash/spr_update) to drop
+      # whatever flash -- this animation's own decayed-away one, or an
+      # unrelated one -- is currently in flight on that enemy sprite. A nil
+      # target_index (an ally-scoped animation, no on-screen sprite) or a
+      # missing @ui (the animation already finished/the fight already
+      # ended) is a silent no-op, matching #fire_target_flash's own guard.
+      def clear_target_flash(target_index)
+        sprites = @ui && @ui[:enemy_sprites]
+        spr = target_index && sprites ? sprites[target_index] : nil
+        spr.flash(nil, 0) if spr
+      end
+
+      # yado.tk / the LCF schema itself (`animation_timing`'s flash_scope field,
+      # 0 none / 1 target / 2 screen): a Battle Animation frame's flash can pulse
+      # its *target* instead of the whole screen -- previously dropped outright,
+      # since only flash_scope 2 was ever handled here. Scoped to the
+      # battle-round path (a skill/item's `target_index`, see
+      # #battle_animation_pixel): RPG2000's battle is front-view, so an
+      # ally-targeted entry has no on-screen sprite to flash (target_index is
+      # nil there, same as it already is for centring the animation itself).
+      # A map-triggered Show Battle Animation (11210) aimed at a map character
+      # is a different target class entirely, handled by #fire_map_target_flash
+      # below. Uses the RGSS Sprite#flash/#update primitive
+      # (mruby-rgss/src/lib.cxx) already ported natively but unused elsewhere
+      # in this codebase, decayed each frame by #update_enemy_flashes.
+      def fire_target_flash(target_index, t)
+        sprites = @ui && @ui[:enemy_sprites]
+        spr = target_index && sprites ? sprites[target_index] : nil
+        return unless spr
+        spr.flash(Color.new((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
+                            (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8),
+                  Map::ANIM_FLASH_FRAMES)
+      end
+
+      # The screen_shaking-1 counterpart to #fire_target_flash: arms a timed
+      # shake of just the animation's own target sprite, mirroring EasyRPG's
+      # actual C++ source verbatim -- both `BattleAnimationBattle::
+      # ShakeTargets` and `BattleAnimationBattler::ShakeTargets`
+      # (src/battle_animation.cpp) shake every one of the animation's own
+      # battler targets with `battler->ShakeOnce(str, spd, time)`, the exact
+      # same triple `ProcessAnimationTiming` already fires for the screen
+      # case. This codebase's front-view battle has no per-sprite native
+      # shake primitive the way Sprite#flash exists for the colour pulse, so
+      # the state is tracked in a plain `@ui[:enemy_shake]` hash
+      # (paralleling `enemy_sprites` by index) and stepped by
+      # #update_enemy_shakes every frame -- the same `Shake::NextPosition`
+      # sine-wave port Game::Screen#update_shake already drives for the
+      # whole-screen case, just applied to one sprite's own x. RPG2000's
+      # battle is front-view, so an ally-targeted entry has no sprite to
+      # shake (target_index is nil there, the same gap #fire_target_flash's
+      # own comment already documents) -- a silent no-op, not an error.
+      def fire_target_shake(target_index)
+        sprites = @ui && @ui[:enemy_sprites]
+        return unless target_index && sprites && sprites[target_index]
+        @ui[:enemy_shake] ||= []
+        @ui[:enemy_shake][target_index] =
+          { power: Map::ANIM_SHAKE_POWER, speed: Map::ANIM_SHAKE_SPEED,
+            frames: Map::ANIM_SHAKE_FRAMES, offset: 0 }
+      end
+
+      # Advance every in-flight #fire_target_shake state by one frame --
+      # called from #update every frame, right alongside
+      # #update_enemy_flashes/#update_enemy_positions. A direct port of
+      # Game::Screen#update_shake's own step (see there for the EasyRPG
+      # `Shake::NextPosition`/`Shake::Update` provenance), just keyed per
+      # troop-member index instead of a single screen-wide state, and applied
+      # to that member's own sprite x (recomputed from its live database
+      # position the same way #update_enemy_positions already recomputes y
+      # for a levitating member, so a sprite rebuilt mid-shake --
+      # #reveal_battle_monster, #remove_fled_monster -- is never left
+      # offset from a stale base). A slot with nothing active costs nothing.
+      def update_enemy_shakes
+        shakes = @ui[:enemy_shake]
+        return unless shakes
+        sprites = @ui[:enemy_sprites]
+        troop = @ui[:troop]
+        shakes.each_index do |i|
+          st = shakes[i]
+          next unless st
+          spr = sprites && sprites[i]
+          member = troop && troop.members[i]
+          unless spr && member
+            shakes[i] = nil
+            next
+          end
+          st[:frames] -= 1
+          if st[:frames] <= 0
+            st[:offset] = 0
+            shakes[i] = nil
+          else
+            amplitude = 1 + 2 * st[:power]
+            phase = (st[:frames] * 4 * (st[:speed] + 2)) % 256
+            newpos = (amplitude * Math.sin(phase * Math::PI / 128) * -1).to_i
+            cutoff = (st[:speed] * amplitude) / 8 + 1
+            st[:offset] = Game.clamp(newpos, st[:offset] - cutoff, st[:offset] + cutoff)
+          end
+          spr.x = member.x - spr.bitmap.width / 2 + st[:offset]
+        end
+      end
+    end
+  end
+end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -166,7 +166,8 @@ class RPG2k
         @inn_bgm_started = false
         @inn_fading_out = false
         @shop = nil
-        @battle_ui = nil
+        # The running fight, or nil between encounters -- see Scene::Battle.
+        @battle = nil
         @name_ui = nil
         @wait_timer = nil
         @anim_wait = nil
@@ -247,6 +248,25 @@ class RPG2k
 
       attr_reader :state
 
+      # Services Scene::Battle calls back into ----------------------------
+      #
+      # Scene::Battle owns everything the fight itself is made of; what it
+      # reaches back into this scene for is the handful of things a running
+      # fight shares with the field map: the graphic caches (a monster or
+      # backdrop decoded in one encounter stays warm for the next one on the
+      # same map visit), the RNG the map's own event/move-route code already
+      # shares with the party, the windowskin (a Change System Graphic run
+      # from a battle event page reloads this scene's own copy), and the
+      # animation player a round's skill/item animation shares with the
+      # map's own Show Battle Animation command. Every reader here backs one
+      # of those; the methods a few screens down (#play_battle_bgm,
+      # #terrain_backdrop, #perform_game_over, ...) are the same kind of
+      # service, just too tied to their own surrounding map code to move next
+      # to their readers.
+      attr_reader :rng, :monster_cache, :backdrop_cache, :battlecharset_cache,
+                  :system2_cache, :windowskin
+      attr_accessor :map_animation
+
       def dispose
         close_message(animate: false)
         (@closing_windows || []).each(&:dispose)
@@ -310,8 +330,8 @@ class RPG2k
         # then), so any true here is unambiguously that case. Mirrors Terminate
         # Battle's own :abort outcome (#finish_terminated_battle), just reachable
         # from any battle phase rather than only the battle-event one.
-        if @state.tick_timer(!@battle_ui.nil?) && @battle_ui
-          finish_battle(:abort)
+        if @state.tick_timer(!@battle.nil?) && @battle
+          @battle.finish_battle(:abort)
         end
         @state.screen.update # screen tint progresses every frame, even in events
         @state.update_pictures # picture moves progress every frame too
@@ -1190,13 +1210,13 @@ class RPG2k
           # A battle a Parallel Process opened (#drive_parallel_wait's :battle
           # case) is exactly as busy as one the foreground itself opened --
           # before that fix existed only @interpreter could ever hold
-          # @battle_ui, so @interpreter.waiting? alone already covered this;
-          # now that a Common Event's or a map event's own Parallel Process
-          # can own the single battle slot too, its mere presence has to gate
-          # ordinary player movement/menu/Auto-Start here on its own, the same
-          # way #parallels_paused? already gates every *other* parallel
-          # process on it.
-          !@battle_ui.nil?
+          # @battle, so @interpreter.waiting? alone already covered this; now
+          # that a Common Event's or a map event's own Parallel Process can own
+          # the single battle slot too, its mere presence has to gate ordinary
+          # player movement/menu/Auto-Start here on its own, the same way
+          # #parallels_paused? already gates every *other* parallel process on
+          # it.
+          !@battle.nil?
       end
 
       # Whether a message window or choice list (Show Message / Show Choices /
@@ -1242,7 +1262,7 @@ class RPG2k
       # still-bursting case (in practice: a command list heavy enough to spill
       # past a single frame's MAX_STEPS budget without hitting a wait).
       def parallels_paused?
-        !@battle_ui.nil? || (@interpreter.running? && !@interpreter.waiting?)
+        !@battle.nil? || (@interpreter.running? && !@interpreter.waiting?)
       end
 
       # Drive the just-started foreground Auto-Start process, then -- yado.tk
@@ -1471,9 +1491,9 @@ class RPG2k
       end
 
       # Keep a Parallel Process's own battle advancing once it has opened one
-      # (#drive_parallel_wait's :battle case). @battle_ui's mere presence
-      # pauses #step_parallels for every *other* parallel process for the
-      # fight's duration (#parallels_paused?, "Common events never run during
+      # (#drive_parallel_wait's :battle case). @battle's mere presence pauses
+      # #step_parallels for every *other* parallel process for the fight's
+      # duration (#parallels_paused?, "Common events never run during
       # battle") -- but the one that opened it is not a bystander: it still
       # needs exactly the same per-frame #drive_battle service #drive_event's
       # own :battle case already gives a foreground-opened fight, or the
@@ -1484,8 +1504,8 @@ class RPG2k
       # battle belongs to the foreground (nothing here to step) or there is
       # no battle open at all.
       def step_battle_owner_parallel
-        return unless @battle_ui
-        owner = @battle_ui[:owner]
+        return unless @battle
+        owner = @battle.owner
         return if owner.nil? || owner.equal?(@interpreter)
         p = @parallels.find { |pp| pp[:interp].equal?(owner) }
         step_parallel(p) if p
@@ -1601,7 +1621,7 @@ class RPG2k
           # never ran either. #drive_battle itself now takes the interpreter
           # to drive explicitly (`it` here), and keeps being called back
           # into on every later frame by #step_battle_owner_parallel, since
-          # @battle_ui's own presence pauses the ordinary #step_parallels
+          # @battle's own presence pauses the ordinary #step_parallels
           # pass this entry would otherwise need for that (#parallels_paused?).
           drive_battle(it)
         elsif it.wait_kind == :movement
@@ -2969,7 +2989,7 @@ class RPG2k
       # explicit #update each frame" contract #update_enemy_flashes already
       # drives for the battle-only enemy sprites (mruby-rgss/src/lib.cxx's
       # spr_flash/spr_update). Called unconditionally every real frame from
-      # #update, not gated on @battle_ui, since a vehicle can be flashed by a
+      # #update, not gated on @battle, since a vehicle can be flashed by a
       # map-triggered Show Battle Animation with no fight running at all. A
       # sprite with no flash in flight costs nothing here (native #update
       # no-ops).
@@ -3630,13 +3650,13 @@ class RPG2k
       # changelog.d/test-play-gated-debug-tooling.added.md). A battle does NOT
       # block it, per community RPG_RT trivia (@2000_battle_bot /
       # デフォ戦bot): "テストプレイ中にＦ９キーを押せば スイッチ・変数の値を
-      # 好きに変えられる。これは戦闘中でも行える。" -- so `@battle_ui` alone is
-      # excluded from the busy check here (see #drive_battle's own call),
-      # while every other #event_busy? condition (a message window, an
-      # interpreter mid-wait) still gates the ordinary field-map case exactly
-      # as before.
+      # 好きに変えられる。これは戦闘中でも行える。" -- so `@battle` alone is
+      # excluded from the busy check here (Scene::Battle#update calls this
+      # directly, see there), while every other #event_busy? condition (a
+      # message window, an interpreter mid-wait) still gates the ordinary
+      # field-map case exactly as before.
       def try_open_debug_menu
-        return if event_busy? && @battle_ui.nil?
+        return if event_busy? && @battle.nil?
         return unless @parent.test_play
         return unless Input.trigger?(Input::F9)
         @parent.push Scene::DebugMenu.new(@parent, @state)
@@ -3662,7 +3682,7 @@ class RPG2k
 
         # A battle opened by a Parallel Process's own Battle Processing
         # command (#drive_parallel_wait's :battle case) owns the single
-        # @battle_ui slot exactly the way the foreground does when it opens
+        # @battle slot exactly the way the foreground does when it opens
         # one itself. While someone else holds it, the foreground must not
         # keep grinding through its own unrelated commands underneath the
         # fight -- the same freeze every *other* parallel process already
@@ -3670,7 +3690,7 @@ class RPG2k
         # battle"). The message/choice/number dispatch above is left
         # unblocked either way, since a shown window is a shared resource
         # independent of who owns the battle.
-        return if @battle_ui && !@battle_ui[:owner].equal?(@interpreter)
+        return if @battle && !@battle.owner.equal?(@interpreter)
 
         if @interpreter.waiting?
           case @interpreter.wait_kind
@@ -3691,10 +3711,11 @@ class RPG2k
             # yado.tk 09_bug/016_ikinari_end + 017_heiretu_totyu_end/hei_mukou:
             # a Battle "Lose: Branch" handler's own recovery (a Full Heal right
             # after the encounter) races a still-running Parallel Process's own
-            # Game Over check -- #finish_battle already clears @battle_ui (so
-            # #parallels_paused? no longer holds parallel processes back) and
-            # calls #resume_battle *before* this frame's own #step_parallels has
-            # any more chances to run this frame, but #resume_battle only flips
+            # Game Over check -- Scene::Battle#finish_battle already clears
+            # @battle (via #close_battle, so #parallels_paused? no longer
+            # holds parallel processes back) and calls #resume_battle *before*
+            # this frame's own #step_parallels has any more chances to run
+            # this frame, but #resume_battle only flips
             # the interpreter off its :battle wait; nothing then drives it any
             # further until #update's *next* frame -- one whole frame during
             # which the party sits at 0 HP, unrevived, for the very next
@@ -4403,28 +4424,20 @@ class RPG2k
       end
 
       # -- Enemy Encounter (turn-based battle) --------------------------------
-
-      # The battle runs on Combatant snapshots of the party (Game::Battle), so a
-      # resolved fight leaves the real party HP untouched for now — persisting HP
-      # is still to come. On victory the troop's EXP / gold are granted and the
-      # [Victory] handler runs; escape routes its handler. A defeat routes the
-      # [Defeat] handler when the encounter defines one, or ends the game (return
-      # to title) when its defeat mode is "game over".
+      #
+      # The fight itself -- command menu, round animation, battle-event pages,
+      # the result screen -- is Scene::Battle now (mruby-rpg2k/mrblib/scene/
+      # battle.rb); this scene only owns the single slot it runs in and the
+      # frame-by-frame dance of handing control to it.
       #
       # Drive the turn-based battle screen the map shows during a :battle wait.
-      # Each round the player commands every living party member — Attack a chosen
-      # enemy, cast a Skill (on an enemy or ally), use an Item on an ally, or
-      # Defend — then the round plays out action by action in agility order (one
-      # action landing per BATTLE_ANIM_FRAMES, each bannered with its HP tick)
-      # until a side falls. B on the first actor flees when the encounter allows
-      # it. Dismissing the result resumes the event with the outcome.
-      # `it` is whichever interpreter actually raised the :battle wait -- the
+      # `it` is whichever interpreter actually raised the wait -- the
       # foreground event by default, or a Parallel Process's own interpreter
       # when #drive_parallel_wait dispatches here (see there and
       # #step_battle_owner_parallel, which keeps calling back in on every
       # later frame since a battle a Parallel Process opened stops the
       # ordinary #step_parallels pass from ever reaching it again). Only one
-      # fight can be open at a time: if @battle_ui already belongs to a
+      # fight can be open at a time: if @battle already belongs to a
       # *different* interpreter (two Battle Processing commands landing the
       # same real frame, one from each of two independent interpreters), this
       # one simply waits its turn and tries again next frame, the same
@@ -4432,543 +4445,30 @@ class RPG2k
       def drive_battle(it = @interpreter)
         req = it.battle_request
         return it.resume_battle(:victory) unless req
-        if @battle_ui.nil?
-          open_battle(req, it) # opened this frame; take input from the next one
+        if @battle.nil?
+          @battle = Scene::Battle.new(self, req, it)
+          @battle.start # opened this frame; take input from the next one
           return
         end
-        return unless @battle_ui[:owner].equal?(it)
-        update_enemy_flashes
-        update_enemy_positions
-        update_enemy_shakes
-        case @battle_ui[:phase]
-        when :encounter_message then drive_battle_encounter_message
-        when :battle_options then drive_battle_options
-        when :command     then drive_battle_command
-        when :target      then drive_battle_target
-        when :skill       then drive_battle_skill
-        when :item        then drive_battle_item
-        when :ally_target then drive_battle_ally_target
-        when :animate     then drive_battle_animate
-        when :result      then drive_battle_result
-        when :event       then drive_battle_event
-        end
-        # F9 opens the debug menu mid-fight too (see #try_open_debug_menu) --
-        # the ordinary field-map call site only ever runs once #event_busy? is
-        # fully clear, which a battle never is, so this is the one place that
-        # reaches the check while @battle_ui is up.
-        try_open_debug_menu
+        return unless @battle.owner.equal?(it)
+        @battle.update
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle failed: #{e.message}"
-        owner = (@battle_ui && @battle_ui[:owner]) || it
+        owner = @battle ? @battle.owner : it
         close_battle
         owner.resume_battle(:victory)
       end
 
-      def open_battle(req, owner = @interpreter)
-        # RPG_RT's own `Scene_Battle` constructor (src/scene_battle.cpp) plays
-        # the database's Battle Start system SE (`SFX_BeginBattle`) as its very
-        # first act, unconditionally and before even the battle BGM swap --
-        # `#play_system_se`/`SFX_BATTLE` already exist (Scene::Base's shared
-        # system-SE table, `DB_SE_FIELD`), but nothing here ever called them for
-        # this slot: Escape/dodge/damage/death/item all already fire at their
-        # own moments (SFX_ESCAPE/SFX_DODGE/SFX_ENEMY_DAMAGE/SFX_ACTOR_DAMAGE/
-        # SFX_ENEMY_DEATH/SFX_ITEM), only the battle-open moment itself was
-        # silent.
-        # Fires for every encounter this scene ever opens through -- a foreground
-        # Enemy Encounter command, one issued from a Parallel Process, and a
-        # random/wandering-monster encounter -- since #open_battle is their one
-        # shared entry point.
-        play_system_se(SFX_BATTLE)
-        play_battle_bgm
-        troop = Game::Troop.new(db, req[:troop_id])
-        allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
-        foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
-        # The database's state table drives per-turn afflictions (poison slip,
-        # sleep skip) in battle.
-        situations = db.respond_to?(:situation) ? db.situation : nil
-        properties = db.respond_to?(:property) ? db.property : nil
-        @battle_ui = { phase: :command, req: req, troop: troop, owner: owner,
-                       # Whether the Battle/Auto Battle/Escape options window
-                       # has already shown its once-per-battle automatic
-                       # appearance (see #enter_command_phase) -- distinct
-                       # from `opt`, the cursor row inside it whenever it is
-                       # open (set fresh by #open_battle_options each time).
-                       options_shown: false, opt: 0,
-                       # `allies.dup`, not `allies` itself: `@battle_ui[:allies]`
-                       # below stays the exact same array Game::Battle is
-                       # handed here would otherwise *be* -- Ruby arrays are
-                       # mutable objects, so without the dup, deleting a
-                       # departed member from the render-facing
-                       # `@battle_ui[:allies]` (#remove_battle_actor_sprite)
-                       # would delete it from Game::Battle's own bookkeeping
-                       # array too, breaking the rejoin-reuses-the-same-
-                       # Combatant guarantee #sync_allies_from_party depends
-                       # on (ADR 0050). The two arrays start with the same
-                       # Combatant *objects* (so a lookup through either one
-                       # sees the same battle-only state) but are free to
-                       # diverge in which objects they each hold.
-                       battle: Game::Battle.new(allies.dup, foes, @rng,
-                                                situations, true, true, true,
-                                                req[:first_strike] ? true : false,
-                                                properties,
-                                                # Lets the troop run its 行動パターン:
-                                                # skills, transformations and the
-                                                # switch / party-level conditions.
-                                                Game::EnemyAi.new(db, @state),
-                                                # A negative attribute rank rate
-                                                # (see #apply_attr_multiplier)
-                                                # is handled differently per
-                                                # edition.
-                                                rpg2003: db.respond_to?(:rpg2003?) && db.rpg2003?,
-                                                # Mid-battle roster sync
-                                                # (Game::Battle#sync_allies_from_party):
-                                                # a Change Party Member command
-                                                # run from a battle event page
-                                                # mutates this same live
-                                                # Game::Party, and the battle
-                                                # re-derives its own @allies
-                                                # from it every round/action
-                                                # rather than staying pinned to
-                                                # the `allies` snapshot taken
-                                                # just above. The screen itself
-                                                # (`@battle_ui[:allies]`, the
-                                                # status window, actor sprites)
-                                                # follows the same change the
-                                                # instant it happens instead --
-                                                # see #on_battle_party_changed,
-                                                # reached from
-                                                # Interpreter#do_change_party
-                                                # via `@battle_ui[:events].
-                                                # battle_screen` below.
-                                                party: @state.party),
-                       allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
-                       skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
-                       skills: [], items: [],
-                       status_win: nil, cmd_win: nil, target_win: nil,
-                       skill_win: nil, item_win: nil, ally_win: nil,
-                       action_win: nil, anim_timer: 0,
-                       back_sprite: nil, enemy_sprites: nil,
-                       result_win: nil, result: nil,
-                       # The troop's battle-event pages: their own interpreter,
-                       # the message window they draw into, and which pages have
-                       # already fired this turn (RPG2000 runs a page once per
-                       # turn its condition holds, so this resets each round).
-                       events: Game::Interpreter.new(@state), event_win: nil,
-                       pages_run: {},
-                       # Whether the just-drained #step_action entry finished
-                       # its battler's whole action (see #drive_battle_animate),
-                       # and which phase a running battle-event page resumes to
-                       # once it finishes (see #run_battle_events).
-                       battler_boundary: false, event_return_phase: :command,
-                       # Frames elapsed since this battle opened -- cosmetic
-                       # only (drives a levitating enemy's bob, #flying_offset),
-                       # never read for any combat/save-affecting purpose, so
-                       # it needs no seeding beyond starting at 0 every fight.
-                       frame: 0 }
-        @battle_ui[:events].battle = @battle_ui[:battle]
-        # Lets a Change Party Member command run from a battle event page
-        # (Interpreter#do_change_party) reach back into this screen the
-        # moment it fires -- see #on_battle_party_changed. `@battle_ui[:events]`
-        # is the one interpreter ever running commands while a battle is open
-        # (the foreground/parallel interpreters are held off by `event_busy?`/
-        # `parallels_paused?` for as long as `@battle_ui` exists), so this is
-        # never set on any other interpreter.
-        @battle_ui[:events].battle_screen = self
-        # A battle page can Call Common Event (1005), so it needs the same
-        # resolver the encounter's own owning interpreter runs against --
-        # the foreground by default, or a Parallel Process's own interpreter
-        # for a fight it opened itself (see `owner` above).
-        @battle_ui[:events].resolver = owner.resolver
-        build_battle_sprites
-        build_actor_sprites
-        refresh_battle_status
-        # RPG_RT's own `Scene_Battle_Rpg2k::ProcessSceneActionStart`
-        # (EasyRPG Player's `src/scene_battle_rpg2k.cpp`) narrates the
-        # encounter before the party is ever asked for a command: one
-        # `terms.encounter` line per visible (non-`hidden`) troop member
-        # -- `Game_EnemyParty::GetActiveBattlers`, "not dead or hidden" --
-        # each built by concatenating the enemy's own name in front of the
-        # term (`Window_BattleMessage::PushWithSubject`'s stock, non-
-        # Maniac-Patch branch: `subject + message`, no placeholder), then,
-        # if this encounter is a first-strike ambush
-        # (`req[:first_strike]`, already threaded through to `Game::Battle`
-        # above for the actual mechanic), a final fixed `terms.
-        # special_combat` line with no name substitution -- pushed
-        # *in addition to*, not instead of, the per-enemy lines, exactly as
-        # real RPG_RT orders them. Nothing shows when the troop is entirely
-        # hidden and the fight is not a first strike, matching
-        # `if (!visible_enemies.empty()) SetWait(...)` gating the whole
-        # substate there.
-        lines = battle_encounter_lines(troop, req)
-        if lines.empty?
-          return if run_battle_events
-          settle_already_finished_battle || enter_command_phase
-        else
-          show_battle_banner(lines)
-          @battle_ui[:phase] = :encounter_message
-          @battle_ui[:anim_timer] = BATTLE_ENCOUNTER_MSG_FRAMES
-        end
-      end
-
-      # The encounter narration lines built above -- see #open_battle's own
-      # comment for the real-RPG_RT sourcing. Returns [] when there is
-      # nothing to say (every troop member hidden, no first strike).
-      def battle_encounter_lines(troop, req)
-        lines = troop.members.reject(&:hidden).map do |enemy|
-          "#{enemy.name}#{term(:encounter, ' appeared!')}"
-        end
-        lines << term(:special_combat, 'You get the first strike!') if req[:first_strike]
-        lines
-      end
-
-      # How long the encounter banner lingers before the command phase opens.
-      # Real RPG_RT paces this per-line with wordwrap and per-page wait
-      # timers (`SetWait(4, 4)` / `SetWait(8, 8)` / `SetWait(30, 70)`); this
-      # screen has no per-page message window (see #battle_result_lines'
-      # own comment on the same simplification), so the whole banner -- every
-      # line at once -- holds for one flat beat instead, matching only
-      # RPG_RT's own minimum `SetWait(4, 4)` gate rather than the full
-      # per-line reading pause -- long enough to register as its own frame
-      # of input-free banner before the command menu takes over the same
-      # screen rect.
-      BATTLE_ENCOUNTER_MSG_FRAMES = 4
-
-      # Drive the encounter-message phase: hold the banner for
-      # `BATTLE_ENCOUNTER_MSG_FRAMES`, then drop it and fall into the same
-      # turn-0-battle-event / command-phase flow #open_battle used to reach
-      # directly.
-      def drive_battle_encounter_message
-        if @battle_ui[:anim_timer] > 0
-          @battle_ui[:anim_timer] -= 1
-          return
-        end
-        close_battle_action
-        @battle_ui[:phase] = :command
-        return if run_battle_events
-        settle_already_finished_battle || enter_command_phase
-      end
-
-      # An encounter can start already decided — an empty party (every member
-      # removed via Change Party Member) or one left all-KO'd from a prior
-      # fight, with no revive in between, both read as no living ally at all.
-      # `#draw_battle_command`'s `current_actor` (`living_allies[actor_i]`) is
-      # nil either way, so it already declines to open a command window
-      # (`return unless actor`) rather than crash — but nothing then moved the
-      # battle on, since a round only ever starts once the player picks a
-      # command for *some* actor. The command phase sat frozen forever, never
-      # reaching the `battle.finished?` check `#finish_round_animation`/
-      # `#leave_battle_event_phase` run after every other round, instead of
-      # yado.tk's documented "battling with an empty party is instant defeat"
-      # (worded the same way for an all-KO'd one). `Game::Battle#end_round`
-      # is what actually computes `#result` (`alive?(@allies) ? :victory :
-      # :defeat`); calling it here settles the same way an ordinary round
-      # ending would, with nothing to clear (`@allies.each` no-ops on an empty
-      # or already-KO'd roster). Returns whether it fired, so `#open_battle`
-      # only falls back to the normal command window when there is actually
-      # someone to command.
-      def settle_already_finished_battle
-        battle = @battle_ui[:battle]
-        return false unless battle.finished?
-        battle.end_round
-        enter_battle_result(battle.result)
-        true
-      end
-
-      # A troop member's sprite depth for its add-order index `i` (0-based).
-      # RPG2000 numbers troop members by add-order and renders the
-      # **lower**-numbered member closer to the camera (yado.tk); the native
-      # renderer draws the *highest*-z sprite on top (see `gfx_update`'s own
-      # "leaving the greatest z on top"), so index 0 needs the highest z here
-      # -- the reverse of the add-order index itself.
-      def battler_z(i)
-        100 + (@battle_ui[:troop].members.size - 1 - i)
-      end
-
-      # Vertical pixel bob for a levitating (`Game::Enemy#levitate`) troop
-      # member, or 0 for everyone else. yado.tk only ever says the "airborne"
-      # flag "changes its Y position on screen" with no magnitude or edition
-      # given; EasyRPG's own `Game_Enemy::GetFlyingOffset` supplies both
-      # missing facts and, more importantly, the edition gate the yado.tk
-      # source never mentioned at all: `if (!Player::IsRPG2k3() || !IsFlying())
-      # return 0;` -- "2k does not support flying, albeit mentioned in the
-      # help file" (their comment). So a genuine RPG2000 database's own
-      # `levitate` flag has no on-screen effect whatsoever, real RPG_RT bug and
-      # all; only an RPG2003 one draws the +/-4px, 256-frame-period sine bob
-      # (`round(sin(2*PI*frame/256) * 4)`, their `frame` a per-battler counter
-      # incremented once per battle frame) computed here from this scene's own
-      # per-battle `@battle_ui[:frame]` instead -- a single shared phase for
-      # every levitating member rather than EasyRPG's per-battler-randomized
-      # start offset, since nothing in either wiki mirror (both unreachable
-      # this session) describes members desyncing from one another, only that
-      # each one "changes its Y position".
-      FLYING_AMPLITUDE = 4
-      FLYING_PERIOD = 256
-      def flying_offset(member)
-        return 0 unless member.levitate && @state.party.rpg2003?
-        frame = @battle_ui[:frame] || 0
-        (Math.sin(2 * Math::PI * frame / FLYING_PERIOD.to_f) * FLYING_AMPLITUDE).round
-      end
-
-      # A troop member's on-screen y, centred on its database position and
-      # nudged by #flying_offset -- shared by every site that (re)builds an
-      # enemy sprite so the three stay in lockstep with the per-frame update
-      # (#update_enemy_positions) that keeps a levitating one bobbing after.
-      def battler_y(member, bmp)
-        member.y - bmp.height / 2 + flying_offset(member)
-      end
-
-      # A troop member's sprite opacity: 160/255 (~63%) for one flagged
-      # "Appear Transparent" (`Game::Enemy#transparent`, database field 10),
-      # 255 (fully opaque) for everyone else -- verified against EasyRPG
-      # Player's actual C++ source, `Sprite_Enemy::Draw`'s `alpha = 160 * alpha
-      # / 255` (`src/sprite_enemy.cpp`), with `alpha` at its 255 baseline since
-      # this codebase has no death-fade/explode sprite animation to scale it
-      # from. Purely cosmetic, no accuracy/evasion effect, same as
-      # #flying_offset -- shared by every site that (re)builds an enemy sprite
-      # so all three agree.
-      TRANSPARENT_ENEMY_OPACITY = 160
-      def battler_opacity(member)
-        member.transparent ? TRANSPARENT_ENEMY_OPACITY : 255
-      end
-
-      # RPG2000 is a front-view battle: the enemy troop is drawn as sprites over a
-      # battle background, while the party is represented by the status window (not
-      # sprites). Build the backdrop and one sprite per visible troop member,
-      # centred on its database position. Hidden (invisible) members get no sprite
-      # until a battle event reveals them — a mechanism still to come.
-      def build_battle_sprites
-        build_battle_back(encounter_backdrop)
-        @battle_ui[:enemy_sprites] = @battle_ui[:troop].members.each_with_index.map do |enemy, i|
-          next nil if enemy.hidden
-          bmp = battler_bitmap(enemy)
-          spr = Sprite.new
-          spr.bitmap = bmp
-          spr.x = enemy.x - bmp.width / 2
-          spr.y = battler_y(enemy, bmp)
-          spr.z = battler_z(i)
-          spr.opacity = battler_opacity(enemy)
-          spr
-        end
-        # The battler (graphic name + hue) each sprite was drawn from, so a
-        # transformation mid-fight is noticed and redrawn (see
-        # #refresh_battle_sprites) -- matching EasyRPG's own
-        # `Sprite_Enemy::Refresh`, which rebuilds on either changing.
-        @battle_ui[:sprite_names] = @battle_ui[:foes].map { |f| f.battler_name }
-        @battle_ui[:sprite_hues] = @battle_ui[:foes].map { |f| f.battler_hue || 0 }
-        refresh_battle_sprites
-      end
-
-      # RPG2003's alternative/gauge battle layouts draw each living party
-      # member as a sprite too (unlike RPG2000's status-window-only layout --
-      # see Game::Party#alternate_battle_layout?), sourced from the
-      # database's Battler Animation table (chunk 32, db.battleranimations --
-      # decoded in a prior change, nothing read it until now). Scoped to the
-      # plain Idle pose only (Pose id 0): no active state, not defending --
-      # EasyRPG's Sprite_Actor::DoIdleAnimation (src/sprite_actor.cpp) swaps
-      # in a Defend or state-mapped pose in those two cases, which is
-      # follow-up work for a later change, not this one. A dead party member
-      # gets no sprite (mirrors a hidden troop member never getting one
-      # either in #build_battle_sprites above); the party status window keeps
-      # showing everyone regardless, so a member left spriteless here (dead,
-      # or any of the gaps #build_actor_sprite itself documents) is never
-      # invisible to the player. A traditional-layout database (or a bare
-      # test fixture whose party doesn't even answer #alternate_battle_layout?)
-      # builds nothing, matching current behaviour exactly.
-      def build_actor_sprites
-        @battle_ui[:actor_sprites] = nil
-        return unless @state.party.respond_to?(:alternate_battle_layout?) &&
-                      @state.party.alternate_battle_layout?
-        @battle_ui[:actor_sprites] = @battle_ui[:allies].each_with_index.map do |ally, i|
-          next nil if ally.dead?
-          build_actor_sprite(ally.actor, i)
-        end
-      end
-
-      # Idle pose id within a `db.battleranimations` entry's `poses` table
-      # (lcf::rpg::BattlerAnimation::Pose_Idle -- schema.rb's own comment on
-      # chunk 32 lists the full 12-pose order).
-      ACTOR_IDLE_POSE = 0
-      # `poses[id].animation_type` values: 0 a BattleCharSet sprite sheet
-      # (implemented below), 1 a full Battle/<name> (CBA) animation sequence
-      # played in place of a static sprite (not implemented here -- see
-      # #build_actor_sprite).
-      ACTOR_POSE_TYPE_BATTLE = 1
-      # A BattleCharSet sheet is framed in fixed 48x48 cells, one row per
-      # `battler_index` (EasyRPG's Sprite_Actor::OnBattlercharsetReady --
-      # `SetSrcRect(Rect(0, battler_index * 48, 48, 48))`).
-      ACTOR_CHARSET_CELL = 48
-      # Clear of both the enemy troop's own z range (#battler_z's 100 +
-      # troop_size-1 span) and the animation overlay's z 150, so an actor
-      # sprite never fights either for draw order; still well below every UI
-      # window (z >= 300).
-      def actor_sprite_z(i)
-        200 + i
-      end
-
-      # A living party member's Idle-pose sprite, or nil when this step
-      # cannot draw one: `actor.battler_animation_id` names no
-      # `db.battleranimations` entry (Game::Actor#battler_animation_id
-      # already logs that diagnostic itself), the resolved entry defines no
-      # Idle pose at all (silent -- an entry legitimately covering only some
-      # of the 12 poses is normal authoring, not a dangling reference), or
-      # the pose uses the `animation_type == 1` battle/CBA format this step
-      # does not implement (logged below, matching this codebase's "reported
-      # gap, not silently invented" convention for unimplemented behaviour).
-      #
-      # Position is the raw database `battle_x`/`battle_y`
-      # (Game_Actor::GetOriginalPosition) -- confirmed against EasyRPG's
-      # actual C++ source this is only what `battlecommands.placement`
-      # manual (0) uses; automatic (1) instead computes a real grid formula
-      # (`CalculateBaseGridPosition`, src/game_battle.cpp) this step does not
-      # implement either, so that case also just logs and falls back to the
-      # same raw coordinates rather than guessing at the formula.
-      def build_actor_sprite(actor, i)
-        anim_id = actor.respond_to?(:battler_animation_id) ? (actor.battler_animation_id || 0) : 0
-        table = db.respond_to?(:battleranimations) ? db.battleranimations : nil
-        entry = (table && anim_id > 0) ? table[anim_id] : nil
-        return nil unless entry
-        pose = entry.respond_to?(:poses) && entry.poses ? entry.poses[ACTOR_IDLE_POSE] : nil
-        return nil unless pose
-
-        if pose.animation_type == ACTOR_POSE_TYPE_BATTLE
-          $stderr.puts "[RPG2k] actor ##{actor.id}: idle pose uses a battle-animation (CBA) " \
-                       "sheet, not a BattleCharSet -- not yet implemented, sprite not drawn"
-          return nil
-        end
-
-        bmp = actor_battlecharset_bitmap(pose.battler_name)
-        return nil unless bmp
-
-        if @state.party.respond_to?(:automatic_battle_placement?) &&
-           @state.party.automatic_battle_placement?
-          $stderr.puts "[RPG2k] actor ##{actor.id}: automatic battler placement not yet " \
-                       "implemented, using the database's manual battle_x/battle_y"
-        end
-
-        spr = Sprite.new
-        spr.bitmap = bmp
-        spr.src_rect = Rect.new(0, (pose.battler_index || 0) * ACTOR_CHARSET_CELL,
-                                ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL)
-        spr.x = actor.respond_to?(:battle_x) ? (actor.battle_x || 0) : 0
-        spr.y = actor.respond_to?(:battle_y) ? (actor.battle_y || 0) : 0
-        spr.z = actor_sprite_z(i)
-        spr
-      end
-
-      # Interpreter#do_change_party's hook (via `@battle_ui[:events].
-      # battle_screen`, set in #open_battle) for a Change Party Member battle
-      # event that actually added or removed a member -- mirrors EasyRPG's
-      # `Game_Party::AddActor`/`RemoveActor` calling
-      # `Scene_Battle_Rpg2k::OnPartyChanged` synchronously, right when the
-      # party changes, rather than leaving the screen to notice on some later
-      # redraw. `actor` is the `Game::Actor` (from `Game::Party#roster`, so it
-      # resolves the same whether they are still a member or just left).
-      # `Game::Battle`'s own roster (`@battle_ui[:battle]`) is left alone --
-      # its `sync_allies_from_party`/`out_of_play?`/`member` bookkeeping
-      # (ADR 0050) already reads correctly from the live party on its own
-      # schedule; this only updates what's drawn.
-      def on_battle_party_changed(actor, added)
-        return unless @battle_ui
-        added ? add_battle_actor_sprite(actor) : remove_battle_actor_sprite(actor)
-        refresh_battle_status
-      end
-      public :on_battle_party_changed
-
-      # An actor just (re)joined the fight: reuse their existing `Combatant`
-      # if `Game::Battle` already has one (they left and are rejoining this
-      # same fight, so the reused object keeps its accumulated battle-only
-      # state -- the same reuse-on-rejoin guarantee ADR 0050 gives the
-      # mechanics), or build a fresh one exactly the way
-      # `Game::Battle#sync_allies_from_party` would on its own next sync --
-      # pushed onto `@battle_ui[:battle].allies` (not just returned) so that
-      # later sync finds it already there and reuses it too, rather than the
-      # render layer and the battle ending up tracking two different
-      # `Combatant` objects for the same actor.
-      def add_battle_actor_sprite(actor)
-        battle = @battle_ui[:battle]
-        combatant = battle.ally_by_actor_id(actor.id)
-        unless combatant
-          combatant = Game::Battle.from_actor(actor)
-          battle.allies.push(combatant)
-        end
-        return if @battle_ui[:allies].any? { |c| c.equal?(combatant) }
-        @battle_ui[:allies].push(combatant)
-        return unless @battle_ui[:actor_sprites]
-        i = @battle_ui[:allies].length - 1
-        @battle_ui[:actor_sprites].push(combatant.dead? ? nil : build_actor_sprite(combatant.actor, i))
-        reset_actor_battler_z
-      end
-
-      # An actor just left the fight: drop their `Combatant` from the
-      # render-facing `@battle_ui[:allies]` (not from `Game::Battle`'s own
-      # roster -- see #on_battle_party_changed) and dispose their specific
-      # sprite, leaving every other actor's sprite untouched. A rejoin later
-      # builds a brand new sprite (#add_battle_actor_sprite always calls
-      # #build_actor_sprite fresh); this never leaves a disposed `Sprite`
-      # sitting in the collection for that to reuse.
-      def remove_battle_actor_sprite(actor)
-        idx = @battle_ui[:allies].index { |c| c.actor && c.actor.id == actor.id }
-        return unless idx
-        @battle_ui[:allies].delete_at(idx)
-        sprites = @battle_ui[:actor_sprites]
-        return unless sprites
-        dispose_battle_sprite(sprites.delete_at(idx))
-        reset_actor_battler_z
-      end
-
-      # Re-derive every surviving actor sprite's Z from its current index in
-      # `@battle_ui[:allies]` (#actor_sprite_z). An add or remove elsewhere in
-      # the roster shifts everyone after it, so without this, two sprites can
-      # end up sharing a Z once enough adds/removes have happened -- e.g.
-      # remove index 1 of 3 (leaving index 2's sprite still at its old Z 202),
-      # then add a new member at the new index 2, which would also compute Z
-      # 202. Matches EasyRPG's own `ResetAllBattlerZ()`, called for the same
-      # reason right after `OnPartyChanged` adds a sprite.
-      def reset_actor_battler_z
-        sprites = @battle_ui[:actor_sprites]
-        return unless sprites
-        sprites.each_with_index { |spr, i| spr.z = actor_sprite_z(i) if spr }
-      end
-
-      # The BattleCharSet bitmap for an actor pose's `battler_name`, cached
-      # like every other named battle graphic (see #cached_bitmap) and
-      # colour-keyed the same way CharSet/Monster are. A missing/empty name
-      # or a failed load draws the same solid placeholder block
-      # #battler_bitmap falls back to for a missing enemy graphic (see
-      # #placeholder_battler), sized to one BattleCharSet cell so the
-      # src_rect crop in #build_actor_sprite still makes sense against it.
-      def actor_battlecharset_bitmap(name)
-        key = (name && !name.empty?) ? name : nil
-        cached_bitmap(@battlecharset_cache, key) do
-          if key
-            begin
-              Bitmap.new("BattleCharSet/#{name}", true)
-            rescue StandardError => e
-              $stderr.puts "[RPG2k] actor battler '#{name}' load failed: #{e.message}"
-              actor_placeholder_battler
-            end
-          else
-            actor_placeholder_battler
-          end
-        end
-      end
-
-      def actor_placeholder_battler
-        bmp = Bitmap.new(ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL)
-        bmp.fill_rect 0, 0, ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL, Color.new(180, 60, 60, 255)
-        bmp
-      end
-
-      # Where a battle-event page's message panel sits — above the action banner,
-      # so a page talking mid-round does not fight it for the same row.
-      BATTLE_EVENT_MSG_Y = 8
-
-      # The backdrop this encounter fights over: whatever Game::Backdrop resolves
-      # for the current map, given the terrain the party is standing on. '' when
-      # nothing names one, which draws the flat field.
-      def encounter_backdrop
-        Game::Backdrop.name_for(@state.map_id, map_properties,
-                                terrain_backdrop(@state.x, @state.y))
+      # Tear the running fight down (dispose its windows/sprites) and drop
+      # this scene's own reference to it. The counterpart to Scene::Battle
+      # being created inline in #drive_battle above -- called from there (a
+      # battle that failed mid-update), from Scene::Battle#finish_battle
+      # itself (a battle that resolved normally), and from #dispose (scene
+      # teardown while a fight happens to be open).
+      def close_battle
+        return unless @battle
+        @battle.dispose
+        @battle = nil
       end
 
       # The map tree's map_properties table, or nil when this build has no tree
@@ -5063,7 +4563,7 @@ class RPG2k
       # replaces `Scene_Map` outright, so no part of the map is on screen while
       # a fight runs, and the chosen Backdrop/<name> image is all there is
       # behind the troop. This port instead runs the fight inline on Scene::Map
-      # (gated on @battle_ui), and #render kept compositing the map every frame
+      # (gated on @battle), and #render kept compositing the map every frame
       # underneath it -- which put the map *over* the battle background, since
       # the backdrop sprite's z 5 (EasyRPG Player's own `Priority_Background`,
       # `src/drawable.h`, correct there precisely because no map is ever drawn
@@ -5076,1299 +4576,12 @@ class RPG2k
       # Hidden for the fight's whole duration, and #render skips the tile /
       # parallax / character compositing outright rather than leaving a stale
       # frame hidden underneath -- the same treatment the picture layer already
-      # gets there. Both un-hide and redraw on the first frame after @battle_ui
+      # gets there. Both un-hide and redraw on the first frame after @battle
       # clears; the hero frame's own @last_frame cache is untouched by the
       # skipped frames, so an unchanged pose is not needlessly rebuilt then.
       def set_map_layers_visible(visible)
         @map_viewport.visible = visible if @map_viewport
         @upper_viewport.visible = visible if @upper_viewport
-      end
-
-      def build_battle_back(name = nil)
-        bmp = battle_back_bitmap(name)
-        spr = Sprite.new
-        spr.bitmap = bmp
-        spr.z = 5
-        @battle_ui[:back_sprite] = spr
-      end
-
-      # The battle backdrop: the Backdrop/<name> image a Change Battle Background
-      # command (or the encounter) named, falling back to the flat colour field
-      # when there is no name or the file is missing — the same fallback the map
-      # uses for a missing chipset. Cached by name (see #cached_bitmap) so
-      # re-entering the same encounter, or a battle event that swaps back to a
-      # backdrop already shown this visit, does not re-decode it.
-      def battle_back_bitmap(name)
-        key = (name && !name.empty?) ? name : nil
-        cached_bitmap(@backdrop_cache, key) do
-          if key
-            begin
-              Bitmap.new("Backdrop/#{key}")
-            rescue StandardError => e
-              $stderr.puts "[RPG2k] battle backdrop '#{key}' failed to load: #{e.message}"
-              flat_battle_back
-            end
-          else
-            flat_battle_back
-          end
-        end
-      end
-
-      def flat_battle_back
-        bmp = Bitmap.new(SCREEN_W, SCREEN_H)
-        bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(16, 16, 32, 255)
-        bmp
-      end
-
-      # Change Battle Background (13210): swap the backdrop mid-fight, releasing
-      # the sprite and bitmap the old one held.
-      def rebuild_battle_back(name)
-        dispose_battle_sprite(@battle_ui[:back_sprite])
-        @battle_ui[:back_sprite] = nil
-        build_battle_back(name)
-      end
-
-      # The battler graphic for `enemy` (Monster/<battler_name>, colour-keyed), or
-      # a solid placeholder block when it has no graphic or the file is missing —
-      # the same fallback strategy the map uses for a missing chipset. Cached by
-      # name+hue (see #cached_bitmap) so a monster reused across troop slots, or a
-      # transformation that returns to a battler already shown this visit, is
-      # decoded (and hue-rotated) once. The hue rotation (database field 3, see
-      # `Game::Enemy#battler_hue`) is applied to this decode alone, never to a
-      # cached bitmap already shared by a same-named, differently-hued sibling —
-      # `Bitmap#hue_change` (`mruby-rgss/src/lib.cxx`) mutates in place, so the
-      # cache key must fold hue in rather than rotate a shared entry.
-      def battler_bitmap(enemy)
-        name = enemy.battler_name
-        hue = enemy.respond_to?(:battler_hue) ? (enemy.battler_hue || 0) : 0
-        key = (name && !name.empty?) ? "#{name}\0#{hue}" : nil
-        cached_bitmap(@monster_cache, key) do
-          if key
-            begin
-              bmp = Bitmap.new("Monster/#{name}", true)
-              bmp.hue_change(hue) if hue != 0
-              bmp
-            rescue StandardError => e
-              $stderr.puts "[RPG2k] battler load failed for #{enemy.name}: #{e.message}"
-              placeholder_battler
-            end
-          else
-            placeholder_battler
-          end
-        end
-      end
-
-      def placeholder_battler
-        bmp = Bitmap.new(32, 32)
-        bmp.fill_rect 0, 0, 32, 32, Color.new(180, 60, 60, 255)
-        bmp
-      end
-
-      # Decay any in-flight target-scope Battle Animation flash (#fire_target_flash)
-      # by one frame. RGSS's native Sprite#flash bakes its colour into the
-      # composite and fades it linearly, but only when driven by an explicit
-      # Sprite#update each frame (mruby-rgss/src/lib.cxx) -- the same contract
-      # #update_map_tone already drives on @map_viewport/@upper_viewport, just
-      # for the per-enemy sprites instead of a viewport tone. A sprite with no
-      # flash in flight costs nothing here (native #update no-ops).
-      def update_enemy_flashes
-        (@battle_ui[:enemy_sprites] || []).each { |s| s.update if s }
-      end
-
-      # Advance the per-battle frame counter #flying_offset reads and re-seat
-      # any levitating troop member's sprite at its new bob height. A no-op
-      # (bar the counter tick) for a plain RPG2000 fight or a troop with no
-      # `levitate` member: #flying_offset already reads 0 for both, so the
-      # assignment below is just re-writing the same y already set.
-      def update_enemy_positions
-        @battle_ui[:frame] = (@battle_ui[:frame] || 0) + 1
-        sprites = @battle_ui[:enemy_sprites]
-        return unless sprites
-        @battle_ui[:troop].members.each_with_index do |member, i|
-          spr = sprites[i]
-          next unless spr && member.levitate
-          spr.y = battler_y(member, spr.bitmap)
-        end
-      end
-
-      # Show a living enemy's sprite, hide a defeated one — called after each
-      # animated action so a downed enemy vanishes from the field.
-      def refresh_battle_sprites
-        sprites = @battle_ui[:enemy_sprites]
-        return unless sprites
-        # A transformation swaps a monster's graphic mid-fight, so redraw any
-        # combatant no longer wearing the battler its sprite was built from
-        # before deciding what is visible.
-        names = (@battle_ui[:sprite_names] ||= [])
-        hues = (@battle_ui[:sprite_hues] ||= [])
-        @battle_ui[:foes].each_with_index do |foe, i|
-          changed = names[i] != foe.battler_name || hues[i] != (foe.battler_hue || 0)
-          rebuild_battler_sprite(i, foe) if sprites[i] && changed
-        end
-        @battle_ui[:foes].each_with_index do |foe, i|
-          spr = sprites[i]
-          # Out of play, not merely dead: a monster that has fled (its own Escape
-          # action, or a page's Force Flee) or one still flagged invisible is off
-          # the field and must not be drawn — the same test #living_foes uses to
-          # keep it out of the target cursor.
-          spr.visible = !foe.out_of_play? if spr
-        end
-      end
-
-      # Redraw troop slot `i` with `foe`'s current battler graphic, keeping its
-      # place and depth, and release the sprite and bitmap the old one held.
-      def rebuild_battler_sprite(i, foe)
-        sprites = @battle_ui[:enemy_sprites]
-        member = @battle_ui[:troop].members[i]
-        return unless member
-        old = sprites[i]
-        bmp = battler_bitmap(foe)
-        spr = Sprite.new
-        spr.bitmap = bmp
-        spr.x = member.x - bmp.width / 2
-        spr.y = battler_y(member, bmp)
-        spr.z = battler_z(i)
-        spr.opacity = battler_opacity(member)
-        spr.visible = !foe.out_of_play?
-        sprites[i] = spr
-        dispose_battle_sprite(old)
-        @battle_ui[:sprite_names][i] = foe.battler_name
-        @battle_ui[:sprite_hues][i] = foe.battler_hue || 0
-      end
-
-      def living_allies; @battle_ui[:allies].reject(&:dead?); end
-
-      # Living allies selectable as a manually-chosen Battle Item target right
-      # now: `#living_allies` narrowed by the pending item's own 使用可能キャラ
-      # (`actor_set`) restriction when there is one -- the same per-recipient
-      # gate `Game::Party#use_medicine` already applies in the field menu
-      # (`Game::Party#item_usable_by?`), which this picker had never
-      # consulted at all, so a party member the item cannot affect used to be
-      # offered as a choice anyway rather than not appearing in the first
-      # place. A pending skill is untouched -- actor_set only gates
-      # equipment/items, never skills. `@state.party` not answering
-      # `item_usable_by?` (a battle test's stub party, which never models
-      # equipment restrictions) degrades to "unrestricted", the same default
-      # the real method itself falls back to for an item with no actor_set at
-      # all.
-      def battle_ally_targets
-        allies = living_allies
-        return allies unless pending_kind == :item
-        return allies unless @state.party.respond_to?(:item_usable_by?)
-        it = @battle_ui[:pending] && @battle_ui[:pending][:it]
-        return allies unless it
-        allies.select { |a| a.actor.nil? || @state.party.item_usable_by?(it, a.actor.id) }
-      end
-      # Targetable foes: alive *and* in play, so a troop member still flagged
-      # invisible never appears in the target cursor.
-      def living_foes;   @battle_ui[:foes].reject(&:out_of_play?); end
-      def current_actor; living_allies[@battle_ui[:actor_i]]; end
-
-      # The real Game::Actor behind the current battler (the snapshots are built
-      # from the party in order), so the Skill menu can read its known skills.
-      def current_actor_row
-        idx = @battle_ui[:allies].index(current_actor)
-        idx ? @state.party.actors[idx] : nil
-      end
-
-      # The per-actor commands, in menu order (the cursor row is 1 + index,
-      # below the actor-name header): each a `{ label:, action: }` pair, drawn
-      # by `#battle_commands` below and dispatched by `#select_battle_command`.
-      #
-      # An acting actor whose own RPG2003 battle-command list
-      # (`Game::Actor#battle_commands`, edited by Change Battle Commands (1009)
-      # or a class change) resolves to at least one usable entry drives the
-      # menu; otherwise this falls back to the fixed **Attack, Skill, Defend,
-      # Item** four — EasyRPG's `Scene_Battle_Rpg2k::CreateBattleCommandWindow`
-      # builds that exact array (`command_attack`, `command_skill`,
-      # `command_defend`, `command_item`), not the Item-before-Defend order
-      # this used to assume, read from the database's battle-command terms with
-      # the standard RPG2k labels as fallback. The Skill slot is not memoized:
-      # it substitutes the acting actor's own RPG2000 rename
-      # (`#skill_command_label` below) when the database sets one, so it can
-      # change from one actor's turn to the next.
-      def battle_command_rows
-        actor = current_actor_row
-        custom = actor && custom_battle_commands(actor)
-        return custom if custom
-
-        [
-          { label: term(:battle_attack, 'Attack'), action: :attack },
-          { label: skill_command_label, action: :skill },
-          { label: term(:battle_defend, 'Defend'), action: :defend },
-          { label: term(:battle_item, 'Item'), action: :item }
-        ]
-      end
-
-      # `actor`'s own RPG2003 battle-command list resolved to menu rows, or nil
-      # when there is nothing usable in it (no data at all -- an RPG2000
-      # database, or a class/actor row that never set field 80, both of which
-      # `Game::Actor#battle_commands` itself already reports as `[0]`, Row
-      # alone -- or every entry turned out unsupported), so the caller falls
-      # back to the fixed four.
-      #
-      # Each id is either 0 (Row -- not a menu row here any more than in
-      # EasyRPG's own `Game_Actor::GetBattleCommands`, whose comment marks it
-      # "not impl" and skips it the same way), -1 (an empty padding slot,
-      # likewise skipped), or a positive ref into the database's own
-      # Battle-Commands table (`Game::Actor#battle_command_row`) naming one
-      # entry's `name` + `type`. Only the four types this engine actually
-      # drives -- Attack, (sub)Skill, Defense, Item -- become a row; Escape
-      # (the first actor's own Cancel already offers it) and Special (no
-      # handler modelled anywhere in this engine) are skipped, same as an
-      # unresolvable ref (a project whose database has no Battle-Commands
-      # table decoded, or an id it doesn't define).
-      def custom_battle_commands(actor)
-        return nil unless actor.respond_to?(:battle_commands)
-        cmds = actor.battle_commands
-        return nil unless cmds
-        rows = cmds.each_with_object([]) do |cmd_id, out|
-          next if cmd_id.nil? || cmd_id <= 0 # Row / empty slot
-
-          row = actor.battle_command_row(cmd_id)
-          next unless row
-
-          case row.type
-          when Game::Actor::BATTLE_COMMAND_ATTACK
-            out << { label: nonblank(row.name, term(:battle_attack, 'Attack')), action: :attack }
-          when Game::Actor::BATTLE_COMMAND_SKILL, Game::Actor::BATTLE_COMMAND_SUBSKILL
-            out << { label: nonblank(row.name, skill_command_label), action: :skill }
-          when Game::Actor::BATTLE_COMMAND_DEFENSE
-            out << { label: nonblank(row.name, term(:battle_defend, 'Defend')), action: :defend }
-          when Game::Actor::BATTLE_COMMAND_ITEM
-            out << { label: nonblank(row.name, term(:battle_item, 'Item')), action: :item }
-          end
-          # Escape / Special: no menu row (see the method comment above).
-        end
-        rows.empty? ? nil : rows
-      end
-
-      def battle_commands
-        battle_command_rows.map { |c| c[:label] }
-      end
-
-      # The Skill command's own label. RPG2000's Actor sheet has a "custom
-      # battle command" checkbox + name field (database fields 66/67,
-      # `Game::Actor#rename_skill?` / `#skill_command_name`) that renames just
-      # this one slot — EasyRPG's own `Game_Actor::GetSkillName`: `rename_skill
-      # ? skill_name : Data::terms.command_skill`. Parsed by the schema and
-      # never read anywhere in this gem before now, so a game that set it (e.g.
-      # renaming Skill to "Magic") showed the generic term regardless.
-      def skill_command_label
-        actor = current_actor_row
-        if actor && actor.respond_to?(:rename_skill?) && actor.rename_skill?
-          nonblank(actor.skill_command_name, term(:battle_skill, 'Skill'))
-        else
-          term(:battle_skill, 'Skill')
-        end
-      end
-
-      # Per-actor command menu: Attack, Skill, Defend or Item.
-      def drive_battle_command
-        if Input.trigger?(Input::DOWN)
-          @battle_ui[:cmd] += 1
-          @battle_ui[:cmd] %= battle_commands.length
-          draw_battle_command
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
-          @battle_ui[:cmd] -= 1
-          @battle_ui[:cmd] %= battle_commands.length
-          draw_battle_command
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::C)
-          select_battle_command
-        elsif Input.trigger?(Input::B)
-          # `ProcessSceneActionCommand`'s own B/Cancel branch plays Cancel
-          # unconditionally, *before* deciding where it lands: `...Cancel...;
-          # --actor_index; SelectPreviousActor();`. `SelectPreviousActor()`
-          # itself is what branches on whether an earlier commandable ally
-          # is left to re-command.
-          play_system_se(SFX_CANCEL)
-          prev_i = prev_commandable_actor_index
-          if prev_i.nil?
-            # `SelectPreviousActor()`'s `allies[0] == active_actor` branch:
-            # the actor whose command list is open is already the first
-            # commandable member, so this reopens the Battle/Auto Battle/
-            # Escape options window (`SetState(State_SelectOption)`) rather
-            # than attempting Escape directly.
-            open_battle_options
-          else
-            # Re-commanding the previous actor is the ordinary case.
-            @battle_ui[:actor_i] = prev_i # re-command the previous commandable member
-            @battle_ui[:cmd] = 0
-            draw_battle_command
-          end
-        end
-      end
-
-      # The Battle/Auto Battle/Escape options window's own menu rows, in
-      # display order (top to bottom, matching real RPG2k's
-      # `battle_options`/`Window_Command` build). `battle_fight`/
-      # `battle_auto`/`battle_escape` are the database's Term fields
-      # 101/102/103 -- decoded by the schema but never read before this.
-      def battle_option_rows
-        [
-          { label: term(:battle_fight, 'Fight'), action: :battle },
-          { label: term(:battle_auto, 'Auto Battle'), action: :auto_battle },
-          { label: term(:battle_escape, 'Escape'), action: :escape }
-        ]
-      end
-
-      # Whether any living ally could actually be handed a manual command
-      # this round -- EasyRPG's own `IsAnyControllable()` guard inside
-      # `ProcessSceneActionFightAutoEscape`, which skips the options window
-      # entirely (straight to actor selection) when the whole party is
-      # asleep/paralysed/similarly restricted or already flagged for auto
-      # battle, since neither Battle nor Auto Battle would have anything left
-      # to act on. `Game_Actor::IsControllable()` is exactly this pair of
-      # checks: `GetSignificantRestriction() == Restriction_normal &&
-      # !GetAutoBattle()`.
-      def any_commandable_ally?
-        battle = @battle_ui[:battle]
-        living_allies.any? { |a| !battle.command_restricted?(a) && !force_ai_actor?(a) }
-      end
-
-      # The command phase's first entry for this battle only -- opens the
-      # options window once, automatically, the way `ProcessSceneActionStart`'s
-      # final substate does unconditionally after the encounter/turn-0-event
-      # messages resolve (`battle_message_window->Clear();
-      # SetState(State_SelectOption);`). Every later re-entry into the command
-      # phase this battle (round 2+, back from a between-rounds battle event
-      # page) goes straight to the ordinary per-actor command window instead --
-      # the window's *other* trigger, B/Cancel on the first commandable actor,
-      # is wired separately in #drive_battle_command and is not gated by this
-      # flag, matching `SelectPreviousActor()`'s own unconditional re-entry.
-      def enter_command_phase
-        if @battle_ui[:options_shown] || !any_commandable_ally?
-          @battle_ui[:options_shown] = true
-          open_next_command
-        else
-          @battle_ui[:options_shown] = true
-          open_battle_options
-        end
-      end
-
-      def open_battle_options
-        @battle_ui[:phase] = :battle_options
-        @battle_ui[:opt] = 0
-        draw_battle_options
-      end
-
-      # The options window's cursor menu -- Up/Down move the cursor, C
-      # confirms the highlighted row. B/Cancel is a deliberate no-op: this is
-      # the state machine's own root here (matching
-      # `ProcessSceneActionFightAutoEscape`'s `eWaitForInput` substate, which
-      # has no cancel handling at all -- there is no parent state to cancel
-      # back to).
-      def drive_battle_options
-        rows = battle_option_rows
-        if Input.trigger?(Input::DOWN)
-          @battle_ui[:opt] += 1
-          @battle_ui[:opt] %= rows.length
-          draw_battle_options
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
-          @battle_ui[:opt] -= 1
-          @battle_ui[:opt] %= rows.length
-          draw_battle_options
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::C)
-          select_battle_option
-        end
-      end
-
-      # Act on the highlighted options-window row. Battle dismisses the
-      # window and falls through to the ordinary per-actor command menu,
-      # exactly where the battle already was before the window opened. Auto
-      # Battle hands the whole round to `#queue_auto_battle_round`. Escape
-      # reuses `#try_battle_escape` verbatim -- the same Decision-vs-Buzzer
-      # gate on `allow_escape` this engine's old direct-B-press shortcut
-      # already had, just triggered from the window instead.
-      def select_battle_option
-        case battle_option_rows[@battle_ui[:opt]][:action]
-        when :battle
-          play_system_se(SFX_DECISION)
-          @battle_ui[:phase] = :command
-          # `open_next_command`, not a direct `draw_battle_command` -- the
-          # window opening never advanced `actor_i` past a restricted/
-          # Forced-AI leading actor (matching real RPG_RT's own
-          # `SelectNextActor` doing that skip itself once `State_SelectActor`
-          # is entered from here, not before).
-          open_next_command
-        when :auto_battle
-          play_system_se(SFX_DECISION)
-          queue_auto_battle_round
-        when :escape
-          if @battle_ui[:req][:allow_escape]
-            play_system_se(SFX_DECISION)
-            try_battle_escape
-          else
-            play_system_se(SFX_BUZZER)
-          end
-        end
-      end
-
-      # "Auto Battle": every commandable living ally gets
-      # `Game::Battle#choose_auto_battle_command`'s AI pick queued for the
-      # round instead of the manual per-actor command menu -- the same
-      # engine `#skip_restricted_actors` already calls per-actor for a
-      # 強制AI-flagged ally (see `#force_ai_actor?`), just applied to the
-      # whole party at once rather than one actor. A restricted ally
-      # (asleep/paralysed/forced) is left alone exactly as the ordinary
-      # command phase already leaves it -- its round action is decided
-      # elsewhere, not by a queued command.
-      def queue_auto_battle_round
-        battle = @battle_ui[:battle]
-        living_allies.each do |a|
-          next if battle.command_restricted?(a)
-          battle.choose_auto_battle_command(a)
-        end
-        @battle_ui[:actor_i] = living_allies.length
-        @battle_ui[:phase] = :command
-        open_next_command
-      end
-
-      # Escape command (cancel on the first actor's menu): roll the party's
-      # agility-based escape chance. On success show the result window (the
-      # database's own `escape_success` wording, like a victory or defeat) and
-      # flee once it is dismissed; on a failed roll the party forfeits the
-      # round — every member skips and only the enemies act, bannered with
-      # `escape_failure` the same way a landed hit is — and the next attempt is
-      # likelier (Game::Battle#attempt_escape).
-      def try_battle_escape
-        battle = @battle_ui[:battle]
-        if battle.attempt_escape
-          # A dedicated Escape SE, not Decision -- confirmed against
-          # EasyRPG's own ProcessSceneActionEscape: the success branch plays
-          # `GetSystemSE(SFX_Escape)` right before ending the battle. A
-          # failed attempt plays no SE at all there, just the message.
-          play_system_se(SFX_ESCAPE)
-          enter_battle_result(:escape)
-        else
-          $stderr.puts '[RPG2k battle] escape failed'
-          show_battle_banner([term(:escape_failure, "Couldn't escape!")])
-          living_allies.each { |a| battle.command_skip(a) }
-          start_round_animation
-        end
-      end
-
-      # Act on the highlighted command: Attack / Skill open a selection, Defend
-      # is committed at once. Dispatches by `#battle_command_rows`' own
-      # `action` for the highlighted row rather than a fixed row index, so a
-      # customized, reordered or shortened list (`#custom_battle_commands`)
-      # still routes to the right handler regardless of where each command
-      # landed.
-      # Which SE each command plays on confirm -- Decision immediately for
-      # Attack/Defend (`Scene_Battle::AttackSelected`/`DefendSelected` both
-      # play it as their own first statement, before doing anything else),
-      # Skill/Item deferred to #open_battle_skill/#open_battle_item since
-      # RPG_RT's own Decision-on-opening-the-submenu and Buzzer-on-nothing-
-      # to-pick are both conditional on that submenu's own state there.
-      def select_battle_command
-        case battle_command_rows[@battle_ui[:cmd]][:action]
-        when :attack
-          play_system_se(SFX_DECISION)
-          @battle_ui[:pending] = { kind: :attack }
-          @battle_ui[:target_i] = 0
-          @battle_ui[:phase] = :target
-          draw_battle_target
-        when :skill then open_battle_skill
-        when :defend
-          play_system_se(SFX_DECISION)
-          @battle_ui[:battle].command_defend(current_actor)
-          advance_actor
-        when :item then open_battle_item
-        end
-      end
-
-      # Enemy target-selection menu: pick which living enemy the Attack (or an
-      # enemy-scope Skill) hits.
-      def drive_battle_target
-        foes = living_foes
-        if Input.trigger?(Input::DOWN) && !foes.empty?
-          @battle_ui[:target_i] += 1
-          @battle_ui[:target_i] %= foes.length
-          draw_battle_target
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !foes.empty?
-          @battle_ui[:target_i] -= 1
-          @battle_ui[:target_i] %= foes.length
-          draw_battle_target
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::C)
-          play_system_se(SFX_DECISION)
-          target = foes[@battle_ui[:target_i]]
-          close_battle_target
-          if pending_kind == :skill
-            apply_pending_skill(target)
-          else
-            @battle_ui[:battle].command_attack(current_actor, target)
-            @battle_ui[:pending] = nil
-            @battle_ui[:phase] = :command
-            advance_actor
-          end
-        elsif Input.trigger?(Input::B)
-          play_system_se(SFX_CANCEL)
-          close_battle_target
-          if pending_kind == :skill
-            @battle_ui[:phase] = :skill
-            draw_battle_skill
-          else
-            @battle_ui[:pending] = nil
-            @battle_ui[:phase] = :command
-            draw_battle_command
-          end
-        end
-      end
-
-      def pending_kind; @battle_ui[:pending] && @battle_ui[:pending][:kind]; end
-
-      # -- Skill sub-menu ------------------------------------------------------
-
-      # Open the current actor's battle-skill list (nothing to open if they know
-      # no battle-usable skill).
-      def open_battle_skill
-        actor = current_actor_row
-        list = actor ? @state.party.battle_skills(actor, current_actor) : []
-        # A status that seals skills (封印 / Silence) takes them off the menu
-        # rather than letting the actor pick one that would be refused.
-        battle = @battle_ui[:battle]
-        battler = current_actor
-        if battle && battler
-          list = list.reject do |sid, _cost|
-            battle.skill_sealed?(battler, @state.party.db_skill(sid))
-          end
-        end
-        @battle_ui[:skills] = list
-        # RPG_RT always plays Decision opening this list, and Buzzer only
-        # once a confirm inside it finds nothing usable
-        # (`Scene_Battle::SkillSelected`'s own `!skill || !CheckEnable`
-        # check) -- this engine instead never opens an empty list at all, so
-        # Buzzer plays here, at the one point that same "nothing to pick"
-        # outcome is actually known.
-        if @battle_ui[:skills].empty?
-          play_system_se(SFX_BUZZER)
-          return
-        end
-        play_system_se(SFX_DECISION)
-        @battle_ui[:skill_i] = 0
-        @battle_ui[:phase] = :skill
-        draw_battle_skill
-      end
-
-      def drive_battle_skill
-        skills = @battle_ui[:skills]
-        if Input.trigger?(Input::DOWN) && !skills.empty?
-          @battle_ui[:skill_i] += 1
-          @battle_ui[:skill_i] %= skills.length
-          draw_battle_skill
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !skills.empty?
-          @battle_ui[:skill_i] -= 1
-          @battle_ui[:skill_i] %= skills.length
-          draw_battle_skill
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::C)
-          confirm_battle_skill
-        elsif Input.trigger?(Input::B)
-          play_system_se(SFX_CANCEL)
-          close_battle_skill
-          @battle_ui[:phase] = :command
-          draw_battle_command
-        end
-      end
-
-      # Choose the highlighted skill: if the caster cannot afford its SP, this
-      # is RPG_RT's own Buzzer case (`SkillSelected`'s `CheckEnable` covers
-      # affordability); otherwise Decision, then route to enemy / ally target
-      # selection (or cast at once on a self-scope skill).
-      def confirm_battle_skill
-        sid, cost = @battle_ui[:skills][@battle_ui[:skill_i]]
-        if current_actor.mp < cost # can't afford: stay on the list
-          play_system_se(SFX_BUZZER)
-          return
-        end
-        play_system_se(SFX_DECISION)
-        sk = @state.party.db_skill(sid)
-        @battle_ui[:pending] = { kind: :skill, sk: sk, sid: sid }
-        close_battle_skill
-        case @state.party.battle_skill_target(sk)
-        when :self
-          apply_pending_skill(current_actor)
-        when :enemy
-          @battle_ui[:target_i] = 0
-          @battle_ui[:phase] = :target
-          draw_battle_target
-        when :all_enemy
-          apply_pending_skill_all(living_foes)
-        when :all_ally
-          apply_pending_skill_all(living_allies)
-        else # :ally
-          @battle_ui[:ally_i] = 0
-          @battle_ui[:phase] = :ally_target
-          draw_battle_ally_target
-        end
-      end
-
-      # Commit the pending skill on `target` (SP cost / effect from the model),
-      # then move to the next actor.
-      def apply_pending_skill(target)
-        sk = @battle_ui[:pending][:sk]
-        sid = @battle_ui[:pending][:sid]
-        c = @state.party.battle_skill_command(sk, current_actor, target)
-        @battle_ui[:battle].command_skill(current_actor, target,
-                                          name: sk.name, skill_id: sid,
-                                          absorb: c[:absorb] ? true : false,
-                                          # Left as `c[:attack]` verbatim (not coerced to a
-                                          # boolean): a stub `battle_skill_command` in the test
-                                          # suite that omits the key entirely needs `nil` to
-                                          # reach #apply_skill_hit so its own sign-of-hp
-                                          # fallback still applies, matching this build's real
-                                          # Game::Party#battle_skill_command before this key
-                                          # existed at all.
-                                          attack: c[:attack],
-                                          cost: c[:cost],
-                                          hp: c[:hp], mp: c[:mp],
-                                          inflict: c[:inflict], chance: c[:chance],
-                                          variance: c[:variance] || 0,
-                                          attributes: c[:attributes],
-                                          attr_shift: c[:attr_shift],
-                                          attr_ids: c[:attr_ids],
-                                          stat_mod_keys: c[:stat_mod_keys],
-                                          stat_effect: c[:stat_effect] || 0,
-                                          cured: c[:cured])
-        @battle_ui[:pending] = nil
-        @battle_ui[:phase] = :command
-        advance_actor
-      end
-
-      # Commit the pending all-target skill on every `targets` combatant (all
-      # living enemies for an attack skill, all living allies for a heal): build
-      # one per-target effect from the model (attack damage varies with each
-      # target's defence) and queue them as a single volley. The shared SP cost /
-      # infliction ride along once.
-      def apply_pending_skill_all(targets)
-        sk = @battle_ui[:pending][:sk]
-        sid = @battle_ui[:pending][:sid]
-        meta = @state.party.battle_skill_command(sk, current_actor, targets.first)
-        effects = targets.map do |t|
-          c = @state.party.battle_skill_command(sk, current_actor, t)
-          { target: t, hp: c[:hp], mp: c[:mp] }
-        end
-        @battle_ui[:battle].command_skill_all(current_actor, effects,
-                                              name: sk.name, skill_id: sid,
-                                              absorb: meta[:absorb] ? true : false,
-                                              attack: meta[:attack], # see #apply_pending_skill's comment
-                                              cost: meta[:cost],
-                                              inflict: meta[:inflict], chance: meta[:chance],
-                                              variance: meta[:variance] || 0,
-                                              attributes: meta[:attributes],
-                                              attr_shift: meta[:attr_shift],
-                                              attr_ids: meta[:attr_ids],
-                                              stat_mod_keys: meta[:stat_mod_keys],
-                                              stat_effect: meta[:stat_effect] || 0,
-                                              cured: meta[:cured])
-        @battle_ui[:pending] = nil
-        @battle_ui[:phase] = :command
-        advance_actor
-      end
-
-      # -- Item sub-menu -------------------------------------------------------
-
-      # Open the party's battle-usable items (nothing to open if the bag holds
-      # none).
-      def open_battle_item
-        @battle_ui[:items] = @state.party.battle_items
-        # See #open_battle_skill's identical comment -- the same Decision/
-        # Buzzer split, ported from `Scene_Battle::ItemSelected`.
-        if @battle_ui[:items].empty?
-          play_system_se(SFX_BUZZER)
-          return
-        end
-        play_system_se(SFX_DECISION)
-        @battle_ui[:item_i] = 0
-        @battle_ui[:phase] = :item
-        draw_battle_item
-      end
-
-      def drive_battle_item
-        items = @battle_ui[:items]
-        if Input.trigger?(Input::DOWN) && !items.empty?
-          @battle_ui[:item_i] += 1
-          @battle_ui[:item_i] %= items.length
-          draw_battle_item
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !items.empty?
-          @battle_ui[:item_i] -= 1
-          @battle_ui[:item_i] %= items.length
-          draw_battle_item
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::C)
-          play_system_se(SFX_DECISION)
-          item_id, _count = @battle_ui[:items][@battle_ui[:item_i]]
-          it = @state.party.db_item(item_id)
-          @battle_ui[:pending] = { kind: :item, item_id: item_id, it: it }
-          close_battle_item
-          if @state.party.switch_item?(item_id)
-            apply_pending_switch_item
-          elsif @state.party.item_all_allies?(it)
-            apply_pending_item_all(living_allies)
-          else
-            @battle_ui[:ally_i] = 0
-            @battle_ui[:phase] = :ally_target
-            draw_battle_ally_target
-          end
-        elsif Input.trigger?(Input::B)
-          play_system_se(SFX_CANCEL)
-          close_battle_item
-          @battle_ui[:phase] = :command
-          draw_battle_command
-        end
-      end
-
-      # -- Ally target (heal skill / medicine) --------------------------------
-
-      def drive_battle_ally_target
-        allies = battle_ally_targets
-        if Input.trigger?(Input::DOWN) && !allies.empty?
-          @battle_ui[:ally_i] += 1
-          @battle_ui[:ally_i] %= allies.length
-          draw_battle_ally_target
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !allies.empty?
-          @battle_ui[:ally_i] -= 1
-          @battle_ui[:ally_i] %= allies.length
-          draw_battle_ally_target
-          play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::C) && !allies.empty?
-          # `Scene_Battle::AllySelected` was not itself fetched verbatim,
-          # but it is one of the same family of "Selected" callbacks as
-          # Attack/Defend/Item/Skill above, every one of which plays
-          # Decision as its own first statement before acting.
-          play_system_se(SFX_DECISION)
-          target = allies[@battle_ui[:ally_i]]
-          close_battle_ally_target
-          if pending_kind == :skill
-            apply_pending_skill(target)
-          else
-            apply_pending_item(target)
-          end
-        elsif Input.trigger?(Input::B)
-          play_system_se(SFX_CANCEL)
-          close_battle_ally_target
-          if pending_kind == :skill
-            @battle_ui[:phase] = :skill
-            draw_battle_skill
-          else
-            @battle_ui[:phase] = :item
-            draw_battle_item
-          end
-        end
-      end
-
-      # Commit a switch item: it has no target at all -- the same as the field
-      # menu's own switch item (Scene::ItemMenu#apply_switch_item) skips
-      # straight past target selection -- so this queues immediately off
-      # #drive_battle_item's Confirm, with `current_actor` standing in for
-      # `command_item`'s `target:` (never read for a switch effect; a switch
-      # item's hp/mp are always 0, so it does not touch its HP/MP either).
-      # `switch_id` rides the log entry the same way `item_id` does, so
-      # #drive_battle_animate can flip it -- and only then, deferred to when
-      # the action actually lands, exactly like the bag deduction it sits
-      # beside there.
-      def apply_pending_switch_item
-        pending = @battle_ui[:pending]
-        @battle_ui[:battle].command_item(current_actor, current_actor,
-                                         item_id: pending[:item_id],
-                                         name: pending[:it].name,
-                                         switch_id: pending[:it].switch_id)
-        @battle_ui[:pending] = nil
-        @battle_ui[:phase] = :command
-        advance_actor
-      end
-
-      # Commit the pending item on `target` (recovery from the model; the bag is
-      # consumed later, when the action lands), then move to the next actor.
-      def apply_pending_item(target)
-        pending = @battle_ui[:pending]
-        c = @state.party.battle_item_command(pending[:it], target)
-        @battle_ui[:battle].command_item(current_actor, target,
-                                         item_id: pending[:item_id],
-                                         name: pending[:it].name,
-                                         hp: c[:hp], mp: c[:mp], cured: c[:cured])
-        @battle_ui[:pending] = nil
-        @battle_ui[:phase] = :command
-        advance_actor
-      end
-
-      # Commit an all-party item on every living ally: one per-member recovery
-      # from the model, queued as a single volley that consumes one item.
-      def apply_pending_item_all(targets)
-        pending = @battle_ui[:pending]
-        effects = targets.map do |t|
-          c = @state.party.battle_item_command(pending[:it], t)
-          { target: t, hp: c[:hp], mp: c[:mp] }
-        end
-        cured = @state.party.battle_item_command(pending[:it], targets.first)[:cured]
-        @battle_ui[:battle].command_item_all(current_actor, effects,
-                                             item_id: pending[:item_id],
-                                             name: pending[:it].name, cured: cured)
-        @battle_ui[:pending] = nil
-        @battle_ui[:phase] = :command
-        advance_actor
-      end
-
-      # Move to the next living party member, or start playing out the round once
-      # every member has a command.
-      def advance_actor
-        @battle_ui[:actor_i] += 1
-        @battle_ui[:cmd] = 0
-        open_next_command
-      end
-
-      # Advance `actor_i` past any living ally the round already decides
-      # for automatically -- a "do nothing" or forced attack-ally/
-      # attack-enemy restriction, see `Game::Battle#command_restricted?` --
-      # then either open the next actually-commandable ally's menu or, if
-      # every remaining living ally is restricted, start the round right
-      # away exactly as running out of allies after the last command
-      # already does. Without this, an asleep/paralysed/confused/berserk
-      # ally still got the ordinary Attack/Skill/Defend/Item prompt, and a
-      # party entirely under such states (e.g. everyone put to sleep by an
-      # enemy's spell) froze the command phase forever waiting on choices
-      # that could never change the outcome -- the "unrecoverable
-      # input-blocking state lock" case flagged as still open next to the
-      # empty/all-KO'd-party fix above.
-      def open_next_command
-        skip_restricted_actors
-        if @battle_ui[:actor_i] >= living_allies.length
-          start_round_animation
-        else
-          draw_battle_command
-        end
-      end
-
-      # Also auto-commands (rather than merely skipping) a 強制AI-flagged ally
-      # that isn't otherwise restricted: `Game::Actor#force_ai?` -- checked
-      # only once `#command_restricted?` has already answered false, matching
-      # `Scene_Battle_Rpg2k::SelectNextActor`'s own real check order (CanAct
-      # -> forced attack-ally/attack-enemy restriction -> auto_battle) -- gets
-      # `Game::Battle#choose_auto_battle_command` to queue its action right
-      # here instead of ever drawing the manual command window for it.
-      def skip_restricted_actors
-        battle = @battle_ui[:battle]
-        allies = living_allies
-        i = @battle_ui[:actor_i]
-        loop do
-          a = allies[i]
-          break unless a
-          if battle.command_restricted?(a)
-            i += 1
-          elsif force_ai_actor?(a)
-            battle.choose_auto_battle_command(a)
-            i += 1
-          else
-            break
-          end
-        end
-        @battle_ui[:actor_i] = i
-      end
-
-      def force_ai_actor?(combatant)
-        combatant.actor && combatant.actor.respond_to?(:force_ai?) && combatant.actor.force_ai?
-      end
-
-      # The index of the previous living ally free to receive a manual
-      # command, walking backward from just before the current one and
-      # skipping any restricted ally the same way `#skip_restricted_actors`
-      # does going forward -- nil once nothing earlier is left to
-      # re-command, matching EasyRPG's `SelectPreviousActor` recursing back
-      # to the Fight/Auto/Escape menu once it would land on the very first
-      # ally.
-      def prev_commandable_actor_index
-        battle = @battle_ui[:battle]
-        allies = living_allies
-        i = @battle_ui[:actor_i] - 1
-        i -= 1 while i >= 0 && (battle.command_restricted?(allies[i]) || force_ai_actor?(allies[i]))
-        i >= 0 ? i : nil
-      end
-
-      # Frames each attack of the round lingers on screen before the next lands —
-      # a beat long enough to read the hit and see the HP tick, at ~1/3s / 60fps.
-      BATTLE_ANIM_FRAMES = 20
-
-      # Begin animating the commanded round: dismiss the command menu and prime
-      # the battle's per-action queue. From here #drive_battle_animate lands one
-      # attack per BATTLE_ANIM_FRAMES until the round's queue empties.
-      def start_round_animation
-        if @battle_ui[:cmd_win]
-          @battle_ui[:cmd_win].dispose
-          @battle_ui[:cmd_win] = nil
-        end
-        @battle_ui[:battle].begin_round
-        @battle_ui[:phase] = :animate
-        @battle_ui[:anim_timer] = 0 # land the first attack next frame
-      end
-
-      # One attack per BATTLE_ANIM_FRAMES: land the next action (mutating a single
-      # battler's HP), tick the HP display, and banner the hit. When the round's
-      # queue empties, settle it and either show the result or re-open commands —
-      # so the round plays out action by action rather than all at once.
-      def drive_battle_animate
-        # A skill or item that names a battle animation plays it over the target
-        # before the round moves on, so the round is paced by the animation
-        # rather than by the fixed banner timer.
-        if battle_animation_playing?
-          step_map_animation
-          return
-        end
-        if @battle_ui[:anim_timer] > 0
-          @battle_ui[:anim_timer] -= 1
-          return
-        end
-        # A battle page is checked once per *acting battler*, not once per
-        # round -- EasyRPG's CheckBattleEndAndScheduleEvents runs "before each
-        # battler acts and also right after the last battler acts" (the
-        # latter half is #finish_round_animation's own check, already in
-        # place). The boundary between two battlers' actions is exactly where
-        # the previous #step_action call left nothing buffered (a dual-wield
-        # swing or an all-target Skill/Item queues several hits from *one*
-        # battler; the check belongs between battlers, not between hits).
-        if @battle_ui[:battler_boundary]
-          @battle_ui[:battler_boundary] = false
-          return if run_battle_events(:animate)
-        end
-        entry = @battle_ui[:battle].step_action
-        if entry
-          # An Item action spends one *use* from the real bag when it lands (so
-          # backing out during the command phase never spends it), which only
-          # costs a copy once the item's 使用回数 runs out -- the same
-          # Game::Party#consume_item_use the field menu goes through, so a
-          # multi-use bomb or a 特殊効果 weapon behaves identically in a fight.
-          # A switch item flips its switch at the same moment -- the state table
-          # is the scene's, same as the field menu's own Scene::ItemMenu, and
-          # this is the only place a queued switch-item action ever reaches it.
-          @state.party.consume_item_use(entry[:item_id]) if entry[:item_id]
-          @state.switches[entry[:switch_id]] = true if entry[:switch_id]
-          log_round([entry])
-          refresh_battle_status
-          refresh_battle_sprites
-          show_battle_action(entry)
-          play_battle_action_se(entry)
-          # When an animation plays, it is the wait; otherwise the banner timer
-          # is, exactly as before.
-          @battle_ui[:anim_timer] =
-            start_battle_animation(entry) ? 0 : BATTLE_ANIM_FRAMES
-          @battle_ui[:battler_boundary] = @battle_ui[:battle].pending_empty?
-        else
-          finish_round_animation
-        end
-      end
-
-      def battle_animation_playing?
-        !@map_animation.nil? && @map_animation[:battle]
-      end
-
-      # Play the animation this action names, over its target. RPG2000 keeps the
-      # animation on the **skill** and on the **item**, not on the action -- 557
-      # skill rows and 170 item rows across the test beds name one, and none of
-      # them played. Returns true when one started.
-      #
-      # A plain attack now plays one too: Game::Battle#deal_attack resolves
-      # the attacking actor's own weapon/unarmed animation (Actor#
-      # attack_animation_id) and carries it on the log entry as
-      # `attack_animation_id`, which #battle_animation_id below reads once
-      # neither a skill nor an item claims the entry.
-      def start_battle_animation(entry)
-        id = battle_animation_id(entry)
-        return false unless id && id > 0
-        tx, ty, height = battle_animation_pixel(entry)
-        anim = build_animation(id, tx, ty, true, target_index: entry[:target_index],
-                               target_height: height)
-        return false unless anim
-        @map_animation = anim
-        fire_animation_flashes(anim) # frame 0 flashes, as the map path does
-        true
-      rescue StandardError => e
-        $stderr.puts "[RPG2k] battle animation failed: #{e.message}"
-        false
-      end
-
-      def battle_animation_id(entry)
-        row =
-          if entry[:skill_id] && db.respond_to?(:skill) && db.skill
-            db.skill[entry[:skill_id]]
-          elsif entry[:item_id] && db.respond_to?(:item) && db.item
-            db.item[entry[:item_id]]
-          end
-        return row.animation_id if row && row.respond_to?(:animation_id)
-        # Neither a skill nor an item: a plain Attack, whose own animation
-        # Game::Battle#deal_attack already resolved onto the log entry.
-        entry[:attack_animation_id]
-      end
-
-      # Where it plays: over the targeted enemy's sprite. RPG2000 draws no sprite
-      # for a party member -- its battle is first-person -- so an action aimed at
-      # one plays over the middle of the screen instead of nowhere. The third
-      # element is the sprite's own pixel height, for #animation_position_offset
-      # to split into head/feet thirds -- nil for the screen-centre fallback,
-      # which has no sprite to measure and so never moves off it.
-      def battle_animation_pixel(entry)
-        i = entry[:target_index]
-        sprites = @battle_ui[:enemy_sprites]
-        spr = i && sprites ? sprites[i] : nil
-        bmp = spr && spr.bitmap
-        return [SCREEN_W / 2, SCREEN_H / 2, nil] unless bmp
-        [spr.x + bmp.width / 2, spr.y + bmp.height / 2, bmp.height]
-      end
-
-      # Close out an animated round: clear the commands, drop the action banner,
-      # and branch to the result window or the next command phase.
-      def finish_round_animation
-        battle = @battle_ui[:battle]
-        battle.end_round
-        close_battle_action
-        if battle.finished?
-          enter_battle_result(battle.result)
-        else
-          @battle_ui[:actor_i] = 0
-          @battle_ui[:cmd] = 0
-          @battle_ui[:phase] = :command
-          # A new turn re-arms every page: RPG2000 fires a battle page once per
-          # turn in which its condition holds, not once per battle.
-          @battle_ui[:pages_run] = {}
-          open_next_command unless run_battle_events
-        end
-      end
-
-      # -- battle-event pages --------------------------------------------------
-
-      # Start the next troop battle-event page whose condition holds and that has
-      # not yet fired this turn, switching to the :event phase. Returns whether a
-      # page was started, so the caller knows whether to draw the command window
-      # or hand the frame to the event. A troop that scripts nothing, or whose
-      # pages have all fired, simply returns false.
-      #
-      # `return_phase` is where #leave_battle_event_phase resumes once the page
-      # (and any chained page after it) finishes: `:command` for the between-
-      # rounds check (the default -- the normal case, opening the next round's
-      # command menu), `:animate` for the between-battlers check
-      # (#drive_battle_animate), which needs to pick back up mid-round rather
-      # than restart the command phase.
-      def run_battle_events(return_phase = :command)
-        ui = @battle_ui
-        return false unless ui && ui[:troop].pages
-        matched = Game::BattlePage.select_all(ui[:troop].pages, @state.switches,
-                                              @state.variables, ui[:battle])
-        entry = matched.find { |(id, _)| !ui[:pages_run][id] }
-        return false unless entry
-        ui[:pages_run][entry[0]] = true
-        cmds = entry[1].event
-        return run_battle_events(return_phase) if cmds.nil? || cmds.empty? # empty page: try the next
-        ui[:events].battle = ui[:battle]
-        ui[:events].start(cmds)
-        ui[:event_return_phase] = return_phase
-        ui[:phase] = :event
-        true
-      rescue StandardError => e
-        $stderr.puts "[RPG2k] battle event page failed: #{e.message}"
-        false
-      end
-
-      # Advance the running battle-event page one frame. Battle pages use the
-      # ordinary command set (messages, switches, variables, audio) on top of the
-      # battle-only commands, so the interpreter is driven the same way the map
-      # drives an event — only the UI it may reach for is narrower.
-      def drive_battle_event
-        it = @battle_ui[:events]
-        apply_battle_event_requests(it)
-        return if finish_terminated_battle
-        if it.waiting?
-          drive_battle_event_wait(it)
-        elsif it.running?
-          it.update
-        else
-          leave_battle_event_phase
-        end
-      end
-
-      def drive_battle_event_wait(it)
-        case it.wait_kind
-        when :message, :choice then drive_battle_event_message(it)
-        when :animation then drive_map_animation(it)
-        when :wait
-          @battle_ui[:event_timer] ||= frames_from_tenths(it.wait_frames)
-          if @battle_ui[:event_timer] <= 0
-            @battle_ui[:event_timer] = nil
-            it.resume
-          else
-            @battle_ui[:event_timer] -= 1
-          end
-        else
-          # A battle page cannot open the map's teleport / shop / menu UI; those
-          # requests are released so the page runs on rather than wedging here.
-          it.resume
-        end
-      end
-
-      # Show the page's message lines in a battle text panel and dismiss it on a
-      # button press. A [Show Choices] in a battle page is displayed the same way
-      # and takes the first option, which is what the runtime can answer without
-      # a battle choice widget.
-      def drive_battle_event_message(it)
-        unless @battle_ui[:event_win]
-          lines = it.wait_kind == :choice ? it.choice_labels : it.message_lines
-          @battle_ui[:event_win] =
-            battle_text_window(lines || [], BATTLE_EVENT_MSG_Y, 340)
-          return # shown this frame; take the button from the next one
-        end
-        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        choice = it.wait_kind == :choice
-        close_battle_event_window
-        choice ? it.choose(0) : it.resume
-      end
-
-      def close_battle_event_window
-        return unless @battle_ui && @battle_ui[:event_win]
-        @battle_ui[:event_win].dispose
-        @battle_ui[:event_win] = nil
-      end
-
-      # Apply the requests a battle page queued: revealed troop members get the
-      # sprite they never had, and a Change Battle Background rebuilds the
-      # backdrop.
-      #
-      # The status panel is rebuilt unconditionally afterwards. A battle page's
-      # Change Monster HP / MP / Condition commands write straight to the live
-      # combatants rather than queueing a request, so nothing here would have
-      # told the panel it is stale — a page that poisoned the boss changed the
-      # fight but not the screen until the next action happened to redraw it.
-      def apply_battle_event_requests(it)
-        it.take_revealed_monsters.each { |i| reveal_battle_monster(i) }
-        fled = it.take_fled_monsters
-        fled.each { |i| remove_fled_monster(i) }
-        play_escape_se unless fled.empty?
-        name = it.take_battle_background
-        rebuild_battle_back(name) unless name.nil?
-        refresh_battle_status
-      rescue StandardError => e
-        $stderr.puts "[RPG2k] battle event request failed: #{e.message}"
-        nil
-      end
-
-      # Show Hidden Monster: clear the member's hidden flag and build the sprite
-      # build_battle_sprites skipped, so it appears mid-fight.
-      def reveal_battle_monster(index)
-        member = @battle_ui[:troop].members[index]
-        return unless member && member.hidden
-        member.hidden = false
-        # Bring the combatant into the fight as well, not just the sprite: until
-        # now it took no turn and could not be targeted (Combatant#out_of_play?).
-        foe = @battle_ui[:battle].enemy(index)
-        foe.hidden = false if foe
-        bmp = battler_bitmap(member)
-        spr = Sprite.new
-        spr.bitmap = bmp
-        spr.x = member.x - bmp.width / 2
-        spr.y = battler_y(member, bmp)
-        spr.z = battler_z(index)
-        spr.opacity = battler_opacity(member)
-        dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
-        @battle_ui[:enemy_sprites][index] = spr
-      end
-
-      # Force Flee: the troop member ran, so drop its sprite. Game::Battle has
-      # already hidden the combatant (which takes it out of play without counting
-      # as a kill), and the troop member's own flag is set so a later rebuild does
-      # not draw it again.
-      def remove_fled_monster(index)
-        member = @battle_ui[:troop].members[index]
-        member.hidden = true if member
-        dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
-        @battle_ui[:enemy_sprites][index] = nil
-      end
-
-      # The escape sound RPG_RT plays when a Force Flee sends enemies running.
-      def play_escape_se
-        play_system_se(SFX_ESCAPE)
-      end
-
-      # Terminate Battle: leave the fight with no victory / defeat processing.
-      # Returns whether the battle was ended, so the caller stops driving it.
-      def finish_terminated_battle
-        return false unless @battle_ui[:battle].terminated?
-        close_battle_event_window
-        finish_battle(:abort)
-        true
-      end
-
-      # The running page finished: fire the next matching page (chained pages
-      # keep the same return_phase, so a battler-boundary check that opens
-      # several pages in a row still resumes mid-round rather than jumping to
-      # the command phase partway through), or hand the turn back — to the
-      # result window when the page decided the fight, to the mid-round
-      # animation loop when this page was a between-battlers check, otherwise
-      # to the party's command phase (a between-rounds check, the default).
-      def leave_battle_event_phase
-        close_battle_event_window
-        return_phase = @battle_ui[:event_return_phase] || :command
-        return if run_battle_events(return_phase)
-        battle = @battle_ui[:battle]
-        if battle.finished?
-          enter_battle_result(battle.result)
-        elsif return_phase == :animate
-          @battle_ui[:phase] = :animate
-        else
-          @battle_ui[:phase] = :command
-          enter_command_phase
-        end
-      end
-
-      def enter_battle_result(result)
-        @battle_ui[:result] = result
-        play_victory_bgm if result == :victory
-        lines = battle_result_lines(result, @battle_ui[:troop])
-        [@battle_ui[:status_win], @battle_ui[:cmd_win]].each { |w| w.dispose if w }
-        @battle_ui[:status_win] = nil
-        @battle_ui[:cmd_win] = nil
-        open_battle_result(lines)
-        @battle_ui[:phase] = :result
-      end
-
-      def drive_battle_result
-        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        finish_battle(@battle_ui[:result])
-      end
-
-      # Close the battle and hand the outcome back to the event. A defeat in an
-      # encounter whose defeat mode is "game over" (rather than a [Defeat]
-      # handler) ends the game instead of resuming the event; every other outcome
-      # — victory, escape, or a defeat with a custom handler — resumes it. Hands
-      # the outcome to whichever interpreter actually opened this fight
-      # (`@battle_ui[:owner]` -- the foreground by default, or a Parallel
-      # Process's own interpreter, see #drive_battle), captured before
-      # #close_battle clears @battle_ui out from under it.
-      def finish_battle(result)
-        # Persist the party's post-battle HP (and any knock-outs) before leaving
-        # the fight, so damage taken sticks and a downed member stays down.
-        @battle_ui[:battle].apply_to_party
-        # Capture the fight's own round count (Game::Battle#turn, its live
-        # @rounds counter) before #close_battle discards the Battle object --
-        # this is RPG2000's "turns passed in latest battle" (Game::State
-        # #last_battle_turns, LCF inventory chunk 109 field 41).
-        @state.last_battle_turns = @battle_ui[:battle].turn
-        # A defeat in "game over" mode (no custom [Defeat] handler) with the whole
-        # party knocked out ends the game; every other outcome resumes the event.
-        game_over = result == :defeat && @battle_ui[:req][:defeat_game_over] &&
-                    @state.party.all_dead?
-        owner = @battle_ui[:owner] || @interpreter
-        close_battle
-        if game_over
-          perform_game_over(owner)
-        else
-          restore_pre_battle_bgm
-          owner.resume_battle(result)
-        end
       end
 
       # Game over: the party was wiped in an encounter that ends the game on
@@ -6393,990 +4606,6 @@ class RPG2k
       rescue StandardError => e
         $stderr.puts "[RPG2k] Game over failed: #{e.message}"
         interp.stop
-      end
-
-      def log_round(entries)
-        entries.each do |e|
-          battle_action_lines(e).each { |l| $stderr.puts "[RPG2k battle] #{l}" }
-        end
-      end
-
-      # What an action says, in the game's own words. RPG2000 keeps the sentences
-      # in the 用語 table as *predicates* — 「の攻撃！」, 「のダメージを与えた！」 —
-      # and RPG_RT prints the battler's name in front of each. Both test beds
-      # fill 126 of the 127 fields in, so a log that invents its own English is
-      # ignoring text the author wrote.
-      #
-      # RPG_RT says it in more than one line: what the battler did, then what it
-      # did to the target. This returns them in that order, and falls back to the
-      # composed English for any field the database leaves blank — an
-      # English-release table with half the battle terms empty still reads.
-      def battle_action_body(e)
-        # An item announces itself with the `use_item` term, still unread, and
-        # "does nothing" is worded by the state that caused it rather than by a
-        # term — both keep the composed wording. A skill has its own two
-        # sentences and takes the branch below.
-        return [battle_action_line(e)] if e[:nothing]
-        return battle_skill_body(e) if e[:skill_id]
-        return battle_item_body(e) if e[:item_id]
-        return [battle_action_line(e)] if e[:recover] || e[:skill]
-        t = db.respond_to?(:term) ? db.term : nil
-        want_start = battle_start_field(e)
-        want_result = battle_result_wanted?(e)
-        want_crit = e[:critical] ? true : false
-        start = want_start && battle_start_line(t, e, want_start)
-        result = want_result && battle_result_line(t, e)
-        crit = want_crit &&
-               Game::States::BattleText.critical(t, e[:target_ally] ? true : false)
-        # All or nothing per entry: a half-translated line ("スライムの攻撃！"
-        # with no damage sentence under it) reads worse than the composed
-        # English, so a blank term drops the whole entry back to the fallback
-        # — which already carries the crit note itself (`battle_action_line`'s
-        # ' (critical!)' suffix), so a blank `actor_critical` / `enemy_critical`
-        # loses nothing by falling back whole.
-        return [battle_action_line(e)] if (want_start && !start) ||
-                                          (want_result && !result) ||
-                                          (want_crit && !crit)
-        lines = []
-        lines << start if start
-        lines << crit if crit
-        lines << result if result
-        lines.empty? ? [battle_action_line(e)] : lines
-      end
-
-      # A skill's own two sentences, then what it did. `using_message1` follows
-      # the caster's name and `using_message2` stands alone as a second line, so
-      # a spell reads 「リトは炎を放った！」 / 「あたりが真っ赤に染まる！」 before
-      # 「スライムに 42 のダメージを与えた！」.
-      #
-      # A skill that achieved nothing takes its own failure sentence instead of a
-      # damage line — the skill row's `failure_message` picks which of the three
-      # 用語 failure lines (or the dodge line) says so.
-      #
-      # A skill row that sets no sentence at all keeps the composed wording, for
-      # the same reason a blank term does: the bare damage line would lose the
-      # only thing naming what was cast.
-      def battle_skill_body(e)
-        bt = Game::States::BattleText
-        row = db.respond_to?(:skill) && db.skill ? db.skill[e[:skill_id]] : nil
-        caster = (e[:recover] ? e[:actor] : e[:attacker]).to_s
-        lines = bt.skill_start(row, caster)
-        return [battle_action_line(e)] if lines.empty?
-        t = db.respond_to?(:term) ? db.term : nil
-        rest = battle_skill_result(t, row, e)
-        return [battle_action_line(e)] unless rest
-        lines + rest
-      rescue StandardError => ex
-        $stderr.puts "[RPG2k] skill message lookup failed: #{ex.message}"
-        [battle_action_line(e)]
-      end
-
-      # What the skill did: the damage / dodge line for an attack, nothing extra
-      # for a recovery that worked, and the failure sentence for one that did
-      # not. nil when a needed sentence is missing, so the caller falls back
-      # whole rather than printing half of one.
-      def battle_skill_result(t, row, e)
-        bt = Game::States::BattleText
-        return [] if e[:target].nil?
-        if skill_achieved_nothing?(e)
-          line = bt.skill_failure(t, row, e[:target].to_s)
-          return line ? [line] : nil
-        end
-        return battle_recovery_lines(t, e) if e[:recover]
-        line = battle_result_line(t, e)
-        return nil unless line
-        [line] + battle_absorb_lines(t, e)
-      end
-
-      # What a 吸収 skill took from its target, after the damage line. [] when
-      # the skill drained nothing or the database has no wording -- unlike the
-      # damage line this one is additive, so a missing term drops the extra
-      # sentence rather than the whole entry.
-      def battle_absorb_lines(t, e)
-        amount = e[:absorbed_hp] || 0
-        return [] unless amount > 0
-        line = Game::States::BattleText.absorbed(
-          t, e[:target].to_s, amount, :hp, e[:target_ally] ? true : false
-        )
-        line ? [line] : []
-      end
-
-      # An item borrows the `use_item` term rather than carrying a sentence of
-      # its own -- 「リトはポーションを使った！」 is the only line RPG2000 builds
-      # from two names -- and then says what it restored.
-      def battle_item_body(e)
-        bt = Game::States::BattleText
-        t = db.respond_to?(:term) ? db.term : nil
-        start = bt.item_start(t, e[:actor].to_s, e[:source].to_s)
-        return [battle_action_line(e)] unless start
-        rest =
-          if e[:switch_id]
-            # A switch item always "does something" (flips its switch), even
-            # though it restores no HP/MP and cures nothing -- unlike a
-            # medicine it never "achieves nothing", so it is just the "used
-            # it!" line alone, the same silent flip the field menu shows.
-            []
-          elsif skill_achieved_nothing?(e)
-            # An item that did nothing has no `failure_message` to choose with,
-            # so RPG2000 has no sentence for it: the composed line still says
-            # more than the bare "used it" would.
-            nil
-          else
-            battle_recovery_lines(t, e)
-          end
-        return [battle_action_line(e)] unless rest
-        [start] + rest
-      rescue StandardError => ex
-        $stderr.puts "[RPG2k] item message lookup failed: #{ex.message}"
-        [battle_action_line(e)]
-      end
-
-      # What a heal restored: one line per pool it filled, in the game's own
-      # words (「リトのＨＰが 30 回復した！」). [] when it restored nothing but
-      # cured something -- the state sentences carry that -- and nil when the
-      # database has no wording, so the caller falls back whole.
-      def battle_recovery_lines(t, e)
-        bt = Game::States::BattleText
-        name = e[:target].to_s
-        lines = []
-        [[:hp, e[:recover_hp]], [:mp, e[:recover_mp]]].each do |pool, amount|
-          next unless amount && amount > 0
-          line = bt.recovered(t, name, amount, pool)
-          return nil unless line
-          lines << line
-        end
-        lines
-      end
-
-      # A skill with nothing to show for itself: a heal that restored no HP or SP
-      # and cured nothing, or an attack that was dodged.
-      def skill_achieved_nothing?(e)
-        return true if e[:missed]
-        return false unless e[:recover]
-        (e[:recover_hp] || 0) <= 0 && (e[:recover_mp] || 0) <= 0 &&
-          (e[:cured] || []).empty? && (e[:inflicted] || []).empty?
-      end
-
-      # Which term words this entry's "so-and-so did a thing" line, or nil when
-      # RPG2000 has none for it — a skill or an item names itself instead (its
-      # own `using_message` is a separate field, still unread), and "does
-      # nothing" is a state's own sentence rather than a term.
-      def battle_start_field(e)
-        return nil if e[:recover] || e[:skill] || e[:nothing]
-        return :enemy_transform if e[:transform]
-        return :defending if e[:defend]
-        return :observing if e[:observe]
-        return :focus if e[:charge]
-        return :enemy_escape if e[:fled]
-        return :autodestruction if e[:autodestruct]
-        :attacking
-      end
-
-      def battle_start_line(t, e, field)
-        Game::States::BattleText.action(t, e[:attacker].to_s, field)
-      end
-
-      # Does this entry report on a target at all? A Defend, a flee or an
-      # autodestruct that found nobody has no one to report on.
-      def battle_result_wanted?(e)
-        return false if e[:recover] || e[:target].nil?
-        e[:missed] || !e[:damage].nil? ? true : false
-      end
-
-      # What it did to that target: a miss, a blow that got through for nothing,
-      # or the damage.
-      def battle_result_line(t, e)
-        bt = Game::States::BattleText
-        name = e[:target].to_s
-        ally = e[:target_ally] ? true : false
-        return bt.dodge(t, name) if e[:missed]
-        return bt.damage(t, name, e[:damage], ally) if e[:damage] > 0
-        bt.undamaged(t, name, ally)
-      end
-
-      # A one-line description of a battle log entry, for the on-screen banner and
-      # the console trace. A recovery (heal skill / medicine) reads as a restore;
-      # a skill attack names the skill; a plain attack is "A hits B for N".
-      #
-      # This is the fallback now: it words an entry whose terms the database left
-      # blank. `battle_action_body` prefers the game's own sentences.
-      def battle_action_line(e)
-        if e[:recover]
-          parts = []
-          parts << "#{e[:recover_hp]} HP" if e[:recover_hp] && e[:recover_hp] > 0
-          parts << "#{e[:recover_mp]} MP" if e[:recover_mp] && e[:recover_mp] > 0
-          body = if !parts.empty? then "+#{parts.join(' / ')}"
-                 elsif e[:switch_id] then 'switch on'
-                 else 'no effect'
-                 end
-          "#{e[:actor]}'s #{e[:source]}: #{e[:target]} #{body}"
-        elsif e[:missed]
-          "#{e[:attacker]} misses #{e[:target]}"
-        elsif e[:transform]
-          "#{e[:attacker]} transforms!"
-        elsif e[:defend]
-          "#{e[:attacker]} defends"
-        elsif e[:observe]
-          "#{e[:attacker]} watches closely"
-        elsif e[:charge]
-          "#{e[:attacker]} gathers strength"
-        elsif e[:fled]
-          "#{e[:attacker]} flees!"
-        elsif e[:nothing]
-          "#{e[:attacker]} does nothing"
-        else
-          hits = if e[:autodestruct] then ' blows itself up on'
-                 elsif e[:skill] then "'s #{e[:skill]} hits"
-                 else ' hits'
-                 end
-          line = "#{e[:attacker]}#{hits} #{e[:target]} for #{e[:damage]}"
-          line += ' (critical!)' if e[:critical]
-          line += ' (charged)' if e[:charged]
-          line
-        end
-      end
-
-      # Everything the action announces: what it did, then the conditions it
-      # changed. `log_round` traces all of it and `show_battle_action` banners
-      # all of it, so the console and the screen never disagree.
-      def battle_action_lines(entry)
-        battle_action_body(entry) + battle_state_lines(entry)
-      end
-
-      # The result window's text: the outcome, and on a win the EXP / gold gained
-      # (granted here). RPG2000 shows this after the fight before returning to the
-      # map. The headline is the database's own wording -- the 用語 table's
-      # `victory` / `defeat` fields, the same table (and the same "falls back to
-      # composed English when the database leaves it blank" rule)
-      # Game::States::BattleText already reads every per-action line from.
-      # The EXP / gold / item lines are composed from their own terms too now
-      # (`exp_received`, the `gold_received_a` / `_b` pair, `item_received`),
-      # confirmed against EasyRPG Player's actual C++ source rather than
-      # guessed at: `PartyMessage::GetExperienceGainedMessage` /
-      # `GetGoldReceivedMessage` / `GetItemReceivedMessage`
-      # (`src/game_message_terms.cpp`), stock-RPG2000 (non-`Feature::
-      # HasPlaceholders`, non-Maniac-Patch) branch -- `exp << terms.
-      # exp_received` (no separating space outside the RPG2k3-English
-      # release), `terms.gold_recieved_a << " " << money << terms.gold <<
-      # terms.gold_recieved_b`, `item_name << terms.item_recieved`. These
-      # three term fields were parsed by the schema and never read anywhere
-      # in `mruby-rpg2k` before now, so a game that customised them (a
-      # translation, a non-English original) showed this codebase's
-      # hardcoded English regardless.
-      #
-      # A level-up (and any skill the growth table teaches at it) is
-      # announced too now, the missing half of the same gap: EasyRPG's
-      # `Scene_Battle_Rpg2k::ProcessSceneActionVictory`
-      # (`src/scene_battle_rpg2k.cpp`) builds the EXP/gold/item summary as one
-      # page, then calls `Game_Actor::ChangeExp` once per active ally right
-      # after it, which is exactly `Game::Interpreter#do_change_exp`'s own
-      # gain_exp-then-announce shape (`queue_level_up_messages`,
-      # `mrblib/interpreter.rb`) -- so each actor's level/skill snapshot is
-      # taken here the same way, right before its own `#gain_exp`. Unlike
-      # that interpreter path (still the documented "plain English line for
-      # now" simplification), this screen already reads real database terms
-      # for every other line, so `#battle_level_up_message` /
-      # `#battle_skill_learned_message` below do too, built from EasyRPG's
-      # `ActorMessage::GetLevelUpMessage` / `GetLearningMessage`
-      # (`src/game_message_terms.cpp`), stock-RPG2000/CP932 branch: `name <<
-      # "は" << terms.level << " " << new_level << " " << terms.level_up` and
-      # `skill.name << terms.skill_learned` (no actor name -- it always
-      # follows that actor's own level-up line, same as here). RPG_RT shows
-      # these on their own page per actor rather than inline with the EXP
-      # tally; this screen has no per-page window, only one flat line list
-      # for the whole result, so they are appended to that list instead, in
-      # the same after-the-tally order the real sequence uses.
-      def battle_result_lines(result, troop)
-        return [term(:escape_success, 'Escaped!')] if result == :escape
-        return [term(:defeat, 'The party was defeated...')] unless result == :victory
-        exp = troop.total_exp
-        gold = troop.total_gold
-        @state.party.gain_gold(gold)
-        lines = [term(:victory, 'Victory!')]
-        lines << "#{exp}#{term(:exp_received, ' EXP gained.')}" if exp > 0
-        if gold > 0
-          lines << "#{term(:gold_received_a, 'Found')} #{gold}#{term(:gold, 'G')}" \
-                   "#{term(:gold_received_b, '.')}"
-        end
-        # Each defeated enemy may drop its treasure item (rolled on the battle's
-        # own RNG); grant it to the bag and name it in the result window.
-        troop.drops(@battle_ui[:battle].rng).each do |iid|
-          @state.party.gain_item(iid, 1)
-          it = @state.party.db_item(iid)
-          name = it ? it.name : "item #{iid}"
-          lines << "#{name}#{term(:item_received, ' obtained.')}"
-        end
-        @state.party.actors.each do |a|
-          before_level = a.respond_to?(:level) ? a.level : nil
-          before_skills = a.respond_to?(:skills) ? a.skills.dup : []
-          a.gain_exp(exp)
-          lines.concat(battle_level_up_lines(a, before_level, before_skills)) if before_level
-        end
-        lines
-      end
-
-      # Level-up (and, for each level, any growth-table skill it teaches)
-      # lines for one actor's post-battle EXP gain, mirroring
-      # `Game::Interpreter#queue_level_up_messages`'s own before/after skill
-      # comparison: `before_skills` is that actor's skill list snapshotted
-      # right before `#gain_exp`, so a skill already known (an earlier
-      # explicit Change Skill teach) is told apart from one this exact gain
-      # just taught. Returns [] when the level did not rise.
-      def battle_level_up_lines(actor, before_level, before_skills)
-        return [] if actor.level <= before_level
-        lines = []
-        ((before_level + 1)..actor.level).each do |lv|
-          lines << battle_level_up_message(actor, lv)
-          next unless actor.respond_to?(:learn_table)
-          actor.learn_table.each do |sid, at|
-            next unless at == lv && !before_skills.include?(sid)
-            sk = @state.party.db_skill(sid)
-            lines << battle_skill_learned_message(actor, sk) if sk
-          end
-        end
-        lines
-      end
-
-      # The one line a level-up announces, built from the database's own
-      # `level`/`level_up` terms the way EasyRPG's stock/CP932
-      # `GetLevelUpMessage` branch does (see `#battle_result_lines`'s own
-      # comment) -- falls back to composed English, matching every other
-      # line on this screen, only when the database leaves `level_up` blank
-      # (a raw `level_up` term with no `level` term set still gets the
-      # 'Lv' stand-in rather than losing the whole line to English).
-      def battle_level_up_message(actor, level)
-        up = term(:level_up, nil)
-        return "#{actor.name} is now level #{level}!" unless up
-        "#{actor.name}は#{term(:level, 'Lv')} #{level} #{up}"
-      end
-
-      # The one line a newly-learned skill announces, immediately following
-      # its level's own line above -- EasyRPG's stock/CP932
-      # `GetLearningMessage` branch names only the skill, never the actor,
-      # since it always trails that actor's own level-up line the way it
-      # does here too. Falls back to composed English (which does name the
-      # actor, since a database leaving `skill_learned` blank gets no
-      # level-up line's context to lean on either) when the term is blank.
-      def battle_skill_learned_message(actor, sk)
-        learned = term(:skill_learned, nil)
-        return "#{actor.name} learned #{sk.name}!" unless learned
-        "#{sk.name}#{learned}"
-      end
-
-      # RPG_RT's battle windows share one fixed panel: a 320x80 strip along the
-      # bottom edge with 16px rows -- not the content-fitted, 14px-row windows
-      # this screen used to draw. EasyRPG's Scene_Battle_Rpg2k / Scene_Battle
-      # construct status_window / command_window / target_window / item_window /
-      # skill_window / battle_message_window all at
-      # `(x, screen_height - 80, w, 80)`, and Window_Selectable's own
-      # `menu_item_height` (16, matching this screen's message-window
-      # `MSG_LINE_H`) is what actually spaces their rows.
-      BATTLE_LINE_H = 16
-      BATTLE_PANEL_Y = SCREEN_H - 80
-      BATTLE_PANEL_H = 80
-      # The actor-command window is a fixed 76px (`option_command_mov` in
-      # EasyRPG), docked to the right edge; the status window takes the rest of
-      # the row (`MENU_WIDTH - option_command_mov`).
-      BATTLE_CMD_W = 76
-      BATTLE_STATUS_W = SCREEN_W - BATTLE_CMD_W
-      # The enemy target list (`CreateBattleTargetWindow`) is a fixed 136px, and
-      # only ever covers the status window's footprint -- the command window
-      # stays on screen beside it.
-      BATTLE_TARGET_W = 136
-      # How many rows show at once before a longer list (an 8-monster troop, a
-      # long skill list) scrolls: the panel's fixed 64px content area (80 minus
-      # the 8px border on each side) divided by the 16px row height.
-      BATTLE_VISIBLE_ROWS = 4
-
-      # Column origins within the status panel's contents, in the order RPG_RT's
-      # battle status window uses them: who, what condition they are in, then the
-      # gauges. The condition column is why this window is laid out in columns at
-      # all — a state is drawn in its *own* palette colour, which a single
-      # `draw_text` of a whole line cannot do. (EasyRPG's
-      # `Window_BattleStatus::Refresh`, RPG2k branch: name at 4, state at 86,
-      # HP at 142, SP at 202 for a party with no maxima over 999.)
-      STATUS_NAME_X  = 4
-      STATUS_STATE_X = 86
-      STATUS_HP_X    = 142
-      STATUS_MP_X    = 202
-
-      # Rebuild the status panel: the party's HP and SP, each with the one
-      # condition RPG_RT shows — the significant state, or the database's
-      # "normal" term when there is none — so a status inflicted by a skill or
-      # by a battle page's Change Monster Condition is visible rather than only
-      # simulated. RPG2000 is front-view: the enemy troop is never listed here
-      # (EasyRPG's Scene_Battle_Rpg2k builds exactly one Window_BattleStatus,
-      # defaulted to `enemy: false`) -- it is represented only by its battler
-      # sprites and, when targeted, by the target window's name list. The row
-      # of whichever actor is currently being commanded gets the cursor,
-      # mirroring `status_window->SetIndex` in EasyRPG's `SelectNextActor`.
-      #
-      # `battle_type` 2 (gauge, `#gauge_battle_layout?`) replaces this whole
-      # panel with RPG2003's face/bar "gauge card" layout instead
-      # (`#battle_status_gauge_window`) -- `battle_type` 1 (alternative) is
-      # unchanged, and still builds the same text rows this always has, since
-      # only 2 asks for the card presentation (EasyRPG's own
-      # `Window_BattleStatus::Refresh`/`RefreshGauge` branch the same way, on
-      # `battle_type == BattleType_gauge` specifically, not on "not
-      # traditional"). Falls back to the text rows when the gauge window
-      # cannot be built (no System2 graphic, or a failed load) rather than
-      # leaving the panel blank.
-      def refresh_battle_status
-        @battle_ui[:status_win].dispose if @battle_ui[:status_win]
-        win = battle_status_gauge_window(@battle_ui[:allies]) if gauge_battle_layout?
-        @battle_ui[:status_win] = win || begin
-          rows = @battle_ui[:allies].map { |a| battle_status_row(a) }
-          # No row highlighted while the options window is open -- matching
-          # `status_window->SetIndex(-1)` in `ProcessSceneActionFightAutoEscape`'s
-          # own `eMoveWindow` substate; nobody is "the acting actor" until
-          # Battle or Auto Battle is chosen.
-          idx = @battle_ui[:phase] == :battle_options ? nil : @battle_ui[:allies].index(current_actor)
-          battle_status_window(rows, idx)
-        end
-      end
-
-      # Whether the database's `battlecommands.battle_type` is specifically 2
-      # (gauge) -- distinct from `Game::Party#alternate_battle_layout?`, which
-      # is also true for the plain sprite-only layout (1) and still uses the
-      # unchanged text status window for that case. A bare test fixture (or
-      # any database `#alternate_battle_layout?` itself already reads false
-      # for) reads false here too.
-      def gauge_battle_layout?
-        @state.party.respond_to?(:gauge_battle_layout?) && @state.party.gauge_battle_layout?
-      end
-
-      # One party member's row as [text, x, colour index] segments: name,
-      # condition, then the HP / SP gauges.
-      def battle_status_row(b)
-        hp = b.hp < 0 ? 0 : b.hp
-        [[b.name, STATUS_NAME_X, 0], battle_state_segment(b),
-         ["HP #{hp}/#{b.max_hp}", STATUS_HP_X, 0],
-         ["MP #{b.mp}/#{b.max_mp}", STATUS_MP_X, 0]]
-      end
-
-      # The condition column, as a status-panel segment: the same reading the
-      # field windows draw (Scene::Base#state_display), placed in its column.
-      def battle_state_segment(b)
-        text, color = state_display(b.states)
-        [text, STATUS_STATE_X, color]
-      end
-
-      # `Window_BattleStatus`'s own default `actor_face_height` (24) -- the
-      # small-window variant (14) is `battlecommands.window_size`, which
-      # schema.rb has not decoded yet (see this change's changelog entry), so
-      # every gauge card always uses the large-window offset.
-      ACTOR_FACE_HEIGHT = 24
-
-      # The gauge card layout (`battle_type` 2): one 80px-wide card per party
-      # member -- face, HP/SP bars and digit-glyph numbers, drawn straight
-      # from the database's own System2 graphic -- ported column-for-column
-      # from EasyRPG's real `Window_BattleStatus::Refresh`/`RefreshGauge`
-      # (the `!enemy && battle_type == BattleType_gauge` branch of each).
-      # Borderless like RPG_RT's own gauge window (`Window#transparent=` --
-      # EasyRPG's constructor sets `border_x = border_y = 0` and
-      # `SetOpacity(0)` for this same case, "simulate a borderless window...
-      # makes the implementation on scene-side easier"), and never gets a
-      # cursor rect: `UpdateCursorRect` returns an empty rect unconditionally
-      # for this battle_type, so no row is ever highlighted here, unlike the
-      # text status window's acting-actor cursor. The ATB/wait gauge row
-      # `RefreshGauge` also draws (`DrawGaugeSystem2(..., GetAtbGauge,
-      # GetMaxAtbGauge, 2)`) is skipped -- this runtime has no ATB/wait-timer
-      # subsystem to read a value from. Returns nil (so `#refresh_battle_status`
-      # falls back to the plain text rows) when the database names no System2
-      # graphic, or names one that fails to load -- there is no sensible
-      # placeholder gauge sprite sheet the way there's a placeholder colour
-      # block for a missing battler graphic.
-      def battle_status_gauge_window(allies)
-        system2 = battle_system2_bitmap
-        return nil unless system2
-        inner_w = BATTLE_STATUS_W - Window::BORDER * 2
-        inner_h = BATTLE_PANEL_H - Window::BORDER * 2
-        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
-        win.z = 300
-        win.transparent = true
-        c = Bitmap.new(inner_w, inner_h)
-        allies.each_with_index { |ally, i| draw_battle_gauge_card(c, system2, ally, i) }
-        win.contents = c
-        win
-      end
-
-      # One party member's gauge card at column `i`. `ally` is a
-      # `Game::Battle::Combatant` (`Game::Battle.from_actor`) -- its `.actor`
-      # is the underlying `Game::Actor`, the only place `faceset_name`/
-      # `faceset_index` (chunk 11 fields 15/16, including any Change Actor
-      # Face override) live. Ported from `RefreshGauge`'s own gauge-card
-      # block: the face, then the bar's left cap / stretched centre / right
-      # cap at `System2` (0,32,16,48)/(16,32,16,48)/(32,32,16,48), then the
-      # HP row (`which` 0) and SP row (`which` 1) fills and numbers -- the
-      # exact x/y arithmetic (`32 + 80*i`, `40 + 80*i`, `y + 12 + 4`) is
-      # copied from the real source rather than re-derived.
-      def draw_battle_gauge_card(c, system2, ally, i)
-        draw_battle_gauge_face(c, ally.actor, i)
-        x = 32 + i * 80
-        y = ACTOR_FACE_HEIGHT
-        c.blt x, y, system2, Rect.new(0, 32, 16, 48)
-        x += 16
-        fill_x = x
-        c.stretch_blt Rect.new(x, y, 25, 48), system2, Rect.new(16, 32, 16, 48)
-        x += 25
-        c.blt x, y, system2, Rect.new(32, 32, 16, 48)
-        hp = ally.hp < 0 ? 0 : ally.hp
-        draw_gauge_system2(c, system2, fill_x, y, hp, ally.max_hp, 0)
-        draw_gauge_system2(c, system2, fill_x, y + 16, ally.mp, ally.max_mp, 1)
-        num_x = 40 + 80 * i
-        draw_number_system2(c, system2, num_x, y, hp)
-        draw_number_system2(c, system2, num_x, y + 12 + 4, ally.mp)
-      end
-
-      # The card's face portrait -- the same 48x48 FaceSet crop
-      # `#load_face_bitmap`/`FACE_SIZE` already draw for the name-entry and
-      # message-face screens, just placed at this card's column instead of
-      # its own window. Draws nothing (leaving the card's bars/numbers alone)
-      # for an actor with no faceset set, or a faceset file that fails to
-      # load, the same "a missing portrait shows nothing" rule
-      # `#load_face`/`#draw_kana_face` already use -- and, matching every
-      # other optional actor field this screen reads (`battler_animation_id`,
-      # `battle_x`/`battle_y`), `#respond_to?`-guarded so a bare test fixture
-      # actor with no faceset fields at all still draws the rest of the card.
-      def draw_battle_gauge_face(c, actor, i)
-        return unless actor && actor.respond_to?(:faceset_name)
-        face = load_face_bitmap(actor.faceset_name)
-        return unless face
-        index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
-        src = Rect.new((index % 4) * FACE_SIZE, (index / 4) * FACE_SIZE, FACE_SIZE, FACE_SIZE)
-        c.blt 80 * i, ACTOR_FACE_HEIGHT, face, src
-      end
-
-      # The HP (`which` 0) or SP (`which` 1) bar fill: a `25 * cur / max`
-      # wide stretch of the fill tile at `System2` `(48, 32 + 16*which, 16,
-      # 16)` -- except an exactly-full gauge (`cur == max`) reads the
-      # visually distinct "full" fill tile 16px over, at `(64, ...)`,
-      # instead of the normal partial-fill one. Ported from
-      # `Window_BattleStatus::DrawGaugeSystem2` exactly, including its
-      # `max == 0` no-draw guard (a stat with no pool at all, e.g. an actor
-      # with 0 max SP, draws no fill for that row).
-      def draw_gauge_system2(c, system2, x, y, cur, max, which)
-        return if max == 0
-        gauge_x = cur == max ? 16 : 0
-        width = 25 * cur / max
-        c.stretch_blt Rect.new(x, y, width, 16), system2,
-                     Rect.new(48 + gauge_x, 32 + 16 * which, 16, 16)
-      end
-
-      # Right-aligned up-to-4-digit number in 8x16 glyph cells (`System2`
-      # `(digit * 8, 80, 8, 16)`), leading zeros suppressed rather than drawn
-      # -- ported from `Window_BattleStatus::DrawNumberSystem2` exactly,
-      # including its exact leading-zero cascade: a thousands (or hundreds)
-      # digit that comes out to 0 still lets the *next* digit down draw via
-      # its own `handle_zero` carry, so 100 draws all three digits ("100")
-      # while 7 draws only the ones cell (three blank cells then "7") and 42
-      # draws the tens+ones cells ("42", blank above).
-      def draw_number_system2(c, system2, x, y, value)
-        handle_zero = false
-        if value >= 1000
-          c.blt x, y, system2, Rect.new((value / 1000) * 8, 80, 8, 16)
-          value %= 1000
-          handle_zero = true if value < 100
-        end
-        if handle_zero || value >= 100
-          handle_zero = false
-          c.blt x + 8, y, system2, Rect.new((value / 100) * 8, 80, 8, 16)
-          value %= 100
-          handle_zero = true if value < 10
-        end
-        if handle_zero || value >= 10
-          c.blt x + 16, y, system2, Rect.new((value / 10) * 8, 80, 8, 16)
-          value %= 10
-        end
-        c.blt x + 24, y, system2, Rect.new(value * 8, 80, 8, 16)
-      end
-
-      # The RPG2003 System2 graphic (gauge fill/caps and the digit glyphs the
-      # gauge card draws numbers with) -- one cache entry, keyed by name like
-      # every other named battle graphic (`#cached_bitmap`), since a project
-      # only ever declares the one in `system.system2_name` (chunk 22 field
-      # 20, schema.rb). A blank name or a failed load returns nil (and logs,
-      # for the latter) so `#battle_status_gauge_window` falls back to the
-      # plain text status row instead of crashing -- unlike
-      # `#battler_bitmap`/`#actor_battlecharset_bitmap`, there is no sensible
-      # placeholder gauge sprite sheet to draw in its place.
-      def battle_system2_bitmap
-        name = db.system.respond_to?(:system2_name) ? db.system.system2_name : nil
-        return nil unless name && !name.empty?
-        cached_bitmap(@system2_cache, name) do
-          begin
-            Bitmap.new("System2/#{name}", true)
-          rescue StandardError => e
-            $stderr.puts "[RPG2k] System2 graphic '#{name}' load failed: #{e.message}"
-            nil
-          end
-        end
-      end
-
-      # The current actor's command menu — Attack / Skill / Defend / Item, with
-      # a cursor. RPG_RT does not put the actor's name in this window at all
-      # (EasyRPG's `CreateBattleCommandWindow` builds it once from the four
-      # command terms in that order): the acting actor is shown by the cursor
-      # `#refresh_battle_status` puts on their row in the status window instead
-      # (EasyRPG's `status_window->SetIndex(actor_index)`). The Skill slot's own
-      # label can still change per actor (`#skill_command_label`), the same way
-      # EasyRPG's `RefreshCommandWindow` calls `SetItemText` on that one row
-      # after the window is built rather than rebuilding the whole thing.
-      def draw_battle_command
-        actor = current_actor
-        return unless actor
-        @battle_ui[:cmd_win].dispose if @battle_ui[:cmd_win]
-        labels = battle_commands
-        win = Window.new(BATTLE_STATUS_W, BATTLE_PANEL_Y, BATTLE_CMD_W, BATTLE_PANEL_H)
-        win.z = 320
-        win.windowskin = @windowskin
-        inner_w = BATTLE_CMD_W - Window::BORDER * 2
-        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
-        c.font.color = Color.new(255, 255, 255, 255)
-        labels.each_with_index do |label, i|
-          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
-        end
-        win.contents = c
-        win.cursor_rect =
-          Rect.new(0, @battle_ui[:cmd] * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
-        @battle_ui[:cmd_win] = win
-        refresh_battle_status
-      end
-
-      # The Battle/Auto Battle/Escape options window -- the same panel and
-      # rect the per-actor command window uses (only one of the two is ever
-      # on screen at a time), just with `#battle_option_rows`' three entries
-      # instead of the usual four.
-      def draw_battle_options
-        @battle_ui[:cmd_win].dispose if @battle_ui[:cmd_win]
-        labels = battle_option_rows.map { |r| r[:label] }
-        win = Window.new(BATTLE_STATUS_W, BATTLE_PANEL_Y, BATTLE_CMD_W, BATTLE_PANEL_H)
-        win.z = 320
-        win.windowskin = @windowskin
-        inner_w = BATTLE_CMD_W - Window::BORDER * 2
-        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
-        c.font.color = Color.new(255, 255, 255, 255)
-        labels.each_with_index do |label, i|
-          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
-        end
-        win.contents = c
-        win.cursor_rect =
-          Rect.new(0, @battle_ui[:opt] * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
-        @battle_ui[:cmd_win] = win
-        refresh_battle_status
-      end
-
-      # The target-selection menu — the living enemies, with a cursor. Fixed at
-      # `CreateBattleTargetWindow`'s own rect: it covers the status window's
-      # footprint (not the command window's, which stays on screen beside it).
-      def draw_battle_target
-        foes = living_foes
-        @battle_ui[:target_win].dispose if @battle_ui[:target_win]
-        @battle_ui[:target_win] =
-          battle_list_window(0, BATTLE_TARGET_W, foes.map(&:name),
-                             @battle_ui[:target_i], 330)
-      end
-
-      def close_battle_target
-        return unless @battle_ui[:target_win]
-        @battle_ui[:target_win].dispose
-        @battle_ui[:target_win] = nil
-      end
-
-      # A bottom-anchored list window of `labels` with the cursor on `sel`, at
-      # left edge `x` and width `w`, fixed to the panel's own height (80px, the
-      # shape every RPG_RT battle list window shares) — the shared shape of the
-      # Skill / Item / target / ally-target menus. A list longer than
-      # `BATTLE_VISIBLE_ROWS` scrolls, keeping `sel` in view, the way
-      # `Window_Selectable`'s own scrolling does for an oversized troop or
-      # skill list.
-      def battle_list_window(x, w, labels, sel, z)
-        rows = BATTLE_VISIBLE_ROWS
-        scroll = labels.length > rows ? [[sel - rows + 1, 0].max, labels.length - rows].min : 0
-        win = Window.new(x, BATTLE_PANEL_Y, w, BATTLE_PANEL_H)
-        win.z = z
-        win.windowskin = @windowskin
-        inner_w = w - Window::BORDER * 2
-        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
-        c.font.color = Color.new(255, 255, 255, 255)
-        labels.each_with_index do |label, i|
-          next if i < scroll || i >= scroll + rows
-          c.draw_text 0, (i - scroll) * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
-        end
-        win.contents = c
-        unless labels.empty?
-          win.cursor_rect = Rect.new(0, (sel - scroll) * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
-        end
-        win
-      end
-
-      # The current actor's battle skills as "Name  cost", with a cursor. Full
-      # width, same rect as the item menu — RPG_RT's skill and item windows
-      # cover both the status and command windows while open (EasyRPG's
-      # `skill_window` / `item_window`, `(0, screen_height - 80, MENU_WIDTH,
-      # 80)`).
-      def draw_battle_skill
-        @battle_ui[:skill_win].dispose if @battle_ui[:skill_win]
-        labels = @battle_ui[:skills].map do |sid, cost|
-          sk = @state.party.db_skill(sid)
-          "#{sk ? sk.name : "Skill #{sid}"}  #{cost}"
-        end
-        @battle_ui[:skill_win] = battle_list_window(0, SCREEN_W, labels, @battle_ui[:skill_i], 325)
-      end
-
-      def close_battle_skill
-        return unless @battle_ui[:skill_win]
-        @battle_ui[:skill_win].dispose
-        @battle_ui[:skill_win] = nil
-      end
-
-      # The party's battle items as "Name  xN", with a cursor.
-      def draw_battle_item
-        @battle_ui[:item_win].dispose if @battle_ui[:item_win]
-        labels = @battle_ui[:items].map do |id, count|
-          it = @state.party.db_item(id)
-          "#{it ? it.name : "Item #{id}"}  x#{count}"
-        end
-        @battle_ui[:item_win] = battle_list_window(0, SCREEN_W, labels, @battle_ui[:item_i], 325)
-      end
-
-      def close_battle_item
-        return unless @battle_ui[:item_win]
-        @battle_ui[:item_win].dispose
-        @battle_ui[:item_win] = nil
-      end
-
-      # The living party members selectable as a heal target ("Name HP h/mh"),
-      # with a cursor -- narrowed by #battle_ally_targets when a pending item's
-      # actor_set excludes some of them. RPG_RT reuses the status window itself
-      # for this (`status_window->SetChoiceMode`); this screen still draws a
-      # separate window, but at the status window's own rect and footprint so
-      # it reads the same way -- covering the party's HP display, leaving the
-      # command window in view beside it.
-      def draw_battle_ally_target
-        @battle_ui[:ally_win].dispose if @battle_ui[:ally_win]
-        labels = battle_ally_targets.map do |a|
-          "#{a.name}  #{a.hp < 0 ? 0 : a.hp}/#{a.max_hp}"
-        end
-        @battle_ui[:ally_win] =
-          battle_list_window(0, BATTLE_STATUS_W, labels, @battle_ui[:ally_i], 335)
-      end
-
-      def close_battle_ally_target
-        return unless @battle_ui[:ally_win]
-        @battle_ui[:ally_win].dispose
-        @battle_ui[:ally_win] = nil
-      end
-
-      # Banner the attack that just landed ("Hero hits Slime for 12", "…
-      # defeated!") low on the screen while the round animates, so each action
-      # reads on screen as well as its HP tick. Replaced by the next action's
-      # banner and dropped when the round settles.
-      def show_battle_action(entry)
-        show_battle_banner(battle_action_lines(entry))
-      end
-
-      # The low action banner itself, shared by a landed hit (#show_battle_action)
-      # and a failed Escape attempt: both are transient status text over the
-      # still-running fight, replaced by whatever banners next and dropped when
-      # the round settles.
-      def show_battle_banner(lines)
-        @battle_ui[:action_win].dispose if @battle_ui[:action_win]
-        @battle_ui[:action_win] = battle_panel_window(lines, 340)
-      end
-
-      # The system SFX a landed action plays, alongside its banner. Each check
-      # is independent rather than an elsif chain -- RPG_RT plays its own cue
-      # for each thing that happened to the same hit, not one sound standing in
-      # for all of them: a killing blow plays the damage sound and then the
-      # death cry, and an item that lands a hit plays the item's own cue
-      # alongside the hit's (EasyRPG's Scene_Battle_Rpg2k fires
-      # SFX_EnemyDamage / SFX_AllyDamage and, on top of a kill, SFX_EnemyKill,
-      # as separate calls rather than one replacing another).
-      def play_battle_action_se(entry)
-        # `attacker_ally` only rides on a plain Attack's own entry (never a
-        # skill/item hit -- see Battle#deal_attack), and is `false` rather
-        # than absent for an enemy's swing, so this fires before the hit's
-        # own resolution SE, matching RPG_RT playing it at the very start of
-        # the action.
-        play_system_se(SFX_ENEMY_ATTACK) if entry[:attacker_ally] == false
-        play_system_se(SFX_DODGE) if entry[:missed]
-        if entry[:damage] && entry[:damage] > 0
-          play_system_se(entry[:target_ally] ? SFX_ACTOR_DAMAGE : SFX_ENEMY_DAMAGE)
-        end
-        play_system_se(SFX_ENEMY_DEATH) if entry[:defeated] && !entry[:target_ally]
-        play_system_se(SFX_ITEM) if entry[:item_id]
-      end
-
-      # The conditions the action just landed or lifted, one sentence each under
-      # the action's own line — RPG_RT announces every one of them, and until now
-      # a skill that poisoned its target said only how much damage it did.
-      #
-      # The sentences come from the state row itself (`message_actor` /
-      # `message_enemy` for one landing, `message_recovery` for one lifting),
-      # which is where the game's own wording lives. An English-release database
-      # leaves them blank, so a plain composition stands in.
-      def battle_state_lines(entry)
-        table = db.respond_to?(:situation) ? db.situation : nil
-        name = entry[:target].to_s
-        ally = entry[:target_ally] ? true : false
-        lines = []
-        (entry[:inflicted] || []).each do |id|
-          lines << (Game::States.inflict_message(id, table, name, ally) ||
-                    "#{name} is #{state_label(id, table)}")
-        end
-        # A state the target already carried when the skill tried to inflict it
-        # again. RPG_RT announces it rather than going quiet, in the state's own
-        # words ("はすでに毒に冒されている！"), and reports it as a *success*.
-        (entry[:already] || []).each do |id|
-          lines << (Game::States.already_message(id, table, name) ||
-                    "#{name} is already #{state_label(id, table)}")
-        end
-        # `cured` is a medicine or a cure skill lifting a state; `woke` is a blow
-        # shaking one off (a state's `release_by_attack`). Both are the state
-        # lifting, which has one wording whichever side it happened to.
-        ((entry[:cured] || []) + (entry[:woke] || [])).each do |id|
-          lines << (Game::States.recovery_message(id, table, name) ||
-                    "#{name} recovers from #{state_label(id, table)}")
-        end
-        # Being downed is state 1 landing, and RPG_RT announces it with that
-        # state's own sentence — which is worded from the *speaker's* side, so a
-        # Japanese game says "ゼロは倒れた！" of a party member and "スライムを
-        # 倒した！" of an enemy. The simulation reports it as a flag on the hit
-        # rather than through `inflicted`, so it is read from there.
-        if entry[:defeated]
-          lines << (Game::States.inflict_message(Game::States::DEATH_ID, table,
-                                                 name, ally) ||
-                    "#{name} is defeated!")
-        end
-        terms = db.respond_to?(:term) ? db.term : nil
-        (entry[:stat_changed] || {}).each do |key, delta|
-          term_name = STAT_CHANGE_TERM[key]
-          next unless term_name && delta && delta != 0
-          lines << (Game::States::BattleText.parameter_change(terms, name, delta, term_name) ||
-                    "#{name}'s #{term_name} #{delta > 0 ? 'rose' : 'fell'} by #{delta.abs}")
-        end
-        attr_ids = entry[:attr_shifted] || []
-        unless attr_ids.empty?
-          positive = (entry[:attr_shift_dir] || 1) > 0
-          props = db.respond_to?(:property) ? db.property : nil
-          attr_ids.each do |aid|
-            row = props ? props[aid] : nil
-            attr_name = row && row.respond_to?(:name) ? row.name : "attribute #{aid}"
-            lines << (Game::States::BattleText.attribute_shift(terms, name, positive, attr_name) ||
-                      "#{name}'s resistance to #{attr_name} #{positive ? 'rose' : 'fell'}")
-          end
-        end
-        lines
-      end
-
-      # The 用語 field naming each ATK/DEF/SPI(mind)/AGI stat itself (as
-      # opposed to `Game::Battle::STAT_MOD_FIELD`, which names the Combatant
-      # accessor that holds the modifier) -- what #battle_state_lines passes
-      # `BattleText.parameter_change` as `points`.
-      STAT_CHANGE_TERM = { atk: :attack, def: :defense, spi: :mind, agi: :agility }.freeze
-
-      def state_label(id, table)
-        Game::States.name(id, table) || "state #{id}"
-      end
-
-      def close_battle_action
-        return unless @battle_ui[:action_win]
-        @battle_ui[:action_win].dispose
-        @battle_ui[:action_win] = nil
-      end
-
-      def open_battle_result(lines)
-        @battle_ui[:result_win] = battle_panel_window(lines, 320)
-      end
-
-      # RPG_RT's battle message window (the per-action banner, the result
-      # panel) is a fixed 320x80 strip at the bottom of the screen -- the same
-      # rect as the status/command windows it visually replaces while it is up
-      # (EasyRPG's `Window_BattleMessage`, `(0, screen_height - 80, MENU_WIDTH,
-      # 80)`) -- not a panel sized to fit its text.
-      def battle_panel_window(lines, z)
-        inner_w = SCREEN_W - Window::BORDER * 2
-        win = Window.new(0, BATTLE_PANEL_Y, SCREEN_W, BATTLE_PANEL_H)
-        win.z = z
-        win.windowskin = @windowskin
-        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
-        c.font.color = Color.new(255, 255, 255, 255)
-        lines.each_with_index do |line, i|
-          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, line
-        end
-        win.contents = c
-        win
-      end
-
-      # A text panel of `lines` at vertical position `y` and depth `z`, sized to
-      # fit its content -- used for the battle-event page message window, which
-      # this screen deliberately keeps off the bottom panel's rect (see
-      # `BATTLE_EVENT_MSG_Y`) so a page talking mid-round does not fight the
-      # action banner for the same row.
-      def battle_text_window(lines, y, z)
-        inner_w = SCREEN_W - 20 - Window::BORDER * 2
-        inner_h = [lines.length, 1].max * BATTLE_LINE_H
-        win = Window.new(10, y, SCREEN_W - 20, inner_h + Window::BORDER * 2)
-        win.z = z
-        win.windowskin = @windowskin
-        c = Bitmap.new(inner_w, inner_h)
-        c.font.color = Color.new(255, 255, 255, 255)
-        lines.each_with_index do |line, i|
-          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, line
-        end
-        win.contents = c
-        win
-      end
-
-      # The party status panel: each row is a list of [text, x, colour index]
-      # segments rather than one string, so a row can mix colours. Drawn through
-      # `draw_system_text`, which fills the glyphs from the System graphic's own
-      # palette swatch (and falls back to flat white text when the project ships
-      # no windowskin) — the way RPG_RT colours a state name. Fixed at the
-      # bottom-left of the panel (`Window_BattleStatus`'s own rect), with a
-      # cursor on `cursor_idx`'s row when the acting actor is one of these rows.
-      def battle_status_window(rows, cursor_idx = nil)
-        inner_w = BATTLE_STATUS_W - Window::BORDER * 2
-        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
-        win.z = 300
-        win.windowskin = @windowskin
-        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
-        c.font.color = Color.new(255, 255, 255, 255)
-        rows.each_with_index do |segments, i|
-          segments.each do |text, x, color|
-            draw_system_text c, x, i * BATTLE_LINE_H, inner_w - x,
-                             BATTLE_LINE_H, text.to_s, @windowskin, color
-          end
-        end
-        win.contents = c
-        if cursor_idx
-          win.cursor_rect = Rect.new(0, cursor_idx * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
-        end
-        win
-      end
-
-      def close_battle
-        return unless @battle_ui
-        [@battle_ui[:status_win], @battle_ui[:cmd_win],
-         @battle_ui[:target_win], @battle_ui[:skill_win],
-         @battle_ui[:item_win], @battle_ui[:ally_win],
-         @battle_ui[:action_win], @battle_ui[:result_win],
-         @battle_ui[:event_win]].each { |w| w.dispose if w }
-        dispose_battle_sprite(@battle_ui[:back_sprite])
-        (@battle_ui[:enemy_sprites] || []).each { |s| dispose_battle_sprite(s) }
-        (@battle_ui[:actor_sprites] || []).each { |s| dispose_battle_sprite(s) }
-        @battle_ui = nil
-      end
-
-      # Dispose a battle sprite. Its bitmap (the backdrop or a battler, see
-      # #battle_back_bitmap / #battler_bitmap) is a shared @backdrop_cache or
-      # @monster_cache entry that may still be referenced elsewhere (another
-      # troop slot, a later encounter reusing the same graphic this visit),
-      # so only the sprite itself is freed here.
-      def dispose_battle_sprite(spr)
-        return unless spr
-        spr.dispose
       end
 
       # -- Enter Hero Name (name-entry widget) --------------------------------
@@ -8011,23 +5240,12 @@ class RPG2k
         if hold && hold > 0
           ma[:target_flash_hold] = hold - 1
         else
-          ma[:battle] ? clear_target_flash(ma[:target_index]) : clear_map_target_flash(ma[:flash_target])
+          if ma[:battle]
+            @battle.clear_target_flash(ma[:target_index])
+          else
+            clear_map_target_flash(ma[:flash_target])
+          end
         end
-      end
-
-      # The battle-round half of #hold_animation_target_flash's forced clear:
-      # the same RGSS Sprite#flash primitive #fire_target_flash arms a flash
-      # with, called with a zero duration (flash_count 0 reads as "not
-      # flashing," mruby-rgss/src/lib.cxx's own spr_flash/spr_update) to drop
-      # whatever flash -- this animation's own decayed-away one, or an
-      # unrelated one -- is currently in flight on that enemy sprite. A nil
-      # target_index (an ally-scoped animation, no on-screen sprite) or a
-      # missing @battle_ui (the animation already finished/the fight already
-      # ended) is a silent no-op, matching #fire_target_flash's own guard.
-      def clear_target_flash(target_index)
-        sprites = @battle_ui && @battle_ui[:enemy_sprites]
-        spr = target_index && sprites ? sprites[target_index] : nil
-        spr.flash(nil, 0) if spr
       end
 
       # The map-triggered half: drop @player_flash / an @events entry's own
@@ -8077,7 +5295,7 @@ class RPG2k
       # rather than always reading `req[:target]` the map way.
       def start_map_animation(req)
         return nil unless req
-        return start_battle_page_animation(req) if req[:battle]
+        return @battle.start_battle_page_animation(req) if req[:battle]
         tx, ty = animation_target_pixel(req[:target])
         # Every map target -- the player, a map event, a vehicle -- gets the
         # same fixed height for #animation_position_offset's Head/Feet split
@@ -8086,22 +5304,6 @@ class RPG2k
         # known without asking what kind of character this actually is.
         build_animation(req[:animation], tx, ty, target_height: ANIM_MAP_TARGET_HEIGHT,
                          flash_target: map_animation_flash_target(req[:target]))
-      end
-
-      # Show Battle Animation (13260), the battle-page form of 11210: it needs
-      # the battle-*round*'s own positioning (#battle_animation_pixel, the
-      # targeted enemy's live sprite -- or the ally-side screen-centre
-      # fallback) and its Character Flash mechanism (#fire_target_flash, an
-      # `@battle_ui[:enemy_sprites]` entry), the same two `battle_animation_id`/
-      # `entry`-shaped inputs #start_battle_animation already builds from a
-      # round's own log entry -- just keyed off `req[:target]` (the command's
-      # own troop-member param) directly instead of an entry's
-      # `target_index`, since a battle page names its target explicitly
-      # rather than inheriting it from whichever action just landed.
-      def start_battle_page_animation(req)
-        tx, ty, height = battle_animation_pixel(target_index: req[:target])
-        build_animation(req[:animation], tx, ty, true, target_index: req[:target],
-                         target_height: height)
       end
 
       # The character a map-triggered flash_scope-1 timing (see
@@ -8254,7 +5456,11 @@ class RPG2k
             # frame for as long as the animation itself owns the slot.
             ma[:screen_flash_hold] = ANIM_FLASH_FRAMES
           when 1
-            ma[:battle] ? fire_target_flash(ma[:target_index], t) : fire_map_target_flash(ma[:flash_target], t)
+            if ma[:battle]
+              @battle.fire_target_flash(ma[:target_index], t)
+            else
+              fire_map_target_flash(ma[:flash_target], t)
+            end
             # #hold_animation_target_flash keeps re-asserting this fire (and,
             # once it lapses, forcibly clearing the target's flash outright)
             # every real frame, the exact same shape as #ma[:screen_flash_hold]
@@ -8276,95 +5482,8 @@ class RPG2k
             # Animation path) is a genuine empty no-op in EasyRPG's real
             # source, not a dropped feature -- so this only ever fires in
             # battle, matching #fire_target_shake's own battle-only scope.
-            fire_target_shake(ma[:target_index]) if ma[:battle]
+            @battle.fire_target_shake(ma[:target_index]) if ma[:battle]
           end
-        end
-      end
-
-      # yado.tk / the LCF schema itself (`animation_timing`'s flash_scope field,
-      # 0 none / 1 target / 2 screen): a Battle Animation frame's flash can pulse
-      # its *target* instead of the whole screen -- previously dropped outright,
-      # since only flash_scope 2 was ever handled here. Scoped to the
-      # battle-round path (a skill/item's `target_index`, see
-      # #battle_animation_pixel): RPG2000's battle is front-view, so an
-      # ally-targeted entry has no on-screen sprite to flash (target_index is
-      # nil there, same as it already is for centring the animation itself).
-      # A map-triggered Show Battle Animation (11210) aimed at a map character
-      # is a different target class entirely, handled by #fire_map_target_flash
-      # below. Uses the RGSS Sprite#flash/#update primitive
-      # (mruby-rgss/src/lib.cxx) already ported natively but unused elsewhere
-      # in this codebase, decayed each frame by #update_enemy_flashes.
-      def fire_target_flash(target_index, t)
-        sprites = @battle_ui && @battle_ui[:enemy_sprites]
-        spr = target_index && sprites ? sprites[target_index] : nil
-        return unless spr
-        spr.flash(Color.new((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
-                            (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8),
-                  ANIM_FLASH_FRAMES)
-      end
-
-      # The screen_shaking-1 counterpart to #fire_target_flash: arms a timed
-      # shake of just the animation's own target sprite, mirroring EasyRPG's
-      # actual C++ source verbatim -- both `BattleAnimationBattle::
-      # ShakeTargets` and `BattleAnimationBattler::ShakeTargets`
-      # (src/battle_animation.cpp) shake every one of the animation's own
-      # battler targets with `battler->ShakeOnce(str, spd, time)`, the exact
-      # same triple `ProcessAnimationTiming` already fires for the screen
-      # case. This codebase's front-view battle has no per-sprite native
-      # shake primitive the way Sprite#flash exists for the colour pulse, so
-      # the state is tracked in a plain `@battle_ui[:enemy_shake]` hash
-      # (paralleling `enemy_sprites` by index) and stepped by
-      # #update_enemy_shakes every frame -- the same `Shake::NextPosition`
-      # sine-wave port Game::Screen#update_shake already drives for the
-      # whole-screen case, just applied to one sprite's own x. RPG2000's
-      # battle is front-view, so an ally-targeted entry has no sprite to
-      # shake (target_index is nil there, the same gap #fire_target_flash's
-      # own comment already documents) -- a silent no-op, not an error.
-      def fire_target_shake(target_index)
-        sprites = @battle_ui && @battle_ui[:enemy_sprites]
-        return unless target_index && sprites && sprites[target_index]
-        @battle_ui[:enemy_shake] ||= []
-        @battle_ui[:enemy_shake][target_index] =
-          { power: ANIM_SHAKE_POWER, speed: ANIM_SHAKE_SPEED, frames: ANIM_SHAKE_FRAMES, offset: 0 }
-      end
-
-      # Advance every in-flight #fire_target_shake state by one frame --
-      # called from #drive_battle every frame, right alongside
-      # #update_enemy_flashes/#update_enemy_positions. A direct port of
-      # Game::Screen#update_shake's own step (see there for the EasyRPG
-      # `Shake::NextPosition`/`Shake::Update` provenance), just keyed per
-      # troop-member index instead of a single screen-wide state, and applied
-      # to that member's own sprite x (recomputed from its live database
-      # position the same way #update_enemy_positions already recomputes y
-      # for a levitating member, so a sprite rebuilt mid-shake --
-      # #reveal_battle_monster, #remove_fled_monster -- is never left
-      # offset from a stale base). A slot with nothing active costs nothing.
-      def update_enemy_shakes
-        shakes = @battle_ui[:enemy_shake]
-        return unless shakes
-        sprites = @battle_ui[:enemy_sprites]
-        troop = @battle_ui[:troop]
-        shakes.each_index do |i|
-          st = shakes[i]
-          next unless st
-          spr = sprites && sprites[i]
-          member = troop && troop.members[i]
-          unless spr && member
-            shakes[i] = nil
-            next
-          end
-          st[:frames] -= 1
-          if st[:frames] <= 0
-            st[:offset] = 0
-            shakes[i] = nil
-          else
-            amplitude = 1 + 2 * st[:power]
-            phase = (st[:frames] * 4 * (st[:speed] + 2)) % 256
-            newpos = (amplitude * Math.sin(phase * Math::PI / 128) * -1).to_i
-            cutoff = (st[:speed] * amplitude) / 8 + 1
-            st[:offset] = Game.clamp(newpos, st[:offset] - cutoff, st[:offset] + cutoff)
-          end
-          spr.x = member.x - spr.bitmap.width / 2 + st[:offset]
         end
       end
 
@@ -8819,7 +5938,7 @@ class RPG2k
         win.transparent = cfg.transparent
         # No animation mid-battle: RPG_RT's own message/gold windows pop
         # straight in there instead of unrolling (see MSG_ANIM_FRAMES above).
-        open_frames = @battle_ui.nil? ? MSG_ANIM_FRAMES : 0
+        open_frames = @battle.nil? ? MSG_ANIM_FRAMES : 0
         win.open_animation(open_frames)
 
         contents = Bitmap.new(inner_w, inner_h)
@@ -9285,7 +6404,7 @@ class RPG2k
         return unless @message
         win = @message[:window]
         gold = @message[:gold_window]
-        frames = (animate && @battle_ui.nil?) ? MSG_ANIM_FRAMES : 0
+        frames = (animate && @battle.nil?) ? MSG_ANIM_FRAMES : 0
         if frames > 0
           win.close_animation(frames)
           (@closing_windows ||= []) << win
@@ -9805,6 +6924,17 @@ class RPG2k
       end
       public :camera_position, :character_screen_position
 
+      # The rest of the "services Scene::Battle calls back into" (see the
+      # readers next to #dispose): BGM, backdrop, animation-player and
+      # debug-menu methods a fight shares with the field map, reached from
+      # Scene::Battle with an explicit `@map.` receiver, which -- like any
+      # cross-object call -- only reaches a public method.
+      public :play_battle_bgm, :play_victory_bgm, :restore_pre_battle_bgm,
+             :terrain_backdrop, :map_properties, :perform_game_over,
+             :try_open_debug_menu, :build_animation, :drive_map_animation,
+             :fire_animation_flashes, :frames_from_tenths, :load_face_bitmap,
+             :step_map_animation, :close_battle
+
       def render
         px, py = player_pixel
         cam_x, cam_y = camera_position
@@ -9812,7 +6942,7 @@ class RPG2k
         # The map itself never shows on the battle screen -- see
         # #set_map_layers_visible, which explains why the backdrop needs it gone
         # rather than merely sitting above it.
-        if @battle_ui
+        if @battle
           set_map_layers_visible false
         else
           set_map_layers_visible true
@@ -9841,13 +6971,13 @@ class RPG2k
         # screen, which is already covered by its own opaque field background
         # sitting above the picture layer (see Scene::Base#build_field_background),
         # nothing else painted over @picture_sprite (z 250) while a fight is
-        # running: the battle backdrop (@battle_ui[:back_sprite]) sits well below
+        # running: the battle backdrop (Scene::Battle's own back sprite) sits well below
         # it, so a picture shown before the encounter (or by a Parallel Process
         # still running during it) would otherwise draw straight over the battle
         # UI. Hidden for the fight's whole duration and stops compositing
         # entirely (not just hidden with a stale frame underneath), then resumes
         # -- and immediately redraws -- the instant the battle UI is gone.
-        if @battle_ui
+        if @battle
           @picture_sprite.visible = false
         else
           @picture_sprite.visible = true
@@ -9907,7 +7037,7 @@ class RPG2k
       # rather than the `Scene_Map::Continue` reuse a mere return from a
       # pushed menu/battle scene gets.
       def draw_timer
-        battle = !@battle_ui.nil?
+        battle = !@battle.nil?
         @timer_sprites ||= [nil, nil]
         2.times { |id| draw_one_timer(id, battle) }
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8658,8 +8658,9 @@ check 'to_lsd/from_lsd round-trips the latest battle\'s turn count' do
   # undecoded: there was no per-battle turn tracker on the Ruby side to
   # source it from (see the step-counter-and-battle-tallies check above).
   # There is now -- Game::Battle already counts its own rounds live
-  # (@rounds, exposed by #turn); Scene::Map#finish_battle (scene/map.rb)
-  # captures it onto Game::State#last_battle_turns right before the fought
+  # (@rounds, exposed by #turn); Scene::Battle#finish_battle
+  # (mruby-rpg2k/mrblib/scene/battle.rb) captures it onto
+  # Game::State#last_battle_turns right before the fought
   # Battle object is discarded. This exercises that capture + round-trip
   # without going through the scene layer: run a fight for a fixed number of
   # rounds, read #turn the way #finish_battle does, then round-trip it

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -292,6 +292,28 @@ def eq(exp, act, msg = nil)
   raise "expected #{exp.inspect}, got #{act.inspect}#{msg ? " (#{msg})" : ''}"
 end
 
+# The fight's own live state (RPG2k::Scene::Battle#ui) is a plain hash again,
+# same shape a check written against the old Scene::Map#@battle_ui already
+# expects -- reached through the scene's own @battle (nil between
+# encounters), so this is the one place a check has to know the fight moved
+# out to its own scene object at all.
+def battle_ui(scene)
+  b = scene.instance_variable_get(:@battle)
+  b && b.ui
+end
+
+# Fabricate a running fight directly, the way a handful of checks below poke
+# @battle_ui without ever driving a real encounter open (a parallel-process
+# pause check, the F9-during-battle checks, ...). Bypasses Scene::Battle#start
+# entirely -- `ui` only needs to carry whatever keys the check itself reads.
+def fake_battle(scene, ui)
+  battle = RPG2k::Scene::Battle.allocate
+  battle.instance_variable_set(:@map, scene)
+  battle.instance_variable_set(:@ui, ui)
+  scene.instance_variable_set(:@battle, battle)
+  battle
+end
+
 # Runs the block with $stderr redirected to a StringIO and returns everything
 # written to it, for checks that assert on a "[RPG2k] ..." diagnostic line.
 def capture_stderr
@@ -2802,7 +2824,7 @@ check 'parallel processes pause during battle' do
   par = page(trigger: 4)
   par.event_commands = [add_var_cmd(1)]
   scene = new_scene({ 1 => event(4, 4, par) })
-  scene.instance_variable_set(:@battle_ui, { phase: :command })
+  fake_battle(scene, { phase: :command })
   10.times { scene.update }
   eq 0, scene.instance_variable_get(:@state).variables[1],
      'a parallel process must not advance while a battle is in progress'
@@ -5376,7 +5398,7 @@ end
 # fight spans a few hundred frames.
 def battle_attack_to_end(scene, max = 600)
   max.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :result
     # A pressed C on :battle_options picks the cursor's default row 0,
     # "Battle" -- dismissing the once-per-battle automatic options window
@@ -5395,7 +5417,7 @@ def battle_until_phase(scene, phase, max = 15)
   ui = nil
   max.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == phase
   end
   ui
@@ -5480,9 +5502,9 @@ check 'Enemy Encounter scene: opening a battle plays the database Battle Start S
   RGSS::Audio.reset_se
   10.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
   end
-  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+  ok battle_ui(scene), 'the battle actually opened'
   ok RGSS::Audio.se_calls.any? { |c| c[0] == 'BattleStart1' },
      'the database Battle Start SE played the instant the fight opened'
 end
@@ -5499,9 +5521,9 @@ check 'Enemy Encounter scene: a Change System SFX battle-start override wins ove
   RGSS::Audio.reset_se
   10.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
   end
-  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+  ok battle_ui(scene), 'the battle actually opened'
   ok RGSS::Audio.se_calls.any? { |c| c[0] == 'CustomBattleStart' },
      'the override plays instead of the database BattleStart1'
   ok !RGSS::Audio.se_calls.any? { |c| c[0] == 'BattleStart1' },
@@ -5593,7 +5615,7 @@ check "Enemy Encounter scene: battle math reuses the scene's own advancing " \
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
   2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   rng = scene.instance_variable_get(:@rng)
   ok ui[:battle].rng.equal?(rng),
      "the battle's own combat math should draw from the scene's single, " \
@@ -5610,7 +5632,7 @@ check 'Enemy Encounter scene: rolls already spent by earlier map activity change
   scene_a.instance_variable_get(:@state)
           .instance_variable_set(:@party, BattleStubParty.new)
   battle_attack_to_end(scene_a)
-  log_a = scene_a.instance_variable_get(:@battle_ui)[:battle].log.dup
+  log_a = battle_ui(scene_a)[:battle].log.dup
 
   scene_b = new_scene({ 1 => event(2, 2, auto) })
   scene_b.instance_variable_get(:@state)
@@ -5620,7 +5642,7 @@ check 'Enemy Encounter scene: rolls already spent by earlier map activity change
   # entirely -- all of which draw from this same per-scene RNG stream.
   7.times { scene_b.instance_variable_get(:@rng).next_int }
   battle_attack_to_end(scene_b)
-  log_b = scene_b.instance_variable_get(:@battle_ui)[:battle].log.dup
+  log_b = battle_ui(scene_b)[:battle].log.dup
 
   ok log_a != log_b,
      'a fight reached after other map-side rolls should not replay the exact ' \
@@ -5887,7 +5909,7 @@ check 'Enemy Encounter scene: the Battle/Auto Battle/Escape options window opens
   eq :battle_options, ui[:phase], 'the options window shows before any per-actor command menu'
   eq 0, ui[:opt], 'the cursor starts on the first row, Battle'
   eq %w[Fight AutoBattle Escape].map { |s| s == 'AutoBattle' ? 'Auto Battle' : s },
-     scene.send(:battle_option_rows).map { |r| r[:label] },
+     scene.instance_variable_get(:@battle).send(:battle_option_rows).map { |r| r[:label] },
      'fake_db leaves the battle_fight/battle_auto/battle_escape terms blank, so these are ' \
      'the composed English fallbacks'
 end
@@ -6024,7 +6046,7 @@ check 'Enemy Encounter scene: the options window does not reappear automatically
   40.times do
     RGSS::Input.triggered = [RGSS::Input::C] if %i[command target].include?(ui[:phase])
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = []
     saw_options_again ||= ui && ui[:phase] == :battle_options
     break if ui.nil? || ui[:phase] == :result
@@ -6232,9 +6254,9 @@ check "a Common Event Parallel Process's own Battle Processing now actually open
   scene = new_scene({}, common: { 1 => ce })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  eq nil, scene.instance_variable_get(:@battle_ui), 'no battle before the process reaches it'
+  eq nil, battle_ui(scene), 'no battle before the process reaches it'
   battle_attack_to_end(scene) # Attack the Slimes each round until they fall
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui, "the parallel process's own Enemy Encounter actually opened a real battle screen"
   eq :result, ui[:phase]
   fg = scene.instance_variable_get(:@interpreter)
@@ -6268,7 +6290,7 @@ check "a battle a Parallel Process opened blocks player movement, just like one 
   RGSS::Input.dir_value = 6 # hold right the whole time
   12.times { scene.update }
   RGSS::Input.dir_value = 0
-  ok scene.instance_variable_get(:@battle_ui), 'the fight is open by now'
+  ok battle_ui(scene), 'the fight is open by now'
   eq 0, st.x, "the party must not walk anywhere while a Parallel Process's own fight is up"
 end
 
@@ -8452,7 +8474,7 @@ check 'a timer without the battle flag pauses and hides for the fight, and drops
   eq 4, spr.y, 'parked at the top outside of battle'
 
   frames = st.timer(0).frames
-  scene.instance_variable_set(:@battle_ui, { phase: :command })
+  fake_battle(scene, { phase: :command })
   scene.update
   eq frames, st.timer(0).frames, 'it stopped counting for the fight'
   ok !spr.visible, 'and is hidden'
@@ -8523,11 +8545,11 @@ check 'Enemy Encounter scene: the round animates action by action, not at once' 
   # cursor row 0, "Battle") along the way.
   ui = nil
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
   # Command the sole hero to Attack the first enemy: C picks Attack, C confirms
@@ -8537,7 +8559,7 @@ check 'Enemy Encounter scene: the round animates action by action, not at once' 
     scene.update
     RGSS::Input.triggered = []
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   eq :animate, ui[:phase], 'the commanded round now plays out as an animation'
   eq 0, ui[:battle].log.length, 'no hit has landed the instant the round starts'
 
@@ -8610,11 +8632,11 @@ end
 def battle_to_command(scene)
   ui = nil
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
   ui
@@ -9132,7 +9154,7 @@ check "Enemy Encounter scene: a restricted item's ally-target picker skips the a
   press_key(scene, RGSS::Input::C)    # choose the Potion -> ally target
   eq :ally_target, ui[:phase]
   eq 2, ui[:allies].reject(&:dead?).length, 'both actors are alive and in the fight'
-  targets = scene.send(:battle_ally_targets)
+  targets = scene.instance_variable_get(:@battle).send(:battle_ally_targets)
   eq 1, targets.length, 'the restricted actor never appears as a choice'
   eq 1, targets.first.actor.id, 'only the allowed actor is offered'
   eq 0, ui[:ally_i], 'starts on the sole remaining candidate'
@@ -9289,14 +9311,14 @@ check 'Enemy Encounter scene: an "Appear Transparent" enemy draws at reduced ' \
   # reduced opacity, not just the initial build.
   ui[:foes][0].battler_name = 'Wraith'
   ui[:foes][0].name = 'Wraith'
-  scene.send(:refresh_battle_sprites)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_sprites)
   eq 160, ui[:enemy_sprites][0].opacity,
      'a transformation redraw keeps the reduced opacity'
 
   # Show Hidden Monster (#reveal_battle_monster) builds a fresh sprite too.
   ui[:foes][0].hidden = true
   ui[:troop].members[0].hidden = true
-  scene.send(:reveal_battle_monster, 0)
+  scene.instance_variable_get(:@battle).send(:reveal_battle_monster, 0)
   eq 160, ui[:enemy_sprites][0].opacity,
      'Show Hidden Monster also draws it at the reduced opacity'
 end
@@ -9333,7 +9355,7 @@ check 'Enemy Encounter scene: a battle-graphic hue shift rotates the battler ' \
   # very same "Slime" battler file -- its own decode must stay unrotated
   # rather than being mutated by the Red Slime's #hue_change call above,
   # since #battler_bitmap keys the cache by name+hue rather than name alone.
-  plain = scene.send(:battler_bitmap, Game::Enemy.new(scene.db, 2))
+  plain = scene.instance_variable_get(:@battle).send(:battler_bitmap, Game::Enemy.new(scene.db, 2))
   ok plain.hue_calls.nil? || plain.hue_calls.empty?,
      'a same-file, zero-hue enemy decodes its own unrotated bitmap'
 
@@ -9343,7 +9365,7 @@ check 'Enemy Encounter scene: a battle-graphic hue shift rotates the battler ' \
   ui[:foes][0].battler_name = 'Slime'
   ui[:foes][0].battler_hue = 0
   ui[:foes][0].name = 'Slime'
-  scene.send(:refresh_battle_sprites)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_sprites)
   ok ui[:enemy_sprites][0].bitmap.hue_calls.nil? ||
      ui[:enemy_sprites][0].bitmap.hue_calls.empty?,
      'transforming into the zero-hue battler redraws with no hue rotation'
@@ -9363,7 +9385,7 @@ check 'Enemy Encounter scene: a monster that leaves the field is not drawn' do
   # a page's Force Flee), which used to stay on screen because visibility keyed
   # off `dead?` alone.
   ui[:foes][0].hidden = true
-  scene.send(:refresh_battle_sprites)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_sprites)
   ok !sprites[0].visible, 'a monster that fled is taken off the field'
   ok !ui[:foes][0].dead?, 'without counting as a kill'
   ok sprites[1].visible, 'its companion is untouched'
@@ -9390,13 +9412,13 @@ check 'Scene::Map#flying_offset: RPG2003 + levitate is a +/-4px, 256-frame sine 
   ok member.levitate, 'the fixture enemy (id 3, Bat) carries the flag'
 
   ui[:frame] = 0
-  eq 0, scene.send(:flying_offset, member), 'frame 0: sin(0) = 0'
+  eq 0, scene.instance_variable_get(:@battle).send(:flying_offset, member), 'frame 0: sin(0) = 0'
   ui[:frame] = 64 # a quarter period: sin(pi/2) = 1
-  eq 4, scene.send(:flying_offset, member), 'a quarter period in: the +4px peak'
+  eq 4, scene.instance_variable_get(:@battle).send(:flying_offset, member), 'a quarter period in: the +4px peak'
   ui[:frame] = 128 # half period: sin(pi) = 0
-  eq 0, scene.send(:flying_offset, member), 'half a period in: back through 0'
+  eq 0, scene.instance_variable_get(:@battle).send(:flying_offset, member), 'half a period in: back through 0'
   ui[:frame] = 192 # three-quarter period: sin(3pi/2) = -1
-  eq(-4, scene.send(:flying_offset, member), 'three-quarters in: the -4px trough')
+  eq(-4, scene.instance_variable_get(:@battle).send(:flying_offset, member), 'three-quarters in: the -4px trough')
 end
 
 check 'Scene::Map#update_enemy_positions: an RPG2003 fight actually bobs the sprite ' \
@@ -10197,10 +10219,10 @@ check 'entering a battle with an empty party is instant defeat, not a frozen com
   st.party.instance_variable_set(:@actors, [])
   12.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :result
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui, 'the battle is open'
   eq :result, ui[:phase], 'no living ally settles the fight immediately instead of stalling in :command'
   eq :defeat, ui[:result], 'an empty party reads the same as a wipeout'
@@ -10211,10 +10233,10 @@ check 'entering a battle with an all-KO\'d party is instant defeat too' do
   st.party.instance_variable_set(:@actors, [BattleStubActor.new(hp: 0)])
   12.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :result
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui, 'the battle is open'
   eq :result, ui[:phase], 'no living ally settles the fight immediately instead of stalling in :command'
   eq :defeat, ui[:result]
@@ -10236,16 +10258,16 @@ check 'an asleep ally is skipped straight to the next commandable one, no comman
                                             BattleStubActor.new(id: 2)])
   ui = nil
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
   ok ui, 'the battle opened'
   eq :command, ui[:phase], 'a still-commandable ally is left to open the prompt'
-  eq ui[:allies][1], scene.send(:current_actor),
+  eq ui[:allies][1], scene.instance_variable_get(:@battle).send(:current_actor),
      'the asleep ally at index 0 was skipped straight to the awake one at index 1'
 end
 
@@ -10256,7 +10278,7 @@ check 'a lone ally under a do-nothing state (asleep) never gets a command prompt
   ui = nil
   30.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     saw_animate ||= ui && ui[:phase] == :animate
     break if ui && ui[:phase] == :result
   end
@@ -10285,7 +10307,7 @@ check 'a lone Forced-AI ally never gets a command prompt -- the round starts on 
   ui = nil
   30.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     saw_animate ||= ui && ui[:phase] == :animate
     break if ui && ui[:phase] == :result
   end
@@ -10301,16 +10323,16 @@ check 'a Forced-AI ally is skipped straight to the next manually-commandable one
                                             BattleStubActor.new(id: 2)])
   ui = nil
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
   ok ui, 'the battle opened'
   eq :command, ui[:phase], 'the still-manually-commandable second ally is left to open the prompt'
-  eq ui[:allies][1], scene.send(:current_actor),
+  eq ui[:allies][1], scene.instance_variable_get(:@battle).send(:current_actor),
      'the Forced-AI ally at index 0 was skipped straight to the manual one at index 1'
   ok ui[:allies][0].action || ui[:allies][0].command,
      'the skipped Forced-AI ally already has its own action queued automatically'
@@ -10326,7 +10348,7 @@ check 'a turn-0 battle-event page runs as the fight opens' do
   end
   ok st.switches[12], 'the page ran before the command phase'
   scene.update # the exhausted page hands the turn back
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui, 'the battle is still open'
   # Control returns to the party through the options window first -- its own
   # once-per-battle automatic appearance, the same one a bare encounter with
@@ -10370,11 +10392,11 @@ check 'a battle page conditioned on enemy HP fires mid-round, before the round s
   scene, st = battle_scene_with_pages(pages)
   phase_when_fired = nil
   60.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && %i[command target battle_options].include?(ui[:phase])
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     if st.switches[20] && phase_when_fired.nil?
       phase_when_fired = ui && ui[:phase]
     end
@@ -10405,14 +10427,14 @@ check 'a battle page reveals a reinforcement before the round can end in a prema
                             Game::BattlePage::ENEMY_HP, enemy_id: 0, enemy_hp_max: 0) }
   scene, st = battle_scene_with_pages(pages)
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   # Troop member 1 stands in for a placed-but-invisible reinforcement.
   ui[:foes][1].hidden = true
   ui[:troop].members[1].hidden = true
@@ -10433,10 +10455,10 @@ check 'a battle page reveals a reinforcement before the round can end in a prema
   ui[:battler_boundary] = true
   revealed_before_victory = nil
   20.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break unless ui
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break unless ui
     next if ui[:foes][1].hidden
     revealed_before_victory = ui[:phase] != :result
@@ -10449,8 +10471,8 @@ check 'a battle page reveals a reinforcement before the round can end in a prema
   # #reveal_battle_monster returns immediately once `hidden` is already false,
   # so a second reveal neither rebuilds the sprite nor errors.
   sprite_before = ui[:enemy_sprites][1]
-  scene.send(:reveal_battle_monster, 1)
-  eq sprite_before, scene.instance_variable_get(:@battle_ui)[:enemy_sprites][1],
+  scene.instance_variable_get(:@battle).send(:reveal_battle_monster, 1)
+  eq sprite_before, battle_ui(scene)[:enemy_sprites][1],
      'revealing an already-visible member again is a no-op, not a sprite rebuild'
 end
 
@@ -10464,14 +10486,14 @@ end
 def open_then_close_battle(scene, open_budget: 10, close_budget: 20)
   open_budget.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
   end
-  ok scene.instance_variable_get(:@battle_ui), 'the battle opened'
+  ok battle_ui(scene), 'the battle opened'
   close_budget.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui).nil?
+    break if battle_ui(scene).nil?
   end
-  eq nil, scene.instance_variable_get(:@battle_ui), 'the battle closed again'
+  eq nil, battle_ui(scene), 'the battle closed again'
 end
 
 check 'Terminate Battle from a page ends the fight and resumes the event' do
@@ -10498,10 +10520,10 @@ check 'pictures are hidden while the battle screen is up (yado.tk: none show on 
 
   10.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
     ok sprite.visible, 'the picture layer draws normally before any fight opens'
   end
-  ok scene.instance_variable_get(:@battle_ui), 'the battle opened'
+  ok battle_ui(scene), 'the battle opened'
   ok !sprite.visible, 'the picture layer is hidden the instant the battle screen is up'
   bmp.clear_stretch_calls
   scene.update
@@ -10509,9 +10531,9 @@ check 'pictures are hidden while the battle screen is up (yado.tk: none show on 
 
   20.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui).nil?
+    break if battle_ui(scene).nil?
   end
-  eq nil, scene.instance_variable_get(:@battle_ui), 'the battle closed again'
+  eq nil, battle_ui(scene), 'the battle closed again'
   ok sprite.visible, 'the picture layer reappears the instant the fight ends'
 end
 
@@ -10532,7 +10554,7 @@ check 'the map is hidden while the battle screen is up, so the backdrop actually
 
   10.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
     # `!= false` rather than a plain truth test: RGSS::Viewport#visible
     # defaults to true on the real backend but nil on this stub, so a bare
     # `ok vp.visible` here would be asserting the stub's default, not the
@@ -10544,7 +10566,7 @@ check 'the map is hidden while the battle screen is up, so the backdrop actually
     # the events drawn over it -- is what says compositing happened at all.
     ok !(lower_bmp.copy_blt_calls || []).empty?, 'and the tile layers do composite'
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui, 'the battle opened'
   ok ui[:back_sprite], 'the fight has a battle background sprite'
   ok ui[:back_sprite].z < vp.z, 'whose z sits below the map viewport ...'
@@ -10561,9 +10583,9 @@ check 'the map is hidden while the battle screen is up, so the backdrop actually
 
   20.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui).nil?
+    break if battle_ui(scene).nil?
   end
-  eq nil, scene.instance_variable_get(:@battle_ui), 'the battle closed again'
+  eq nil, battle_ui(scene), 'the battle closed again'
   eq true, vp.visible, 'the map view reappears the instant the fight ends'
   eq true, upper.visible, 'and so does the above-character layer'
   ok !(lower_bmp.copy_blt_calls || []).empty?, 'and the tile layers composite again'
@@ -10593,9 +10615,9 @@ check 'a battle-valid Timer reaching 0:00 force-ends the fight (yado.tk)' do
   scene, st = battle_scene_with_pages({})
   10.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
   end
-  ok scene.instance_variable_get(:@battle_ui), 'the battle opened'
+  ok battle_ui(scene), 'the battle opened'
   # A timer already at 0:00-next-tick, marked to count during battle.
   t = st.timer(0)
   t.frames = 1
@@ -10603,7 +10625,7 @@ check 'a battle-valid Timer reaching 0:00 force-ends the fight (yado.tk)' do
   t.visible = true
   t.in_battle = true
   scene.update
-  eq nil, scene.instance_variable_get(:@battle_ui),
+  eq nil, battle_ui(scene),
      'the battle force-ends the instant the timer reaches 0:00, mid-command-phase'
   ok !st.switches[1] && !st.switches[2] && !st.switches[3],
      'no Win/Escape/Defeat handler matched -- an unlabeled third outcome, same as Terminate Battle'
@@ -10614,14 +10636,14 @@ check 'a page can wound a monster through Change Monster HP' do
   pages = { 1 => troop_page([ECmd.new(ic::CHANGE_MONSTER_HP, [0, 1, 0, 7, 1])]) }
   scene, _st = battle_scene_with_pages(pages)
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   foe = ui[:battle].enemy(0)
   eq foe.max_hp - 7, foe.hp, 'the page took 7 HP off the first troop member'
 end
@@ -10632,15 +10654,15 @@ check 'Change Battle Background from a page rebuilds the backdrop sprite' do
   scene, _st = battle_scene_with_pages(pages)
   before = nil
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     before ||= ui && ui[:back_sprite]
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui[:back_sprite], 'a backdrop is still in place'
   ok !ui[:back_sprite].equal?(before), 'and it was rebuilt for the new name'
 end
@@ -10669,7 +10691,7 @@ check "a battle page's Show Battle Animation actually holds the page, not resumi
   it = nil
   60.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     it = ui && ui[:events]
     break if it && it.waiting? && it.wait_kind == :animation
   end
@@ -10695,7 +10717,7 @@ check "a battle page's Show Battle Animation draws over the targeted troop membe
   ma_seen = nil
   40.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     anim_spr = scene.instance_variable_get(:@animation_sprite)
     spr_shown ||= anim_spr && anim_spr.visible
     ma = scene.instance_variable_get(:@map_animation)
@@ -10705,7 +10727,7 @@ check "a battle page's Show Battle Animation draws over the targeted troop membe
   ok spr_shown, 'the animation sprite actually drew'
   ok ma_seen, 'the request was recorded as a live animation, not silently dropped'
   ok ma_seen[:battle], 'positioned in screen space, like a battle-round animation'
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   spr = ui[:enemy_sprites][1]
   eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
      [ma_seen[:tx], ma_seen[:ty]], "centred on troop member 1's sprite, the command's own target param"
@@ -10725,7 +10747,7 @@ check "a battle page's Show Battle Animation target-scope flash pulses the named
   bystander_flashed = false
   40.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     next unless ui && ui[:enemy_sprites]
     target_flashed ||= !!ui[:enemy_sprites][0].flash_color
     bystander_flashed ||= !!ui[:enemy_sprites][1].flash_color
@@ -10744,10 +10766,10 @@ check 'a battle page shows its message in a battle panel and waits for a key' do
   scene, st = battle_scene_with_pages(pages)
   10.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:event_win]
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui[:event_win], 'the message panel is up'
   ok !st.switches[15], 'the page is held at the message'
   RGSS::Input.triggered = [RGSS::Input::C]
@@ -10755,32 +10777,32 @@ check 'a battle page shows its message in a battle panel and waits for a key' do
   RGSS::Input.triggered = []
   3.times { scene.update }
   ok st.switches[15], 'the button dismissed it and the page ran on'
-  eq nil, scene.instance_variable_get(:@battle_ui)[:event_win],
+  eq nil, battle_ui(scene)[:event_win],
      'the panel closed with the message'
 end
 
 check 'a hidden troop member is not targetable until it is revealed' do
   scene, _st = battle_scene_with_pages(nil)
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   eq 2, ui[:foes].length
   # Hide the second member the way an invisible troop entry would have.
   ui[:foes][1].hidden = true
   ui[:troop].members[1].hidden = true
-  targets = scene.send(:living_foes)
+  targets = scene.instance_variable_get(:@battle).send(:living_foes)
   eq 1, targets.length, 'the target cursor skips the hidden member'
   ok !targets.include?(ui[:foes][1])
 
-  scene.send(:reveal_battle_monster, 1)
+  scene.instance_variable_get(:@battle).send(:reveal_battle_monster, 1)
   ok !ui[:foes][1].hidden, 'revealing clears the combatant flag, not just the sprite'
-  eq 2, scene.send(:living_foes).length, 'and it becomes targetable'
+  eq 2, scene.instance_variable_get(:@battle).send(:living_foes).length, 'and it becomes targetable'
   ok ui[:enemy_sprites][1], 'with a sprite built for it'
 end
 
@@ -10976,7 +10998,7 @@ check 'Enemy Encounter scene: the result window shows the database Victory term'
   state.instance_variable_set(:@party, BattleStubParty.new)
   scene.update
   battle_attack_to_end(scene)
-  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  texts = window_texts(battle_ui(scene)[:result_win])
   ok texts.any? { |t| t.include?('戦いに勝利した！') }, 'the database term is shown'
   ok !texts.any? { |t| t.include?('Victory!') }, 'not the composed English fallback'
 end
@@ -11001,7 +11023,7 @@ check 'Enemy Encounter scene: the result window composes the database EXP/gold/i
   state.instance_variable_set(:@party, BattleStubParty.new(item_db: db.item))
   scene.update
   battle_attack_to_end(scene)
-  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  texts = window_texts(battle_ui(scene)[:result_win])
   ok texts.any? { |t| t.include?('10の経験値を得た！') },
      'the EXP term is composed as amount-then-term (GetExperienceGainedMessage)'
   ok texts.any? { |t| t.include?('仲間は 20ゴールドを手に入れた！') },
@@ -11024,7 +11046,7 @@ check 'Enemy Encounter scene: blank database EXP/gold/item received terms fall b
   state.instance_variable_set(:@party, BattleStubParty.new(item_db: db.item))
   scene.update
   battle_attack_to_end(scene)
-  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  texts = window_texts(battle_ui(scene)[:result_win])
   ok texts.any? { |t| t.include?('10 EXP gained.') }, 'a blank exp_received term falls back'
   ok texts.any? { |t| t.include?('Found 20G.') }, 'blank gold_received_a/gold/gold_received_b fall back'
   ok texts.count { |t| t.include?('Potion obtained.') } == 2, 'a blank item_received term falls back'
@@ -11051,7 +11073,7 @@ check 'Enemy Encounter scene: the result window announces a level-up and the ski
   state.instance_variable_set(:@party, BattleStubParty.new(actor, skill_db: db.skill))
   scene.update
   battle_attack_to_end(scene)
-  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  texts = window_texts(battle_ui(scene)[:result_win])
   eq 2, actor.level, 'the EXP gain crossed the one threshold configured'
   ok texts.any? { |t| t.include?('Heroはレベル 2 に上がった！') },
      'the level-up line reads name + level term + number + level_up term ' \
@@ -11074,7 +11096,7 @@ check 'Enemy Encounter scene: blank database level_up/skill_learned terms fall b
   state.instance_variable_set(:@party, BattleStubParty.new(actor, skill_db: db.skill))
   scene.update
   battle_attack_to_end(scene)
-  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  texts = window_texts(battle_ui(scene)[:result_win])
   ok texts.any? { |t| t.include?('Hero is now level 2!') }, 'a blank level_up term falls back'
   ok texts.any? { |t| t.include?('Hero learned Meteor!') }, 'a blank skill_learned term falls back'
 end
@@ -11089,7 +11111,7 @@ check 'Enemy Encounter scene: a blank database Victory/Defeat term falls back to
                            BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
   scene.update
   battle_attack_to_end(scene)
-  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  texts = window_texts(battle_ui(scene)[:result_win])
   ok texts.any? { |t| t.include?('The party was defeated...') },
      'a blank database term still falls back to the composed English'
 end
@@ -11149,11 +11171,11 @@ def battle_at_command(pages = nil, party: BattleStubParty.new, battleranimations
   scene, = battle_scene_with_pages(pages, party: party, battleranimations: battleranimations)
   ui = nil
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
   [scene, ui]
@@ -11167,7 +11189,7 @@ check 'a skill that names an animation plays it over the targeted enemy' do
   scene, ui = battle_at_command
   entry = { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
             skill_id: 8, target_index: 0, target_ally: false }
-  ok scene.send(:start_battle_animation, entry), 'an animation started'
+  ok scene.instance_variable_get(:@battle).send(:start_battle_animation, entry), 'an animation started'
   ma = scene.instance_variable_get(:@map_animation)
   ok ma, 'the player was armed'
   ok ma[:battle], 'and flagged as a battle animation'
@@ -11203,7 +11225,7 @@ check 'a target-scope animation flash pulses the hit enemy, not the screen or a 
   eq nil, bystander.flash_color, 'the other, untargeted enemy sprite is untouched'
   # Driven every frame the way #drive_battle already does (#update_enemy_flashes),
   # the flash fades out and clears after its own duration -- not left stuck on.
-  anim_flash_frames.times { scene.send(:update_enemy_flashes) }
+  anim_flash_frames.times { scene.instance_variable_get(:@battle).send(:update_enemy_flashes) }
   eq nil, spr.flash_color, 'the flash faded out after its duration'
 end
 
@@ -11257,7 +11279,7 @@ check 'a target-scope animation shake jitters the hit enemy sprite, not a bystan
   scene.send(:fire_animation_flashes, ma)
   moved = false
   RPG2k::Scene::Map::ANIM_SHAKE_FRAMES.times do
-    scene.send(:update_enemy_shakes)
+    scene.instance_variable_get(:@battle).send(:update_enemy_shakes)
     moved ||= spr.x != base_x
   end
   ok moved, "the targeted enemy sprite's x moved off its base position at some point during the shake"
@@ -11347,7 +11369,7 @@ end
 
 check 'a skill that names none plays nothing' do
   scene, = battle_at_command
-  ok !scene.send(:start_battle_animation,
+  ok !scene.instance_variable_get(:@battle).send(:start_battle_animation,
                  { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Heal',
                    skill_id: 9, target_index: 0, target_ally: false })
   eq nil, scene.instance_variable_get(:@map_animation)
@@ -11391,7 +11413,7 @@ check 'a skill naming a since-deleted battle animation plays nothing, but report
   entry = { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
             skill_id: 8, target_index: 0, target_ally: false }
   out = capture_stderr do
-    ok !scene.send(:start_battle_animation, entry), 'nothing plays -- unchanged from before this diagnostic'
+    ok !scene.instance_variable_get(:@battle).send(:start_battle_animation, entry), 'nothing plays -- unchanged from before this diagnostic'
   end
   eq nil, scene.instance_variable_get(:@map_animation), 'draws nothing, same as always'
   ok out.include?('[RPG2k] battle animation #8 not found in database, nothing drawn'), out
@@ -11403,7 +11425,7 @@ check 'an action on a party member plays over the middle of the screen' do
   scene, = battle_at_command
   entry = { attacker: 'Slime', target: 'Hero', damage: 7, skill: 'Fire',
             skill_id: 8, target_index: nil, target_ally: true }
-  ok scene.send(:start_battle_animation, entry)
+  ok scene.instance_variable_get(:@battle).send(:start_battle_animation, entry)
   ma = scene.instance_variable_get(:@map_animation)
   eq [RPG2k::Scene::Map::SCREEN_W / 2, RPG2k::Scene::Map::SCREEN_H / 2],
      [ma[:tx], ma[:ty]]
@@ -11412,19 +11434,19 @@ end
 check 'the round waits for the animation instead of the banner timer' do
   scene, ui = battle_at_command
   ui[:phase] = :animate
-  scene.send(:start_battle_animation,
+  scene.instance_variable_get(:@battle).send(:start_battle_animation,
              { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
                skill_id: 8, target_index: 0, target_ally: false })
-  ok scene.send(:battle_animation_playing?), 'the round is held'
+  ok scene.instance_variable_get(:@battle).send(:battle_animation_playing?), 'the round is held'
   # It plays out frame by frame and clears itself; nothing else advances while
   # it does, and no interpreter is resumed (a battle animation has no event
   # waiting on it, unlike the map's Show Battle Animation).
   200.times do
     break if scene.instance_variable_get(:@map_animation).nil?
-    scene.send(:drive_battle_animate)
+    scene.instance_variable_get(:@battle).send(:drive_battle_animate)
   end
   eq nil, scene.instance_variable_get(:@map_animation), 'it finished'
-  ok !scene.send(:battle_animation_playing?)
+  ok !scene.instance_variable_get(:@battle).send(:battle_animation_playing?)
 end
 
 # Real RPG_RT (EasyRPG's BattleAnimation::Update, src/battle_animation.cpp)
@@ -11435,7 +11457,7 @@ end
 # comment in scene/map.rb for the fuller citation.
 check 'each battle animation frame is held for exactly ANIM_CELL_FRAMES ticks (2, 1/30s)' do
   scene, = battle_at_command
-  scene.send(:start_battle_animation,
+  scene.instance_variable_get(:@battle).send(:start_battle_animation,
              { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
                skill_id: 8, target_index: 0, target_ally: false })
   ma = scene.instance_variable_get(:@map_animation)
@@ -11451,13 +11473,13 @@ end
 
 check 'an item names its animation the same way a skill does' do
   scene, = battle_at_command
-  eq nil, scene.send(:battle_animation_id,
+  eq nil, scene.instance_variable_get(:@battle).send(:battle_animation_id,
                      { item_id: 3, recover: true }),
      'the fixture Potion names none'
-  eq 8, scene.send(:battle_animation_id, { skill_id: 8 })
-  eq nil, scene.send(:battle_animation_id, { attacker: 'Hero' }),
+  eq 8, scene.instance_variable_get(:@battle).send(:battle_animation_id, { skill_id: 8 })
+  eq nil, scene.instance_variable_get(:@battle).send(:battle_animation_id, { attacker: 'Hero' }),
      'a plain attack with no attack_animation_id resolved (a bare fixture Combatant, or an enemy) carries none'
-  eq 5, scene.send(:battle_animation_id, { attacker: 'Hero', attack_animation_id: 5 }),
+  eq 5, scene.instance_variable_get(:@battle).send(:battle_animation_id, { attacker: 'Hero', attack_animation_id: 5 }),
      'a plain attack falls back to the id Game::Battle#deal_attack already resolved onto the entry'
 end
 
@@ -11469,7 +11491,7 @@ check 'a plain attack with a resolved weapon animation plays it over the targete
   scene, ui = battle_at_command
   entry = { attacker: 'Hero', target: 'Slime', damage: 7,
             attack_animation_id: 8, target_index: 0, target_ally: false }
-  ok scene.send(:start_battle_animation, entry), 'an animation started, same as a skill would'
+  ok scene.instance_variable_get(:@battle).send(:start_battle_animation, entry), 'an animation started, same as a skill would'
   ma = scene.instance_variable_get(:@map_animation)
   ok ma, 'the player was armed'
   spr = ui[:enemy_sprites][0]
@@ -11479,7 +11501,7 @@ end
 
 check 'a plain attack with nothing resolved plays no animation' do
   scene, = battle_at_command
-  ok !scene.send(:start_battle_animation,
+  ok !scene.instance_variable_get(:@battle).send(:start_battle_animation,
                  { attacker: 'Hero', target: 'Slime', damage: 7, target_index: 0 }),
      'an unarmed attacker with no unarmed_animation configured, or an enemy, carries no id'
   eq nil, scene.instance_variable_get(:@map_animation)
@@ -11487,7 +11509,7 @@ end
 
 check 'the battle animation draws in screen pixels, not map ones' do
   scene, = battle_at_command
-  scene.send(:start_battle_animation,
+  scene.instance_variable_get(:@battle).send(:start_battle_animation,
              { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
                skill_id: 8, target_index: 0, target_ally: false })
   ma = scene.instance_variable_get(:@map_animation)
@@ -11531,7 +11553,7 @@ end
 
 check 'a head/feet Show Battle Animation position offsets where it draws over the enemy sprite' do
   scene, = battle_at_command
-  scene.send(:start_battle_animation,
+  scene.instance_variable_get(:@battle).send(:start_battle_animation,
              { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
                skill_id: 8, target_index: 0, target_ally: false })
   ma = scene.instance_variable_get(:@map_animation)
@@ -11578,7 +11600,7 @@ check 'the Battle/ animation sheet is loaded colour-keyed, like every other spri
      'palette index 0 must decode transparent, or every cell paints an opaque 96x96 block'
   # The four full-screen backdrops are the deliberate exceptions, and stay
   # opaque -- they have no transparent colour to key out.
-  eq false, scene.send(:battle_back_bitmap, 'Back').load_transparent,
+  eq false, scene.instance_variable_get(:@battle).send(:battle_back_bitmap, 'Back').load_transparent,
      'Backdrop/ is a full-screen image and stays opaque'
 end
 
@@ -11605,7 +11627,7 @@ end
 
 check 'a battle animation cell blits at its own transparency' do
   scene, = battle_at_command
-  scene.send(:start_battle_animation,
+  scene.instance_variable_get(:@battle).send(:start_battle_animation,
              { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
                skill_id: 8, target_index: 0, target_ally: false })
   ma = scene.instance_variable_get(:@map_animation)
@@ -11641,7 +11663,7 @@ check 'the battle status window shows each ally condition, or the normal term' d
      'the one ally starts clear, showing the database normal term'
 
   ui[:allies][0].states = [4]                    # Sleep
-  scene.send(:refresh_battle_status)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_status)
   texts = window_texts(ui[:status_win])
   ok texts.include?('Sleep'), 'the afflicted ally shows its state'
   # RPG2000 is front-view: EasyRPG's Scene_Battle_Rpg2k builds exactly one
@@ -11654,10 +11676,10 @@ check 'the condition shown is the significant state, in the state colour' do
   scene, ui = battle_at_command
   # Sleep (priority 80) outranks Silence (10) whichever order they landed in.
   ui[:allies][0].states = [4, 5]
-  scene.send(:refresh_battle_status)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_status)
   ok window_texts(ui[:status_win]).include?('Sleep'), 'the higher priority wins'
   ui[:allies][0].states = [5, 4]
-  scene.send(:refresh_battle_status)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_status)
   ok window_texts(ui[:status_win]).include?('Sleep'), 'regardless of order'
 
   # The state's own palette colour reaches the draw call. This project ships no
@@ -11692,7 +11714,7 @@ end
 
 check 'battle_type 0 (no gauge layout) still draws the plain text status row' do
   scene, ui = battle_at_command
-  ok !scene.send(:gauge_battle_layout?), 'the plain fixture answers false'
+  ok !scene.instance_variable_get(:@battle).send(:gauge_battle_layout?), 'the plain fixture answers false'
   texts = window_texts(ui[:status_win])
   ok texts.include?('Hero'), 'the text status row is unchanged'
   eq [], ui[:status_win].contents.blt_calls || [],
@@ -11705,8 +11727,8 @@ check 'battle_type 1 (alternative) keeps the unchanged text status row too, ' \
   party = BattleStubParty.new(actor, alternate_layout: true, gauge_layout: false)
   scene, ui = battle_at_command(nil, party: party)
   scene.db.system.system2_name = 'BattleStatus'
-  scene.send(:refresh_battle_status)
-  ok !scene.send(:gauge_battle_layout?),
+  scene.instance_variable_get(:@battle).send(:refresh_battle_status)
+  ok !scene.instance_variable_get(:@battle).send(:gauge_battle_layout?),
      'battle_type 1 answers false to #gauge_battle_layout? -- only 2 does'
   texts = window_texts(ui[:status_win])
   ok texts.include?('Hero'), 'the text status row is still what battle_type 1 draws'
@@ -11717,9 +11739,9 @@ check 'battle_type 2 (gauge) with no System2 graphic falls back to the text ' \
   actor = BattleStubActor.new
   party = BattleStubParty.new(actor, gauge_layout: true)
   scene, ui = battle_at_command(nil, party: party)
-  ok scene.send(:gauge_battle_layout?), 'the fixture asks for the gauge layout'
+  ok scene.instance_variable_get(:@battle).send(:gauge_battle_layout?), 'the fixture asks for the gauge layout'
   ok !scene.db.system.respond_to?(:system2_name), 'and the database names no System2 graphic'
-  scene.send(:refresh_battle_status)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_status)
   texts = window_texts(ui[:status_win])
   ok texts.include?('Hero'), 'falls back to the plain text row rather than an empty/crashed panel'
 end
@@ -11732,7 +11754,7 @@ check 'battle_type 2 (gauge) draws the gauge card: face, HP/SP bars, digit numbe
   # A non-full HP (so this same window also exercises the normal, not
   # "full", fill tile) alongside SP's still-full 20/20.
   ui[:allies][0].hp = 100
-  scene.send(:refresh_battle_status)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_status)
   win = ui[:status_win]
 
   ok window_texts(win).empty?,
@@ -11777,12 +11799,14 @@ end
 
 check 'DrawGaugeSystem2 stretches the fill by 25 * cur / max, and reads the ' \
       'distinct "full" tile only when cur == max' do
-  scene = new_scene({})
+  # A pure function of its own arguments (no @ui / fight state touched), so a
+  # bare, never-#start'ed Scene::Battle is enough to call it on.
+  battle = RPG2k::Scene::Battle.allocate
   system2 = RGSS::Bitmap.new(80, 96)
   c = RGSS::Bitmap.new(64, 16)
   draw = lambda do |cur, max, which|
     c.clear_stretch_calls
-    scene.send(:draw_gauge_system2, c, system2, 100, 200, cur, max, which)
+    battle.send(:draw_gauge_system2, c, system2, 100, 200, cur, max, which)
     c.stretch_calls.last
   end
 
@@ -11804,17 +11828,17 @@ check 'DrawGaugeSystem2 stretches the fill by 25 * cur / max, and reads the ' \
      'which=1 (SP) reads its own row, 16px down -- still the "full" tile at cur == max'
 
   c.clear_stretch_calls
-  scene.send(:draw_gauge_system2, c, system2, 100, 200, 5, 0, 0)
+  battle.send(:draw_gauge_system2, c, system2, 100, 200, 5, 0, 0)
   eq nil, c.stretch_calls.last, 'max == 0 draws nothing at all, matching the real max_value guard'
 end
 
 check 'DrawNumberSystem2 leading-zero cascade matches EasyRPG exactly (7, 42, 100, 999)' do
-  scene = new_scene({})
+  battle = RPG2k::Scene::Battle.allocate
   system2 = RGSS::Bitmap.new(80, 96)
   c = RGSS::Bitmap.new(64, 16)
   glyphs = lambda do |value|
     c.clear_blt_calls
-    scene.send(:draw_number_system2, c, system2, 0, 0, value)
+    battle.send(:draw_number_system2, c, system2, 0, 0, value)
     c.blt_calls.map { |call| [call[0], call[3].x / 8] }
   end
 
@@ -11878,7 +11902,7 @@ check 'a Change Party Member remove on a battle page disposes only that ' \
   ui = nil
   10.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui
   end
   ok ui, 'the battle opened'
@@ -11891,7 +11915,7 @@ check 'a Change Party Member remove on a battle page disposes only that ' \
     RGSS::Input.triggered = [RGSS::Input::C] if ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui[:phase] == :command
   end
   eq :command, ui[:phase], 'the page ran (and handed control back) along the way'
@@ -11929,11 +11953,11 @@ check 'a Change Party Member add reaches the gauge-card status panel ' \
 
   ui = nil
   30.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
   eq :command, ui[:phase]
@@ -11961,12 +11985,12 @@ check 'leaving and rejoining the same fight reuses the same Combatant (and ' \
   ok original_combatant && original_sprite
 
   original_combatant.states = [5] # an accumulated battle-only status
-  scene.send(:on_battle_party_changed, ally, false) # leaves
+  scene.instance_variable_get(:@battle).send(:on_battle_party_changed, ally, false) # leaves
   eq 1, ui[:allies].length, 'dropped from the render roster'
   ok !ui[:actor_sprites].include?(original_sprite)
   ok original_sprite.disposed?, 'their sprite was disposed on the way out'
 
-  scene.send(:on_battle_party_changed, ally, true) # rejoins the same fight
+  scene.instance_variable_get(:@battle).send(:on_battle_party_changed, ally, true) # rejoins the same fight
   eq 2, ui[:allies].length, 'back in the render roster, not duplicated'
   eq 1, ui[:allies].count { |c| c.actor && c.actor.id == 2 }, 'no leaked duplicate Combatant'
   rejoined_combatant = ui[:allies].find { |c| c.actor.id == 2 }
@@ -11991,11 +12015,11 @@ check 'actor sprite Z stays collision-free across a remove-then-add cycle, ' \
   scene, ui = battle_at_command(nil, party: party, battleranimations: anims)
   eq [200, 201, 202], ui[:actor_sprites].map(&:z), 'starting Z per index (#actor_sprite_z)'
 
-  scene.send(:on_battle_party_changed, ally, false) # remove the middle member
+  scene.instance_variable_get(:@battle).send(:on_battle_party_changed, ally, false) # remove the middle member
   eq [200, 201], ui[:actor_sprites].map(&:z),
      "Third's Z was recomputed for its new index (1), not left stale at 202"
 
-  scene.send(:on_battle_party_changed, newcomer, true) # a brand new member joins
+  scene.instance_variable_get(:@battle).send(:on_battle_party_changed, newcomer, true) # a brand new member joins
   zs = ui[:actor_sprites].map(&:z)
   eq [200, 201, 202], zs
   eq zs.uniq.length, zs.length, 'no two actor sprites end up sharing a Z'
@@ -12005,7 +12029,7 @@ end
 
 check 'a plain attack reads as RPG_RT words it: the attack, then the damage' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Hero', target: 'Slime', damage: 42,
                        target_ally: false })
   eq ['Heroの攻撃！', 'Slimeに 42 のダメージを与えた！'], lines
@@ -12013,7 +12037,7 @@ end
 
 check 'and from the other side, with the other predicate and particle' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Slime', target: 'Hero', damage: 7,
                        target_ally: true })
   eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！'], lines
@@ -12021,7 +12045,7 @@ end
 
 check 'a miss reads as the target dodging' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Hero', target: 'Slime', damage: 0,
                        missed: true, target_ally: false })
   eq ['Heroの攻撃！', 'Slimeは身をかわした！'], lines
@@ -12029,7 +12053,7 @@ end
 
 check 'a blow that gets through for nothing says so' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Hero', target: 'Slime', damage: 0,
                        target_ally: false })
   eq ['Heroの攻撃！', 'Slimeにダメージを与えられない！'], lines
@@ -12041,7 +12065,7 @@ end
 # damage predicates themselves, not on which side dealt it.
 check 'a critical hit adds the game\'s own line between the attack and the damage' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Hero', target: 'Slime', damage: 42,
                        critical: true, target_ally: false })
   eq ['Heroの攻撃！', '会心の一撃！！', 'Slimeに 42 のダメージを与えた！'], lines
@@ -12049,7 +12073,7 @@ end
 
 check 'and from the other side, the term keyed on the party member taking it' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Slime', target: 'Hero', damage: 7,
                        critical: true, target_ally: true })
   eq ['Slimeの攻撃！', '痛恨の一撃！！', 'Heroは 7 のダメージを受けた！'], lines
@@ -12059,7 +12083,7 @@ check 'a blank critical term drops the whole entry back to the composed ' \
       'wording, "(critical!)" included' do
   scene, = battle_at_command
   scene.db.term.enemy_critical = ''
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Hero', target: 'Slime', damage: 42,
                        critical: true, target_ally: false })
   eq ['Hero hits Slime for 42 (critical!)'], lines
@@ -12068,20 +12092,20 @@ end
 check 'the basic actions with no target are one line each' do
   scene, = battle_at_command
   eq ['Slimeは身を守っている'],
-     scene.send(:battle_action_lines, { attacker: 'Slime', defend: true })
+     scene.instance_variable_get(:@battle).send(:battle_action_lines, { attacker: 'Slime', defend: true })
   eq ['Slimeは力をためている・・・'],
-     scene.send(:battle_action_lines, { attacker: 'Slime', charge: true })
+     scene.instance_variable_get(:@battle).send(:battle_action_lines, { attacker: 'Slime', charge: true })
   eq ['Slimeは逃げてしまった！'],
-     scene.send(:battle_action_lines, { attacker: 'Slime', fled: true })
+     scene.instance_variable_get(:@battle).send(:battle_action_lines, { attacker: 'Slime', fled: true })
   eq ['Slimeは変身した！'],
-     scene.send(:battle_action_lines, { attacker: 'Slime', transform: true,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines, { attacker: 'Slime', transform: true,
                                         target: 'Bat' })
 end
 
 check 'an autodestruct names itself and then the damage it did' do
   scene, = battle_at_command
   eq ['Slimeは自爆した！', 'Heroは 20 のダメージを受けた！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Slime', target: 'Hero', damage: 20,
                   autodestruct: true, target_ally: true })
 end
@@ -12092,7 +12116,7 @@ check 'a blank term drops the whole entry back to the composed wording' do
   # `observing` is blank in the fixture, so Observe cannot be worded from the
   # table and the entry falls back whole rather than printing a bare name.
   eq ['Slime watches closely'],
-     scene.send(:battle_action_lines, { attacker: 'Slime', observe: true })
+     scene.instance_variable_get(:@battle).send(:battle_action_lines, { attacker: 'Slime', observe: true })
 end
 
 check 'a skill keeps its composed line until its own sentence is read' do
@@ -12100,14 +12124,14 @@ check 'a skill keeps its composed line until its own sentence is read' do
   # using_message1 / use_item are still unread; dropping to the bare damage line
   # would lose the only thing naming what was cast.
   eq ["Hero's Venom hits Slime for 7"],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Venom',
                   target_ally: false })
 end
 
 check 'the state sentences still follow the action ones' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Slime', target: 'Hero', damage: 7,
                        inflicted: [3], target_ally: true })
   eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！', 'Hero is poisoned!'], lines
@@ -12125,17 +12149,17 @@ end
 check 'an affect_attack/defense/spirit/agility skill announces the stat rise ' \
       'or drop, in the game\'s own words' do
   scene, = battle_at_command
-  up = scene.send(:battle_state_lines, { target: 'Hero', target_ally: true,
+  up = scene.instance_variable_get(:@battle).send(:battle_state_lines, { target: 'Hero', target_ally: true,
                                          stat_changed: { atk: 10 } })
   eq ['Heroの攻撃力が 10 上がった！'], up
 
-  down = scene.send(:battle_state_lines, { target: 'Slime', target_ally: false,
+  down = scene.instance_variable_get(:@battle).send(:battle_state_lines, { target: 'Slime', target_ally: false,
                                            stat_changed: { def: -4 } })
   eq ['Slimeの防御力が 4 下がった！'], down
 
   # Every ability-value key the mechanic can touch, and in the order
   # #apply_stat_mods reports them.
-  all_four = scene.send(:battle_state_lines,
+  all_four = scene.instance_variable_get(:@battle).send(:battle_state_lines,
                         { target: 'Hero', target_ally: true,
                           stat_changed: { atk: 3, def: -2, spi: 1, agi: -5 } })
   eq ['Heroの攻撃力が 3 上がった！', 'Heroの防御力が 2 下がった！',
@@ -12144,7 +12168,7 @@ end
 
 check 'a zero-delta stat entry (already pinned at its cap) says nothing' do
   scene, = battle_at_command
-  eq [], scene.send(:battle_state_lines,
+  eq [], scene.instance_variable_get(:@battle).send(:battle_state_lines,
                     { target: 'Hero', target_ally: true, stat_changed: { atk: 0 } })
 end
 
@@ -12152,12 +12176,12 @@ check 'an affect_attr_defence skill announces which way the target\'s ' \
       'resistance moved, by the attribute\'s own name -- no magnitude, ' \
       'matching EasyRPG\'s GetAttributeShiftMessage' do
   scene, = battle_at_command
-  raised = scene.send(:battle_state_lines,
+  raised = scene.instance_variable_get(:@battle).send(:battle_state_lines,
                       { target: 'Hero', target_ally: true,
                         attr_shifted: [1], attr_shift_dir: 1 })
   eq ['Heroは火 耐性が上がった！'], raised
 
-  lowered = scene.send(:battle_state_lines,
+  lowered = scene.instance_variable_get(:@battle).send(:battle_state_lines,
                        { target: 'Slime', target_ally: false,
                          attr_shifted: [1], attr_shift_dir: -1 })
   eq ['Slimeは火 耐性が下がった！'], lowered
@@ -12166,7 +12190,7 @@ end
 check 'the stat and attribute-shift lines follow the damage line, like every ' \
       'other landed condition' do
   scene, = battle_at_command
-  lines = scene.send(:battle_action_lines,
+  lines = scene.instance_variable_get(:@battle).send(:battle_action_lines,
                      { attacker: 'Slime', target: 'Hero', damage: 7,
                        target_ally: true, stat_changed: { def: -5 },
                        attr_shifted: [1], attr_shift_dir: -1 })
@@ -12178,7 +12202,7 @@ check 'a skill announces itself with its own two sentences, then the damage' do
   scene, = battle_at_command
   eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
       'Slimeに 42 のダメージを与えた！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 42, skill: 'Fire',
                   skill_id: 8, target_ally: false })
 end
@@ -12186,7 +12210,7 @@ end
 check 'a skill with only a first sentence gives one line before the damage' do
   scene, = battle_at_command
   eq ['Heroは光をまとった！', 'Slimeに 5 のダメージを与えた！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 5, skill: 'Heal',
                   skill_id: 9, target_ally: false })
 end
@@ -12194,7 +12218,7 @@ end
 check 'a skill row with no sentence keeps the composed line' do
   scene, = battle_at_command
   eq ["Hero's Mute hits Slime for 5"],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 5, skill: 'Mute',
                   skill_id: 10, target_ally: false })
 end
@@ -12202,7 +12226,7 @@ end
 check 'a skill that misses takes its own failure sentence, not the damage line' do
   scene, = battle_at_command
   eq ['Heroは呪文を唱えた！', 'Slimeは眠らなかった！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 0, missed: true,
                   skill: 'Sleep', skill_id: 11, target_ally: false })
 end
@@ -12210,7 +12234,7 @@ end
 check 'a heal that restored nothing reads as a failure' do
   scene, = battle_at_command
   eq ['Heroは光をまとった！', 'Heroには効かなかった！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
                   target: 'Hero', recover_hp: 0, recover_mp: 0,
                   cured: [], target_ally: true })
@@ -12219,7 +12243,7 @@ end
 check 'a heal that worked says what it restored, in the game own words' do
   scene, = battle_at_command
   eq ['Heroは光をまとった！', 'HeroのＨＰが 30 回復した！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
                   target: 'Hero', recover_hp: 30, recover_mp: 0,
                   cured: [], target_ally: true })
@@ -12229,7 +12253,7 @@ check 'a heal that filled both pools says so once per pool' do
   scene, = battle_at_command
   eq ['Heroは光をまとった！', 'HeroのＨＰが 30 回復した！',
       'HeroのＭＰが 12 回復した！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
                   target: 'Hero', recover_hp: 30, recover_mp: 12,
                   cured: [], target_ally: true })
@@ -12238,7 +12262,7 @@ end
 check 'an item names itself with the caster, the item and the term' do
   scene, = battle_at_command
   eq ['HeroはPotionを使った！', 'HeroのＨＰが 30 回復した！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { recover: true, actor: 'Hero', source: 'Potion', item_id: 3,
                   target: 'Hero', recover_hp: 30, recover_mp: 0,
                   cured: [], target_ally: true })
@@ -12247,7 +12271,7 @@ end
 check 'an item that only cured says so through the state sentence' do
   scene, = battle_at_command
   eq ['HeroはAntidoteを使った！', 'Hero is cured.'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { recover: true, actor: 'Hero', source: 'Antidote', item_id: 5,
                   target: 'Hero', recover_hp: 0, recover_mp: 0,
                   cured: [3], target_ally: true })
@@ -12257,7 +12281,7 @@ check 'an item that did nothing keeps the composed line' do
   scene, = battle_at_command
   # RPG2000 gives an item no failure sentence to choose from -- unlike a skill,
   # it has no failure_message -- so the composed wording still says more.
-  ok scene.send(:battle_action_lines,
+  ok scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { recover: true, actor: 'Hero', source: 'Potion', item_id: 3,
                   target: 'Hero', recover_hp: 0, recover_mp: 0,
                   cured: [], target_ally: true })
@@ -12268,7 +12292,7 @@ check 'a drain adds its own line after the damage' do
   scene, = battle_at_command
   eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
       'Slimeに 20 のダメージを与えた！', 'SlimeのＨＰを 20 奪った！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 20, skill: 'Fire',
                   skill_id: 8, absorbed_hp: 20, target_ally: false })
 end
@@ -12277,7 +12301,7 @@ check 'a drain on a party member is worded from their side' do
   scene, = battle_at_command
   eq ['Slimeは炎を放った！', 'あたりが真っ赤に染まる！',
       'Heroは 20 のダメージを受けた！', 'HeroはＨＰを 20 奪われた！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Slime', target: 'Hero', damage: 20, skill: 'Fire',
                   skill_id: 8, absorbed_hp: 20, target_ally: true })
 end
@@ -12286,7 +12310,7 @@ check 'a skill that drained nothing adds no line' do
   scene, = battle_at_command
   eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
       'Slimeに 20 のダメージを与えた！'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 20, skill: 'Fire',
                   skill_id: 8, absorbed_hp: 0, target_ally: false })
 end
@@ -12295,7 +12319,7 @@ check 'a skill still trails the states it landed' do
   scene, = battle_at_command
   eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
       'Slimeに 7 のダメージを与えた！', 'Slime looks ill!'],
-     scene.send(:battle_action_lines,
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
                   skill_id: 8, inflicted: [3], target_ally: false })
 end
@@ -12303,34 +12327,34 @@ end
 check 'the action banner announces the states an action landed and lifted' do
   scene, = battle_at_command
   # The database's own sentences, printed straight after the target's name.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Venom',
                inflicted: [3], target_ally: false })
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   texts = window_texts(ui[:action_win])
   ok texts.any? { |t| t.include?('Venom') }, 'the action itself still reads'
   ok texts.include?('Slime looks ill!'), 'with the enemy wording for the state'
 
   # The same state on a party member takes the actor wording.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Slime', target: 'Hero', damage: 7,
                inflicted: [3], target_ally: true })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Hero is poisoned!'), 'and the actor wording for an ally'
 
   # A cure reads the recovery sentence.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { recover: true, actor: 'Hero', source: 'Antidote', target: 'Hero',
                recover_hp: 0, recover_mp: 0, cured: [3], target_ally: true })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Hero is cured.'), 'the recovery sentence'
 
   # So does a state a blow shook off (`woke`, a state's release_by_attack) --
   # the state lifting is the same event however it happened.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Hero', target: 'Slime', damage: 9,
                woke: [3], target_ally: false })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Slime is cured.'), 'a state shaken off by a blow reads the same'
 end
 
@@ -12338,30 +12362,30 @@ check 'being downed is announced with the death state own sentence' do
   scene, = battle_at_command
   # State 1 is death; the fake database words it from the speaker's side, the
   # way a real one does.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Hero', target: 'Slime', damage: 30,
                defeated: true, target_ally: false })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Slime is struck down!'), 'the enemy wording'
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Slime', target: 'Hero', damage: 30,
                defeated: true, target_ally: true })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Hero falls!'), 'and the actor wording'
 end
 
 check 'a status the target already had is announced, in the state own words' do
   scene, = battle_at_command
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Slime', target: 'Hero', damage: 3,
                already: [3], target_ally: true })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Hero is already poisoned!'),
      'one wording, whichever side the target is on'
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Hero', target: 'Slime', damage: 3,
                already: [3], target_ally: false })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Slime is already poisoned!')
 end
 
@@ -12369,10 +12393,10 @@ check 'an already-carried state with no sentence still gets announced' do
   scene, = battle_at_command
   # State 4 (Sleep) has a name but no message_already, which is what an
   # English-release database looks like.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Slime', target: 'Hero', damage: 3,
                already: [4], target_ally: true })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Hero is already Sleep'), 'the scene composes its own wording'
 end
 
@@ -12380,17 +12404,17 @@ check 'a state the database gives no sentence still gets announced' do
   scene, = battle_at_command
   # State 5 (Silence) has a name but no message_actor / message_enemy, which is
   # what an English-release database looks like.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Slime', target: 'Hero', damage: 3,
                inflicted: [5], target_ally: true })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Hero is Silence'), 'the scene composes its own wording'
 
   # An id the table does not define at all still reads as something.
-  scene.send(:show_battle_action,
+  scene.instance_variable_get(:@battle).send(:show_battle_action,
              { attacker: 'Slime', target: 'Hero', damage: 3,
                inflicted: [99], target_ally: true })
-  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+  ok window_texts(battle_ui(scene)[:action_win])
       .include?('Hero is state 99'), 'falling back to the id'
 end
 
@@ -15064,26 +15088,26 @@ end
 check 'a transformed monster is redrawn with its new battler graphic' do
   scene, _st = battle_scene_with_pages(nil)
   10.times do
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
     RGSS::Input.triggered = []
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui && ui[:phase] == :command
   end
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   before = ui[:enemy_sprites][0]
   ok before, 'the monster is on the field'
   # What Game::Battle's transform action does to the combatant.
   ui[:foes][0].battler_name = 'Dragon'
   ui[:foes][0].name = 'Dragon'
-  scene.send(:refresh_battle_sprites)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_sprites)
   ok !ui[:enemy_sprites][0].equal?(before), 'its sprite is rebuilt'
   eq 'Dragon', ui[:sprite_names][0], 'and tracked against the new battler'
   ok ui[:enemy_sprites][0].visible, 'still on the field'
   # A second refresh with nothing changed must not churn the sprite again.
   same = ui[:enemy_sprites][0]
-  scene.send(:refresh_battle_sprites)
+  scene.instance_variable_get(:@battle).send(:refresh_battle_sprites)
   ok ui[:enemy_sprites][0].equal?(same), 'an unchanged battler is left alone'
 end
 
@@ -15105,7 +15129,7 @@ check 'a random encounter opens a battle with the map-tree node\'s own troop' do
   ui = nil
   20.times do
     scene.update
-    ui = scene.instance_variable_get(:@battle_ui)
+    ui = battle_ui(scene)
     break if ui
   end
   RGSS::Input.dir_value = 0
@@ -15120,7 +15144,7 @@ check 'an empty encounter list never starts a random battle' do
   RGSS::Input.dir_value = 6
   15.times { scene.update }
   RGSS::Input.dir_value = 0
-  ok scene.instance_variable_get(:@battle_ui).nil?,
+  ok battle_ui(scene).nil?,
      'the roll succeeds but there is nothing to fight, so no battle opens'
 end
 
@@ -15130,7 +15154,7 @@ check 'riding the airship skips the random-encounter roll entirely' do
   st = scene.instance_variable_get(:@state)
   st.boarded = :airship
   scene.send(:check_random_encounter)
-  ok scene.instance_variable_get(:@battle_ui).nil?, 'flying is RPG_RT\'s one blanket exemption'
+  ok battle_ui(scene).nil?, 'flying is RPG_RT\'s one blanket exemption'
   eq 0, st.encounter_total, 'the accumulator never even started'
 end
 
@@ -15148,7 +15172,7 @@ check 'a forced move route does not roll for a random encounter' do
   st = scene.instance_variable_get(:@state)
   30.times { scene.update }
   ok st.x > 0, "the forced route actually moved the player, at x=#{st.x}"
-  ok scene.instance_variable_get(:@battle_ui).nil?,
+  ok battle_ui(scene).nil?,
      'the whole forced route ran without ever rolling for an encounter'
 end
 
@@ -15165,7 +15189,7 @@ check 'standing on a Hero Touch event tile suppresses the random-encounter roll'
   st = scene.instance_variable_get(:@state)
   scene.send(:check_random_encounter)
   scene.update # give it a frame too, in case a battle wait was queued anyway
-  ok scene.instance_variable_get(:@battle_ui).nil?,
+  ok battle_ui(scene).nil?,
      "the party is standing on a Hero Touch event's own tile: no roll"
   eq 0, st.encounter_total, 'the step never accumulated, matching the flying early-out above'
 end
@@ -15181,7 +15205,7 @@ check 'standing on an Event Touch tile still rolls for a random encounter' do
   scene = new_scene({ 1 => event(0, 0, other) }, player: [0, 0], map_tree: tree)
   scene.send(:check_random_encounter)
   scene.update # the roll only queues a :battle wait; a frame turns it into @battle_ui
-  ui = scene.instance_variable_get(:@battle_ui)
+  ui = battle_ui(scene)
   ok ui, 'an Event Touch event on the tile does not suppress the roll'
   eq 1, ui[:troop].id, "the map tree node's own troop"
 end
@@ -15208,7 +15232,7 @@ check 'an encounter-steps of 0 disables random encounters and resets the accumul
   st.encounter_total = 55
   scene.send(:check_random_encounter)
   eq 0, st.encounter_total, 'the accumulator resets rather than piling up while encounters are off'
-  ok scene.instance_variable_get(:@battle_ui).nil?
+  ok battle_ui(scene).nil?
 end
 
 # -- Debug keys (RPG2k#test_play only -- see mruby-rpg2k/mrblib/scene/map.rb
@@ -15239,7 +15263,7 @@ check 'Ctrl during Test Play suppresses the random-encounter roll' do
   st = scene.instance_variable_get(:@state)
   RGSS::Input.triggered = [RGSS::Input::CTRL]
   scene.send(:check_random_encounter)
-  ok scene.instance_variable_get(:@battle_ui).nil?,
+  ok battle_ui(scene).nil?,
      'Ctrl held: a guaranteed roll (encount_steps 1, default terrain rate) never fires'
   eq 0, st.encounter_total, 'the accumulator never even started'
 end
@@ -15321,16 +15345,16 @@ check 'F9 opens the debug menu during Test Play even with a battle open' do
   st.instance_variable_set(:@party, BattleStubParty.new)
   10.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
   end
-  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+  ok battle_ui(scene), 'the battle actually opened'
 
   RGSS::Input.triggered = [RGSS::Input::F9]
   scene.update
   pushed = scene.parent.pushed
   eq 1, pushed.size, 'F9 pushed exactly one scene, mid-battle'
   ok pushed.first.is_a?(RPG2k::Scene::DebugMenu), 'the pushed scene is the debug menu'
-  ok scene.instance_variable_get(:@battle_ui), 'the battle stays open behind the debug menu'
+  ok battle_ui(scene), 'the battle stays open behind the debug menu'
 end
 
 check 'F9 does nothing during a battle outside Test Play' do
@@ -15342,9 +15366,9 @@ check 'F9 does nothing during a battle outside Test Play' do
   st.instance_variable_set(:@party, BattleStubParty.new)
   10.times do
     scene.update
-    break if scene.instance_variable_get(:@battle_ui)
+    break if battle_ui(scene)
   end
-  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+  ok battle_ui(scene), 'the battle actually opened'
 
   RGSS::Input.triggered = [RGSS::Input::F9]
   scene.update


### PR DESCRIPTION
## Summary

This PR extracts the battle system from being a mode of `Scene::Map` into its own dedicated `Scene::Battle` class. Previously, ~3,000 lines of battle logic lived inline within `Scene::Map`, with battle state stored in a `@battle_ui` hash on the map scene. Battle is now a first-class scene object with its own lifecycle and state management.

## Key Changes

- **New `Scene::Battle` class** (`mruby-rpg2k/mrblib/scene/battle.rb`): Extracted ~3,030 lines of battle logic from `Scene::Map`, including command/target/skill/item windows, troop and party sprites, round animation, battle events, and result screen handling
- **Refactored `Scene::Map`** (`mruby-rpg2k/mrblib/scene/map.rb`): Removed ~2,975 lines of battle-specific code; map scene now delegates to `Scene::Battle` via `@battle` instance variable
- **Updated test infrastructure** (`scripts/rpg2k_scene_check.rb`): 
  - Added `battle_ui(scene)` helper to access battle state through the new scene structure
  - Added `fake_battle(scene, ui)` helper to fabricate test battles without driving full encounters
  - Updated all battle-related test assertions to use new accessors
- **Documentation**: Added ADR 0052 explaining the architectural rationale and migration details
- **Changelog entry**: Documented the user-facing change

## Implementation Details

- Battle state (`@ui` hash) maintains the same shape as before, ensuring compatibility with existing state checks
- `Scene::Map#update` now delegates battle driving to `Scene::Battle` rather than handling it inline
- The `@battle` instance variable on `Scene::Map` holds the active `Scene::Battle` (nil between encounters)
- Test suite updated to work with the new scene hierarchy while maintaining test semantics

https://claude.ai/code/session_01ATurDaNuqhZzVYo8ourovu