### PR TITLE
Fix SAVE_MOVABLE's charset_index to the correct liblcf tag (74, not 75)

### DIFF
--- a/changelog.d/rpg2k-lsd-charset-index-tag.fixed.md
+++ b/changelog.d/rpg2k-lsd-charset-index-tag.fixed.md
@@ -1,0 +1,7 @@
+- **A Change Actor Sprite / Change Vehicle Graphic override's character-sheet
+  index is now written to, and read from, the correct field of a real .lsd
+  save.** It used to land on the field liblcf actually uses for unrelated
+  per-frame bookkeeping, which only surfaced against a genuine third-party
+  save (or a save this engine exports being opened elsewhere) since this
+  engine's own Save/Continue used the same wrong field consistently on both
+  sides.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6810,6 +6810,41 @@ not yet verified:
   absent"), all four confirmed to fail against the pre-fix code before the
   fix. `ninja -C build test` (mruby-lcf's own suite, since schema.rb
   changed) still passes.
+- ✅ **A Change Actor Sprite / Change Vehicle Graphic override's *index* now
+  round-trips through `.lsd` at the correct liblcf tag — it was being
+  written to, and read from, the wrong field of the save's hero/vehicle
+  record.** ADR 0020 mapped `SAVE_MOVABLE`'s `charset_index` to tag 75,
+  citing "liblcf's `RPG::SaveSystem`" — but `SaveSystem`'s own fields 73-75
+  (`generator/csv/fields.csv`) are `battle_end_music`/`inn_music`/
+  `current_music`, nothing to do with a character graphic; the struct chunk
+  104 (hero) and 105-107 (vehicles) actually use is `SaveMapEventBase`
+  (already correctly named two fields up, for `move_route_index`'s own
+  citation), whose `sprite_id` is tag **74** (`0x4A`). Tag 75 (`0x4B`) there
+  is `processed`, an unrelated per-frame flag ("has this event already
+  taken its movement step this frame") liblcf documents on every movable
+  record, hero included. Confirmed against the repo's own real save fixture
+  (Nepheshel `Save01.lsd`'s hero record, decoded past the schema to see
+  every raw tag present): tag 75 is present with a plausible `processed`
+  byte while tags 73 (`sprite_name`) and 74 (`sprite_id`) are both entirely
+  absent — exactly what "no sprite override, saved mid-frame" looks like,
+  not what a genuine `sprite_id` co-occurring without its paired
+  `sprite_name` would ever produce. The bug was self-masking: `Game::State
+  #to_lsd`/`.from_lsd` (`mruby-rpg2k/mrblib/game.rb`) both consistently used
+  the same wrong tag, so this engine's own Save→Continue round-trip (and
+  `scripts/rpg2k_save_load_check.rb`'s guard, which only re-reads what this
+  engine itself wrote) never disagreed with itself — it only manifests
+  against a genuine third-party `.lsd` (misreading the real `processed`
+  flag as a bogus sprite index) or when a `.lsd` this engine exports is
+  opened in real RPG_RT/EasyRPG (the real sprite index landing on
+  `processed` instead). Fixed by moving `SAVE_MOVABLE`'s `charset_index`
+  from tag 75 to 74 and the two `#to_lsd` write sites (leader, and each
+  placed vehicle) to match; no read-site changes needed, since both already
+  go through the schema-driven `.charset_index` accessor. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check that inspects the actual raw tag
+  `#to_lsd` writes to (not merely a same-engine round-trip, which — being
+  internally self-consistent either way — could never have caught this),
+  confirmed to fail against the pre-fix code before the fix (the field
+  simply didn't exist under the corrected tag number yet).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1078,8 +1078,21 @@ module LCF
       # than 0 -- Game::State.from_lsd tells "no saved cursor, restart the
       # route from the top" from "explicitly at command 0" the same way.
       43 => { name: :move_route_index, type: :int },
+      # liblcf's `SaveMapEventBase` (generator/csv/fields.csv): `sprite_name`
+      # 0x49 == 73, `sprite_id` 0x4A == 74. Field 75 (0x4B) is `processed`, an
+      # unrelated per-frame flag ("has this event already taken its movement
+      # step this frame") -- ADR 0020 originally mapped charset_index to 75,
+      # citing "liblcf's RPG::SaveSystem", but SaveSystem's own fields 73-75
+      # are battle_end_music/inn_music/current_music, nothing to do with a
+      # character graphic; SaveMapEventBase (the struct chunk 104/105-107
+      # actually use, already correctly named two fields up for
+      # move_route_index) is the right one. Confirmed against a real save
+      # (Nepheshel Save01's hero record): field 75 is present (`\x01`, a
+      # plausible `processed` value) while 73/74 are both absent -- exactly
+      # what "no sprite override, mid-frame" looks like, not what a genuine
+      # sprite_id co-occurring without its paired sprite_name ever would.
       73 => { name: :charset_name, type: :string },
-      75 => { name: :charset_index, type: :int },
+      74 => { name: :charset_index, type: :int },
     }
 
     # https://w.atwiki.jp/rpg2kpsp/pages/21.html

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11608,7 +11608,7 @@ module Game
       hero[22] = @direction || 2
       if leader
         hero[73] = leader.charset_name || ''
-        hero[75] = leader.charset_index || 0
+        hero[74] = leader.charset_index || 0
       end
       save[104] = hero
 
@@ -11624,7 +11624,7 @@ module Game
         mv[13] = v.y
         mv[22] = v.direction
         mv[73] = v.charset_name || ''
-        mv[75] = v.charset_index || 0
+        mv[74] = v.charset_index || 0
         save[chunk] = mv
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3529,6 +3529,37 @@ check 'to_lsd/from_lsd round-trips a Change Class back to "no class" (id 0)' do
   ok restored.class_changed?
 end
 
+# ADR 0020 mapped SAVE_MOVABLE's charset_index to liblcf tag 75, citing
+# "RPG::SaveSystem" -- but SaveSystem's own fields 73-75 are
+# battle_end_music/inn_music/current_music, unrelated to a character
+# graphic. The struct chunk 104 (hero) and 105-107 (vehicles) actually use is
+# SaveMapEventBase, whose sprite_id is tag 74; tag 75 there is `processed`,
+# an unrelated per-frame movement-scheduling flag. A same-engine round-trip
+# never caught this (both the writer and reader used the same wrong tag
+# consistently) -- only inspecting the actual on-disk tag number does.
+check 'to_lsd writes the leader/vehicle sprite index at the correct liblcf ' \
+      'tag (SaveMapEventBase sprite_id, 74 -- not 75, which is `processed`)' do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.leader.set_charset('HeroAlt', 5)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 1
+  boat.y = 1
+  boat.charset_name = 'Boat1'
+  boat.charset_index = 2
+
+  hero = st.to_lsd[104]
+  eq 'HeroAlt', hero[73], "sprite_name at its correct tag (liblcf's 0x49)"
+  eq 5, hero[74], "sprite_id at its correct tag (liblcf's 0x4A)"
+
+  boat_chunk = st.to_lsd[105]
+  eq 'Boat1', boat_chunk[73]
+  eq 2, boat_chunk[74]
+end
+
 check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrides' do
   # do_change_system_bgm/_sfx (interpreter.rb) stash overrides in
   # @state.system_bgm/@state.system_sfx, keyed by slot -- the same slots


### PR DESCRIPTION
## Summary

- ADR 0020 mapped `SAVE_MOVABLE`'s `charset_index` to liblcf tag 75, citing "liblcf's `RPG::SaveSystem`" — but `SaveSystem`'s own fields 73-75 (`generator/csv/fields.csv`) are `battle_end_music`/`inn_music`/`current_music`, nothing to do with a character graphic. The struct chunk 104 (hero) and 105-107 (vehicles) actually use is `SaveMapEventBase` (already correctly named two fields up in the same table, for `move_route_index`'s own citation), whose `sprite_id` is tag **74** (`0x4A`). Tag 75 (`0x4B`) there is `processed`, an unrelated per-frame flag ("has this event already taken its movement step this frame") liblcf documents on every movable record, hero included.
- Confirmed against the repo's own real save fixture (Nepheshel `Save01.lsd`'s hero record, decoded past the schema to see every raw tag present): tag 75 is present with a plausible `processed` byte while tags 73 (`sprite_name`) and 74 (`sprite_id`) are both entirely absent — exactly what "no sprite override, saved mid-frame" looks like, not what a genuine `sprite_id` co-occurring without its paired `sprite_name` would ever produce.
- The bug was self-masking: `Game::State#to_lsd`/`.from_lsd` both consistently used the same wrong tag, so this engine's own Save→Continue round-trip (and `scripts/rpg2k_save_load_check.rb`'s guard, which only re-reads what this engine itself wrote) never disagreed with itself — it only manifests against a genuine third-party `.lsd` (misreading the real `processed` flag as a bogus sprite index), or when a `.lsd` this engine exports is opened in real RPG_RT/EasyRPG (the real sprite index landing on `processed` instead).
- Fixed by moving `SAVE_MOVABLE`'s `charset_index` from tag 75 to 74 and the two `#to_lsd` write sites (leader, and each placed vehicle) to match. No read-site changes needed, since both already go through the schema-driven `.charset_index` accessor.

## Test plan

- One new `scripts/rpg2k_logic_check.rb` check that inspects the actual raw tag `#to_lsd` writes to (not merely a same-engine round-trip, which — being internally self-consistent either way — could never have caught this).
- Confirmed to fail against the pre-fix code before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 938 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly
- `ninja -C build test` (mruby-lcf's own suite, since `schema.rb` changed) — 8/8 passed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_