### PR TITLE
Lock a battler's do-nothing restriction at queue time, not dequeue

### DIFF
--- a/changelog.d/battle-restriction-locked-at-queue.fixed.md
+++ b/changelog.d/battle-restriction-locked-at-queue.fixed.md
@@ -1,0 +1,6 @@
+- **Battle** a battler asleep/paralysed when the round's turn order is built
+  no longer regains its turn just because the restriction is cured by
+  something else before its own turn comes up — RPG_RT locks "cannot act" in
+  once the queue is built (or the instant a restriction lands mid-round), and
+  never reverses it, confirmed against EasyRPG's `SelectNextActor`/
+  `PrepareBattleAction`/`Game_Battler::AddState`. See ADR 0052.

--- a/docs/adr/0052-battle-restriction-locked-at-queue-time.md
+++ b/docs/adr/0052-battle-restriction-locked-at-queue-time.md
@@ -1,0 +1,130 @@
+# 52. A do-nothing restriction is locked in when a battler's turn is queued, not re-checked live when it runs
+
+Date: 2026-08-15
+
+## Status
+
+Accepted
+
+## Context
+
+`Game::Battle#step`/`#step_action` call `#apply_turn_states(b)` on a battler
+the instant it is dequeued and about to act. That method rolls the battler's
+states for auto-recovery, applies slip HP/SP, and returns whether the battler
+may act at all this turn (`false` for a still-active "do nothing" restriction
+-- asleep/paralysed). Because it reads `b.states` live, at dequeue time, a
+battler who was asleep when this round's turn order was built but gets cured
+by *something else* before its own turn comes up -- an ally's Esna/Cure this
+same round, or any other mid-round state removal -- was allowed to act.
+
+Found via community デフォ戦bot trivia: "once afflicted with a 'cannot act'
+status, even if it's cured before your turn comes up, you still can't act
+that turn; the same goes for Silence blocking magic." Checked against
+EasyRPG's real source rather than trusted from the trivia alone, the same
+discipline PR #861 (mid-battle party roster sync) and PR #883 (self-destruct/
+hidden) applied earlier this session:
+
+- `Scene_Battle_Rpg2k::SelectNextActor`/`CreateEnemyActions`
+  (`src/scene_battle_rpg2k.cpp`) decide each battler's action for the round.
+  For an actor: `if (!active_actor->CanAct()) { SetBattleAlgorithm(None);
+  battle_actions.push_back(active_actor); ... }` -- a restricted battler is
+  queued with a `None` algorithm right there, at selection time, before the
+  round's `battle_actions` queue is even sorted by `CreateExecutionOrder`.
+- `Game_Battler::AddState` (`src/game_battler.cpp`) fires whenever a state
+  lands on a battler mid-round, live: if the battler's `GetSignificantRestriction()`
+  is no longer `Restriction_normal` (or, for a queued Skill, the skill itself
+  becomes unusable -- Silence), it overrides that battler's *already-queued*
+  algorithm to `None`, again right there, live -- this is what stops a
+  battler who was fine at selection time but gets put to sleep by an earlier
+  action this same round.
+- `Scene_Battle::PrepareBattleAction` (`src/scene_battle.cpp`) runs again
+  immediately before each queued action actually executes (`ePreAction`,
+  right before `eBattleAction`): `if (!battler->CanAct()) { if (...GetType()
+  != None) SetBattleAlgorithm(None); return; }`. This can only ever *tighten*
+  the lock (force `None` if not already); it has no branch that turns an
+  already-`None` algorithm back into a real one.
+- `ProcessBattleActionBegin` (`src/scene_battle_rpg2k.cpp`), the very start of
+  running a queued action, calls `BattleStateHeal()`/`ApplyConditions()` --
+  this codebase's own `#apply_turn_states` -- unconditionally, live, at this
+  exact moment (the same relative timing this codebase already used). But its
+  result (a state healing right here, or not) never feeds back into which
+  algorithm runs: `ProcessBattleActionUsage`'s own gate is `if
+  (action->GetType() == None) { finish without acting; }`, checked against
+  whatever `PrepareBattleAction` already decided, upstream of this call.
+
+So real RPG_RT's "can this battler act" decision is a **one-way lock**, not a
+live read: a battler is barred from acting the moment a do-nothing (or, for a
+queued Skill, silence) restriction is true -- at selection/queue time, or the
+instant one lands mid-round via `AddState` -- and nothing in the reference
+ever reverses that lock for the rest of the round, no matter what cures the
+underlying state afterward, including the battler's own turn-start heal roll
+running in that same call. This codebase's live re-check at dequeue got the
+"newly restricted mid-round" half of that right (by accident of always
+re-reading current `states`) but missed the "cured before the queued turn
+runs" half entirely.
+
+## Decision
+
+- `Combatant` gains one field, `queued_no_act` (nil/false = "not locked",
+  matching every existing fixture that never goes through `#refill_queue` at
+  all -- direct `Game::Battle.new` construction followed by `#run`/`#run_round`
+  without `#begin_round` still calls `#refill_queue` via `#step`, so this is
+  covered, but a bare `#apply_turn_states(b)` call in isolation, as a few
+  older checks still do, is unaffected).
+- `#refill_queue` snapshots it once the round's queue is built: `@queue.each
+  { |b| b.queued_no_act = do_nothing_restricted?(b) }`, mirroring
+  `SelectNextActor`/`CreateEnemyActions`'s `!CanAct()` check at the same
+  relative point (nothing acts between queue-build and this snapshot, so
+  checking here is equivalent to checking at selection time).
+- `#step` and `#step_action` still call `#apply_turn_states(b)` unconditionally
+  at dequeue -- slip damage, regen and the auto-recovery roll are real,
+  visible effects that must still happen even for a battler who cannot act --
+  but now additionally force `can_act = false if b.queued_no_act`, so a lock
+  set at queue time (or picked up live by the unchanged `#apply_turn_states`
+  read, for the "newly restricted mid-round" case `AddState` covers) always
+  wins over anything that clears the state in between.
+
+Deliberately not attempted: the full bidirectional ratchet EasyRPG's
+`AddState`/`RemoveStates` implement, where a state landing on a battler
+*after* the round's queue was built also permanently locks that battler out
+even if it is cured again before their own turn -- e.g. afflicted by an
+earlier ally's stray effect, then cured by a second effect, all before this
+battler's own queued turn, in the same round. That would need hooking every
+site in this codebase that inflicts a state on a battler mid-battle (skill
+effects, weapon-on-attack states, counter effects, ...) to also set
+`queued_no_act`, which is a much larger, invasive change touching call sites
+across the skill/attack system rather than the two queue/dequeue points this
+fix touches. The `#apply_turn_states` live read at dequeue still catches the
+much more common case -- restricted mid-round and *still* restricted at
+dequeue -- unchanged; only the narrower double-flip inside one round is out
+of scope here, and does not match the trivia's own claim, which is about a
+single cure before the queued turn, not a cure-after-a-second-affliction.
+
+The Silence half of the trivia ("cured before your turn, still can't use
+magic") is the same lock mechanism from RPG_RT's side (a Skill queued before
+Silence lands has its algorithm forced to `None`/skipped by `AddState`'s
+`IsSkillUsable` recheck, same as the do-nothing case), but this codebase does
+not yet consult `#skill_sealed?` when a skill command is being selected at
+all (a battler can freely queue and cast a sealed skill today -- see
+`#skill_sealed?`'s own comment: "nothing consulted either field"). That gap
+is unrelated to timing and pre-dates this fix; it is not touched here.
+
+## Consequences
+
+A battler asleep/paralysed when this round's queue was built loses that
+turn even if the state clears by some other means before its own turn comes
+up -- matching real RPG_RT, not the live-recheck this codebase had before. A
+battler who becomes newly restricted mid-round, before their own queued turn,
+still correctly loses that turn too (unchanged, still covered by the live
+`#apply_turn_states` read `queued_no_act` is OR'd against, not replaced by).
+Every other `#apply_turn_states` call site -- direct calls in older checks
+that never go through `#refill_queue` -- is unaffected, since `queued_no_act`
+defaults to falsy.
+
+Covered by two new checks in `scripts/rpg2k_logic_check.rb`, each written to
+fail under the *other* implementation as well as the pre-fix one: a do-nothing
+restriction present when the queue is built still blocks the turn even after
+the state is cleared before dequeue (fails under a purely-live recheck); a
+do-nothing restriction that lands only after the queue is built still blocks
+the turn live (fails under a purely queue-time-locked implementation with no
+live recheck at all).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7987,7 +7987,29 @@ module Game
                            # exact object rather than rebuilding a fresh one
                            # and losing its accumulated battle-only state (see
                            # this Struct's own class comment).
-                           :member) do
+                           :member,
+                           # Whether this battler was under a "do nothing"
+                           # restriction (asleep/paralysed) at the moment its
+                           # action entered this round's queue (#refill_queue),
+                           # snapshotted there and consulted -- not
+                           # re-derived -- when the action is dequeued
+                           # (#step/#step_action). See #apply_turn_states'
+                           # own comment for why a live re-check at dequeue
+                           # time is wrong: EasyRPG's `PrepareBattleAction`
+                           # (src/scene_battle.cpp) locks a restricted
+                           # battler's queued algorithm to `None` right when
+                           # it is chosen (`Scene_Battle_Rpg2k::
+                           # SelectNextActor`/`CreateEnemyActions`) or first
+                           # afflicted mid-round (`Game_Battler::AddState`),
+                           # and nothing in the reference ever reverses that
+                           # once the restriction later clears -- curing
+                           # Sleep/Paralysis after the round's queue is built
+                           # does not give the battler its turn back. nil
+                           # (never queued this round yet) reads as "not
+                           # locked", matching every existing fixture that
+                           # calls #apply_turn_states directly without going
+                           # through #refill_queue first.
+                           :queued_no_act) do
       def dead?; hp <= 0; end
 
       # Swings per basic attack: 2 with a 二刀流 weapon, 1 otherwise. Struct
@@ -8415,6 +8437,11 @@ module Game
         # once the action lands (EasyRPG's Scene_Battle::NextTurn).
         b.next_battle_turn
         can_act = apply_turn_states(b)
+        # A do-nothing restriction locked in when this round's queue was
+        # built (or picked up live, above, from one inflicted since) always
+        # wins over a cure that landed in between -- see the Combatant
+        # `queued_no_act` field's own comment.
+        can_act = false if b.queued_no_act
         next if b.dead? || !can_act
         entry = record_action(strike(b))
         next unless entry # attacker had no living target; try the next
@@ -8926,6 +8953,10 @@ module Game
         # (which cannot itself knock it out -- see apply_turn_states) and, if it
         # cannot act (asleep / paralysed), its turn is skipped.
         can_act = apply_turn_states(b)
+        # ...unless a do-nothing restriction was already locked in when this
+        # round's queue was built -- see #step's own comment and the
+        # Combatant `queued_no_act` field's.
+        can_act = false if b.queued_no_act
         next if b.dead? || !can_act
         entry = record_action(strike(b))
         next unless entry
@@ -9137,6 +9168,16 @@ module Game
       # A pre-emptive first strike catches the enemies off guard: they skip the
       # opening round, so only the party acts in round 1.
       @queue = @queue.reject { |b| side_of(b) == :enemy } if @first_strike && @rounds == 1
+      # Lock in "cannot act" for the round right here, matching EasyRPG's
+      # `SelectNextActor`/`CreateEnemyActions` (`!CanAct()` -> a `None`
+      # algorithm queued on the spot) -- see the Combatant `queued_no_act`
+      # field's own comment. #apply_turn_states still runs live at dequeue
+      # for slip damage/auto-recovery and to catch a battler newly afflicted
+      # *after* this point but before its own turn (mirrors
+      # `Game_Battler::AddState`'s live override); this flag only ever adds
+      # to that, it never lets a battler restricted here act again once its
+      # state clears before its turn comes up.
+      @queue.each { |b| b.queued_no_act = do_nothing_restricted?(b) }
     end
 
     # Re-derive @allies from the live Game::Party (`party:` on #initialize) --

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11425,6 +11425,83 @@ check 'battle: a "do nothing" state (restriction 1) skips the turn' do
   eq 100, slime.hp                                   # the asleep hero never struck
 end
 
+# デフォ戦bot: "once afflicted with a 'cannot act' state, curing it before your
+# turn comes up still doesn't let you act that turn; likewise Silence cured
+# before your turn still blocks magic." Checked directly against EasyRPG's
+# real source rather than trusted from the trivia alone (`SelectNextActor`/
+# `CreateEnemyActions`, `PrepareBattleAction`, `Game_Battler::AddState`, all
+# in `src/scene_battle*.cpp`/`game_battler.cpp`): a do-nothing restriction
+# (`!CanAct()`) locks an actor's queued algorithm to `Game_BattleAlgorithm::
+# None` the moment it is decided -- at `SelectNextActor`/`CreateEnemyActions`
+# (queue-build time) if already restricted then, or live via `AddState`'s own
+# override if the restriction lands later, mid-round, before the actor's
+# queued turn runs. Nothing in the reference ever reverses that lock once set
+# -- `PrepareBattleAction`, which runs again immediately before each queued
+# action executes, only ever *tightens* it (`!CanAct()` -> force `None`); it
+# never turns an already-`None` algorithm back into a real one, even when
+# `BattleStateHeal`/`ApplyConditions` (this codebase's own #apply_turn_states)
+# cures the state in that exact same call. #refill_queue's new `queued_no_act`
+# snapshot (Combatant field) and #step/#step_action's `can_act = false if
+# b.queued_no_act` port this lock; the live #apply_turn_states recheck stays,
+# since it is what still catches a battler newly restricted *after* the
+# queue was built (mirrors `AddState`'s own live override) -- these two
+# checks are written to fail under either a purely-live implementation (the
+# first) or a purely-locked-at-queue-time-only implementation (the second),
+# not just under the code as it stood before this fix.
+check 'battle: a do-nothing restriction locked in when queued still blocks a turn cured before it resolves' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) } # do-nothing, 0% auto-release
+  healthy = combatant('Healthy', 40, 0, 100, 100)         # fast -- acts first
+  sleepy = combatant('Sleepy', 40, 0, 1, 100)             # slow -- acts second, asleep at queue time
+  sleepy.states = [8]
+  slime = combatant('Slime', 0, 0, 5, 100_000)            # punching bag, stays alive through the round
+  bat = Game::Battle.new([healthy, sleepy], [slime], Game::Rng.new(1), states)
+
+  bat.begin_round
+  eq true, sleepy.queued_no_act, 'locked in as unable to act when this round\'s queue was built'
+
+  first = bat.step_action
+  eq 'Healthy', first[:attacker], 'the fast ally goes first'
+
+  # A cure lands on Sleepy before its own queued turn comes up -- an ally's
+  # Esna/Cure this same round, auto-release, anything; the mechanism does not
+  # matter here, only that the state is gone by the time Sleepy is dequeued.
+  sleepy.states = []
+
+  entries = []
+  loop { e = bat.step_action; break unless e; entries << e }
+  bat.end_round
+  ok entries.none? { |e| e[:attacker] == 'Sleepy' },
+     'cured before its turn, but the queue already locked this round\'s turn out -- a purely-live ' \
+     'recheck at dequeue (no states left) would wrongly let Sleepy act here'
+end
+
+check 'battle: a do-nothing state inflicted after queueing still blocks the turn live' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) } # do-nothing, 0% auto-release
+  healthy = combatant('Healthy', 40, 0, 100, 100)         # fast -- acts first
+  victim = combatant('Victim', 40, 0, 1, 100)             # fine at queue time, acts second
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([healthy, victim], [slime], Game::Rng.new(1), states)
+
+  bat.begin_round
+  eq false, victim.queued_no_act, 'not restricted yet when this round\'s queue was built'
+
+  first = bat.step_action
+  eq 'Healthy', first[:attacker]
+
+  # Something in the round (an earlier ally/enemy action, a troop page) puts
+  # Victim to sleep before its own queued turn comes up -- EasyRPG's
+  # Game_Battler::AddState overrides an already-queued action to None the
+  # moment this happens, live, not only at the round's original queue-build.
+  victim.states = [8]
+
+  entries = []
+  loop { e = bat.step_action; break unless e; entries << e }
+  bat.end_round
+  ok entries.none? { |e| e[:attacker] == 'Victim' },
+     'newly afflicted before its turn -- a purely queue-time-locked implementation (no live ' \
+     'recheck at dequeue) would wrongly let Victim act here'
+end
+
 check 'battle poison slips SP too when the battler has max SP' do
   states = { 4 => FakeStateDef.new(0, 3, 0, 2, 0) }  # 3 HP + 2 SP / turn
   mage = combatant_mp('Mage', 40, 0, 20, 100, 10)


### PR DESCRIPTION
## Summary

- `Game::Battle#step`/`#step_action` re-derived a battler's "can act" status live, right when it was dequeued, by re-reading its current `states` — so a battler asleep/paralysed when the round's queue was built could act after all if something cured the state before its own turn came up.
- Verified against EasyRPG's real source (not trusted from the community デフォ戦bot trivia alone, same discipline as #861/#883 earlier this session): `SelectNextActor`/`CreateEnemyActions` queue a `None` algorithm for a restricted battler the instant its action is decided; `Game_Battler::AddState` overrides an already-queued action to `None` live if a restriction lands mid-round; `PrepareBattleAction` (run again immediately before each queued action executes) only ever *tightens* that lock, never reverses it — not even when the battler's own turn-start heal roll (`BattleStateHeal`/`ApplyConditions`, this codebase's `#apply_turn_states`) cures the state in that same call. The trivia's claim held up.
- `Combatant` gains `queued_no_act`, snapshotted by `#refill_queue` when the round's turn order is built (mirrors `SelectNextActor`/`CreateEnemyActions`'s timing) and consulted at dequeue in `#step`/`#step_action`, alongside the existing live `#apply_turn_states` recheck — which still catches a restriction landing *after* the queue was built, matching `AddState`'s own live override. Neither check replaces the other.
- Does not touch the mid-battle party roster sync (`member?`/`out_of_play?`) PR #861 added, or the RPG2003 alternate battle screen.
- ADR: `docs/adr/0052-battle-restriction-locked-at-queue-time.md` (also documents a deliberately out-of-scope edge case: a restriction inflicted *and* cured again, both within the same round before the battler's own turn — would need hooking every state-infliction site, a much larger change than this fix).

## Test plan

- [x] Two new checks in `scripts/rpg2k_logic_check.rb`, each written to fail under the *other* interpretation (not just the pre-fix code): a restriction present at queue-build time still blocks the turn after being cured before dequeue (fails under a purely-live recheck); a restriction landing only after queue-build still blocks the turn (fails under a purely queue-time-locked implementation with no live recheck).
- [x] `ruby scripts/rpg2k_logic_check.rb` — 916 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 630 checks passed
- [x] Native build (`scripts/native-build-without-nix.bash`, `ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01F3Dnwqz6fmNov57NjSiZzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3Dnwqz6fmNov57NjSiZzX)_