### PR TITLE
Honour RPG2003's Show Battle Animation Ally/Enemy target flag

### DIFF
--- a/changelog.d/rpg2k-battle-page-show-animation-ally-target.fixed.md
+++ b/changelog.d/rpg2k-battle-page-show-animation-ally-target.fixed.md
@@ -1,0 +1,4 @@
+- **A troop battle-event page's Show Battle Animation now honours RPG2003's
+  Ally/Enemy target-type flag.** An animation aimed at "Ally #1" used to
+  play over the troop's own second monster instead of any party member, in
+  any fight with two or more enemies.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7044,6 +7044,39 @@ not yet verified:
   of re-arming — three of the four confirmed to fail against the pre-fix
   code before the fix (the fallback check already passed, since the
   pre-fix code always behaved as mode 0 regardless).
+- ✅ **A troop battle-event page's Show Battle Animation now honours RPG2003's
+  Ally/Enemy target-type flag instead of always indexing the enemy troop —
+  an "Ally #1" target used to play over the troop's own *second* monster in
+  any troop with 2+ members, not any party member at all.** Confirmed
+  against EasyRPG's actual C++ source: `Game_Interpreter_Battle::
+  CommandShowBattleAnimation` (`src/game_interpreter_battle.cpp`) reads
+  `allies = com.parameters[3] != 0` only `if (Player::IsRPG2k3() &&
+  com.parameters.size() > 3)` — the same trailing-RPG2003-parameter gate
+  already used for Flash/Shake Screen — and, when `allies` is set, resolves
+  the target as `(*Main_Data::game_party)[target - 1]` (party members
+  counted from 1) instead of indexing the enemy troop.
+  `Interpreter#do_show_battle_animation_b`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) never read a 4th parameter at all,
+  so `@battle_animation[:target]` was always resolved against
+  `@ui[:enemy_sprites]` in `Scene::Battle#start_battle_page_animation`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) regardless of which side the
+  editor's own Ally/Enemy radio button actually picked. Fixed by carrying
+  a new `allies` flag through the request; when set,
+  `start_battle_page_animation` now uses the same ally-side screen-centre
+  fallback (and no `target_index`, so no enemy sprite is ever flashed or
+  shaken) every ordinary ally-targeted battle-round entry already uses —
+  RPG2000's front-view battle draws no on-screen ally sprite to position
+  over or point a `target_index`-keyed flash/shake at. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (the flag parses correctly off
+  param3, and is ignored outside RPG2003 or a short parameter list) and a
+  new `scripts/rpg2k_scene_check.rb` check (an ally-targeted animation
+  lands at screen centre with no enemy sprite ever flashed, instead of
+  hitting the troop's second member), three checks total confirmed to fail
+  against the pre-fix code before the fix. The `target < 0` "whole side"
+  case EasyRPG's own function also handles (playing one animation over
+  every living ally or enemy at once) stays out of scope — this codebase's
+  animation player only ever tracks a single `target_index`, and extending
+  it to a full battler list is a separate, larger change.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2436,11 +2436,18 @@ module Game
 
     # Show Battle Animation (13260), the battle-page form of 11210. param0 is
     # the animation, param1 the target troop member and param2 the wait flag.
-    # Raised through the same request/wait the map command uses, so the scene
-    # drives one animation player for both.
+    # RPG2003 adds an Ally/Enemy radio button to the command's target picker,
+    # stored as a param3 flag -- matches EasyRPG's own
+    # `Game_Interpreter_Battle::CommandShowBattleAnimation`
+    # (src/game_interpreter_battle.cpp): `allies = com.parameters[3] != 0`,
+    # read only `if (Player::IsRPG2k3() && com.parameters.size() > 3)`, same
+    # gate already used for Flash/Shake Screen's own trailing RPG2003
+    # parameter. Raised through the same request/wait the map command uses,
+    # so the scene drives one animation player for both.
     def do_show_battle_animation_b(cmd)
+      allies = @state.party.rpg2003? && cmd.parameters.size > 3 && cmd.param(3) != 0
       @battle_animation = { animation: cmd.param(0), target: cmd.param(1),
-                            wait: cmd.param(2) != 0, battle: true }
+                            wait: cmd.param(2) != 0, battle: true, allies: allies }
       return unless cmd.param(2) != 0
       @wait_kind = :animation
       @waiting = true

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1746,9 +1746,24 @@ class RPG2k
       # rather than inheriting it from whichever action just landed. Called
       # from Scene::Map#start_map_animation, which every battle-page-issued
       # Show Battle Animation request (`req[:battle]`) dispatches to.
+      #
+      # `req[:allies]` is RPG2003's own Ally/Enemy target-type flag
+      # (Interpreter#do_show_battle_animation_b) -- an ally-targeted
+      # animation gets no `target_index` at all, the same convention every
+      # ally-targeted battle-round entry already uses (`@enemies.index` in
+      # Game::Battle returns nil for a party member), which in turn is why
+      # #battle_animation_pixel's own nil-sprite branch already falls back to
+      # screen-centre: RPG2000's battle draws no on-screen ally sprite to
+      # target at all.
       def start_battle_page_animation(req)
-        tx, ty, height = battle_animation_pixel(target_index: req[:target])
-        @map.build_animation(req[:animation], tx, ty, true, target_index: req[:target],
+        tx, ty, height =
+          if req[:allies]
+            [SCREEN_W / 2, SCREEN_H / 2, nil]
+          else
+            battle_animation_pixel(target_index: req[:target])
+          end
+        target_index = req[:allies] ? nil : req[:target]
+        @map.build_animation(req[:animation], tx, ty, true, target_index: target_index,
                              target_height: height)
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14576,6 +14576,34 @@ check 'Show Battle Animation (battle form) waits like the map form' do
   eq true, it.battle_animation[:battle]
 end
 
+# Ports EasyRPG's own `Game_Interpreter_Battle::CommandShowBattleAnimation`
+# (src/game_interpreter_battle.cpp): `allies = com.parameters[3] != 0`, read
+# only `if (Player::IsRPG2k3() && com.parameters.size() > 3)` -- the same
+# trailing-RPG2003-parameter gate already used for Flash/Shake Screen.
+check 'Show Battle Animation (battle form) reads the RPG2003 Ally/Enemy target-type flag' do
+  b = battle_with
+  it = Game::Interpreter.new(new_state(rpg2003: true))
+  it.battle = b
+  it.start([FakeCmd.new(IC::SHOW_BATTLE_ANIM_B, [7, 1, 0, 1])]) # anim 7, ally #1, no wait, allies=1
+  it.update
+  eq true, it.battle_animation[:allies]
+end
+
+check 'Show Battle Animation (battle form) ignores param3 outside RPG2003 or a short parameter list' do
+  b = battle_with
+  it = Game::Interpreter.new(new_state(rpg2003: false))
+  it.battle = b
+  it.start([FakeCmd.new(IC::SHOW_BATTLE_ANIM_B, [7, 1, 0, 1])])
+  it.update
+  eq false, it.battle_animation[:allies], 'a non-RPG2003 database always targets the enemy troop'
+
+  it2 = Game::Interpreter.new(new_state(rpg2003: true))
+  it2.battle = b
+  it2.start([FakeCmd.new(IC::SHOW_BATTLE_ANIM_B, [7, 1, 0])]) # only 3 parameters, no param3 at all
+  it2.update
+  eq false, it2.battle_animation[:allies], 'a pre-RPG2003-layout command list always targets the enemy troop'
+end
+
 # -- hidden troop members stay out of the fight --------------------------------
 
 # A troop member the editor flagged invisible: from_enemy must carry that

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11277,6 +11277,39 @@ check "a battle page's Show Battle Animation target-scope flash pulses the named
   ok st.switches[23], 'and the page still ran on once the animation finished'
 end
 
+# RPG2003's Ally/Enemy target-type flag on Show Battle Animation
+# (Interpreter#do_show_battle_animation_b's param3, matching EasyRPG's
+# `Game_Interpreter_Battle::CommandShowBattleAnimation`) used to be dropped
+# entirely: an "Ally #1" target still indexed straight into
+# `@ui[:enemy_sprites]` -- the troop's own *second* monster in any troop
+# with 2+ members, not any party member at all. Fixed by carrying the flag
+# through to #start_battle_page_animation, which now falls back to the same
+# ally-side screen-centre positioning (and no `target_index`, so no enemy
+# sprite is ever flashed/shaken) every ally-targeted battle-round entry
+# already uses.
+check "a battle page's Show Battle Animation targets the party, not a troop member, when the RPG2003 ally flag is set" do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [9, 1, 1, 1], indent: 0), # anim 9, ally #1, wait, allies=1
+                             ECmd.new(ic::CONTROL_SWITCHES, [0, 24, 24, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages, party: BattleStubParty.new(rpg2003: true))
+  ma_seen = nil
+  150.times do
+    scene.update
+    ui = battle_ui(scene)
+    ma = scene.instance_variable_get(:@map_animation)
+    ma_seen ||= ma
+    if ui && ui[:enemy_sprites]
+      ui[:enemy_sprites].each { |s| ok !s.flash_color, 'no enemy sprite was flashed -- the target is an ally' }
+    end
+    break if st.switches[24]
+  end
+  ok ma_seen, 'the request was recorded as a live animation, not silently dropped'
+  eq [RPG2k::WIDTH / 2, RPG2k::HEIGHT / 2], [ma_seen[:tx], ma_seen[:ty]],
+     'the ally-side screen-centre fallback, not any enemy sprite position'
+  ok !ma_seen[:target_index], 'no enemy troop-member index -- an ally target has no on-screen sprite'
+  ok st.switches[24], 'and the page still ran on once it finished'
+end
+
 check 'a battle page shows its message in a battle panel and waits for a key' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::SHOW_MESSAGE, [], string: 'It appears!'),


### PR DESCRIPTION
## Summary
- `Interpreter#do_show_battle_animation_b` (`mruby-rpg2k/mrblib/interpreter.rb`) never read the Show Battle Animation command's 4th parameter, so `@battle_animation[:target]` was always resolved against `@ui[:enemy_sprites]` in `Scene::Battle#start_battle_page_animation` — even when the RPG2003 editor's own Ally/Enemy radio button picked "Ally".
- Confirmed against EasyRPG's actual C++ source: `Game_Interpreter_Battle::CommandShowBattleAnimation` (`src/game_interpreter_battle.cpp`) reads `allies = com.parameters[3] != 0` only `if (Player::IsRPG2k3() && com.parameters.size() > 3)` (the same trailing-RPG2003-parameter gate already used for Flash/Shake Screen), and when `allies` is set resolves the target as `(*Main_Data::game_party)[target - 1]` (party members counted from 1) instead of the enemy troop.
- Concretely: an "Ally #1" target on a 2+-enemy troop used to play the animation over the troop's own *second monster*, not any party member at all.
- Fixed by carrying an `allies` flag through the request; `start_battle_page_animation` now falls back to the same ally-side screen-centre position (and no `target_index`, so no enemy sprite is ever flashed/shaken) every ordinary ally-targeted battle-round entry already uses — RPG2000's front-view battle draws no on-screen ally sprite.
- The `target < 0` "whole side" case EasyRPG's function also handles (animating every living ally/enemy at once) stays out of scope: this codebase's animation player only ever tracks a single `target_index`, and extending it to a full battler list is a separate, larger change.

## Test plan
- Added 2 `scripts/rpg2k_logic_check.rb` checks: the ally flag parses correctly off param3, and is ignored outside RPG2003 or a short parameter list.
- Added 1 `scripts/rpg2k_scene_check.rb` check: an ally-targeted animation lands at screen centre with no enemy sprite ever flashed, instead of hitting the troop's second member.
- All 3 confirmed to fail against the pre-fix code (`git stash` — `2 of 949` + `1 of 649` checks FAILED) before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 949 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 649 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_