### PR TITLE
Implement utf8_to_cp932 native encoder in mruby-lcf

### DIFF
--- a/changelog.d/lsd-export-utf8-to-cp932-native.fixed.md
+++ b/changelog.d/lsd-export-utf8-to-cp932-native.fixed.md
@@ -1,0 +1,12 @@
+- **Saving a game no longer crashes the `.lsd` export.** ADR 0018 added
+  `LCF.utf8_to_cp932` to `mruby-lcf/mrblib/lcf.rb` (`LCF.encode`'s `:string`
+  branch) as the write-side mirror of the native `LCF.cp932_to_utf8` reader,
+  but the native uni-algo encoder itself was never added to
+  `mruby-lcf/src/lcf.cxx` — only the CRuby test harnesses got a stand-in. The
+  real mruby build therefore had no `LCF.utf8_to_cp932` at all, so any save
+  with a `:string` field (actor/hero names, the BGM name in the extended
+  system fields) raised `undefined method 'utf8_to_cp932' for Module` and
+  aborted the `.lsd` export. `utf8_to_cp932` is now implemented in
+  `mruby-lcf/src/lcf.cxx`, built from the same `cp932_table` `cp932_to_utf8`
+  already uses (reversed and re-sorted by Unicode code point instead of by
+  CP932 code), and registered alongside it in `mrb_mruby_lcf_gem_init`.

--- a/mruby-lcf/src/lcf.cxx
+++ b/mruby-lcf/src/lcf.cxx
@@ -3,6 +3,8 @@
 
 #include <algorithm>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include <uni_algo/conv.h>
 
@@ -60,11 +62,75 @@ mrb_value cp932_to_utf8(mrb_state* M, mrb_value self) {
   return mrb_str_new(M, ret.data(), ret.size());
 }
 
+// Inverse of cp932_to_utf8, built by reversing the same cp932_table: sorted
+// by Unicode code point (rather than by CP932 code) so a code point can be
+// looked up the same way the decoder looks up a CP932 byte sequence. A
+// looked-up value <= 0xff is a single CP932 byte (e.g. halfwidth katakana);
+// anything larger is a two-byte code, emitted big-endian to match the byte
+// order cp932_to_utf8 reads it in.
+mrb_value utf8_to_cp932(mrb_state* M, mrb_value self) {
+  const uint8_t* p;
+  mrb_int l;
+  mrb_get_args(M, "s", &p, &l);
+
+  static const std::vector<std::pair<uint16_t, uint16_t>> reverse_table = [] {
+    std::vector<std::pair<uint16_t, uint16_t>> t;
+    t.reserve(cp932_table_len);
+    for (size_t i = 0; i < cp932_table_len; ++i)
+      t.emplace_back(cp932_table[i].second, cp932_table[i].first);
+    std::sort(t.begin(), t.end());
+    return t;
+  }();
+
+  const auto find_cp932 = [](const uint16_t v) -> std::optional<uint16_t> {
+    const auto cmp = [](const std::pair<uint16_t, uint16_t>& l,
+                        const uint16_t& r) -> bool { return l.first < r; };
+    const auto* b = reverse_table.data();
+    const auto* e = b + reverse_table.size();
+    const auto* i = std::lower_bound(b, e, v, cmp);
+    if (i < e and i->first == v)
+      return i->second;
+    else
+      return std::nullopt;
+  };
+
+  const std::u32string str =
+      una::utf8to32u(std::string(reinterpret_cast<const char*>(p), l));
+
+  std::string ret;
+  for (const char32_t c : str) {
+    // ASCII passes through as a single raw byte, mirroring the decoder's
+    // ASCII shortcut, which takes priority over any table entry.
+    if (c < 0x80) {
+      ret.push_back(static_cast<char>(c));
+      continue;
+    }
+    const std::optional<uint16_t> b =
+        c <= 0xffff ? find_cp932(static_cast<uint16_t>(c)) : std::nullopt;
+    if (!b) {
+      // Unmappable code point: emit '?' rather than corrupting the byte
+      // stream, matching cp932_to_utf8's best-effort handling on read.
+      ret.push_back('?');
+      continue;
+    }
+    if (*b > 0xff) {
+      ret.push_back(static_cast<char>((*b >> 8) & 0xff));
+      ret.push_back(static_cast<char>(*b & 0xff));
+    } else {
+      ret.push_back(static_cast<char>(*b & 0xff));
+    }
+  }
+
+  return mrb_str_new(M, ret.data(), ret.size());
+}
+
 }  // namespace
 
 extern "C" void mrb_mruby_lcf_gem_init(mrb_state* M) {
   RClass* mod = mrb_define_module(M, "LCF");
   mrb_define_module_function(M, mod, "cp932_to_utf8", cp932_to_utf8,
+                             MRB_ARGS_REQ(1));
+  mrb_define_module_function(M, mod, "utf8_to_cp932", utf8_to_cp932,
                              MRB_ARGS_REQ(1));
 }
 


### PR DESCRIPTION
## Summary
Adds the missing native implementation of `LCF.utf8_to_cp932` to `mruby-lcf/src/lcf.cxx`. This fixes a crash when saving games with string fields (actor names, BGM names, etc.) to `.lsd` format, which was previously raising `undefined method 'utf8_to_cp932' for Module`.

## Changes
- **Added required headers**: `<string>` and `<vector>` for string/vector operations
- **Implemented `utf8_to_cp932` function**: 
  - Converts UTF-8 strings to CP932 (Shift JIS) encoding
  - Builds a reverse lookup table from the existing `cp932_table` at runtime, sorted by Unicode code point for efficient binary search
  - Handles single-byte CP932 codes (≤ 0xff) and two-byte codes (emitted big-endian)
  - Preserves ASCII characters (< 0x80) as single bytes, matching the decoder's behavior
  - Replaces unmappable code points with '?' to maintain byte stream integrity
- **Registered the function**: Added `utf8_to_cp932` to the mruby module exports in `mrb_mruby_lcf_gem_init`

## Implementation Details
The reverse lookup table is constructed as a static lambda-initialized vector that pairs Unicode code points with their CP932 equivalents. This mirrors the structure of `cp932_to_utf8` but with the mapping direction reversed and sorted by Unicode value rather than CP932 code, enabling the same efficient binary search pattern used by the decoder.

https://claude.ai/code/session_012MjJNVGQaHRyaSbcFfCJwv