### PR TITLE
Skip a KO'd party member when granting battle-victory EXP

### DIFF
--- a/changelog.d/rpg2k-battle-victory-exp-skips-dead.fixed.md
+++ b/changelog.d/rpg2k-battle-victory-exp-skips-dead.fixed.md
@@ -1,0 +1,7 @@
+- **A KO'd party member no longer earns EXP from a battle victory.**
+  Confirmed against EasyRPG Player's source: the battle-victory EXP loop
+  iterates only active battlers (`Game_Party_Base::GetActiveBattlers`, which
+  excludes anyone failing `!IsDead()`). This build granted EXP to every
+  current party member unconditionally, so a fallen ally still enrolled in
+  the party at the moment of victory could earn (and even level up from) EXP
+  it never fought for.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6153,6 +6153,32 @@ not yet verified:
   transforming a 950-HP/40-SP monster into a 100-max-HP/10-max-SP form and
   asserting both current values survive exactly, confirmed to fail against
   the pre-fix code (`expected 950, got 100`) before the fix.
+- ✅ **A KO'd party member no longer earns EXP from a battle victory.**
+  Confirmed against EasyRPG's actual C++ source: `Scene_Battle_Rpg2k
+  ::ProcessSceneActionVictory` (`src/scene_battle_rpg2k.cpp`) grants the
+  troop's EXP by looping `ally_battlers`, populated via
+  `Game_Party_Base::GetActiveBattlers` (`src/game_party_base.cpp`) — not the
+  raw party roster — which only collects a battler passing
+  `Game_Battler::Exists()` (`src/game_battler.h`:
+  `!IsHidden() && !IsDead() && IsInParty()`). `Scene::Map#battle_result_lines`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) instead iterated
+  `@state.party.actors` — the plain roster, no alive/dead filter at all —
+  calling `#gain_exp` on every member unconditionally. This is reachable in
+  practice because victory only requires *one* ally still standing
+  (`Game::Battle#end_round`'s `alive?(@allies)`), so a fight can legitimately
+  end in victory with one or more party members dead. Concretely: Alice
+  (alive) and Bob (KO'd, still enrolled) win a fight worth 50 EXP — real
+  RPG_RT/EasyRPG credits only Alice; this build credited both, and could
+  even level Bob up (and teach him a growth-table skill, announced in the
+  result window) purely from a fight he never regained consciousness in.
+  Fixed by skipping `a.dead?` before `#gain_exp` in the loop, mirroring
+  `Exists()`'s `!IsDead()` half (`Game::Actor#dead?` already exists and is
+  the right predicate; this build has no per-actor "hidden" concept to mirror
+  the other half). Covered by a new `scripts/rpg2k_scene_check.rb` check
+  driving a real two-party-member Enemy Encounter (one already KO'd going
+  in) to victory and asserting only the survivor's EXP total rises,
+  confirmed to fail against the pre-fix code (`expected 0, got 10`) before
+  the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6707,6 +6707,12 @@ class RPG2k
           lines << "#{name}#{term(:item_received, ' obtained.')}"
         end
         @state.party.actors.each do |a|
+          # A KO'd party member earns nothing from the victory -- EasyRPG's own
+          # EXP-granting loop (Scene_Battle_Rpg2k::ProcessSceneActionVictory)
+          # iterates Game_Party_Base::GetActiveBattlers, not the raw roster,
+          # and GetActiveBattlers excludes anyone failing Game_Battler::
+          # Exists() (`!IsHidden() && !IsDead() && IsInParty()`).
+          next if a.respond_to?(:dead?) && a.dead?
           before_level = a.respond_to?(:level) ? a.level : nil
           before_skills = a.respond_to?(:skills) ? a.skills.dup : []
           a.gain_exp(exp)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5434,6 +5434,27 @@ check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Vi
   ok !st.switches[2], 'the Escape handler was skipped'
 end
 
+# EasyRPG's own EXP-granting loop (Scene_Battle_Rpg2k::
+# ProcessSceneActionVictory) iterates Game_Party_Base::GetActiveBattlers, not
+# the raw party roster, and GetActiveBattlers excludes anyone failing
+# Game_Battler::Exists() (`!IsHidden() && !IsDead() && IsInParty()`) -- a
+# fallen ally still enrolled in the party at the moment of victory gets
+# nothing.
+check "Enemy Encounter scene: a KO'd party member earns no EXP from the victory" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  alive = BattleStubActor.new(id: 1)
+  fallen = BattleStubActor.new(id: 2, hp: 0) # already KO'd going into the fight
+  st.instance_variable_set(:@party, BattleStubParty.new(actors: [alive, fallen]))
+  scene.update
+  battle_attack_to_end(scene) # only the living actor's Attack drives it to victory
+  eq 10, alive.exp, 'the surviving actor still gains the troop EXP (2 Slimes x 5)'
+  eq 0, fallen.exp, "a KO'd party member earns nothing from the victory"
+end
+
 # `Game::Battle` already tracks the fight's own round count live (`@rounds`,
 # `#turn`), but nothing captured it before `#close_battle` discarded the
 # `Battle` object once the fight ended -- see docs/TODO.md's "turns passed in


### PR DESCRIPTION
## Summary
- `Scene::Map#battle_result_lines` (`mruby-rpg2k/mrblib/scene/map.rb`) granted the troop's battle-victory EXP to every current party member unconditionally, with no alive/dead filter. Victory only requires *one* ally still standing (`Game::Battle#end_round`'s `alive?(@allies)`), so a fight can legitimately end in victory with one or more party members dead — and those fallen members still got EXP, and could even level up (with growth-table skills announced in the result window) from a fight they never regained consciousness in.
- Confirmed against EasyRPG Player's actual C++ source: `Scene_Battle_Rpg2k::ProcessSceneActionVictory` (`src/scene_battle_rpg2k.cpp`) grants EXP by looping `ally_battlers`, populated via `Game_Party_Base::GetActiveBattlers` (`src/game_party_base.cpp`) — not the raw party roster — which only collects a battler passing `Game_Battler::Exists()` (`src/game_battler.h`: `!IsHidden() && !IsDead() && IsInParty()`).
- Fixed by skipping `a.dead?` before `#gain_exp` in the loop, mirroring `Exists()`'s `!IsDead()` half (`Game::Actor#dead?` already exists and is the right predicate).

## Test plan
- New `scripts/rpg2k_scene_check.rb` check drives a real two-party-member Enemy Encounter (one already KO'd going in) to victory and asserts only the survivor's EXP total rises, confirmed to fail against the pre-fix code (`expected 0, got 10`) before the fix, via `git stash`.
- All four CRuby suites pass (912 + 629 + save/load + 130 checks), the native `rpg_maker_clone` target rebuilds cleanly, and `ninja test` (native mruby suite) passes.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_