### PR TITLE
Fix Fade Out BGM fading 100x too slowly

### DIFF
--- a/changelog.d/rpg2k-fadeout-bgm-duration-units.fixed.md
+++ b/changelog.d/rpg2k-fadeout-bgm-duration-units.fixed.md
@@ -1,0 +1,5 @@
+- **Fade Out BGM no longer fades the music 100x too slowly.** Confirmed
+  against EasyRPG Player's source: the event command's duration parameter is
+  already milliseconds, passed straight through with no scaling. This build
+  treated it as tenths of a second and multiplied by 100, turning an
+  intended 0.8-second fade into an 80-second one.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6275,6 +6275,31 @@ not yet verified:
   a new `scripts/rpg2k_logic_check.rb` check driving a type-11 Conditional
   Branch through a full true/else pair and asserting the else branch ran,
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **Fade Out BGM (11520) no longer fades the music over a duration 100x too
+  long.** Confirmed against EasyRPG's actual C++ source:
+  `Game_Interpreter::CommandFadeOutBGM` (`src/game_interpreter.cpp`) passes
+  `com.parameters[0]` straight through to `Game_System::BgmFade` with no
+  scaling at all, and `BgmFade`'s own doc comment (`src/game_system.h`)
+  reads "duration Duration in ms" — corroborated by every other real
+  `BgmFade(...)` call site in EasyRPG (`player.cpp`, `scene_end.cpp`,
+  `scene_map.cpp`), all bare millisecond literals (`400`/`800`) with no
+  conversion. `Interpreter#do_fadeout_bgm`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) instead treated the parameter as
+  *tenths of a second* and multiplied by a `MS_PER_TENTH = 100` constant
+  before calling `RGSS::Audio.bgm_fade` — a unit this codebase's own other
+  `bgm_fade` call site (`Scene::Menu`'s End Game handler,
+  `bgm_fade(400)`) never uses, confirming `RGSS::Audio.bgm_fade` itself
+  already expects milliseconds. Concretely: a designer sets the field to
+  RPG_RT's own common default, `800` — real RPG_RT/EasyRPG fades over
+  800ms (0.8 seconds); this build computed `800 * 100 = 80,000`ms, an
+  80-second fade for what should be under a second. Fixed by removing the
+  `* MS_PER_TENTH` multiplication entirely — the parameter now passes
+  straight through, matching EasyRPG exactly. The pre-existing
+  `scripts/rpg2k_logic_check.rb` "Fade Out BGM" check had baked the wrong
+  `param 20 → 2000ms` conversion directly into its own assertion (masking
+  the bug rather than catching it); its expected value is corrected to the
+  pass-through relationship (`param 2000 → 2000ms`), confirmed to fail
+  against the pre-fix code (`expected 2000, got 200000`) before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3141,16 +3141,24 @@ module Game
       @state.weather.set(cmd.param(0), cmd.param(1))
     end
 
-    # Fade Out BGM (11520): fade the music to silence over param0 tenths of a
-    # second, then leave nothing playing. Clears the current-BGM record so a
-    # Memorize BGM taken afterwards memorises silence, as RPG_RT does.
-    # Non-blocking — the event runs on while the music fades.
-    MS_PER_TENTH = 100
-
+    # Fade Out BGM (11520): fade the music to silence over param0
+    # milliseconds, then leave nothing playing. Clears the current-BGM
+    # record so a Memorize BGM taken afterwards memorises silence, as
+    # RPG_RT does. Non-blocking — the event runs on while the music fades.
+    #
+    # param0 is already milliseconds, not tenths of a second: EasyRPG's
+    # `CommandFadeOutBGM` (src/game_interpreter.cpp) passes
+    # `com.parameters[0]` straight through to `Game_System::BgmFade`, whose
+    # own doc comment (src/game_system.h) reads "duration Duration in ms" --
+    # confirmed by every other real `BgmFade(...)` call site in EasyRPG
+    # (player.cpp, scene_end.cpp, scene_map.cpp), all bare millisecond
+    # literals (400/800) with no scaling. This codebase's own
+    # `RGSS::Audio.bgm_fade` already expects milliseconds too --
+    # `Scene::Menu`'s own End Game call passes `bgm_fade(400)` directly.
     def do_fadeout_bgm(cmd)
       @state.current_bgm = nil
       @state.bgm_looped = false
-      RGSS::Audio.bgm_fade(cmd.param(0) * MS_PER_TENTH)
+      RGSS::Audio.bgm_fade(cmd.param(0))
     rescue StandardError => e
       $stderr.puts "[RPG2k] BGM fade-out failed: #{e.message}"
       nil

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13044,16 +13044,20 @@ check 'Flash Sprite without its wait flag does not pause the interpreter' do
 end
 
 check 'Fade Out BGM fades the music and forgets the current track' do
+  # param0 is already milliseconds -- EasyRPG's CommandFadeOutBGM passes it
+  # straight through to Game_System::BgmFade with no scaling (confirmed
+  # against its "Duration in ms" doc comment and every real call site, all
+  # bare millisecond literals).
   st = new_state
   RGSS::Audio.log = []
   it = Game::Interpreter.new(st)
   it.start([
     FakeCmd.new(IC::PLAY_BGM, [0, 100, 100], string: 'Town'),
-    FakeCmd.new(IC::FADEOUT_BGM, [20]), # 2 seconds
+    FakeCmd.new(IC::FADEOUT_BGM, [2000]), # 2000 ms
   ])
   it.update
   eq nil, st.current_bgm, 'nothing is playing after a fade-out'
-  eq [:bgm_fade, 2000], RGSS::Audio.log.last, 'faded over 2000 ms'
+  eq [:bgm_fade, 2000], RGSS::Audio.log.last, 'the parameter is passed straight through as ms'
 end
 
 check 'Play Movie records the request instead of dropping it' do


### PR DESCRIPTION
## Summary
- `Interpreter#do_fadeout_bgm` (`mruby-rpg2k/mrblib/interpreter.rb`) treated the Fade Out BGM (11520) command's duration parameter as tenths of a second and multiplied it by a `MS_PER_TENTH = 100` constant before calling `RGSS::Audio.bgm_fade`.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Interpreter::CommandFadeOutBGM` (`src/game_interpreter.cpp`) passes `com.parameters[0]` straight through to `Game_System::BgmFade` with no scaling at all, and `BgmFade`'s own doc comment (`src/game_system.h`) reads "duration Duration in ms" — corroborated by every other real `BgmFade(...)` call site in EasyRPG (`player.cpp`, `scene_end.cpp`, `scene_map.cpp`), all bare millisecond literals (`400`/`800`) with no conversion.
- This codebase's own other `bgm_fade` call site (`Scene::Menu`'s End Game handler, `bgm_fade(400)`) already agrees the primitive expects milliseconds directly — `do_fadeout_bgm` was the only caller multiplying by 100.
- Concretely: a designer sets the field to RPG_RT's own common default, `800` — real RPG_RT/EasyRPG fades over 800ms (0.8 seconds); this build computed `800 * 100 = 80,000`ms, an 80-second fade for what should be under a second.
- Fixed by removing the `* MS_PER_TENTH` multiplication entirely — the parameter now passes straight through, matching EasyRPG exactly.

## Test plan
- The pre-existing `scripts/rpg2k_logic_check.rb` "Fade Out BGM" check had baked the wrong `param 20 → 2000ms` conversion directly into its own assertion, masking the bug rather than catching it. Its expected value is corrected to the pass-through relationship (`param 2000 → 2000ms`), confirmed to fail against the pre-fix code (`expected 2000, got 200000`) before the fix, via `git stash`.
- All four CRuby suites pass (918 + 637 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_