### PR TITLE
Implement whole-side battle-page Show Battle Animation (target -1)

### DIFF
--- a/changelog.d/whole-side-battle-animation.added.md
+++ b/changelog.d/whole-side-battle-animation.added.md
@@ -1,0 +1,10 @@
+- **Battle-page Show Battle Animation (13260)** now supports `target -1`, the
+  "whole side" sentinel EasyRPG's `Game_Interpreter_Battle::
+  CommandShowBattleAnimation` uses: one animation plays over every living troop
+  member at once instead of a single index. The animation player
+  (`Scene::Map#build_animation`) was generalised from a single `target_index`
+  to a `targets` array, so `#draw_map_animation` blits each frame over every
+  target and `#fire_animation_flashes` / `#hold_animation_target_flash` flash
+  and clear every target's sprite. An ally-flagged whole side collapses to the
+  single screen-centre fallback (RPG2000's front view draws no ally sprite).
+  Covered by two new checks in `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7101,11 +7101,26 @@ not yet verified:
   new `scripts/rpg2k_scene_check.rb` check (an ally-targeted animation
   lands at screen centre with no enemy sprite ever flashed, instead of
   hitting the troop's second member), three checks total confirmed to fail
-  against the pre-fix code before the fix. The `target < 0` "whole side"
-  case EasyRPG's own function also handles (playing one animation over
-  every living ally or enemy at once) stays out of scope — this codebase's
-  animation player only ever tracks a single `target_index`, and extending
-  it to a full battler list is a separate, larger change.
+   against the pre-fix code before the fix. **The `target < 0` "whole side"
+   case is now implemented too** — `Scene::Battle#start_battle_page_animation`
+   (`mruby-rpg2k/mrblib/scene/battle.rb`) now reads the target as
+   EasyRPG's `Game_Interpreter_Battle::CommandShowBattleAnimation` does: a
+   `target` below 0 plays one animation over every living troop member at
+   once, not a single index. That needed generalising the animation player
+   (`Scene::Map#build_animation`) away from a single `target_index` to a
+   `targets` array of per-side descriptors — `#draw_map_animation` blits the
+   frame over each, and `#fire_animation_flashes` / `#hold_animation_target_flash`
+   flash and clear every target's sprite. `#whole_side_anim_targets` skips the
+   hidden / out-of-play members (the same `@ui[:foes]`/`@ui[:enemy_sprites]`
+   pair a single target already indexes). An ally-flagged whole side
+   (`allies` set, RPG2003) collapses to the single screen-centre fallback,
+   since RPG2000's front-view battle draws no ally sprite to point at — the
+   same convention every ally-targeted entry already uses. Covered by two new
+   `scripts/rpg2k_scene_check.rb` checks (a `target -1` enemy animation
+   builds one target per living enemy and flashes each; a `target -1` ally
+   animation collapses to the single screen-centre target with no enemy
+   sprite flashed), both confirmed against the prior single-target-only
+   behaviour.
 - ✅ **Weather Effects now clamps an RPG2003-only weather type back to none on
   RPG2000, and clamps strength to at most 2 on every edition — both used to
   be stored verbatim off the raw command bytes with no bound at all.**

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1695,8 +1695,9 @@ class RPG2k
         id = battle_animation_id(entry)
         return false unless id && id > 0
         tx, ty, height = battle_animation_pixel(entry)
-        anim = @map.build_animation(id, tx, ty, true, target_index: entry[:target_index],
-                               target_height: height)
+        target = @map.anim_target(tx, ty, height: height, index: entry[:target_index],
+                                  flash_target: nil)
+        anim = @map.build_animation(id, [target], true)
         return false unless anim
         @map.map_animation = anim
         @map.fire_animation_flashes(anim) # frame 0 flashes, as the map path does
@@ -1755,16 +1756,52 @@ class RPG2k
       # #battle_animation_pixel's own nil-sprite branch already falls back to
       # screen-centre: RPG2000's battle draws no on-screen ally sprite to
       # target at all.
+      #
+      # A `target` of -1 is EasyRPG's "whole side" sentinel
+      # (`Game_Interpreter_Battle::CommandShowBattleAnimation`): the animation
+      # plays over every living troop member at once -- every living enemy
+      # when the ally flag is clear, or a single screen-centre animation (the
+      # same ally-side fallback above) when it is set, since RPG2000's
+      # front-view battle draws no ally sprite to point at.
       def start_battle_page_animation(req)
-        tx, ty, height =
-          if req[:allies]
-            [SCREEN_W / 2, SCREEN_H / 2, nil]
+        targets =
+          if req[:target] && req[:target] < 0
+            whole_side_anim_targets(req[:allies])
+          elsif req[:allies]
+            [@map.anim_target(SCREEN_W / 2, SCREEN_H / 2, height: nil, index: nil,
+                              flash_target: nil)]
           else
-            battle_animation_pixel(target_index: req[:target])
+            tx, ty, height = battle_animation_pixel(target_index: req[:target])
+            [@map.anim_target(tx, ty, height: height, index: req[:target],
+                              flash_target: nil)]
           end
-        target_index = req[:allies] ? nil : req[:target]
-        @map.build_animation(req[:animation], tx, ty, true, target_index: target_index,
-                             target_height: height)
+        @map.build_animation(req[:animation], targets, true)
+      end
+
+      # The target descriptors for a whole-side Show Battle Animation: one per
+      # living, on-screen troop member. Skips slots with no sprite (a hidden
+      # troop member -- #build_battle_sprites never created one) and any member
+      # now out of play (dead or fled -- its sprite is hidden, its index still
+      # present in `@ui[:enemy_sprites]`); the remaining sprites' live on-screen
+      # positions are what the animation is drawn over, and their indices are
+      # what a flash_scope-1 / screen_shaking-1 timing pulses. Ally-side
+      # animations get no on-screen sprite in RPG2000's front view, so the
+      # whole side collapses to the single screen-centre fallback.
+      def whole_side_anim_targets(allies)
+        return [@map.anim_target(SCREEN_W / 2, SCREEN_H / 2, height: nil, index: nil,
+                                 flash_target: nil)] if allies
+        sprites = @ui[:enemy_sprites] || []
+        foes = @ui[:foes] || []
+        out = []
+        sprites.each_with_index do |spr, i|
+          foe = foes[i]
+          next if spr.nil? || (foe && foe.out_of_play?)
+          bmp = spr.bitmap
+          next unless bmp
+          out << @map.anim_target(spr.x + bmp.width / 2, spr.y + bmp.height / 2,
+                                  height: bmp.height, index: i, flash_target: nil)
+        end
+        out
       end
 
       # Close out an animated round: clear the commands, drop the action banner,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5510,10 +5510,12 @@ class RPG2k
         if hold && hold > 0
           ma[:target_flash_hold] = hold - 1
         else
-          if ma[:battle]
-            @battle.clear_target_flash(ma[:target_index])
-          else
-            clear_map_target_flash(ma[:flash_target])
+          (ma[:targets] || []).each do |tgt|
+            if ma[:battle]
+              @battle.clear_target_flash(tgt[:index]) if tgt[:index]
+            else
+              clear_map_target_flash(tgt[:flash_target])
+            end
           end
         end
       end
@@ -5572,8 +5574,9 @@ class RPG2k
         # (see ANIM_MAP_TARGET_HEIGHT's own comment for why this is 24, not
         # the CharSet frame's actual 32px), so the sprite bounding box is
         # known without asking what kind of character this actually is.
-        build_animation(req[:animation], tx, ty, target_height: ANIM_MAP_TARGET_HEIGHT,
-                         flash_target: map_animation_flash_target(req[:target]))
+        target = anim_target(tx, ty, height: ANIM_MAP_TARGET_HEIGHT, index: nil,
+                             flash_target: map_animation_flash_target(req[:target]))
+        build_animation(req[:animation], [target], false)
       end
 
       # The character a map-triggered flash_scope-1 timing (see
@@ -5598,17 +5601,28 @@ class RPG2k
         end
       end
 
+      # One target descriptor for #build_animation's `targets` array: `tx`/`ty`
+      # the centre pixel the animation is drawn over, `height` the target
+      # sprite's own pixel height (for #animation_position_offset -- nil when
+      # there is no real sprite to measure, e.g. the ally-side screen-centre
+      # fallback), `index` the enemy-sprite index to flash/shake in a fight
+      # (nil for an ally / map target, which has no battle-sprite to pulse),
+      # and `flash_target` the map-character (player/event/vehicle) a
+      # flash_scope-1 timing pulses on the map path.
+      def anim_target(tx, ty, height:, index:, flash_target:)
+        { tx: tx, ty: ty, height: height, index: index, flash_target: flash_target }
+      end
+
       # The animation player itself, shared by the map's Show Battle Animation
       # command and by a battle round. `battle` says the pixel is already a
       # screen position rather than a map one, and that nothing is waiting on the
-      # animation to finish. `target_height` is the target sprite's own pixel
-      # height, when known (see #animation_position_offset) -- nil when there is
-      # no real sprite to measure (the ally-side "middle of the screen"
-      # fallback), which leaves every position setting drawing at the plain
-      # centre pixel, same as before this field existed. nil when the animation
-      # is unknown or its Battle/<name> sheet is missing.
-      def build_animation(id, tx, ty, battle = false, target_index: nil, target_height: nil,
-                          flash_target: nil)
+      # animation to finish. `targets` is an array of #anim_target descriptors
+      # -- usually one (the animation plays over a single character), but a
+      # whole-side battle animation (target < 0, EasyRPG's own
+      # `Game_Interpreter_Battle::CommandShowBattleAnimation`) passes every
+      # living ally or enemy at once, and the player draws each one in turn.
+      # nil when the animation is unknown or its Battle/<name> sheet is missing.
+      def build_animation(id, targets, battle = false, position: nil)
         anim = animation_row(id)
         return nil unless anim
         frames = table_entries(anim.frames)
@@ -5616,9 +5630,8 @@ class RPG2k
         sheet = animation_sheet(anim.animation_name)
         return nil unless sheet
         { frames: frames, timings: table_entries(anim.timings), sheet: sheet,
-          position: (anim.position || 1), tx: tx, ty: ty, frame_i: 0,
-          timer: ANIM_CELL_FRAMES, battle: battle, target_index: target_index,
-          target_height: target_height, flash_target: flash_target }
+          position: (position || anim.position || 1), frame_i: 0,
+          timer: ANIM_CELL_FRAMES, battle: battle, targets: targets }
       end
 
       # The single choke point every battle-animation lookup goes through: a
@@ -5727,9 +5740,13 @@ class RPG2k
             ma[:screen_flash_hold] = ANIM_FLASH_FRAMES
           when 1
             if ma[:battle]
-              @battle.fire_target_flash(ma[:target_index], t)
+              (ma[:targets] || []).each do |tgt|
+                @battle.fire_target_flash(tgt[:index], t) if tgt[:index]
+              end
             else
-              fire_map_target_flash(ma[:flash_target], t)
+              (ma[:targets] || []).each do |tgt|
+                fire_map_target_flash(tgt[:flash_target], t)
+              end
             end
             # #hold_animation_target_flash keeps re-asserting this fire (and,
             # once it lapses, forcibly clearing the target's flash outright)
@@ -5752,7 +5769,11 @@ class RPG2k
             # Animation path) is a genuine empty no-op in EasyRPG's real
             # source, not a dropped feature -- so this only ever fires in
             # battle, matching #fire_target_shake's own battle-only scope.
-            @battle.fire_target_shake(ma[:target_index]) if ma[:battle]
+            if ma[:battle]
+              (ma[:targets] || []).each do |tgt|
+                @battle.fire_target_shake(tgt[:index]) if tgt[:index]
+              end
+            end
           end
         end
       end
@@ -5833,13 +5854,17 @@ class RPG2k
         frame = ma[:frames][ma[:frame_i]]
         return unless frame
         # A map animation is placed in map pixels and follows the camera; a
-        # battle one is already where it belongs on screen.
-        cx = ma[:battle] ? ma[:tx] : ma[:tx] - cam_x + TILE / 2
-        cy = (ma[:battle] ? ma[:ty] : ma[:ty] - cam_y + TILE / 2) +
-             animation_position_offset(ma)
-        table_entries(frame.cells).each do |cell|
-          next if cell.respond_to?(:visible) && cell.visible == false
-          blit_animation_cell(ma[:sheet], cell, cx, cy)
+        # battle one is already where it belongs on screen. A whole-side
+        # animation carries several target descriptors, so the frame is drawn
+        # over each in turn.
+        (ma[:targets] || []).each do |tgt|
+          cx = ma[:battle] ? tgt[:tx] : tgt[:tx] - cam_x + TILE / 2
+          cy = (ma[:battle] ? tgt[:ty] : tgt[:ty] - cam_y + TILE / 2) +
+               animation_position_offset(tgt, ma[:position])
+          table_entries(frame.cells).each do |cell|
+            next if cell.respond_to?(:visible) && cell.visible == false
+            blit_animation_cell(ma[:sheet], cell, cx, cy)
+          end
         end
       end
 
@@ -5861,10 +5886,10 @@ class RPG2k
       # RPG_RT itself draws at is still approximate pending a wine diff, the
       # same status the message window's own relocation zone boundary has
       # above.
-      def animation_position_offset(ma)
-        h = ma[:target_height]
+      def animation_position_offset(tgt, position)
+        h = tgt[:height]
         return 0 unless h
-        case ma[:position]
+        case position
         when 0 then -(h / 2) # head: half the sprite's height above centre
         when 2 then h / 2    # feet: half the sprite's height below centre
         else 0
@@ -7246,7 +7271,7 @@ class RPG2k
       # cross-object call -- only reaches a public method.
       public :play_battle_bgm, :play_victory_bgm, :restore_pre_battle_bgm,
              :terrain_backdrop, :map_properties, :perform_game_over,
-             :try_open_debug_menu, :build_animation, :drive_map_animation,
+              :try_open_debug_menu, :build_animation, :anim_target, :drive_map_animation,
              :fire_animation_flashes, :frames_from_tenths, :load_face_bitmap,
              :step_map_animation, :close_battle
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7625,9 +7625,9 @@ check "Show Battle Animation targeting a vehicle uses the vehicle's own live pos
     anim = scene.instance_variable_get(:@map_animation)
     break if anim || st.switches[6]
   end
-  ok anim, 'the animation actually started'
-  eq [5 * tile, 7 * tile], [anim[:tx], anim[:ty]],
-     "targeted the boat's own live position, not the player's or the event's"
+   ok anim, 'the animation actually started'
+   eq [5 * tile, 7 * tile], [anim[:targets][0][:tx], anim[:targets][0][:ty]],
+      "targeted the boat's own live position, not the player's or the event's"
 end
 
 # A map-triggered Show Battle Animation's target is always drawn from a
@@ -7654,10 +7654,10 @@ check "a map-triggered Show Battle Animation carries RPG_RT's own 24px map-targe
     anim = scene.instance_variable_get(:@map_animation)
     break if anim
   end
-  ok anim, 'the animation actually started'
-  eq RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT, anim[:target_height],
-     "RPG_RT's own hardcoded 24px map-target height, not the CharSet frame's 32px " \
-     'or the battle-only nil fallback'
+   ok anim, 'the animation actually started'
+   eq RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT, anim[:targets][0][:height],
+      "RPG_RT's own hardcoded 24px map-target height, not the CharSet frame's 32px " \
+      'or the battle-only nil fallback'
 end
 
 # A map-triggered Show Battle Animation's flash_scope-1 timing used to be
@@ -11306,8 +11306,8 @@ check "a battle page's Show Battle Animation draws over the targeted troop membe
   ok ma_seen[:battle], 'positioned in screen space, like a battle-round animation'
   ui = battle_ui(scene)
   spr = ui[:enemy_sprites][1]
-  eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
-     [ma_seen[:tx], ma_seen[:ty]], "centred on troop member 1's sprite, the command's own target param"
+   eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
+      [ma_seen[:targets][0][:tx], ma_seen[:targets][0][:ty]], "centred on troop member 1's sprite, the command's own target param"
   ok st.switches[22], 'and the page still ran on once it finished'
 end
 
@@ -11362,11 +11362,67 @@ check "a battle page's Show Battle Animation targets the party, not a troop memb
     end
     break if st.switches[24]
   end
+   ok ma_seen, 'the request was recorded as a live animation, not silently dropped'
+   eq [RPG2k::WIDTH / 2, RPG2k::HEIGHT / 2], [ma_seen[:targets][0][:tx], ma_seen[:targets][0][:ty]],
+      'the ally-side screen-centre fallback, not any enemy sprite position'
+   ok !ma_seen[:targets][0][:index], 'no enemy troop-member index -- an ally target has no on-screen sprite'
+   ok st.switches[24], 'and the page still ran on once it finished'
+end
+
+check "a battle page's Show Battle Animation with target -1 plays over every living enemy (the whole-side case)" do
+  ic = Game::Interpreter::Cmd
+  # anim 9 carries a flash_scope-1 ("target") timing on frame 0 (see fake_db),
+  # so each enemy sprite should be pulsed by the whole-side play.
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [9, -1, 1], indent: 0), # anim 9, whole side, wait
+                           ECmd.new(ic::CONTROL_SWITCHES, [0, 25, 25, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages)
+  ma_seen = nil
+  flashed = {}
+  150.times do
+    scene.update
+    ui = battle_ui(scene)
+    ma = scene.instance_variable_get(:@map_animation)
+    ma_seen ||= ma
+    if ui && ui[:enemy_sprites]
+      ui[:enemy_sprites].each_with_index { |s, i| flashed[i] = true if s && s.flash_color }
+    end
+    break if st.switches[25]
+  end
   ok ma_seen, 'the request was recorded as a live animation, not silently dropped'
-  eq [RPG2k::WIDTH / 2, RPG2k::HEIGHT / 2], [ma_seen[:tx], ma_seen[:ty]],
+  ui = battle_ui(scene)
+  living = ui[:enemy_sprites].reject(&:nil?)
+  eq living.size, ma_seen[:targets].size, 'one target descriptor per living enemy sprite'
+  ma_seen[:targets].each { |t| ok !t[:index].nil?, 'each whole-side target names a troop-member sprite index' }
+  living.each_index { |i| ok flashed[i], "enemy #{i} was flashed by the flash_scope-1 timing" }
+  ok !st.screen.flashing?, 'a flash_scope-1 timing never touches the screen flash'
+  ok st.switches[25], 'and the page still ran on once it finished'
+end
+
+check "a battle page's Show Battle Animation with target -1 and the ally flag plays a single screen-centre animation" do
+  ic = Game::Interpreter::Cmd
+  # RPG2000's front-view battle draws no ally sprite, so an ally whole-side
+  # animation collapses to the same single screen-centre fallback a single
+  # ally target already uses -- no enemy sprite is ever flashed.
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [9, -1, 1, 1], indent: 0), # anim 9, whole side, wait, allies=1
+                           ECmd.new(ic::CONTROL_SWITCHES, [0, 26, 26, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages, party: BattleStubParty.new(rpg2003: true))
+  ma_seen = nil
+  150.times do
+    scene.update
+    ma = scene.instance_variable_get(:@map_animation)
+    ma_seen ||= ma
+    ui = battle_ui(scene)
+    if ui && ui[:enemy_sprites]
+      ui[:enemy_sprites].each { |s| ok !s.flash_color, 'no enemy sprite flashed -- the ally whole-side targets none' }
+    end
+    break if st.switches[26]
+  end
+  ok ma_seen, 'the request was recorded as a live animation, not silently dropped'
+  eq 1, ma_seen[:targets].size, 'a single target, not one per ally'
+  eq [RPG2k::WIDTH / 2, RPG2k::HEIGHT / 2], [ma_seen[:targets][0][:tx], ma_seen[:targets][0][:ty]],
      'the ally-side screen-centre fallback, not any enemy sprite position'
-  ok !ma_seen[:target_index], 'no enemy troop-member index -- an ally target has no on-screen sprite'
-  ok st.switches[24], 'and the page still ran on once it finished'
+  ok ma_seen[:targets][0][:index].nil?, 'no enemy troop-member index -- an ally target has no on-screen sprite'
+  ok st.switches[26], 'and the page still ran on once it finished'
 end
 
 check 'a battle page shows its message in a battle panel and waits for a key' do
@@ -11804,8 +11860,8 @@ check 'a skill that names an animation plays it over the targeted enemy' do
   ok ma, 'the player was armed'
   ok ma[:battle], 'and flagged as a battle animation'
   spr = ui[:enemy_sprites][0]
-  eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
-     [ma[:tx], ma[:ty]], 'centred on the enemy sprite'
+   eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
+      [ma[:targets][0][:tx], ma[:targets][0][:ty]], 'centred on the enemy sprite'
 end
 
 # flash_scope 1 ("target") -- previously dropped outright, since
@@ -11821,7 +11877,9 @@ check 'a target-scope animation flash pulses the hit enemy, not the screen or a 
   bystander = ui[:enemy_sprites][1]
   timing = OpenStruct.new(frame: 0, flash_scope: 1, flash_red: 31, flash_green: 0,
                           flash_blue: 0, flash_power: 20)
-  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: 0,
+         targets: [{ index: 0, flash_target: nil, tx: 0, ty: 0, height: nil }],
+         timings: [timing] }
   scene.send(:fire_animation_flashes, ma)
   ok spr.flash_color, 'the targeted enemy sprite was flashed'
   eq [248, 0, 0, 160],
@@ -11851,7 +11909,9 @@ check 'a screen-scope animation shake triggers the same Game::Screen#shake state
   st = scene.instance_variable_get(:@state)
   ok !st.screen.shaking?, 'not shaking to start with'
   timing = OpenStruct.new(frame: 0, screen_shaking: 2)
-  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: 0,
+         targets: [{ index: 0, flash_target: nil, tx: 0, ty: 0, height: nil }],
+         timings: [timing] }
   scene.send(:fire_animation_flashes, ma)
   ok st.screen.shaking?, 'the screen shake started'
   RPG2k::Scene::Map::ANIM_SHAKE_FRAMES.times { st.screen.update }
@@ -11866,7 +11926,9 @@ check 'a screen_shaking-0 (default) timing triggers no shake' do
   scene, = battle_at_command
   st = scene.instance_variable_get(:@state)
   timing = OpenStruct.new(frame: 0, flash_scope: 0, screen_shaking: 0)
-  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: 0,
+         targets: [{ index: 0, flash_target: nil, tx: 0, ty: 0, height: nil }],
+         timings: [timing] }
   scene.send(:fire_animation_flashes, ma)
   ok !st.screen.shaking?, 'screen_shaking 0 (the schema default) never touches the screen shake'
 end
@@ -11885,7 +11947,9 @@ check 'a target-scope animation shake jitters the hit enemy sprite, not a bystan
   base_x = spr.x
   bystander_x = bystander.x
   timing = OpenStruct.new(frame: 0, screen_shaking: 1)
-  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: 0,
+         targets: [{ index: 0, flash_target: nil, tx: 0, ty: 0, height: nil }],
+         timings: [timing] }
   scene.send(:fire_animation_flashes, ma)
   moved = false
   RPG2k::Scene::Map::ANIM_SHAKE_FRAMES.times do
@@ -11907,7 +11971,9 @@ end
 check 'a target-scope shake with no resolvable target sprite is a silent no-op' do
   scene, = battle_at_command
   timing = OpenStruct.new(frame: 0, screen_shaking: 1)
-  ma = { frame_i: 0, battle: true, target_index: nil, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: nil,
+         targets: [{ index: nil, flash_target: nil, tx: 0, ty: 0, height: nil }],
+         timings: [timing] }
   scene.send(:fire_animation_flashes, ma) # must not raise
   ok true, 'no exception targeting nothing'
 end
@@ -11950,7 +12016,9 @@ check 'a target-scope flash with no resolvable target sprite is a silent no-op' 
   scene, = battle_at_command
   timing = OpenStruct.new(frame: 0, flash_scope: 1, flash_red: 31, flash_green: 0,
                           flash_blue: 0, flash_power: 20)
-  ma = { frame_i: 0, battle: true, target_index: nil, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: nil,
+         targets: [{ index: nil, flash_target: nil, tx: 0, ty: 0, height: nil }],
+         timings: [timing] }
   scene.send(:fire_animation_flashes, ma) # must not raise
   ok true, 'no exception targeting nothing'
 end
@@ -11971,7 +12039,9 @@ check 'a Character Flash concurrent with a battle-round animation on the same en
   spr.flash(Color.new(200, 0, 0, 200), 60)
   bystander.flash(Color.new(0, 200, 0, 200), 60)
   ok spr.flash_color && bystander.flash_color, 'both unrelated flashes are in flight to start with'
-  ma = { frame_i: 0, battle: true, target_index: 0, timings: [] } # no target_flash_hold armed
+  ma = { frame_i: 0, battle: true, target_index: 0,
+         targets: [{ index: 0, flash_target: nil, tx: 0, ty: 0, height: nil }],
+         timings: [] } # no target_flash_hold armed
   scene.send(:hold_animation_target_flash, ma)
   eq nil, spr.flash_color, "the animation's own target sprite had its unrelated flash stomped to nothing"
   ok bystander.flash_color, 'the untargeted bystander sprite is untouched'
@@ -12037,8 +12107,8 @@ check 'an action on a party member plays over the middle of the screen' do
             skill_id: 8, target_index: nil, target_ally: true }
   ok scene.instance_variable_get(:@battle).send(:start_battle_animation, entry)
   ma = scene.instance_variable_get(:@map_animation)
-  eq [RPG2k::Scene::Map::SCREEN_W / 2, RPG2k::Scene::Map::SCREEN_H / 2],
-     [ma[:tx], ma[:ty]]
+   eq [RPG2k::Scene::Map::SCREEN_W / 2, RPG2k::Scene::Map::SCREEN_H / 2],
+      [ma[:targets][0][:tx], ma[:targets][0][:ty]]
 end
 
 check 'the round waits for the animation instead of the banner timer' do
@@ -12105,8 +12175,8 @@ check 'a plain attack with a resolved weapon animation plays it over the targete
   ma = scene.instance_variable_get(:@map_animation)
   ok ma, 'the player was armed'
   spr = ui[:enemy_sprites][0]
-  eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
-     [ma[:tx], ma[:ty]], 'centred on the targeted enemy sprite, same as a skill/item animation'
+   eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
+      [ma[:targets][0][:tx], ma[:targets][0][:ty]], 'centred on the targeted enemy sprite, same as a skill/item animation'
 end
 
 check 'a plain attack with nothing resolved plays no animation' do
@@ -12129,8 +12199,8 @@ check 'the battle animation draws in screen pixels, not map ones' do
   scene.send(:draw_map_animation, 500, 400)
   ok !bmp.blt_calls.empty?, 'a cell was laid down'
   call = bmp.blt_calls.first
-  eq [ma[:tx] - 48, ma[:ty] - 48], [call[0], call[1]],
-     'placed from the target pixel itself, ignoring the camera'
+   eq [ma[:targets][0][:tx] - 48, ma[:targets][0][:ty] - 48], [call[0], call[1]],
+      'placed from the target pixel itself, ignoring the camera'
 end
 
 # The battle_anime row's own `position` field (0 head / 1 center / 2 feet,
@@ -12144,21 +12214,21 @@ end
 # exact old behaviour).
 check 'animation_position_offset splits head/center/feet around the target sprite' do
   scene, = battle_at_command
-  eq 0, scene.send(:animation_position_offset, { position: 1, target_height: 32 }),
+  eq 0, scene.send(:animation_position_offset, { height: 32 }, 1),
      'center is the plain centre pixel, unmoved'
-  eq(-16, scene.send(:animation_position_offset, { position: 0, target_height: 32 }),
+  eq(-16, scene.send(:animation_position_offset, { height: 32 }, 0),
      'head rises half the sprite height above centre')
-  eq 16, scene.send(:animation_position_offset, { position: 2, target_height: 32 }),
+  eq 16, scene.send(:animation_position_offset, { height: 32 }, 2),
      'feet sink half the sprite height below centre'
-  eq 0, scene.send(:animation_position_offset, { position: 0, target_height: nil }),
+  eq 0, scene.send(:animation_position_offset, { height: nil }, 0),
      'no known height (the ally-side screen-centre fallback) is never offset'
   # The real map-target value every #start_map_animation caller actually
   # hands this (ANIM_MAP_TARGET_HEIGHT, 24 -- RPG_RT's own hardcoded
   # constant, not the 32px CharSet frame), split at its own halves.
   eq(-12, scene.send(:animation_position_offset,
-                     { position: 0, target_height: RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT }))
+                     { height: RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT }, 0))
   eq 12, scene.send(:animation_position_offset,
-                    { position: 2, target_height: RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT })
+                    { height: RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT }, 2)
 end
 
 check 'a head/feet Show Battle Animation position offsets where it draws over the enemy sprite' do
@@ -12168,29 +12238,29 @@ check 'a head/feet Show Battle Animation position offsets where it draws over th
                skill_id: 8, target_index: 0, target_ally: false })
   ma = scene.instance_variable_get(:@map_animation)
   bmp = scene.instance_variable_get(:@animation_bmp)
-  ok ma[:target_height], 'start_battle_animation carried the enemy sprite\'s real height through'
-  half_height = ma[:target_height] / 2
+   ok ma[:targets][0][:height], 'start_battle_animation carried the enemy sprite\'s real height through'
+   half_height = ma[:targets][0][:height] / 2
 
-  ma[:position] = 0
-  bmp.clear_blt_calls
-  scene.send(:draw_map_animation, 500, 400)
-  call = bmp.blt_calls.first
-  eq [ma[:tx] - 48, ma[:ty] - 48 - half_height], [call[0], call[1]],
-     'position 0 (head) draws half the sprite height above the plain centre'
+   ma[:position] = 0
+   bmp.clear_blt_calls
+   scene.send(:draw_map_animation, 500, 400)
+   call = bmp.blt_calls.first
+   eq [ma[:targets][0][:tx] - 48, ma[:targets][0][:ty] - 48 - half_height], [call[0], call[1]],
+      'position 0 (head) draws half the sprite height above the plain centre'
 
-  ma[:position] = 2
-  bmp.clear_blt_calls
-  scene.send(:draw_map_animation, 500, 400)
-  call = bmp.blt_calls.first
-  eq [ma[:tx] - 48, ma[:ty] - 48 + half_height], [call[0], call[1]],
-     'position 2 (feet) draws half the sprite height below the plain centre'
+   ma[:position] = 2
+   bmp.clear_blt_calls
+   scene.send(:draw_map_animation, 500, 400)
+   call = bmp.blt_calls.first
+   eq [ma[:targets][0][:tx] - 48, ma[:targets][0][:ty] - 48 + half_height], [call[0], call[1]],
+      'position 2 (feet) draws half the sprite height below the plain centre'
 
-  ma[:position] = 1
-  bmp.clear_blt_calls
-  scene.send(:draw_map_animation, 500, 400)
-  call = bmp.blt_calls.first
-  eq [ma[:tx] - 48, ma[:ty] - 48], [call[0], call[1]],
-     'position 1 (center), the schema default, is unchanged from the plain centre pixel'
+   ma[:position] = 1
+   bmp.clear_blt_calls
+   scene.send(:draw_map_animation, 500, 400)
+   call = bmp.blt_calls.first
+   eq [ma[:targets][0][:tx] - 48, ma[:targets][0][:ty] - 48], [call[0], call[1]],
+      'position 1 (center), the schema default, is unchanged from the plain centre pixel'
 end
 
 # An RPG2000 animation sheet is a grid of 96x96 cells whose whole background is
@@ -12254,8 +12324,8 @@ check 'a battle animation cell blits at its own transparency' do
   scene.send(:draw_map_animation, 500, 400)
   eq 1, bmp.blt_calls.size, 'still one cell'
   eq 102, bmp.blt_calls.first[4], '60% transparent blits at 255 * 40 / 100'
-  eq [ma[:tx] - 48, ma[:ty] - 48], bmp.blt_calls.first[0, 2],
-     'and lands in exactly the same place -- opacity is the only thing that changed'
+   eq [ma[:targets][0][:tx] - 48, ma[:targets][0][:ty] - 48], bmp.blt_calls.first[0, 2],
+      'and lands in exactly the same place -- opacity is the only thing that changed'
 
   cell.transparency = 100
   bmp.clear_blt_calls


### PR DESCRIPTION
Generalize the animation player from a single target_index to a targets array so a battle-page Show Battle Animation with target < 0 (EasyRPG's "whole side" sentinel) plays one animation over every living troop member at once. Scene::Battle#whole_side_anim_targets skips hidden / out-of-play members; an ally-flagged whole side collapses to the screen-centre fallback since RPG2000's front view draws no ally sprites.