### PR TITLE
Implement RPG2003's random-encounter Death Handler

### DIFF
--- a/changelog.d/rpg2k-death-handler.added.md
+++ b/changelog.d/rpg2k-death-handler.added.md
@@ -1,0 +1,5 @@
+- **RPG2003's "Death Handler" is now implemented.** A wandering-monster
+  encounter's party wipe used to always end the game outright; when the
+  database's `System > Battle Commands > Death Handler` setting is active,
+  it now runs the configured common event and/or teleports the party
+  instead, matching real RPG_RT.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7133,6 +7133,54 @@ not yet verified:
   RPG2003 one still correctly reads inactive, since the runtime cannot
   answer it yet — the RPG2000 case confirmed to fail against the pre-fix
   code before the fix.
+- ✅ **RPG2003's "Death Handler" is now implemented: a wandering-monster
+  encounter's party wipe runs a common event and/or teleports the party
+  instead of always forcing the ordinary Game Over screen, when the
+  database's own `System > Battle Commands > Death Handler` setting is
+  active.** Confirmed against EasyRPG's actual C++ source:
+  `Game_Battle::HasDeathHandler`/`GetDeathHandlerCommonEvent`/
+  `GetDeathHandlerTeleport` (`src/game_battle.cpp`) gate all three on
+  `Player::IsRPG2k3() && db.death_handler`, and `Game_Map::OnEncounterEnd`
+  (`src/game_map.cpp`) — the callback `Game_Map::PrepareEncounter` wires
+  specifically for a *random* encounter, not the scripted Battle Processing
+  command — pushes `Game_Battle::GetDeathHandlerCommonEvent()` as a common
+  event on defeat, then reserves `GetDeathHandlerTeleport()`'s teleport,
+  instead of pushing `Scene_Gameover` when no death handler is active.
+  `Interpreter#start_random_battle` (`mruby-rpg2k/mrblib/interpreter.rb`)
+  hardcoded `defeat_game_over: true` unconditionally — a wandering
+  encounter's party wipe always ended the game outright, regardless of the
+  database setting, a complete divergence for any project using this
+  well-documented RPG2003 feature. A scripted Enemy Encounter command's own
+  `defeat_game_over: cmd.param(4) == 0` (its own [Defeat] handler) was
+  already correct and untouched by this fix — the death handler applies to
+  random encounters only. Fixed by adding `battlecommands` schema fields
+  15/16/25-29 (`death_handler`/`death_event`/`death_teleport`/
+  `death_teleport_id`/`_x`/`_y`/`_face` — confirmed against liblcf's own
+  `generator/csv/fields.csv`, not guessed) and `Game::Party#death_handler?`/
+  `#death_handler_event`/`#death_handler_teleport`
+  (`mruby-rpg2k/mrblib/game.rb`), mirroring the three EasyRPG functions
+  exactly; `start_random_battle` now computes `defeat_game_over:
+  !party.death_handler?` and marks the request `random: true` so
+  `Scene::Battle#finish_battle` can tell a wandering encounter apart from a
+  scripted one. A new `Interpreter#start_death_handler` runs the death
+  event's own commands the same way Call Event does, then appends the
+  configured teleport as a trailing synthetic Teleport command so it plays
+  through the ordinary `#do_teleport` machinery once those commands (if
+  any) finish — `death_teleport_face` turned out to follow the exact same
+  1-based up/right/down/left-with-0-meaning-"keep the current facing"
+  layout as the Teleport command's own facing parameter (liblcf's
+  `BattleCommands_Facing` enum, `generator/csv/enums.csv`), so
+  `Interpreter#teleport_facing` converts it unchanged. Covered by four new
+  `scripts/rpg2k_logic_check.rb` checks — an active Death Handler clears
+  the game-over flag on `start_random_battle`, an inactive one (RPG2000 or
+  an RPG2003 database with the bit unset) still sets it, `start_death_handler`
+  runs the death event's commands then arms the `:teleport` wait with the
+  Death Handler's own map/x/y/facing, and a Death Handler with neither a
+  resolvable event nor a configured teleport is a no-op — three of the four
+  confirmed to fail against the pre-fix code before the fix (the
+  inactive-handler check already passed, matching the previous hardcoded
+  behaviour). `ninja -C build test` (mruby-lcf's own `lcf_test.rb`) also run
+  and passing, since this fix touches `schema.rb`.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -790,7 +790,31 @@ module LCF
                 # its own shortcut), 3 defense, 4 item, 5 escape, 6 special.
                 2 => { name: :type, type: :int, default: 0 },
               }
-            }
+            },
+            # RPG2003's "Death Handler": when set, a wandering-monster
+            # encounter's party wipe runs common event `death_event` and/or
+            # teleports the party instead of the ordinary Game Over screen --
+            # confirmed against liblcf's own generator/csv/fields.csv (not
+            # guessed), which also carries a `death_handler_unused` boolean
+            # at 0x04 the editor always writes alongside this one but real
+            # RPG_RT never reads, so it is deliberately left out of this
+            # schema. See Game::Party#death_handler? (mruby-rpg2k/mrblib/
+            # game.rb), which also gates this on `Player::IsRPG2k3()`
+            # (EasyRPG's `Game_Battle::HasDeathHandler`, src/game_battle.cpp)
+            # the same way every other RPG2003-only flag in this codebase is.
+            15 => { name: :death_handler, type: :bool, default: false },
+            16 => { name: :death_event, type: :int, default: 1 },
+            # `death_teleport_face` follows the same 1-based up/right/down/
+            # left-with-0-meaning-"keep the current facing" layout as the
+            # Teleport event command's own facing parameter (liblcf's
+            # `BattleCommands_Facing` enum, generator/csv/enums.csv: 0
+            # retain, 1 up, 2 right, 3 down, 4 left) -- see Interpreter
+            # #teleport_facing, reused as-is for this field.
+            25 => { name: :death_teleport, type: :bool, default: false },
+            26 => { name: :death_teleport_id, type: :int, default: 1 },
+            27 => { name: :death_teleport_x, type: :int, default: 0 },
+            28 => { name: :death_teleport_y, type: :int, default: 0 },
+            29 => { name: :death_teleport_face, type: :int, default: 0 },
           }
         },
         30 => {

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3377,6 +3377,47 @@ module Game
       table && table.respond_to?(:placement) && table.placement == 1 ? true : false
     end
 
+    # RPG2003's "Death Handler" (`battlecommands.death_handler`, chunk 29
+    # field 0x0F -- see mruby-lcf/mrblib/schema.rb): when active, a random
+    # (wandering-monster) encounter's party wipe skips the ordinary Game
+    # Over screen and instead runs a common event and/or teleports the
+    # party. Matches EasyRPG's `Game_Battle::HasDeathHandler`
+    # (src/game_battle.cpp): `Player::IsRPG2k3() && db.death_handler`. A
+    # scripted Battle Processing command's own [Defeat] handler is a
+    # separate, already-correct mechanism (Interpreter#do_enemy_encounter's
+    # own `defeat_game_over: cmd.param(4) == 0`) that never consults this --
+    # the death handler applies to wandering encounters only. A bare test
+    # fixture with no `#battlecommands` table, or an RPG2000 database, reads
+    # false, same as `#alternate_battle_layout?` above.
+    def death_handler?
+      return false unless rpg2003? && @db.respond_to?(:battlecommands)
+      table = @db.battlecommands
+      table && table.respond_to?(:death_handler) && table.death_handler ? true : false
+    end
+
+    # The common event id a Death Handler runs (`battlecommands.death_event`),
+    # or 0 when the handler is not active -- matches EasyRPG's
+    # `Game_Battle::GetDeathHandlerCommonEvent`.
+    def death_handler_event
+      return 0 unless death_handler?
+      table = @db.battlecommands
+      table.respond_to?(:death_event) ? (table.death_event || 0) : 0
+    end
+
+    # The Death Handler's own teleport target as [map_id, x, y, facing] (the
+    # same 1-based-facing-or-0-for-keep-current layout the Teleport event
+    # command's own facing parameter uses -- see Interpreter
+    # #teleport_facing, and schema.rb's `death_teleport_face` comment for
+    # why they line up), or nil when no teleport is configured. Matches
+    # EasyRPG's `Game_Battle::GetDeathHandlerTeleport`.
+    def death_handler_teleport
+      return nil unless death_handler?
+      table = @db.battlecommands
+      return nil unless table.respond_to?(:death_teleport) && table.death_teleport
+      [table.death_teleport_id, table.death_teleport_x, table.death_teleport_y,
+       table.death_teleport_face]
+    end
+
     # Whether item `id` can be used from the field (main-menu) item screen: a
     # medicine or switch item the party holds whose "usable in field" occasion is
     # set (a battle-only medicine is hidden here, mirroring #battle_usable?), or a

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1423,12 +1423,18 @@ module Game
     # mode, so #resume_battle's job shrinks to tallying the outcome and
     # clearing the wait. Only valid while this interpreter is otherwise idle
     # (Scene::Map only calls it from ordinary player movement, never while an
-    # event is running); escape is always allowed and a wipe is always game
-    # over, since a random encounter carries no encounter-specific settings of
-    # its own to say otherwise. A troop id the database no longer has (the
-    # map's own encounter list can go stale the same way a scripted Enemy
-    # Encounter's can) logs and simply never arms the wait -- there is no
-    # event to resume here, so movement just continues uninterrupted.
+    # event is running); escape is always allowed. A wipe is game over unless
+    # the database's own RPG2003 Death Handler is active
+    # (Game::Party#death_handler?, matching EasyRPG's `Game_Battle::
+    # HasDeathHandler`) -- Scene::Battle#finish_battle runs it instead (see
+    # #start_death_handler below) when it applies. `random: true` marks the
+    # request so #finish_battle can tell a wandering encounter apart from a
+    # scripted Battle Processing command, whose own [Defeat] handler is a
+    # separate mechanism this flag never touches. A troop id the database no
+    # longer has (the map's own encounter list can go stale the same way a
+    # scripted Enemy Encounter's can) logs and simply never arms the wait --
+    # there is no event to resume here, so movement just continues
+    # uninterrupted.
     def start_random_battle(troop_id, first_strike: false)
       unless party.db_enemy_group(troop_id)
         $stderr.puts "[RPG2k] Enemy Encounter: enemy group #{troop_id} not " \
@@ -1438,12 +1444,41 @@ module Game
       @battle_has_handlers = false
       @battle_escape_aborts = false
       @battle_request = { troop_id: troop_id, allow_escape: true,
-                          first_strike: first_strike, defeat_game_over: true }
+                          first_strike: first_strike,
+                          defeat_game_over: !party.death_handler?, random: true }
       @state.battle_count += 1
       @wait_kind = :battle
       @waiting = true
     end
     public :start_random_battle
+
+    # RPG2003's Death Handler, run by Scene::Battle#finish_battle in place of
+    # the ordinary Game Over screen once a random encounter's party is
+    # wiped and Game::Party#death_handler? says the database wants this
+    # instead. Matches EasyRPG's `Game_Map::OnEncounterEnd`
+    # (src/game_map.cpp): the death event's own commands run first (pushed
+    # the same way Call Event starts a common event, #do_call_event), then
+    # the configured teleport (if any) is appended as a trailing synthetic
+    # Teleport command, so it runs through the ordinary #do_teleport
+    # machinery once those commands (if any) finish. Only ever called on an
+    # idle interpreter -- #finish_battle only reaches this for a random
+    # encounter, which by construction never has an owning event running
+    # underneath it (see #start_random_battle above) -- so this simply
+    # starts a fresh top-level command list rather than pushing a call
+    # frame. A death handler with neither a resolvable event nor a
+    # configured teleport is a silent no-op, the same as EasyRPG's own
+    # empty-cases-are-inert function bodies.
+    def start_death_handler
+      cmds = []
+      event_id = party.death_handler_event
+      ev_cmds = event_id > 0 ? common_event_commands(event_id) : nil
+      cmds.concat(ev_cmds) if ev_cmds
+      tp = party.death_handler_teleport
+      cmds << LCF::EventCommand.new(Cmd::TELEPORT, 0, '', tp) if tp
+      return if cmds.empty?
+      start(cmds)
+    end
+    public :start_death_handler
 
     # -- state commands -------------------------------------------------------
 

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1994,6 +1994,15 @@ class RPG2k
       # Process's own interpreter, see Scene::Map#drive_battle), captured before
       # #dispose clears @ui out from under it (via Scene::Map#close_battle,
       # which drops the map's own @battle reference too).
+      #
+      # A random encounter's wipe with an active RPG2003 Death Handler
+      # (`@req[:random]` and `!@req[:defeat_game_over]`, see Interpreter
+      # #start_random_battle) is neither of those two outcomes: it skips the
+      # Game Over screen the way any other non-"game over" defeat does, but
+      # then runs the death handler itself (Interpreter#start_death_handler)
+      # in place of the ordinary "resume the event that opened this" a
+      # scripted encounter's own [Defeat] handler would get -- a random
+      # encounter has no such event to resume into.
       def finish_battle(result)
         # Persist the party's post-battle HP (and any knock-outs) before leaving
         # the fight, so damage taken sticks and a downed member stays down.
@@ -2007,6 +2016,8 @@ class RPG2k
         # party knocked out ends the game; every other outcome resumes the event.
         game_over = result == :defeat && @req[:defeat_game_over] &&
                     @state.party.all_dead?
+        death_handler = result == :defeat && @req[:random] &&
+                        !@req[:defeat_game_over] && @state.party.all_dead?
         owner = @owner
         @map.close_battle
         if game_over
@@ -2014,6 +2025,7 @@ class RPG2k
         else
           @map.restore_pre_battle_bgm
           owner.resume_battle(result)
+          owner.start_death_handler if death_handler
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3424,7 +3424,19 @@ FakeBattleCommandsTable = Struct.new(:commands, :battle_type,
                                      # as everywhere else in this file: nil
                                      # reads as manual, matching the schema
                                      # default.
-                                     :placement)
+                                     :placement,
+                                     # RPG2003's Death Handler (chunk 29
+                                     # fields 0x0F/0x10/0x19-0x1D --
+                                     # Game::Party#death_handler?/
+                                     # #death_handler_event/
+                                     # #death_handler_teleport's own source).
+                                     # Appended last, same reasoning as
+                                     # `placement` above: nil/false reads as
+                                     # "no death handler", matching the
+                                     # schema defaults.
+                                     :death_handler, :death_event, :death_teleport,
+                                     :death_teleport_id, :death_teleport_x,
+                                     :death_teleport_y, :death_teleport_face)
 FakeBattleCommand = Struct.new(:name, :type)
 # A `db.battleranimations[id]` entry (chunk 32): a name plus a poses hash
 # keyed by Pose id (0 idle, matching schema.rb's own comment on the chunk).
@@ -9171,6 +9183,65 @@ check 'a random encounter reports and skips a missing troop id without arming th
   ok capture_stderr { it.start_random_battle(1) }.empty?, 'an existing troop id logs nothing'
   ok it.waiting?
   eq :battle, it.wait_kind
+end
+
+# Ports EasyRPG's own `Game_Battle::HasDeathHandler`/
+# `GetDeathHandlerCommonEvent`/`GetDeathHandlerTeleport` (src/game_battle.cpp):
+# `Player::IsRPG2k3() && db.death_handler` gates all three. A scripted Battle
+# Processing command's own [Defeat] handler (`defeat_game_over: cmd.param(4)
+# == 0`, above) is unaffected either way -- this only changes a *random*
+# encounter's own hardcoded "a wipe is always game over" default.
+check 'a random encounter with an active RPG2003 Death Handler is not marked game-over' do
+  table = FakeBattleCommandsTable.new({}, 0, 0, true, 5, true, 3, 10, 20, 2)
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], rpg2003: true, battlecommands: table)
+  it = Game::Interpreter.new(Game::State.new(Game::Party.new(db), 1, 0, 0))
+  it.start_random_battle(1)
+  eq false, it.battle_request[:defeat_game_over]
+  eq true, it.battle_request[:random]
+end
+
+check 'a random encounter is still marked game-over without an active Death Handler' do
+  # RPG2000 (rpg2003: false) with no battlecommands table at all, and RPG2003
+  # with a battlecommands table whose death_handler bit is unset, both read
+  # the same as before this fix.
+  it = Game::Interpreter.new(party_state)
+  it.start_random_battle(1)
+  eq true, it.battle_request[:defeat_game_over]
+
+  table = FakeBattleCommandsTable.new({}, 0, 0, false)
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], rpg2003: true, battlecommands: table)
+  it2 = Game::Interpreter.new(Game::State.new(Game::Party.new(db), 1, 0, 0))
+  it2.start_random_battle(1)
+  eq true, it2.battle_request[:defeat_game_over]
+end
+
+check 'Interpreter#start_death_handler runs the death event then a synthetic Teleport' do
+  common = { 5 => [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0], indent: 0)] }
+  table = FakeBattleCommandsTable.new({}, 0, 0, true, 5, true, 3, 10, 20, 2)
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], rpg2003: true, battlecommands: table)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: common)
+  it.start_death_handler
+  it.update
+  eq true, st.switches[9], 'the death event\'s own commands ran'
+  ok it.waiting?, 'the trailing synthetic Teleport armed the :teleport wait'
+  eq :teleport, it.wait_kind
+  eq [3, 10, 20, 6], it.teleport,
+     'map/x/y from the Death Handler fields, facing 2 (right) converted to numpad 6'
+end
+
+check 'Interpreter#start_death_handler is a no-op with neither an event nor a teleport configured' do
+  table = FakeBattleCommandsTable.new({}, 0, 0, true, 0, false)
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], rpg2003: true, battlecommands: table)
+  it = Game::Interpreter.new(Game::State.new(Game::Party.new(db), 1, 0, 0))
+  it.start_death_handler
+  ok !it.waiting?
+  ok !it.running?
 end
 
 # -- Battle (headless auto-battle) --------------------------------------------


### PR DESCRIPTION
## Summary
- `Interpreter#start_random_battle` (`mruby-rpg2k/mrblib/interpreter.rb`) hardcoded `defeat_game_over: true` unconditionally — a wandering-monster encounter's party wipe always ended the game outright, regardless of the database's `System > Battle Commands > Death Handler` setting.
- Confirmed against EasyRPG's actual C++ source: `Game_Battle::HasDeathHandler`/`GetDeathHandlerCommonEvent`/`GetDeathHandlerTeleport` (`src/game_battle.cpp`) gate all three on `Player::IsRPG2k3() && db.death_handler`, and `Game_Map::OnEncounterEnd` (`src/game_map.cpp`) — the callback `Game_Map::PrepareEncounter` wires specifically for a *random* encounter, not the scripted Battle Processing command — pushes the death event as a common event on defeat, then reserves the configured teleport, instead of pushing `Scene_Gameover` when no death handler is active.
- A scripted Enemy Encounter command's own `defeat_game_over: cmd.param(4) == 0` (its own [Defeat] handler) was already correct and is untouched by this fix — the death handler applies to random encounters only.
- Fixed by adding `battlecommands` schema fields 15/16/25-29 (`death_handler`/`death_event`/`death_teleport`/`death_teleport_id`/`_x`/`_y`/`_face` — confirmed against liblcf's own `generator/csv/fields.csv`, not guessed) and `Game::Party#death_handler?`/`#death_handler_event`/`#death_handler_teleport` (`mruby-rpg2k/mrblib/game.rb`), mirroring the three EasyRPG functions exactly. `start_random_battle` now computes `defeat_game_over: !party.death_handler?` and marks the request `random: true` so `Scene::Battle#finish_battle` can tell a wandering encounter apart from a scripted one. A new `Interpreter#start_death_handler` runs the death event's own commands the same way Call Event does, then appends the configured teleport as a trailing synthetic Teleport command so it plays through the ordinary `#do_teleport` machinery once those commands finish.
- `death_teleport_face` turned out to follow the exact same 1-based up/right/down/left-with-0-meaning-"keep the current facing" layout as the Teleport command's own facing parameter (liblcf's `BattleCommands_Facing` enum), so `Interpreter#teleport_facing` converts it unchanged with no new logic needed.

## Test plan
- Added 4 `scripts/rpg2k_logic_check.rb` checks: an active Death Handler clears the game-over flag on `start_random_battle`, an inactive one (RPG2000 or an RPG2003 database with the bit unset) still sets it, `start_death_handler` runs the death event's commands then arms the `:teleport` wait with the Death Handler's own map/x/y/facing, and a Death Handler with neither a resolvable event nor a configured teleport is a no-op.
- 3 of the 4 confirmed to fail against the pre-fix code (`git stash` — `3 of 957 checks FAILED`); the inactive-handler check already passed, matching the previous hardcoded behaviour.
- `ruby scripts/rpg2k_logic_check.rb` — 957 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 649 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.
- `ninja -C build test` (mruby-lcf's own `lcf_test.rb`) — all 8 tests pass, since this fix touches `schema.rb`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_