### PR TITLE
Redirect a Move Event targeting a ridden vehicle onto the player

### DIFF
--- a/changelog.d/rpg2k-move-event-ridden-vehicle.fixed.md
+++ b/changelog.d/rpg2k-move-event-ridden-vehicle.fixed.md
@@ -1,0 +1,5 @@
+- **Move Event now works when it targets a boat, ship, or airship the party
+  is currently riding.** It used to be silently dropped instead of steering
+  the vehicle the party is standing on -- the technique real RPG_RT uses to
+  script a boat or airship sailing across the map with the party aboard now
+  works here too.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6601,6 +6601,36 @@ not yet verified:
   ally now appears in the battle Item ally-target picker and can be
   selected and queued as the command's target), all three confirmed to fail
   against the pre-fix code before the fix.
+- ✅ **A Move Event targeting a boat/ship/airship the party is currently
+  riding now redirects onto the player, driving a scripted vehicle ride,
+  instead of the whole move route being silently dropped.** Confirmed
+  against EasyRPG's actual C++ source: `Game_Interpreter::CommandMoveEvent`
+  (code 11330, `src/game_interpreter.cpp`) — "If the event is a vehicle in
+  use, push the commands to the player instead" — reassigns its target to
+  `Main_Data::game_player.get()` whenever `Game_Vehicle::IsInUse()`
+  (`Main_Data::game_player->GetVehicle() == this`, `src/game_vehicle.cpp`)
+  is true, then calls `ForceMoveRoute` on whichever character it ended up
+  with. This is how a genuine RPG2000/2003 event scripts "the boat sails
+  across the map while the party stands on it": the player is what actually
+  moves, and a ridden vehicle already mirrors the player's tile every frame
+  (this build's own `#follow_vehicle`). `Scene::Map#apply_move_request`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) routed every boat/ship/airship target
+  straight into `#force_vehicle_route` regardless of who was riding it, and
+  that method explicitly no-ops while the vehicle is boarded (`return if
+  @state.boarded == type` — needed so a *parked* vehicle's own route never
+  fights `#follow_vehicle` once someone boards it mid-route) — so a Move
+  Event issued at a boat the party is standing on did nothing at all: no
+  movement, no error, silently discarded. Fixed by having
+  `#apply_move_request` check `@state.boarded == type` itself and call the
+  already-existing `#start_player_route` (the same method Set Move Route
+  targeting the player itself uses) instead of `#force_vehicle_route` when
+  the target vehicle is the one currently ridden — no new state or rendering
+  path, just reusing the existing player-route mechanism EasyRPG's own
+  redirect maps onto. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  (a Move Event issued at a boarded boat now sails the party — and the boat
+  riding along with it — east, with no separate vehicle-character route ever
+  armed), confirmed to fail against the pre-fix code (stayed at x=0) before
+  the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3300,7 +3300,21 @@ class RPG2k
           force_event_route(this_event, route, r[:frequency]) if this_event
         when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
           type = Game::Vehicle::TYPES[r[:target] - MOVE_TARGET_BOAT]
-          force_vehicle_route(type, route, r[:frequency])
+          # EasyRPG's own `Game_Interpreter::CommandMoveEvent` (code 11330):
+          # "If the event is a vehicle in use, push the commands to the
+          # player instead" (`event = Main_Data::game_player.get()` when
+          # `Game_Vehicle::IsInUse()`) -- a scripted vehicle ride (sail the
+          # boat/airship across the map while the party stands on it) works
+          # by driving the *player*, which the ridden vehicle already
+          # mirrors every frame (#follow_vehicle). This used to fall
+          # straight into #force_vehicle_route, which explicitly no-ops
+          # while ridden (`return if @state.boarded == type`) -- the whole
+          # route was silently dropped instead of redirected.
+          if @state.boarded == type
+            start_player_route(route, r[:frequency])
+          else
+            force_vehicle_route(type, route, r[:frequency])
+          end
         else
           ev = @events.find { |e| e[:id] == r[:target] }
           if ev
@@ -3438,13 +3452,16 @@ class RPG2k
       end
 
       # Give vehicle `type` a forced route (Move Event / Set Move Route
-      # targeting a boat/ship/airship). A no-op when the vehicle is not
-      # placed on the current map (nothing here simulates a map that is not
-      # loaded) or is currently ridden -- the party's own #follow_vehicle
-      # already claims the ridden vehicle's position every frame, and RPG_RT
-      # has no documented "pilot the vehicle you're standing on by event"
-      # interaction, so the simplest, safest reading is that boarding and a
-      # route on the same vehicle just don't mix.
+      # targeting a boat/ship/airship, and only that -- a ridden vehicle is
+      # redirected onto the player before this is ever reached, see
+      # #apply_move_request). A no-op when the vehicle is not placed on the
+      # current map (nothing here simulates a map that is not loaded); the
+      # `@state.boarded == type` guard below is now unreachable through
+      # #apply_move_request's own redirect but stays as a defensive no-op
+      # for any other caller this method gains -- the party's own
+      # #follow_vehicle already claims a ridden vehicle's position every
+      # frame, so a route driving the vehicle character directly while
+      # boarded would fight that.
       def force_vehicle_route(type, route, freq)
         v = @state.vehicle(type)
         return unless v.placed? && v.map_id == @state.map_id

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7078,6 +7078,37 @@ check 'a Move Route request targeting a currently-ridden vehicle is ignored' do
      'the route request was dropped rather than fighting #follow_vehicle'
 end
 
+# EasyRPG's own Game_Interpreter::CommandMoveEvent (code 11330,
+# src/game_interpreter.cpp): "If the event is a vehicle in use, push the
+# commands to the player instead" -- a Move Event targeting a boat the party
+# is currently riding drives the *player*, which the ridden boat already
+# mirrors every frame (#follow_vehicle), producing a scripted "sail the boat
+# across the map while the party stands on it" cutscene. #apply_move_request
+# used to route this straight into #force_vehicle_route above, which
+# deliberately no-ops while ridden -- so the whole move route was silently
+# dropped instead of redirected onto the player.
+check 'Move Event targeting a currently-ridden vehicle redirects onto the ' \
+      'player instead of being dropped' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10002 (boat), freq 8, repeat off, skippable on, MOVE_RIGHT.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10002, 8, 0, 1, R::MOVE_RIGHT])]
+  scene = new_scene({ 1 => event(0, 4, auto) }, player: [0, 1], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  st.boarded = :boat
+  20.times { scene.update }
+  ok st.x > 0,
+     "the player (and the vehicle riding along with it) should have sailed " \
+     "east under the redirected route, at x=#{st.x}"
+  eq boat.x, st.x, "the ridden boat mirrors the player it was redirected onto"
+  eq nil, scene.instance_variable_get(:@vehicle_routes)[:boat],
+     'no separate vehicle-character route was ever armed for the boat itself'
+end
+
 check 'Change Event Location repositions a vehicle' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Map#apply_move_request` (`mruby-rpg2k/mrblib/scene/map.rb`) routed every boat/ship/airship Move Event target straight into `#force_vehicle_route`, which explicitly no-ops while the target vehicle is boarded (`return if @state.boarded == type`) — that guard exists so a *parked* vehicle's own route never fights `#follow_vehicle` once someone boards it mid-route. The side effect: a Move Event issued at a boat the party is currently riding did nothing at all — no movement, no error, silently discarded.
- EasyRPG's own `Game_Interpreter::CommandMoveEvent` (`src/game_interpreter.cpp`, code 11330) redirects such a request onto the *player* instead whenever `Game_Vehicle::IsInUse()` (`Main_Data::game_player->GetVehicle() == this`, `src/game_vehicle.cpp`) is true: `event = Main_Data::game_player.get()`, then `ForceMoveRoute` runs on that. This is how a genuine RPG2000/2003 event scripts "the boat/airship sails across the map while the party stands on it" — a ridden vehicle already mirrors the player's tile every frame (this build's own `#follow_vehicle`), so driving the player *is* driving the vehicle.
- Fixed by having `#apply_move_request` check `@state.boarded == type` itself and call the already-existing `#start_player_route` (the same method Set Move Route targeting the player itself uses) instead of `#force_vehicle_route` when the move target is the currently-ridden vehicle. No new persistent state or rendering path — reuses the existing player-route mechanism, matching exactly what EasyRPG's redirect maps onto.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: a Move Event issued at a boarded boat now sails the party (and the boat riding along with it) east, with no separate vehicle-character route ever armed for the boat itself.
- Confirmed to fail against the pre-fix code (stayed at x=0, route silently dropped) before the fix.
- `ruby scripts/rpg2k_scene_check.rb` — 646 checks passed
- `ruby scripts/rpg2k_logic_check.rb` — 926 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_