### PR TITLE
Default an unrecognized Conditional Branch type to false, not true

### DIFF
--- a/changelog.d/rpg2k-conditional-branch-unknown-type-defaults-false.fixed.md
+++ b/changelog.d/rpg2k-conditional-branch-unknown-type-defaults-false.fixed.md
@@ -1,0 +1,8 @@
+- **A Conditional Branch of an unrecognized type now takes the else branch,
+  instead of always taking the true one.** Confirmed against EasyRPG
+  Player's source: an unhandled condition type (RPG Maker 2003 v1.11's own
+  "EX conditions" — savestate available, Test Play, ATB-wait, fullscreen —
+  or a Maniac Patch type) defaults to false. This build defaulted such a
+  branch to true, so any project using one of these newer condition types
+  always ran the wrong branch — most seriously, a debug/cheat-content gate
+  meant to hide under normal play would instead always show.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6248,6 +6248,33 @@ not yet verified:
   `#map_step_damaged?` itself (LOSE, bare GAIN, and mixed LOSE+GAIN-net-heal)
   and a new `scripts/rpg2k_scene_check.rb` end-to-end walking check, both
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **A Conditional Branch of an unrecognized type now takes the else branch,
+  instead of always taking the true one.** Confirmed against EasyRPG's
+  actual C++ source: `Game_Interpreter::CommandConditionalBranch`
+  (`src/game_interpreter.cpp`, code 12010) initializes its local `result` to
+  `false` before the type switch, and its `default:` arm — reached by any
+  condition type the switch has no `case` for — only logs a warning, never
+  touching `result`, so it stays at its initial `false` and the interpreter
+  falls to the else branch. `Interpreter#eval_condition`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) handles types 0–10 (switch, variable,
+  timer, gold, item, actor, orientation, vehicle, decision-key,
+  BGM-looped, Timer2) but ended its `case` with `else true` — the exact
+  opposite default. This is reachable on real data: RPG Maker 2003 v1.11
+  added an official type-11 "EX condition" (savestate available / Test Play
+  / ATB-wait / fullscreen), and the Maniac Patch adds several more (12–16)
+  — none of which this build's `eval_condition` recognizes, so every one of
+  them silently always took the true branch. Concretely: a type-11/param1=1
+  ("Is Test Play mode?") branch gating debug/cheat content so it only shows
+  under Test Play — EasyRPG's `result` stays `false` outside Test Play (the
+  event's `default:` catches the unimplemented type-11 case exactly the
+  same as a type this codebase has never heard of), taking the else branch
+  and hiding the debug content from ordinary players; this build took the
+  **true** branch unconditionally, exposing the debug content to every
+  player regardless of Test Play state. Fixed by flipping the fallback from
+  `true` to `false`, a one-line change with no redesign implied. Covered by
+  a new `scripts/rpg2k_logic_check.rb` check driving a type-11 Conditional
+  Branch through a full true/else pair and asserting the else branch ran,
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2553,7 +2553,17 @@ module Game
         @state.bgm_looped ? true : false
       when 10 # RPG2003's second timer, laid out exactly like type 2
         timer_condition(cmd, 1)
-      else true
+      else
+        # An unhandled/unsupported branch type (RPG2003 v1.11's own type 11
+        # "EX" conditions -- savestate available, Test Play, ATB-wait,
+        # fullscreen -- Maniac Patch types 12-16, or malformed data) defaults
+        # to false, taking the else branch, not the true one. Confirmed
+        # against EasyRPG's `Game_Interpreter::CommandConditionalBranch`
+        # (src/game_interpreter.cpp): `result` is initialized `false` at the
+        # top of the function and is only ever set inside a matched `case`;
+        # its `default:` arm only logs a warning, leaving `result` at its
+        # initial `false`.
+        false
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2647,6 +2647,26 @@ check 'Control Variables and Conditional Branch read the second timer' do
   eq 2, st.variables[3], 'type 2 still reads the first timer'
 end
 
+# Ports EasyRPG's `Game_Interpreter::CommandConditionalBranch`
+# (src/game_interpreter.cpp): its local `result` is initialized `false`
+# before the type switch, and the `default:` arm (any condition type it
+# doesn't recognize -- RPG2003 v1.11's own type 11 "EX" conditions, a
+# Maniac Patch type, or malformed data) only logs a warning, never touching
+# `result` -- so an unhandled type takes the *else* branch, not the true
+# one.
+check 'Conditional Branch: an unrecognized condition type defaults to false, not true' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONDITIONAL, [11, 0, 0], indent: 0), # type 11: unhandled here
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+            FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+            FakeCmd.new(IC::END_BRANCH, [], indent: 0)])
+  it.update
+  ok !st.switches[1], 'the true branch did not run'
+  ok st.switches[2], 'an unrecognized type falls through to the else branch'
+end
+
 # -- Memorize / Recall Location ----------------------------------------------
 
 check 'Memorize Location stores map/x/y into three variables' do


### PR DESCRIPTION
## Summary
- `Interpreter#eval_condition` (`mruby-rpg2k/mrblib/interpreter.rb`) handles Conditional Branch types 0–10 (switch, variable, timer, gold, item, actor, orientation, vehicle, decision-key, BGM-looped, Timer2) but ended its `case` with `else true` — so any condition type it doesn't recognize always took the *true* branch.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Interpreter::CommandConditionalBranch` (`src/game_interpreter.cpp`, code 12010) initializes its local `result` to `false` before the type switch, and its `default:` arm — reached by any unhandled condition type — only logs a warning, never touching `result`, so it stays `false` and the interpreter falls to the else branch.
- This is reachable on real data: RPG Maker 2003 v1.11 added an official type-11 "EX condition" (savestate available / Test Play / ATB-wait / fullscreen), and the Maniac Patch adds several more (12–16) — none of which this build recognizes. Most notably, a type-11/param1=1 ("Is Test Play mode?") branch gating debug/cheat content so it only shows under Test Play would, in EasyRPG, correctly hide that content from ordinary players (falls to else outside Test Play); this build instead exposed it to every player unconditionally.
- Fixed by flipping the fallback from `true` to `false` — a one-line change with no redesign implied.

## Test plan
- New `scripts/rpg2k_logic_check.rb` check drives a type-11 Conditional Branch through a full true/else pair and asserts the else branch ran, confirmed to fail against the pre-fix code before the fix, via `git stash`.
- All four CRuby suites pass (916 + 631 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_