### PR TITLE
Cache Wine prefix to skip RTP installer on CI cache hits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,20 @@ jobs:
         # Network-bound cache restore; see "Restore and cache Nix store" above.
         timeout-minutes: 10
         background: true
+      - name: cache wine prefix
+        uses: actions/cache@v6
+        id: wine-prefix-cache
+        with:
+          # rtp_install.bash / rtp_xp_install.bash default WINEPREFIX to
+          # $HOME/.wine and skip the wine RTP installer entirely once they
+          # find it already populated here, so a cache hit turns "Download
+          # RTP" into a couple of `ls` calls instead of two wine installs.
+          path: ~/.wine
+          key: wine-prefix-${{ hashFiles('./scripts/rtp*_install.bash') }}
+          restore-keys: wine-prefix-
+        # Network-bound cache restore; see "Restore and cache Nix store" above.
+        timeout-minutes: 10
+        background: true
       - name: cache test game
         uses: actions/cache@v6
         id: cache

--- a/changelog.d/ci-cache-wine-prefix.changed.md
+++ b/changelog.d/ci-cache-wine-prefix.changed.md
@@ -1,0 +1,7 @@
+- CI: the `build` job now caches `~/.wine` (the shared `WINEPREFIX`
+  `rtp_install.bash` / `rtp_xp_install.bash` install into), keyed like the
+  existing RTP zip cache. `rtp_install.bash` and `rtp_xp_install.bash` each
+  check for their RTP's install directory in `WINEPREFIX` first and skip the
+  wine round-trip (`winecfg` + the RTP installer under Xvfb) entirely on a
+  cache hit, so a warm cache turns "Download RTP" into a couple of `ls`
+  checks instead of two wine installs.

--- a/scripts/rtp_install.bash
+++ b/scripts/rtp_install.bash
@@ -27,6 +27,16 @@ if [ ! -v WINEPREFIX ] ; then
   export WINEPREFIX=$HOME/.wine
 fi
 
+RTP_INSTALL_DIR="${WINEPREFIX}/drive_c/Program Files (x86)/ASCII"
+
+# A cached WINEPREFIX (see the CI workflow's "cache wine prefix" step) already
+# has the RTP installed, so skip the wine round-trip entirely and just verify
+# it landed.
+if [ -d "${RTP_INSTALL_DIR}" ] ; then
+  ls "${RTP_INSTALL_DIR}"
+  exit 0
+fi
+
 export DISPLAY=:1024
 Xvfb "${DISPLAY}" -screen 0 1920x1080x24 &
 
@@ -42,6 +52,6 @@ cp setup.iss "${WINEPREFIX}/drive_c"
 
 wine ./RPG2000RTP.exe /s /a /s /sms /f1C:\\setup.iss
 
-ls "${WINEPREFIX}/drive_c/Program Files (x86)/ASCII"
+ls "${RTP_INSTALL_DIR}"
 
 kill %1

--- a/scripts/rtp_xp_install.bash
+++ b/scripts/rtp_xp_install.bash
@@ -20,6 +20,17 @@ if [ ! -v WINEPREFIX ] ; then
   export WINEPREFIX=$HOME/.wine
 fi
 
+RTP_INSTALL_DIR_X86="${WINEPREFIX}/drive_c/Program Files (x86)/Common Files/Enterbrain/RGSS/Standard"
+RTP_INSTALL_DIR="${WINEPREFIX}/drive_c/Program Files/Common Files/Enterbrain/RGSS/Standard"
+
+# A cached WINEPREFIX (see the CI workflow's "cache wine prefix" step) already
+# has the RTP installed, so skip the wine round-trip entirely and just verify
+# it landed.
+if [ -d "${RTP_INSTALL_DIR_X86}" ] || [ -d "${RTP_INSTALL_DIR}" ] ; then
+  ls "${RTP_INSTALL_DIR_X86}" || ls "${RTP_INSTALL_DIR}"
+  exit 0
+fi
+
 export DISPLAY=:1024
 Xvfb "${DISPLAY}" -screen 0 1920x1080x24 &
 
@@ -34,7 +45,6 @@ cp setup.iss "${WINEPREFIX}/drive_c"
 
 wine ./RPGXP_RTP103/Setup.exe /verysilent
 
-ls "${WINEPREFIX}/drive_c/Program Files (x86)/Common Files/Enterbrain/RGSS/Standard" ||
-  ls "${WINEPREFIX}/drive_c/Program Files/Common Files/Enterbrain/RGSS/Standard"
+ls "${RTP_INSTALL_DIR_X86}" || ls "${RTP_INSTALL_DIR}"
 
 kill %1


### PR DESCRIPTION
## Summary
This PR adds caching of the Wine prefix (`~/.wine`) in CI to avoid redundant RTP (Runtime Package) installations. When the cache is hit, the RTP installation scripts now skip the expensive wine round-trip and simply verify the RTP files are present.

## Key Changes
- **CI Workflow**: Added a new cache step in `.github/workflows/build.yml` that caches `~/.wine` keyed by the RTP installation scripts' content hash
- **RTP Installation Scripts**: Both `rtp_install.bash` and `rtp_xp_install.bash` now:
  - Define variables for the RTP installation directories
  - Check if the RTP is already installed in the cached `WINEPREFIX` before proceeding
  - Skip the wine/Xvfb setup entirely on cache hits, reducing to simple `ls` verification calls
  - Use the defined directory variables consistently throughout

## Implementation Details
- The cache key is based on `hashFiles('./scripts/rtp*_install.bash')`, ensuring the cache is invalidated if the installation scripts change
- Cache restoration is set to run in the background with a 10-minute timeout, consistent with the existing Nix store cache
- The early-exit optimization in both scripts checks for the presence of the RTP installation directory and exits immediately if found, avoiding the overhead of starting Xvfb and running wine
- A changelog entry documents this CI improvement

https://claude.ai/code/session_01SGz4chUmB93r4bzqKj5DHR