### PR TITLE
Fix player_transparent's .lsd tag: SAVE_MOVABLE field 24, not SAVE_SYSTEM 55

### DIFF
--- a/changelog.d/rpg2k-lsd-player-transparent-tag.fixed.md
+++ b/changelog.d/rpg2k-lsd-player-transparent-tag.fixed.md
@@ -1,0 +1,6 @@
+- **Fixed a real .lsd save bug that could leave the hero permanently
+  invisible after Continue.** Set Transparent Flag's saved state was being
+  read from an unrelated field that a genuine RPG_RT save often happens to
+  set for its own reasons -- loading such a save could silently hide the
+  player sprite for the rest of the game. It now round-trips through the
+  correct field.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6845,6 +6845,39 @@ not yet verified:
   internally self-consistent either way — could never have caught this),
   confirmed to fail against the pre-fix code before the fix (the field
   simply didn't exist under the corrected tag number yet).
+- ✅ **Set Transparent Flag's saved state now lives at the correct `.lsd`
+  field — a genuine RPG_RT save could make the hero permanently, silently
+  invisible on Continue, since this engine used to read an unrelated flag
+  as the player-hidden override.** ADR 0020 mapped `player_transparent` to
+  `SAVE_SYSTEM` field 55, citing no source for the claim; liblcf actually
+  names that field `event_message_active`
+  (`generator/csv/fields.csv`: "A flag set by RPG_RT when a message is
+  spawned by ShowMessage; ShowChoices; or ShowNumberInput and cleared when
+  message spawned for any other reason") — entirely unrelated to visibility.
+  The real home for Set Transparent Flag's (Player Visibility, 11310)
+  runtime override is `SaveMapEventBase.transparency` (`0x18` = field 24,
+  "0 or 3"), on the *hero's own* movable record (chunk 104) — a field
+  `SAVE_MOVABLE` never declared at all. Confirmed against the repo's own
+  real save fixture: `Save01.lsd`'s `event_message_active` (55) decodes
+  `true`, exactly the state a save taken with a message on screen leaves —
+  loading that genuine save through this engine's old code set `@state.
+  player_transparent = true` and hid the hero sprite outright
+  (`Scene::Map#player_hidden?`), a directly observable regression on common,
+  unremarkable third-party saves, not merely a naming slip. Self-masking for
+  the usual reason: `#to_lsd`/`.from_lsd` both consistently used field 55,
+  so this engine's own Save→Continue round-trip never disagreed with
+  itself. Fixed by declaring `SAVE_MOVABLE` field 24 (`:transparency`,
+  liblcf's own name), writing `hero[24] = @player_transparent ? 3 : 0` in
+  `#to_lsd` and reading it back the same way in `.from_lsd`, and removing
+  the wrong claim on `SAVE_SYSTEM` field 55 entirely (nothing in this engine
+  needs `event_message_active` modelled). Covered by a new
+  `scripts/rpg2k_logic_check.rb` check that inspects the actual raw tag
+  `#to_lsd` writes the flag to and confirms `SAVE_SYSTEM` no longer claims
+  field 55 at all, confirmed to fail against the pre-fix code before the
+  fix. `mruby-lcf/test/lcf_test.rb`'s own from-scratch system-chunk
+  round-trip (which explicitly exercised the now-removed field 55) was
+  updated to match, and gained its own from-scratch check for the corrected
+  `SAVE_MOVABLE` field. `ninja -C build test` still passes.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1063,6 +1063,24 @@ module LCF
       13 => { name: :y, type: :int },
       # 0 = down, 1 = right, 2 = up, 3 = left.
       22 => { name: :direction, type: :int },
+      # liblcf's `SaveMapEventBase.transparency` (generator/csv/fields.csv,
+      # 0x18 == 24): "0 or 3 - Transparency level of the current event page".
+      # On the *hero's* own record (chunk 104) this is Set Transparent Flag's
+      # (Player Visibility, 11310) runtime override -- Game::State
+      # #player_transparent. It used to be smuggled into SAVE_SYSTEM's own
+      # field 55 instead, which liblcf actually names `event_message_active`
+      # (a flag ShowMessage/ShowChoices/ShowNumberInput set, unrelated to
+      # transparency at all) -- ADR 0020 declared it `:transparent` with no
+      # citation for the claim. Confirmed against the repo's own real save
+      # fixture: `event_message_active` (55) decodes true on Nepheshel
+      # Save01.lsd, which would have made Continue permanently hide the hero
+      # on any save taken with a message on screen -- a real, severe
+      # regression a genuine RPG_RT save can trigger, not merely a naming
+      # slip. The vehicle chunks (105-107) never used field 55 for anything,
+      # so this field is otherwise new to them too -- vehicles have no
+      # runtime "hidden" state to persist, so their own #load_movable simply
+      # never reads it.
+      24 => { name: :transparency, type: :int, default: 0 },
       35 => { name: :animation_type, type: :int },
       37 => { name: :move_speed, type: :int },
       # SaveMapEventBase's own move-route cursor: how far into a page's
@@ -1323,7 +1341,11 @@ module LCF
       52 => { name: :face_index, type: :int, default: 0 },
       53 => { name: :face_right_position, type: :int, default: 0 },
       54 => { name: :face_flip, type: :bool, default: false },
-      55 => { name: :transparent, type: :bool, default: false },
+      # NOT field 55: that is liblcf's own `event_message_active`
+      # (ShowMessage/ShowChoices/ShowNumberInput bookkeeping, unrelated to
+      # transparency), not a player-visibility override -- see SAVE_MOVABLE's
+      # field 24 for where Set Transparent Flag's state actually lives, and
+      # why it was wrongly modelled here before.
       # Overridden BGM/SE playback state. An empty file name means "use the
       # database value".
       71 => { name: :title_bgm, type: :Array1D, elements: BGM },

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -673,7 +673,6 @@ assert 'SaveData title chunk + system message/bgm/access fields round-trip from 
   sys = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SYSTEM })
   sys[41] = 1; sys[42] = 0; sys[43] = false
   sys[51] = "MsgFace"; sys[52] = 4; sys[53] = 1; sys[54] = true
-  sys[55] = true
   cur = LCF::Array1D.new('', { elements: LCF::Schema::BGM })
   cur[1] = "Field"; cur[3] = 80; cur[4] = 120
   sys[75] = cur
@@ -696,7 +695,6 @@ assert 'SaveData title chunk + system message/bgm/access fields round-trip from 
   assert_equal 4, s.face_index
   assert_equal 1, s.face_right_position
   assert_true s.face_flip
-  assert_true s.transparent
   assert_equal "Field", s.current_bgm.file
   assert_equal 80, s.current_bgm.volume
   assert_equal 120, s.current_bgm.pitch
@@ -704,6 +702,16 @@ assert 'SaveData title chunk + system message/bgm/access fields round-trip from 
   assert_false s.escape_allowed
   assert_false s.save_allowed
   assert_true s.menu_allowed
+end
+
+assert 'SAVE_MOVABLE transparency (Set Transparent Flag on the hero record, ' \
+       'field 24 -- not SAVE_SYSTEM field 55) round-trips from scratch' do
+  hero = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+  hero[11] = 3; hero[12] = 5; hero[13] = 7
+  hero[24] = 3 # liblcf's own "0 or 3" convention
+  reread = LCF::Array1D.new(hero.to_lcf, { elements: LCF::Schema::SAVE_MOVABLE })
+  assert_equal 3, reread.map_id
+  assert_equal 3, reread.transparency
 end
 
 assert 'Array2D built from scratch serialises and reads back' do

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11606,6 +11606,11 @@ module Game
       hero[12] = @x
       hero[13] = @y
       hero[22] = @direction || 2
+      # Set Transparent Flag's own override (Player Visibility, 11310) --
+      # liblcf's own "0 or 3" convention for this field (see schema.rb's
+      # SAVE_MOVABLE comment on why it lives here, on the hero's own movable
+      # record, not the system chunk).
+      hero[24] = @player_transparent ? 3 : 0
       if leader
         hero[73] = leader.charset_name || ''
         hero[74] = leader.charset_index || 0
@@ -11653,7 +11658,6 @@ module Game
       sys[52] = mc.face_index || 0
       sys[53] = mc.face_right ? 1 : 0
       sys[54] = mc.face_flipped ? true : false
-      sys[55] = @player_transparent ? true : false
       sys[75] = bgm_chunk(@current_bgm) if @current_bgm
       sys[78] = bgm_chunk(@memorized_bgm) if @memorized_bgm
       # Change System BGM (10660) / Change System SFX (10670) overrides, one
@@ -11916,6 +11920,10 @@ module Game
                        hp: hp, mp: mp)
       state = new(party, hero.map_id, hero.x, hero.y)
       state.direction = hero.direction || 2
+      # Set Transparent Flag's own override (Player Visibility, 11310):
+      # liblcf's "0 or 3" convention on the hero's own movable record (see
+      # #to_lsd's own citation on why this lives here, not the system chunk).
+      state.player_transparent = (hero.transparency || 0) != 0
       # Vehicle locations (chunks 105 boat / 106 ship / 107 airship), each a
       # SAVE_MOVABLE; an absent chunk leaves that vehicle unplaced.
       state.vehicle(:boat).load_movable(save.boat)
@@ -11943,7 +11951,6 @@ module Game
       mc.face_index = sys.face_index || 0
       mc.face_right = (sys.face_right_position || 0) != 0
       mc.face_flipped = sys.face_flip ? true : false
-      state.player_transparent = sys.transparent ? true : false
       # Overridden BGM playback state; an empty file name means "none".
       state.current_bgm = bgm_from_chunk(sys.current_bgm)
       state.memorized_bgm = bgm_from_chunk(sys.stored_bgm)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7427,6 +7427,38 @@ check 'player_transparent round-trips through the save' do
   eq false, Game::State.load(db, legacy).player_transparent
 end
 
+# ADR 0020 mapped player_transparent to SAVE_SYSTEM's own field 55, citing no
+# source -- but liblcf actually names that field `event_message_active`
+# (ShowMessage/ShowChoices/ShowNumberInput bookkeeping, generator/csv/
+# fields.csv), unrelated to transparency. The real home is SAVE_MOVABLE field
+# 24 (`SaveMapEventBase.transparency`) on the hero's own record (chunk 104).
+# The wrong mapping was self-masking: this engine's own to_lsd/from_lsd both
+# used field 55 consistently, so its own round-trip never caught it -- only
+# a genuine save (or inspecting the actual on-disk tag) would, since a real
+# save's field 55 (event_message_active) is often true on its own, unrelated
+# to whether the player is hidden, and would have made Continue permanently
+# hide the hero after any save taken with a message on screen.
+check 'to_lsd writes player_transparent to the hero record (SAVE_MOVABLE ' \
+      'field 24), not SAVE_SYSTEM field 55' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.player_transparent = true
+  saved = st.to_lsd
+  eq 3, saved[104][24], "liblcf's own 0-or-3 convention for transparency"
+  round = Game::State.from_lsd(db, saved)
+  eq true, round.player_transparent, 'and it round-trips back correctly'
+
+  # SAVE_SYSTEM no longer declares field 55 as :transparent at all, so a
+  # genuine save's own event_message_active (unrelated to visibility) has no
+  # code path left that could ever misread it as one.
+  ok !LCF::Schema::SAVE_SYSTEM.key?(55),
+     'field 55 is no longer claimed as player-transparent'
+end
+
 check 'common_event_progress (a Parallel Process interpreter checkpoint) round-trips through the save' do
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,


### PR DESCRIPTION
## Summary

- ADR 0020 mapped `player_transparent` to `SAVE_SYSTEM` field 55 with no cited source; liblcf actually names that field `event_message_active` (`generator/csv/fields.csv`: "A flag set by RPG_RT when a message is spawned by ShowMessage; ShowChoices; or ShowNumberInput and cleared when message spawned for any other reason") — entirely unrelated to visibility. The real home for Set Transparent Flag's (Player Visibility, 11310) runtime override is `SaveMapEventBase.transparency` (`0x18` = field 24, "0 or 3"), on the *hero's own* movable record (chunk 104), which `SAVE_MOVABLE` never declared at all.
- Confirmed against the repo's own real save fixture: `Save01.lsd`'s `event_message_active` (55) decodes `true` — exactly the state a save taken with a message on screen leaves. Loading that genuine save through the old code set `@state.player_transparent = true` and hid the hero sprite outright (`Scene::Map#player_hidden?`) — a real, directly observable regression on ordinary third-party saves, not merely a naming slip.
- Self-masking for the usual reason: `#to_lsd`/`.from_lsd` both consistently used field 55, so this engine's own Save→Continue round-trip never disagreed with itself.
- Fixed by declaring `SAVE_MOVABLE` field 24 (`:transparency`, liblcf's own name), writing `hero[24] = @player_transparent ? 3 : 0` in `#to_lsd` and reading it back the same way in `.from_lsd`, and removing the wrong claim on `SAVE_SYSTEM` field 55 entirely (nothing in this engine needs `event_message_active` modelled).

## Test plan

- One new `scripts/rpg2k_logic_check.rb` check that inspects the actual raw tag `#to_lsd` writes the flag to and confirms `SAVE_SYSTEM` no longer claims field 55 at all.
- Confirmed to fail against the pre-fix code before the fix.
- `mruby-lcf/test/lcf_test.rb`'s own from-scratch system-chunk round-trip (which explicitly exercised the now-removed field 55) was updated to match, and gained its own from-scratch check for the corrected `SAVE_MOVABLE` field.
- `ruby scripts/rpg2k_logic_check.rb` — 939 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly
- `ninja -C build test` (mruby-lcf's own suite) — 8/8 passed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_