### PR TITLE
Let elemental-resistance equipment actually resist that element

### DIFF
--- a/changelog.d/rpg2k-attribute-resist-equipment.fixed.md
+++ b/changelog.d/rpg2k-attribute-resist-equipment.fixed.md
@@ -1,0 +1,8 @@
+- **Elemental-resistance equipment (armor/shield/helmet/accessory) now
+  actually resists that element**, instead of having no effect on the
+  wearer. Confirmed against EasyRPG Player's source
+  (`Game_Actor::GetBaseAttributeRate`): a defensive item flagging an
+  attribute in its own `attribute_set` grants a flat +1 defensive rank for
+  that element, on top of the actor's own database rank. This build parsed
+  the field but only ever consumed it on the offensive (weapon) side, so a
+  "Fire Ring" or similar resistance item had no defensive effect at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6179,6 +6179,41 @@ not yet verified:
   in) to victory and asserting only the survivor's EXP total rises,
   confirmed to fail against the pre-fix code (`expected 0, got 10`) before
   the fix.
+- ✅ **Elemental-resistance equipment (a shield/armor/helmet/accessory
+  flagging an attribute in its own `attribute_set`) now actually grants
+  resistance, instead of having zero effect on the wearer.** Confirmed
+  against EasyRPG's actual C++ source: `Game_Actor::GetBaseAttributeRate`
+  (`src/game_actor.cpp`) starts from the actor's own database
+  `attribute_ranks` row (default C/rank 2 when absent), then OR's a flat
+  `+1` boost from every equipped shield/armor/helmet/accessory whose own
+  `attribute_set` flags that attribute — `ForEachEquipment<allow_weapon=
+  false, allow_armor=true>` explicitly excludes the weapon slot — clamping
+  the result to `0..4`. `Game::Actor#attribute_ranks`
+  (`mruby-rpg2k/mrblib/game.rb`) only ever read the actor's own database row;
+  `attribute_set` (LCF item field 66) was already parsed and already
+  consumed, but only off the *weapon* slot, for the opposite (offensive)
+  purpose (`#weapon_attributes`, what element a basic attack carries) and
+  for RPG2003 skill-cast gating (`Party#weapon_attribute_ready?`, which the
+  existing `can_cast?` test already proves armor does *not* satisfy — a
+  different, correctly-scoped mechanic this fix leaves untouched). No code
+  path anywhere read a defensive item's `attribute_set` at all. Concretely:
+  an actor with no database override for Fire (rank-C default, 100%) wearing
+  an armor piece that flags Fire faces a 100-damage Fire attack — real
+  RPG_RT/EasyRPG lands it for `50` (rank C(2) + the +1 boost = D(3), 50% on
+  the RPG2000 default table); this build landed the full `100`, the armor
+  silently doing nothing. Fixed with a new `Actor#defensive_attribute_ids`
+  (the defensive counterpart of `#weapon_attributes`, gated on
+  `Party::ITEM_SHIELD/_ARMOR/_HELMET/_ACCESSORY` instead of the weapon slot),
+  OR'd into `#attribute_ranks`' returned `{ attribute_id => rank }` map as a
+  `+1` (clamped at 4) — baked in at the rank-table level, not the battle
+  layer, since `GetBaseAttributeRate` computes its `rate = 2` default
+  *before* ever consulting equipment, so an attribute the database row never
+  lists must still resist once a matching item is equipped. Covered by two
+  new `scripts/rpg2k_logic_check.rb` checks — one on `Actor#attribute_ranks`
+  itself (bare vs. weapon vs. armor vs. armor+accessory both flagging the
+  same element, proving the OR-not-stack rule), one end-to-end through
+  `Battle#apply_attr_multiplier` proving the actual damage reduction — both
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1797,13 +1797,47 @@ module Game
     # The actor's per-attribute defence ranks as `{ attribute_id => rank }`, read
     # from the database row's `attribute_ranks` byte array (rank 0 = A, most
     # vulnerable .. 4 = E, immune). An attribute the row omits defaults to C
-    # (100%) at the battle layer. A fixture row without the field yields {}.
+    # (100%) at the battle layer. A fixture row without the field, and no
+    # resistance gear equipped either, yields {}.
+    #
+    # Equipped shield/armor/helmet/accessory gear (never a weapon) that flags
+    # an attribute in its own `attribute_set` grants a flat +1 to that
+    # attribute's defence rank -- ports EasyRPG's `Game_Actor
+    # ::GetBaseAttributeRate` (src/game_actor.cpp): every matching piece worn
+    # is OR'd into a single one-step boost, not stacked per item, clamped at
+    # E (4, immune). This is why the boost is baked in here rather than left
+    # to the battle layer's own default: an attribute an actor's database row
+    # never lists (no explicit rank) still resists once a matching item is
+    # equipped, exactly as `GetBaseAttributeRate` computes `rate = 2` before
+    # ever consulting equipment.
     def attribute_ranks
       ranks = {}
       arr = @db_row.respond_to?(:attribute_ranks) ? @db_row.attribute_ranks : nil
-      return ranks unless arr
-      arr.each_with_index { |v, i| ranks[i + 1] = v }
+      arr.each_with_index { |v, i| ranks[i + 1] = v } if arr
+      defensive_attribute_ids.each do |aid|
+        ranks[aid] = [(ranks[aid] || 2) + 1, 4].min
+      end
       ranks
+    end
+
+    # The attribute ids an equipped shield/armor/helmet/accessory (never a
+    # weapon) flags in its own `attribute_set` -- the defensive counterpart of
+    # #weapon_attributes, which reads the same field off the weapon slot only,
+    # for the opposite (offensive) purpose.
+    def defensive_attribute_ids
+      ids = []
+      return ids unless @db.respond_to?(:item)
+      @equipment.each do |iid|
+        next if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next unless it && it.respond_to?(:type) &&
+                    [Party::ITEM_SHIELD, Party::ITEM_ARMOR, Party::ITEM_HELMET,
+                     Party::ITEM_ACCESSORY].include?(it.type)
+        set = it.respond_to?(:attribute_set) ? it.attribute_set : nil
+        next unless set
+        set.each_index { |i| ids << (i + 1) if set[i] && set[i] != 0 }
+      end
+      ids.uniq
     end
 
     # The actor's per-state susceptibility ranks as `{ state_id => rank }`, read

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5799,6 +5799,52 @@ check "can_cast?: a weapon-type Attribute skill needs a weapon carrying it equip
   eq true, st.party.can_cast?(hero, 8)
 end
 
+# Ports EasyRPG's `Game_Actor::GetBaseAttributeRate` (src/game_actor.cpp): a
+# shield/armor/helmet/accessory that flags an attribute in its own
+# `attribute_set` grants the wearer a flat +1 defensive rank for that
+# element, OR'd across every matching piece worn (not stacked per item),
+# clamped at E (4, immune) -- the defensive counterpart of
+# `#weapon_attributes`, which reads the very same field off the weapon slot
+# only, for the opposite (offensive) purpose.
+check "Actor#attribute_ranks: equipped defensive gear grants a flat +1 resistance rank" do
+  items = {
+    10 => fake_item(type: 1, name: 'Flame Sword', attribute_set: [true]),  # weapon, attr 1
+    11 => fake_item(type: 3, name: 'Flame Armor', attribute_set: [true]),  # armour, attr 1
+    12 => fake_item(type: 5, name: 'Fire Charm', attribute_set: [true]),   # accessory, attr 1 too
+  }
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  st = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1], items)), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  eq({}, hero.attribute_ranks, 'nothing equipped, no database ranks -- no entries at all')
+
+  hero.equip([10, 0, 0, 0, 0]) # the Flame Sword, weapon slot
+  eq({}, hero.attribute_ranks, "a weapon's own attribute_set grants no defensive resistance")
+
+  hero.equip([0, 0, 11, 0, 0]) # the Flame Armor, armour slot
+  eq({ 1 => 3 }, hero.attribute_ranks, 'base default C(2) + the armour boost = D(3)')
+
+  hero.equip([0, 0, 11, 0, 12]) # armour + accessory, both flagging attribute 1
+  eq({ 1 => 3 }, hero.attribute_ranks, 'two matching pieces OR together, not stack, to +1 total')
+end
+
+check 'battle: equipped defensive gear reduces elemental damage taken, on top of the ' \
+      "target's own rank" do
+  items = { 11 => fake_item(type: 3, name: 'Flame Armor', attribute_set: [true]) } # armour, attr 1
+  st = skill_party({}, items)
+  a = st.party.actor_by_id(1)
+  bare = Game::Battle.from_actor(a)
+  foe = Game::Battle::Combatant.new('Foe', 0, 0, 5, 999, 999)
+  bat = Game::Battle.new([bare], [foe], Game::Rng.new(1))
+  eq 100, bat.send(:apply_attr_multiplier, 100, [1], bare),
+     'no armour yet -- default rank C (100%)'
+
+  a.equip([0, 0, 11, 0, 0])
+  worn = Game::Battle.from_actor(a)
+  eq 50, bat.send(:apply_attr_multiplier, 100, [1], worn),
+     'rank C(2) + the armour boost = D(3) -- 50% of the RPG2000 default table'
+end
+
 check 'an all-ally heal skill heals the whole party (caster included) and spends SP' do
   skills = { 5 => fake_skill(scope: 4, sp_cost: 8, power: 30, hp: true) }
   st = skill_party(skills)


### PR DESCRIPTION
## Summary
- `Game::Actor#attribute_ranks` (`mruby-rpg2k/mrblib/game.rb`) only ever read the actor's own database `attribute_ranks` row. `attribute_set` (LCF item field 66) was already parsed and already consumed — but only off the *weapon* slot, for the opposite (offensive) purpose (`#weapon_attributes`, what element a basic attack carries) and for RPG2003 skill-cast gating. No code path anywhere read a defensive item's `attribute_set` at all, so an elemental-resistance armor/shield/helmet/accessory had zero effect on its wearer.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Actor::GetBaseAttributeRate` (`src/game_actor.cpp`) starts from the actor's own database row (default C/rank 2 when absent), then OR's a flat `+1` boost from every equipped shield/armor/helmet/accessory whose own `attribute_set` flags that attribute — `ForEachEquipment<allow_weapon=false, allow_armor=true>` explicitly excludes the weapon slot — clamped to `0..4`.
- Fixed with a new `Actor#defensive_attribute_ids` (the defensive counterpart of `#weapon_attributes`), OR'd into `#attribute_ranks`' returned map as a `+1` (clamped at 4) — baked in at the rank-table level since `GetBaseAttributeRate` computes its `rate = 2` default *before* ever consulting equipment, so an attribute the database row never lists must still resist once a matching item is equipped.

## Test plan
- Two new `scripts/rpg2k_logic_check.rb` checks: one on `Actor#attribute_ranks` itself (bare vs. weapon vs. armor vs. armor+accessory both flagging the same element, proving the OR-not-stack rule), one end-to-end through `Battle#apply_attr_multiplier` proving the actual damage reduction (100 → 50 for a rank C→D shift).
- Both confirmed to fail against the pre-fix code before the fix, via `git stash`.
- All four CRuby suites pass (914 + 629 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_