### PR TITLE
Tint the battle backdrop under a Change Screen Tone

### DIFF
--- a/changelog.d/battle-backdrop-tone.fixed.md
+++ b/changelog.d/battle-backdrop-tone.fixed.md
@@ -1,0 +1,9 @@
+- **Battle backdrop now receives Change Screen Tone.** `Scene::Map#update_map_tone`
+  pushes the map layer's tone onto the live battle backdrop (`@battle.apply_backdrop_tone`)
+  every time the tint changes, and `Scene::Battle#build_battle_back` seeds the
+  freshly built sprite from `Scene::Map#current_map_tone`, so a Tint Screen
+  active during a fight tints what is actually on screen instead of only the
+  (hidden) map layer. RPG_RT tints the battle background — confirmed against
+  EasyRPG Player's `Spriteset_Battle::Update` (`background->SetTone(...)`) —
+  so this port now matches. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1524,10 +1524,23 @@ The work below is roughly ordered by the critical path to a walkable game
   below) — with both back on the first frame after `@battle_ui` clears. The
   in-battle Show Battle Animation is deliberately *not* gated with them: it
   renders through `@animation_sprite`, a top-level sprite at z 150 (above the
-  battlers, below the pictures), not through either map viewport. Still open,
-  and a separate question: Change Screen Tone rides on `@map_viewport`'s tone,
-  so it reaches the map and not the backdrop — whether RPG_RT tints the battle
-  background needs a wine diff before anything is changed.
+  battlers, below the pictures), not through either map viewport.
+- ✅ **Change Screen Tone now reaches the battle backdrop too.** The battle
+  backdrop (`Scene::Battle`'s `@ui[:back_sprite]`, a top-level sprite at z 5)
+  rides none of the toned viewports, so a Tint Screen active during a fight
+  reached only the (hidden) map layer and skipped the one element actually on
+  screen. `Scene::Map#update_map_tone` now pushes the same tone it puts on
+  `@map_viewport` onto the live backdrop every time the tint changes
+  (`@battle.apply_backdrop_tone`), and `Scene::Battle#build_battle_back`
+  seeds the freshly built sprite from `Scene::Map#current_map_tone` so a tint
+  already active when the encounter opens is covered too. The open question
+  the old TODO flagged — whether RPG_RT tints the battle background — is
+  answered by EasyRPG Player's own `Spriteset_Battle::Update`, which does
+  `background->SetTone(Main_Data::game_screen->GetTone())`: the battle
+  background is tinted, so this port now matches. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check that drives a Tint Screen through
+  `#update_map_tone` with a fight open and asserts the backdrop tone tracks
+  the map layer (and is left alone once the fight is closed).
   **Enemies now run their 行動パターン** (action pattern, enemy chunk 42) rather
   than only ever attacking — the single biggest silent gap left in the battle
   system, since **510 of the 959 enemy actions across the two test beds are

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -644,7 +644,27 @@ class RPG2k
         spr = Sprite.new
         spr.bitmap = bmp
         spr.z = 5
+        # The map layer the screen tone rides on is hidden for the fight, so
+        # seed the backdrop with the live map tone -- otherwise a Tint Screen
+        # already active when the encounter opened would reach the (hidden)
+        # map and not the one element on screen until the tint next changes.
+        # #update_map_tone keeps it in lockstep thereafter.
+        spr.tone = @map.current_map_tone if @map.respond_to?(:current_map_tone)
         @ui[:back_sprite] = spr
+      end
+
+      # Mirror the map layer's screen tone onto the battle backdrop. The
+      # backdrop is a top-level sprite, not a child of the toned
+      # @map_viewport, so a Change Screen Tone active during a fight would
+      # otherwise only reach the (hidden) map and skip the one element on
+      # screen. RPG_RT tints the battle background under a Tint Screen;
+      # EasyRPG Player's Spriteset_Battle::Update confirms it
+      # (`background->SetTone(game_screen->GetTone())`), so #update_map_tone
+      # calls this whenever the tint changes and #build_battle_back seeds it
+      # on build.
+      def apply_backdrop_tone(tone)
+        spr = @ui[:back_sprite]
+        spr.tone = tone if spr
       end
 
       # The battle backdrop: the Backdrop/<name> image a Change Battle Background

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -876,6 +876,15 @@ class RPG2k
       # other way from RGSS's grey: below 100 is *less* saturated, so a value
       # under neutral becomes positive desaturation. Skipped entirely while the
       # tone is neutral, so an untinted map never pays for it.
+      # The tone currently on the map layer (or nil before the first
+      # #update_map_tone). Exposed so the battle backdrop -- a top-level sprite
+      # outside the toned @map_viewport -- can seed its own tone when it is
+      # built mid-tint (#build_battle_back) and stay in lockstep with the map
+      # layer for the rest of the fight.
+      def current_map_tone
+        @map_viewport&.tone
+      end
+
       def update_map_tone(tint)
         return unless @map_viewport
         r, g, b, sat = tint
@@ -895,6 +904,16 @@ class RPG2k
           @upper_viewport.tone = Tone.new(tr, tg, tb, tsat)
           @upper_viewport.update if @upper_viewport.respond_to?(:update)
         end
+        # The battle backdrop rides none of the toned viewports -- it is a
+        # top-level sprite (Scene::Battle#build_battle_back), so a Tint Screen
+        # active mid-fight would otherwise only reach the (hidden) map layer
+        # and skip the one element actually on screen. RPG_RT tints the battle
+        # background under a Tint Screen; EasyRPG Player confirms it
+        # (Spriteset_Battle::Update does
+        # `background->SetTone(game_screen->GetTone())`), so mirror the map
+        # tone onto the live backdrop. #build_battle_back seeds it on build so
+        # a tint already active when the encounter opens is covered too.
+        @battle.apply_backdrop_tone(Tone.new(tr, tg, tb, tsat)) if @battle
       rescue StandardError => e
         $stderr.puts "[RPG2k] screen tone failed, map drawn untinted: #{e.message}"
         nil

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -129,7 +129,7 @@ module RGSS
   Tone = Struct.new(:red, :green, :blue, :gray)
 
   class Sprite
-    attr_accessor :bitmap, :x, :y, :z, :visible, :opacity, :src_rect
+    attr_accessor :bitmap, :x, :y, :z, :visible, :opacity, :src_rect, :tone
     # Which viewport the sprite was built in, so the tone checks can assert that
     # the map layers share one and the overlays do not.
     attr_reader :viewport
@@ -5253,6 +5253,30 @@ check 'an untinted picture skips the tone pass entirely' do
   scene.update
   eq 0, scene.instance_variable_get(:@picture_tone_cache).size,
      'a neutral tone costs no work'
+end
+
+check 'battle backdrop receives the screen tone under a Tint Screen' do
+  scene = new_scene({})
+  back = RGSS::Sprite.new
+  fake_battle(scene, back_sprite: back)
+  # A non-default tint, applied twice so the "unchanged tint" early-return in
+  # #update_map_tone does not skip the push to the backdrop.
+  tint = [120, 80, 100, 100]
+  scene.send(:update_map_tone, tint)
+  scene.send(:update_map_tone, tint)
+  eq scene.send(:current_map_tone), back.tone,
+     'the live battle backdrop carries the map layer tone'
+  # And a mid-fight tint change is tracked onto the backdrop too.
+  tint2 = [80, 120, 100, 100]
+  scene.send(:update_map_tone, tint2)
+  eq scene.send(:current_map_tone), back.tone,
+     'a tint change during the fight re-tints the backdrop'
+  # The push is gated on @battle: with the fight closed, a tint change still
+  # updates the map layer but leaves a (now-detached) backdrop untouched.
+  expected = back.tone
+  scene.instance_variable_set(:@battle, nil)
+  scene.send(:update_map_tone, [100, 100, 100, 100])
+  eq expected, back.tone, 'no fight open means no backdrop re-tint'
 end
 
 check 'a picture saturation below neutral desaturates' do


### PR DESCRIPTION
The battle backdrop (Scene::Battle's @ui[:back_sprite], a top-level sprite at z 5) rides none of the toned viewports, so a Tint Screen active during a fight reached only the (hidden) map layer and skipped the one element actually on screen. Scene::Map#update_map_tone now pushes the same tone it puts on @map_viewport onto the live backdrop every time the tint changes (@battle.apply_backdrop_tone), and Scene::Battle#build_battle_back seeds the freshly built sprite from Scene::Map#current_map_tone, so a tint already active when the encounter opens is covered too.

Whether RPG_RT tints the battle background was the open question the old TODO flagged; EasyRPG Player's Spriteset_Battle::Update settles it -- it does background->SetTone(game_screen->GetTone()) -- so this port now matches. Covered by a new scripts/rpg2k_scene_check.rb check that drives a Tint Screen through #update_map_tone with a fight open and asserts the backdrop tone tracks the map layer (and is left alone once the fight is closed).