### PR TITLE
Implement CalcSkillToHit's physical hit formula for battle skills

### DIFF
--- a/changelog.d/rpg2k-skill-physical-hit.added.md
+++ b/changelog.d/rpg2k-skill-physical-hit.added.md
@@ -1,0 +1,7 @@
+- **Battle skill hit chance** now uses `CalcSkillToHit`'s fuller agility-adjusted
+  physical formula for enemy-scope skills flagged with the "physical" failure
+  message (`failure_message == 3`), matching a basic attack's evasion-aware AGI
+  roll instead of the flat `skill.hit`; every other skill keeps the flat rate.
+  Ported from EasyRPG's `Algo::CalcSkillToHit` into `Game::Party#skill_to_hit`
+  and wired into `Game::Party#battle_skill_command`. Covered by seven new checks
+  in `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5484,8 +5484,37 @@ not yet verified:
   missing at its own roll boundary, the existing @accuracy-off default still
   applying every effect unconditionally, a heal skill's HP and SP landing
   independently of each other, and a compound skill's stat-mod effect landing
-  on its own roll while its HP effect misses on a different one), each
-  confirmed to fail against the pre-fix code before the fix.
+   on its own roll while its HP effect misses on a different one), each
+   confirmed to fail against the pre-fix code before the fix.
+- ✅ **`CalcSkillToHit`'s fuller agility-adjusted physical formula is now
+   implemented for enemy-scope skills flagged with the "physical" failure
+   message (`failure_message == 3`) — closing the `Not implemented` edge case
+   the skill-hit bullet above left for a follow-up.** Confirmed against
+   EasyRPG's actual `Algo::CalcSkillToHit` (`src/algo.cpp`): the physical branch
+   (`skill.failure_message == 3 && !SkillTargetsAllies(skill)`) runs the same
+   evasion-aware, agility-adjusted formula a basic attack uses — `to_hit =
+   skill.hit`, then `do_nothing`-restricted target → always 100, then
+   `to_hit *= source's state hit-modifier / 100`, then (unless the source
+   `ignores_evasion`) the AGI term `100 - (100 - to_hit) * (src + tgt) / (2 *
+   src)`, then `-25` if the target has `raise_evasion` — whereas every other
+   skill keeps the flat `skill.hit` reading (RPG_RT's non-physical skill formula
+   ignores the target's agility). `Game::Party#skill_to_hit` (a faithful port,
+   reading the state table through the party's own `@db.situation` so it works
+   for a bare `Game::Actor` caster too, like the rest of `Game::Party`'s
+   skill-formula helpers) now feeds `chance:` in `Game::Party#
+   battle_skill_command`'s attack and recovery branches, replacing the previous
+   unconditional `skill_hit(sk)` — the per-effect roll (`#skill_effect_hits?`)
+   is unchanged, so each affected HP/SP/stat field still re-rolls the one shared
+   rate. RPG2000's own editor cannot set the flag, so in practice it only shows
+   up in converted / hex-edited projects and the odd 2k3 database, but RPG_RT
+   honours the bit whenever it is set. Covered by seven new
+   `scripts/rpg2k_logic_check.rb` checks (an enemy-scope physical skill landing
+   at its agility-adjusted rate vs. the flat `skill.hit`, equal agility reducing
+   the term to identity, a non-physical skill ignoring the flag, an
+   ally-scoped physical-flagged skill staying flat, a physical-evasion-up target
+   losing 25, a `do_nothing`-restricted target always hit, and an
+   evasion-ignoring caster skipping the AGI term), each confirmed to fail
+   against the pre-fix code.
 - ✅ **`Game::Battle#fatigue` (the RPG2003 `fatigue` page condition) now
   rounds an exact tie to the nearest *even* whole percent, not always up.**
   A prior version of this method's own comment claimed it used "the same

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4465,6 +4465,11 @@ module Game
       adjust_stat((b.respond_to?(:spi) ? b.spi : 0) || 0, stat_mode(b, :affect_spirit))
     end
 
+    def effective_agi(b)
+      adjust_stat((b.respond_to?(:agi) ? b.agi : 0) || 0,
+                  stat_mode(b, :affect_agility))
+    end
+
     # The base HP/SP amount a recovery skill restores, per RPG2000's formula
     # `power + physical_rate*attack/20 + magical_rate*spirit/40` (spirit is the
     # `int` stat), computed from the caster deterministically -- battle applies a
@@ -4720,6 +4725,84 @@ module Game
       sk.respond_to?(:hit) ? (sk.hit || 100) : 100
     end
 
+    # A Skill's to-hit chance, ported from EasyRPG's `Algo::CalcSkillToHit`
+    # (`src/algo.cpp`). The overwhelming majority of skills use a flat
+    # `skill.hit` reading (already what `skill_hit` returns), which ignores the
+    # target's agility the way RPG_RT's non-physical skill formula does. Only an
+    # *enemy-scope* skill the editor flagged with the "physical" failure message
+    # (`failure_message == 3`) runs the fuller, agility-adjusted, evasion-aware
+    # physical formula — RPG2000's own editor hides that flag, so in practice it
+    # survives only from converted / hex-edited projects and a handful of 2k3
+    # databases, but RPG_RT still honours the bit whenever it is set (see the
+    # "Not implemented: CalcSkillToHit" note in docs/TODO.md). `source` is the
+    # caster, `target` the first foe the skill lands on.
+    def skill_to_hit(sk, source, target)
+      return skill_hit(sk) unless sk.respond_to?(:failure_message) && sk.failure_message == 3
+      # The physical formula is enemy-only: an ally/self-scoped skill (scope 2/3/4)
+      # always falls back to the flat rate regardless of the flag — EasyRPG's
+      # `CalcSkillToHit` guards the whole physical branch behind
+      # `!SkillTargetsAllies(skill)`, and its own comment notes the 2k3 editor
+      # can no longer even set the flag, so the branch is reached only by skills
+      # that still target the opposing side (scope 0 single / 1 all enemy).
+      scope = sk.respond_to?(:scope) ? sk.scope.to_i : 0
+      return skill_hit(sk) unless scope == 0 || scope == 1
+
+      to_hit = skill_hit(sk)
+      # A do-nothing-restricted target cannot dodge: the attack always connects.
+      return 100 if do_nothing_restricted?(target)
+      # The caster's own statuses (e.g. Blind) sour its aim first, before the
+      # agility term — the same ordering `Game::Battle#to_hit` already uses for a
+      # basic attack.
+      to_hit = to_hit * hit_modifier(source) / 100
+      # 必中: a source that ignores evasion skips the agility term entirely.
+      return to_hit if source.ignores_evasion
+      src = effective_agi(source)
+      src = 1 if src < 1
+      tgt = effective_agi(target)
+      agi_adjusted = 100 - (100 - to_hit) * (src + tgt) / (2 * src)
+      # 物理回避率アップ: a shield/armour/helmet/accessory flagged
+      # `raise_evasion` subtracts a flat 25, after the AGI term.
+      agi_adjusted -= 25 if target.evasion_up
+      Game.clamp(agi_adjusted, 0, 100)
+    end
+
+    # Whether any state afflicting `b` forces "do nothing" (restriction 1), in
+    # which case it cannot dodge a physical skill. Mirrors
+    # `Game::Battle#do_nothing_restricted?` but reads the state table through
+    # this party's own `@db.situation` (a battle-skill's caster/target is
+    # sometimes a bare Game::Actor with no Battle behind it, see Party#stat_mode).
+    def do_nothing_restricted?(b)
+      return false unless b.respond_to?(:states)
+      (b.states || []).each do |sid|
+        d = @db.respond_to?(:situation) ? @db.situation[sid] : nil
+        return true if d.respond_to?(:restriction) && (d.restriction || 0) == 1
+      end
+      false
+    end
+
+    # How much `b`'s own statuses cut its accuracy: the lowest `reduce_hit_ratio`
+    # among its states (EasyRPG's `GetHitChanceModifierFromStates` takes a
+    # running min). 100 means unhindered. Part of #skill_to_hit's physical
+    # formula, mirroring `Game::Battle#hit_modifier`.
+    def hit_modifier(b)
+      m = 100
+      return m unless b.respond_to?(:states)
+      (b.states || []).each do |sid|
+        d = @db.respond_to?(:situation) ? @db.situation[sid] : nil
+        r = state_hit_ratio(d)
+        m = r if r < m
+      end
+      m
+    end
+
+    # A state's `reduce_hit_ratio`, defaulting to 100 (no reduction) for an
+    # unknown state or a fixture row without the field.
+    def state_hit_ratio(d)
+      return 100 unless d.respond_to?(:reduce_hit_ratio)
+      v = d.reduce_hit_ratio
+      v.nil? ? 100 : v
+    end
+
     # A skill's damage variance (its `variance` field on the 0-10 scale, default
     # 4), the spread applied to its battle damage when the fight rolls variance.
     def skill_variance(sk)
@@ -4852,7 +4935,7 @@ module Game
           # @2000_battle_bot/デフォ戦bot trivia on the HP-reaches-zero
           # interaction below) never touches HP at all.
           hp: sk.affect_hp ? -dmg : 0, mp: sk.affect_sp ? -dmg : 0, attack: true,
-          inflict: inflict_ids, chance: skill_hit(sk),
+          inflict: inflict_ids, chance: skill_to_hit(sk, caster, target),
           variance: skill_variance(sk), attributes: skill_attributes(sk),
           # 吸収 — the caster takes what the target loses. RPG_RT reads the flag
           # only on an *offensive* skill (EasyRPG's `skill.absorb_damage &&
@@ -4898,7 +4981,7 @@ module Game
           # machinery when curing (no roll, matching a battle medicine's own
           # state cure) and its `cmd[:inflict]`/`cmd[:chance]` roll when the
           # RPG2003 reverse case above turns this into an inflict instead.
-          cured: cure_ids, inflict: inflict_ids, chance: skill_hit(sk) }
+          cured: cure_ids, inflict: inflict_ids, chance: skill_to_hit(sk, caster, target) }
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3237,20 +3237,25 @@ FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost
                        # affect_attr_defence above -- see
                        # Game::Party#skill_stat_mod_keys / Game::Battle#
                        # apply_stat_mods. Appended last, for the same reason.
-                       :affect_attack, :affect_defense, :affect_spirit,
-                       :affect_agility)
+                        :affect_attack, :affect_defense, :affect_spirit,
+                        :affect_agility,
+                        # "physical" failure message flag (schema field 7, the
+                        # bit CalcSkillToHit reads to pick the agility-adjusted
+                        # physical hit formula for an enemy-scope skill).
+                        :failure_message)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
                occ_battle: true, state_effects: nil, reverse_state: false, hit: 100,
                variance: 4, attribute_effects: nil, switch_id: 1,
                ignore_defense: false, affect_attr_defence: false,
-               affect_attack: false, affect_defense: false,
-               affect_spirit: false, affect_agility: false)
+                affect_attack: false, affect_defense: false,
+                affect_spirit: false, affect_agility: false,
+                failure_message: 0)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
-                prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
-                variance, attribute_effects, switch_id, ignore_defense,
-                affect_attr_defence, affect_attack, affect_defense,
-                affect_spirit, affect_agility)
+                 prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
+                 variance, attribute_effects, switch_id, ignore_defense,
+                 affect_attr_defence, affect_attack, affect_defense,
+                 affect_spirit, affect_agility, failure_message)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
 # per-turn slip damage (hp/sp change), action restriction and auto-recovery.
@@ -5773,16 +5778,16 @@ end
 
 # A two-actor party (Hero atk 10 / spirit 12 / max SP 30, Ally max HP 50) plus
 # the given skill table, for the field-skill checks.
-def skill_party(skills, items = {}, rpg2003: false)
-  players = {
-    1 => FakePlayerRow.new('Hero', '', 0, 5,
-                           max_hp: 100, max_mp: 30, atk: 10, def: 8, int: 12, agi: 7),
-    2 => FakePlayerRow.new('Ally', '', 0, 3,
-                           max_hp: 50, max_mp: 20, atk: 6, def: 5, int: 4, agi: 6),
-  }
-  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items, skills,
-                                                   rpg2003: rpg2003)), 1, 0, 0)
-end
+ def skill_party(skills, items = {}, rpg2003: false, situation: nil)
+   players = {
+     1 => FakePlayerRow.new('Hero', '', 0, 5,
+                            max_hp: 100, max_mp: 30, atk: 10, def: 8, int: 12, agi: 7),
+     2 => FakePlayerRow.new('Ally', '', 0, 3,
+                            max_hp: 50, max_mp: 20, atk: 6, def: 5, int: 4, agi: 6),
+   }
+   Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items, skills,
+                                                    {}, situation, rpg2003: rpg2003)), 1, 0, 0)
+ end
 
 check 'an RPG2003 subskill category behaves as an ordinary skill' do
   # Types from 4 up are 2003's custom battle-command categories, not a different
@@ -10135,15 +10140,97 @@ check "battle: a database state's own rank rate gates the infliction" do
   ok !foe.state?(3)
 end
 
-check 'Party#battle_skill_command carries the skill elemental attributes' do
-  skills = { 7 => fake_skill(name: 'Ice', scope: 0, power: 20, mrate: 40,
-                             attribute_effects: [false, false, true]) } # element 3
-  st = skill_party(skills)
-  mage = Game::Battle.from_actor(st.party.actor_by_id(1))
-  slime = combatant('Slime', 0, 0, 5, 100)
-  c = st.party.battle_skill_command(st.party.db_skill(7), mage, slime)
-  eq [3], c[:attributes]
-end
+ check 'Party#battle_skill_command carries the skill elemental attributes' do
+   skills = { 7 => fake_skill(name: 'Ice', scope: 0, power: 20, mrate: 40,
+                              attribute_effects: [false, false, true]) } # element 3
+   st = skill_party(skills)
+   mage = Game::Battle.from_actor(st.party.actor_by_id(1))
+   slime = combatant('Slime', 0, 0, 5, 100)
+   c = st.party.battle_skill_command(st.party.db_skill(7), mage, slime)
+   eq [3], c[:attributes]
+ end
+
+ # A "physical" failure message (failure_message == 3) on an enemy-scope skill
+ # switches its to-hit from the flat `skill.hit` to the agility-adjusted,
+ # evasion-aware physical formula (EasyRPG Algo::CalcSkillToHit) -- the
+ # CalcSkillToHit edge case docs/TODO.md left unimplemented. See Game::Battle#
+ # skill_to_hit.
+ check 'a physical-flagged enemy-scope skill uses the agility-adjusted hit formula' do
+   skills = { 7 => fake_skill(name: 'Punch', scope: 0, hit: 90, failure_message: 3) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.agi = 5
+   foe = combatant('Foe', 0, 0, 10, 100)         # faster target -> harder to hit
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   # 90, then AGI: 100 - (100-90)*(5+10)/(2*5) = 100 - 10*15/10 = 85
+   eq 85, c[:chance]
+ end
+
+ check 'a physical skill at equal agility hits at its flat rate' do
+   skills = { 7 => fake_skill(name: 'Punch', scope: 0, hit: 90, failure_message: 3) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.agi = 7
+   foe = combatant('Foe', 0, 0, 7, 100)
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   eq 90, c[:chance]                            # AGI term reduces to identity
+ end
+
+ check 'a non-physical skill ignores the flag and uses the flat hit rate' do
+   skills = { 7 => fake_skill(name: 'Bolt', scope: 0, hit: 90, failure_message: 0) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.agi = 5
+   foe = combatant('Foe', 0, 0, 10, 100)
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   eq 90, c[:chance]                            # no agility term, just skill.hit
+ end
+
+ check 'an ally-scoped physical-flagged skill stays on the flat hit rate' do
+   skills = { 7 => fake_skill(name: 'Mend', scope: 3, hit: 90, failure_message: 3) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.agi = 5
+   ally = Game::Battle.from_actor(st.party.actor_by_id(1))
+   ally.agi = 10
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, ally)
+   eq 90, c[:chance]                            # physical formula is enemy-only
+ end
+
+ check 'a physical skill subtracts 25 for a physical-evasion-up target' do
+   skills = { 7 => fake_skill(name: 'Punch', scope: 0, hit: 90, failure_message: 3) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.agi = 5
+   foe = combatant('Foe', 0, 0, 10, 100)
+   foe.evasion_up = true
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   eq 60, c[:chance]                            # 85 - 25
+ end
+
+ check 'a physical skill always hits a do-nothing-restricted target' do
+   skills = { 7 => fake_skill(name: 'Punch', scope: 0, hit: 90, failure_message: 3) }
+   # a do-nothing state (restriction 1) in the situation table
+   st = skill_party(skills, situation: { 1 => FakeStateDef.new(1) })
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.agi = 5
+   foe = combatant('Foe', 0, 0, 10, 100)
+   foe.states = [1]
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   eq 100, c[:chance]
+ end
+
+ check 'a physical skill skips the agility term for an evasion-ignoring caster' do
+   skills = { 7 => fake_skill(name: 'Punch', scope: 0, hit: 90, failure_message: 3) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.agi = 5
+   hero.ignores_evasion = true
+   foe = combatant('Foe', 0, 0, 10, 100)
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   eq 90, c[:chance]                            # returns before the AGI term
+ end
+
 
 check 'Actor weapon/attribute readers feed the combatant snapshot' do
   items = { 7 => fake_item(type: 1, atk: 10, attribute_set: [true, false, true]) }


### PR DESCRIPTION
An enemy-scope skill flagged with the "physical" failure message (failure_message == 3) now uses the agility-adjusted, evasion-aware physical hit formula (EasyRPG Algo::CalcSkillToHit) instead of the flat skill.hit rate. Game::Party#skill_to_hit ports the formula and feeds chance: in battle_skill_command; every other skill keeps the flat rate. Covered by seven new rpg2k_logic_check.rb checks.