### PR TITLE
Gate auto-battle's percent skill cost to RPG2003, like skill_cost

### DIFF
--- a/changelog.d/rpg2k-auto-battle-cost-rpg2003-gate.fixed.md
+++ b/changelog.d/rpg2k-auto-battle-cost-rpg2003-gate.fixed.md
@@ -1,0 +1,8 @@
+- **A Forced-AI actor's auto-battle skill ranking no longer overcharges a
+  skill's cost with an RPG2003-only formula on an RPG2000 database.**
+  Confirmed against EasyRPG Player's source: the percent-cost formula used
+  when ranking a skill against a plain Attack is gated on the project being
+  RPG2003, matching the same gate this codebase already applies to the SP
+  actually charged. The ranking-only cost term was missing that gate, so a
+  stray database byte could inflate a skill's apparent cost 5x and change
+  which action a Forced-AI actor picks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6348,6 +6348,36 @@ not yet verified:
   the bug rather than catching it); its expected value is corrected to the
   pass-through relationship (`param 2000 → 2000ms`), confirmed to fail
   against the pre-fix code (`expected 2000, got 200000`) before the fix.
+- ✅ **A Forced-AI actor's auto-battle skill-ranking cost is no longer
+  inflated by a percent-cost formula RPG2000 never applies.**
+  `Game::Battle#auto_battle_raw_cost` (`mruby-rpg2k/mrblib/game.rb`) is the
+  cost term `#auto_battle_damage_rank`/`#auto_battle_heal_rank` subtract when
+  scoring a candidate skill against a plain Attack — its own header comment
+  already cites EasyRPG's `CalcSkillCostAutoBattle` under `emulate_bugs:
+  true` (always the case for `AutoBattle::RpgRtCompat`, the algorithm this
+  build ports), which routes through `Algo::CalcSkillCost`
+  (`src/algo.cpp`): `(Player::IsRPG2k3() && skill.sp_type ==
+  SpType_percent) ? max_sp * skill.sp_percent / 100 / div : (skill.sp_cost +
+  half) / div` — the percent-cost branch is gated on `IsRPG2k3()`. This
+  function's own condition read only `sk.sp_type == 1`, no edition check at
+  all, even though `Game::Battle` already carries an `@rpg2003` ivar
+  (used elsewhere in the same class, e.g. the damage cap) and its sibling
+  `Game::Party#skill_cost` — which computes the SP actually *charged* for
+  the exact same field once the action is queued — already applies the
+  identical `rpg2003? && sk.sp_type == 1` gate, with its own comment
+  explaining why: a stray nonzero `sp_type` byte can sit on an RPG2000
+  database row even though the field's schema default is 0 and the RPG2000
+  editor UI never writes to it. Concretely: an RPG2000 skill carries
+  `sp_cost: 10` (the actual charge) but also a stray `sp_type: 1,
+  sp_percent: 50`; for a caster with `max_mp: 100`, the real charge (and
+  what `#skill_cost` correctly computes) is `10`, but this function computed
+  `100 * 50 / 100 = 50` — a 5x-too-high ranking-only cost, large enough to
+  flip which of two competing skills (or skill vs. plain Attack) a
+  Forced-AI actor picks. Fixed by adding the same `@rpg2003 &&` gate.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check calling
+  `#auto_battle_raw_cost` directly against both an RPG2000 and an RPG2003
+  `Game::Battle`, confirmed to fail against the pre-fix code (`expected 10,
+  got 50`) before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9856,7 +9856,16 @@ module Game
     # `cost:` (the amount actually spent once the action is queued) already
     # reuses unchanged.
     def auto_battle_raw_cost(sk, caster)
-      if sk.respond_to?(:sp_type) && sk.sp_type == 1
+      # The percent-cost branch is RPG2003-only, exactly like
+      # Game::Party#skill_cost's own `rpg2003? && sk.sp_type == 1` gate --
+      # ported from the same edition check EasyRPG's `Algo::CalcSkillCost`
+      # applies (`Player::IsRPG2k3() && skill.sp_type == SpType_percent`).
+      # Without it, a stray nonzero `sp_type` byte on an RPG2000 database (the
+      # field's schema default is 0, but the RPG2000 editor never controls it,
+      # so a hand-edited row can carry anything) would route through the
+      # percent formula here even though the actual charge (#skill_cost) never
+      # would, inflating the ranking-only cost term this feeds.
+      if @rpg2003 && sk.respond_to?(:sp_type) && sk.sp_type == 1
         (caster.max_mp || 0) * (sk.respond_to?(:sp_percent) ? (sk.sp_percent || 0) : 0) / 100
       else
         sk.respond_to?(:sp_cost) ? (sk.sp_cost || 0) : 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14600,6 +14600,30 @@ check 'Game::Actor#force_ai? reads the row (or its RPG2003 class) exactly like #
   ok !st.party.actor_by_id(2).force_ai?, 'an unflagged actor reads false'
 end
 
+# Ports EasyRPG's `Algo::CalcSkillCost` edition gate (`Player::IsRPG2k3() &&
+# skill.sp_type == SpType_percent`), reached via `CalcSkillCostAutoBattle`'s
+# own `emulate_bugs: true` path (`AutoBattle::RpgRtCompat` always calls it
+# that way) -- the exact same gate `Game::Party#skill_cost` already applies
+# for the SP actually charged once the action is queued. Without it, a stray
+# nonzero `sp_type` byte on an RPG2000 database (the field's schema default
+# is 0, but the RPG2000 editor never writes to it) would route through the
+# percent formula here even though the real charge never would, inflating
+# the ranking-only cost term #auto_battle_damage_rank/#auto_battle_heal_rank
+# both subtract.
+check "battle: auto_battle_raw_cost's percent-cost branch is RPG2003-only, matching #skill_cost" do
+  sk = FakeAiSkill.new(name: 'Spell', sp_type: 1, sp_percent: 50, sp_cost: 10)
+  caster = combatant_mp('Caster', 10, 0, 5, 100, 100) # max_mp 100
+  foe = combatant('Foe', 0, 0, 5, 100)
+  bat2k = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+  eq 10, bat2k.send(:auto_battle_raw_cost, sk, caster),
+     "RPG2000: sp_type is ignored, the flat sp_cost is used, matching #skill_cost's own gate"
+
+  bat2k3 = Game::Battle.new([caster], [foe], Game::Rng.new(1), nil, false, false, false, false,
+                            nil, nil, rpg2003: true)
+  eq 50, bat2k3.send(:auto_battle_raw_cost, sk, caster),
+     'RPG2003: the percent formula applies -- 100 max_mp * 50% = 50'
+end
+
 check 'battle: a Forced-AI actor picks a clearly-better Skill over Attack, with no manual command' do
   # 強制AI (mruby-lcf/mrblib/schema.rb, player/job field 23, force_ai) --
   # parsed but never read anywhere in mruby-rpg2k before this fix. Ported


### PR DESCRIPTION
## Summary
- `Game::Battle#auto_battle_raw_cost` (`mruby-rpg2k/mrblib/game.rb`) is the cost term `#auto_battle_damage_rank`/`#auto_battle_heal_rank` subtract when scoring a candidate skill against a plain Attack for a Forced-AI actor. Its percent-cost branch checked only `sk.sp_type == 1`, with no edition guard at all.
- Its sibling `Game::Party#skill_cost` — which computes the SP actually *charged* for the exact same field once the action is queued — already gates that same branch on `rpg2003?`, with its own comment explaining why: a stray nonzero `sp_type` byte can sit on an RPG2000 database row even though the field's schema default is 0 and the RPG2000 editor UI never writes to it.
- Confirmed against EasyRPG Player's actual C++ source: `Algo::CalcSkillCost` (`src/algo.cpp`) gates the percent-cost formula on `Player::IsRPG2k3()`, and `CalcSkillCostAutoBattle` (`src/autobattle.cpp`) always routes through it under `emulate_bugs: true` — which `AutoBattle::RpgRtCompat` (the algorithm this build ports, per `auto_battle_raw_cost`'s own header comment) always passes.
- Concretely: an RPG2000 skill carries `sp_cost: 10` (the actual charge) but also a stray `sp_type: 1, sp_percent: 50`; for a caster with `max_mp: 100`, the real charge is `10`, but this function computed `100 * 50 / 100 = 50` — a 5x-too-high ranking-only cost, large enough to flip which of two competing skills (or skill vs. plain Attack) a Forced-AI actor picks.
- Fixed by adding the same `@rpg2003 &&` gate `Party#skill_cost` already applies.

## Test plan
- New `scripts/rpg2k_logic_check.rb` check calling `#auto_battle_raw_cost` directly against both an RPG2000 and an RPG2003 `Game::Battle`, confirmed to fail against the pre-fix code (`expected 10, got 50`) before the fix, via `git stash`.
- All four CRuby suites pass (920 + 639 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_