### PR TITLE
Add --rpg2k_preview_map flag to preview maps from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@
   already has, held down instead of tapped); press **F9** to open a debug
   menu listing every switch and variable, ten at a time, with a signed number
   editor for variables
+- `--rpg2k_preview_map=<id>` starts New Game on a chosen map, centred on its
+  middle tile, instead of the database's configured start position — a quick
+  way to inspect one map's rendering without a save file positioned there.
+  Combine with the terminal backends below and `--timeout_ms` to preview a map
+  straight from the command line:
+
+  ```sh
+  ./rpg_maker_clone --iterm --game_dir path/to/game --rpg2k_preview_map=5 \
+      --timeout_ms=2000
+  ```
 
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,

--- a/changelog.d/rpg2k-preview-map.added.md
+++ b/changelog.d/rpg2k-preview-map.added.md
@@ -1,0 +1,6 @@
+- **RPG Maker 2000/2003: `--rpg2k_preview_map=<id>`** starts New Game on a
+  chosen map, centred on its middle tile, instead of the database's configured
+  start position — a quick way to preview one map's rendering without a save
+  file positioned there. Combined with `--iterm` (or `--sixel`) and
+  `--timeout_ms`, it dumps the map straight to the terminal via the iTerm2
+  inline-image protocol and exits.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -666,17 +666,25 @@ class RPG2k
   # position from the map tree, load the starting map and enter the map scene.
   # The map/player renderer is not wired up yet, so this establishes the running
   # game state and transitions scenes without drawing the map.
+  #
+  # --rpg2k_preview_map overrides both the map and the start position with a
+  # chosen map's centre tile (see #preview_map_id below) -- a quick way to
+  # inspect one map's rendering, e.g. piped through --iterm, without a save
+  # file positioned there.
   def start_new_game
     init = map_tree.initial
-    state = Game::State.new Game::Party.new(@db), init.initial_map_id,
-                            init.initial_x, init.initial_y
+    map_id = preview_map_id || init.initial_map_id
+    map = load_map map_id
+    x, y = preview_map_id ? [map.width / 2, map.height / 2]
+                           : [init.initial_x, init.initial_y]
+    state = Game::State.new Game::Party.new(@db), map_id, x, y
     # The database's System tab configures the six screen transitions a
     # "use the configured transition" (-1) Erase / Show Screen resolves against.
     state.seed_screen_transitions @db
     # The map tree's own boat/ship/airship starting positions, the editor's
     # counterpart to the hero's initial_map_id/x/y just above.
     state.seed_vehicle_positions map_tree
-    state.map = load_map state.map_id
+    state.map = map
     # Build the play scene first; only tear down the title once it succeeds so a
     # data problem leaves the title intact instead of a blank screen.
     scene = Scene::Map.new(self, state)
@@ -689,6 +697,17 @@ class RPG2k
   rescue StandardError => e
     # Never let a data problem crash the title screen; report and stay put.
     $stderr.puts "[RPG2k] Failed to start new game: #{e.message}"
+  end
+
+  # --rpg2k_preview_map: the map id to preview, or nil when unset (0, the
+  # default -- see src/main.cxx; map ids start at 1). Guarded the same way as
+  # #native_test_play?: an undefined RPG2K_PREVIEW_MAP (the CRuby-only host
+  # harnesses that load this file never define it) raises NameError, rescued
+  # to nil.
+  def preview_map_id
+    RPG2K_PREVIEW_MAP.zero? ? nil : RPG2K_PREVIEW_MAP
+  rescue StandardError
+    nil
   end
 
   # Save file path for a slot. Saving still uses our own portable Marshal

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -156,7 +156,11 @@ class RPG2k
         if auto_new_game?
           @auto_started = true
           @selected_index = 0
-          $stderr.puts '[RPG2k] --rpg2k_new_game: selecting New Game'
+          if (map_id = preview_map_id)
+            $stderr.puts "[RPG2k] --rpg2k_preview_map=#{map_id}: selecting New Game"
+          else
+            $stderr.puts '[RPG2k] --rpg2k_new_game: selecting New Game'
+          end
           true
         elsif auto_continue?
           @auto_started = true
@@ -168,7 +172,18 @@ class RPG2k
         end
       end
 
+      # --rpg2k_preview_map also triggers this (see #preview_map_id below), so
+      # a preview needs only that one flag, not this one too. Each source is
+      # read through its own `begin`/`rescue` rather than a shared helper: an
+      # undefined constant (either flag, checked independently) must not sink
+      # the other, which a single `RPG2K_NEW_GAME || preview_map_id` guarded by
+      # one outer rescue would do -- resolving the bare, undefined
+      # RPG2K_NEW_GAME raises before `||` ever reaches preview_map_id.
       def auto_new_game?
+        new_game_flag? || preview_map_id
+      end
+
+      def new_game_flag?
         RPG2K_NEW_GAME
       rescue StandardError
         false
@@ -178,6 +193,17 @@ class RPG2k
         RPG2K_CONTINUE
       rescue StandardError
         false
+      end
+
+      # --rpg2k_preview_map also auto-selects New Game (see #auto_new_game?
+      # above), so a preview needs only that one flag. Guarded the same way as
+      # #hide_title?/#continue_available? below: a bare Title built without a
+      # real parent (scripts/rpg2k_scene_check.rb) answers nil rather than
+      # raising.
+      def preview_map_id
+        parent.preview_map_id
+      rescue StandardError
+        nil
       end
 
       # HideTitle, as RPG2k#initialize parsed it off RPG_RT.exe's legacy CLI

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10042,6 +10042,39 @@ check 'neither flag set leaves the title screen waiting for input' do
   ok !scene.send(:auto_select?), 'no auto-select without a flag'
 end
 
+# -- --rpg2k_preview_map (map preview, see README.md's "Map exploration") ----
+#
+# RPG2k#preview_map_id reads the RPG2K_PREVIEW_MAP constant main.cxx sets from
+# the flag (0 = unset, since map ids start at 1); Scene::Title#auto_new_game?
+# then also fires on it, exactly like --rpg2k_new_game, so a preview needs
+# only the one flag. #start_new_game itself (which loads the chosen map and
+# centres the party on it) needs a real database and .lmu, so it is only
+# exercised by the native boot check against real game data -- these two pin
+# just the flag plumbing, in CRuby, without either.
+check 'RPG2k#preview_map_id reads RPG2K_PREVIEW_MAP, 0 meaning unset' do
+  read = lambda do |v|
+    Object.send(:remove_const, :RPG2K_PREVIEW_MAP) if Object.const_defined?(:RPG2K_PREVIEW_MAP)
+    Object.const_set(:RPG2K_PREVIEW_MAP, v) unless v.nil?
+    RPG2k.allocate.send(:preview_map_id)
+  end
+  eq nil, read.call(nil), 'undefined constant (the CRuby-only checks) -> nil'
+  eq nil, read.call(0), '0, the flag default -> nil'
+  eq 7, read.call(7)
+  Object.send(:remove_const, :RPG2K_PREVIEW_MAP) if Object.const_defined?(:RPG2K_PREVIEW_MAP)
+end
+
+check '--rpg2k_preview_map auto-selects New Game, like --rpg2k_new_game' do
+  clear_title_flags
+  parent = Struct.new(:preview_map_id).new(7)
+  scene = RPG2k::Scene::Title.allocate
+  scene.instance_variable_set(:@auto_started, false)
+  scene.instance_variable_set(:@selected_index, 0)
+  scene.instance_variable_set(:@parent, parent)
+  ok scene.send(:auto_select?), 'the first frame fires the auto-select'
+  eq 0, scene.instance_variable_get(:@selected_index), 'New Game is entry 1'
+  ok !scene.send(:auto_select?), 'it does not fire again on the next frame'
+end
+
 # -- RPG_RT.exe legacy CLI arg: HideTitle --------------------------------------
 #
 # RPG_RT.exe (and the RPG2000/2003 editor's own Test Play button) is launched

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -80,6 +80,16 @@ DEFINE_bool(
     "and a genuine RPG_RT.exe be brought to the same in-game map from the same "
     "Save<N>.lsd (see scripts/compare-nepheshel-save-wine.bash) instead of "
     "being driven there by counting key presses");
+DEFINE_int32(
+    rpg2k_preview_map,
+    0,
+    "For RPG Maker 2000/2003: once the title screen appears, auto-select New "
+    "Game like --rpg2k_new_game, but start on this map id, centred on its "
+    "middle tile, instead of the database's configured start position -- a "
+    "quick way to inspect one map's rendering without a save file positioned "
+    "there. Combine with --iterm (or --sixel) and --timeout_ms to dump the "
+    "map to the terminal and exit. 0 disables the override (default; map ids "
+    "start at 1)");
 DEFINE_bool(
     rgss_script_host,
     true,
@@ -896,6 +906,7 @@ static void disable_non_test_play_flags() {
 
   reset_bool(FLAGS_rpg2k_new_game, "rpg2k_new_game");
   reset_bool(FLAGS_rpg2k_continue, "rpg2k_continue");
+  reset_int(FLAGS_rpg2k_preview_map, "rpg2k_preview_map");
   reset_bool(FLAGS_rgss_host_new_game, "rgss_host_new_game");
   reset_bool(FLAGS_rgss_host_move_test, "rgss_host_move_test");
   reset_bool(FLAGS_rgss_host_menu_test, "rgss_host_menu_test");
@@ -1271,6 +1282,13 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RPG2K_CONTINUE"),
                 mrb_bool_value(FLAGS_rpg2k_continue));
+  // --rpg2k_preview_map: the map id RPG2k#start_new_game (mruby-rpg2k) should
+  // jump New Game to instead of the database's configured start position, or 0
+  // when unset. See the flag's own definition above for the map-preview use
+  // case.
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RPG2K_PREVIEW_MAP"),
+                mrb_fixnum_value(FLAGS_rpg2k_preview_map));
   // Whether the RGSS script host runs the project's own scripts (the default)
   // or the built-in flow does. Resolved from --rgss_script_host and the
   // RGSS_SCRIPT_HOST environment variable above, because the Ruby side cannot


### PR DESCRIPTION
## Summary
Adds a new `--rpg2k_preview_map=<id>` command-line flag for RPG Maker 2000/2003 games that allows quick previewing of individual maps by starting a new game on a specified map, centered on its middle tile, instead of the database's configured start position.

## Key Changes

- **Command-line flag definition** (`src/main.cxx`): Added `--rpg2k_preview_map` integer flag (default 0, disabled) that gets passed to mruby as the `RPG2K_PREVIEW_MAP` constant
- **Game initialization** (`mruby-rpg2k/mrblib/main.rb`): Modified `start_new_game` to check for preview map override and center the party on the target map's middle tile instead of the configured start position
- **Title screen auto-selection** (`mruby-rpg2k/mrblib/scene/title.rb`): Extended `auto_select?` to trigger on preview map flag (like `--rpg2k_new_game`), and refactored `auto_new_game?` to check both flags independently to avoid short-circuit evaluation issues
- **Test coverage** (`scripts/rpg2k_scene_check.rb`): Added comprehensive tests for the preview map flag plumbing and auto-selection behavior
- **Documentation** (`README.md`, `changelog.d/`): Added usage examples showing how to combine with terminal backends and `--timeout_ms` for quick map inspection

## Implementation Details

- The preview map flag is guarded with exception handling (like existing flags) to safely handle undefined constants in test environments
- Map loading happens before state initialization to allow centering on the map's actual dimensions
- The flag uses 0 as the "unset" value since RPG Maker map IDs start at 1
- Both `auto_new_game?` and `preview_map_id` are checked through separate try/rescue blocks to prevent one undefined constant from masking the other

https://claude.ai/code/session_018TsLFjdRdciHkmL9QhaKK4