### PR TITLE
Honour a troop's Appear Randomly option

### DIFF
--- a/changelog.d/rpg2k-troop-appear-randomly.fixed.md
+++ b/changelog.d/rpg2k-troop-appear-randomly.fixed.md
@@ -1,0 +1,7 @@
+- **A troop's "Appear Randomly" option is now honoured**, instead of every
+  member always showing up at battle start regardless of the setting.
+  Confirmed against EasyRPG Player's source: a flagged troop rolls each
+  initially-visible member for a 40% chance to start hidden instead,
+  stopping once only one member is left visible, giving variable, replayable
+  encounter difficulty. This build never parsed the field at all, so the
+  option had no effect.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6519,6 +6519,48 @@ not yet verified:
   separately covered, matching its own foreground counterpart's existing
   test shape (mode is the only difference from Open Save Menu, already
   proven by the pre-existing foreground Load Menu check).
+- ✅ **A troop's ランダムに出現 (Appear Randomly, chunk 15 field 6) option is now
+  honoured: a flagged troop's own members can start a fight already hidden,
+  instead of every member always showing up regardless of the setting.**
+  The field was parsed by neither the schema nor any runtime code — a "parsed
+  but never read" gap one level up from the usual case, since it was never
+  even decoded out of the .ldb data at all. Confirmed against EasyRPG's
+  actual C++ source: `Game_EnemyParty::ResetBattle`
+  (`src/game_enemyparty.cpp`) rolls each initially-visible member for a flat
+  `Rand::PercentChance(40)` chance to start hidden instead, in member order,
+  stopping the instant only one member is left visible (a fight always needs
+  at least one visible foe to open against) — unconditional on RPG2000 vs
+  RPG2003 or the battle system, gated only on the troop's own
+  `appear_randomly` bool. `mruby-lcf/mrblib/schema.rb`'s `enemy_group`
+  (chunk 15) element table declared fields 1/2/4/5/11 but never 3
+  (`auto_alignment`, a separate, unrelated battle-formation feature not
+  investigated here) or 6 (`appear_randomly`), and `Game::Troop#initialize`
+  (`mruby-rpg2k/mrblib/game.rb`) built `@members` purely from each member's
+  own static `invisible` field, with no troop-level random-hide pass
+  anywhere in `game.rb`/`interpreter.rb`/`scene/battle.rb`. Concretely: a
+  4-member "Slime Swarm" troop with the box checked and every member
+  visible — real RPG_RT/EasyRPG rolls each of the 4 independently (stopping
+  once only 1 remains showing), so anywhere from 1 to 4 slimes actually
+  appear, varying fight to fight, with EXP/gold/drops scaling accordingly
+  (only non-hidden/dead members count, per the already-shipped "Troop
+  EXP/gold/drops exclude a member still hidden" fix above); this build
+  always showed all 4, every single time, forever — the intended
+  easier/harder variable-encounter design was silently absent. Fixed by
+  adding field 6 to the schema and a new `Game::Troop
+  #apply_appear_randomly(row, rng)`, called from `#initialize` (now taking
+  an optional third `rng` parameter) and reproducing EasyRPG's loop exactly
+  — an already-individually-invisible member (its own separate `invisible`
+  field) is skipped, never re-rolled or counted against the "one must stay
+  visible" floor. `Scene::Battle#start`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) now passes its own `@rng` through
+  to `Game::Troop.new`; every other caller (the seeded harness fixtures
+  included) passes none, which skips the whole pass and keeps building a
+  troop deterministically, exactly as before. Covered by four new
+  `scripts/rpg2k_logic_check.rb` checks — the core roll-until-one-remains
+  behaviour, the exact `< 40` (not `<= 40`) threshold, the flag/no-RNG
+  no-op cases, and the already-invisible-member-is-skipped case — all four
+  confirmed to fail against the pre-fix code (`ArgumentError`, since
+  `Troop.new` didn't even accept a third argument yet) before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -287,6 +287,9 @@ module LCF
             },
             4 => { name: :terrain_data_size, type: :int, default: 0 },
             5 => { name: :terrain_set, type: :int8_array },                # bool[]
+            # ランダムに出現 (Appear Randomly): rolled once at battle start,
+            # see Game::Troop#apply_appear_randomly (mruby-rpg2k/mrblib/game.rb).
+            6 => { name: :appear_randomly, type: :bool, default: false },
             11 => {
               name: :pages, type: :Array2D,
               elements: {

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7410,7 +7410,7 @@ module Game
     # interpreter runs. nil / empty for a troop that scripts nothing.
     attr_reader :pages
 
-    def initialize(db, id)
+    def initialize(db, id, rng = nil)
       row = db.enemy_group[id]
       @id = id
       @name = row ? row.name.to_s : ''
@@ -7418,6 +7418,7 @@ module Game
       # Array2D#each yields (id, entry); a plain Hash test double does the same.
       row.members.each { |_, m| @members << member(db, m) } if row && row.members
       @pages = row && row.respond_to?(:pages) ? row.pages : nil
+      apply_appear_randomly(row, rng) if row && rng
     end
 
     # EXP / gold / drops are only earned from members that actually fell in
@@ -7474,6 +7475,30 @@ module Game
 
     def member(db, m)
       Enemy.new(db, m.enemy_id, m.x, m.y, m.invisible)
+    end
+
+    # ランダムに出現 (Appear Randomly, chunk 15 field 6): once per battle, roll
+    # each initially-visible member for a 40% chance to start hidden instead,
+    # stopping the instant only one member is left visible -- a fight always
+    # needs at least one visible foe to open against. Ports EasyRPG's
+    # `Game_EnemyParty::ResetBattle` (src/game_enemyparty.cpp) exactly: a
+    # per-member `Rand::PercentChance(40)` roll, an already-hidden member
+    # (its own individual chunk-15-member field 4, `invisible`) skipped
+    # rather than re-rolled or counted against the "one must stay visible"
+    # floor, and the roll happening once, in member order, not a
+    # roll-then-reveal-one-back pass. `rng` is optional (nil skips the whole
+    # pass) since most callers -- the seeded harness fixtures included --
+    # have no RNG to hand in and expect a `Troop` to build deterministically.
+    def apply_appear_randomly(row, rng)
+      return unless row.respond_to?(:appear_randomly) && row.appear_randomly
+      non_hidden = @members.count { |m| !m.hidden }
+      @members.each do |m|
+        break if non_hidden <= 1
+        next if m.hidden
+        next unless rng.random(100) < 40
+        m.hidden = true
+        non_hidden -= 1
+      end
     end
   end
 

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -140,7 +140,7 @@ class RPG2k
         # shared entry point.
         play_system_se(SFX_BATTLE)
         @map.play_battle_bgm
-        troop = Game::Troop.new(db, @req[:troop_id])
+        troop = Game::Troop.new(db, @req[:troop_id], @rng)
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
         foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
         # The database's state table drives per-turn afflictions (poison slip,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9167,6 +9167,63 @@ class FixedRng
   def random(n); n <= 0 ? 0 : @value % n; end
 end
 
+# ランダムに出現 (Appear Randomly, chunk 15 field 6): parsed but never read
+# before this fix -- every troop with the box checked behaved exactly like
+# one without it. Ports EasyRPG's actual C++ source, `Game_EnemyParty
+# ::ResetBattle` (src/game_enemyparty.cpp): a per-member
+# `Rand::PercentChance(40)` roll in member order, stopping the instant only
+# one member is left visible.
+AppearRandomRow = Struct.new(:name, :members, :appear_randomly)
+
+def appear_random_db(flag: true)
+  BattleDB.new(
+    { 2 => EnemyRow.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10) },
+    { 1 => AppearRandomRow.new('Mob', { 1 => GroupMember.new(2, 0, 0, false),
+                                        2 => GroupMember.new(2, 0, 0, false),
+                                        3 => GroupMember.new(2, 0, 0, false),
+                                        4 => GroupMember.new(2, 0, 0, false) }, flag) })
+end
+
+check 'Game::Troop honours Appear Randomly: a 40% per-member roll hides all ' \
+      'but the last visible member' do
+  db = appear_random_db
+  troop = Game::Troop.new(db, 1, FixedRng.new(0)) # a roll of 0 always succeeds (< 40)
+  eq 1, troop.members.count { |m| !m.hidden }, 'exactly one member stays visible'
+  eq 3, troop.members.count(&:hidden)
+end
+
+check 'Appear Randomly succeeds on a roll under 40, not on 40 itself' do
+  db = appear_random_db
+  hides = Game::Troop.new(db, 1, FixedRng.new(39)).members.count(&:hidden)
+  ok hides > 0, 'a roll of 39 (< 40) succeeds'
+  no_hides = Game::Troop.new(db, 1, FixedRng.new(40)).members.count(&:hidden)
+  eq 0, no_hides, 'a roll of 40 (not < 40) never succeeds'
+end
+
+check 'Appear Randomly leaves every member visible without the flag set, or ' \
+      'without an RNG handed in at all' do
+  eq 0, Game::Troop.new(appear_random_db(flag: false), 1, FixedRng.new(0)).members.count(&:hidden),
+     'the flag is off -- an always-succeeding roll still hides nobody'
+  eq 0, Game::Troop.new(appear_random_db, 1).members.count(&:hidden),
+     'no RNG handed in at all -- the pass is skipped entirely, not rolled against a default'
+end
+
+check 'Appear Randomly never re-rolls a member already individually flagged ' \
+      'invisible' do
+  db = BattleDB.new(
+    { 2 => EnemyRow.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10) },
+    { 1 => AppearRandomRow.new('Mob', { 1 => GroupMember.new(2, 0, 0, true), # already invisible
+                                        2 => GroupMember.new(2, 0, 0, false),
+                                        3 => GroupMember.new(2, 0, 0, false) }, true) })
+  troop = Game::Troop.new(db, 1, FixedRng.new(0)) # always succeeds
+  # 2 members start visible; the roll stops once only 1 remains, so exactly
+  # one of the two gets hidden -- the already-invisible member is never
+  # touched by the loop at all.
+  eq 2, troop.members.count(&:hidden), 'the pre-invisible member plus one newly-rolled one'
+  ok troop.members[0].hidden, 'the already-invisible member stays hidden (never re-rolled)'
+  ok !troop.members[2].hidden, 'the loop stopped once one member was left visible'
+end
+
 check 'battle: the crit roll is read against a whole-percent scale' do
   # A rate of N must crit on a roll of N-1 and not on N -- EasyRPG's
   # Rand::PercentChance(int rate), `GetRandomNumber(0, 99) < rate`.


### PR DESCRIPTION
## Summary
- A troop's ランダムに出現 (Appear Randomly, LDB chunk 15 field 6) option was never even parsed by the schema, let alone consumed at runtime — a "parsed but never read" gap one level up from the usual case, since it was never decoded out of the `.ldb` data at all. Every troop with the box checked behaved exactly like one without it, always showing every member at battle start.
- Confirmed against EasyRPG Player's actual C++ source: `Game_EnemyParty::ResetBattle` (`src/game_enemyparty.cpp`) rolls each initially-visible member for a flat `Rand::PercentChance(40)` chance to start hidden instead, in member order, stopping the instant only one member is left visible — unconditional on RPG2000 vs RPG2003 or the battle system.
- Concretely: a 4-member "Slime Swarm" troop with the box checked — real RPG_RT/EasyRPG rolls each of the 4 independently, so anywhere from 1 to 4 slimes actually appear, varying fight to fight, with EXP/gold/drops scaling accordingly; this build always showed all 4, every single time, forever.
- Fixed by adding field 6 to `mruby-lcf/mrblib/schema.rb` and a new `Game::Troop#apply_appear_randomly(row, rng)`, called from `#initialize` (now taking an optional third `rng` parameter) and reproducing EasyRPG's loop exactly — an already-individually-invisible member is skipped, never re-rolled or counted against the "one must stay visible" floor. `Scene::Battle#start` now passes its own `@rng` through to `Game::Troop.new`; every other caller (the seeded harness fixtures included) passes none, which skips the whole pass and keeps building a troop deterministically, exactly as before.

## Test plan
- Four new `scripts/rpg2k_logic_check.rb` checks — the core roll-until-one-remains behaviour, the exact `< 40` (not `<= 40`) threshold, the flag/no-RNG no-op cases, and the already-invisible-member-is-skipped case — all four confirmed to fail against the pre-fix code (`ArgumentError`, since `Troop.new` didn't even accept a third argument yet) before the fix, via `git stash`.
- All four CRuby suites pass (924 + 644 + save/load + 130 checks), the native `rpg_maker_clone` target rebuilds cleanly, and `ninja test` (native mruby suite, run since this touched `schema.rb`) passes.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_