### PR TITLE
Persist Change Class / Change Battle Commands through .lsd Save/Continue

### DIFF
--- a/changelog.d/rpg2k-lsd-change-class-persist.fixed.md
+++ b/changelog.d/rpg2k-lsd-change-class-persist.fixed.md
@@ -1,0 +1,6 @@
+- **A Change Class or Change Battle Commands edit now survives a real .lsd
+  Save/Continue.** Both used to silently revert to the database default the
+  moment the exported save was read back, even though the level and stats
+  earned under the new class stayed -- an actor changed to a different class
+  mid-game would keep their new level/HP/MP but snap back to their old
+  class's skills, growth curve and battle commands on Continue.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6746,6 +6746,70 @@ not yet verified:
   before the fix (the third is a same-behaviour-either-way regression
   check). `ninja -C build test` (mruby-lcf's own suite, since schema.rb
   changed) still passes.
+- ✅ **A live RPG2003 Change Class or Change Battle Commands now survives a
+  real `.lsd` Save/Continue — chunk 108 (SAVE_PARTY_ACTOR) never carried the
+  class id or the battle-command-list override at all, so both silently
+  reverted to the database default the moment the exported save was read
+  back.** Confirmed against liblcf's own field table
+  (`generator/csv/fields.csv`): `SaveActor` declares `class_id` (0x5A = field
+  90, default **-1**, "int class-id"), `battle_commands` (0x50 = field 80,
+  "array of int32") and `changed_battle_commands` (0x53 = field 83, a
+  boolean gate) as real, persisted fields of the same struct `LSD_Reader`/
+  `LSD_Writer` round-trip — `mruby-lcf/mrblib/schema.rb`'s `SAVE_PARTY_ACTOR`
+  table declared none of the three. `Game::Actor#change_class`
+  (`mruby-rpg2k/mrblib/game.rb`) already models the runtime effect correctly
+  (growth curve, skills, battle commands all switch for the rest of that
+  session), but `Game::State#to_lsd`'s per-roster-actor loop wrote only
+  name/title/level/exp/skills/equipment/hp/mp/states — never `a.class_id` —
+  and `.from_lsd`'s matching restore loop never touched it either, while
+  `Game::Party.from_lsd` always rebuilds every actor fresh from its database
+  row, whose own `class_id` is whatever the *editor* set as the starting
+  class. Concretely: Change Class swaps an actor from no class to Mage
+  mid-session — the Mage growth curve, skill list and battle-command set all
+  apply correctly for the rest of that play session, and the level/EXP/HP/MP
+  accumulated under that curve are genuinely saved — but a real .lsd Save
+  then Continue silently reverted the class itself (and the battle-command
+  list Change Class had materialized) to the pre-change default, while the
+  level-derived numbers earned under the *new* curve stayed. Fixed by
+  declaring the three fields (field 90 defaulting to **-1**, liblcf's own
+  "never changed" sentinel — *not* 0, since Change Class to "no class" is
+  itself a real, persisted change distinct from "field absent"); having
+  `#to_lsd` write `class_id` once a live or restored Change Class has
+  actually run (`Actor#class_changed?`, a new public reader for the
+  `@class_changed` flag `#battler_animation_id` already relies on
+  internally) and `battle_commands`/`changed_battle_commands` once either
+  command has materialized the list (`Actor#battle_commands_changed?`, which
+  reads the raw ivar rather than the memoizing public accessor); and having
+  `.from_lsd`'s actor loop call the already-existing `Actor#restore_class`
+  before restoring level/EXP — mirroring `Party#load_state`'s own
+  established ordering ("the class comes back first: it decides which
+  growth and EXP curves the restored EXP is then read against"). Fixing this
+  also surfaced (and fixed) a real bug in `#restore_class` itself: its own
+  `#set_level` call defaulted to `preserve_mod: true`, which re-expresses
+  the actor's *pre-restore* stat total as a delta from the *new* class's
+  curve and adds it straight back — reproducing the wrong-class numbers
+  verbatim rather than the new class's own baseline. This was silently
+  masked in the pre-existing `Party#load_state` path (which always
+  overwrites the result with the saved absolute `base_raw` immediately
+  after, via `#restore_base`) but surfaced directly once `.from_lsd` called
+  `#restore_class` with no such follow-up — fixed by passing `preserve_mod:
+  false`, matching `#change_class`'s own already-correct call. The four
+  Change-Parameters stat-mod fields (`attack_mod`/`defense_mod`/
+  `spirit_mod`/`agility_mod`, plus `hp_mod`/`sp_mod`) are a distinct,
+  deliberately deferred follow-up: EasyRPG stores them as *deltas from the
+  class curve*, not the absolute running total this runtime's own
+  `@base_raw` represents, so round-tripping them correctly needs a genuine
+  unit conversion at both write and read time, not just a field mapping —
+  left undone here rather than risk getting that conversion wrong. Covered
+  by four new `scripts/rpg2k_logic_check.rb` checks (a live Change Class and
+  its materialized battle commands both round-trip with the new class's own
+  stats intact; a Change Battle Commands edit with no class change involved
+  round-trips on its own without a spurious class-changed flag; an
+  untouched actor keeps reading as unchanged on both counts; and Change
+  Class to "no class" — id 0 — round-trips as a real change, not as "field
+  absent"), all four confirmed to fail against the pre-fix code before the
+  fix. `ninja -C build test` (mruby-lcf's own suite, since schema.rb
+  changed) still passes.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1155,6 +1155,21 @@ module LCF
       72 => { name: :mp, type: :int },                     # 現在ＭＰ
       81 => { name: :state_size, type: :int, default: 0 }, # 『状態』情報のデータ数
       82 => { name: :states, type: :int16_array },         # 『状態』情報 (uint16[])
+
+      # RPG2003 Change Battle Commands (Game::Actor#battle_commands=):
+      # `changed_battle_commands` (83) gates whether `battle_commands` (80)
+      # overrides the database/class default at all, or is simply the
+      # not-yet-touched default -- mirroring `#battle_commands`'s own
+      # nil-means-"still deferring to the class/database" convention.
+      80 => { name: :battle_commands, type: :int32_array, default: [] },
+      83 => { name: :changed_battle_commands, type: :bool, default: false },
+
+      # RPG2003 Change Class (Game::Actor#change_class / #restore_class):
+      # -1, liblcf's own default, means "never changed -- still whatever the
+      # actor's own database row declares", not class id 0 ("no class" is a
+      # legitimate Change Class target in its own right, distinct from
+      # "unset").
+      90 => { name: :class_id, type: :int, default: -1 }, # 職業ID (Change Class)
     }
 
     # https://w.atwiki.jp/rpg2kpsp/pages/37.html

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2642,18 +2642,53 @@ module Game
     # Put the actor back into class `id` without any of Change Class's side
     # effects (Continue restoring a saved class): the curves are re-read at the
     # current level, but equipment, EXP and skills are restored separately from
-    # the save and must not be reset here.
+    # the save and must not be reset here. `@class_changed` is set the same
+    # way #change_class itself sets it -- a restored non-default class is, by
+    # definition, one a live Change Class already changed at some point in the
+    # session that got saved, so #battler_animation_id's own "only once
+    # Change Class has actually run" gate must see it as changed too.
+    #
+    # `preserve_mod: false`, matching #change_class's own call: #set_level's
+    # default carries the *previous* base_raw forward as a delta from the
+    # *new* class's curve, which is exactly backwards here -- it would
+    # reproduce the pre-restore (wrong-class) numbers verbatim rather than
+    # the new class's own baseline. The caller (Party#load_state /
+    # State.from_lsd) re-applies the actual saved base_raw afterward
+    # regardless, via #restore_base -- this only has to leave a sane
+    # intermediate value for a caller that has none to restore.
     def restore_class(id)
       set_class_id(id)
-      set_level(@level)
+      set_level(@level, preserve_mod: false)
       @battle_commands = nil
+      @class_changed = true
     end
+
+    # Whether a Change Class (or a restored one, see #restore_class) has ever
+    # run this session -- EasyRPG's own distinction between an actor's
+    # database-declared starting class and one actually switched at runtime
+    # (see #battler_animation_id's citation of `Game_Actor::ChangeClass`'s
+    # comment). Exposed for #to_lsd, which only needs to persist a class
+    # override that is genuinely a change, not every actor's inert starting
+    # class id.
+    def class_changed?; @class_changed; end
 
     # Replace the battle-command list (Continue restoring a saved one). nil keeps
     # whatever the database / class defines.
     def battle_commands=(ids)
       @battle_commands = ids && !ids.empty? ? ids.dup : nil
     end
+
+    # Whether #battle_commands has ever been materialized -- by a live Change
+    # Class/Change Battle Commands, or by restoring a save that carried
+    # either -- rather than still lazily deferring to the database/class
+    # default. Mirrors EasyRPG's `changed_battle_commands` flag (`Game_Actor::
+    # ChangeClass`/`ChangeBattleCommands` both set it unconditionally, the
+    # same way #change_class/#change_battle_commands here always leave
+    # `@battle_commands` non-nil once either has run). Reading the public
+    # #battle_commands accessor instead would always answer true, since it
+    # memoizes the class/database default into `@battle_commands` on first
+    # read -- this checks the raw ivar before any such memoization.
+    def battle_commands_changed?; !@battle_commands.nil?; end
 
     # The RPG2003 battle combo an Enable Combo (1007) armed: the battle command
     # to repeat and how many times. nil until a battle page arms one.
@@ -11671,6 +11706,20 @@ module Game
           e[81] = a.states.size
           e[82] = a.states
         end
+        # A live Change Class survives Save/Continue too, not just the name/
+        # title/sprite overrides above -- only once #change_class (or a
+        # restored one) has actually run, matching EasyRPG's own
+        # `class_id != -1` "changed at all" sentinel (liblcf's own field
+        # default), not merely "class_id > 0" -- Change Class to "no class"
+        # (id 0) is itself a real, persisted change.
+        e[90] = a.class_id if a.class_changed?
+        # Same for a live Change Battle Commands (or a Change Class, which
+        # also materializes the list): EasyRPG's `changed_battle_commands`
+        # flag, mirrored by #battle_commands_changed?'s own raw-ivar check.
+        if a.battle_commands_changed?
+          e[80] = a.battle_commands
+          e[83] = true
+        end
         actors[a.id] = e
       end
       save[108] = actors
@@ -11823,11 +11872,24 @@ module Game
       (save[108] || []).each do |aid, sa|
         actor = party.roster[aid]
         if actor
+          # The class comes back first, mirroring Party#load_state's own
+          # ordering comment: it decides which growth/EXP curves the level
+          # and exp restored just below are read against. -1 (liblcf's own
+          # field default) means "never changed", not "class 0" -- Change
+          # Class to "no class" is itself a real, persisted change.
+          cid = sa.class_id
+          actor.restore_class(cid) if cid && cid != -1
           actor.set_level(sa.level) if sa.level
           actor.exp = sa.exp if sa.exp
           actor.equip(sa.equipment) if sa.equipment
           actor.skills = sa.skills if sa.skills
           actor.states = sa.states if sa.states
+          # A live Change Battle Commands (or a Change Class, which also
+          # materializes the list) -- gated on `changed_battle_commands` the
+          # same way EasyRPG's own read does, not merely "the field is
+          # present", since an empty list is schema.rb's own declared
+          # default rather than a real Change Battle Commands to nothing.
+          actor.battle_commands = sa.battle_commands if sa.changed_battle_commands
           # A Change Actor Name override on *any* roster member, not just the
           # leader (whose name chunk 100's title also carries below). ADR
           # 0014 already flagged this field's other case when it was first

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3436,6 +3436,99 @@ check 'to_lsd/from_lsd round-trips a Change Actor Title override' do
   eq '', cleared.party.leader.title, 'a cleared title round-trips as an empty string, not the database default'
 end
 
+# RPG2003's Change Class and Change Battle Commands are permanent edits, the
+# same as Change Actor Name/Title above -- but chunk 108 (SAVE_PARTY_ACTOR)
+# never carried class_id (field 90) or battle_commands/changed_battle_commands
+# (fields 80/83) at all, so a live class change or command-list edit silently
+# reverted to the database default the moment a real .lsd was written and
+# read back (Game::Party.from_lsd rebuilds every actor from the database row,
+# which always re-seeds class_id from there).
+check 'to_lsd/from_lsd round-trips a live Change Class, and the battle ' \
+      'commands it materializes' do
+  actor_curve = []
+  3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
+  job1 = []
+  3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, [], 0, nil) }
+  jobs = { 1 => JobRow.new('Mage', job1) }
+  db = FakeActorDB.new(players, [1], {}, {}, jobs)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+  eq 0, hero.class_id, 'no starting class'
+  eq false, hero.class_changed?
+
+  hero.change_class(1, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                    Game::Actor::CLASS_PARAM_RESET_LEVEL)
+  eq 1, hero.class_id
+  ok hero.class_changed?
+  new_max_hp = hero.max_hp
+  new_commands = hero.battle_commands
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.party.leader
+  eq 1, restored.class_id, 'Change Class survives Save/Continue via .lsd'
+  eq new_max_hp, restored.max_hp,
+     "restored via the new class's own curve, not reverted to the pre-change one"
+  eq new_commands, restored.battle_commands,
+     "Change Class's own materialized battle-command list round-trips too"
+end
+
+check 'to_lsd/from_lsd round-trips a Change Battle Commands edit with no ' \
+      'Change Class involved' do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+  eq false, hero.battle_commands_changed?
+  hero.change_battle_commands(true, 7)
+  ok hero.battle_commands_changed?
+  eq 0, hero.class_id, 'no class involved at all'
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.party.leader
+  eq hero.battle_commands, restored.battle_commands,
+     'the edited command list round-trips even with no Change Class'
+  eq false, restored.class_changed?, 'and no spurious class change was recorded'
+end
+
+check 'to_lsd/from_lsd leaves an actor untouched by either command exactly ' \
+      'as it was' do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.party.leader
+  eq 0, restored.class_id
+  eq false, restored.class_changed?
+  eq false, restored.battle_commands_changed?
+end
+
+check 'to_lsd/from_lsd round-trips a Change Class back to "no class" (id 0)' do
+  actor_curve = []
+  3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
+  job1 = []
+  3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, [], 1, nil) }
+  jobs = { 1 => JobRow.new('Mage', job1) }
+  db = FakeActorDB.new(players, [1], {}, {}, jobs)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+  eq 1, hero.class_id, 'starts classed'
+
+  hero.change_class(0, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                    Game::Actor::CLASS_PARAM_RESET_LEVEL)
+  eq 0, hero.class_id, 'explicitly reverted to no class'
+  ok hero.class_changed?
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.party.leader
+  eq 0, restored.class_id,
+     'class id 0 is a real, persisted change -- not "field absent"'
+  ok restored.class_changed?
+end
+
 check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrides' do
   # do_change_system_bgm/_sfx (interpreter.rb) stash overrides in
   # @state.system_bgm/@state.system_sfx, keyed by slot -- the same slots


### PR DESCRIPTION
## Summary

- `Game::State#to_lsd`'s per-roster-actor loop (`mruby-rpg2k/mrblib/game.rb`) never wrote `class_id` or the battle-command-list override at all, and `.from_lsd` never read them back — `Game::Party.from_lsd` always rebuilds every actor fresh from its database row, so a live Change Class or Change Battle Commands silently reverted to the database default the instant a real `.lsd` was written and read back, even though the level/EXP/HP/MP earned under the new class stayed.
- liblcf's `SaveActor` struct declares `class_id` (field 90, default **-1** — "never changed", distinct from class `0`, which is a real, persisted "revert to no class"), `battle_commands` (field 80) and `changed_battle_commands` (field 83) as genuine persisted fields (`generator/csv/fields.csv`); `mruby-lcf/mrblib/schema.rb`'s `SAVE_PARTY_ACTOR` declared none of them.
- Fixed by declaring the three fields; having `#to_lsd` write `class_id` once a live or restored Change Class has actually run (`Actor#class_changed?`, a new public reader for the `@class_changed` flag `#battler_animation_id` already relies on internally) and `battle_commands`/`changed_battle_commands` once either command has materialized the list (`Actor#battle_commands_changed?`, which reads the raw ivar rather than the memoizing public accessor); and having `.from_lsd`'s actor loop call the already-existing `Actor#restore_class` before restoring level/EXP, mirroring `Party#load_state`'s own established ordering ("the class comes back first: it decides which growth and EXP curves the restored EXP is then read against").
- Fixing this also surfaced (and fixed) a real latent bug in `#restore_class` itself: its own `#set_level` call defaulted to `preserve_mod: true`, which re-expresses the actor's *pre-restore* stat total as a delta from the *new* class's curve and adds it straight back — reproducing the wrong-class numbers verbatim. This was silently masked in the pre-existing `Party#load_state` path (which always overwrites the result with the saved absolute `base_raw` immediately after, via `#restore_base`), but surfaced directly once `.from_lsd` called `#restore_class` with no such follow-up. Fixed by passing `preserve_mod: false`, matching `#change_class`'s own already-correct call.
- The four Change-Parameters stat-mod fields (`attack_mod`/`defense_mod`/`spirit_mod`/`agility_mod`, plus `hp_mod`/`sp_mod`) are a distinct, deliberately deferred follow-up: EasyRPG stores them as *deltas from the class curve*, not the absolute running total this runtime's own `@base_raw` represents, so round-tripping them correctly needs a genuine unit conversion at both write and read time, not just a field mapping — left undone here rather than risk getting that conversion wrong.

## Test plan

- Four new `scripts/rpg2k_logic_check.rb` checks: a live Change Class and its materialized battle commands both round-trip with the new class's own stats intact; a Change Battle Commands edit with no class change involved round-trips on its own without a spurious class-changed flag; an untouched actor keeps reading as unchanged on both counts; and Change Class to "no class" (id 0) round-trips as a real change, not as "field absent".
- All four confirmed to fail against the pre-fix code before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 937 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly
- `ninja -C build test` (mruby-lcf's own suite, since `schema.rb` changed) — 8/8 passed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_