### PR TITLE
Decode SAVE_MOVABLE's facing through liblcf's 0..3 convention

### DIFF
--- a/changelog.d/rpg2k-lsd-direction-encoding.fixed.md
+++ b/changelog.d/rpg2k-lsd-direction-encoding.fixed.md
@@ -1,0 +1,7 @@
+- **A hero's, vehicle's or map event's saved facing now decodes correctly
+  from a real .lsd save.** It used to read the save format's raw direction
+  value as if it were already this engine's own internal convention with no
+  conversion at all, silently facing the character the wrong way on
+  Continue for anyone facing right, up, or left when they saved (facing
+  down happened to read correctly either way, which is why this went
+  unnoticed).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6878,6 +6878,44 @@ not yet verified:
   round-trip (which explicitly exercised the now-removed field 55) was
   updated to match, and gained its own from-scratch check for the corrected
   `SAVE_MOVABLE` field. `ninja -C build test` still passes.
+- ✅ **A hero's, vehicle's or map event's saved facing is now decoded (and
+  encoded) correctly — this build used to read/write liblcf's raw wire value
+  for the field as if it were already this runtime's own numpad convention,
+  with no conversion at all, silently mis-restoring any facing other than
+  "down".** `SaveMapEventBase.facing` (`generator/csv/fields.csv`, `0x16` ==
+  22) is `0` up / `1` right / `2` down / `3` left — `Game_Character::
+  Direction`'s own enum order (`src/game_character.h`) — not RPG2000's
+  numpad scheme (2/4/6/8) this runtime's own `@direction` uses everywhere
+  else. `SAVE_MOVABLE`'s field-22 comment claimed "0 = down, 1 = right, 2 =
+  up, 3 = left" with no citation at all — itself wrong on both counts (not
+  liblcf's order, and not this runtime's numpad order either). This codebase
+  already solved the identical problem for the *database*-side event-page
+  facing field (`Game::EventGraphic::LCF_DIR_TO_NUMPAD`, used by `Scene::Map
+  #page_direction`) but the save-side field never got the same treatment.
+  Because the two schemes coincide exactly for "down" (`2` either way), and
+  a hero standing on their own save tile more often than not faces down or
+  was never turned since spawning, the bug hid behind that coincidence in
+  every same-engine round-trip and in the repo's own real save fixture
+  (`Save01.lsd`'s hero record happens to read down, `2`, both ways) — only a
+  save where the character actually faces right, up or left exposes it.
+  Fixed by threading the existing `EventGraphic.numpad_direction` (decode)
+  and `Game::CharSet::DIR_ROW` (encode — numerically the same up/right/down/
+  left table, already used to pick a CharSet sprite row) through every
+  `SAVE_MOVABLE` read/write site: the hero and each vehicle in `#to_lsd`/
+  `.from_lsd`, `Game::Vehicle#load_movable`, and chunk 111's per-map-event
+  position table both ways. Also corrected the stale, uncited schema.rb
+  comment to cite the real source. Two pre-existing tests
+  (`scripts/rpg2k_logic_check.rb`'s map-event custom-route round-trip and
+  `scripts/rpg2k_save_load_check.rb`'s vehicle-location round-trip) used
+  direction `1` as a placeholder — not a valid numpad direction under either
+  the old or the new code, just an arbitrary passthrough value — and needed
+  updating to a real numpad direction (`6`, right) to keep asserting
+  something meaningful; both were confirmed to still pass under the
+  corrected semantics. Covered by a new `scripts/rpg2k_logic_check.rb` check
+  that inspects the actual raw wire value `#to_lsd` writes for a non-down
+  facing on both the hero and a vehicle, and confirms it decodes back to the
+  correct numpad direction, confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1061,7 +1061,14 @@ module LCF
       11 => { name: :map_id, type: :int },
       12 => { name: :x, type: :int },
       13 => { name: :y, type: :int },
-      # 0 = down, 1 = right, 2 = up, 3 = left.
+      # liblcf's `SaveMapEventBase.facing` (generator/csv/fields.csv, 0x16 ==
+      # 22): 0 = up, 1 = right, 2 = down, 3 = left, matching `Game_Character::
+      # Direction`'s own enum order (src/game_character.h) -- *not* this
+      # runtime's numpad convention (2/4/6/8). `Game::CharSet::DIR_ROW`
+      # (numpad -> row index) is numerically the same up/right/down/left
+      # table, so it doubles as the encoder here; `EventGraphic.
+      # numpad_direction` is the decoder, the same conversion the database-
+      # side event-page facing field already needs.
       22 => { name: :direction, type: :int },
       # liblcf's `SaveMapEventBase.transparency` (generator/csv/fields.csv,
       # 0x18 == 24): "0 or 3 - Transparency level of the current event page".

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11015,7 +11015,11 @@ module Game
       @map_id = m.map_id || 0
       @x = m.x || 0
       @y = m.y || 0
-      @direction = m.direction || 2
+      # liblcf's own 0..3 (up/right/down/left) convention on the wire --
+      # #numpad_direction is the same conversion Change Event Location's own
+      # facing sub-parameter and the database-side event-page facing field
+      # already go through (EventGraphic::LCF_DIR_TO_NUMPAD).
+      @direction = EventGraphic.numpad_direction(m.direction)
       @charset_name = m.charset_name || ''
       @charset_index = m.charset_index || 0
     end
@@ -11605,7 +11609,12 @@ module Game
       hero[11] = @map_id
       hero[12] = @x
       hero[13] = @y
-      hero[22] = @direction || 2
+      # @direction is RPG2000's own numpad convention (2/4/6/8); the wire
+      # format is liblcf's 0..3 (up/right/down/left) -- CharSet::DIR_ROW is
+      # the same numpad -> 0..3 table the renderer already uses to pick a
+      # CharSet row, which is numerically identical to liblcf's own facing
+      # enum (both walk up/right/down/left in that order).
+      hero[22] = CharSet::DIR_ROW[@direction] || 2
       # Set Transparent Flag's own override (Player Visibility, 11310) --
       # liblcf's own "0 or 3" convention for this field (see schema.rb's
       # SAVE_MOVABLE comment on why it lives here, on the hero's own movable
@@ -11627,7 +11636,7 @@ module Game
         mv[11] = v.map_id
         mv[12] = v.x
         mv[13] = v.y
-        mv[22] = v.direction
+        mv[22] = CharSet::DIR_ROW[v.direction] || 2
         mv[73] = v.charset_name || ''
         mv[74] = v.charset_index || 0
         save[chunk] = mv
@@ -11776,7 +11785,7 @@ module Game
           e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
           e[12] = x
           e[13] = y
-          e[22] = direction
+          e[22] = CharSet::DIR_ROW[direction] || 2
           idx = @map_event_route_index[id]
           e[43] = idx if idx
           events[id] = e
@@ -11919,7 +11928,11 @@ module Game
       party.load_state(items: items, item_usage: usage, gold: inv.gold,
                        hp: hp, mp: mp)
       state = new(party, hero.map_id, hero.x, hero.y)
-      state.direction = hero.direction || 2
+      # liblcf's own 0..3 (up/right/down/left) convention on the wire; see
+      # #to_lsd's own citation for why this needs the same conversion
+      # EventGraphic::LCF_DIR_TO_NUMPAD already applies to the identically-
+      # encoded database-side event-page facing field.
+      state.direction = EventGraphic.numpad_direction(hero.direction)
       # Set Transparent Flag's own override (Player Visibility, 11310):
       # liblcf's "0 or 3" convention on the hero's own movable record (see
       # #to_lsd's own citation on why this lives here, not the system chunk).
@@ -12056,7 +12069,7 @@ module Game
         route_index = {}
         saved_events.each do |id, mv|
           next unless mv.x && mv.y
-          positions[id] = [mv.x, mv.y, mv.direction || 2]
+          positions[id] = [mv.x, mv.y, EventGraphic.numpad_direction(mv.direction)]
           idx = mv.move_route_index
           route_index[id] = idx unless idx.nil?
         end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9092,12 +9092,14 @@ check 'to_lsd/from_lsd round-trips a map event\'s custom-route index' do
   # fields (12/13/22) chunk 111 already covers.
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
-  st.map_event_positions = { 3 => [5, 7, 1] }
+  # 6 = numpad right, a real direction value (not the wire's own 0..3 --
+  # see the field-22 encoding check below for that distinction).
+  st.map_event_positions = { 3 => [5, 7, 6] }
   st.map_event_route_index = { 3 => 4 }
 
   saved = st.to_lsd
   round = Game::State.from_lsd(db, saved)
-  eq [5, 7, 1], round.map_event_positions[3], 'the event\'s position round-trips'
+  eq [5, 7, 6], round.map_event_positions[3], 'the event\'s position round-trips'
   eq 4, round.map_event_route_index[3], 'the mid-route cursor round-trips'
 
   # A save written before this field existed (or one taken before this event
@@ -9108,8 +9110,36 @@ check 'to_lsd/from_lsd round-trips a map event\'s custom-route index' do
   legacy = st.to_lsd
   legacy[111].events[3].delete(43)
   old = Game::State.from_lsd(db, legacy)
-  eq [5, 7, 1], old.map_event_positions[3], 'position still round-trips without a route index'
+  eq [5, 7, 6], old.map_event_positions[3], 'position still round-trips without a route index'
   eq nil, old.map_event_route_index[3], 'no saved cursor means the route restarts at 0'
+end
+
+# liblcf's SaveMapEventBase.facing (generator/csv/fields.csv, 0x16 == 22) is
+# 0=up/1=right/2=down/3=left (Game_Character::Direction's own enum order),
+# not this runtime's numpad convention (2/4/6/8) -- the two schemes only
+# coincide for "down" (2 either way), which is exactly how this bug hid
+# undetected in a same-engine round-trip. Confirmed against the repo's own
+# real save fixture: Nepheshel Save01.lsd's hero record decodes raw field 22
+# as 2 (down, coincidentally identical either way) -- this check instead
+# proves the actual wire value for a non-down facing, which the coincidence
+# can't mask.
+check 'to_lsd encodes a character\'s facing in liblcf\'s 0..3 convention, ' \
+      'not raw numpad' do
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.direction = 6 # numpad right
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 1; boat.y = 1
+  boat.direction = 4 # numpad left
+
+  saved = st.to_lsd
+  eq 1, saved[104][22], "numpad right (6) -> liblcf's right (1)"
+  eq 3, saved[105][22], "numpad left (4) -> liblcf's left (3)"
+
+  round = Game::State.from_lsd(db, saved)
+  eq 6, round.direction, 'and it converts back to numpad right on read'
+  eq 4, round.vehicle(:boat).direction, 'and the boat reads back numpad left too'
 end
 
 # EasyRPG models an actor's and an enemy's own "state id the target's

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -249,7 +249,7 @@ def check_game(dir)
   state.vehicle(:boat).map_id = 12
   state.vehicle(:boat).x = 9
   state.vehicle(:boat).y = 4
-  state.vehicle(:boat).direction = 1
+  state.vehicle(:boat).direction = 6 # numpad right
   state.vehicle(:airship).map_id = 3
   state.vehicle(:airship).x = 15
   state.vehicle(:airship).y = 7
@@ -285,7 +285,7 @@ def check_game(dir)
   end
   # Parked vehicles (chunks 105 boat / 107 airship) survive; the untouched ship
   # (chunk 106) is absent and stays unplaced.
-  eq [12, 9, 4, 1], [round.vehicle(:boat).map_id, round.vehicle(:boat).x,
+  eq [12, 9, 4, 6], [round.vehicle(:boat).map_id, round.vehicle(:boat).x,
                      round.vehicle(:boat).y, round.vehicle(:boat).direction],
      'to_lsd: boat location'
   eq [3, 15, 7], [round.vehicle(:airship).map_id, round.vehicle(:airship).x,


### PR DESCRIPTION
## Summary

- This engine read/wrote liblcf's raw `SaveMapEventBase.facing` wire value (`0`=up/`1`=right/`2`=down/`3`=left, `Game_Character::Direction`'s own enum order, `src/game_character.h`) as if it were already this runtime's own numpad convention (2/4/6/8), with **no conversion at all** — silently mis-restoring any facing other than "down" on a real `.lsd` Save/Continue.
- The two schemes coincide only for down (`2` either way), which is exactly why this hid behind every same-engine round-trip and the repo's own real save fixture (whose hero happens to face down at save time).
- This codebase already solved the identical problem for the *database*-side event-page facing field (`Game::EventGraphic::LCF_DIR_TO_NUMPAD`, used by `Scene::Map#page_direction`) but the save-side field never got the same treatment; `SAVE_MOVABLE`'s own field-22 comment claimed an order that matched neither liblcf's convention nor this runtime's numpad one, with no citation at all.
- Fixed by threading the existing `EventGraphic.numpad_direction` (decode) and `Game::CharSet::DIR_ROW` (encode — numerically the same up/right/down/left table already used to pick a CharSet sprite row) through every `SAVE_MOVABLE` read/write site: the hero and each vehicle in `#to_lsd`/`.from_lsd`, `Game::Vehicle#load_movable`, and chunk 111's per-map-event position table both ways. Also corrected the stale schema.rb comment to cite the real source.
- Two pre-existing tests (`scripts/rpg2k_logic_check.rb`'s map-event custom-route round-trip and `scripts/rpg2k_save_load_check.rb`'s vehicle-location round-trip) used direction `1` as a placeholder — not a valid numpad direction under either the old or new code, just an arbitrary passthrough value — and needed updating to a real numpad direction (`6`, right) to keep asserting something meaningful; both confirmed to still pass under the corrected semantics.

## Test plan

- One new `scripts/rpg2k_logic_check.rb` check that inspects the actual raw wire value `#to_lsd` writes for a non-down facing on both the hero and a vehicle, and confirms it decodes back to the correct numpad direction.
- Confirmed to fail against the pre-fix code before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 940 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly
- `ninja -C build test` (mruby-lcf's own suite) — 8/8 passed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_