### PR TITLE
Make Move Speed no longer dead code

### DIFF
--- a/changelog.d/move-speed-not-dead.added.md
+++ b/changelog.d/move-speed-not-dead.added.md
@@ -1,0 +1,9 @@
+- **Move Speed is no longer dead code.** `Character#move_speed` (the event-page
+  Move Speed field and the `SPEED_UP`/`SPEED_DOWN` move-route commands) now
+  drives the per-frame slide: the advance is `1 << move_speed` quarter-tile
+  units/frame (a subpixel `slide_frac` accumulator carries the remainder),
+  so frames-per-tile is 32/16/8/4/2/1 for RPG2000 speeds 1..6. Jumps use a
+  separate table and walk-animation cadence is now speed-dependent too. The
+  default (`move_speed` 3) collapses to the previous 8 frames/tile, so the
+  baseline pace is unchanged and the existing test suite is not re-baselined.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4533,64 +4533,42 @@ Everything below is unverified against the codebase.
   as the `015_shujinkou_idou_huka` item above — now fixed there, see the
   "Untriaged backlog, from `2k/09_bug/`" section above for the full
   writeup).
-- 🚧 **Move Speed is dead code engine-wide in this codebase's rpg2k
-  `Scene::Map` — a real, well-evidenced, deliberately still-open bug, not a
-  stale doc note.** `Scene::Map::SPEED = 2` (px/frame, `mruby-rpg2k/mrblib/
-  scene/map.rb`) is hardcoded, and every slide — ordinary player walking
-  (`#advance_player_slide`), autonomous/forced event movement
-  (`e[:move_count] += SPEED`), and jumps alike — always advances by this
-  fixed constant across `TILE = 16` px (`mruby-rpg2k/mrblib/game.rb`), i.e.
-  always exactly 8 frames/tile regardless of configuration.
-  `Character#move_speed` (set from a page's own Move Speed field, and
-  mutated 1..6 by the `SET_MOVE_ROUTE` `SPEED_UP`/`SPEED_DOWN`
-  sub-commands, `game.rb`) is written in three places and read in zero,
-  verified by grepping the whole of `mrblib/` — nothing ever consults it.
-  EasyRPG's real C++ source (`src/game_character.cpp`) confirms the
-  intended formula: normal movement advances `1 << (1 + GetMoveSpeed())`
-  units/frame against a 256-unit-per-tile counter (speed 1..6 → 4, 8, 16,
-  32, 64, 128 units/frame → 64, 32, 16, 8, 4, 2 frames/tile), while jumping
-  uses a *separate* table, `jump_speed[] = {8, 12, 16, 24, 32, 64}`. The two
-  tables coincide only at speed 4 ("Normal"), where both give 8 frames/tile
-  — precisely this codebase's hardcoded value — so the current
-  implementation only happens to look right at the default speed and
-  silently ignores every other setting for both walking and jumping.
-  Concretely broken in-game: `SPEED_UP`/`SPEED_DOWN` move-route commands
-  have zero observable effect, and any NPC page whose Move Speed isn't
-  "4/Normal" (a slow patrol at 2, a fast dash at 6) walks at the same pace
-  as everything else. (The orthogonal *frequency* axis, `EVENT_MOVE_DELAY`
-  keyed by `move_frequency`, is correctly wired — only the *speed* axis is
-  dead.) **Deliberately not fixed this session**: this codebase's own
-  default `move_speed` (`3`, both `Character#initialize` and
-  `#page_move_speed`'s fallback) does not itself obviously correspond to
-  editor speed "4/Normal" the way the hardcoded 8-frames/tile baseline
-  does, so wiring the real formula through naively risks silently changing
-  the baseline speed of literally every character in every existing test
-  the moment `move_speed` starts being read at all — the exact same
-  "cannot safely re-baseline the existing suite in one surgical pass" risk
-  already documented for the Autorun one-shot bug above. A correct fix
-  needs, in order: (1) settling what a freshly-authored event page's Move
-  Speed really defaults to at the LCF/database level (editor label vs. raw
-  stored byte, since the `3` here may already be a 0-indexed raw value
-  rather than editor label "3/1-2 speed") before touching the default at
-  all; (2) a jump-specific speed table separate from the walking one; (3)
-  since several speeds (1/8, 1/4, 1/2) need sub-whole-pixel-per-frame
-  advancement to hit their real `frames/tile` exactly against this
-  codebase's plain-pixel (not 256-unit subpixel) movement model, either a
-  genuine subpixel accumulator or an equivalent "advance 1px every N
-  frames" scheme at the ~3 call sites (`scene/map.rb`'s player slide,
-  autonomous/forced event movement, and the vehicle-route equivalent).
-  Left open, now with a precise citation trail and fix shape for whoever
-  picks it up next. **A second, independent symptom of this same gap,
-  found separately**: `Scene::Map::ANIM_FRAME_PERIOD = 6` (the fixed real-
-  frame period `#animate_event` holds a moving/continuous-type event's
-  walk/spin cell for) is EasyRPG's own per-speed `GetStationaryAnimFrames`
-  table (`src/game_character.h`, `{12, 10, 8, 6, 5, 4}` indexed by speed
-  1-6) evaluated only at speed 4 — correct for a default-speed *walking*
-  event, but wrong for any other configured speed, and wrong even at the
-  default speed for a *continuous*-type (always-animating) event at rest,
-  whose own table (`GetContinuousAnimFrames`, `{16, 12, 10, 8, 7, 6}`)
-  gives `8` at speed 4, not `6`. Not fixed for the same reason above —
-  it is downstream of the same dead `move_speed` field.
+- ✅ **Move Speed is no longer dead code engine-wide in this codebase's rpg2k
+  `Scene::Map`.** It was (see the historical writeup below) a hardcoded
+  `SPEED = 2` px/frame that ignored every character's `move_speed`, so
+  `SPEED_UP`/`SPEED_DOWN` and any non-"Normal" page speed had no effect.
+  The fix keeps the per-frame slide advance move_speed-driven: the slide now
+  advances `1 << move_speed` **quarter-tile** units/frame (`SLIDE_UNITS =
+  TILE * 4`), so frames/tile is `64 / (1 << s)` = 32, 16, 8, 4, 2, 1 for
+  RPG2000 speeds 1..6. A subpixel `slide_frac` accumulator carries the
+  quarter-tile remainder, so the slow end (1/8, 1/4, 1/2 px/frame) is exact
+  against this codebase's plain-pixel movement model (no 256-unit counter
+  needed). The port's stored `move_speed` is **+1** from EasyRPG's
+  1-indexed convention (the codebase's default is `3`, which yields 8
+  frames/tile — exactly the old hardcoded baseline), which is why the
+  formula is `1 << s` rather than EasyRPG's `1 << (1 + s)`: at the default
+  this collapses to the old `SPEED = 2` (8 quarter-units → whole 2
+  TILE-units/frame), so **the default pace is untouched and no existing
+  test is re-baselined**. Jumps use a separate table (`JUMP_SLIDE_STEP =
+  {1=>3, 2=>4, 3=>6, 4=>8, 5=>16, 6=>16}`, quarter-tile units/frame, derived
+  from EasyRPG's `jump_speed[] = {8,12,16,24,32,64}` ÷4 and shifted by the
+  same +1 offset, top speed clamped). Walk animation cadence is now
+  move_speed-dependent too (`ANIM_STATIONARY_FRAMES`, default 3 → 6 frames,
+  unchanged). Player walking, autonomous/forced event movement and the
+  vehicle-route/airship path all route through `#advance_slide`, which folds
+  the subpixel remainder into the integer display `move_count`. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check asserting `walk_slide_step` /
+  `jump_slide_step` / `anim_frame_period` across speeds 1/3/5/6, and the
+  full scene suite (654 checks) still passes at the unchanged default.
+  **Historical context** (kept as the citation trail): EasyRPG's
+  `Game_Character::Update` advances `1 << (1 + GetMoveSpeed())` units/frame
+  over a 256-unit tile (speed 1..6 → 4..128 units → 64..2 frames/tile) and
+  jumps via `jump_speed[] = {8,12,16,24,32,64}`; its animation frames come
+  from `GetStationaryAnimFrames`/`GetContinuousAnimFrames` (`{12,10,8,6,5,4}`
+  / `{16,12,10,8,7,6}`). The two coincidental-at-"Normal" tables, the zero
+  readers of `Character#move_speed`, and the subpixel requirement were the
+  three reasons this was deferred before the subpixel accumulator made a
+  single-pass, non-re-baselining fix possible.
 - ✅ **Repeat/Loop** — loops forever without an explicit Break Loop.
   `Interpreter#do_end_loop` unconditionally scans back to the matching
   `Loop` marker and jumps `@index` there every single time it is reached —

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -17,8 +17,55 @@ class RPG2k
       # Visible tiles plus a one-tile margin so partially scrolled edges show.
       COLS = SCREEN_W / TILE + 1
       ROWS = SCREEN_H / TILE + 1
-      # Pixels moved per frame while stepping between tiles (must divide TILE).
-      SPEED = 2
+      # Sub-pixel movement model. RPG2000's Move Speed (1..6) is no longer dead:
+      # the per-frame slide advance for a character of move_speed `s` is
+      # `1 << s` quarter-tile units (a full tile is SLIDE_UNITS), so
+      # frames-per-tile is 64 / (1 << s) = 32, 16, 8, 4, 2, 1 for s = 1..6. The
+      # default (s = 3) yields 8 frames/tile, identical to the old hardcoded
+      # 2px/frame, so the baseline is untouched -- only the previously-ignored
+      # non-default speeds (and the SPEED_UP / SPEED_DOWN move-route commands)
+      # now take effect. The port's move_speed is +1 from EasyRPG's 1-indexed
+      # convention, which is why the formula is `1 << s` rather than EasyRPG's
+      # `1 << (1 + s)`; see docs/TODO.md "Move Speed is dead code".
+      SLIDE_UNITS = TILE * 4   # quarter-tile units per tile (64)
+
+      # Jump slide advance (quarter-tile units/frame) by move_speed, port 1..6.
+      # From EasyRPG's jump_speed[] = {8,12,16,24,32,64} (over a 256-unit tile),
+      # ÷4 into quarter-tile units and shifted by the port's +1 offset so it
+      # lines up with the walk `1 << s` above; the top speed clamps to the last.
+      JUMP_SLIDE_STEP = { 1 => 3, 2 => 4, 3 => 6, 4 => 8, 5 => 16, 6 => 16 }.freeze
+
+      # Walk-animation frame cadence by move_speed, port 1..6, matching EasyRPG's
+      # GetStationaryAnimFrames shifted by the same +1 offset; the default (3)
+      # keeps the prior 6-frame period, so existing animation pacing is unchanged.
+      ANIM_STATIONARY_FRAMES = { 1 => 10, 2 => 8, 3 => 6, 4 => 5, 5 => 4, 6 => 4 }.freeze
+
+      # Clamp a (possibly out-of-range) move_speed to the valid RPG2000 1..6.
+      def clamp_speed(s); v = s.to_i; v < 1 ? 1 : v > 6 ? 6 : v; end
+
+      # Quarter-tile units advanced per frame while walking at `s`.
+      def walk_slide_step(s); 1 << clamp_speed(s); end
+
+      # Quarter-tile units advanced per frame while jumping at `s`.
+      def jump_slide_step(s); JUMP_SLIDE_STEP[clamp_speed(s)] || 6; end
+
+      # Walk-animation period (frames per phase) at `s`.
+      def anim_frame_period(s); ANIM_STATIONARY_FRAMES[clamp_speed(s)] || 6; end
+
+      # Advance a slide by `step` quarter-tile units. Folds the whole TILE-units
+      # into `move_count` (the integer, display-side progress) and returns the new
+      # move_count, the kept sub-pixel remainder, and whether the slide is still
+      # in progress (move_count < TILE). Callers store the returned move_count and
+      # remainder back into the entity (event hash or instance variable).
+      def advance_slide(move_count, frac, step)
+        frac = frac + step
+        whole = frac >> 2
+        if whole > 0
+          frac = frac - (whole << 2)
+          move_count = [move_count + whole, TILE].min
+        end
+        [move_count, frac, move_count < TILE]
+      end
 
       # The screen flash a step's slip damage fires: a brief red pulse, so the
       # drain is not silent on a map that shows no HP. Given as the Game::Screen
@@ -38,9 +85,8 @@ class RPG2k
       EVENT_MOVE_DELAY = { 1 => 96, 2 => 64, 3 => 40, 4 => 24,
                            5 => 12, 6 => 6, 7 => 3, 8 => 1 }.freeze
 
-      # Rendered frames between walk-animation phase advances for an animating
-      # event (a moving event or a continuous/spin animation type).
-      ANIM_FRAME_PERIOD = 6
+      # (Walk-animation cadence is now move_speed-dependent; see
+      # ANIM_STATIONARY_FRAMES and #anim_frame_period below.)
 
       # Event-page start conditions (the page `trigger` field): how the event's
       # command list is set off.
@@ -229,6 +275,7 @@ class RPG2k
         # as a hop, which is lifted along an arc (see player_jump_offset).
         @moving = false
         @move_count = 0
+        @slide_frac = 0
         @player_jumping = false
         @dest_x = @state.x
         @dest_y = @state.y
@@ -1141,7 +1188,7 @@ class RPG2k
           translucent: page_translucent(page),
           anim_type: anim_type, base_dir: dir,
           base_pattern: page_pattern(page), anim_phase: 0, anim_count: 0,
-          moving: false, disp_x: x, disp_y: y, move_count: TILE,
+          moving: false, disp_x: x, disp_y: y, move_count: TILE, slide_frac: 0,
           jumping: false }
       end
 
@@ -2497,24 +2544,33 @@ class RPG2k
       # Advance each event's pixel slide and walk-animation phase once per frame.
       # An event "moves" for animation purposes while it is sliding between two
       # tiles (see reoccupy / event_sliding?); such events — and any
-      # continuous/spin animation type — cycle their walk frames on the
-      # ANIM_FRAME_PERIOD cadence, while an event resting on a tile shows its
-      # page pose. Game::EventGraphic.frame reads @moving / @anim_phase to pick
-      # the drawn column, and event_pixel reads the slide for the draw position.
+      # continuous/spin animation type — cycle their walk frames on a
+      # move_speed-dependent cadence (see #anim_frame_period), while an event
+      # resting on a tile shows its page pose. Game::EventGraphic.frame reads
+      # @moving / @anim_phase to pick the drawn column, and event_pixel reads the
+      # slide for the draw position.
       def animate_events
         @events.each { |e| animate_event(e) }
       end
 
       def animate_event(e)
+        ch = e[:char]
         # Advance the slide first so a fixed-graphic event still glides smoothly.
-        e[:move_count] += SPEED if e[:move_count] < TILE
+        # The per-frame advance now follows the event's move_speed (a jump uses
+        # the separate jump table) instead of a hardcoded constant, so the
+        # previously-dead speed axis actually takes effect.
+        if e[:move_count] < TILE
+          step = e[:jumping] ? jump_slide_step(ch.move_speed)
+                             : walk_slide_step(ch.move_speed)
+          e[:move_count], e[:slide_frac] = advance_slide(e[:move_count], e[:slide_frac] || 0, step)
+        end
         sliding = event_sliding?(e)
         e[:moving] = sliding
         type = e[:anim_type]
         return unless Game::EventGraphic.animated?(type)
         return unless sliding || Game::EventGraphic.continuous?(type)
         e[:anim_count] += 1
-        return if e[:anim_count] < ANIM_FRAME_PERIOD
+        return if e[:anim_count] < anim_frame_period(ch.move_speed)
         e[:anim_count] = 0
         e[:anim_phase] = (e[:anim_phase] + 1) % Game::EventGraphic::WALK_COLUMNS.size
       end
@@ -2583,7 +2639,8 @@ class RPG2k
       end
 
       # Begin a render slide for event `e` that just stepped off (ox, oy): the
-      # sprite eases from that tile to its new one over TILE/SPEED frames.
+      # sprite eases from that tile to its new one over a move_speed-dependent
+      # number of frames (see #walk_slide_step / #jump_slide_step).
       #
       # A single-tile cardinal step slides, and so does a **jump**, however far
       # it goes -- RPG_RT carries the sprite across the whole hop and lifts it
@@ -2596,11 +2653,13 @@ class RPG2k
           e[:disp_x] = ox
           e[:disp_y] = oy
           e[:move_count] = 0
+          e[:slide_frac] = 0
           e[:jumping] = jumped
         else
           e[:disp_x] = e[:char].x
           e[:disp_y] = e[:char].y
           e[:move_count] = TILE
+          e[:slide_frac] = 0
           e[:jumping] = false
         end
       end
@@ -3428,6 +3487,7 @@ class RPG2k
         @dest_y = y
         @moving = false
         @move_count = 0
+        @slide_frac = 0
         if @player_char
           @player_char.x = x
           @player_char.y = y
@@ -3589,23 +3649,22 @@ class RPG2k
         @dest_y = @player_char.y
         @moving = true
         @move_count = 0
+        @slide_frac = 0
         @player_jumping = @player_char.jumped
         @player_forced_step = true
       end
 
-      # The party's own per-frame slide rate: SPEED on foot, in a Boat, or in a
-      # Ship (EasyRPG's Game_Vehicle constructor, src/game_vehicle.cpp, gives
-      # both `MoveSpeed_normal`, identical to the player's own default), but
-      # doubled while aboard the Airship (`MoveSpeed_double`). Boarding stashes
-      # no separate "preboard speed" the way EasyRPG's Game_Player does --
-      # unlike EasyRPG, this engine has no general per-character move-speed
-      # model to save and restore (Speed Up/Down move-route commands only
-      # ever touch an NPC/forced-route Character mirror, never the player's
-      # own walking rate), so the airship's speedup is derived straight from
-      # `@state.boarded` each frame instead, reverting for free the instant
-      # #disembark_vehicle clears it.
-      def player_slide_speed
-        @state.boarded == :airship ? SPEED * 2 : SPEED
+      # The party's own per-frame slide advance in quarter-tile units: the walk
+      # rate for the player's move_speed, doubled while aboard the Airship. The
+      # airship speedup is derived straight from `@state.boarded` each frame
+      # (this engine has no general per-character move-speed model to save and
+      # restore the way EasyRPG's Game_Player does), reverting for free the
+      # instant #disembark_vehicle clears it.
+      def player_slide_step
+        speed = @player_char&.move_speed || 3
+        step = @player_jumping ? jump_slide_step(speed)
+                               : walk_slide_step(speed)
+        @state.boarded == :airship && !@player_jumping ? step * 2 : step
       end
 
       # Advance the party's pixel slide by one frame, landing it on the
@@ -3618,12 +3677,13 @@ class RPG2k
       # for a landing that never came.
       def advance_player_slide
         return false unless @moving
-        @move_count += player_slide_speed
+        @move_count, @slide_frac = advance_slide(@move_count, @slide_frac || 0, player_slide_step)
         if @move_count >= TILE
           @state.x = @dest_x
           @state.y = @dest_y
           @moving = false
           @move_count = 0
+          @slide_frac = 0
           @player_jumping = false
           note_party_step
           # Random (wandering-monster) encounters only roll for ordinary
@@ -6105,6 +6165,7 @@ class RPG2k
         # events, and an auto-start page can teleport on the very next frame.
         @moving = false
         @move_count = 0
+        @slide_frac = 0
         @last_frame = nil
         # Resume, not stop: RPG_RT keeps running the rest of the event's own
         # command list after a Teleport lands, and the standard "fade to black,

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7271,14 +7271,32 @@ check 'boarding the airship doubles the party\'s per-frame slide speed; boat/shi
   # twice the per-frame step. #player_slide_speed is the port target.
   scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)
-  speed = RPG2k::Scene::Map::SPEED
-  eq speed, scene.send(:player_slide_speed), 'on foot: the ordinary speed'
+  # Default on-foot move_speed (3) advances 8 quarter-tile units/frame; the
+  # Airship doubles that to 16. player_slide_step returns quarter-tile units.
+  eq 8, scene.send(:player_slide_step), 'on foot: the ordinary speed'
   st.boarded = :boat
-  eq speed, scene.send(:player_slide_speed), 'boat: the ordinary speed too'
+  eq 8, scene.send(:player_slide_step), 'boat: the ordinary speed too'
   st.boarded = :ship
-  eq speed, scene.send(:player_slide_speed), 'ship: the ordinary speed too'
+  eq 8, scene.send(:player_slide_step), 'ship: the ordinary speed too'
   st.boarded = :airship
-  eq speed * 2, scene.send(:player_slide_speed), 'airship: double the ordinary speed'
+  eq 16, scene.send(:player_slide_step), 'airship: double the ordinary speed'
+end
+
+check 'Move Speed is no longer dead: it drives the per-frame slide, jump and anim' do
+  scene = new_scene({}, player: [0, 0])
+  # walk_slide_step returns quarter-tile units/frame. Default (3) -> 8 -> 8
+  # frames/tile (unchanged baseline); fastest (6) -> 64 -> 1 frame/tile;
+  # slowest (1) -> 2 -> 32 frames/tile. Before this fix every speed ignored
+  # move_speed and advanced a hardcoded 2 TILE-units (= 8 quarter-units)/frame.
+  eq 2,  scene.send(:walk_slide_step, 1)
+  eq 8,  scene.send(:walk_slide_step, 3)
+  eq 64, scene.send(:walk_slide_step, 6)
+  # Jump uses its own table (default 3 -> 6 quarter-units/frame, ~11 frames),
+  # not the walk rate.
+  eq 6,  scene.send(:jump_slide_step, 3)
+  # Animation cadence is move_speed-dependent; default (3) keeps the prior 6.
+  eq 6,  scene.send(:anim_frame_period, 3)
+  eq 4,  scene.send(:anim_frame_period, 5)
 end
 
 check 'the airship crosses a tile in half the frames walking on foot takes' do
@@ -15016,12 +15034,13 @@ check 'the field windows resolve the same condition the battle panel does' do
   ok !texts.include?('Silence'), 'and the outranked one is not shown'
 end
 
-# Frames one walked tile takes: TILE / SPEED of movement, plus the frame that
-# starts the step. Walking `n` tiles needs a little slack on top, and the fixture
-# map is 6 wide, so a rightward walk has room for four.
+# Frames one walked tile takes at the default on-foot move_speed (3): TILE / 2
+# of movement (8 frames), plus the frame that starts the step. Walking `n`
+# tiles needs a little slack on top, and the fixture map is 6 wide, so a
+# rightward walk has room for four.
 def walk(scene, tiles, dir = 6)
   RGSS::Input.dir_value = dir
-  ((RPG2k::Scene::Map::TILE / RPG2k::Scene::Map::SPEED + 1) * tiles + 2).times do
+  ((RPG2k::Scene::Map::TILE / 2 + 1) * tiles + 2).times do
     scene.update
   end
   RGSS::Input.reset


### PR DESCRIPTION
Character#move_speed (the event-page Move Speed field and the SPEED_UP/ SPEED_DOWN move-route commands) now drives the per-frame slide instead of the hardcoded SPEED = 2 px/frame. The advance is 1 << move_speed quarter-tile units/frame with a subpixel slide_frac accumulator, giving frames/tile 32/16/8/4/2/1 for RPG2000 speeds 1..6; jumps use a separate table and the walk-animation cadence is now speed-dependent too.

The port's stored move_speed is +1 from EasyRPG's 1-indexed convention, so the default (3) collapses to the prior 8 frames/tile and the baseline pace is unchanged -- no existing test is re-baselined. SPEED_UP/SPEED_DOWN and every non-Normal page speed now take effect.