### PR TITLE
Honour RPG2003's global equip-by-Class setting

### DIFF
--- a/changelog.d/rpg2k-equipment-setting-by-class.fixed.md
+++ b/changelog.d/rpg2k-equipment-setting-by-class.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003's global "equip/use by Class" setting is now honoured.** A
+  database configured to restrict item and equipment usability by Class
+  instead of by Actor used to have every restriction decided per-Actor
+  regardless -- letting anyone equip or use items the designer meant to
+  limit to specific classes, and blocking a `use_skill` equipment item's own
+  class check one slot off from the class it actually named.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6696,6 +6696,56 @@ not yet verified:
   and a new `scripts/rpg2k_scene_check.rb` check (the boarded party visibly
   rides along with a relocated boat), all four confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **RPG2003's global "使用可能キャラ → by Class" equipment setting is now
+  honoured — item/equipment usability was always decided per-Actor, even on
+  a database explicitly configured to decide it per-Class instead.**
+  Confirmed against EasyRPG's actual C++ source: `Game_Actor::IsItemUsable`
+  (`src/game_actor.cpp`) reads exactly one of two restriction lists per item
+  — `actor_set` or `class_set` — chosen by a single, database-wide toggle,
+  `System#equipment_setting` (LDB chunk 22 field 97, liblcf: "Whether
+  equipment usage is by Actor or by Class. This is a global setting in
+  RM2k3!"): `if (Player::IsRPG2k3() && lcf::Data::system.equipment_setting
+  == EquipmentSetting_class) { query_idx = cls ? cls->ID : 0; query_set =
+  &item->class_set; }` — not per item, and never both at once.
+  `mruby-lcf/mrblib/schema.rb`'s System-chunk element table declared field 96
+  and jumped straight to 99; field 97 was never even parsed out of the .ldb
+  data at all, so `db.system.equipment_setting` did not exist to read.
+  `Game::Party#item_usable_by?` (`mruby-rpg2k/mrblib/game.rb`), the single
+  choke-point every item-usability check in this codebase funnels through
+  (equip-candidate listing, equip-from-bag, medicine/special/switch items,
+  ko_only revive gating, ...) — mirroring EasyRPG's own `Game_Party::
+  IsItemUsable`, the identical single funnel on that side — checked only
+  `actor_set`, unconditionally. The one place `class_set` *was* read,
+  `#use_equip_skill_item`'s free-cast gate for a `use_skill`-flagged
+  equipment item, treated it as an extra restriction layered on top of
+  `actor_set` rather than the global toggle's replacement for it, and
+  indexed it `class_id - 1` — liblcf reserves class_set index 0 for "no
+  class" (the first real class is index 1), so every genuine class lookup
+  landed one slot short of its intended row. Concretely: an RPG2003 database
+  set to "by Class" with an item whose `class_set` allows only its Mage
+  class, `actor_set` left at the designer's now-irrelevant default (all
+  false) since they configured the class grid instead — before this fix,
+  every actor could equip/use the item regardless of class, because
+  `item_usable_by?` never looked at `class_set` or the global toggle at all
+  and an empty `actor_set` reads as unrestricted. Fixed by declaring field 97
+  in `schema.rb`; adding `Game::Party#equip_by_class?` (RPG2003 and
+  `equipment_setting == 1`, defensively rescued the same way
+  `#seed_screen_transitions` already reads other `db.system` fields, since a
+  raw `LCF::Database` driven through the pure-Ruby test-bed harness resolves
+  `db.system` through `Kernel#system` before its own field lookup); having
+  `#item_usable_by?` dispatch to the class_set branch first when that toggle
+  is on, RPG2000 and the default "by Actor" RPG2003 setting both keeping the
+  unchanged actor_set path; correcting `#item_usable_by_class?`'s indexing to
+  the actor's class id directly, no `- 1`; and dropping the now-redundant,
+  wrongly-scoped extra AND in `#use_equip_skill_item`, matching EasyRPG's
+  single-funnel shape. Covered by three new `scripts/rpg2k_logic_check.rb`
+  checks (the corrected class-set gating on a use_skill equipment item and
+  on an ordinary medicine alike, and that the default "by Actor" setting
+  still ignores class_set entirely even on an RPG2003 database with
+  classes), two of which are confirmed to fail against the pre-fix code
+  before the fix (the third is a same-behaviour-either-way regression
+  check). `ninja -C build test` (mruby-lcf's own suite, since schema.rb
+  changed) still passes.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -724,6 +724,11 @@ module LCF
             95 => { name: :battle_test_formation, type: :int, default: 0 },
             96 => { name: :battle_test_condition, type: :int, default: 0 },
 
+            # Whether 使用可能キャラ item/equipment restriction is decided per
+            # Actor (0, the default) or per Class (1) -- a single global
+            # RPG2003 toggle (Game::Party#item_usable_by?'s own source).
+            97 => { name: :equipment_setting, type: :int, default: 0 },
+
             # Decorative window (2003)
             99 => { name: :show_frame, type: :bool, default: false },
             100 => { name: :frame_name, type: :string, default: '' },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3513,17 +3513,26 @@ module Game
       !actor.dead?
     end
 
-    # 使用可能キャラ (`actor_set`, item field 62): whether item `it` names
-    # `actor_id` among the specific characters allowed to use or equip it at
-    # all. The one restriction list gates both uses (EasyRPG's
-    # `Game_Actor::IsItemUsable`, read by `Game_Party::IsItemUsable`'s
-    # per-target overload for using an item and by `ChangeEquipment` for
-    # equipping one) — a book, seed, medicine or piece of gear can all be
-    # limited to a named cast member this way, not just weapons/armour. An
+    # 使用可能キャラ (`actor_set`, item field 62) / RPG2003's 使用可能クラス
+    # (`class_set`, item field 73): whether item `it` may be used or equipped
+    # by `actor_id` at all. EasyRPG's `Game_Actor::IsItemUsable`
+    # (src/game_actor.cpp) reads exactly one of the two restriction lists per
+    # item, chosen by a single *global*, database-wide RPG2003 toggle --
+    # `System#equipment_setting` (LDB chunk 22 field 97) -- never both at
+    # once and never per item: a database configured "by Class" ignores
+    # actor_set entirely and checks class_set instead; RPG2000 (no classes
+    # exist at all) and an RPG2003 database left on the default "by Actor"
+    # setting both keep the ordinary actor_set behavior. This is the one
+    # choke-point every item-usability check in this codebase funnels
+    # through (equip-candidate listing, equip-from-bag, medicine/special/
+    # switch items, ko_only revive gating, ...), matching EasyRPG's own
+    # `Game_Party::IsItemUsable`, which is likewise the single funnel every
+    # item-use path checks before ever looking at the item's own type. An
     # actor id the array is too short to reach defaults to allowed, the same
     # "missing entry reads as the field's default" rule this runtime's other
-    # bit-array fields (terrain_set, class_set-adjacent ones) already follow.
+    # bit-array fields already follow.
     def item_usable_by?(it, actor_id)
+      return item_usable_by_class?(it, actor_id) if equip_by_class?
       return true unless it.respond_to?(:actor_set) && it.actor_set
       return true if actor_id.nil?
       set = it.actor_set
@@ -3532,24 +3541,40 @@ module Game
       set[idx] ? true : false
     end
 
-    # `class_set` (item field 73), `use_skill`'s companion restriction list:
-    # whether `actor`'s RPG2003 class (Actor#class_id) is among the classes
-    # allowed to trigger this item's skill, when the item actually restricts by
-    # class (a non-empty `class_set`, i.e. `class_set_size` field 72 > 0).
-    # Mirrors EasyRPG's `Game_Actor::IsItemUsable` class_set arm and follows
-    # #item_usable_by?'s own "empty/short array reads as allowed" convention
-    # for this bit-array field pair (the `_size` field itself is never read --
-    # the array's own length already carries it, as for actor_set/state_set/
-    # attribute_set). An actor with no class (RPG2000 has none) is always
-    # allowed.
-    def item_usable_by_class?(it, actor)
+    # Whether this database is RPG2003 and configured for its "使用可能キャラ
+    # -> by Class" global toggle rather than the default per-Actor one
+    # (`System#equipment_setting == 1`, `Player::IsRPG2k3()` in EasyRPG). A
+    # bare test fixture whose `db.system` does not answer `equipment_setting`
+    # at all reads as "by Actor", the same default the field itself has in a
+    # genuine database. Rescued the same defensive way
+    # `#seed_screen_transitions` already reads other `db.system` fields: a raw
+    # `LCF::Database` driven through the pure-Ruby test-bed harness (not the
+    # compiled engine) resolves `db.system` through `Kernel#system` before
+    # ever reaching its own field lookup, so any error there — not just a
+    # missing field — degrades to the ordinary "by Actor" default rather than
+    # raising.
+    def equip_by_class?
+      rpg2003? && @db.respond_to?(:system) && @db.system.respond_to?(:equipment_setting) &&
+        @db.system.equipment_setting == 1
+    rescue StandardError
+      false
+    end
+
+    # The class_set half of #item_usable_by?, used in place of actor_set once
+    # #equip_by_class? is on. Indexed by the actor's own class id *directly*
+    # (EasyRPG: `cls ? cls->ID : 0`) — not `class_id - 1` the way actor_set's
+    # bit array is — since liblcf reserves class_set index 0 for "no class"
+    # rather than naming a real row; the first real class is index 1. An
+    # actor with no class at all (RPG2000 has none, and an RPG2003 actor can
+    # simply start unclassed) reads index 0.
+    def item_usable_by_class?(it, actor_id)
       return true unless it.respond_to?(:class_set) && it.class_set
+      return true if actor_id.nil?
+      actor = @roster[actor_id]
       class_id = actor && actor.respond_to?(:class_id) ? (actor.class_id || 0) : 0
-      return true if class_id <= 0
       set = it.class_set
-      idx = class_id - 1
-      return true if idx < 0 || set.size <= idx
-      set[idx] ? true : false
+      return true if set.size <= class_id
+      set[class_id] ? true : false
     end
 
     # Whether using item `id` on `actor` would change anything, so the menu can
@@ -3685,9 +3710,13 @@ module Game
 
     # A weapon/shield/armour/helmet/accessory item flagged `use_skill` invokes
     # its `skill_id` skill directly, without being equipped -- the same free
-    # cast #use_special_item gives a type-9 special item, gated additionally by
-    # `class_set` (#item_usable_by_class?), the restriction list a use_skill
-    # equipment item carries that a special item does not.
+    # cast #use_special_item gives a type-9 special item. `#item_usable_by?`
+    # alone already covers whatever restriction this item carries, actor_set
+    # or class_set alike (see its own doc) -- this used to additionally AND
+    # in `#item_usable_by_class?` here, as if a use_skill equipment item were
+    # the one place class_set applied; it is not a use_skill-specific rule at
+    # all, just the ordinary database-wide "by Class" toggle every item type
+    # is equally subject to.
     #
     # The weapon itself is **not** consumed, however often it is used: RPG_RT
     # returns from `ConsumeItemUse` on the five equipment types before it ever
@@ -3696,7 +3725,7 @@ module Game
     # through #consume_item_use is what gets that right -- this used to spend
     # the weapon on its first use and leave the party without it.
     def use_equip_skill_item(it, id, actor)
-      return [] unless actor && item_usable_by?(it, actor.id) && item_usable_by_class?(it, actor)
+      return [] unless actor && item_usable_by?(it, actor.id)
       affected = cast_skill(actor, it.skill_id, actor, true)
       consume_item_use(id) unless affected.empty?
       affected

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3048,7 +3048,10 @@ class SkillRow < CurveRow
 
   def skills; FakeLearnTable.new(@learns); end
 end
-FakeActorSystem = Struct.new(:party)
+# `equipment_setting` mirrors System field 97 (Game::Party#equip_by_class?'s
+# own source) -- nil, the default, reads as "by Actor" the same way a
+# genuine database's own field default (0) does.
+FakeActorSystem = Struct.new(:party, :equipment_setting)
 # A database item row exposing the equipment-bonus fields Game::Actor reads plus
 # the medicine recovery/scope fields Game::Party#use_item reads.
 # The occasion fields are named the way the real item row names them:
@@ -3098,11 +3101,14 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       # special item, without being equipped
                       # (Game::Party#use_equip_skill_item).
                       :use_skill,
-                      # 使用可能職業 (field 73): `use_skill`'s companion --
-                      # the RPG2003 class ids (0-based index, bool per class)
-                      # allowed to trigger it this way
-                      # (Game::Party#item_usable_by_class?). Appended last,
-                      # same positional-safety reasoning as every field above.
+                      # 使用可能職業 (field 73): the RPG2003 class ids allowed
+                      # to use/equip this item, read in place of actor_set
+                      # once the database's global equipment_setting is "by
+                      # Class" (Game::Party#item_usable_by_class?). Index 0 is
+                      # reserved for "no class"; the first real class is
+                      # index 1, unlike actor_set's own 0-based indexing.
+                      # Appended last, same positional-safety reasoning as
+                      # every field above.
                       :class_set,
                       # 使用回数 (field 6): how many times one copy may be used
                       # before it is spent, 0 meaning 無制限
@@ -3301,9 +3307,10 @@ class FakeActorDB
   # Actor#battler_animation_id's resolved id to name a real entry.
   def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil,
                  property = nil, rpg2003: false, battlecommands: nil,
-                 enemy_group: Hash.new(true), battleranimations: nil)
+                 enemy_group: Hash.new(true), battleranimations: nil,
+                 equipment_setting: nil)
     @player = players
-    @system = FakeActorSystem.new(party_ids)
+    @system = FakeActorSystem.new(party_ids, equipment_setting)
     @item = items
     @skill = skills
     @job = jobs
@@ -5630,7 +5637,8 @@ check 'a use_skill-flagged equipment item invokes its skill directly, free ' \
 end
 
 check 'a use_skill equipment item restricted by class_set is only usable by ' \
-      'an actor in one of its listed classes' do
+      'an actor in one of its listed classes, under the RPG2003 "by Class" ' \
+      'equipment setting' do
   actor_curve = []
   3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
   job1 = []
@@ -5638,10 +5646,11 @@ check 'a use_skill equipment item restricted by class_set is only usable by ' \
   job2 = []
   3.times { |i| job2.concat([50 + i * 10, 10, 5 + i, 4, 3, 2]) }
   skills = { 8 => fake_skill(name: 'Elixir', scope: 3, sp_cost: 99, power: 40, hp: true) }
-  # class_set index 0 (class 1) false, index 1 (class 2) true: only class 2 may
-  # trigger it.
+  # class_set index 0 is EasyRPG's reserved "no class" slot, never a real
+  # class -- the first real class is index 1. Index 1 (class 1) false,
+  # index 2 (class 2) true: only class 2 may trigger it.
   items = { 4 => fake_item(type: 1, skill_id: 8, use_skill: true,
-                           class_set: [false, true], name: 'Class Rune') }
+                           class_set: [false, false, true], name: 'Class Rune') }
   players = {
     1 => ClassedRow.new('Warrior', '', 0, 3, actor_curve, [], 1, nil),
     2 => ClassedRow.new('Mage', '', 0, 3, actor_curve, [], 2, nil),
@@ -5650,7 +5659,8 @@ check 'a use_skill equipment item restricted by class_set is only usable by ' \
     1 => JobRow.new('Fighter', job1),
     2 => JobRow.new('Mage', job2),
   }
-  db = FakeActorDB.new(players, [1, 2], items, skills, jobs)
+  db = FakeActorDB.new(players, [1, 2], items, skills, jobs,
+                       rpg2003: true, equipment_setting: 1)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   warrior = st.party.actor_by_id(1)
   mage = st.party.actor_by_id(2)
@@ -5665,6 +5675,55 @@ check 'a use_skill equipment item restricted by class_set is only usable by ' \
   # Equipment is never consumed by being used this way, whatever its class_set
   # says -- see the use_skill check above and Game::Party#consume_item_use.
   eq 2, st.party.item_count(4), 'and the rune itself is not consumed'
+end
+
+# EasyRPG's Game_Actor::IsItemUsable (src/game_actor.cpp): the "by Class"
+# System#equipment_setting toggle is a single global switch every item type
+# is equally subject to, not a use_skill-equipment-only rule -- an ordinary
+# medicine with a class_set is gated the exact same way.
+check 'an ordinary medicine is gated by class_set too, under "by Class"' do
+  actor_curve = []
+  3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
+  job1 = []
+  3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
+  job2 = []
+  3.times { |i| job2.concat([50 + i * 10, 10, 5 + i, 4, 3, 2]) }
+  items = { 4 => fake_item(type: 6, rhp: 40, class_set: [false, false, true],
+                           name: 'Mage Draught') }
+  players = {
+    1 => ClassedRow.new('Warrior', '', 0, 3, actor_curve, [], 1, nil),
+    2 => ClassedRow.new('Mage', '', 0, 3, actor_curve, [], 2, nil),
+  }
+  jobs = { 1 => JobRow.new('Fighter', job1), 2 => JobRow.new('Mage', job2) }
+  db = FakeActorDB.new(players, [1, 2], items, {}, jobs,
+                       rpg2003: true, equipment_setting: 1)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  warrior = st.party.actor_by_id(1)
+  mage = st.party.actor_by_id(2)
+  eq 1, warrior.class_id
+  eq 2, mage.class_id
+  eq false, st.party.item_usable_by?(items[4], warrior.id), 'class 1 excluded'
+  eq true, st.party.item_usable_by?(items[4], mage.id), 'class 2 listed'
+end
+
+# Under the *default* "by Actor" setting (equipment_setting left at 0, or a
+# fixture that never sets it at all), class_set is ignored entirely and
+# actor_set decides, even in an RPG2003 database with classes -- matching
+# EasyRPG's own `if` branch, which only switches to class_set once
+# `equipment_setting == EquipmentSetting_class`.
+check 'class_set is ignored under the default "by Actor" equipment setting' do
+  items = { 4 => fake_item(type: 6, rhp: 40, actor_set: [true, false],
+                           class_set: [false, false, false], name: 'Hero Draught') }
+  players = {
+    1 => ClassedRow.new('Warrior', '', 0, 3, [], [], 1, nil),
+    2 => ClassedRow.new('Mage', '', 0, 3, [], [], 2, nil),
+  }
+  db = FakeActorDB.new(players, [1, 2], items, {}, {}, rpg2003: true)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq true, st.party.item_usable_by?(items[4], 1), 'actor_set allows actor 1'
+  eq false, st.party.item_usable_by?(items[4], 2),
+     "actor_set excludes actor 2, even though class_set (all false) would " \
+     "have excluded both"
 end
 
 check 'a special item invoking an Escape skill is hidden with no runtime ' \


### PR DESCRIPTION
## Summary

- `Game::Party#item_usable_by?` (`mruby-rpg2k/mrblib/game.rb`) — the single choke-point every item-usability check in this codebase funnels through (equip-candidate listing, equip-from-bag, medicine/special/switch items, `ko_only` revive gating, ...) — always decided restriction via `actor_set`, even on an RPG2003 database explicitly configured to decide it by Class instead. `mruby-lcf/mrblib/schema.rb`'s System-chunk element table declared field 96 and jumped straight to field 99; field 97 (`equipment_setting`) was never even parsed out of the `.ldb` data at all.
- EasyRPG's `Game_Actor::IsItemUsable` (`src/game_actor.cpp`) reads exactly one of `actor_set`/`class_set` per item, chosen by this single database-wide toggle — never per item, never both at once: `if (Player::IsRPG2k3() && lcf::Data::system.equipment_setting == EquipmentSetting_class) { query_idx = cls ? cls->ID : 0; query_set = &item->class_set; }`.
- The one place `class_set` *was* already read here, `#use_equip_skill_item`'s free-cast gate for a `use_skill`-flagged equipment item, treated it as an extra restriction layered on top of `actor_set` rather than the global toggle's replacement for it — and indexed it `class_id - 1`, when liblcf reserves `class_set` index 0 for "no class" (the first real class is index 1), so every genuine lookup landed one slot short of its intended row.
- Concretely: an RPG2003 database set to "by Class" with an item whose `class_set` allows only its Mage class, `actor_set` left at the designer's now-irrelevant default (all false, since they configured the class grid instead) — before this fix, every actor could equip/use the item regardless of class.
- Fixed by declaring field 97 in `schema.rb`; adding `Game::Party#equip_by_class?` (RPG2003 and `equipment_setting == 1` — defensively rescued the same way `#seed_screen_transitions` already reads other `db.system` fields, since a raw `LCF::Database` driven through the pure-Ruby test-bed harness resolves `db.system` through `Kernel#system` before its own field lookup); having `#item_usable_by?` dispatch to the `class_set` branch first when that toggle is on; correcting `#item_usable_by_class?`'s indexing to the actor's class id directly (no `- 1`); and dropping the now-redundant, wrongly-scoped extra AND in `#use_equip_skill_item`, matching EasyRPG's single-funnel shape.

## Test plan

- Three new `scripts/rpg2k_logic_check.rb` checks: the corrected class-set gating on a `use_skill` equipment item and on an ordinary medicine alike, and confirmation that the default "by Actor" setting still ignores `class_set` entirely even on an RPG2003 database with classes.
- Two of the three confirmed to fail against the pre-fix code before the fix (the third is a same-behaviour-either-way regression check, correctly passing both before and after).
- `ruby scripts/rpg2k_logic_check.rb` — 933 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly
- `ninja -C build test` (mruby-lcf's own suite, since `schema.rb` changed) — 8/8 passed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_