### PR TITLE
Gate Force Flee, Enable Combo, Call Common Event on RPG2003

### DIFF
--- a/changelog.d/rpg2k-battle-page-2k3-commands.fixed.md
+++ b/changelog.d/rpg2k-battle-page-2k3-commands.fixed.md
@@ -1,0 +1,4 @@
+- **Three RPG2003-only battle-page commands — Force Flee, Enable Combo, and
+  Call Common Event — are now correctly restricted to that edition.** On
+  RPG2000 they used to run exactly as authored, even though that edition's
+  own battle event editor has no way to create any of the three.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7295,6 +7295,39 @@ not yet verified:
   well past the ignored duration, then resumes the instant the Decision key
   is pressed) — all three confirmed to fail against the pre-fix code before
   the fix.
+- ✅ **Three RPG2003-only battle-page commands — Force Flee (1006), Enable
+  Combo (1007), and Call Common Event (1005) — are now correctly gated to
+  that edition; on RPG2000 they used to run exactly as authored, which the
+  editor itself has no UI to author at all.** Confirmed against EasyRPG's
+  actual C++ source: `Game_Interpreter_Battle::CommandForceFlee`/
+  `CommandEnableCombo`/`CommandCallCommonEvent`
+  (`src/game_interpreter_battle.cpp`) each open with `if (!Player::
+  IsRPG2k3Commands()) { return true; }` — checked against every other
+  sibling in the same battle-page command switch (`ChangeMonsterHP`/
+  `ChangeMonsterMP`/`ChangeMonsterCondition`/`ShowHiddenMonster`, none of
+  which carry the guard) to confirm this is specific to these three, not a
+  blanket pattern this repo already covers. `Interpreter#do_force_flee`/
+  `#do_enable_combo`/`#do_call_common_event`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) each already had a comment
+  documenting "RPG2003-only," but none of the three code bodies actually
+  enforced it — only gated on `@battle`/`@resolver` truthy, the same class
+  of gap already fixed this session for the map-event TIMER2 condition and
+  the four troop-page condition flags in this very file's own sibling
+  function `AreConditionsMet`, just on the **command-execution** side this
+  time rather than a condition check. Concretely: a Force Flee (target 0,
+  "grant the party") reaching this dispatch on an RPG2000 database used to
+  set `@force_flee = true`, guaranteeing the party's next Flee choice
+  succeeds regardless of the normal agility-based roll — an outcome real
+  RPG_RT 2000 could never produce, since its own battle event editor has no
+  Force Flee command at all. Fixed by adding `&& @state.party.rpg2003?` to
+  each method's existing guard. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check exercising all three commands on an
+  RPG2000 database (no escape granted, no combo armed, no common event
+  called — the page still runs on past it, same as any unrecognized
+  command would), confirmed to fail against the pre-fix code before the
+  fix; the five pre-existing checks covering these commands' actual
+  matching logic were updated to construct an explicit RPG2003 fixture so
+  the new edition gate does not mask what they test.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2418,9 +2418,15 @@ module Game
     # condition" flag, which suppresses the flee in a pincer / surround ambush;
     # this runtime models neither formation, so every fight counts as a normal
     # one and the flee always goes ahead. Enemies that leave are recorded so the
-    # scene can drop their sprites and play the escape sound.
+    # scene can drop their sprites and play the escape sound. Matches EasyRPG's
+    # own `Game_Interpreter_Battle::CommandForceFlee`
+    # (src/game_interpreter_battle.cpp): `if (!Player::IsRPG2k3Commands()) {
+    # return true; }` -- the RPG2003 editor's battle event editor is the only
+    # one with this command at all, so a genuine RPG2000 database's own
+    # command list should never carry it, but an unguarded dispatch reads it
+    # as live the instant one does.
     def do_force_flee(cmd)
-      return unless @battle
+      return unless @battle && @state.party.rpg2003?
       case cmd.param(0)
       when 0 then @battle.force_flee_party
       when 1 then @fled_monsters.concat(@battle.flee_all_enemies)
@@ -2434,9 +2440,11 @@ module Game
     # to repeat param2 times. The actor is named by id, so it resolves through the
     # roster like the other fixed-id commands. Recorded on the actor; the ATB
     # battle system that spends a combo is not modelled here, so nothing acts on
-    # it yet.
+    # it yet. Matches EasyRPG's own `Game_Interpreter_Battle::
+    # CommandEnableCombo` (src/game_interpreter_battle.cpp), the same
+    # `IsRPG2k3Commands()` gate as Force Flee above.
     def do_enable_combo(cmd)
-      return unless @battle
+      return unless @battle && @state.party.rpg2003?
       actor = identity_target(cmd)
       return unless actor
       actor.set_battle_combo(cmd.param(1), cmd.param(2))
@@ -2444,9 +2452,12 @@ module Game
 
     # Call Common Event (1005), the RPG2003 battle page's own call command:
     # param0 is the common event id, and unlike the map's Call Event (12330)
-    # there is no map-event form. Runs through the same call stack.
+    # there is no map-event form. Runs through the same call stack. Matches
+    # EasyRPG's own `Game_Interpreter_Battle::CommandCallCommonEvent`
+    # (src/game_interpreter_battle.cpp), the same `IsRPG2k3Commands()` gate
+    # as Force Flee/Enable Combo above.
     def do_call_common_event(cmd)
-      return unless @resolver
+      return unless @resolver && @state.party.rpg2003?
       cmds = common_event_commands(cmd.param(0))
       return if cmds.nil? || cmds.empty?
       return if @call_stack.size >= MAX_CALL_DEPTH

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14670,7 +14670,7 @@ end
 
 check 'Force Flee target 0 grants the party a guaranteed escape' do
   b = escape_battle(5, 20)                 # 0% by agility: never flees on its own
-  it = Game::Interpreter.new(new_state)
+  it = Game::Interpreter.new(new_state(rpg2003: true))
   it.battle = b
   it.start([FakeCmd.new(IC::FORCE_FLEE, [0, 0, 0])])
   it.update
@@ -14685,7 +14685,7 @@ check 'Force Flee target 2 takes one troop member out of the fight' do
   hero = combatant('Hero', 10, 0, 10, 100)
   foes = [combatant('Slime', 5, 0, 5, 30), combatant('Bat', 5, 0, 5, 30)]
   b = Game::Battle.new([hero], foes, Game::Rng.new(1))
-  it = Game::Interpreter.new(new_state)
+  it = Game::Interpreter.new(new_state(rpg2003: true))
   it.battle = b
   it.start([FakeCmd.new(IC::FORCE_FLEE, [2, 1, 0])])
   it.update
@@ -14700,7 +14700,7 @@ check 'Force Flee target 1 empties the troop and ends the fight' do
   hero = combatant('Hero', 10, 0, 10, 100)
   foes = [combatant('Slime', 5, 0, 5, 30), combatant('Bat', 5, 0, 5, 0)]
   b = Game::Battle.new([hero], foes, Game::Rng.new(1))
-  it = Game::Interpreter.new(new_state)
+  it = Game::Interpreter.new(new_state(rpg2003: true))
   it.battle = b
   it.start([FakeCmd.new(IC::FORCE_FLEE, [1, 0, 0])])
   it.update
@@ -14712,7 +14712,9 @@ check 'Force Flee target 1 empties the troop and ends the fight' do
 end
 
 check 'Enable Combo arms a battle combo on a party actor' do
-  st = class_state
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], rpg2003: true)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   it = Game::Interpreter.new(st)
   it.battle = battle_with
   it.start([FakeCmd.new(IC::ENABLE_COMBO, [1, 4, 3]),
@@ -14722,7 +14724,7 @@ check 'Enable Combo arms a battle combo on a party actor' do
 end
 
 check 'Call Common Event runs the common event and returns to the page' do
-  st = new_state
+  st = new_state(rpg2003: true)
   called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
   it = Game::Interpreter.new(st)
   it.resolver = FakeResolver.new(common: { 4 => called })
@@ -14731,6 +14733,40 @@ check 'Call Common Event runs the common event and returns to the page' do
   it.update
   eq true, st.switches[9], 'the common event ran'
   eq true, st.switches[1], 'and control came back'
+end
+
+# Ports EasyRPG's own `Game_Interpreter_Battle::CommandForceFlee`/
+# `CommandEnableCombo`/`CommandCallCommonEvent`
+# (src/game_interpreter_battle.cpp): all three open with `if (!Player::
+# IsRPG2k3Commands()) { return true; }` -- the RPG2003 battle event editor
+# is the only one with any of these three commands at all, so a genuine
+# RPG2000 database's own battle page should never carry one, but an
+# unguarded dispatch reads it as live the instant one does.
+check 'Force Flee / Enable Combo / Call Common Event are all RPG2003-only' do
+  b = escape_battle(5, 20) # 0% by agility: never flees on its own
+  it = Game::Interpreter.new(new_state(rpg2003: false))
+  it.battle = b
+  it.start([FakeCmd.new(IC::FORCE_FLEE, [0, 0, 0])])
+  it.update
+  ok !b.force_flee?, 'Force Flee never touched the battle on a non-RPG2003 database'
+
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0) # rpg2003: false, the default
+  it2 = Game::Interpreter.new(st)
+  it2.battle = battle_with
+  it2.start([FakeCmd.new(IC::ENABLE_COMBO, [1, 4, 3])])
+  it2.update
+  eq nil, st.party.actor_by_id(1).battle_combo, 'Enable Combo never armed anything'
+
+  st3 = new_state(rpg2003: false)
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  it3 = Game::Interpreter.new(st3)
+  it3.resolver = FakeResolver.new(common: { 4 => called })
+  it3.start([FakeCmd.new(IC::CALL_COMMON_EVENT, [4]),
+             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it3.update
+  eq false, st3.switches[9], 'Call Common Event never ran the common event'
+  eq true, st3.switches[1], 'the page still ran on past it, same as an unrecognized command would'
 end
 
 check 'Call Common Event with no resolver or an unknown id is a safe no-op' do


### PR DESCRIPTION
## Summary
- `Interpreter#do_force_flee`/`#do_enable_combo`/`#do_call_common_event` (`mruby-rpg2k/mrblib/interpreter.rb`) each already had a comment documenting "RPG2003-only," but none of the three code bodies actually enforced it — only gated on `@battle`/`@resolver` truthy.
- Confirmed against EasyRPG's actual C++ source: `Game_Interpreter_Battle::CommandForceFlee`/`CommandEnableCombo`/`CommandCallCommonEvent` (`src/game_interpreter_battle.cpp`) each open with `if (!Player::IsRPG2k3Commands()) { return true; }` — checked against every other sibling in the same battle-page command switch (`ChangeMonsterHP`/`ChangeMonsterMP`/`ChangeMonsterCondition`/`ShowHiddenMonster`, none of which carry the guard) to confirm this is specific to these three, not a blanket pattern this repo already covers.
- This is the same class of gap already fixed this session for the map-event TIMER2 condition and the four troop-page condition flags in this very file's own sibling function `AreConditionsMet` — just on the **command-execution** side this time rather than a condition check.
- Concretely: a Force Flee (target 0, "grant the party") reaching this dispatch on an RPG2000 database used to set `@force_flee = true`, guaranteeing the party's next Flee choice succeeds regardless of the normal agility-based roll — an outcome real RPG_RT 2000 could never produce, since its own battle event editor has no Force Flee command at all.
- Fixed by adding `&& @state.party.rpg2003?` to each method's existing guard.

## Test plan
- Added a `scripts/rpg2k_logic_check.rb` check exercising all three commands on an RPG2000 database (no escape granted, no combo armed, no common event called — the page still runs on past it, same as any unrecognized command would).
- Confirmed to fail against the pre-fix code (`git stash` — `1 of 966 checks FAILED`).
- The five pre-existing checks covering these commands' actual matching logic were updated to construct an explicit RPG2003 fixture so the new edition gate does not mask what they test.
- `ruby scripts/rpg2k_logic_check.rb` — 966 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 650 checks passed.
- `ruby scripts/rpg2k_save_load_check.rb` — passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed.
- `ninja -C build rpg_maker_clone` — native rebuild succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_