### PR TITLE
rpg2k: self-destruct hides the caster instead of killing it

### DIFF
--- a/changelog.d/enemy-autodestruct-hidden.fixed.md
+++ b/changelog.d/enemy-autodestruct-hidden.fixed.md
@@ -1,0 +1,11 @@
+- An enemy's Autodestruct (self-destruct) attack no longer zeroes its own HP
+  and grants full EXP / gold / item drops for a kill it never took. Verified
+  against EasyRPG Player's actual C++ source
+  (`Game_BattleAlgorithm::SelfDestruct`): the algorithm never writes the
+  caster's own HP, only `SetHidden(true)`, so the caster is taken out of play
+  the same way a fled monster is — not killed. `Game::Battle#enemy_autodestruct`
+  now sets `hidden` instead of zeroing HP, and `Scene::Map#refresh_battle_sprites`
+  mirrors that onto the troop member so `Troop#total_exp`/`#total_gold`/`#drops`
+  correctly exclude it, matching the community デフォ戦bot trivia that a
+  self-destructed enemy drops no reward, its HP reads unchanged if inspected,
+  and "Enemy Appears" (Show Hidden Monster) brings it back exactly as before.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7358,28 +7358,36 @@ module Game
     end
 
     # EXP / gold / drops are only earned from members that actually fell in
-    # this fight -- a member still flagged `hidden` at victory time (either
-    # never revealed by a Show Hidden Monster page, or sent running by a
-    # page's own Force Flee) contributes none of the three, even though a
-    # fight can end in victory while such a member is technically still at
-    # full HP: `Game::Battle#incapacitated?` (`mruby-rpg2k/mrblib/game.rb`)
-    # already treats hidden the same as dead for win/loss purposes
-    # (`out_of_play?`), so `alive?(@enemies)` goes false -- and victory fires
-    # -- the instant every *visible* member is down, with no requirement that
-    # a still-hidden one ever engaged at all. Matches EasyRPG's actual C++
-    # source: `Game_EnemyParty::GetExp`/`GetMoney`/`GenerateDrops`
-    # (`src/game_enemyparty.cpp`) each loop `if (enemy.IsDead())` before
+    # this fight -- a member still flagged `hidden` at victory time (never
+    # revealed by a Show Hidden Monster page, sent running by a page's own
+    # Force Flee, sent running by its own basic Escape action, or blown up by
+    # its own basic Autodestruct -- see `Game::Battle#enemy_autodestruct`)
+    # contributes none of the three, even though a fight can end in victory
+    # while such a member is technically still at full HP:
+    # `Game::Battle#incapacitated?` (`mruby-rpg2k/mrblib/game.rb`) already
+    # treats hidden the same as dead for win/loss purposes (`out_of_play?`),
+    # so `alive?(@enemies)` goes false -- and victory fires -- the instant
+    # every *visible* member is down, with no requirement that a still-hidden
+    # one ever engaged at all. Matches EasyRPG's actual C++ source:
+    # `Game_EnemyParty::GetExp`/`GetMoney`/`GenerateDrops` (`src/
+    # game_enemyparty.cpp`) each loop `if (enemy.IsDead())` before
     # summing/rolling that member at all, and `Game_Battler::IsDead` (`src/
     # game_battler.h`) is a bare `GetHp() == 0` check -- a hidden member's own
-    # HP is never touched by never fighting, and a Force-Fled member's isn't
-    # either (`SetHidden` alone, no `Kill`), so both read `IsDead() == false`
-    # and are skipped by all three real methods. This class never lets a
-    # member's HP move at all -- the actual combat plays out on parallel
-    # `Combatant` structs in `Game::Battle`, not on `Troop`'s own `Enemy`
-    # objects -- so `hidden` (kept live by `Scene::Map#reveal_battle_monster`/
-    # `#remove_fled_monster`) is the one signal available here, and by the
-    # "hidden ~ not dead" equivalence above it is also the *correct* one: a
-    # non-hidden member reaching this call is always the dead case.
+    # HP is never touched by never fighting, a Force-Fled/Escaped member's
+    # isn't either (`SetHidden` alone, no `Kill`), and neither is a
+    # self-destructed one's (`Game_BattleAlgorithm::SelfDestruct` only ever
+    # calls `SetHidden` on its own caster, never touching its HP -- see
+    # `enemy_autodestruct`'s own comment), so all three read `IsDead() ==
+    # false` and are skipped by all three real reward methods. This class
+    # never lets a member's HP move at all -- the actual combat plays out on
+    # parallel `Combatant` structs in `Game::Battle`, not on `Troop`'s own
+    # `Enemy` objects -- so `hidden` (kept live by
+    # `Scene::Map#reveal_battle_monster`/`#remove_fled_monster` for a battle
+    # page's own commands, and by `Scene::Map#refresh_battle_sprites` for
+    # anything a combatant does to itself mid-fight) is the one signal
+    # available here, and by the "hidden ~ not dead" equivalence above it is
+    # also the *correct* one: a non-hidden member reaching this call is
+    # always the dead case.
     def total_exp;  live_members.reduce(0) { |s, e| s + e.exp } end
     def total_gold; live_members.reduce(0) { |s, e| s + e.gold } end
 
@@ -9434,10 +9442,21 @@ module Game
 
     # Self-destruction (basic 5): the enemy blows itself up, hitting every living
     # party member for `atk - def/2` (EasyRPG's CalcSelfDestructEffect, floored at
-    # 0 and spread by the usual variance), and dies doing it. Defending halves
-    # the blow, and 強力防御 halves it again -- the same `AdjustDamageForDefend`
-    # `#deal_attack` already applies, shared verbatim by EasyRPG's own
-    # `SelfDestruct::vExecute` rather than a self-destruct-specific rule.
+    # 0 and spread by the usual variance). Defending halves the blow, and 強力防御
+    # halves it again -- the same `AdjustDamageForDefend` `#deal_attack` already
+    # applies, shared verbatim by EasyRPG's own `SelfDestruct::vExecute` rather
+    # than a self-destruct-specific rule. It does not kill the caster itself,
+    # though -- verified against EasyRPG Player's actual C++ source:
+    # `Game_BattleAlgorithm::SelfDestruct::vExecute` (`src/
+    # game_battlealgorithm.cpp`) calls `SetAffectedHp` against the *target* only,
+    # never the source, and `ApplyCustomEffect` reacts to the caster with nothing
+    # but `enemy->SetHidden(true)` (plus an explode-animation timer) -- no HP
+    # write at all. So the caster is hidden, exactly like a page's Force Flee or
+    # its own basic Escape action, not killed: this matches the community
+    # デフォ戦bot trivia that a self-destructed enemy drops no EXP / gold / items,
+    # that its HP reads unchanged (not 0) if a battle event variable-assigns it,
+    # and that "Enemy Appears" (Show Hidden Monster) brings it right back with
+    # whatever HP it already had.
     def enemy_autodestruct(b)
       targets = @allies.reject(&:out_of_play?)
       entries = targets.map do |t|
@@ -9462,8 +9481,8 @@ module Game
         entry[:woke] = woke unless woke.empty?
         entry
       end
-      # The blast kills the caster whether or not it found anyone to hit.
-      b.hp = 0
+      # Hidden, not killed -- see the method comment above.
+      b.hidden = true
       entries.empty? ? { attacker: b.name, autodestruct: true } : entries
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5220,6 +5220,15 @@ class RPG2k
           # the field and must not be drawn — the same test #living_foes uses to
           # keep it out of the target cursor.
           spr.visible = !foe.out_of_play? if spr
+          # A combatant hidden by anything other than a battle page's own Force
+          # Flee (its own Escape action, or self-destruct -- Game::Battle#
+          # enemy_autodestruct) never runs through #remove_fled_monster, so
+          # mirror it onto the *troop* member here. #total_exp/#total_gold/
+          # #drops key off the troop member's own `hidden`, not the combatant's
+          # -- without this they would still pay out for a monster that never
+          # actually died this fight.
+          member = @battle_ui[:troop].members[i]
+          member.hidden = true if member && foe.hidden && !member.hidden
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8459,6 +8459,18 @@ check 'Troop EXP/gold/drops exclude a member still hidden at victory time (yado.
   eq 5, fled_troop.total_exp, 'a fled member grants no EXP even though it started visible'
   eq 10, fled_troop.total_gold
   eq [7], fled_troop.drops(Game::Rng.new(1)), 'and no drop either'
+
+  # A self-destructed member: Game::Battle#enemy_autodestruct only hides its
+  # Combatant (see that method's own comment, verified against EasyRPG's
+  # Game_BattleAlgorithm::SelfDestruct), and Scene::Map#refresh_battle_sprites
+  # mirrors that onto the troop member the same way #remove_fled_monster does
+  # for a scripted Force Flee -- so it drops nothing either, matching the
+  # community デフォ戦bot trivia (自爆した敵は経験値・お金・アイテムを落とさない).
+  exploded_troop = Game::Troop.new(db, 1)
+  exploded_troop.members[1].hidden = true # simulates a mid-battle self-destruct
+  eq 5, exploded_troop.total_exp, 'a self-destructed member grants no EXP'
+  eq 10, exploded_troop.total_gold
+  eq [7], exploded_troop.drops(Game::Rng.new(1)), 'and no drop either'
 end
 
 check 'a missing troop / enemy degrades to an empty, harmless model' do
@@ -14015,16 +14027,24 @@ check 'an escaping enemy leaves the fight without counting as a kill' do
   eq :victory, b.run, 'the fight is over with the troop gone'
 end
 
-check 'self-destruction hits the party for atk - def/2 and kills the caster' do
+check 'self-destruction hits the party for atk - def/2 and hides the caster, ' \
+      'not kills it (2000_battle_bot / デフォ戦bot trivia, verified against ' \
+      'EasyRPG: Game_BattleAlgorithm::SelfDestruct::vExecute sets the ' \
+      'affected HP on the target only, and ApplyCustomEffect reacts to the ' \
+      'caster with SetHidden(true) alone, no HP write)' do
   hero = combatant('Hero', 40, 10, 20, 500)
   foe = combatant('Bomb', 60, 0, 5, 500)
   b = ai_battle([enemy_action(kind: 0, basic: 5)], nil, foe: foe, hero: hero)
   b.begin_round
-  b.step_action
+  b.step_action # the faster hero (agi 20 > 5) swings first: 40/2 - 10/4 = 18 dmg
+  hp_before_blast = foe.hp
   e = b.step_action
   eq true, e[:autodestruct]
   eq 55, e[:damage], '60 - 10/2'
-  ok foe.dead?, 'the bomb dies doing it'
+  ok !foe.dead?, 'the bomb does not die doing it'
+  eq hp_before_blast, foe.hp, "its own HP is untouched by the blast itself, " \
+    'exactly as a variable read of it would show in real RPG_RT'
+  ok foe.hidden, 'but it is taken out of play, the same as a fled monster'
 end
 
 # -- the rating-weighted choice ------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9397,6 +9397,54 @@ check 'Enemy Encounter scene: a monster that leaves the field is not drawn' do
   ok !sprites[0].visible, 'a monster that fled is taken off the field'
   ok !ui[:foes][0].dead?, 'without counting as a kill'
   ok sprites[1].visible, 'its companion is untouched'
+  # #refresh_battle_sprites also mirrors the combatant's `hidden` onto the
+  # *troop* member -- the flag #total_exp/#total_gold/#drops actually key off
+  # -- since neither an AI Escape action nor Game::Battle#enemy_autodestruct
+  # runs through the interpreter's Force-Flee queue (#remove_fled_monster).
+  # Without this a self-fled/self-destructed monster would still pay full
+  # rewards on victory.
+  ok ui[:troop].members[0].hidden, 'the troop member is marked hidden too'
+  ok !ui[:troop].members[1].hidden, 'its companion is untouched'
+end
+
+# 2000_battle_bot / デフォ戦bot trivia: 自爆した敵は、経験値・お金・アイテムを落と
+# さない。しかもデータ内部では逃走した状態と同じ扱いになっており、敵ＨＰを変数に
+# 代入してみると0になっていない。更に自爆後にイベントコマンド「敵キャラの出現」で
+# 指定すると何喰わぬ顔で元に戻る。Verified against EasyRPG Player's actual C++
+# source (see Game::Battle#enemy_autodestruct's own comment in mrblib/game.rb):
+# Game_BattleAlgorithm::SelfDestruct never writes the caster's own HP, only
+# SetHidden(true) -- so this scene-level check exercises the same "hidden, not
+# killed" path a real self-destruct takes through #refresh_battle_sprites, and
+# that Show Hidden Monster ("Enemy Appears") brings it right back unharmed.
+check 'Enemy Encounter scene: a self-destructed monster drops no reward and ' \
+      '"Enemy Appears" brings it back exactly as before (デフォ戦bot trivia)' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_to_command(scene)
+  starting_hp = ui[:foes][0].hp
+  # What Game::Battle#enemy_autodestruct now does to its own caster: hide it,
+  # leave its HP untouched (no `b.hp = 0`).
+  ui[:foes][0].hidden = true
+  scene.send(:refresh_battle_sprites)
+  ok !ui[:foes][0].dead?, 'the caster does not die'
+  eq starting_hp, ui[:foes][0].hp,
+     'its HP reads unchanged, exactly as a variable assignment would show in real RPG_RT'
+  ok ui[:troop].members[0].hidden, 'excluded from the troop reward roll'
+  eq [ui[:troop].members[1]], ui[:troop].send(:live_members),
+     'only the untouched companion still counts toward EXP/gold/drops'
+
+  # "Enemy Appears" (Show Hidden Monster, 13150) targeting the exploded slot
+  # brings it right back -- same path a genuinely-fled monster already uses.
+  scene.send(:reveal_battle_monster, 0)
+  ok !ui[:troop].members[0].hidden, 'visible again'
+  ok !ui[:foes][0].hidden, 'back in play'
+  eq starting_hp, ui[:foes][0].hp, 'with the same HP it had before it blew up'
+  eq [ui[:troop].members[0], ui[:troop].members[1]], ui[:troop].send(:live_members),
+     'and it counts toward rewards again, same as any other live member'
 end
 
 # yado.tk's own text on the "airborne" enemy flag names no pixel offset or


### PR DESCRIPTION
## Summary

Community RPG_RT trivia (2000_battle_bot / デフォ戦bot) claims a self-destructed enemy drops no EXP/gold/items, reads as internally "fled" (HP unchanged if a variable reads it), and can be brought right back with "Enemy Appears" (Show Hidden Monster). I verified this against EasyRPG Player's actual C++ source rather than trusting the trivia at face value:

- `Game_BattleAlgorithm::SelfDestruct::vExecute` (`src/game_battlealgorithm.cpp`) computes `SetAffectedHp` against the **target** only — the caster's own HP is never written by the algorithm at all.
- `SelfDestruct::ApplyCustomEffect` reacts to the caster with `enemy->SetHidden(true)` alone (plus an explode-animation timer) — no HP write, no `Kill()`.
- `Game_EnemyParty::GetExp`/`GetMoney`/`GenerateDrops` (`src/game_enemyparty.cpp`) gate purely on `enemy.IsDead()`, and `Game_Battler::IsDead` is a bare `GetHp() == 0` check.

So EasyRPG's self-destruct is **not** guaranteed-lethal to the caster — it's the same "hidden, not killed" treatment as a fled monster. That settles the open question in favor of the trivia and against this codebase's prior `b.hp = 0`.

## Changes

- `Game::Battle#enemy_autodestruct` (`mruby-rpg2k/mrblib/game.rb`) now sets `hidden = true` on the caster instead of zeroing its HP.
- `Scene::Map#refresh_battle_sprites` (`mruby-rpg2k/mrblib/scene/map.rb`) now mirrors a combatant's mid-fight `hidden` onto the matching `Troop::Enemy` member — the flag `Troop#total_exp`/`#total_gold`/`#drops` actually key off. This was needed for the fix to actually work end-to-end: neither an AI Escape action nor self-destruct runs through the interpreter's Force-Flee queue (`#remove_fled_monster`), so without this sync a self-destructed (or fled) enemy's Combatant would go `hidden`, but the Troop-level reward gate would stay unaware and still pay out full rewards. This also fixes the same latent gap for the AI's own basic Escape action, which used the identical `hidden = true` pattern and already claimed (in its own comment) to match Force Flee's exclusion — a claim that wasn't actually true until this sync existed.
- Re-summoning via "Enemy Appears" (Show Hidden Monster, 13150) already went through `reveal_battle_monster`, which needed no changes — since HP is never touched by the fix, a re-summoned self-destructed enemy comes back with exactly the HP it had before exploding, matching the trivia's "何喰わぬ顔で元に戻る".
- Added/updated coverage in `scripts/rpg2k_logic_check.rb` (self-destruct no longer kills/zeroes HP; Troop reward exclusion) and `scripts/rpg2k_scene_check.rb` (the new Combatant→Troop hidden sync, and a full self-destruct → excluded-from-rewards → re-summoned-with-original-HP scene-level check).
- Changelog fragment: `changelog.d/enemy-autodestruct-hidden.fixed.md`.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 912 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 630 checks passed
- [x] `ninja rpg_maker_clone` — native rebuild succeeds

https://claude.ai/code/session_01Bgyu51wpEfWgygu9ptZgoJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgyu51wpEfWgygu9ptZgoJ)_