### PR TITLE
Let Return to Title / Exit Game fire from a Parallel Process

### DIFF
--- a/changelog.d/rpg2k-return-title-exit-game-parallel-process.fixed.md
+++ b/changelog.d/rpg2k-return-title-exit-game-parallel-process.fixed.md
@@ -1,0 +1,7 @@
+- **Return to Title Screen and Exit Game now actually fire when issued from a
+  Parallel Process**, instead of silently doing nothing. Confirmed against
+  EasyRPG Player's source: both commands run identically for the foreground
+  and any Parallel Process. This build's dispatch table for non-foreground
+  interpreters had no case for either, so a "reset the game" trap event or an
+  "auto-quit once switch X turns on" idiom built entirely inside a Parallel
+  Process would never actually fire.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6448,6 +6448,38 @@ not yet verified:
   Open Shop through open → buy → confirm → leave → resume into its
   [Transaction] branch, confirmed to fail against the pre-fix code (the shop
   screen never opened at all) before the fix.
+- ✅ **Return to Title Screen (12510) and Exit Game (5002) now actually fire
+  when issued from a Parallel Process, instead of silently doing nothing.**
+  The same missing-branch defect as Enter Hero Name / Open Shop above, but
+  for two *terminal* commands (nothing is ever resumed afterward, since the
+  whole scene tears down) rather than a resumable modal screen. Confirmed
+  against EasyRPG's actual C++ source: `Game_Interpreter
+  ::CommandReturnToTitleScreen` and `Game_Interpreter::CommandExitGame`
+  (`src/game_interpreter.cpp`) are both plain `Game_Interpreter` methods
+  gated only on `Game_Message::IsMessageActive()`, with no `main_flag`
+  reference anywhere in either body — same as Open Shop/Enter Hero Name.
+  Show Inn is the one exception in this whole family (its own
+  `main_flag`/`CanShowMessage` nuance is why it stays deliberately
+  unfixed); these two have no such asymmetry to reproduce at all.
+  `Scene::Map#drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) had
+  no `:return_title`/`:exit_game` branches, so both fell into the generic
+  `else` → unconditional `it.resume`, silently discarding the request and
+  letting the parallel process's command list continue as though the
+  command had been a no-op — a "reset the game" trap event, an alternate
+  Game-Over-to-title flow, or the classic "auto-quit once switch X turns
+  on" idiom built entirely inside a Parallel Process would never actually
+  fire. Fixed by threading the owning interpreter through
+  `#perform_return_to_title(it = @interpreter)` and
+  `#perform_exit_game(it = @interpreter)` and adding the two missing
+  branches to `#drive_parallel_wait` — no shared-resource gate needed
+  (unlike `:shop`/`:name_input`), since the whole scene ends the instant
+  either one runs, leaving nothing to race. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check driving a Parallel-Process-issued
+  Return to Title Screen and confirming the app is told to return to the
+  title screen, confirmed to fail against the pre-fix code before the fix
+  (Exit Game itself is not covered by an automated check, matching the
+  pre-existing foreground Exit Game command's own lack of test coverage,
+  since it calls a real process exit).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1847,6 +1847,28 @@ class RPG2k
           if (@shop.nil? || @shop[:interp].equal?(it)) && @message.nil? && @name_ui.nil?
             drive_shop(it)
           end
+        elsif it.wait_kind == :return_title
+          # Return to Title Screen issued from a Parallel Process: EasyRPG's
+          # `Game_Interpreter::CommandReturnToTitleScreen`
+          # (src/game_interpreter.cpp) is a plain `Game_Interpreter` method
+          # with no `main_flag` gate at all -- unlike Open Shop/Enter Hero
+          # Name, there is no foreground-vs-parallel distinction whatsoever
+          # here. Before this branch existed this fell into the generic
+          # #resume below, so a Parallel Process's own Return to Title
+          # silently never happened -- a "reset the game" trap event, or an
+          # alternate Game-Over-to-title flow, was a permanent no-op instead
+          # of ending the play session. No shared-resource gate is needed
+          # (unlike :shop/:name_input): the whole scene tears down the
+          # instant this runs, so there is nothing left to race.
+          perform_return_to_title(it)
+        elsif it.wait_kind == :exit_game
+          # Exit Game issued from a Parallel Process: same reasoning as
+          # :return_title just above -- EasyRPG's `Game_Interpreter
+          # ::CommandExitGame` (src/game_interpreter.cpp) has no `main_flag`
+          # gate either. Before this branch existed a Parallel Process's own
+          # Exit Game silently never quit the game at all -- the classic
+          # "auto-quit once switch X is on" idiom was a permanent no-op.
+          perform_exit_game(it)
         else
           # :message, :choice and :number are all handled above now.
           it.resume
@@ -3162,9 +3184,17 @@ class RPG2k
       end
 
       # Exit Game (5002, RPG2003): quit, the way the title screen's Shutdown
-      # entry does.
-      def perform_exit_game
-        @interpreter.stop
+      # entry does. `it` defaults to the foreground @interpreter but
+      # #drive_parallel_wait passes its own parallel interpreter here too --
+      # EasyRPG's `Game_Interpreter::CommandExitGame` (src/game_interpreter.cpp)
+      # is a plain `Game_Interpreter` method with no `main_flag` gate, unlike
+      # Open Shop/Enter Hero Name's own foreground-vs-parallel distinction, so
+      # every interpreter reaches it identically. Which interpreter's own
+      # #stop runs barely matters here -- #exit tears down the whole process
+      # immediately after -- but it is threaded through for consistency with
+      # #perform_return_to_title just below.
+      def perform_exit_game(it = @interpreter)
+        it.stop
         exit
       end
 
@@ -5942,13 +5972,19 @@ class RPG2k
 
       # Return to Title Screen: stop the running event and hand control back to
       # the app, which tears the play scenes down and shows a fresh title. There
-      # is nothing to resume afterwards — this scene is being disposed.
-      def perform_return_to_title
-        @interpreter.stop
+      # is nothing to resume afterwards — this scene is being disposed. `it`
+      # defaults to the foreground @interpreter but #drive_parallel_wait
+      # passes its own parallel interpreter here too -- EasyRPG's
+      # `Game_Interpreter::CommandReturnToTitleScreen` (src/game_interpreter.cpp)
+      # is a plain `Game_Interpreter` method with no `main_flag` gate, so a
+      # Common Event's or a map event's own Parallel Process can trigger it
+      # exactly like the foreground can.
+      def perform_return_to_title(it = @interpreter)
+        it.stop
         @parent.return_to_title
       rescue StandardError => e
         $stderr.puts "[RPG2k] Return to Title failed: #{e.message}"
-        @interpreter.stop
+        it.stop
       end
 
       # -- message / choice window --------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3208,6 +3208,24 @@ check 'Return to Title Screen hands control back to the app' do
   ok parent.returned_to_title, 'the app was told to return to the title screen'
 end
 
+# EasyRPG's `Game_Interpreter::CommandReturnToTitleScreen`
+# (src/game_interpreter.cpp) is a plain `Game_Interpreter` method with no
+# `main_flag` gate at all, so every interpreter -- foreground or a Parallel
+# Process's own -- reaches it identically. Before this fix,
+# `Scene::Map#drive_parallel_wait` had no `:return_title` branch, so it fell
+# into the generic "background: resume" default and a Parallel Process's own
+# Return to Title Screen silently never happened at all.
+check 'Return to Title Screen issued from a Parallel Process also hands control back' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4) # Parallel Process
+  par.event_commands = [ECmd.new(ic::RETURN_TO_TITLE, [])]
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [0, 0])
+  parent = scene.instance_variable_get(:@parent)
+  5.times { scene.update }
+  ok parent.returned_to_title,
+     'the app was told to return to the title screen from a Parallel Process too'
+end
+
 check 'Change Event Location snaps another event to a tile' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3) # auto-start: place event 2 at (5, 3)


### PR DESCRIPTION
## Summary
- `Scene::Map#drive_parallel_wait` had no `:return_title`/`:exit_game` branches, so both fell into the generic `else` and were silently discarded via an unconditional `it.resume` — a Parallel Process's own Return to Title Screen or Exit Game command never actually did anything.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Interpreter::CommandReturnToTitleScreen` and `Game_Interpreter::CommandExitGame` (`src/game_interpreter.cpp`) are both plain `Game_Interpreter` methods gated only on `Game_Message::IsMessageActive()`, with no `main_flag` reference anywhere in either body — same as the already-fixed Open Shop/Enter Hero Name. (Show Inn is the one exception in this family — its own `main_flag`/`CanShowMessage` nuance is why it stays deliberately unfixed.)
- This is reachable on real data: a "reset the game" trap event, an alternate Game-Over-to-title flow, or the classic "auto-quit once switch X turns on" idiom built entirely inside a Parallel Process would never actually fire.
- Fixed by threading the owning interpreter through `#perform_return_to_title(it = @interpreter)` and `#perform_exit_game(it = @interpreter)` and adding the two missing branches to `#drive_parallel_wait` — no shared-resource gate needed (unlike `:shop`/`:name_input`), since the whole scene tears down the instant either one runs, leaving nothing to race.

## Test plan
- New `scripts/rpg2k_scene_check.rb` check driving a Parallel-Process-issued Return to Title Screen and confirming the app is told to return to the title screen, confirmed to fail against the pre-fix code before the fix, via `git stash`.
- Exit Game itself is not covered by an automated check, matching the pre-existing foreground Exit Game command's own lack of test coverage, since it calls a real process exit.
- All four CRuby suites pass (920 + 642 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_