### PR TITLE
Clamp Weather Effects type and strength like real RPG_RT

### DIFF
--- a/changelog.d/rpg2k-weather-effects-type-strength-clamp.fixed.md
+++ b/changelog.d/rpg2k-weather-effects-type-strength-clamp.fixed.md
@@ -1,0 +1,4 @@
+- **Weather Effects now clamps its type and strength the same way real
+  RPG_RT does.** An RPG2003-only weather type used to persist on an RPG2000
+  game instead of reading as no weather, and an out-of-range strength byte
+  used to be saved past the strongest defined level instead of clamping.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7077,6 +7077,33 @@ not yet verified:
   every living ally or enemy at once) stays out of scope — this codebase's
   animation player only ever tracks a single `target_index`, and extending
   it to a full battler list is a separate, larger change.
+- ✅ **Weather Effects now clamps an RPG2003-only weather type back to none on
+  RPG2000, and clamps strength to at most 2 on every edition — both used to
+  be stored verbatim off the raw command bytes with no bound at all.**
+  Confirmed against EasyRPG's actual C++ source: `Game_Interpreter::
+  CommandWeatherEffects` (`src/game_interpreter.cpp`, code 11070) computes
+  `strength = std::min(str, 2)` unconditionally, then `if (!Player::
+  IsRPG2k3Commands() && type > 2) type = 0;` — the RPG2000 editor's own
+  dialog offers no weather type past Snow (2) at all, so a stray higher
+  value (a hex-edited event, a converted project) should clamp back to none
+  rather than linger, the same trailing-RPG2003-value gate already mined
+  repeatedly this session, just on a plain parameter instead of a trailing
+  extra one. `Interpreter#do_weather` (`mruby-rpg2k/mrblib/interpreter.rb`)
+  passed both `cmd.param(0)`/`cmd.param(1)` straight through to `Game::
+  Weather#set` with neither check — `Weather Effects [3, 2]` on an RPG2000
+  database used to set `weather.type == 3` (and keep it there through
+  Save/Continue) where real RPG_RT/EasyRPG show no weather at all, and any
+  out-of-range strength byte (`Weather Effects [1, 9]`) persisted past the
+  strongest defined level instead of clamping — the one downstream renderer
+  read (`Scene::Map`'s particle-count lookup) already clamps at draw time,
+  but the *stored*, saved state still diverged from what real RPG_RT would
+  ever hold. Fixed by mirroring both checks directly in `do_weather`.
+  Covered by three new `scripts/rpg2k_logic_check.rb` checks — an RPG2003
+  type forced to none on RPG2000, the same type kept on an actual RPG2003
+  database, and an out-of-range strength clamped to 2 — two of the three
+  confirmed to fail against the pre-fix code before the fix (the
+  RPG2003-database check already passed, since the pre-fix code applied no
+  gate on any edition).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3194,8 +3194,18 @@ module Game
     # / tint overlays this records the Ruby-half model only — compositing the
     # rain/snow particles is native renderer work still to come — but the setting
     # is applied and persists through Save / Continue.
+    # Matches EasyRPG's `Game_Interpreter::CommandWeatherEffects`
+    # (src/game_interpreter.cpp): `strength = std::min(str, 2)` unconditionally
+    # (a stray value above 2 in the raw command bytes clamps down rather than
+    # persisting out of range), and `type` above 2 (an RPG2003-only weather
+    # type) is forced back to 0 (none) `if (!Player::IsRPG2k3Commands())` —
+    # the RPG2000 editor's own Weather Effects dialog offers no type past
+    # Snow at all, so a stray higher value should never linger on that
+    # edition.
     def do_weather(cmd)
-      @state.weather.set(cmd.param(0), cmd.param(1))
+      type = cmd.param(0)
+      type = 0 if !@state.party.rpg2003? && type > 2
+      @state.weather.set(type, [cmd.param(1), 2].min)
     end
 
     # Fade Out BGM (11520): fade the music to silence over param0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8041,6 +8041,41 @@ check 'Weather Effects sets the weather type and strength, non-blocking' do
   eq true, st.switches[1], 'the command after it still ran'
 end
 
+# Ports EasyRPG's own `Game_Interpreter::CommandWeatherEffects`
+# (src/game_interpreter.cpp): `if (!Player::IsRPG2k3Commands() && type > 2)
+# type = 0;` -- the RPG2000 editor's own Weather Effects dialog offers no
+# type past Snow (2) at all, so a stray higher value in the raw command
+# bytes (a hex-edited event, a converted project) should clamp back to none
+# rather than linger.
+check 'Weather Effects clamps an RPG2003-only weather type back to none on RPG2000' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::WEATHER_EFFECTS, [3, 2])]) # a 2003-only type
+  it.update
+  eq 0, st.weather.type, 'forced back to none on a non-RPG2003 database'
+  ok st.weather.none?
+end
+
+check 'Weather Effects keeps an RPG2003-only weather type on an RPG2003 database' do
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], rpg2003: true)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::WEATHER_EFFECTS, [3, 2])])
+  it.update
+  eq 3, st.weather.type, 'an RPG2003 database keeps the higher type'
+end
+
+# `int strength = std::min(str, 2);` in the same EasyRPG function, applied
+# unconditionally on every edition.
+check 'Weather Effects clamps strength to at most 2 on any edition' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::WEATHER_EFFECTS, [1, 9])]) # rain, an out-of-range strength
+  it.update
+  eq 2, st.weather.strength, 'clamped to the strongest defined level'
+end
+
 check 'Weather round-trips through the save' do
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,


### PR DESCRIPTION
## Summary
- `Interpreter#do_weather` (`mruby-rpg2k/mrblib/interpreter.rb`) passed both `cmd.param(0)` (weather type) and `cmd.param(1)` (strength) straight through to `Game::Weather#set` with no bound at all.
- Confirmed against EasyRPG's actual C++ source: `Game_Interpreter::CommandWeatherEffects` (`src/game_interpreter.cpp`, code 11070) computes `strength = std::min(str, 2)` unconditionally, then `if (!Player::IsRPG2k3Commands() && type > 2) type = 0;` — the RPG2000 editor's own Weather Effects dialog offers no type past Snow (2) at all, so a stray higher value (a hex-edited event, a converted project) should clamp back to none rather than linger.
- Concretely: `Weather Effects [3, 2]` on an RPG2000 database used to set `weather.type == 3` and keep it there through Save/Continue, where real RPG_RT/EasyRPG show no weather at all. An out-of-range strength (`Weather Effects [1, 9]`) persisted past the strongest defined level — the one downstream renderer read (`Scene::Map`'s particle-count lookup) already clamps at draw time, but the *stored*, saved state still diverged from what real RPG_RT would ever hold.
- Fixed by mirroring both checks directly in `do_weather`.

## Test plan
- Added 3 `scripts/rpg2k_logic_check.rb` checks: an RPG2003 type forced to none on RPG2000, the same type kept on an actual RPG2003 database, and an out-of-range strength clamped to 2.
- 2 of the 3 confirmed to fail against the pre-fix code (`git stash` — `2 of 952 checks FAILED`); the RPG2003-database check already passed since the pre-fix code applied no gate on any edition.
- `ruby scripts/rpg2k_logic_check.rb` — 952 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 649 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_