### PR TITLE
Implement RPG2003's cursed/forced-state armor equip effect

### DIFF
--- a/changelog.d/rpg2k-cursed-armor-states.added.md
+++ b/changelog.d/rpg2k-cursed-armor-states.added.md
@@ -1,0 +1,5 @@
+- **RPG2003's "cursed"/forced-state armor now works.** A shield, armor,
+  helmet, or accessory item flagged to inflict a state while worn (e.g. a
+  cursed berserker armor) now actually inflicts it the instant it's
+  equipped, and cures it the instant it comes off, instead of behaving as
+  ordinary stat-boosting gear.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7181,6 +7181,41 @@ not yet verified:
   inactive-handler check already passed, matching the previous hardcoded
   behaviour). `ninja -C build test` (mruby-lcf's own `lcf_test.rb`) also run
   and passing, since this fix touches `schema.rb`.
+- ✅ **RPG2003's "cursed"/forced-state armor (a shield/armor/helmet/accessory
+  item with its `reverse_state_effect` flag set) now inflicts the states its
+  own `state_set` marks the instant it's worn, and cures them the instant
+  it comes off — it used to have zero gameplay effect from this mechanic at
+  all.** Confirmed against EasyRPG's actual C++ source: `Game_Actor::
+  AdjustEquipmentStates` (`src/game_actor.cpp`) is called from every
+  equip-mutation path (`SetEquipment`, in turn `ChangeEquipment`, both the
+  equip menu and the Change Equipment event command's own route) and adds
+  every state a piece of `IsArmorType` (shield/armor/helmet/accessory,
+  never a weapon) equipment flags in its `state_set` when
+  `Player::IsRPG2k3() && item->reverse_state_effect`, removing them again
+  when the item comes off. `Actor#equip_item`/`#unequip`/`#equip`
+  (`mruby-rpg2k/mrblib/game.rb`) only ever touched `@equipment` and
+  recomputed stats — no code path called `#add_state`/`#remove_state` in
+  response to an equip change, so a classic "cursed berserker armor" (item
+  flagged to force a Berserk-like state while worn) behaved as ordinary
+  stat-boosting gear with none of its intended mechanic. Also ported: a
+  two-handed weapon bumping a cursed shield out of the other hand
+  (`#free_two_handed_slot`) cures that shield's own states too, matching
+  EasyRPG's own `ChangeEquipment(other_slot, 0)` recursion into the
+  displaced slot. Fixed by adding `Actor#adjust_equipment_states`, wired
+  into all three equip-mutation methods, reusing the existing
+  `Party::ITEM_SHIELD/ARMOR/HELMET/ACCESSORY` constants already used
+  elsewhere in this file for the identical armor-type test. The separate
+  "this state can't be healed by ordinary means while the armor stays
+  equipped" rule (EasyRPG's own `GetPermanentStates`) is not implemented
+  here — a real but distinct question this fix leaves open, the same way
+  the session's earlier attribute-defence fix left `reverse_state_effect`'s
+  sibling battle-formula question open before a follow-up closed it.
+  Covered by three new `scripts/rpg2k_logic_check.rb` checks — equip
+  inflicts and unequip cures on an RPG2003 database, the same equip is
+  inert on RPG2000, and a two-handed weapon swap cures a displaced cursed
+  shield too — two of the three confirmed to fail against the pre-fix code
+  before the fix (the RPG2000 check already passed, since the pre-fix code
+  never inflicted anything on any edition).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1588,9 +1588,22 @@ module Game
     end
 
     # Replace the equipped items (an array of up to five item ids in EQUIP_ORDER,
-    # 0/nil for an empty slot) and recompute the boosted stats.
+    # 0/nil for an empty slot) and recompute the boosted stats. Adjusts
+    # #adjust_equipment_states for every slot whose item actually changes,
+    # same as a single #equip_item/#unequip would -- every real caller
+    # (Party#load_state's own actor-roster restore) immediately overwrites
+    # `@states` afterward with the save's own authoritative list anyway, so
+    # this only matters for a future bulk-equip caller that does not.
     def equip(ids)
-      @equipment = normalize_equipment(ids)
+      new_equipment = normalize_equipment(ids)
+      EQUIP_ORDER.size.times do |slot|
+        old_id = @equipment[slot]
+        new_id = new_equipment[slot]
+        next if old_id == new_id
+        adjust_equipment_states(old_id, false)
+        adjust_equipment_states(new_id, true)
+      end
+      @equipment = new_equipment
       recompute_stats
     end
 
@@ -1615,8 +1628,12 @@ module Game
       return unless it
       slot ||= it.type - 1
       return unless slot >= 0 && slot < EQUIP_ORDER.size
+      old_id = @equipment[slot]
       @equipment[slot] = item_id
       freed = free_two_handed_slot(slot)
+      adjust_equipment_states(old_id, false)
+      adjust_equipment_states(freed, false) if freed
+      adjust_equipment_states(item_id, true)
       recompute_stats
       freed
     end
@@ -1664,8 +1681,10 @@ module Game
     # command's remove operation.
     def unequip(slot)
       if slot == EQUIP_ORDER.size
+        @equipment.each { |id| adjust_equipment_states(id, false) }
         @equipment = EQUIP_ORDER.map { 0 }
       elsif slot >= 0 && slot < EQUIP_ORDER.size
+        adjust_equipment_states(@equipment[slot], false)
         @equipment[slot] = 0
       else
         return
@@ -1754,6 +1773,37 @@ module Game
     # `#rpg2003?` of its own reads false, matching a genuine RPG2000 database.
     def rpg2003?
       @db.respond_to?(:rpg2003?) && @db.rpg2003?
+    end
+
+    # RPG2003's "cursed"/forced-state armor (a shield/armor/helmet/accessory
+    # item whose `reverse_state_effect` flag is set): equipping or
+    # unequipping it inflicts or cures every state its own `state_set`
+    # marks, matching EasyRPG's `Game_Actor::AdjustEquipmentStates`
+    # (src/game_actor.cpp), called from every equip-mutation path there
+    # (`SetEquipment`, in turn `ChangeEquipment`). `IsArmorType` there
+    # covers the same four item types `Party::ITEM_SHIELD/ARMOR/HELMET/
+    # ACCESSORY` already name for the identical distinction elsewhere in
+    # this file (see e.g. #defensive_attribute_ids below) -- weapons never
+    # carry a state_set in the editor and are excluded the same way. A
+    # non-RPG2003 database, an unknown/absent item id, a non-armor item, or
+    # one with the flag unset is a no-op, matching real RPG_RT. The
+    # separate "this state can't be healed by ordinary means while the
+    # armor stays equipped" rule (EasyRPG's own `GetPermanentStates`) is
+    # not implemented here; this only ports the inflict/cure-on-equip-
+    # change half.
+    def adjust_equipment_states(item_id, add)
+      return unless rpg2003?
+      return if item_id.nil? || item_id == 0 || !@db.respond_to?(:item)
+      it = @db.item[item_id]
+      return unless it
+      return unless [Party::ITEM_SHIELD, Party::ITEM_ARMOR, Party::ITEM_HELMET,
+                     Party::ITEM_ACCESSORY].include?(it.type)
+      return unless it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+      return unless it.respond_to?(:state_set) && it.state_set
+      it.state_set.each_with_index do |set, i|
+        next unless set && set != 0
+        add ? add_state(i + 1) : remove_state(i + 1)
+      end
     end
 
     # The effective max HP ceiling #recompute_stats clamps against --

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4149,6 +4149,51 @@ check 'Actor equipment adds item bonuses to the effective stats' do
   eq [8, 2, 4, 1], [a.atk, a.def, a.agi, a.int]
 end
 
+# Ports EasyRPG's own `Game_Actor::AdjustEquipmentStates`/`IsArmorType`
+# (src/game_actor.cpp): equipping RPG2003 "cursed"/forced-state armor
+# (armor field 68, reverse_state_effect) inflicts every state its own
+# state_set flags; unequipping cures them. Confirmed against the actual
+# C++: gated on `Player::IsRPG2k3()`, and `IsArmorType` excludes
+# `Type_weapon`, so a weapon never carries this effect either way.
+check 'equipping RPG2003 cursed armor inflicts its own states; unequipping cures them' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, rpg2003: true)
+  a = Game::Party.new(db).leader
+  eq [], a.states
+  a.equip_item(20)
+  eq [4], a.states, 'the state came on the instant it was worn'
+  a.unequip(2) # armor slot
+  eq [], a.states, 'and left the instant it came off'
+end
+
+check 'cursed armor state infliction is RPG2003-only' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items) # rpg2003: false, the default
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  eq [], a.states, 'RPG2000 has no editor control for this at all, so it never applies'
+end
+
+check 'cursed armor unequipped via a two-handed weapon swap loses its own state too' do
+  # A two-handed weapon claims the shield slot too (#free_two_handed_slot);
+  # EasyRPG's own ChangeEquipment recurses into that same displaced slot
+  # (`ChangeEquipment(other_slot, 0)`), so its own AdjustEquipmentStates
+  # call runs for the shield being bumped out, not just the weapon going in.
+  items = {
+    20 => fake_item(type: 2, state_set: [0, 0, 0, 1], reverse_state: true), # cursed shield
+    21 => fake_item(type: 1, two_handed: 1), # a two-handed weapon
+  }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  eq [4], a.states
+  a.equip_item(21) # claims the weapon slot and bumps the shield
+  eq [], a.states, 'the displaced cursed shield lost its state along with its slot'
+end
+
 check 'Actor equipment never adds max_hp_points/max_sp_points to max HP/MP' do
   # Verified against EasyRPG's actual C++ source: Game_Actor::GetMaxHp/GetMaxSp
   # resolve to GetBaseMaxHp/GetBaseMaxSp with no per-equipment summation at all


### PR DESCRIPTION
## Summary
- `Actor#equip_item`/`#unequip`/`#equip` (`mruby-rpg2k/mrblib/game.rb`) only ever touched `@equipment` and recomputed stats — no code path called `#add_state`/`#remove_state` in response to an equip change.
- Confirmed against EasyRPG's actual C++ source: `Game_Actor::AdjustEquipmentStates` (`src/game_actor.cpp`) is called from every equip-mutation path (`SetEquipment`, in turn `ChangeEquipment` — both the equip menu and the Change Equipment event command's route) and adds every state a piece of `IsArmorType` (shield/armor/helmet/accessory, never a weapon) equipment flags in its `state_set` when `Player::IsRPG2k3() && item->reverse_state_effect`, removing them again when the item comes off.
- Concretely: a classic "cursed berserker armor" (item flagged to force a Berserk-like state while worn) behaved as ordinary stat-boosting gear with zero effect from its intended mechanic.
- Also ported: a two-handed weapon bumping a cursed shield out of the other hand (`#free_two_handed_slot`) cures that shield's own states too, matching EasyRPG's own `ChangeEquipment(other_slot, 0)` recursion into the displaced slot.
- Fixed by adding `Actor#adjust_equipment_states`, wired into all three equip-mutation methods, reusing the existing `Party::ITEM_SHIELD/ARMOR/HELMET/ACCESSORY` constants already used elsewhere in this file for the identical armor-type test.
- The separate "this state can't be healed by ordinary means while the armor stays equipped" rule (EasyRPG's own `GetPermanentStates`) is not implemented here — a real but distinct question left open, same as other adjacent-but-separate gaps this session has deliberately deferred.

## Test plan
- Added 3 `scripts/rpg2k_logic_check.rb` checks: equip inflicts and unequip cures on an RPG2003 database, the same equip is inert on RPG2000, and a two-handed weapon swap cures a displaced cursed shield too.
- 2 of the 3 confirmed to fail against the pre-fix code (`git stash` — `2 of 960 checks FAILED`); the RPG2000 check already passed, since the pre-fix code never inflicted anything on any edition.
- `ruby scripts/rpg2k_logic_check.rb` — 960 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 649 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_