### PR TITLE
Let a Battle Item target a downed ally, and honour ko_only in battle

### DIFF
--- a/changelog.d/rpg2k-battle-revive-item-ko-only.fixed.md
+++ b/changelog.d/rpg2k-battle-revive-item-ko-only.fixed.md
@@ -1,0 +1,7 @@
+- **A downed party member can now be targeted with a Battle Item, and a
+  revive-only (`ko_only`) item cast in battle actually revives them.**
+  Confirmed against EasyRPG Player's source: the battle Item ally picker used
+  to exclude every KO'd ally outright, so a revive item could never be aimed
+  at the person it was meant to save, and the battle code path never checked
+  the "does nothing unless the target is down" flag at all, so casting one on
+  a living ally silently worked as a free full heal instead.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6561,6 +6561,46 @@ not yet verified:
   no-op cases, and the already-invisible-member-is-skipped case — all four
   confirmed to fail against the pre-fix code (`ArgumentError`, since
   `Troop.new` didn't even accept a third argument yet) before the fix.
+- ✅ **A downed ally can now be aimed at with a Battle Item, and a 蘇生専用
+  (`ko_only`) revive item cast in battle actually revives them — both were
+  broken.** Confirmed against EasyRPG's actual C++ source, both sides.
+  `Scene_Battle::ItemSelected`/`AssignSkill` (`src/scene_battle.cpp`) put the
+  status window into `Window_BattleStatus::ChoiceMode_All` for a
+  single-target medicine, and `IsChoiceValid`'s `ChoiceMode_All` case
+  (`src/window_battlestatus.cpp`) is an unconditional `return true` — nothing
+  excludes a KO'd party member from being offered as a target. This build's
+  `Scene::Battle#battle_ally_targets` (`mruby-rpg2k/mrblib/scene/battle.rb`)
+  started from `#living_allies` instead, so a KO'd ally never even appeared
+  in the ally-target picker in the first place — the item meant to revive
+  them had no way to be aimed at them at all. Separately,
+  `Game_BattleAlgorithm::Item::vExecute` (`src/game_battlealgorithm.cpp`)
+  returns before *either* the state cure or the HP/SP recovery is computed
+  once `item.ko_only && !GetTarget()->IsDead()`; `Game::Party#battle_item_
+  command` (`mruby-rpg2k/mrblib/game.rb`) had no such gate at all, unlike its
+  field-menu sibling `#use_medicine` (already fixed, see `#ko_only_blocked?`
+  above) — so even on the rare occasion a battle test build did target a
+  downed ally by other means, a revive item aimed at a *living* one instead
+  quietly worked as a free full heal rather than doing nothing. Concretely:
+  Nepheshel's ドラゴンハート (`ko_only`, restores 100% max HP) with 3 of 4
+  party members down — before this fix, the Battle Item ally picker offered
+  only the one standing member, and using it there landed a full heal on
+  someone who was never in danger; the three actually-KO'd allies it exists
+  to revive could never be selected at all. Fixed by widening
+  `#battle_ally_targets`'s item branch (only the item branch — a pending
+  skill still starts from `#living_allies`, since EasyRPG's own dead-target
+  handling for `Scope_ally` skills, `Game_BattleAlgorithm::Skill::vExecute`,
+  is a materially larger state machine left for its own fix) to the whole
+  roster, dead members included, still narrowed by the same 使用可能キャラ
+  (`actor_set`) gate as before; widening `#apply_pending_item_all`'s target
+  list the same way, matching EasyRPG's entire-party medicine branch
+  targeting the whole `Game_Party` rather than a living subset; and adding
+  the missing `ko_only_blocked?` gate to `#battle_item_command`. Covered by
+  two new `scripts/rpg2k_logic_check.rb` checks (a `ko_only` item on a
+  standing target now returns no HP/MP/cure at all, and on a downed one
+  returns both) and a new `scripts/rpg2k_scene_check.rb` check (a downed
+  ally now appears in the battle Item ally-target picker and can be
+  selected and queued as the command's target), all three confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4748,7 +4748,17 @@ module Game
     # which target may be *offered* at all, not of what this formula computes
     # once one legitimately is — see `Scene::Map#battle_ally_targets`, which is
     # where that gate actually lives for a battle-cast item.
+    #
+    # A 蘇生専用 (`ko_only`) item on a target who is not down does nothing at
+    # all, not even the state cure -- EasyRPG's `Game_BattleAlgorithm::Item::
+    # vExecute` returns before state removal *and* HP/SP recovery are ever
+    # computed once `item.ko_only && !GetTarget()->IsDead()` (game_
+    # battlealgorithm.cpp). `#use_medicine` already applies this on the field
+    # menu path (`ko_only_blocked?`); the battle path had never checked it,
+    # so a revive item cast on a still-standing ally quietly worked as a free
+    # full heal instead of doing nothing.
     def battle_item_command(it, target)
+      return { hp: 0, mp: 0, cured: [] } if ko_only_blocked?(it, target)
       hp, mp = item_recovery(it, target)
       { hp: hp, mp: mp, cured: item_cured_states(it) }
     end

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -802,22 +802,31 @@ class RPG2k
 
       def living_allies; @ui[:allies].reject(&:dead?); end
 
-      # Living allies selectable as a manually-chosen Battle Item target right
-      # now: `#living_allies` narrowed by the pending item's own 使用可能キャラ
-      # (`actor_set`) restriction when there is one -- the same per-recipient
-      # gate `Game::Party#use_medicine` already applies in the field menu
-      # (`Game::Party#item_usable_by?`), which this picker had never
-      # consulted at all, so a party member the item cannot affect used to be
-      # offered as a choice anyway rather than not appearing in the first
-      # place. A pending skill is untouched -- actor_set only gates
-      # equipment/items, never skills. `@state.party` not answering
-      # `item_usable_by?` (a battle test's stub party, which never models
-      # equipment restrictions) degrades to "unrestricted", the same default
-      # the real method itself falls back to for an item with no actor_set at
-      # all.
+      # Allies selectable as a manually-chosen Battle Item target right now.
+      # Unlike a skill target (still `#living_allies` below -- EasyRPG's own
+      # `Skill::vExecute` dead-target handling is a materially larger state
+      # machine this fix does not touch), an item target is drawn from the
+      # *whole* roster, dead members included: EasyRPG's `Scene_Battle::
+      # ItemSelected`/`AssignSkill` both put the status window into
+      # `Window_BattleStatus::ChoiceMode_All` for a single-target medicine or
+      # an ally-scope skill, and `IsChoiceValid`'s `ChoiceMode_All` case is an
+      # unconditional `return true` (src/window_battlestatus.cpp) -- nothing
+      # there excludes a KO'd party member. This picker used to start from
+      # `#living_allies` instead, so a 蘇生専用 (`ko_only`) revive item could
+      # never even be aimed at the ally it was meant to revive. Then narrowed
+      # by the pending item's own 使用可能キャラ (`actor_set`) restriction
+      # when there is one -- the same per-recipient gate `Game::Party#
+      # use_medicine` already applies in the field menu (`Game::Party#
+      # item_usable_by?`), which this picker had never consulted at all, so a
+      # party member the item cannot affect used to be offered as a choice
+      # anyway rather than not appearing in the first place. `@state.party`
+      # not answering `item_usable_by?` (a battle test's stub party, which
+      # never models equipment restrictions) degrades to "unrestricted", the
+      # same default the real method itself falls back to for an item with no
+      # actor_set at all.
       def battle_ally_targets
-        allies = living_allies
-        return allies unless pending_kind == :item
+        return living_allies unless pending_kind == :item
+        allies = @ui[:allies]
         return allies unless @state.party.respond_to?(:item_usable_by?)
         it = @ui[:pending] && @ui[:pending][:it]
         return allies unless it
@@ -1381,7 +1390,12 @@ class RPG2k
           if @state.party.switch_item?(item_id)
             apply_pending_switch_item
           elsif @state.party.item_all_allies?(it)
-            apply_pending_item_all(living_allies)
+            # The whole roster, dead included -- EasyRPG's own entire_party
+            # branch (`Scene_Battle::ItemSelected`) targets `Main_Data::
+            # game_party.get()` itself, not a living-only subset, which is
+            # what lets an all-party 蘇生専用 item revive every KO'd member
+            # in one cast.
+            apply_pending_item_all(@ui[:allies])
           else
             @ui[:ally_i] = 0
             @ui[:phase] = :ally_target

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11393,6 +11393,31 @@ check 'battle_items lists battle medicines; battle_item_command recovers' do
      st.party.battle_item_command(st.party.db_item(5), target))
 end
 
+# A 蘇生専用 (`ko_only`) item cast from the battle Item menu: EasyRPG's
+# `Game_BattleAlgorithm::Item::vExecute` returns before either the HP/SP
+# recovery or the state cure is ever computed once `item.ko_only &&
+# !GetTarget()->IsDead()`, so a revive item aimed at a target still standing
+# does nothing at all -- not even the percentage HP restore or the cure. The
+# field-menu path (`#use_medicine`) already honoured this; `#battle_item_
+# command` had not.
+check 'battle_item_command does nothing for a ko_only item on a standing target' do
+  items = { 4 => fake_item(type: 6, rhp_rate: 25, state_set: [1], ko_only: true) }
+  st = item_party(items)
+  target = combatant('T', 0, 0, 5, 100)
+  eq({ hp: 0, mp: 0, cured: [] },
+     st.party.battle_item_command(st.party.db_item(4), target))
+end
+
+check 'battle_item_command revives a downed target, HP and cure both landing' do
+  items = { 4 => fake_item(type: 6, rhp_rate: 25, state_set: [1], ko_only: true) }
+  st = item_party(items)
+  target = combatant('T', 0, 0, 5, 100)
+  target.max_mp = 30
+  target.hp = 0
+  eq({ hp: 25, mp: 0, cured: [1] },
+     st.party.battle_item_command(st.party.db_item(4), target))
+end
+
 check 'a battle item cures the target status; states carry out via apply_to_party' do
   # An antidote (a medicine curing state 3) used in battle on a poisoned ally.
   items = { 5 => fake_item(type: 6, state_set: [0, 0, 1]) }

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9506,6 +9506,46 @@ check "Enemy Encounter scene: a restricted item's ally-target picker skips the a
      'the queued Item command targets actor 1, never the restricted actor 2'
 end
 
+# A second actor already down (hp 0) when the fight starts -- exactly the
+# combatant a 蘇生専用 (`ko_only`) revive item exists to target.
+class BattleDownedAllyParty < BattleMagicParty
+  def initialize(hurt: false)
+    super(hurt: hurt)
+    @hero2 = BattleStubActor.new(atk: 10, agi: 5, mp: 5, hp: 150, id: 2)
+    @hero2.hp = 0
+    @actors = [@hero, @hero2]
+  end
+end
+
+check "Enemy Encounter scene: a downed ally is offered as a Battle Item target, not skipped" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleDownedAllyParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  press_key(scene, RGSS::Input::C)    # choose the Potion -> ally target
+  eq :ally_target, ui[:phase]
+  targets = scene.instance_variable_get(:@battle).send(:battle_ally_targets)
+  eq 2, targets.length, 'the downed ally is still offered, not excluded from the picker'
+  ok targets.any?(&:dead?), 'one of the offered targets is the downed ally'
+  press_key(scene, RGSS::Input::DOWN)
+  eq 1, ui[:ally_i], 'the cursor can reach the downed ally, which used to be unreachable'
+  press_key(scene, RGSS::Input::C) # confirm on the downed ally
+  # The only other roster slot is the downed ally itself, which never gets a
+  # command of its own, so the round starts right away rather than moving to
+  # a second actor's command phase (unlike the restricted-item check above,
+  # whose second actor is merely restricted, not dead, and still gets a turn).
+  eq :animate, ui[:phase]
+  eq ui[:allies][1], ui[:allies][0].command[:target],
+     'the queued Item command targets the downed ally, not just the living one'
+end
+
 check 'Enemy Encounter scene: draws a battler sprite per enemy, hidden on death' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Battle#battle_ally_targets` (`mruby-rpg2k/mrblib/scene/battle.rb`) started its item-target list from `#living_allies`, so a KO'd party member could never even be *offered* as a Battle Item target — a revive item had no way to be aimed at the ally it was meant to save. Fixed by widening the item branch (only the item branch — a pending skill still starts from `#living_allies`, since EasyRPG's own dead-target handling for `Scope_ally` skills is a materially larger state machine left for its own fix) to the whole roster, dead members included, still narrowed by the existing 使用可能キャラ (`actor_set`) gate. `#apply_pending_item_all`'s target list is widened the same way, matching EasyRPG's entire-party medicine branch targeting the whole party rather than a living subset.
- `Game::Party#battle_item_command` (`mruby-rpg2k/mrblib/game.rb`) never checked 蘇生専用 (`ko_only`) at all, unlike its field-menu sibling `#use_medicine`, so casting a revive item on a still-standing ally in battle silently worked as a free full heal instead of doing nothing. Added the missing `ko_only_blocked?` gate.

Both confirmed against EasyRPG Player's actual C++ source:
- `Window_BattleStatus::IsChoiceValid`'s `ChoiceMode_All` case (`src/window_battlestatus.cpp`) is an unconditional `return true` — nothing excludes a KO'd party member from being a valid choice, and `Scene_Battle::ItemSelected`/`AssignSkill` (`src/scene_battle.cpp`) put the status window into exactly that mode for a single-target medicine.
- `Game_BattleAlgorithm::Item::vExecute` (`src/game_battlealgorithm.cpp`) returns before either the state cure or the HP/SP recovery is computed once `item.ko_only && !GetTarget()->IsDead()`.

## Test plan

- Two new `scripts/rpg2k_logic_check.rb` checks: a `ko_only` item on a standing target now returns no HP/MP/cure at all; on a downed target it returns both the HP restore and the cure.
- One new `scripts/rpg2k_scene_check.rb` check: a downed ally now appears in the battle Item ally-target picker (2 candidates instead of 1) and can be selected and queued as the command's target.
- All three confirmed to fail against the pre-fix code before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 926 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 645 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_