### PR TITLE
Let Open Shop open from a Parallel Process

### DIFF
--- a/changelog.d/rpg2k-open-shop-parallel-process.fixed.md
+++ b/changelog.d/rpg2k-open-shop-parallel-process.fixed.md
@@ -1,0 +1,6 @@
+- **Open Shop issued from a Parallel Process now actually opens the shop
+  screen**, instead of silently doing nothing. Confirmed against EasyRPG
+  Player's source: the command runs identically for the foreground and any
+  Parallel Process. This build's dispatch table for non-foreground
+  interpreters had no case for it, so the request was discarded and the
+  process moved on as if the command never ran.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6418,6 +6418,36 @@ not yet verified:
   a Parallel-Process caller specifically (it *skips* the message-active
   check rather than honouring it) — both left open for a future, separately
   well-scoped fix rather than folded into this one.
+- ✅ **Open Shop (10720) issued from a Parallel Process now actually opens the
+  shop screen, instead of silently doing nothing.** The exact sibling defect
+  to the Enter Hero Name fix just above, now closed the same way. Confirmed
+  against EasyRPG's actual C++ source: `Game_Interpreter_Map::CommandOpenShop`
+  (`src/game_interpreter_map.cpp`) is the very same method for the foreground
+  and every Parallel Process's own interpreter, gated only on
+  `Game_Message::IsMessageActive()` — no `main_flag`/foreground-only
+  restriction (unlike Show Inn's own documented nuance, see above). This
+  build's `Interpreter#do_shop` (`mruby-rpg2k/mrblib/interpreter.rb`) already
+  correctly recorded the request and suspended on a `:shop` wait regardless of
+  which interpreter ran it, but `Scene::Map#drive_parallel_wait`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) had no `:shop` branch at all — it fell
+  into the final generic `else` branch, which unconditionally calls
+  `it.resume`, clearing the wait and letting the parallel process's command
+  list continue as though Open Shop had been a no-op, the request object
+  discarded unread. `#drive_shop` and `#open_shop` were also both hardcoded to
+  read/resume `@interpreter` specifically, so even reaching them from a
+  parallel interpreter would have resumed the wrong one. Fixed by threading
+  the owning interpreter through `#drive_shop(it = @interpreter)` and
+  `#open_shop(req, it = @interpreter)` (mirroring `#drive_name_input`'s own
+  `it` idiom), storing it as `@shop[:interp]` (mirroring `@name_ui[:interp]` /
+  `@message[:interp]`) so `#leave_shop` resumes the correct owner, and adding
+  the missing `:shop` branch to `#drive_parallel_wait`, blocking until any
+  open message window, name-entry widget, or shop screen clears, then driving
+  this one — the same block-and-retry shape already used for
+  `:message`/`:choice`/`:number`/`:name_input`. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check driving a full Parallel-Process-issued
+  Open Shop through open → buy → confirm → leave → resume into its
+  [Transaction] branch, confirmed to fail against the pre-fix code (the shop
+  screen never opened at all) before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6426,7 +6426,7 @@ not yet verified:
   and every Parallel Process's own interpreter, gated only on
   `Game_Message::IsMessageActive()` — no `main_flag`/foreground-only
   restriction (unlike Show Inn's own documented nuance, see above). This
-  build's `Interpreter#do_shop` (`mruby-rpg2k/mrblib/interpreter.rb`) already
+  build's `Interpreter#do_open_shop` (`mruby-rpg2k/mrblib/interpreter.rb`) already
   correctly recorded the request and suspended on a `:shop` wait regardless of
   which interpreter ran it, but `Scene::Map#drive_parallel_wait`
   (`mruby-rpg2k/mrblib/scene/map.rb`) had no `:shop` branch at all — it fell

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1829,6 +1829,24 @@ class RPG2k
           if (@name_ui.nil? || @name_ui[:interp].equal?(it)) && @message.nil?
             drive_name_input(it)
           end
+        elsif it.wait_kind == :shop
+          # Open Shop issued from a Parallel Process: EasyRPG's
+          # `Game_Interpreter_Map::CommandOpenShop`
+          # (src/game_interpreter_map.cpp) is the very same method for the
+          # foreground and every parallel process's own interpreter, gated
+          # only on `Game_Message::IsMessageActive()` -- there is no
+          # "foreground only" restriction. Before this branch existed this
+          # fell into the generic #resume below, so a Parallel Process's own
+          # Open Shop silently never opened the screen at all -- the command
+          # read as a no-op. The single shop screen is shared the same way
+          # the message window and name-entry widget are (`@shop[:interp]`
+          # mirrors `@name_ui[:interp]` / `@message[:interp]`, see
+          # #drive_shop / #leave_shop): block until whichever message
+          # window, name-entry screen, or shop screen is currently up
+          # closes, then drive this one.
+          if (@shop.nil? || @shop[:interp].equal?(it)) && @message.nil? && @name_ui.nil?
+            drive_shop(it)
+          end
         else
           # :message, :choice and :number are all handled above now.
           it.resume
@@ -4169,11 +4187,19 @@ class RPG2k
       # control returns to the list; leaving resumes the interpreter with
       # whether anything was traded (which picks the [Transaction] /
       # [No Transaction] branch).
-      def drive_shop
-        req = @interpreter.shop_request
-        return @interpreter.resume_shop(false) unless req
+      #
+      # `it` defaults to the foreground @interpreter, but #drive_parallel_wait
+      # passes its own parallel interpreter here too -- see its :shop case for
+      # why, mirroring #drive_name_input's own `it` idiom (`@shop[:interp]`
+      # mirrors `@name_ui[:interp]` / `@message[:interp]`) for the same
+      # "which interpreter actually asked for this shared, singleton screen"
+      # tracking. `@shop[:interp]` is what #leave_shop resumes once the
+      # player leaves.
+      def drive_shop(it = @interpreter)
+        req = it.shop_request
+        return it.resume_shop(false) unless req
         if @shop.nil?
-          open_shop(req) # opened this frame; take input from the next one
+          open_shop(req, it) # opened this frame; take input from the next one
           return
         end
         case @shop[:screen]
@@ -4184,14 +4210,14 @@ class RPG2k
         end
       end
 
-      def open_shop(req)
+      def open_shop(req, it = @interpreter)
         model = Game::Shop.new(db, @state.party, req[:goods],
                                req[:allow_buy], req[:allow_sell])
         has_menu = req[:allow_buy] && req[:allow_sell]
         screen = has_menu ? :command : (req[:allow_buy] ? :buy : :sell)
         @shop = { model: model, has_menu: has_menu, screen: screen, index: 0,
                   window: nil, gold: build_shop_gold_window, status: nil,
-                  terms: shop_terms(req[:type]), browsed: false }
+                  terms: shop_terms(req[:type]), browsed: false, interp: it }
         draw_shop
       end
 
@@ -4507,8 +4533,9 @@ class RPG2k
 
       def leave_shop
         transacted = @shop[:model].did_transaction
+        interp = @shop[:interp]
         close_shop
-        @interpreter.resume_shop(transacted)
+        interp.resume_shop(transacted)
       end
 
       def close_shop

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5506,6 +5506,57 @@ check 'Open Shop scene: leaving without buying runs the No Transaction branch' d
   ok st.switches[2], 'the No Transaction branch ran'
 end
 
+# EasyRPG's `Game_Interpreter_Map::CommandOpenShop`
+# (src/game_interpreter_map.cpp) is the exact same method for the foreground
+# and every Parallel Process's own interpreter -- gated only on
+# `Game_Message::IsMessageActive()`, no "foreground only" restriction. Before
+# this fix, `Scene::Map#drive_parallel_wait` had no `:shop` branch at all, so
+# a Parallel Process's own Open Shop silently never opened the screen -- the
+# command fell into the generic "background: resume" default and read as a
+# complete no-op, the same defect Enter Hero Name (10740) had before its own
+# fix.
+check 'Open Shop issued from a Parallel Process opens the shop screen too' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4) # Parallel Process
+  par.event_commands = [
+    ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3, 5], indent: 0), # buy-only, goods 3/5
+    ECmd.new(ic::SHOP_TRANSACTION, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::SHOP_NO_TRANSACTION, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::SHOP_END, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(500))
+  shop = nil
+  6.times { scene.update; shop = scene.instance_variable_get(:@shop); break if shop }
+  ok shop, 'the shop screen opened for a Parallel-Process-issued command'
+  ok !st.switches[1] && !st.switches[2], 'still shopping'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # select the first good (id 3 @ 100)
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  eq 500, st.party.gold, 'nothing is spent just by opening the counter'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the default quantity of 1
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  eq 400, st.party.gold, 'one Potion bought'
+  eq 1, st.party.item_count(3)
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the "purchased" confirmation
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::B] # leave the shop
+  scene.update
+  scene.update
+  eq nil, scene.instance_variable_get(:@shop), 'the shop screen closed'
+  ok st.switches[1], 'the parallel process resumed into its Transaction branch, not stuck forever'
+  ok !st.switches[2], 'the No Transaction branch was skipped'
+end
+
 # Battle command / result command lists for the encounter tests below.
 def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil, troop_id: 1,
                           first_strike: false)


### PR DESCRIPTION
## Summary

- `Scene::Map#drive_parallel_wait` had no `:shop` branch, so a Parallel Process's own Open Shop (10720) fell into the generic `else` branch and was unconditionally `it.resume`d — the request was discarded and the shop screen silently never opened, exactly the sibling defect Enter Hero Name (10740) had before #893.
- Confirmed against EasyRPG's actual C++ source: `Game_Interpreter_Map::CommandOpenShop` (`src/game_interpreter_map.cpp`) is the very same method for the foreground and every Parallel Process's own interpreter, gated only on `Game_Message::IsMessageActive()` — no `main_flag`/foreground-only restriction.
- `#drive_shop` and `#open_shop` were also both hardcoded to read/resume `@interpreter` specifically, so even reaching them from a parallel interpreter would have resumed the wrong one. Threaded the owning interpreter through both (`#drive_shop(it = @interpreter)`, `#open_shop(req, it = @interpreter)`, mirroring `#drive_name_input`'s own `it` idiom), storing it as `@shop[:interp]` (mirroring `@name_ui[:interp]` / `@message[:interp]`) so `#leave_shop` resumes the correct owner.
- Added the missing `:shop` branch to `#drive_parallel_wait`, blocking until any open message window, name-entry widget, or shop screen clears, then driving this one — the same block-and-retry shape already used for `:message`/`:choice`/`:number`/`:name_input`.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check ("Open Shop issued from a Parallel Process opens the shop screen too") drives a full Parallel-Process-issued Open Shop through open → select good → buy → confirm → leave → resume into its `[Transaction]` branch.
- [x] Confirmed the new check FAILS against the pre-fix code (`git stash` the implementation, rerun — `1 of 641 checks FAILED`, the shop screen never opened), then restored the fix and reran clean.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 920 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 641 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] `ninja -C build rpg_maker_clone` — builds clean (no native code touched, so no `ninja -C build test` run)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_