### PR TITLE
Make RPG2003 cursed armor's forced state resist ordinary cures

### DIFF
--- a/changelog.d/rpg2k-cursed-armor-permanent-states.fixed.md
+++ b/changelog.d/rpg2k-cursed-armor-permanent-states.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2003 cursed armor's forced state can no longer be cured by ordinary
+  means while the item stays equipped.** An Antidote-style medicine, a
+  curative skill, Full Recovery, or the Change Condition event command all
+  used to cure it just like any other status condition; only taking the
+  armor off actually clears it now, matching real RPG_RT.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7216,6 +7216,45 @@ not yet verified:
   shield too — two of the three confirmed to fail against the pre-fix code
   before the fix (the RPG2000 check already passed, since the pre-fix code
   never inflicted anything on any edition).
+- ✅ **RPG2003 cursed armor's forced state can no longer be cured by
+  ordinary means while the item stays equipped — an Antidote-style
+  medicine, a curative skill, Full Recovery, or the Change Condition event
+  command all used to cure it just like any other status condition.**
+  Confirmed against EasyRPG's actual C++ source: `Game_Actor::
+  GetPermanentStates` (`src/game_actor.cpp`) scans the same four armor
+  slots `AdjustEquipmentStates` (the previous fix) already reads, and every
+  state-removal path threads its result through — `Game_Battler::
+  RemoveState`/`RemoveAllStates` (`src/game_battler.cpp`) both pass it to
+  `State::Remove`/`State::RemoveAll` (`src/state.cpp`), whose `if
+  (ps.Has(state_id)) return false;` refuses the cure outright. This is the
+  sibling rule the previous fix explicitly deferred (`AdjustEquipmentStates`
+  only inflicts/cures on equip change; `GetPermanentStates` is what makes a
+  *currently equipped* cursed item's state stick against ordinary cures).
+  `Actor#remove_state`/`#clear_states` (`mruby-rpg2k/mrblib/game.rb`) had
+  no such concept at all, so every cure path built on them — `#use_medicine`,
+  `#cast_skill`, `#full_heal`, `Interpreter#do_change_condition` — cured a
+  cursed-armor-forced state exactly like any other. Fixed by extracting the
+  existing `#adjust_equipment_states` item-matching logic into a shared
+  `#cursed_armor_state_ids` helper, adding `#permanent_states` (mirroring
+  `GetPermanentStates`, scanned live off `@equipment`), and gating
+  `#remove_state`/`#clear_states` on it. A genuine ordering hazard fell out
+  of this: `#equip_item`/`#unequip`/`#equip` must write `@equipment` (or
+  the specific slot) *before* calling `#adjust_equipment_states`, the same
+  order EasyRPG's own `SetEquipment` uses (`data.equipped[...] =
+  new_item_id;` precedes both `AdjustEquipmentStates` calls) — otherwise
+  unequipping a cursed item would see it still equipped in `#permanent_states`
+  and refuse to cure the very state it is trying to remove.
+  `#equip_item` already had the correct order by construction;
+  `#unequip`/`#equip` needed reordering to match (verified against the
+  existing test suite: all pre-existing equip/unequip checks, including the
+  previous fix's own three, still pass unchanged after the reorder, since it
+  is a no-op for any caller with no gated `#remove_state` to trip over).
+  Covered by three new `scripts/rpg2k_logic_check.rb` checks —
+  `#remove_state` refuses a cursed-armor-forced state but still cures an
+  ordinary one and clears immediately once the armor comes off,
+  `#clear_states`/Full Recovery leaves the forced state in place, and a
+  curative medicine item can't touch it either — all three confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1566,17 +1566,25 @@ module Game
 
     # Cure a status condition. Removing the death state revives a downed actor
     # with 1 HP (RPG2000's revive floor); returns the removed id or nil.
+    # Refuses a state #permanent_states names -- RPG2003 cursed armor
+    # currently forcing it -- the same way EasyRPG's `State::Remove`
+    # (src/state.cpp) does: `if (ps.Has(state_id)) return false;`.
     def remove_state(state_id)
+      return nil if permanent_states.include?(state_id)
       removed = @states.delete(state_id)
       @hp = 1 if removed == DEATH_STATE && @hp <= 0
       removed
     end
 
     # Cure every status condition (RPG2000 Full Recovery clears them). If the
-    # actor was down, curing the death state revives it with 1 HP.
+    # actor was down, curing the death state revives it with 1 HP. Leaves any
+    # #permanent_states id in place, matching `State::RemoveAll`
+    # (src/state.cpp): each id is only ever cleared through the same
+    # permanent-states-respecting `State::Remove` every other cure path uses.
     def clear_states
-      revive = @hp <= 0 && @states.include?(DEATH_STATE)
-      @states = []
+      perm = permanent_states
+      revive = @hp <= 0 && @states.include?(DEATH_STATE) && !perm.include?(DEATH_STATE)
+      @states = @states.select { |s| perm.include?(s) }
       @hp = 1 if revive && @hp <= 0
     end
 
@@ -1595,15 +1603,16 @@ module Game
     # `@states` afterward with the save's own authoritative list anyway, so
     # this only matters for a future bulk-equip caller that does not.
     def equip(ids)
+      old_equipment = @equipment
       new_equipment = normalize_equipment(ids)
+      @equipment = new_equipment
       EQUIP_ORDER.size.times do |slot|
-        old_id = @equipment[slot]
+        old_id = old_equipment[slot]
         new_id = new_equipment[slot]
         next if old_id == new_id
         adjust_equipment_states(old_id, false)
         adjust_equipment_states(new_id, true)
       end
-      @equipment = new_equipment
       recompute_stats
     end
 
@@ -1681,11 +1690,13 @@ module Game
     # command's remove operation.
     def unequip(slot)
       if slot == EQUIP_ORDER.size
-        @equipment.each { |id| adjust_equipment_states(id, false) }
+        old_equipment = @equipment
         @equipment = EQUIP_ORDER.map { 0 }
+        old_equipment.each { |id| adjust_equipment_states(id, false) }
       elsif slot >= 0 && slot < EQUIP_ORDER.size
-        adjust_equipment_states(@equipment[slot], false)
+        old_id = @equipment[slot]
         @equipment[slot] = 0
+        adjust_equipment_states(old_id, false)
       else
         return
       end
@@ -1775,35 +1786,62 @@ module Game
       @db.respond_to?(:rpg2003?) && @db.rpg2003?
     end
 
-    # RPG2003's "cursed"/forced-state armor (a shield/armor/helmet/accessory
-    # item whose `reverse_state_effect` flag is set): equipping or
-    # unequipping it inflicts or cures every state its own `state_set`
-    # marks, matching EasyRPG's `Game_Actor::AdjustEquipmentStates`
-    # (src/game_actor.cpp), called from every equip-mutation path there
-    # (`SetEquipment`, in turn `ChangeEquipment`). `IsArmorType` there
-    # covers the same four item types `Party::ITEM_SHIELD/ARMOR/HELMET/
-    # ACCESSORY` already name for the identical distinction elsewhere in
-    # this file (see e.g. #defensive_attribute_ids below) -- weapons never
-    # carry a state_set in the editor and are excluded the same way. A
-    # non-RPG2003 database, an unknown/absent item id, a non-armor item, or
-    # one with the flag unset is a no-op, matching real RPG_RT. The
-    # separate "this state can't be healed by ordinary means while the
-    # armor stays equipped" rule (EasyRPG's own `GetPermanentStates`) is
-    # not implemented here; this only ports the inflict/cure-on-equip-
-    # change half.
-    def adjust_equipment_states(item_id, add)
-      return unless rpg2003?
-      return if item_id.nil? || item_id == 0 || !@db.respond_to?(:item)
+    # RPG2003's "cursed"/forced-state armor rule (a shield/armor/helmet/
+    # accessory item whose `reverse_state_effect` flag is set): the state
+    # ids `item_id`'s own `state_set` marks, or [] when the rule doesn't
+    # apply at all -- a non-RPG2003 database, an unknown/absent item id, a
+    # non-armor item (weapons never carry a state_set in the editor), or
+    # one with the flag unset. Shared by #adjust_equipment_states and
+    # #permanent_states below, matching how EasyRPG's own `IsArmorType`
+    # test (src/game_actor.cpp) backs both `AdjustEquipmentStates` and
+    # `GetPermanentStates`. `Party::ITEM_SHIELD/ARMOR/HELMET/ACCESSORY`
+    # name the same four item types `IsArmorType` covers, already used
+    # elsewhere in this file for the identical distinction (see e.g.
+    # #defensive_attribute_ids below).
+    def cursed_armor_state_ids(item_id)
+      return [] unless rpg2003?
+      return [] if item_id.nil? || item_id == 0 || !@db.respond_to?(:item)
       it = @db.item[item_id]
-      return unless it
-      return unless [Party::ITEM_SHIELD, Party::ITEM_ARMOR, Party::ITEM_HELMET,
-                     Party::ITEM_ACCESSORY].include?(it.type)
-      return unless it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
-      return unless it.respond_to?(:state_set) && it.state_set
-      it.state_set.each_with_index do |set, i|
-        next unless set && set != 0
-        add ? add_state(i + 1) : remove_state(i + 1)
-      end
+      return [] unless it
+      return [] unless [Party::ITEM_SHIELD, Party::ITEM_ARMOR, Party::ITEM_HELMET,
+                        Party::ITEM_ACCESSORY].include?(it.type)
+      return [] unless it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+      return [] unless it.respond_to?(:state_set) && it.state_set
+      ids = []
+      it.state_set.each_with_index { |set, i| ids << (i + 1) if set && set != 0 }
+      ids
+    end
+
+    # Equipping or unequipping RPG2003 cursed armor inflicts or cures every
+    # state #cursed_armor_state_ids names for it, matching EasyRPG's
+    # `Game_Actor::AdjustEquipmentStates` (src/game_actor.cpp), called from
+    # every equip-mutation path there (`SetEquipment`, in turn
+    # `ChangeEquipment`). #equip_item/#unequip/#equip below each write
+    # `@equipment` *before* calling this, the same order `SetEquipment`
+    # itself uses (`data.equipped[...] = new_item_id;` precedes both
+    # `AdjustEquipmentStates` calls) -- #permanent_states, consulted by
+    # #remove_state/#clear_states below, reads `@equipment` live, so
+    # unequipping a cursed item has to stop counting it *before* this then
+    # tries to cure the very state it inflicted, or the cure would refuse
+    # itself.
+    def adjust_equipment_states(item_id, add)
+      cursed_armor_state_ids(item_id).each { |id| add ? add_state(id) : remove_state(id) }
+    end
+
+    # The states an actor's currently-equipped cursed armor (see
+    # #cursed_armor_state_ids) is forcing on right now, matching EasyRPG's
+    # `Game_Actor::GetPermanentStates` (src/game_actor.cpp) -- scanned off
+    # every equipment slot the same way `GetShield`/`GetArmor`/`GetHelmet`/
+    # `GetAccessory` are there (the weapon slot always reads [] anyway,
+    # since #cursed_armor_state_ids excludes `Type_weapon`). #remove_state
+    # and #clear_states consult this so real RPG_RT's own rule holds here
+    # too: an Antidote, a curative skill, Full Recovery, or the Change
+    # Condition event command all fail to cure a state a worn cursed item
+    # is still actively forcing -- only taking the armor off actually
+    # clears it.
+    def permanent_states
+      return [] unless rpg2003?
+      @equipment.flat_map { |id| cursed_armor_state_ids(id) }.uniq
     end
 
     # The effective max HP ceiling #recompute_stats clamps against --

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4194,6 +4194,60 @@ check 'cursed armor unequipped via a two-handed weapon swap loses its own state 
   eq [], a.states, 'the displaced cursed shield lost its state along with its slot'
 end
 
+# Ports EasyRPG's own `Game_Actor::GetPermanentStates` (src/game_actor.cpp)
+# and `State::Remove`/`State::RemoveAll` (src/state.cpp), the sibling rule
+# `#adjust_equipment_states` deliberately left open: a state a worn cursed
+# item is still actively forcing cannot be cured by any ordinary means --
+# only unequipping the item itself can. #remove_state/#clear_states are the
+# single choke point every cure path (an Antidote-style medicine, a
+# curative skill, Full Recovery, the Change Condition event command) routes
+# through, so gating those two closes all of them at once.
+check "#remove_state refuses a state RPG2003 cursed armor is still forcing" do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  eq [4], a.states
+  eq nil, a.remove_state(4), 'refused -- the armor is still equipped'
+  eq [4], a.states, 'the state is still there'
+  # A state the armor does NOT force is cured normally.
+  a.add_state(7)
+  eq 7, a.remove_state(7)
+  eq [4], a.states
+  # Taking the armor off clears it immediately -- #adjust_equipment_states'
+  # own removal call is not itself blocked by the set it is busy shrinking.
+  a.unequip(2) # armor slot
+  eq [], a.states
+end
+
+check "#clear_states (Full Recovery) leaves a cursed-armor-forced state in place" do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  a.add_state(7)
+  a.full_heal
+  eq [4], a.states, 'the cursed-armor state survives Full Recovery; the ordinary one does not'
+end
+
+check "a curative item can't remove a state RPG2003 cursed armor is forcing" do
+  items = {
+    20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true), # cursed armor
+    21 => fake_item(type: 6, state_set: [0, 0, 0, 1]), # a medicine curing the same state
+  }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, rpg2003: true)
+  party = Game::Party.new(db)
+  a = party.leader
+  a.equip_item(20)
+  eq [4], a.states
+  party.gain_item(21)
+  party.use_item(21, a)
+  eq [4], a.states, 'the medicine could not touch a state the worn cursed armor still forces'
+end
+
 check 'Actor equipment never adds max_hp_points/max_sp_points to max HP/MP' do
   # Verified against EasyRPG's actual C++ source: Game_Actor::GetMaxHp/GetMaxSp
   # resolve to GetBaseMaxHp/GetBaseMaxSp with no per-equipment summation at all


### PR DESCRIPTION
## Summary
- `Actor#remove_state`/`#clear_states` (`mruby-rpg2k/mrblib/game.rb`) had no concept of a "permanent" state, so every cure path built on them — `#use_medicine`, `#cast_skill`, `#full_heal`, `Interpreter#do_change_condition` — cured a cursed-armor-forced state exactly like any other status condition.
- Confirmed against EasyRPG's actual C++ source: `Game_Actor::GetPermanentStates` (`src/game_actor.cpp`) scans the same four armor slots `AdjustEquipmentStates` (the previous PR) already reads, and every state-removal path threads its result through — `Game_Battler::RemoveState`/`RemoveAllStates` (`src/game_battler.cpp`) pass it to `State::Remove`/`State::RemoveAll` (`src/state.cpp`), whose `if (ps.Has(state_id)) return false;` refuses the cure outright.
- This is the sibling rule the previous PR explicitly deferred: `AdjustEquipmentStates` only inflicts/cures a state *on equip change*; `GetPermanentStates` is what makes a *currently equipped* cursed item's state stick against ordinary cures.
- Fixed by extracting `#adjust_equipment_states`'s item-matching logic into a shared `#cursed_armor_state_ids` helper, adding `#permanent_states` (mirroring `GetPermanentStates`, scanned live off `@equipment`), and gating `#remove_state`/`#clear_states` on it.
- A genuine ordering hazard fell out of this: `#equip_item`/`#unequip`/`#equip` must write `@equipment` (or the specific slot) *before* calling `#adjust_equipment_states`, the same order EasyRPG's own `SetEquipment` uses (`data.equipped[...] = new_item_id;` precedes both `AdjustEquipmentStates` calls) — otherwise unequipping a cursed item would see it still equipped in `#permanent_states` and refuse to cure the very state it's trying to remove. `#equip_item` already had the correct order by construction; `#unequip`/`#equip` needed reordering to match — verified as behavior-preserving for every existing caller (all pre-existing equip/unequip checks, including the previous PR's own three, still pass unchanged, since the reorder is a no-op for any caller with no gated `#remove_state` to trip over).

## Test plan
- Added 3 `scripts/rpg2k_logic_check.rb` checks: `#remove_state` refuses a cursed-armor-forced state but still cures an ordinary one and clears immediately once the armor comes off, `#clear_states`/Full Recovery leaves the forced state in place, and a curative medicine item can't touch it either.
- All 3 confirmed to fail against the pre-fix code (`git stash` — `3 of 963 checks FAILED`).
- `ruby scripts/rpg2k_logic_check.rb` — 963 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 649 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_