### PR TITLE
Log the [RPG2k-MAP] marker on every teleport, not just the initial map load

### DIFF
--- a/changelog.d/rpg2k-teleport-map-marker.added.md
+++ b/changelog.d/rpg2k-teleport-map-marker.added.md
@@ -1,0 +1,11 @@
+- **`Scene::Map#perform_teleport`** (the single choke point for Transfer
+  Player, Teleport, Recall to Location, and a Teleport/Escape skill's own
+  warp) **now logs the same `[RPG2k-MAP] map=… x=… y=…` marker**
+  `RPG2k#start_new_game`/`#continue_game` already emit once on the initial
+  map load — a play session that walks through several map changes after
+  that now has a marker per change instead of only the first, useful for
+  matching a screenshot's location back to the actual map file and tile
+  while debugging. Existing `[RPG2k-MAP]`-scraping tooling
+  (`scripts/rpg2k_boot_check.bash`, `scripts/compare-nepheshel-save-wine.bash`)
+  is unaffected: one only checks the marker's presence, and the other's
+  `tail -1` never crosses a teleport in the sequence it scripts.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8708,6 +8708,16 @@ class RPG2k
         @state.x = x
         @state.y = y
         @state.direction = dir if dir && dir > 0
+        # Same marker `RPG2k#start_new_game`/`#continue_game` log on the initial
+        # map load (`mruby-rpg2k/mrblib/main.rb`) — those only fire once, so a
+        # session that walks through several Transfer Player/Teleport/Recall to
+        # Location commands after that needs this to know which map and tile it
+        # is actually looking at (see docs on debugging via this marker).
+        # Existing `[RPG2k-MAP]`-scraping tooling (rpg2k_boot_check.bash,
+        # compare-nepheshel-save-wine.bash) stays correct: one only checks the
+        # marker's presence, and the other's `tail -1` never crosses a teleport
+        # in the sequence it scripts.
+        $stderr.puts "[RPG2k-MAP] map=#{@state.map_id} x=#{@state.x} y=#{@state.y}"
         # RPG2000 clears every shown picture when the map changes (RPG2003 is
         # the edition that added a per-picture "keep across map change" flag).
         # Without this, Nepheshel's opening leaves its full-screen credit


### PR DESCRIPTION
## Summary

- `start_new_game`/`continue_game` (`mruby-rpg2k/mrblib/main.rb`) log a `[RPG2k-MAP] map=… x=… y=…` marker once, at the very first map entry — useful for a headless boot check, but silent for the rest of a play session once the party walks through any Transfer Player/Teleport/Recall to Location command.
- `Scene::Map#perform_teleport` is the single choke point all of those (plus a Teleport/Escape skill's own warp) funnel through, so it now logs the same marker — a running log of every map the party visits and where, which is what matching an in-game screenshot back to the actual map file/tile needs for debugging.
- Existing `[RPG2k-MAP]`-scraping tooling is unaffected: `scripts/rpg2k_boot_check.bash` only checks the marker's presence, and `scripts/compare-nepheshel-save-wine.bash`'s `tail -1` never crosses a teleport in the sequence it scripts.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 637 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 918 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed

https://claude.ai/code/session_01DVGoxo8L32Th7y281VvtZ7


---
_Generated by [Claude Code](https://claude.ai/code/session_01DVGoxo8L32Th7y281VvtZ7)_