### PR TITLE
Gate a battle page's turn_enemy/turn_actor/fatigue on RPG2003

### DIFF
--- a/changelog.d/rpg2k-battle-page-2k3-conditions.fixed.md
+++ b/changelog.d/rpg2k-battle-page-2k3-conditions.fixed.md
@@ -1,0 +1,5 @@
+- **A troop battle-event page's turn_enemy/turn_actor/fatigue conditions are
+  now correctly RPG2003-only.** They used to be evaluated on any database,
+  which could make a page conditional (and potentially never fire) when
+  real RPG_RT would have run it unconditionally, since the RPG2000 editor
+  has no controls for these condition types at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6942,6 +6942,45 @@ not yet verified:
   accessors. Covered by a new `scripts/rpg2k_logic_check.rb` check that
   inspects the actual raw tags `#to_lsd` writes to, confirmed to fail
   against the pre-fix code before the fix.
+- ✅ **A troop battle-event page's `turn_enemy` / `turn_actor` / `fatigue`
+  conditions are RPG2003-only — an RPG2000 database that somehow set one of
+  these bits used to have it evaluated (and could fail it) instead of being
+  ignored outright.** Confirmed against EasyRPG's actual C++ source:
+  `Game_Interpreter_Battle::AreConditionsMet`
+  (`src/game_interpreter_battle.cpp`) wraps all three condition checks (and
+  `command_actor`, already correctly handled here — see below) in
+  `Player::IsRPG2k3Commands() &&`, exactly the same edition gate `Game::
+  EventPage.active?` (this same file) already applies to a map event page's
+  RPG2003-only TIMER2 condition. `Game::BattlePage.active?`
+  (`mruby-rpg2k/mrblib/game.rb`) checked `ctx.enemy_turn`/`ctx.actor_turn`/
+  `ctx.fatigue` purely off the condition's flag bits, with no edition check
+  at all. The RPG2000 editor's condition box has no controls for any of
+  these three condition types, so a genuine `.lmt` file should never set
+  them on a non-2k3 database — but an unguarded flag reads as an ordinary,
+  *evaluated* condition the instant one is set (by a corrupted file, a
+  hand-edited one, or a future schema change), rather than the "ignored
+  entirely, page still runs" answer real RPG_RT/EasyRPG give. Concretely: an
+  RPG2000 troop page whose condition byte has only the `fatigue` bit set
+  (`fatigue_min: 50, fatigue_max: 100`) — real RPG_RT never even looks at
+  the flag on a non-2k3 database and runs the page unconditionally; this
+  build instead computed the party's actual fatigue and gated the page on
+  it, a materially different, conditional trigger where none should exist.
+  `command_actor` needed no equivalent fix: this codebase's own `Game::
+  Battle#actor_command` already always answers `nil` regardless of edition
+  (documented above, since RPG2000's own battle scene never has a "source"
+  battler to test against either — EasyRPG's `Scene_Battle_Rpg2k::
+  CheckBattleEndAndScheduleEvents` always schedules pages with a null
+  source), so that condition already reads as permanently unmet on every
+  edition, matching the real engine's own RPG2000 behaviour by coincidence
+  rather than by an explicit gate. Fixed by adding `Game::Battle#rpg2003?`
+  (a public reader for the `@rpg2003` flag the class already carries
+  internally) and gating the `turn_enemy`/`turn_actor`/`fatigue` blocks on
+  `ctx.rpg2003?`. Covered by a new `scripts/rpg2k_logic_check.rb` check (all
+  three conditions read as active on a non-2k3 battle even when they would
+  clearly fail if evaluated), confirmed to fail against the pre-fix code
+  before the fix; the three existing checks that exercised these
+  conditions' actual matching logic were updated to construct an explicit
+  RPG2003 battle so the edition gate does not mask what they test.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5784,12 +5784,22 @@ module Game
         return false unless hp_within?(ctx.ally_by_actor_id(cond.actor_id),
                                        cond.actor_hp_min, cond.actor_hp_max)
       end
-      if (flags & TURN_ENEMY) != 0
+      # turn_enemy / turn_actor / fatigue are RPG2003-only conditions --
+      # EasyRPG's own `Game_Interpreter_Battle::AreConditionsMet`
+      # (src/game_interpreter_battle.cpp) wraps all three (and command_actor,
+      # already handled below) in `Player::IsRPG2k3Commands() &&`. The
+      # RPG2000 editor's condition box has no controls for these bits at
+      # all, so a genuine .lmt should never set them on a non-2k3 database
+      # -- but an untested flag with no guard reads as "always true" the
+      # instant one is set, exactly the same silent-pass-through class of
+      # bug the map-event TIMER2 condition (Game::EventPage.active?, this
+      # file) was already fixed for.
+      if (flags & TURN_ENEMY) != 0 && ctx.rpg2003?
         t = ctx.enemy_turn(cond.turn_enemy_id)
         return false if t.nil?
         return false unless check_turns(t, cond.turn_enemy_b, cond.turn_enemy_a)
       end
-      if (flags & TURN_ACTOR) != 0
+      if (flags & TURN_ACTOR) != 0 && ctx.rpg2003?
         t = ctx.actor_turn(cond.turn_actor_id)
         return false if t.nil?
         return false unless check_turns(t, cond.turn_actor_b, cond.turn_actor_a)
@@ -5797,7 +5807,7 @@ module Game
       if (flags & COMMAND_ACTOR) != 0
         return false unless ctx.actor_command(cond.command_actor_id) == cond.command_id
       end
-      if (flags & FATIGUE) != 0
+      if (flags & FATIGUE) != 0 && ctx.rpg2003?
         f = ctx.fatigue
         return false if f.nil?
         return false if f < cond.fatigue_min || f > cond.fatigue_max
@@ -8428,6 +8438,12 @@ module Game
     def ally_by_actor_id(id)
       @allies.find { |a| a.actor && a.actor.respond_to?(:id) && a.actor.id == id }
     end
+
+    # Whether this fight is running under an RPG2003 database — `Game::Party`'s
+    # own `#rpg2003?` reads the same underlying flag; exposed here too since
+    # `BattlePage.active?` gates the RPG2003-only page conditions on the
+    # battle context (`ctx`, always a `Battle`) rather than the party.
+    def rpg2003?; @rpg2003; end
 
     # Turns taken by troop member `index` / by the party member whose database
     # actor id is `id` — the RPG2003 per-battler turn counters the pages'

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13808,11 +13808,11 @@ end
 # A battle whose allies carry a source actor id, so the actor-keyed conditions
 # and the battle Conditional Branch can find them.
 FakeSourceActor = Struct.new(:id)
-def battle_with(ally_hp: 100, foe_hp: 100, foe_mp: 8)
+def battle_with(ally_hp: 100, foe_hp: 100, foe_mp: 8, rpg2003: false)
   hero = combatant('Hero', 10, 0, 10, ally_hp)
   hero.actor = FakeSourceActor.new(1)
   foe = combatant_mp('Slime', 5, 0, 5, foe_hp, foe_mp)
-  Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  Game::Battle.new([hero], [foe], Game::Rng.new(1), rpg2003: rpg2003)
 end
 
 check 'battle-event opcodes match the LCF Code enum' do
@@ -13909,14 +13909,45 @@ check 'BattlePage.active? fails a condition the runtime cannot answer' do
   # pages with a null source; only the separate 2k3 ATB scene ever passes a
   # real one) -- so this is not a stand-in for a future acting-battler
   # context, it is RPG2000's own battle system never satisfying the
-  # condition either.
+  # condition either. Unlike turn_enemy/turn_actor/fatigue below,
+  # command_actor is tested on every edition (EasyRPG's own
+  # AreConditionsMet still gates it on IsRPG2k3Commands(), but that gate is
+  # moot here since #actor_command always answers nil regardless).
   eq false, BP.active?(battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1,
                                    command_id: 1), st.switches, st.variables, b)
-  # Nor may one keyed to a battler that is not in this fight.
+  # Nor may one keyed to a battler that is not in this fight -- on an
+  # RPG2003 battle, where turn_enemy/turn_actor actually apply (see below).
+  b2003 = battle_with(rpg2003: true)
   eq false, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 9),
-                       st.switches, st.variables, b)
+                       st.switches, st.variables, b2003)
   eq false, BP.active?(battle_cond(BP::TURN_ACTOR, turn_actor_id: 99),
-                       st.switches, st.variables, b)
+                       st.switches, st.variables, b2003)
+end
+
+# turn_enemy / turn_actor / fatigue are RPG2003-only page conditions --
+# EasyRPG's own Game_Interpreter_Battle::AreConditionsMet
+# (src/game_interpreter_battle.cpp) gates all three behind
+# Player::IsRPG2k3Commands(), the same way Game::EventPage.active? already
+# gates a map event page's TIMER2 condition on rpg2003?. An RPG2000 database
+# has no editor control for any of these three condition types at all, so a
+# genuine .lmt should never set the bits -- but an unguarded flag reads as
+# "always true" the instant one is set, silently turning a page meant to be
+# conditional into one that always fires.
+check "BattlePage.active? ignores turn_enemy / turn_actor / fatigue on a " \
+      "non-RPG2003 battle" do
+  b = battle_with # RPG2000 (rpg2003: false, the default)
+  st = new_state
+  # A condition that would clearly fail if evaluated (turn 5 required, no
+  # battler has acted at all yet; fatigue 50-100 required, party untouched)
+  # must still read as active, since RPG2000 never even looks at these bits.
+  eq true, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 0,
+                                  turn_enemy_b: 5, turn_enemy_a: 0),
+                      st.switches, st.variables, b)
+  eq true, BP.active?(battle_cond(BP::TURN_ACTOR, turn_actor_id: 1,
+                                  turn_actor_b: 5, turn_actor_a: 0),
+                      st.switches, st.variables, b)
+  eq true, BP.active?(battle_cond(BP::FATIGUE, fatigue_min: 50, fatigue_max: 100),
+                      st.switches, st.variables, b)
 end
 
 # -- RPG2003 per-battler turn counters and party fatigue ----------------------
@@ -13947,7 +13978,7 @@ check 'turn_enemy / turn_actor read the per-battler counters' do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.actor = FakeSourceActor.new(1)
   slime = combatant('Slime', 5, 0, 5, 999)
-  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), rpg2003: true)
   st = new_state
   # Turn 0 for everyone before anyone has acted.
   eq true, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 0,
@@ -14004,7 +14035,8 @@ end
 
 check 'the fatigue page condition tests the window' do
   hero = combatant_mp('Hero', 10, 0, 10, 100, 50)
-  b = Game::Battle.new([hero], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1))
+  b = Game::Battle.new([hero], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1),
+                       rpg2003: true)
   st = new_state
   # "at least half worn down" fires only once the party is.
   cond = battle_cond(BP::FATIGUE, fatigue_min: 50, fatigue_max: 100)


### PR DESCRIPTION
## Summary

- `Game::BattlePage.active?` (`mruby-rpg2k/mrblib/game.rb`) evaluated the `turn_enemy`/`turn_actor`/`fatigue` condition types purely off the condition's flag bits, with no edition check at all — unlike the sibling `Game::EventPage.active?`, which already correctly gates a map event page's RPG2003-only TIMER2 condition on `rpg2003?`.
- EasyRPG's `Game_Interpreter_Battle::AreConditionsMet` (`src/game_interpreter_battle.cpp`) wraps `turn_enemy`/`turn_actor`/`fatigue` (and `command_actor`) in `Player::IsRPG2k3Commands() &&`. The RPG2000 editor's condition box has no controls for any of these three condition types at all, so a genuine `.lmt` should never set the bits on a non-2k3 database — but an unguarded flag reads as an ordinary, *evaluated* condition the instant one is set, rather than the "ignored entirely, page still runs" answer the real engine gives.
- `command_actor` needed no equivalent fix: `Game::Battle#actor_command` already always answers `nil` regardless of edition (RPG2000's own battle scene never has a "source" battler to test against either — EasyRPG's `Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents` always schedules pages with a null source), so that condition already reads as permanently unmet on every edition, matching the real engine's own RPG2000 behaviour by coincidence rather than an explicit gate.
- Fixed by adding `Game::Battle#rpg2003?` (a public reader for the `@rpg2003` flag the class already carries internally) and gating the `turn_enemy`/`turn_actor`/`fatigue` blocks on `ctx.rpg2003?`.

## Test plan

- One new `scripts/rpg2k_logic_check.rb` check: all three conditions read as active on a non-2k3 battle even when they would clearly fail if evaluated.
- Confirmed to fail against the pre-fix code before the fix.
- The three existing checks that exercised these conditions' actual matching logic were updated to construct an explicit RPG2003 battle so the new edition gate doesn't mask what they test.
- `ruby scripts/rpg2k_logic_check.rb` — 942 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- `ninja -C build rpg_maker_clone` — builds cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_