### PR TITLE
Let Enter Hero Name open from a Parallel Process

### DIFF
--- a/changelog.d/rpg2k-name-input-parallel-process.fixed.md
+++ b/changelog.d/rpg2k-name-input-parallel-process.fixed.md
@@ -1,0 +1,6 @@
+- **Enter Hero Name issued from a Parallel Process now actually opens the
+  name-entry screen**, instead of silently doing nothing. Confirmed against
+  EasyRPG Player's source: the command runs identically for the foreground
+  and any Parallel Process. This build's dispatch table for non-foreground
+  interpreters had no case for it, so the request was discarded and the
+  process moved on as if the command never ran.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6378,6 +6378,46 @@ not yet verified:
   `#auto_battle_raw_cost` directly against both an RPG2000 and an RPG2003
   `Game::Battle`, confirmed to fail against the pre-fix code (`expected 10,
   got 50`) before the fix.
+- ✅ **Enter Hero Name (10740) issued from a Parallel Process now actually
+  opens the name-entry screen, instead of silently doing nothing.**
+  Confirmed against EasyRPG's actual C++ source:
+  `Game_Interpreter_Map::CommandEnterHeroName`
+  (`src/game_interpreter_map.cpp`) is the very same method for the
+  foreground and every Parallel Process's own interpreter — there is no
+  "foreground only" restriction, only a `Game_Message::IsMessageActive()`
+  gate (the same gate `CommandOpenShop` right above it uses). This build's
+  `Interpreter#do_name_input` (`mruby-rpg2k/mrblib/interpreter.rb`) already
+  correctly recorded the request and suspended on a `:name_input` wait
+  regardless of which interpreter ran it, but `Scene::Map
+  #drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) — the dispatch
+  table driving every *non*-foreground interpreter's own wait — had no
+  `:name_input` branch at all, unlike the nine sibling wait kinds
+  (`:message`, `:choice`, `:number`, `:battle`, `:movement`, `:teleport`,
+  `:game_over`, `:screen`/`:picture`/`:sprite_flash`) each already fixed in
+  earlier rounds for the exact same failure mode, each with its own
+  in-code comment citing the history. `:name_input` instead fell into the
+  final generic `else` branch, which unconditionally calls `it.resume` —
+  clearing the wait and letting the parallel process's command list
+  continue as though Enter Hero Name had been a no-op, the request object
+  discarded unread. Fixed by threading the owning interpreter through
+  `#drive_name_input(it = @interpreter)` (mirroring `#open_message`'s own
+  `interp:` idiom, `@message[:interp]`, with `@name_ui[:interp]` as its
+  counterpart here) and adding the missing `:name_input` branch to
+  `#drive_parallel_wait`, blocking until any open message window or
+  name-entry widget clears, then driving this one — the same
+  block-and-retry shape already used for `:message`/`:choice`/`:number`.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check driving a full
+  Parallel-Process-issued Enter Hero Name through open → type → confirm →
+  resume, confirmed to fail against the pre-fix code (the widget never
+  opened at all) before the fix. Scoped narrowly to Enter Hero Name: Open
+  Shop (10720) shares the identical `IsMessageActive()`-gated shape and is
+  presumably affected the same way, but its own drive/finish helpers are
+  spread across several more functions than name-input's tightly-scoped
+  three, and Show Inn (10730) carries EasyRPG's own additional
+  `main_flag`/`CanShowMessage` "Emulates RPG_RT behavior (Bug?)" nuance for
+  a Parallel-Process caller specifically (it *skips* the message-active
+  check rather than honouring it) — both left open for a future, separately
+  well-scoped fix rather than folded into this one.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1812,6 +1812,23 @@ class RPG2k
           # Flash Sprite's own wait flag, the parallel-process equivalent of
           # the :screen/:picture cases just above.
           it.resume unless sprite_flashing?
+        elsif it.wait_kind == :name_input
+          # Enter Hero Name issued from a Parallel Process: EasyRPG's
+          # `Game_Interpreter_Map::CommandEnterHeroName`
+          # (src/game_interpreter_map.cpp) is the very same method for the
+          # foreground and every parallel process's own interpreter, gated
+          # only on `Game_Message::IsMessageActive()` -- there is no
+          # "foreground only" restriction. Before this branch existed this
+          # fell into the generic #resume below, so a Parallel Process's own
+          # Enter Hero Name silently never opened the screen at all -- the
+          # command read as a no-op. The single name-entry widget is shared
+          # the same way the message window is (`@name_ui[:interp]` mirrors
+          # `@message[:interp]`, see #drive_name_input): block until
+          # whichever message window or name-entry screen is currently up
+          # closes, then drive this one.
+          if (@name_ui.nil? || @name_ui[:interp].equal?(it)) && @message.nil?
+            drive_name_input(it)
+          end
         else
           # :message, :choice and :number are all handled above now.
           it.resume
@@ -4763,19 +4780,26 @@ class RPG2k
       # kana grid on the matching page. Either way the widget is seeded with
       # the actor's current name when the command asked for it, and commits to
       # the actor and resumes the event when confirmed.
-      def drive_name_input
-        req = @interpreter.name_input_request
-        return @interpreter.resume_name_input('') unless req
+      #
+      # `it` defaults to the foreground @interpreter, but #drive_parallel_wait
+      # passes its own parallel interpreter here too -- see its :name_input
+      # case for why, mirroring #open_message's own `interp:` idiom
+      # (@message[:interp]) for the same "which interpreter actually asked
+      # for this shared, singleton widget" tracking. `@name_ui[:interp]` is
+      # what #commit_name_input resumes once the actor's name is confirmed.
+      def drive_name_input(it = @interpreter)
+        req = it.name_input_request
+        return it.resume_name_input('') unless req
         if @name_ui.nil?
           background = build_field_background(@windowskin)
           if req[:charset] == 2
             @name_ui = { name: req[:seed] || '', sel: 0, win: nil, kana: false,
-                         background: background }
+                         background: background, interp: it }
             draw_name_input
           else
             @name_ui = { name: req[:seed] || '', sel: 0, kana: true,
                          page: req[:charset] == 1 ? :katakana : :hiragana,
-                         actor_id: req[:actor_id], background: background }
+                         actor_id: req[:actor_id], background: background, interp: it }
             draw_kana_name_input
           end
           return
@@ -4835,8 +4859,9 @@ class RPG2k
 
       def commit_name_input
         name = @name_ui[:name]
+        interp = @name_ui[:interp]
         close_name_input
-        @interpreter.resume_name_input(name)
+        interp.resume_name_input(name)
       end
 
       def draw_name_input

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6521,6 +6521,44 @@ check 'Enter Hero Name: typing on the grid and confirming renames the actor' do
   ok st.switches[5], 'the event resumed after entry'
 end
 
+# EasyRPG's `Game_Interpreter_Map::CommandEnterHeroName`
+# (src/game_interpreter_map.cpp) is the exact same method for the foreground
+# and every Parallel Process's own interpreter -- gated only on
+# `Game_Message::IsMessageActive()`, no "foreground only" restriction. Before
+# this fix, `Scene::Map#drive_parallel_wait` had no `:name_input` branch at
+# all, so a Parallel Process's own Enter Hero Name silently never opened the
+# screen -- the command fell into the generic "background: resume" default
+# and read as a complete no-op.
+check 'Enter Hero Name issued from a Parallel Process opens the entry widget too' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4) # Parallel Process
+  par.event_commands = [
+    ECmd.new(ic::NAME_INPUT, [1, 2, 0], indent: 0), # actor 1, letters, no seed
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  ui = nil
+  6.times { scene.update; ui = scene.instance_variable_get(:@name_ui); break if ui }
+  ok ui, 'the name-entry widget opened for a Parallel-Process-issued command'
+  eq '', ui[:name], 'starts empty (no seed)'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the first cell, 'A'
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'A', ui[:name]
+
+  ui[:sel] = RPG2k::Scene::Map::NAME_CELLS.length - 1 # jump to OK and confirm
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'A', st.party.actor_by_id(1).name, 'the actor was renamed on confirm'
+  eq nil, scene.instance_variable_get(:@name_ui), 'the widget closed'
+  3.times { scene.update }
+  ok st.switches[5], 'the parallel process resumed after entry, not stuck forever'
+end
+
 check 'Enter Hero Name: draws a full-screen background behind the widget' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `Interpreter#do_name_input` already correctly recorded the request and suspended on a `:name_input` wait regardless of which interpreter ran it, but `Scene::Map#drive_parallel_wait` — the dispatch table driving every *non*-foreground interpreter's own wait — had no `:name_input` branch at all, unlike nine sibling wait kinds (`:message`, `:choice`, `:number`, `:battle`, `:movement`, `:teleport`, `:game_over`, `:screen`/`:picture`/`:sprite_flash`) each already fixed in earlier rounds for the exact same failure mode.
- `:name_input` fell into the final generic `else` branch, which unconditionally calls `it.resume` — clearing the wait and letting the parallel process's command list continue as though Enter Hero Name had been a no-op, the request object discarded unread.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Interpreter_Map::CommandEnterHeroName` (`src/game_interpreter_map.cpp`) is the very same method for the foreground and every Parallel Process's own interpreter — there is no "foreground only" restriction, only a `Game_Message::IsMessageActive()` gate.
- Fixed by threading the owning interpreter through `#drive_name_input(it = @interpreter)` (mirroring `#open_message`'s own `interp:` idiom, `@message[:interp]`, with `@name_ui[:interp]` as its counterpart here) and adding the missing `:name_input` branch to `#drive_parallel_wait`, blocking until any open message window or name-entry widget clears, then driving this one — the same block-and-retry shape already used for `:message`/`:choice`/`:number`.
- Scoped narrowly to Enter Hero Name: Open Shop (10720) shares the identical shape but its own drive/finish helpers are spread across several more functions, and Show Inn (10730) carries EasyRPG's own additional `main_flag`/`CanShowMessage` "Emulates RPG_RT behavior (Bug?)" nuance for a Parallel-Process caller specifically — both left open for a future, separately well-scoped fix.

## Test plan
- New `scripts/rpg2k_scene_check.rb` check driving a full Parallel-Process-issued Enter Hero Name through open → type → confirm → resume, confirmed to fail against the pre-fix code (the widget never opened at all) before the fix, via `git stash`.
- All four CRuby suites pass (920 + 640 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_