### PR TITLE
Gate a battle page's command_actor condition on RPG2003 too

### DIFF
--- a/changelog.d/rpg2k-battle-page-command-actor-2k3.fixed.md
+++ b/changelog.d/rpg2k-battle-page-command-actor-2k3.fixed.md
@@ -1,0 +1,5 @@
+- **A troop battle-event page's `command_actor` condition is now correctly
+  RPG2003-only, matching its turn_enemy/turn_actor/fatigue siblings.** It
+  used to be evaluated on every database, which permanently disabled a page
+  using only this condition on an RPG2000 game, where real RPG_RT would
+  have run it unconditionally.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7104,6 +7104,35 @@ not yet verified:
   confirmed to fail against the pre-fix code before the fix (the
   RPG2003-database check already passed, since the pre-fix code applied no
   gate on any edition).
+- ✅ **A troop battle-event page's `command_actor` condition is now correctly
+  RPG2003-only too, closing the one flag `Game::BattlePage.active?`'s own
+  earlier turn_enemy/turn_actor/fatigue fix (above) missed.** Confirmed
+  against EasyRPG's actual C++ source: `Game_Interpreter_Battle::
+  AreConditionsMet` (`src/game_interpreter_battle.cpp`) wraps all *four*
+  RPG2003-only condition types — `turn_enemy`, `turn_actor`, `fatigue`, and
+  `command_actor` — in `Player::IsRPG2k3Commands() &&`, but
+  `Game::BattlePage.active?` (`mruby-rpg2k/mrblib/game.rb`) only ever
+  gated the first three on `ctx.rpg2003?`; `command_actor` kept evaluating
+  unconditionally, and the block comment right above even claimed it was
+  "already handled below" without the code ever doing so. Concretely: a
+  troop page whose condition box has only the `command_actor` bit set
+  (`command_actor_id: 1, command_id: 1`) — real RPG_RT never even looks at
+  the bit on a non-2k3 database and runs the page unconditionally, since
+  this codebase's `Game::Battle#actor_command` is an unimplemented stub
+  that always answers `nil`, `nil == 1` was `false` on every edition,
+  making the page permanently inactive where it should always fire on
+  RPG2000. Fixed by adding the same `&& ctx.rpg2003?` conjunct already used
+  for its three siblings, and correcting the stale comment. On an actual
+  RPG2003 battle the condition still can never be satisfied today (the same
+  `#actor_command` stub), matching this codebase's own documented
+  not-yet-implemented state rather than real RPG_RT's per-battler
+  last-chosen-command tracking. Covered by replacing the old
+  `scripts/rpg2k_logic_check.rb` check (which asserted the bug's own wrong
+  answer and rationalized it in its comment) with two: an RPG2000-only
+  `command_actor` condition now reads active, matching its siblings; an
+  RPG2003 one still correctly reads inactive, since the runtime cannot
+  answer it yet — the RPG2000 case confirmed to fail against the pre-fix
+  code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5784,16 +5784,15 @@ module Game
         return false unless hp_within?(ctx.ally_by_actor_id(cond.actor_id),
                                        cond.actor_hp_min, cond.actor_hp_max)
       end
-      # turn_enemy / turn_actor / fatigue are RPG2003-only conditions --
-      # EasyRPG's own `Game_Interpreter_Battle::AreConditionsMet`
-      # (src/game_interpreter_battle.cpp) wraps all three (and command_actor,
-      # already handled below) in `Player::IsRPG2k3Commands() &&`. The
-      # RPG2000 editor's condition box has no controls for these bits at
-      # all, so a genuine .lmt should never set them on a non-2k3 database
-      # -- but an untested flag with no guard reads as "always true" the
-      # instant one is set, exactly the same silent-pass-through class of
-      # bug the map-event TIMER2 condition (Game::EventPage.active?, this
-      # file) was already fixed for.
+      # turn_enemy / turn_actor / fatigue / command_actor are RPG2003-only
+      # conditions -- EasyRPG's own `Game_Interpreter_Battle::
+      # AreConditionsMet` (src/game_interpreter_battle.cpp) wraps all four in
+      # `Player::IsRPG2k3Commands() &&`. The RPG2000 editor's condition box
+      # has no controls for any of these bits at all, so a genuine .lmt
+      # should never set them on a non-2k3 database -- but an untested flag
+      # with no guard reads as "always true" the instant one is set, exactly
+      # the same silent-pass-through class of bug the map-event TIMER2
+      # condition (Game::EventPage.active?, this file) was already fixed for.
       if (flags & TURN_ENEMY) != 0 && ctx.rpg2003?
         t = ctx.enemy_turn(cond.turn_enemy_id)
         return false if t.nil?
@@ -5804,7 +5803,7 @@ module Game
         return false if t.nil?
         return false unless check_turns(t, cond.turn_actor_b, cond.turn_actor_a)
       end
-      if (flags & COMMAND_ACTOR) != 0
+      if (flags & COMMAND_ACTOR) != 0 && ctx.rpg2003?
         return false unless ctx.actor_command(cond.command_actor_id) == cond.command_id
       end
       if (flags & FATIGUE) != 0 && ctx.rpg2003?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14017,24 +14017,31 @@ check 'BattlePage.active? tests enemy and actor HP windows' do
   eq true, BP.active?(acond, st.switches, st.variables, b)
 end
 
-check 'BattlePage.active? fails a condition the runtime cannot answer' do
-  b = battle_with
+check 'BattlePage.active? ignores command_actor on a non-RPG2003 battle, same as its siblings' do
+  b = battle_with # RPG2000 (rpg2003: false, the default)
   st = new_state
-  # The chosen-command test needs the battler whose action triggered the
-  # check, and RPG_RT's own RPG2000 battle scene never has one to give it
-  # (Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents always schedules
-  # pages with a null source; only the separate 2k3 ATB scene ever passes a
-  # real one) -- so this is not a stand-in for a future acting-battler
-  # context, it is RPG2000's own battle system never satisfying the
-  # condition either. Unlike turn_enemy/turn_actor/fatigue below,
-  # command_actor is tested on every edition (EasyRPG's own
-  # AreConditionsMet still gates it on IsRPG2k3Commands(), but that gate is
-  # moot here since #actor_command always answers nil regardless).
-  eq false, BP.active?(battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1,
-                                   command_id: 1), st.switches, st.variables, b)
-  # Nor may one keyed to a battler that is not in this fight -- on an
-  # RPG2003 battle, where turn_enemy/turn_actor actually apply (see below).
+  # RPG2000's condition box has no command_actor control at all, so this
+  # must read as active regardless of what #actor_command would say --
+  # matching the "ignores turn_enemy / turn_actor / fatigue" check below,
+  # not the old (incorrect) claim that command_actor is tested on every
+  # edition.
+  eq true, BP.active?(battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1,
+                                  command_id: 1), st.switches, st.variables, b)
+end
+
+check 'BattlePage.active? fails a command_actor condition the runtime cannot answer, on RPG2003' do
+  # On a genuine RPG2003 battle the gate now lets the check run -- but this
+  # codebase's own #actor_command (Game::Battle) always answers nil, since
+  # there is no per-battler "last chosen command" tracking implemented yet,
+  # so a command_actor condition can never be satisfied here regardless of
+  # what real RPG_RT's own 2k3 ATB scene would say for a battler that just
+  # chose that exact command.
   b2003 = battle_with(rpg2003: true)
+  st = new_state
+  eq false, BP.active?(battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1,
+                                   command_id: 1), st.switches, st.variables, b2003)
+  # Nor may a turn_enemy/turn_actor condition keyed to a battler that is not
+  # in this fight (see below for the actual matching-logic checks).
   eq false, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 9),
                        st.switches, st.variables, b2003)
   eq false, BP.active?(battle_cond(BP::TURN_ACTOR, turn_actor_id: 99),


### PR DESCRIPTION
## Summary
- `Game::BattlePage.active?` (`mruby-rpg2k/mrblib/game.rb`) gates `turn_enemy`/`turn_actor`/`fatigue` on `ctx.rpg2003?`, but `command_actor` kept evaluating unconditionally — the block comment right above even claimed it was "already handled below" without the code ever doing so.
- Confirmed against EasyRPG's actual C++ source: `Game_Interpreter_Battle::AreConditionsMet` (`src/game_interpreter_battle.cpp`) wraps all *four* RPG2003-only condition types — `turn_enemy`, `turn_actor`, `fatigue`, and `command_actor` — in `Player::IsRPG2k3Commands() &&`.
- Concretely: a troop page whose condition box has only the `command_actor` bit set (`command_actor_id: 1, command_id: 1`) — real RPG_RT never even looks at the bit on a non-2k3 database and runs the page unconditionally. Since this codebase's `Game::Battle#actor_command` is an unimplemented stub that always answers `nil`, `nil == 1` was `false` on every edition, making the page permanently inactive where it should always fire on RPG2000.
- Fixed by adding the same `&& ctx.rpg2003?` conjunct already used for its three siblings, and correcting the stale comment. On an actual RPG2003 battle the condition still can never be satisfied today (the same `#actor_command` stub), matching this codebase's own documented not-yet-implemented state.

## Test plan
- Replaced the old `scripts/rpg2k_logic_check.rb` check (which asserted the bug's own wrong answer and rationalized it in its own comment) with two: an RPG2000-only `command_actor` condition now reads active, matching its siblings; an RPG2003 one still correctly reads inactive, since the runtime cannot answer it yet.
- The RPG2000 case confirmed to fail against the pre-fix code (`git stash` — `1 of 953 checks FAILED`) before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 953 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 649 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_