### PR TITLE
Let Open Save/Main/Load Menu open from a Parallel Process

### DIFF
--- a/changelog.d/rpg2k-menu-save-load-parallel-process.fixed.md
+++ b/changelog.d/rpg2k-menu-save-load-parallel-process.fixed.md
@@ -1,0 +1,7 @@
+- **Open Save Menu, Open Main Menu and Open Load Menu now actually open their
+  screen when issued from a Parallel Process**, instead of silently doing
+  nothing. Confirmed against EasyRPG Player's source: all three commands run
+  identically for the foreground and any Parallel Process. This build's
+  dispatch table for non-foreground interpreters had no case for any of them,
+  so an "auto-save trap" idiom or a custom pause-menu hotkey built entirely
+  inside a Parallel Process would never actually open anything.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6480,6 +6480,45 @@ not yet verified:
   (Exit Game itself is not covered by an automated check, matching the
   pre-existing foreground Exit Game command's own lack of test coverage,
   since it calls a real process exit).
+- ✅ **Open Save Menu (11910), Open Main Menu (11950) and Open Load Menu (5001,
+  RPG2003) now actually open their screen when issued from a Parallel
+  Process, instead of silently doing nothing.** The last three of the
+  seven-command family of Parallel-Process dispatch gaps this session found
+  in `Scene::Map#drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`),
+  after `:shop`/`:name_input`/`:return_title`/`:exit_game` above. Confirmed
+  against EasyRPG's actual C++ source: `Game_Interpreter_Map
+  ::CommandOpenSaveMenu`/`CommandOpenMainMenu`/`CommandOpenLoadMenu`
+  (`src/game_interpreter_map.cpp`) are each gated only on
+  `Game_Message::IsMessageActive()` (`CommandOpenLoadMenu` additionally
+  requires `Player::IsRPG2k3ECommands()`) — no `main_flag` reference
+  anywhere in any of the three, exactly the same "no foreground/parallel
+  distinction at all" shape already confirmed for Return to Title/Exit
+  Game. `drive_parallel_wait` had no `:save_menu`/`:menu`/`:load_menu`
+  branches, so all three fell into the generic `else` → unconditional
+  `it.resume`, silently discarding the request — an "auto-save trap" idiom,
+  a custom pause-menu hotkey built from a polled Key Input Processing
+  variable, or an RPG2003 custom load-menu shortcut, all built entirely
+  inside a Parallel Process, would never actually open anything. Unlike
+  Return to Title/Exit Game, these three *are* resumable (the interpreter
+  needs to pick back up once the pushed `Scene::SaveLoad`/`Scene::Menu`
+  closes), so the fix mirrors `:shop`/`:name_input`'s "track the owner"
+  shape instead: `#perform_event_save`/`#perform_event_load`/
+  `#perform_event_menu` each gain an `it = @interpreter` parameter, and
+  their shared one-visit guard flags (`@event_save_load`, reused by both
+  Save and Load Menu since only one `Scene::SaveLoad` can ever be open at
+  once; `@event_menu` for the field menu) now hold the *owning interpreter*
+  itself (nil when closed) rather than a bare boolean, so the picker/menu
+  resumes whichever interpreter actually opened it. No shared-resource
+  cross-guard is needed the way `:shop`/`:name_input` need one, since a
+  pushed `Scene::SaveLoad`/`Scene::Menu` fully suspends `Scene::Map#update`
+  — and so `#drive_parallel_wait` itself — until it pops, leaving nothing
+  to race. Covered by two new `scripts/rpg2k_scene_check.rb` checks (Open
+  Main Menu and Open Save Menu, each driving a full
+  Parallel-Process-issued open → paused → close → resume cycle), confirmed
+  to fail against the pre-fix code before the fix; Open Load Menu is not
+  separately covered, matching its own foreground counterpart's existing
+  test shape (mode is the only difference from Open Save Menu, already
+  proven by the pre-existing foreground Load Menu check).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1869,6 +1869,31 @@ class RPG2k
           # Exit Game silently never quit the game at all -- the classic
           # "auto-quit once switch X is on" idiom was a permanent no-op.
           perform_exit_game(it)
+        elsif it.wait_kind == :save_menu
+          # Open Save Menu issued from a Parallel Process: EasyRPG's
+          # `Game_Interpreter_Map::CommandOpenSaveMenu`
+          # (src/game_interpreter_map.cpp) is gated only on
+          # `Game_Message::IsMessageActive()`, no `main_flag` restriction --
+          # same reasoning as :shop/:name_input above. Before this branch
+          # existed this fell into the generic #resume below, so an
+          # "auto-save trap" idiom built entirely inside a Parallel Process
+          # silently never opened the save picker at all. No shared-resource
+          # cross-guard is needed the way :shop/:name_input need one: a
+          # pushed Scene::SaveLoad/Scene::Menu fully suspends this scene's
+          # own #update -- and so #drive_parallel_wait itself -- until it
+          # pops, so nothing else can race it open.
+          perform_event_save(it) if @message.nil?
+        elsif it.wait_kind == :menu
+          # Open Main Menu issued from a Parallel Process: same reasoning as
+          # :save_menu just above -- EasyRPG's `Game_Interpreter_Map
+          # ::CommandOpenMainMenu` has no `main_flag` gate either.
+          perform_event_menu(it) if @message.nil?
+        elsif it.wait_kind == :load_menu
+          # Open Load Menu (5001, RPG2003) issued from a Parallel Process:
+          # same reasoning as :save_menu/:menu above -- EasyRPG's
+          # `Game_Interpreter_Map::CommandOpenLoadMenu` has no `main_flag`
+          # gate either.
+          perform_event_load(it) if @message.nil?
         else
           # :message, :choice and :number are all handled above now.
           it.resume
@@ -3144,18 +3169,34 @@ class RPG2k
       # Game::MapAccess::TRISTATE_FORBID`) relies on this command to bypass --
       # confirmed against Nepheshel's real data, which forbids Save on that
       # very map and puts its "SAVE" choice behind Open Save Menu regardless.
-      def perform_event_save
+      # `it` defaults to the foreground @interpreter, but #drive_parallel_wait
+      # passes its own parallel interpreter here too -- EasyRPG's
+      # `Game_Interpreter_Map::CommandOpenSaveMenu` (src/game_interpreter_map.cpp)
+      # is gated only on `Game_Message::IsMessageActive()`, no `main_flag`
+      # restriction, so a Common Event's or a map event's own Parallel Process
+      # can trigger it exactly like the foreground can. `@event_save_load` now
+      # holds the *owning interpreter* (nil when the picker is closed) rather
+      # than a bare boolean, so the second visit resumes whichever interpreter
+      # actually opened it -- mirroring `@shop[:interp]`/`@name_ui[:interp]`'s
+      # own "who asked for this shared, singleton screen" tracking, just kept
+      # as a bare ivar since there is no extra per-open state to carry here
+      # (unlike the shop/name-entry widgets, a pushed Scene::SaveLoad/
+      # Scene::Menu fully suspends this scene's own #update -- and so
+      # #drive_parallel_wait itself -- until it pops, so there is no way for a
+      # second Open Save/Load/Main Menu to race the one already open).
+      def perform_event_save(it = @interpreter)
         if @event_save_load
-          @event_save_load = false
-          @interpreter.resume
+          owner = @event_save_load
+          @event_save_load = nil
+          owner.resume
         else
-          @event_save_load = true
+          @event_save_load = it
           @parent.push Scene::SaveLoad.new(@parent, @state, :save)
         end
       rescue StandardError => e
         $stderr.puts "[RPG2k] Open Save Menu failed: #{e.message}"
-        @event_save_load = false
-        @interpreter.resume
+        @event_save_load = nil
+        it.resume
       end
 
       # Open Load Menu (5001, RPG2003): open Scene::SaveLoad in :load mode, the
@@ -3169,18 +3210,27 @@ class RPG2k
       # that opened the screen carries on from the next command, rather than
       # being abandoned the way the old single-slot version's unconditional
       # #stop did.
-      def perform_event_load
+      # `it` defaults to the foreground @interpreter, but #drive_parallel_wait
+      # passes its own parallel interpreter here too, for the same reason and
+      # the same `@event_save_load`-holds-the-owner shape as #perform_event_save
+      # just above (they deliberately share the one flag -- see its own doc
+      # comment). EasyRPG's `Game_Interpreter_Map::CommandOpenLoadMenu`
+      # (src/game_interpreter_map.cpp) is gated only on
+      # `Game_Message::IsMessageActive()` (plus its own RPG2003-English-release
+      # check), same as Open Save/Main Menu.
+      def perform_event_load(it = @interpreter)
         if @event_save_load
-          @event_save_load = false
-          @interpreter.resume
+          owner = @event_save_load
+          @event_save_load = nil
+          owner.resume
         else
-          @event_save_load = true
+          @event_save_load = it
           @parent.push Scene::SaveLoad.new(@parent, nil, :load)
         end
       rescue StandardError => e
         $stderr.puts "[RPG2k] Open Load Menu failed: #{e.message}"
-        @event_save_load = false
-        @interpreter.resume
+        @event_save_load = nil
+        it.resume
       end
 
       # Exit Game (5002, RPG2003): quit, the way the title screen's Shutdown
@@ -3202,18 +3252,27 @@ class RPG2k
       # event once the player closes it again. `@event_menu` marks that this
       # scene is waiting on its own menu, so the event stays paused for exactly
       # one visit instead of re-opening it every frame.
-      def perform_event_menu
+      # `it` defaults to the foreground @interpreter, but #drive_parallel_wait
+      # passes its own parallel interpreter here too -- EasyRPG's
+      # `Game_Interpreter_Map::CommandOpenMainMenu` (src/game_interpreter_map.cpp)
+      # is gated only on `Game_Message::IsMessageActive()`, no `main_flag`
+      # restriction. `@event_menu` now holds the owning interpreter (nil when
+      # closed) rather than a bare boolean, the same shape (and the same
+      # "a pushed Scene fully suspends #update, so nothing can race it"
+      # reasoning) as `@event_save_load` above.
+      def perform_event_menu(it = @interpreter)
         if @event_menu
-          @event_menu = false
-          @interpreter.resume
+          owner = @event_menu
+          @event_menu = nil
+          owner.resume
         else
-          @event_menu = true
+          @event_menu = it
           @parent.push Scene::Menu.new(@parent, @state)
         end
       rescue StandardError => e
         $stderr.puts "[RPG2k] Open Main Menu failed: #{e.message}"
-        @event_menu = false
-        @interpreter.resume
+        @event_menu = nil
+        it.resume
       end
 
       # -- Move Event (Set Move Route) ----------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10492,8 +10492,6 @@ check 'Enter/Exit Vehicle boards the vehicle the party stands on' do
 end
 
 check 'Open Main Menu pushes the field menu and resumes when it closes' do
-  # A foreground event, not a parallel one: a background process resumes every
-  # UI wait itself, and Open Main Menu is a UI wait.
   cmds = [ECmd.new(IC2::OPEN_MAIN_MENU, []), add_var_cmd(6)]
   scene = new_scene({}, player: [0, 0])
   parent = scene.instance_variable_get(:@parent)
@@ -10506,6 +10504,26 @@ check 'Open Main Menu pushes the field menu and resumes when it closes' do
   scene.update # back from the menu: the wait is released...
   scene.update # ...and the next frame runs the rest of the event
   eq 1, st.variables[6], 'the event resumed after the menu closed'
+end
+
+# EasyRPG's `Game_Interpreter_Map::CommandOpenMainMenu`
+# (src/game_interpreter_map.cpp) is gated only on
+# `Game_Message::IsMessageActive()`, no `main_flag` restriction, so a
+# Parallel Process can trigger it exactly like the foreground can. Before
+# this fix, `Scene::Map#drive_parallel_wait` had no `:menu` branch, so it
+# fell into the generic "background: resume" default and a Parallel
+# Process's own Open Main Menu silently never opened the menu at all.
+check 'Open Main Menu issued from a Parallel Process also pushes the field menu' do
+  par = page(trigger: 4) # Parallel Process
+  par.event_commands = [ECmd.new(IC2::OPEN_MAIN_MENU, []), add_var_cmd(6)]
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [0, 0])
+  parent = scene.instance_variable_get(:@parent)
+  st = scene.instance_variable_get(:@state)
+  2.times { scene.update } # raises the :menu wait, then opens the menu
+  eq 1, parent.pushed.length, 'the menu scene was pushed for a Parallel-Process-issued command'
+  eq 0, st.variables[6], 'the process is paused while the menu is open'
+  2.times { scene.update } # back from the menu: the wait releases, then the process continues
+  eq 1, st.variables[6], 'the process resumed after the menu closed'
 end
 
 check 'Open Main Menu ignores a Change Main Menu Access lock -- unlike the ' \
@@ -13584,6 +13602,30 @@ check 'Open Save Menu pushes Scene::SaveLoad in :save mode and resumes the event
   scene.update # back from the picker: the wait is released...
   scene.update # ...and the next frame runs the rest of the event
   eq 1, st.variables[7], 'the event resumed after the picker closed'
+end
+
+# EasyRPG's `Game_Interpreter_Map::CommandOpenSaveMenu`
+# (src/game_interpreter_map.cpp) is gated only on
+# `Game_Message::IsMessageActive()`, no `main_flag` restriction, so a
+# Parallel Process can trigger it exactly like the foreground can. Before
+# this fix, `Scene::Map#drive_parallel_wait` had no `:save_menu` branch, so
+# it fell into the generic "background: resume" default and a Parallel
+# Process's own Open Save Menu silently never opened the picker at all.
+check 'Open Save Menu issued from a Parallel Process also pushes the save picker' do
+  par = page(trigger: 4) # Parallel Process
+  par.event_commands = [ECmd.new(IC2::OPEN_SAVE_MENU, []), add_var_cmd(7)]
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [0, 0])
+  parent = scene.instance_variable_get(:@parent)
+  st = scene.instance_variable_get(:@state)
+  2.times { scene.update } # raises the :save_menu wait, then opens the picker
+  eq 1, parent.pushed.length,
+     'the save/load picker was pushed for a Parallel-Process-issued command'
+  pushed = parent.pushed.first
+  ok pushed.is_a?(RPG2k::Scene::SaveLoad), "pushed Scene::SaveLoad, got #{pushed.class}"
+  eq :save, pushed.instance_variable_get(:@mode), 'opened in :save mode'
+  eq 0, st.variables[7], 'the process is paused while the picker is open'
+  2.times { scene.update } # back from the picker: the wait releases, then the process continues
+  eq 1, st.variables[7], 'the process resumed after the picker closed'
 end
 
 check 'Open Save Menu: confirming a slot in the pushed picker really saves through ' \


### PR DESCRIPTION
## Summary
- `Scene::Map#drive_parallel_wait` had no `:save_menu`/`:menu`/`:load_menu` branches, so all three fell into the generic `else` and were silently discarded via an unconditional `it.resume` — an "auto-save trap" idiom, a custom pause-menu hotkey built from a polled Key Input Processing variable, or an RPG2003 custom load-menu shortcut, all built entirely inside a Parallel Process, would never actually open anything.
- Confirmed against EasyRPG Player's actual C++ source: `Game_Interpreter_Map::CommandOpenSaveMenu`/`CommandOpenMainMenu`/`CommandOpenLoadMenu` (`src/game_interpreter_map.cpp`) are each gated only on `Game_Message::IsMessageActive()` (`CommandOpenLoadMenu` additionally requires `Player::IsRPG2k3ECommands()`) — no `main_flag` reference anywhere in any of the three, the same "no foreground/parallel distinction at all" shape already confirmed for the previously-fixed Return to Title/Exit Game.
- Unlike Return to Title/Exit Game, these three *are* resumable (the interpreter needs to pick back up once the pushed `Scene::SaveLoad`/`Scene::Menu` closes), so the fix mirrors the `:shop`/`:name_input` "track the owner" shape instead: `#perform_event_save`/`#perform_event_load`/`#perform_event_menu` each gain an `it = @interpreter` parameter, and their shared one-visit guard flags (`@event_save_load`, reused by both Save and Load Menu; `@event_menu`) now hold the *owning interpreter* itself (nil when closed) rather than a bare boolean, so the picker/menu resumes whichever interpreter actually opened it.
- No shared-resource cross-guard is needed the way `:shop`/`:name_input` need one, since a pushed `Scene::SaveLoad`/`Scene::Menu` fully suspends `Scene::Map#update` — and so `#drive_parallel_wait` itself — until it pops, leaving nothing to race.

## Test plan
- Two new `scripts/rpg2k_scene_check.rb` checks (Open Main Menu and Open Save Menu, each driving a full Parallel-Process-issued open → paused → close → resume cycle), confirmed to fail against the pre-fix code before the fix, via `git stash`.
- Open Load Menu is not separately covered, matching its own foreground counterpart's existing test shape (mode is the only difference from Open Save Menu, already proven by the pre-existing foreground Load Menu check).
- All four CRuby suites pass (920 + 644 + save/load + 130 checks) and the native `rpg_maker_clone` target rebuilds cleanly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_