### PR TITLE
Implement RPG2003 Shake Screen Begin/End continuous mode

### DIFF
--- a/changelog.d/rpg2k-shake-screen-2k3-begin-end.fixed.md
+++ b/changelog.d/rpg2k-shake-screen-2k3-begin-end.fixed.md
@@ -1,0 +1,4 @@
+- **RPG2003's Shake Screen Begin/End continuous-strobe mode now works.** A
+  Begin command used to silently do nothing instead of starting an
+  indefinite shake, since the runtime never read the command's mode
+  parameter at all and always fell back to a zero-duration one-shot shake.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7006,6 +7006,44 @@ not yet verified:
   existing check exercising type 10's actual matching logic was updated to
   construct an explicit RPG2003 state so the new edition gate does not mask
   what it tests.
+- ✅ **RPG2003 Shake Screen's Begin/End continuous-strobe mode (param4 = 1 / 2)
+  is now implemented — a Begin command used to silently no-op instead of
+  starting an indefinite shake.** `do_shake_screen`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) never read the command's 5th
+  parameter at all, so a Begin call (`[strength, speed, tenths=0, wait=0,
+  mode=1]`, where `tenths` is meaningless in Begin mode) fell through to the
+  plain timed-shake path with `frames = 0 * FRAMES_PER_TENTH = 0`, and
+  `Game::Screen#shake` (`mruby-rpg2k/mrblib/game.rb`) treats `frames <= 0` as
+  "stop immediately" — the screen never shook at all. Confirmed against
+  EasyRPG's actual C++ source (`src/game_interpreter.cpp`
+  `CommandShakeScreen`, code 11050): a `shake_cmd` byte read from
+  `com.parameters[4]` only `if (com.parameters.size() > 4 &&
+  Player::IsRPG2k3Commands())`, dispatching to `ShakeOnce` (mode 0, the
+  existing behaviour), `ShakeBegin(strength, speed)` (mode 1 — note real
+  RPG_RT's Begin ignores `tenths` too, taking only strength/speed), or
+  `ShakeEnd()` (mode 2). `src/game_screen.cpp`'s `ShakeBegin` sets
+  `shake_time_left` to `Shake::kShakeContinuousTimeStart` (65535, `src/
+  shake.h`) and `shake_continuous = true`; `src/shake.h`'s `Shake::Update`
+  re-arms `time_left` back to that same sentinel every time it counts down
+  to 0 while `continuous` holds, instead of settling — an indefinite strobe
+  until `ShakeEnd()` (or a fresh one-shot shake, which `ShakeOnce` always
+  clears `continuous` for) stops it. Exactly the same gap already fixed for
+  Flash Screen's own Begin/End mode. Fixed by mirroring that precedent:
+  `do_shake_screen` now dispatches on `cmd.param(4)` gated by
+  `@state.party.rpg2003? && cmd.parameters.size > 4`; `Game::Screen` gained
+  `#shake_begin`/`#shake_end` and a `SHAKE_CONTINUOUS_FRAMES = 65535`
+  sentinel, `#shake` now clears `@shake_continuous` on its own one-shot path
+  (matching `ShakeOnce`, so a plain shake after an earlier Begin settles for
+  good instead of inheriting the re-arm), and `#update_shake` re-arms to the
+  sentinel instead of settling to 0 when `@shake_continuous` is set. Covered
+  by four new `scripts/rpg2k_logic_check.rb` checks — Begin starts a shake
+  that never pauses the interpreter and re-arms instead of settling at the
+  end of a forced-short period, End stops a Begin strobe immediately, a
+  non-RPG2003 or short-parameter command always falls back to plain mode 0,
+  and a one-shot shake started after a Begin strobe settles for good instead
+  of re-arming — three of the four confirmed to fail against the pre-fix
+  code before the fix (the fallback check already passed, since the
+  pre-fix code always behaved as mode 0 regardless).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6578,6 +6578,13 @@ module Game
   class Screen
     NEUTRAL = 100 # a channel value that leaves the screen unchanged
 
+    # `Shake::kShakeContinuousTimeStart` (src/shake.h): the frame count a
+    # RPG2003 Shake Screen Begin strobe re-arms to every time it counts down
+    # to 0, rather than settling -- EasyRPG's own comment on the constant
+    # notes it deliberately avoids a real RPG_RT bug where a naive "forever"
+    # sentinel let a continuous shake actually stop after 18m12s.
+    SHAKE_CONTINUOUS_FRAMES = 65535
+
     def initialize
       @r = @g = @b = @sat = NEUTRAL
       @tr = @tg = @tb = @tsat = NEUTRAL
@@ -6586,6 +6593,7 @@ module Game
       @shake_speed = 1
       @shake_frames = 0 # frames left in the current shake (0 = still)
       @shake_offset = 0
+      @shake_continuous = false # RPG2003 Begin/End strobe: re-arms at 0 instead of settling
       @flash_r = @flash_g = @flash_b = 0
       @flash_power = 0 # peak strength of the current flash
       @flash_strength = 0 # current strength, fading to 0 over the duration
@@ -6718,8 +6726,32 @@ module Game
         @shake_frames = 0
         @shake_offset = 0
       else
+        @shake_continuous = false
         @shake_frames = frames
       end
+    end
+
+    # RPG2003 Shake Screen mode 1: begin an indefinite strobe at the given
+    # strength/speed that re-arms every time it counts down instead of
+    # settling -- matches `Game_Screen::ShakeBegin`, which (unlike #shake)
+    # takes no duration at all: only #shake_end (or a fresh one-shot #shake)
+    # stops it. Shake position is deliberately left alone, same as #shake,
+    # so an interrupting shake flows smoothly instead of snapping to centre.
+    def shake_begin(power, speed)
+      @shake_power = Game.clamp(power, 0, 9)
+      @shake_speed = Game.clamp(speed, 1, 9)
+      @shake_continuous = true
+      @shake_frames = SHAKE_CONTINUOUS_FRAMES
+    end
+
+    # RPG2003 Shake Screen mode 2: stop a #shake_begin strobe immediately,
+    # settled back to centre -- matches `Game_Screen::ShakeEnd`. Real RPG_RT
+    # does not clear the continuous flag here (only a fresh one-shot/Begin
+    # call does), though with @shake_frames at 0 it has no effect until
+    # something else sets a shake running again.
+    def shake_end
+      @shake_offset = 0
+      @shake_frames = 0
     end
 
     # Begin a flash of colour (r, g, b) at peak strength `power`, fading linearly
@@ -6880,6 +6912,12 @@ module Game
         return
       end
       @shake_frames -= 1
+      if @shake_frames <= 0 && @shake_continuous
+        # A Begin strobe never settles: re-arm for another full duration
+        # instead of stopping, matching `Shake::Update`'s own continuous
+        # re-arm.
+        @shake_frames = SHAKE_CONTINUOUS_FRAMES
+      end
       if @shake_frames <= 0
         @shake_offset = 0 # settle back to centre when the shake ends
         return

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3058,12 +3058,26 @@ module Game
     # param1 for param2 tenths of a second. When param3 (the wait flag) is set,
     # pause until it finishes — the owning scene advances Game::Screen each frame
     # and resumes us once no screen effect is animating.
+    # RPG2003 extends the command with a param4 mode byte (0 one-shot / 1 begin a
+    # repeating strobe / 2 end one), matching EasyRPG's `CommandShakeScreen`
+    # (src/game_interpreter.cpp): a command list carrying no 5th parameter (an
+    # RPG2000 project, or an RPG2003 one never given the extended layout) always
+    # falls back to a plain one-shot shake, mode 0. Only mode 0 ever waits — Begin
+    # and End never suspend the interpreter, since the strobe runs indefinitely.
     def do_shake_screen(cmd)
-      frames = cmd.param(2) * FRAMES_PER_TENTH
-      @state.screen.shake(cmd.param(0), cmd.param(1), frames)
-      return unless cmd.param(3) != 0 && @state.screen.shaking?
-      @wait_kind = :screen
-      @waiting = true
+      mode = @state.party.rpg2003? && cmd.parameters.size > 4 ? cmd.param(4) : 0
+      case mode
+      when 1
+        @state.screen.shake_begin(cmd.param(0), cmd.param(1))
+      when 2
+        @state.screen.shake_end
+      else
+        frames = cmd.param(2) * FRAMES_PER_TENTH
+        @state.screen.shake(cmd.param(0), cmd.param(1), frames)
+        return unless cmd.param(3) != 0 && @state.screen.shaking?
+        @wait_kind = :screen
+        @waiting = true
+      end
     end
 
     # Whether Show/Move/Erase Picture must no-op this call: per yado.tk, real

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2062,6 +2062,68 @@ check 'Shake Screen with a wait pauses until the shake ends' do
   eq true, st.switches[2], 'resumed once the shake finished'
 end
 
+check 'RPG2003 Shake Screen mode 1 (Begin) strobes indefinitely and never pauses' do
+  st = new_state(rpg2003: true)
+  it = Game::Interpreter.new(st)
+  # power 5, speed 4; tenths/wait play no part in Begin, mode 1.
+  it.start([FakeCmd.new(IC::SHAKE_SCREEN, [5, 4, 0, 0, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Begin never pauses the interpreter'
+  eq true, st.switches[1], 'the command after Begin still ran'
+  ok st.screen.shaking?, 'a shake is in progress'
+  # Force the strobe down to its last frame instead of looping the real
+  # 65535-frame period, then confirm it re-arms rather than settling.
+  st.screen.instance_variable_set(:@shake_frames, 1)
+  st.screen.update
+  eq Game::Screen::SHAKE_CONTINUOUS_FRAMES, st.screen.instance_variable_get(:@shake_frames),
+     're-armed to the continuous sentinel instead of settling at 0'
+  ok st.screen.shaking?, 'still strobing after one full period'
+end
+
+check 'RPG2003 Shake Screen mode 2 (End) stops a Begin strobe immediately' do
+  st = new_state(rpg2003: true)
+  st.screen.shake_begin(5, 4)
+  ok st.screen.shaking?
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHAKE_SCREEN, [0, 0, 0, 0, 2]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'End never pauses the interpreter'
+  eq true, st.switches[1], 'the command after End still ran'
+  ok !st.screen.shaking?, 'End stops the strobe'
+  eq 0, st.screen.shake_offset
+  st.screen.update # further updates are a no-op once ended
+  ok !st.screen.shaking?
+end
+
+check 'A pre-RPG2003 or short-parameter Shake Screen command always falls back to mode 0' do
+  st = new_state(rpg2003: false)
+  it = Game::Interpreter.new(st)
+  # A 5-parameter command list, but not an RPG2003 project: param4's "1"
+  # (Begin) is ignored and this behaves as a plain timed shake instead.
+  it.start([FakeCmd.new(IC::SHAKE_SCREEN, [5, 4, 1, 0, 1])]) # 6 frames
+  it.update
+  ok st.screen.shaking?
+  st.screen.instance_variable_set(:@shake_frames, 1)
+  st.screen.update
+  ok !st.screen.shaking?, 'settled, not re-armed -- mode 0, not Begin'
+end
+
+check 'a one-shot Shake Screen after a Begin strobe stops re-arming once it ends' do
+  # Matches `Game_Screen::ShakeOnce` always clearing the continuous flag: a
+  # plain timed shake started after a Begin strobe must settle for good once
+  # its own duration elapses, not keep re-arming from the earlier Begin.
+  st = new_state(rpg2003: true)
+  st.screen.shake_begin(5, 4)
+  ok st.screen.shaking?
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHAKE_SCREEN, [3, 2, 1, 0])]) # mode 0, 6 frames
+  it.update
+  6.times { st.screen.update }
+  ok !st.screen.shaking?, 'the one-shot settled instead of re-arming from the earlier Begin'
+end
+
 check 'Flash Screen without a wait starts a flash and does not pause' do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary
- `do_shake_screen` (`mruby-rpg2k/mrblib/interpreter.rb`) never read the Shake Screen command's 5th parameter (the RPG2003 mode byte), so a Begin call (`[strength, speed, tenths=0, wait=0, mode=1]`) fell through to the plain timed-shake path with `frames = 0 * FRAMES_PER_TENTH = 0`, and `Game::Screen#shake` treats `frames <= 0` as "stop immediately" — the screen never shook at all.
- Confirmed against EasyRPG's actual C++ source: `Game_Interpreter::CommandShakeScreen` (`src/game_interpreter.cpp`, code 11050) reads `shake_cmd` from `com.parameters[4]` only `if (com.parameters.size() > 4 && Player::IsRPG2k3Commands())`, dispatching to `ShakeOnce` (mode 0), `ShakeBegin(strength, speed)` (mode 1 — ignores tenths entirely), or `ShakeEnd()` (mode 2). `src/game_screen.cpp`'s `ShakeBegin` sets `shake_time_left` to `Shake::kShakeContinuousTimeStart` (65535, `src/shake.h`) with `shake_continuous = true`; `Shake::Update` re-arms back to that sentinel every time it counts down to 0 while `continuous` holds — an indefinite strobe until `ShakeEnd()` (or a fresh one-shot, which `ShakeOnce` always clears `continuous` for).
- Exactly the same gap already fixed for Flash Screen's own Begin/End mode — this mirrors that precedent.
- Fixed: `do_shake_screen` now dispatches on `cmd.param(4)` gated by `@state.party.rpg2003? && cmd.parameters.size > 4`; `Game::Screen` gained `#shake_begin`/`#shake_end` and a `SHAKE_CONTINUOUS_FRAMES = 65535` sentinel, `#shake` now clears `@shake_continuous` on its one-shot path (matching `ShakeOnce`), and `#update_shake` re-arms to the sentinel instead of settling to 0 when continuous.

## Test plan
- Added 4 new `scripts/rpg2k_logic_check.rb` checks: Begin starts a shake that never pauses and re-arms instead of settling (verified by forcing `@shake_frames` to its last frame rather than looping the real 65535-frame period), End stops a Begin strobe immediately, a non-RPG2003/short-parameter command always falls back to plain mode 0, and a one-shot shake after a Begin strobe settles for good instead of re-arming.
- 3 of the 4 new checks confirmed to fail against the pre-fix code (`git stash` — `3 of 947 checks FAILED`); the fallback check already passed since pre-fix code always behaved as mode 0.
- `ruby scripts/rpg2k_logic_check.rb` — 947 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 648 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_