### PR TITLE
Gate in-battle skill selection on the weapon-Attribute equip requirement

### DIFF
--- a/changelog.d/battle-skill-weapon-attribute-gate.fixed.md
+++ b/changelog.d/battle-skill-weapon-attribute-gate.fixed.md
@@ -1,0 +1,16 @@
+- **The in-battle skill menu now respects a skill's weapon-Attribute
+  equip-gate, matching the field menu and Forced-AI.** `Game::Party
+  #battle_skills`/`#battle_skill_command` never consulted `#can_cast?`/
+  `#weapon_attribute_ready?` at all, unlike the field menu's `#cast_skill`
+  (gated on `#can_cast?`) and a Forced-AI actor's own eligibility check
+  (`Game::Battle#skill_ready?`, which already reuses `#can_cast?`) — so a
+  player could select and land a weapon-Attribute skill in battle with no
+  matching weapon equipped, full effect and all. `Scene::Map
+  #confirm_battle_skill` now also checks `#weapon_attribute_ready?` alongside
+  its existing SP-affordability check, Buzzing and staying on the list when
+  either fails — mirroring the field menu's own "listed, but a cast attempt
+  quietly fails" pattern (this codebase never renders a greyed-out state for
+  either menu) rather than excluding the skill from the list. An
+  item-triggered skill cast still bypasses the gate entirely, unaffected.
+  Covered by new `scripts/rpg2k_logic_check.rb` and `scripts/
+  rpg2k_scene_check.rb` checks.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5695,18 +5695,23 @@ class RPG2k
         end
       end
 
-      # Choose the highlighted skill: if the caster cannot afford its SP, this
-      # is RPG_RT's own Buzzer case (`SkillSelected`'s `CheckEnable` covers
-      # affordability); otherwise Decision, then route to enemy / ally target
-      # selection (or cast at once on a self-scope skill).
+      # Choose the highlighted skill: if the caster cannot afford its SP, or is
+      # missing a weapon-type Attribute the skill requires
+      # (`Game::Party#weapon_attribute_ready?` -- the same equip-gate
+      # `#can_cast?` already applies to a field cast and to a Forced-AI actor's
+      # own skill eligibility, see `Game::Battle#skill_ready?`), this is
+      # RPG_RT's own Buzzer case (`SkillSelected`'s `CheckEnable` covers both);
+      # otherwise Decision, then route to enemy / ally target selection (or
+      # cast at once on a self-scope skill).
       def confirm_battle_skill
         sid, cost = @battle_ui[:skills][@battle_ui[:skill_i]]
-        if current_actor.mp < cost # can't afford: stay on the list
+        sk = @state.party.db_skill(sid)
+        if current_actor.mp < cost ||
+           !@state.party.weapon_attribute_ready?(current_actor_row, sk)
           play_system_se(SFX_BUZZER)
           return
         end
         play_system_se(SFX_DECISION)
-        sk = @state.party.db_skill(sid)
         @battle_ui[:pending] = { kind: :skill, sk: sk, sid: sid }
         close_battle_skill
         case @state.party.battle_skill_target(sk)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5819,6 +5819,35 @@ check "can_cast?: a weapon-type Attribute skill needs a weapon carrying it equip
   eq true, st.party.can_cast?(hero, 8)
 end
 
+check 'a special item invoking a weapon-Attribute-gated skill bypasses the ' \
+      'equip gate entirely' do
+  # デフォ戦bot: an ally *casting* a weapon-Attribute skill needs the matching
+  # weapon equipped, but triggering the identical skill through an item does
+  # not -- the item pays for the cast instead, the same way #cast_skill's
+  # `free:` already skips the rest of #can_cast? for an item-triggered cast
+  # (see "a special item invokes its skill, free of SP..." above). No weapon
+  # equipped at all here, matching #can_cast?'s own "no weapon at all -- the
+  # attribute is unmet" refusal above.
+  props = { 1 => AttrTypeRow.new(0) } # attribute 1 is weapon-type
+  skills = { 7 => fake_skill(name: 'Aura Slash', scope: 3, sp_cost: 5, power: 40,
+                             hp: true, attribute_effects: [true]) }
+  items = { 3 => fake_item(type: 9, skill_id: 7, name: 'Vial') }
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  st = Game::State.new(
+    Game::Party.new(FakeActorDB.new(players, [1], items, skills, {}, nil, props)), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(7)
+  hero.change_hp(-50)
+  eq false, st.party.can_cast?(hero, 7), 'casting it directly is refused: no weapon equipped'
+
+  st.party.gain_item(3, 1)
+  affected = st.party.use_item(3, hero)
+  eq [hero], affected, 'the item-triggered cast lands with no weapon equipped at all'
+  eq 90, hero.hp, 'the skill effect actually applied'
+  eq 0, st.party.item_count(3), 'consumed -- the item paid for it, not a weapon'
+end
+
 # Ports EasyRPG's `Game_Actor::GetBaseAttributeRate` (src/game_actor.cpp): a
 # shield/armor/helmet/accessory that flags an attribute in its own
 # `attribute_set` grants the wearer a flat +1 defensive rank for that

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8615,6 +8615,10 @@ class BattleMagicParty
   def db_skill(id); id == 1 ? OpenStruct.new(name: 'Fire', scope: 0) : nil; end
   def battle_skill_target(sk); sk.scope == 0 ? :enemy : :ally; end
   def battle_skill_command(_sk, _caster, _target); { cost: 3, hp: -15, mp: 0 }; end
+  # A skill's weapon-type Attribute requirement -- true (unrestricted) by
+  # default, so every check predating the equip-gate stays on its own path;
+  # see BattleWeaponGateParty below for a check that flips this.
+  def weapon_attribute_ready?(_caster, _sk); true; end
   def battle_items
     @items.keys.sort.select { |id| item_count(id) > 0 }.map { |id| [id, item_count(id)] }
   end
@@ -8816,6 +8820,75 @@ check 'Enemy Encounter scene: confirming an unaffordable skill plays Buzzer, ' \
   press_key(scene, RGSS::Input::C) # try Fire, can't afford it
   eq :skill, ui[:phase], 'an unaffordable skill leaves the player on the list'
   eq 'Buzzer1', RGSS::Audio.se_calls.last[0], 'and plays Buzzer instead of Decision'
+end
+
+# A party whose Fire skill requires a weapon-type Attribute the Hero starts
+# without -- `weapon_ready` flips what Game::Party#weapon_attribute_ready?
+# answers, standing in for equipping the matching weapon (the real equip
+# mechanics are covered by rpg2k_logic_check.rb's own "can_cast?: a
+# weapon-type Attribute skill needs a weapon carrying it equipped" check;
+# this only asserts Scene::Map#confirm_battle_skill wires the answer in).
+class BattleWeaponGateParty < BattleMagicParty
+  attr_accessor :weapon_ready
+  def initialize(hurt: false)
+    super(hurt: hurt)
+    @weapon_ready = false
+  end
+  def weapon_attribute_ready?(_caster, _sk); @weapon_ready; end
+end
+
+check 'Enemy Encounter scene: confirming a skill missing its required weapon ' \
+      'Attribute plays Buzzer, not Decision, and stays on the list -- equipping ' \
+      'the matching weapon makes it castable again' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  party = BattleWeaponGateParty.new
+  st.instance_variable_set(:@party, party)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::C)    # open the skill list
+  eq :skill, ui[:phase]
+
+  RGSS::Audio.reset_se
+  press_key(scene, RGSS::Input::C) # try Fire, missing the required weapon Attribute
+  eq :skill, ui[:phase], 'a skill missing its weapon Attribute leaves the player on the list'
+  eq 'Buzzer1', RGSS::Audio.se_calls.last[0], 'and plays Buzzer instead of Decision'
+
+  party.weapon_ready = true # the matching weapon is now equipped
+  RGSS::Audio.reset_se
+  press_key(scene, RGSS::Input::C) # try Fire again
+  eq :target, ui[:phase], 'the very same skill casts once the weapon requirement is met'
+  eq 'Decision1', RGSS::Audio.se_calls.last[0]
+end
+
+check 'Enemy Encounter scene: an item-triggered heal bypasses the weapon-Attribute ' \
+      'gate -- no skill-eligibility check runs for it at all' do
+  # Regression guard: #confirm_battle_skill's new weapon-Attribute check lives
+  # entirely on the Skill sub-menu path -- the Item sub-menu never calls
+  # #weapon_attribute_ready? (Game::Party#battle_item_command is pure HP/SP
+  # arithmetic, matching the field menu's own free: item-cast bypass covered
+  # in rpg2k_logic_check.rb).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  party = BattleWeaponGateParty.new(hurt: true) # weapon_ready stays false throughout
+  st.instance_variable_set(:@party, party)
+  ui = battle_to_command(scene)
+
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  eq :item, ui[:phase]
+  press_key(scene, RGSS::Input::C)    # choose Potion -> ally target
+  eq :ally_target, ui[:phase]
+  press_key(scene, RGSS::Input::C)    # heal the Hero -> round animates
+  eq :animate, ui[:phase], 'the item cast went through with the weapon requirement still unmet'
 end
 
 # A party whose Hero knows no battle skill at all, so Skill's own list opens


### PR DESCRIPTION
## Summary
- `Game::Party#battle_skills`/`#battle_skill_command` never consulted `#can_cast?`/`#weapon_attribute_ready?` at all, unlike the field menu's `#cast_skill` (gated on `#can_cast?`) and a Forced-AI actor's own eligibility check (`Game::Battle#skill_ready?`, which already reuses `#can_cast?`) — so a player could select and land a weapon-Attribute skill in battle with no matching weapon equipped, full effect and all.
- `Scene::Battle#confirm_battle_skill` now also checks `#weapon_attribute_ready?` alongside its existing SP-affordability check, Buzzing and staying on the list when either fails. (Rebased onto master's battle-scene extraction — `confirm_battle_skill` moved from `Scene::Map` to its own `Scene::Battle` class in `mruby-rpg2k/mrblib/scene/battle.rb`; the fix now lives there.)
- Verified against the field menu's own precedent before implementing: this codebase never renders a greyed-out state for either skill menu — `Game::Party#field_skills` lists every type/scope-eligible skill regardless of `can_cast?`, and an uncastable one simply fails silently ("It had no effect") when `#cast_skill` is actually attempted. The battle fix mirrors that same "listed, but a cast attempt quietly fails" pattern rather than excluding the skill from the list, matching this codebase's existing precedent rather than introducing a new visual-disable mechanic real RPG_RT's `Window_Skill::CheckEnable` has but this engine does not implement anywhere.
- An item-triggered skill cast (`ITEM_SPECIAL`/`use_skill` equipment, `cast_skill(..., free: true)`) still bypasses the gate entirely, as before — confirmed unaffected and covered by a regression check.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a special item invoking a weapon-Attribute-gated skill casts successfully with no weapon equipped at all (regression guard for the item-bypass).
- [x] New `scripts/rpg2k_scene_check.rb` checks: confirming a battle skill missing its weapon Attribute plays Buzzer and stays on the list; the same skill casts once the (stubbed) weapon requirement is met; the Item sub-menu path is unaffected by the new check.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 919 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 639 checks passed.
- [x] Native rebuild: `scripts/native-build-without-nix.bash build` then `ninja rpg_maker_clone` — builds clean, `--rgss_effect_probe` render check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxQ4QZ53nm7yT8YFDnYMJv