### PR TITLE
Menu scene: a use_skill equipment item is now special-cased like a ty…

### DIFF
--- a/changelog.d/menu-use-skill-equipment-item.fixed.md
+++ b/changelog.d/menu-use-skill-equipment-item.fixed.md
@@ -1,0 +1,9 @@
+- **Menu scene:** a `use_skill` equipment item (weapon/shield/armour/helmet/
+  accessory, schema field 71) is now special-cased in the field Item menu the
+  way a type-9 special item already is — a self/all-ally-scope skill casts from
+  the party leader with no target prompt and an Escape/Teleport skill warps
+  straight away, instead of always asking for a target. The warp helpers
+  `Game::Party#use_special_escape_item` / `#use_special_teleport_item` now also
+  accept `use_skill` equipment items (the cast is free and the item, like every
+  equipment type, is not consumed). Covered by new
+  `scripts/rpg2k_scene_check.rb` and `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2376,9 +2376,10 @@ The work below is roughly ordered by the critical path to a walkable game
   the step-count lookup / override / default / disable cases)
 
 #### Menus, save, battle
-- 🚧 Menu scene — opens over the map (cancel button); shows party status and a
+- ✅ Menu scene — opens over the map (cancel button); shows party status and a
   command list. Save, End Game, **Item**, **Skill**, **Equip**, **Status** and
-  **Order** all work.
+  **Order** all work. (The RPG2003 Row and Wait commands stay blocked on the
+  unmodelled RPG2003 battle system; see the body.)
   ✅ **The command list itself now matches the editor that wrote the game**,
   rather than always showing the same fixed six. This line used to claim
   Item/Skill/Equip/Status/Save/End Game was simply "the full main-menu set,"
@@ -2695,13 +2696,25 @@ The work below is roughly ordered by the critical path to a walkable game
   gear (not menu-usable) while the same item flagged `use_skill` behaves
   exactly like an equivalent type-9 special item across all five equipment
   types, and a `class_set`-restricted item triggers for an actor in a listed
-  class but not one outside it. `Scene::ItemMenu#choose_item`'s own dispatch
-  is untouched, so a use_skill equipment item always takes the generic
-  "prompt for a target" branch every other single-ally item takes -- correct
-  for the ordinary case, but not yet special-cased the way a type-9 special
-  item is for a self/all-ally-scope or Escape/Teleport-type attached skill
-  (see the special-item field/battle fixes above); left for whenever such an
-  item shows up in a real game.
+   class but not one outside it. `Scene::ItemMenu#choose_item`'s own dispatch
+   is now special-cased the way a type-9 special item is: `choose_item`
+   routes a `use_skill` equipment item (any of types 1..5 with schema field
+   71 set) through the same branch a special item takes, so a self (2) /
+   all-ally (4) scope skill casts from the party leader with no target prompt
+   and an Escape/Teleport skill warps straight away -- a single-ally scope
+   still prompts for a target, which was already correct. The warp path
+   needed `#use_special_escape_item` / `#use_special_teleport_item`'s own type
+   guard relaxed from `== ITEM_SPECIAL` to also admit a `use_skill`
+   equipment item (the cast is identical -- free, the caster need not know the
+   skill -- and the equipment item is **not** consumed, since RPG_RT returns
+   early from `ConsumeItemUse` on the five equipment types, the same
+   reusable-tool rule `#use_equip_skill_item` already follows). Covered by a
+   new `scripts/rpg2k_scene_check.rb` check (a `use_skill` weapon invoking an
+   all-ally skill is cast by the leader with no prompt) and two new
+   `scripts/rpg2k_logic_check.rb` checks (a `use_skill` equipment item
+   invoking an Escape/Teleport skill warps for free and a plain weapon is
+   never treated as one), confirmed to fail against the pre-fix code. See
+   `changelog.d/menu-use-skill-equipment-item.fixed.md`.
 - 🚧 Save & Continue — the portable `Marshal` save of the game state
   (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
   menu's Save command; "Continue" reloads it. **Reading** the real

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3906,7 +3906,12 @@ module Game
     # consumed, mirroring `Scene::SkillMenu#apply_escape_skill`'s own gate.
     def use_special_escape_item(id, actor, state)
       it = db_item(id)
-      return nil unless it && it.type == ITEM_SPECIAL && actor && item_usable_by?(it, actor.id)
+      # A type-9 special item, or an equipment item flagged `use_skill` (field
+      # 71) invoking an Escape-type skill, both warp free the same way.
+      return nil unless it &&
+                        (it.type == ITEM_SPECIAL ||
+                         (it.use_skill && (1..5).cover?(it.type))) &&
+                        actor && item_usable_by?(it, actor.id)
       target = cast_escape_skill(actor, it.skill_id, state, true)
       return nil unless target
       consume_item_use(id)
@@ -3918,7 +3923,12 @@ module Game
     # which — see `Scene::SkillMenu`'s teleport list, which this mirrors).
     def use_special_teleport_item(id, actor, state, map_id)
       it = db_item(id)
-      return nil unless it && it.type == ITEM_SPECIAL && actor && item_usable_by?(it, actor.id)
+      # A type-9 special item, or an equipment item flagged `use_skill` (field
+      # 71) invoking a Teleport-type skill, both warp free the same way.
+      return nil unless it &&
+                        (it.type == ITEM_SPECIAL ||
+                         (it.use_skill && (1..5).cover?(it.type))) &&
+                        actor && item_usable_by?(it, actor.id)
       target = cast_teleport_skill(actor, it.skill_id, state, map_id, true)
       return nil unless target
       consume_item_use(id)

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -125,7 +125,17 @@ class RPG2k
         # decides the scope — self (2) or all-ally (4) needs no prompt.
         if it && it.type == Game::Party::ITEM_SWITCH
           apply_switch_item(id)
-        elsif it && it.type == Game::Party::ITEM_SPECIAL
+        elsif it && (it.type == Game::Party::ITEM_SPECIAL ||
+                    (it.use_skill && (1..5).cover?(it.type)))
+          # A type-9 special item, or an equipment item flagged `use_skill`
+          # (schema field 71), both invoke the skill named in `skill_id`: the
+          # invoked skill's type/scope decides the dispatch, so a self (2) or
+          # all-ally (4) skill needs no target prompt and an Escape/Teleport
+          # skill warps. Mirrors the special-item path exactly (see the
+          # type-9 fixes above); an equipment item simply reaches the same
+          # `#use_equip_skill_item` / `#use_special_escape_item` /
+          # `#use_special_teleport_item` backing as it already does for an
+          # ordinary targeted cast.
           sk = @state.party.db_skill(it.skill_id)
           if sk && sk.type == Game::Party::SKILL_ESCAPE
             # Escape has one registered target and no picker -- mirroring

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6108,6 +6108,57 @@ check 'a special item invoking a Teleport skill offers every registered ' \
   eq 1, st.party.item_count(4), 'an unregistered destination consumes nothing'
 end
 
+check 'a use_skill equipment item invoking an Escape skill warps for free like a ' \
+      'special item, and a plain weapon does not' do
+  # #use_special_escape_item used to reject anything whose type was not 9
+  # (ITEM_SPECIAL), so an equipment item flagged `use_skill` (field 71) invoking
+  # an Escape skill could never warp through it -- the identical gap the field
+  # Item menu's #choose_item used to have for such an item. The guard now also
+  # admits a use_skill equipment item (types 1..5), matching #use_equip_skill_item.
+  skills = { 6 => fake_skill(name: 'Blade Escape',
+                             type: Game::Party::SKILL_ESCAPE, sp_cost: 4) }
+  items = { 3 => fake_item(type: 1, skill_id: 6, use_skill: true, name: 'Escape Blade') }
+  st = skill_party(skills, items)
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(3, 2)
+  ok !st.party.field_usable?(3, st), 'no access/target yet'
+  st.escape_access = true
+  ok !st.party.field_usable?(3, st), 'access alone is not enough -- no target yet'
+  st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
+  ok st.party.field_usable?(3, st)
+  before = hero.mp
+  eq({ map_id: 3, x: 4, y: 5 }, st.party.use_special_escape_item(3, hero, st))
+  eq before, hero.mp, 'free -- the item pays, not the caster'
+  eq 2, st.party.item_count(3), 'equipment is not consumed -- a reusable tool, like #use_equip_skill_item'
+  # A plain weapon (no use_skill flag) must never be treated as an escape item.
+  plain = { 5 => fake_item(type: 1, skill_id: 6, use_skill: false, name: 'Plain Blade') }
+  st2 = skill_party(skills, plain)
+  st2.escape_access = true
+  st2.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
+  ok !st2.party.field_usable?(5, st2), 'a plain weapon is not menu-usable even matching the skill'
+  ok st2.party.use_special_escape_item(5, st2.party.actor_by_id(1), st2).nil?,
+     'and is not cast as an escape item'
+end
+
+check 'a use_skill equipment item invoking a Teleport skill warps for free like a ' \
+      'special item' do
+  skills = { 7 => fake_skill(name: 'Blade Teleport',
+                             type: Game::Party::SKILL_TELEPORT, sp_cost: 3) }
+  items = { 4 => fake_item(type: 1, skill_id: 7, use_skill: true, name: 'Warp Blade') }
+  st = skill_party(skills, items)
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(4, 1)
+  ok !st.party.field_usable?(4, st), 'no destinations registered yet'
+  st.teleport_access = true
+  st.teleport_targets[10] = { x: 1, y: 2, switch_id: nil }
+  st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
+  ok st.party.field_usable?(4, st), 'access plus any target offers it'
+  before = hero.mp
+  eq({ map_id: 5, x: 8, y: 9 }, st.party.use_special_teleport_item(4, hero, st, 5))
+  eq before, hero.mp, 'free -- no SP spent for an item cast'
+  eq 1, st.party.item_count(4), 'equipment is not consumed -- a reusable tool'
+end
+
 check 'a field heal skill restores HP by the RPG2000 formula and spends SP' do
   # effect = power 20 + physical_rate 0 * atk/20 + magical_rate 40 * spirit 12 /40
   #        = 20 + 0 + 12 = 32

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14251,9 +14251,59 @@ check 'Scene::ItemMenu: an all-ally special item is cast by the party leader, ' 
   scene = menu_scene(RPG2k::Scene::ItemMenu, st)
   RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- no target prompt
   scene.update
-  RGSS::Input.triggered = []
+  RGSS::Input.reset
   eq [[SpecialItemStubParty::SPECIAL_ID, st.party.leader]], st.party.use_item_calls,
      'the party leader casts it, rather than a nil actor #use_special_item rejects outright'
+end
+
+# A party whose only item is an *equipment* item (type 1) flagged `use_skill`
+# (schema field 71) invoking an all-ally scope skill -- the same "item triggers
+# a skill" shape a type-9 special item already gets in #choose_item, just gated
+# on a flag instead of a dedicated type. #choose_item used to send every
+# equipment item (use_skill or not) down the generic "prompt for a target"
+# branch, so a self/all-ally-scope use_skill weapon asked for a target it did
+# not need -- this check pins the now-symmetric dispatch. Game::Party's own
+# decision logic (#field_usable? / #use_equip_skill_item) is covered by
+# scripts/rpg2k_logic_check.rb; the stub only has to hand the scene something
+# that behaves the same way, so this stays about the RGSS wiring.
+class EquipUseSkillItemStubParty < MenuStubParty
+  EQUIP_ID = 60
+
+  attr_reader :use_item_calls
+
+  def initialize
+    super
+    @use_item_calls = []
+  end
+
+  def leader; @actors.first; end
+  def field_items(_state = nil); [[EQUIP_ID, 1]]; end
+
+  def db_item(id)
+    return nil unless id == EQUIP_ID
+    OpenStruct.new(name: 'Holy Blade', type: Game::Actor::ITEM_WEAPON, use_skill: true, skill_id: 95)
+  end
+
+  def db_skill(id)
+    return nil unless id == 95
+    OpenStruct.new(name: 'Bless All', type: 0, scope: 4) # an all-ally skill
+  end
+
+  def use_item(id, actor = nil)
+    @use_item_calls << [id, actor]
+    actor ? [actor] : []
+  end
+end
+
+check 'Scene::ItemMenu: a use_skill equipment item is cast like a special item ' \
+      '(all-ally scope needs no target prompt, leader is the caster)' do
+  st = Game::State.new(EquipUseSkillItemStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::ItemMenu, st)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- no target prompt
+  scene.update
+  RGSS::Input.reset
+  eq [[EquipUseSkillItemStubParty::EQUIP_ID, st.party.leader]], st.party.use_item_calls,
+     'the leader casts it, exactly as a type-9 special item of the same scope would'
 end
 
 # A party whose only item is a special (type 9) one invoking either an Escape


### PR DESCRIPTION
…pe-9 special item

A weapon/shield/armour/helmet/accessory flagged use_skill (schema field 71) used to be sent down Scene::ItemMenu#choose_item's generic 'prompt for a target' branch no matter what skill it invoked, so a self/all-ally-scope skill asked for a target it did not need and an Escape/Teleport skill opened a target prompt instead of warping. #choose_item now routes a use_skill equipment item (any of types 1..5 with the flag) through the same branch a type-9 special item already takes: self (2) / all-ally (4) scope casts from the party leader with no prompt, an Escape/Teleport skill warps straight away, and only a single-ally scope still asks who to use it on.

The warp path needed Game::Party#use_special_escape_item / #use_special_teleport_item's own type guard relaxed from == ITEM_SPECIAL to also admit a use_skill equipment item -- the cast is identical (free, the caster need not know the skill) and the equipment item is not consumed, since RPG_RT returns early from ConsumeItemUse on the five equipment types, the same reusable-tool rule #use_equip_skill_item already follows.

Documented-complete Menu scene TODO (Save/Item/Skill/Equip/Status/Order all work); only RPG2003 Row/Wait stay blocked on the unmodelled battle system.

Covered by a new scripts/rpg2k_scene_check.rb check (a use_skill weapon invoking an all-ally skill is cast by the leader with no prompt) and two new scripts/rpg2k_logic_check.rb checks (a use_skill equipment item invoking an Escape/Teleport skill warps for free, and a plain weapon is never treated as one), confirmed to fail against the pre-fix code.