### PR TITLE
Fix SAVE_SYSTEM's system_graphic/font tags (21/23, not 15/17)

### DIFF
--- a/changelog.d/rpg2k-lsd-system-graphic-font-tag.fixed.md
+++ b/changelog.d/rpg2k-lsd-system-graphic-font-tag.fixed.md
@@ -1,0 +1,5 @@
+- **Change System Graphics' windowskin and font override now round-trip
+  through .lsd saves correctly.** They were being written to, and read from,
+  the wrong field of the save's system chunk (a hex-digits-as-decimal
+  transcription slip), which only surfaced against a genuine third-party
+  save or a save this engine exports being opened elsewhere.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6916,6 +6916,32 @@ not yet verified:
   facing on both the hero and a vehicle, and confirms it decodes back to the
   correct numpad direction, confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **Change System Graphics' windowskin / font override now round-trips
+  through `.lsd` at the correct liblcf tags — this build wrote and read
+  them at the raw hex *digits* of their liblcf field ids instead of the hex
+  *value* converted to decimal, unlike every other field in the same
+  table.** liblcf's `SaveSystem` (`generator/csv/fields.csv`):
+  `graphics_name` is `0x15` == **21**, `message_stretch` is `0x16` == **22**,
+  `font_id` is `0x17` == **23** — `SAVE_SYSTEM` declared them at 15/16/17
+  instead, a transcription slip standing out against every neighbouring
+  field in the exact same table, all of which convert correctly (`0x1F`→31
+  `switches` count, `0x29`→41 `message_transparent`, `0x33`→51 `face_name`,
+  ...). `Game::State#to_lsd`/`.from_lsd` (`mruby-rpg2k/mrblib/game.rb`) read
+  and wrote the same wrong tags symmetrically, so this engine's own
+  Save→Continue round-trip (and the Marshal-based save/load test, which
+  never touches `.lsd` at all) never disagreed with itself — only a genuine
+  RPG_RT save that used Change System Graphics (10680), or this engine's
+  own `.lsd` export opened in real RPG_RT/EasyRPG, would ever surface it.
+  Field 16/22 (`wallpaper_type`/`message_stretch`) was never actually read
+  or written by this engine at all, so its own mistagging had zero live
+  effect — fixed for schema correctness regardless, matching the file's own
+  convention of tagging fields precisely even before something consumes
+  them. Fixed by rekeying the three schema.rb entries to 21/22/23 and the
+  two `#to_lsd` write sites to match; the read side needed no changes,
+  since it already goes through the schema-driven `.system_graphic`/`.font`
+  accessors. Covered by a new `scripts/rpg2k_logic_check.rb` check that
+  inspects the actual raw tags `#to_lsd` writes to, confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1331,9 +1331,19 @@ module LCF
       # 6 title, 7 game over, 8 F9 debug menu.
       1 => { name: :scene, type: :int, default: 0 },
       11 => { name: :frame_count, type: :int },
-      15 => { name: :system_graphic, type: :string },
-      16 => { name: :wallpaper_type, type: :int },
-      17 => { name: :font, type: :int },
+      # liblcf's `SaveSystem` (generator/csv/fields.csv): `graphics_name`
+      # 0x15 == 21, `message_stretch` 0x16 == 22, `font_id` 0x17 == 23 --
+      # these three were declared at their raw hex *digits* (15/16/17)
+      # instead of the hex *value* converted to decimal, unlike every other
+      # field in this table (0x1F==31, 0x29==41, 0x33==51, ... all correctly
+      # converted). `Game::State#to_lsd`/`.from_lsd` read/write the same
+      # wrong tags symmetrically, so a same-engine save/load round-trip
+      # never caught it -- only a genuine RPG_RT save using Change System
+      # Graphics (10680), or this engine's own export opened in real
+      # RPG_RT/EasyRPG, would ever disagree.
+      21 => { name: :system_graphic, type: :string },
+      22 => { name: :wallpaper_type, type: :int },
+      23 => { name: :font, type: :int },
       31 => { name: :switch_size, type: :int, default: 0 },
       32 => { name: :switches, type: :bool_array },
       33 => { name: :variable_size, type: :int, default: 0 },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11226,7 +11226,7 @@ module Game
     # System Graphics (10680), overriding the database defaults. `system_graphic`
     # is nil until a command sets it (the database's own graphic then applies)
     # and `font_id` defaults to 0. Both persist in the save (LSD SAVE_SYSTEM
-    # chunks 15 / 17); Scene::Map reloads the windowskin when the override
+    # chunks 21 / 23); Scene::Map reloads the windowskin when the override
     # changes.
     attr_accessor :system_graphic, :font_id
     # Last known-good resume position of each running Common Event Parallel
@@ -11687,8 +11687,8 @@ module Game
       # Screen-transition slots 0..5 map to chunks 111..116 in order.
       @screen_transitions.each_with_index { |style, i| sys[111 + i] = style || 0 }
       # System windowskin / font override (Change System Graphics).
-      sys[15] = @system_graphic if @system_graphic
-      sys[17] = @font_id
+      sys[21] = @system_graphic if @system_graphic
+      sys[23] = @font_id
       sys[131] = save_count
       sys[132] = 1
       save[101] = sys

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7627,6 +7627,31 @@ check 'Change System Graphics overrides the windowskin / font; round-trips' do
   eq 1, loaded.font_id
 end
 
+# liblcf's SaveSystem (generator/csv/fields.csv): graphics_name is 0x15 == 21,
+# font_id is 0x17 == 23 -- schema.rb used to declare these at the raw hex
+# *digits* (15/17) instead of the hex value converted to decimal, unlike
+# every other field in the same table. #to_lsd/.from_lsd used the same wrong
+# tags symmetrically, so a same-engine round-trip (like the check above, and
+# the Marshal-based one) never caught it -- only inspecting the actual wire
+# tag, or a genuine RPG_RT save, would.
+check 'to_lsd writes the system graphic / font override at the correct ' \
+      'liblcf tags (21 / 23, not 15 / 17)' do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5,
+                                     max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.system_graphic = 'Skin2'
+  st.font_id = 1
+
+  saved = st.to_lsd
+  eq 'Skin2', saved[101][21], "graphics_name at its correct tag (liblcf's 0x15)"
+  eq 1, saved[101][23], "font_id at its correct tag (liblcf's 0x17)"
+
+  round = Game::State.from_lsd(db, saved)
+  eq 'Skin2', round.system_graphic, 'and it round-trips back correctly'
+  eq 1, round.font_id
+end
+
 # -- Enter Hero Name (Name Input) ---------------------------------------------
 
 check 'Enter Hero Name suspends on :name_input and resume renames the actor' do


### PR DESCRIPTION
## Summary

- liblcf's `SaveSystem` (`generator/csv/fields.csv`) declares `graphics_name` at `0x15` (== 21 decimal), `message_stretch` at `0x16` (== 22), and `font_id` at `0x17` (== 23). `schema.rb`'s `SAVE_SYSTEM` declared these at the raw hex *digits* (15/16/17) instead of the hex *value* converted to decimal — a transcription slip standing out against every neighboring field in the exact same table, all of which convert correctly (`0x1F`→31 `switches` count, `0x29`→41 `message_transparent`, `0x33`→51 `face_name`, ...).
- `Game::State#to_lsd`/`.from_lsd` (`mruby-rpg2k/mrblib/game.rb`) read and wrote the same wrong tags symmetrically, so this engine's own Save→Continue round-trip (and the Marshal-based save/load test, which never touches `.lsd` at all) never disagreed with itself — only a genuine RPG_RT save that used Change System Graphics (10680), or this engine's own `.lsd` export opened in real RPG_RT/EasyRPG, would ever surface it.
- Field 16/22 (`wallpaper_type`/`message_stretch`) was never actually read or written by this engine at all, so its own mistagging had zero live effect — fixed for schema correctness regardless.
- Fixed by rekeying the three `schema.rb` entries to 21/22/23 and the two `#to_lsd` write sites to match; the read side needed no changes, since it already goes through the schema-driven `.system_graphic`/`.font` accessors.

## Test plan

- One new `scripts/rpg2k_logic_check.rb` check that inspects the actual raw tags `#to_lsd` writes the override to.
- Confirmed to fail against the pre-fix code before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 941 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly
- `ninja -C build test` (mruby-lcf's own suite) — 8/8 passed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_