### PR TITLE
Stop flashing the screen for a GAIN-type map-step status tick

### DIFF
--- a/changelog.d/rpg2k-map-step-gain-no-flash.fixed.md
+++ b/changelog.d/rpg2k-map-step-gain-no-flash.fixed.md
@@ -1,0 +1,6 @@
+- **A GAIN-type (regen) status condition's map-step tick no longer flashes
+  the screen red.** Confirmed against EasyRPG Player's source
+  (`Game_Party::ApplyStateDamage`): the screen-flash flag is only ever set
+  when a state actually drains HP/SP, never when one heals it. This build
+  flashed the screen on any map-step status tick at all, heal included —
+  the same exemption a healing terrain tile already correctly gets.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6214,6 +6214,40 @@ not yet verified:
   same element, proving the OR-not-stack rule), one end-to-end through
   `Battle#apply_attr_multiplier` proving the actual damage reduction — both
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **A GAIN-type (regen) status condition's own map-step tick no longer
+  flashes the screen red, matching a healing terrain tile's own exemption.**
+  Confirmed against EasyRPG's actual C++ source: `Game_Party::
+  ApplyStateDamage` (`src/game_party.cpp`) sets its `damage` return bool only
+  inside a state's `ChangeType_lose` branch — the `ChangeType_gain` branch
+  heals the actor but leaves `damage` untouched — and
+  `Game_Player::UpdateNextMovementAction` (`src/game_player.cpp`) gates
+  `Game_Screen::FlashMapStepDamage` on exactly that bool.
+  `Game::Party#apply_map_step_damage` (`mruby-rpg2k/mrblib/game.rb`) already
+  correctly signs a GAIN-type state's own delta positive (`Game::States
+  .drain`'s `CHANGE_TYPE_GAIN` case), but `Scene::Map#note_party_step`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) flashed the screen whenever
+  `apply_map_step_damage`'s returned array was non-empty at all — heal
+  included, since the only guard was "did anything change." This is the
+  state-side twin of an already-fixed, already-tested terrain rule (a
+  negative-`damage` terrain tile heals without flashing, `scripts/
+  rpg2k_scene_check.rb`'s "a healing tile never flashes the screen" check) —
+  the state side of the same "your HP just fell and the map has nowhere to
+  say so" moment was never given the equivalent exemption. Concretely: a
+  RPG2003 "Regen" state (`hp_change_map_steps=4`, `hp_change_map_val=1`,
+  `hp_change_type=GAIN`) ticks on an actor's 4th walked tile — real
+  RPG_RT/EasyRPG heals silently; this build healed *and* flashed the screen
+  red, as if the party had just taken damage. Fixed with a new `Game::Party
+  #map_step_damaged?`, tracking (per state, not on the summed net delta —
+  RPG_RT applies each state independently, so a LOSE and a GAIN state
+  landing on the same step both apply, and the tile still counts as damaged
+  if any single state on it was a loss, even when the net HP change is a
+  heal) whether the most recent `#apply_map_step_damage` call included an
+  actual loss; `#note_party_step`'s flash condition now checks that flag (or
+  the existing terrain-damage flag) instead of the returned array's
+  emptiness. Covered by a new `scripts/rpg2k_logic_check.rb` unit check on
+  `#map_step_damaged?` itself (LOSE, bare GAIN, and mixed LOSE+GAIN-net-heal)
+  and a new `scripts/rpg2k_scene_check.rb` end-to-end walking check, both
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3061,16 +3061,18 @@ module Game
     #
     # `table` is the database `situation` array; a caller without one (the seeded
     # harness fixtures) drains nothing. Returns the actors actually affected
-    # (lost *or* gained something), so the scene can flash the screen only when
-    # there is something to report.
+    # (lost *or* gained something) -- #map_step_damaged? (see below) is the one
+    # that answers whether the scene should flash the screen over it.
     def apply_map_step_damage(table, steps)
       hit = []
+      @map_step_damaged = false
       @actors.each do |actor|
         next if actor.nil? || actor.dead?
         hp = 0
         sp = 0
         actor.states.each do |id|
           dhp, dsp = States.map_step_drain(id, table, steps)
+          @map_step_damaged ||= dhp < 0 || dsp < 0
           hp += dhp
           sp += dsp
         end
@@ -3080,6 +3082,24 @@ module Game
         hit << actor
       end
       hit
+    end
+
+    # Whether the most recent #apply_map_step_damage call included at least one
+    # state's own HP/SP *loss* landing on that step -- distinct from
+    # #apply_map_step_damage's own return value, which reports every actor who
+    # changed either way, gain included. Ports EasyRPG's
+    # `Game_Party::ApplyStateDamage` (src/game_party.cpp): its `damage` bool is
+    # only ever set inside the `ChangeType_lose` branches, never the
+    # `ChangeType_gain` ones, and `Game_Player::UpdateNextMovementAction` gates
+    # `Game_Screen::FlashMapStepDamage` on exactly that bool -- a GAIN-type
+    # "regen" state's tick alone must never redden the screen, even though the
+    # actor it healed is still in the returned #apply_map_step_damage array.
+    # Checked per state, not on the summed net delta: a LOSE and a GAIN state
+    # landing on the same step both apply (RPG_RT applies each independently),
+    # so a net-positive tile still counts as damaged if any single state on it
+    # was a loss.
+    def map_step_damaged?
+      @map_step_damaged
     end
 
     # Damage every standing member for walking onto a damaging tile: RPG2000's

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -9559,6 +9559,11 @@ class RPG2k
       def note_party_step
         steps = @state.walk_step
         hit = @state.party.apply_map_step_damage(state_table, steps)
+        # A GAIN-type (regen) state's own tick never flashes red, matching
+        # EasyRPG's `Game_Party::ApplyStateDamage` -- see
+        # Game::Party#map_step_damaged?'s own doc comment.
+        state_damaged = @state.party.respond_to?(:map_step_damaged?) &&
+                        @state.party.map_step_damaged?
         # RPG2000's 地形ダメージ on top of it: the terrain the tile just stepped
         # onto belongs to may take HP off everyone not wearing gear that blocks
         # it -- or, for a terrain with a negative `damage` (a healing tile),
@@ -9574,7 +9579,7 @@ class RPG2k
                           row.damage && row.damage > 0
         play_terrain_footstep_se(row, terrain_damaged)
         return if hit.empty? && !terrain_damaged
-        @state.screen.flash(*STEP_DAMAGE_FLASH)
+        @state.screen.flash(*STEP_DAMAGE_FLASH) if state_damaged || terrain_damaged
       end
 
       # Apply the damage of the terrain under the party, returning the actors it

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -12108,6 +12108,45 @@ check 'map slip damage: a GAIN-type state heals instead of draining, clamped to 
   eq [hero.max_mp, before_mp + 30].min, hero.mp
 end
 
+# Ports EasyRPG's `Game_Party::ApplyStateDamage` (src/game_party.cpp): its
+# `damage` bool is only ever set inside a `ChangeType_lose` branch, never a
+# `ChangeType_gain` one -- #apply_map_step_damage's own return value reports
+# every actor who changed either way, but #map_step_damaged? is the one the
+# scene should gate a red step-damage flash on (Scene::Map#note_party_step).
+check 'Party#map_step_damaged?: true only for an actual LOSE-type slip, never a bare GAIN' do
+  lose_table = { 2 => fake_state(name: 'Poison', hp_map_steps: 1, hp_map_val: 1) }
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2)
+  st.party.apply_map_step_damage(lose_table, 1)
+  eq true, st.party.map_step_damaged?, 'a LOSE-type tick is damage'
+
+  gain_table = { 3 => fake_state(name: 'Regen', hp_map_steps: 1, hp_map_val: 1,
+                                  hp_change_type: Game::States::CHANGE_TYPE_GAIN) }
+  st2 = party_state
+  hero2 = st2.party.actor_by_id(1)
+  hero2.add_state(3)
+  hero2.set_hp(hero2.max_hp - 5)
+  st2.party.apply_map_step_damage(gain_table, 1)
+  eq false, st2.party.map_step_damaged?, 'a bare GAIN-type tick never counts as damage'
+
+  # A LOSE and a GAIN state landing on the same step both apply -- RPG_RT
+  # applies each independently (never sums first), so a net-positive tile
+  # still counts as damaged if any single state on it was a loss.
+  mixed_table = { 2 => fake_state(name: 'Poison', hp_map_steps: 1, hp_map_val: 1),
+                  3 => fake_state(name: 'Regen', hp_map_steps: 1, hp_map_val: 10,
+                                  hp_change_type: Game::States::CHANGE_TYPE_GAIN) }
+  st3 = party_state
+  hero3 = st3.party.actor_by_id(1)
+  hero3.add_state(2)
+  hero3.add_state(3)
+  hero3.set_hp(hero3.max_hp - 20)
+  before = hero3.hp
+  st3.party.apply_map_step_damage(mixed_table, 1)
+  eq before + 9, hero3.hp, 'net +10 gain - 1 loss = +9, still an overall heal'
+  eq true, st3.party.map_step_damaged?, 'the loss half still counts as damage despite the net heal'
+end
+
 check 'two slipping states stack rather than the worse one winning' do
   # The battle-side effects pick a single significant state; the map drain is
   # summed, so a doubly-afflicted member loses both amounts on a step that is a

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -442,7 +442,14 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                  # waking anyone back up mid-test.
                  6 => OpenStruct.new(name: 'Stone', color: 8, priority: 90,
                                      restriction: 1, auto_release_prob: 0),
-                 5 => OpenStruct.new(name: 'Silence', color: 5, priority: 10) },
+                 5 => OpenStruct.new(name: 'Silence', color: 5, priority: 10),
+                 # RPG2003's `hp_change_type` GAIN counterpart to Poison above:
+                 # the same map-step interval/amount fields, but healing --
+                 # exercises the flash-suppression half of
+                 # Game::Party#map_step_damaged?.
+                 7 => OpenStruct.new(name: 'Regen', color: 3, priority: 20,
+                                     hp_change_map_steps: 4, hp_change_map_val: 1,
+                                     hp_change_type: 1) },
     # A tiny item table the Open Shop window prices its goods from.
     item: { 3 => OpenStruct.new(name: 'Potion', price: 100),
             5 => OpenStruct.new(name: 'Herb', price: 40) },
@@ -14395,6 +14402,25 @@ check 'walking slips HP from a poisoned member every fourth tile' do
   walk(scene, 1)
   eq 4, st.steps
   eq 99, hero.hp, 'the fourth tile slips 1 HP'
+end
+
+# Ports EasyRPG's `Game_Party::ApplyStateDamage` (src/game_party.cpp): its
+# `damage` bool is only ever set inside a `ChangeType_lose` branch, never a
+# `ChangeType_gain` one, and `Game_Player::UpdateNextMovementAction` gates the
+# red step-damage flash on exactly that bool. Regen's map-step tick heals, so
+# it must never redden the screen the way Poison's does.
+check "walking a GAIN-type state's own map-step tick heals without flashing the screen" do
+  hero = SlipActor.new([7], 90)                         # Regen
+  scene = new_scene({}, player: [0, 0], members: [hero])
+  st = scene.instance_variable_get(:@state)
+
+  walk(scene, 3)
+  eq 90, hero.hp, 'not a multiple of the interval yet'
+  ok !st.screen.flashing?
+
+  walk(scene, 1)
+  eq 91, hero.hp, 'the fourth tile heals 1 HP'
+  ok !st.screen.flashing?, 'a GAIN-type tick never flashes the screen, unlike a LOSE one'
 end
 
 check 'walking a damaging terrain takes HP every tile' do


### PR DESCRIPTION
## Summary
- `Scene::Map#note_party_step` (`mruby-rpg2k/mrblib/scene/map.rb`) flashed the screen whenever `Party#apply_map_step_damage`'s returned array was non-empty at all — heal included, since the only guard was "did anything change." A GAIN-type (regen) status condition's own map-step tick therefore healed the party *and* flashed the screen red, as if damage had been taken.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Party::ApplyStateDamage` (`src/game_party.cpp`) sets its `damage` return bool only inside a state's `ChangeType_lose` branch — the `ChangeType_gain` branch heals the actor but leaves `damage` untouched — and `Game_Player::UpdateNextMovementAction` (`src/game_player.cpp`) gates `Game_Screen::FlashMapStepDamage` on exactly that bool.
- This is the state-side twin of an already-fixed, already-tested terrain rule (a negative-`damage` terrain tile heals without flashing) — the state side of the same "your HP just fell and the map has nowhere to say so" moment was never given the equivalent exemption.
- Fixed with a new `Game::Party#map_step_damaged?`, tracking (per state, not on the summed net delta — RPG_RT applies each state independently, so a LOSE and a GAIN state landing on the same step both apply, and the tile still counts as damaged if any single state on it was a loss, even when the net HP change is a heal) whether the most recent `#apply_map_step_damage` call included an actual loss; `#note_party_step`'s flash condition now checks that flag (or the existing terrain-damage flag) instead of the returned array's emptiness.

## Test plan
- New `scripts/rpg2k_logic_check.rb` unit check on `#map_step_damaged?` itself (LOSE, bare GAIN, and mixed LOSE+GAIN-net-heal) and a new `scripts/rpg2k_scene_check.rb` end-to-end walking check, both confirmed to fail against the pre-fix code before the fix, via `git stash`.
- All four CRuby suites pass (915 + 631 + save/load + 130 checks), the native `rpg_maker_clone` target rebuilds cleanly, and `ninja test` (native mruby suite) passes.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_