### PR TITLE
Honour Change Event Location's RPG2003 facing sub-parameter

### DIFF
--- a/changelog.d/rpg2k-change-event-location-facing.fixed.md
+++ b/changelog.d/rpg2k-change-event-location-facing.fixed.md
@@ -1,0 +1,4 @@
+- **Change Event Location's RPG2003 "set facing" option now works.** A
+  character moved by the command can snap to face a direction on arrival
+  (e.g. turning a repositioned event to face the camera for a cutscene),
+  instead of always keeping whatever facing it already had.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6631,6 +6631,32 @@ not yet verified:
   riding along with it — east, with no separate vehicle-character route ever
   armed), confirmed to fail against the pre-fix code (stayed at x=0) before
   the fix.
+- ✅ **Change Event Location's RPG2003 facing sub-parameter is now honoured —
+  a target moved by the command can snap to face a direction on arrival,
+  instead of always keeping whatever facing it already had.** Confirmed
+  against EasyRPG's actual C++ source: `Game_Interpreter::
+  CommandChangeEventLocation` (code 10860, `src/game_interpreter.cpp`) reads
+  a 5th parameter as `direction = com.parameters[4] - 1` under
+  `Player::IsRPG2k3Commands()`, then applies it with `event->SetDirection`/
+  `UpdateFacing` — but "only for the constant case, not for variables" (its
+  own comment), i.e. only when the target's x/y came from the literal
+  param2/param3 rather than the variable-appointment mode. `Interpreter#
+  do_change_event_location` (`mruby-rpg2k/mrblib/interpreter.rb`) never read
+  `cmd.param(4)` at all, so an event authored with the editor's "set facing"
+  sub-option — e.g. teleporting a statue onto a cutscene mark and turning it
+  to face the camera — silently kept its old facing instead. Fixed by
+  reusing `#teleport_facing` (the identical 1-based up/right/down/left → this
+  runtime's own numpad-direction conversion Teleport's own param3 already
+  goes through, for the exact same "RPG2000 writes 0 here" reasoning) on
+  `cmd.param(4)`, gated on constant-appointment mode, and threading the
+  result through the queued `:set` location request into `Scene::Map#
+  set_char_location`, which now snaps whichever character type the request
+  targets (player, this event, another map event, or a vehicle) to face it.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (the queued
+  request carries the converted `dir:`, and variable-appointment mode always
+  reads as `0`/no facing change) and a new `scripts/rpg2k_scene_check.rb`
+  check (a targeted event snaps to face down on arrival), all three
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2687,14 +2687,27 @@ module Game
     # constants param2/param3, 1 the values of those two variables); param2/param3
     # the x and y. Queued as a `:set` request the scene applies — non-blocking,
     # so the rest of the command list runs on.
+    #
+    # param4 is the same **RPG2003** facing addition Teleport's own param3 is
+    # (EasyRPG's `CommandChangeEventLocation`, `src/game_interpreter.cpp`: `if
+    # (Player::IsRPG2k3Commands() && com.parameters.size() > 4) direction =
+    # com.parameters[4] - 1;`), 1-based over up/right/down/left, 0 (or absent,
+    # which `#param` already reads as 0) meaning "keep the current facing" —
+    # `#teleport_facing` already converts that exact encoding into this
+    # runtime's own numpad direction, so it is reused verbatim here rather
+    # than duplicated. EasyRPG only applies it "for the constant case, not
+    # for variables" (its own comment) -- the appointment-mode check below
+    # mirrors that.
     def do_change_event_location(cmd)
       x = cmd.param(2)
       y = cmd.param(3)
-      if cmd.param(1) == 1
+      variable_mode = cmd.param(1) == 1
+      if variable_mode
         x = variables[x]
         y = variables[y]
       end
-      @location_requests.push({ op: :set, target: cmd.param(0), x: x, y: y })
+      dir = variable_mode ? 0 : teleport_facing(cmd.param(4))
+      @location_requests.push({ op: :set, target: cmd.param(0), x: x, y: y, dir: dir })
     end
 
     # Trade Event Locations (Swap Event Locations): exchange the tiles of the two

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3361,7 +3361,7 @@ class RPG2k
           set_char_location(r[:a], this_event, b[0], b[1])
           set_char_location(r[:b], this_event, a[0], a[1])
         else
-          set_char_location(r[:target], this_event, r[:x], r[:y])
+          set_char_location(r[:target], this_event, r[:x], r[:y], r[:dir])
         end
       end
 
@@ -3382,18 +3382,32 @@ class RPG2k
         end
       end
 
-      # Instantly move a target character to a tile.
-      def set_char_location(target, this_event, x, y)
+      # Instantly move a target character to a tile, optionally snapping its
+      # facing too (Change Event Location's own RPG2003 facing sub-parameter
+      # -- see #do_change_event_location; nil/0 leaves the current facing
+      # alone, matching Teleport's own "0 means keep it" convention. Trade
+      # Event Locations carries no facing at all, so it always calls this
+      # with `dir` left at its default).
+      def set_char_location(target, this_event, x, y, dir = nil)
         case target
         when MOVE_TARGET_PLAYER
           move_player_to(x, y)
+          @state.direction = dir if dir && dir > 0
         when 0, MOVE_TARGET_THIS
-          move_event_to(this_event, x, y) if this_event
+          if this_event
+            move_event_to(this_event, x, y)
+            this_event[:char].face!(dir) if dir && dir > 0
+          end
         when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
-          move_vehicle_to(Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT], x, y)
+          type = Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT]
+          move_vehicle_to(type, x, y)
+          @state.vehicle(type).direction = dir if dir && dir > 0
         else
           ev = @events.find { |e| e[:id] == target }
-          move_event_to(ev, x, y) if ev
+          if ev
+            move_event_to(ev, x, y)
+            ev[:char].face!(dir) if dir && dir > 0
+          end
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7573,9 +7573,30 @@ check 'Change Event Location queues a :set request (constant and variable modes)
   eq true, st.switches[1]
   reqs = it.take_location_requests
   eq 2, reqs.size
-  eq({ op: :set, target: 3, x: 5, y: 6 }, reqs[0])
-  eq({ op: :set, target: 3, x: 4, y: 9 }, reqs[1], 'variable mode resolves x/y')
+  eq({ op: :set, target: 3, x: 5, y: 6, dir: 0 }, reqs[0],
+     'no 5th param -- reads as 0, "keep the current facing"')
+  eq({ op: :set, target: 3, x: 4, y: 9, dir: 0 }, reqs[1],
+     'variable mode resolves x/y and never applies a facing')
   eq [], it.take_location_requests, 'the queue clears after draining'
+end
+
+# EasyRPG's own CommandChangeEventLocation (src/game_interpreter.cpp): "RPG2k3
+# feature" -- param4 is a 1-based up/right/down/left facing, applied only "for
+# the constant case, not for variables". #teleport_facing (already proven by
+# the Teleport tests above) is what converts that same 1-based encoding into
+# this runtime's own numpad direction, reused verbatim here.
+check 'Change Event Location carries the RPG2003 facing sub-parameter, constant mode only' do
+  st = party_state
+  st.variables[7] = 4
+  st.variables[8] = 9
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_EVENT_LOCATION, [3, 0, 5, 6, 3]),  # constant, face down
+            FakeCmd.new(IC::CHANGE_EVENT_LOCATION, [3, 1, 7, 8, 3])]) # variable, facing ignored
+  it.update
+  reqs = it.take_location_requests
+  eq 2, reqs.size
+  eq 2, reqs[0][:dir], 'constant mode: param4=3 (down) -> numpad 2'
+  eq 0, reqs[1][:dir], 'variable mode never applies the facing param at all'
 end
 
 check 'Trade Event Locations queues a :swap request' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3240,6 +3240,20 @@ check 'Change Event Location snaps another event to a tile' do
   ok !tiles[[1, 1]], 'its old tile was released'
 end
 
+check "Change Event Location's RPG2003 facing sub-parameter snaps another " \
+      'event to face too' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3) # auto-start: place event 2 at (5, 3), facing down
+  auto.event_commands = [ECmd.new(ic::CHANGE_EVENT_LOCATION, [2, 0, 5, 3, 3])]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(1, 1, page) },
+                    player: [5, 5])
+  c = chars(scene)[2]
+  c.direction = 8 # start facing up, so a no-op would be obvious
+  5.times { scene.update }
+  eq [5, 3], [c.x, c.y], 'the event was moved to the target tile'
+  eq 2, c.direction, 'and snapped to face down (facing param 3 -> numpad 2)'
+end
+
 check 'Change Event Location with "this event" moves the runner itself' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Interpreter#do_change_event_location` (`mruby-rpg2k/mrblib/interpreter.rb`) only ever read `cmd.param(0..3)`; `cmd.param(4)` — the RPG2003 editor's optional "set facing" sub-option on Change Event Location — was never touched, so a target moved by the command silently kept whatever facing it already had instead of snapping to face the direction the event names (e.g. teleporting a statue onto a cutscene mark and turning it to face the camera).
- EasyRPG's `Game_Interpreter::CommandChangeEventLocation` (code 10860, `src/game_interpreter.cpp`) reads this as `direction = com.parameters[4] - 1` under `Player::IsRPG2k3Commands()`, and — per its own comment "only for the constant case, not for variables" — applies it only when the target's x/y came from the literal param2/param3, not the variable-appointment mode.
- Fixed by reusing `#teleport_facing` — the exact same 1-based up/right/down/left → this runtime's numpad-direction conversion Teleport's own param3 already goes through, for the identical "an RPG2000 project writes 0 here" reasoning already documented on that method — on `cmd.param(4)`, gated on constant-appointment mode, and threading the resulting `dir:` through the queued `:set` location request into `Scene::Map#set_char_location`, which now snaps whichever character type the request targets (player, this event, another map event, or a vehicle) to face it.

## Test plan

- Two new `scripts/rpg2k_logic_check.rb` checks: the queued request now carries the converted `dir:` (`0` when the 5th param is absent, matching "keep the current facing"); constant mode converts a facing param correctly while variable-appointment mode always reads as `0`/no change.
- One new `scripts/rpg2k_scene_check.rb` check: a targeted event snaps to face down on arrival when the command names one.
- All three confirmed to fail against the pre-fix code before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 927 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 647 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_