### PR TITLE
Gate Conditional Branch type 10 (second timer) on RPG2003

### DIFF
--- a/changelog.d/rpg2k-conditional-branch-timer2-2k3.fixed.md
+++ b/changelog.d/rpg2k-conditional-branch-timer2-2k3.fixed.md
@@ -1,0 +1,5 @@
+- **A Conditional Branch's "second timer" (Timer2) check is now
+  RPG2003-only.** It used to be evaluated on any database, so a stray type-10
+  condition byte on an RPG2000 project would compare against Timer2 live
+  instead of reading as permanently unmet, since the RPG2000 editor has no
+  controls for this condition type at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6981,6 +6981,31 @@ not yet verified:
   before the fix; the three existing checks that exercised these
   conditions' actual matching logic were updated to construct an explicit
   RPG2003 battle so the edition gate does not mask what they test.
+- ✅ **Conditional Branch condition type 10 (RPG2003's second timer, Timer2)
+  is now RPG2003-only — evaluated on an RPG2000 database, it used to compare
+  Timer2's live seconds against the operand exactly like a real RPG2003
+  Conditional Branch would, instead of reading as permanently unmet.**
+  Confirmed against EasyRPG's actual C++ source: `Game_Interpreter::
+  CommandConditionalBranch`'s (`src/game_interpreter.cpp`) `case 10:` block
+  only touches `value1`/`value2`/`result` at all `if (Player::
+  IsRPG2k3Commands())`; on any other edition `result` is left at its
+  initializer, `false` — the same answer the function's own unrecognized-type
+  default arm gives, not a live comparison. The RPG2000 editor has no UI to
+  even build a Conditional Branch against Timer2, so a genuine `.lmt` file
+  should never carry type 10 on a non-2k3 database, but this runtime's
+  `Game::Interpreter#eval_condition` (`mruby-rpg2k/mrblib/interpreter.rb`)
+  called `timer_condition(cmd, 1)` for type 10 unconditionally, with no
+  edition check — the same gap already fixed for a map event page's Timer2
+  bit and a troop battle page's `turn_enemy`/`turn_actor`/`fatigue`
+  conditions (both above). Fixed by gating the branch on `party.rpg2003?`,
+  the same established pattern used at four other sites in this file.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (a type 10 branch
+  that would clearly take the true arm on an RPG2003 database instead falls
+  through to the else arm on RPG2000, matching the "unrecognized type"
+  default), confirmed to fail against the pre-fix code before the fix; the
+  existing check exercising type 10's actual matching logic was updated to
+  construct an explicit RPG2003 state so the new edition gate does not mask
+  what it tests.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2569,7 +2569,13 @@ module Game
       when 9 # the BGM has played through at least once
         @state.bgm_looped ? true : false
       when 10 # RPG2003's second timer, laid out exactly like type 2
-        timer_condition(cmd, 1)
+        # EasyRPG's own CommandConditionalBranch (src/game_interpreter.cpp)
+        # only evaluates this case at all `if (Player::IsRPG2k3Commands())`
+        # -- on an RPG2000 database `result` is left at its initial `false`,
+        # the same "unhandled type" answer the `else` arm below already
+        # gives, not a live comparison against Timer2 (which RPG2000 has no
+        # editor control to even set up a Conditional Branch against).
+        party.rpg2003? && timer_condition(cmd, 1)
       else
         # An unhandled/unsupported branch type (RPG2003 v1.11's own type 11
         # "EX" conditions -- savestate available, Test Play, ATB-wait,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2618,7 +2618,7 @@ check "Timer Operation addresses RPG2003's second timer through param5" do
 end
 
 check 'Control Variables and Conditional Branch read the second timer' do
-  st = new_state
+  st = new_state(rpg2003: true)
   st.timer(0).set(10)
   st.timer(1).set(50)
   it = Game::Interpreter.new(st)
@@ -2645,6 +2645,26 @@ check 'Control Variables and Conditional Branch read the second timer' do
   it.start(branch.call([2, 40, 0]))  # timer 1 at least 40 s -> no
   it.update
   eq 2, st.variables[3], 'type 2 still reads the first timer'
+end
+
+# Ports EasyRPG's `Game_Interpreter::CommandConditionalBranch`
+# (src/game_interpreter.cpp) `case 10:` block, which only touches `value1`/
+# `value2`/`result` at all `if (Player::IsRPG2k3Commands())`. On an RPG2000
+# database `result` is left at its initializer, `false` -- the same answer
+# the "unrecognized type" default arm gives -- rather than a live comparison
+# against Timer2, a condition the RPG2000 editor has no UI to even build.
+check 'Conditional Branch type 10 (second timer) is RPG2000-inert' do
+  st = new_state(rpg2003: false)
+  st.timer(1).set(50)
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONDITIONAL, [10, 40, 0], indent: 0), # timer 2 >= 40s: true on 2003
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+            FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+            FakeCmd.new(IC::END_BRANCH, [], indent: 0)])
+  it.update
+  ok !st.switches[1], 'the true branch did not run on a non-RPG2003 database'
+  ok st.switches[2], 'RPG2000 falls through to the else branch, same as any unrecognized type'
 end
 
 # Ports EasyRPG's `Game_Interpreter::CommandConditionalBranch`


### PR DESCRIPTION
## Summary
- `Game::Interpreter#eval_condition`'s `when 10` (RPG2003's second timer, Timer2) called `timer_condition(cmd, 1)` unconditionally, with no edition check.
- EasyRPG's own `Game_Interpreter::CommandConditionalBranch` (`src/game_interpreter.cpp`) only evaluates this `case 10:` block `if (Player::IsRPG2k3Commands())`; on any other edition `result` is left at its initializer, `false` — the same answer the function's unrecognized-type default arm gives, not a live comparison against Timer2. The RPG2000 editor has no UI to even build a Conditional Branch against Timer2, so a genuine `.lmt` file should never carry type 10 on a non-2k3 database.
- Fixed by gating the branch on `party.rpg2003?`, the same established pattern already used at four other sites in `interpreter.rb`, and mirroring the identical edition-gate fix already shipped for a map event page's Timer2 bit and a troop battle page's `turn_enemy`/`turn_actor`/`fatigue` conditions.

## Test plan
- Added `scripts/rpg2k_logic_check.rb` check `'Conditional Branch type 10 (second timer) is RPG2000-inert'`: a type-10 branch that would clearly take the true arm on an RPG2003 database instead falls through to the else arm on RPG2000. Confirmed to fail against the pre-fix code (`1 of 943 checks FAILED` via `git stash`) before the fix.
- Updated the existing check `'Control Variables and Conditional Branch read the second timer'` to construct an explicit RPG2003 state, so the new edition gate doesn't mask what it was originally testing.
- `ruby scripts/rpg2k_logic_check.rb` — 943 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_