### PR TITLE
Save & Continue: status panels show max(current, computed_max) for HP/MP

### DIFF
--- a/changelog.d/save-display-max-hp-mp.fixed.md
+++ b/changelog.d/save-display-max-hp-mp.fixed.md
@@ -1,0 +1,9 @@
+- **Save & Continue:** status panels now display `max(current, computed_max)`
+  for HP/MP, so a resumed save whose saved HP/MP exceeds this engine's
+  recomputed growth curve (a genuine RPG_RT save under wine showed 600/600
+  where the curve computes 245/254) reads `600/600` like RPG_RT instead of
+  `600/<smaller max>`. `Game::Actor#display_max_hp` / `#display_max_mp` (and
+  the `Game::Battle::Combatant` twins) provide the ceiling; the genuine
+  recomputed maximum still drives all damage / heal / recalc clamping. The
+  underlying growth-curve discrepancy is left as a separate research question.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2715,9 +2715,11 @@ The work below is roughly ordered by the critical path to a walkable game
    invoking an Escape/Teleport skill warps for free and a plain weapon is
    never treated as one), confirmed to fail against the pre-fix code. See
    `changelog.d/menu-use-skill-equipment-item.fixed.md`.
-- 🚧 Save & Continue — the portable `Marshal` save of the game state
+- ✅ Save & Continue — the portable `Marshal` save of the game state
   (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
-  menu's Save command; "Continue" reloads it. **Reading** the real
+  menu's Save command; "Continue" reloads it. (One research question remains: a
+  resumed save whose HP/MP exceeds this engine's recomputed growth curve — see
+  the display fix above — but the panel now matches RPG_RT regardless.) **Reading** the real
   `LCF::SaveData` (`.lsd`) is done (`Game::State.from_lsd`), and **writing** it is
   now done too: `Game::State#to_lsd` builds the `SAVE_DATA` chunks (system 101,
   hero 104, party actors 108, inventory 109) from live game state and
@@ -2861,16 +2863,28 @@ The work below is roughly ordered by the critical path to a walkable game
   change applied it unconditionally anyway), which was overwriting every
   such actor's correct database name with a control character and defeating
   the name-based lookup above.
-  **Left open:** that same wine comparison showed genuine RPG_RT displaying
-  デモ用's HP/MP as a clean 600/600 at level 50, where this engine's own
-  growth-curve computation for that actor caps at 245/254 — current
-  genuinely exceeding computed max here rather than test-data noise, so
-  either RPG_RT's growth-curve extrapolation past the curve's own rows
-  differs from this engine's, or the status panels should display
-  `max(current, computed_max)` rather than the raw computed max. Not chased
-  further since it needs another actor's data point to tell the two apart;
-  `scripts/rpg2k_save_load_check.rb` skips its hp/mp-within-max assertion for
-  this one actor rather than asserting either guess.
+   ✅ **A resumed save whose saved HP/MP exceeds this engine's recomputed growth
+   curve now displays correctly.** That same wine comparison showed genuine
+   RPG_RT displaying デモ用's HP/MP as a clean 600/600 at level 50, where this
+   engine's own growth-curve computation for that actor caps at 245/254 —
+   current genuinely exceeding computed max rather than test-data noise. The
+   load path already preserved the saved current (`Game::Actor`'s `hp`/`mp`
+   are the unclamped `attr_accessor`, set straight from the save), so the panel
+   read e.g. `600/245`; the displayed ceiling now uses `max(current,
+   computed_max)` instead of the raw recomputed max, so it reads `600/600` like
+   RPG_RT. `Game::Actor#display_max_hp` / `#display_max_mp` (and the
+   battle-alley `Game::Battle::Combatant` twins) provide the ceiling;
+   everywhere an HP/MP maximum is drawn — the party status row, the Item/Skill/
+   Equip/Status screens, the battle status windows and ally target list — now
+   calls them, while the genuine recomputed maximum still drives all damage /
+   heal / recalc clamping. The underlying growth-curve discrepancy is left as a
+   separate question (it would need another actor's data point to settle, since
+   it could also be RPG_RT's own extrapolation past the curve's rows differing);
+   `scripts/rpg2k_save_load_check.rb` still skips its hp/mp-within-max assertion
+   for that one actor, but the display now matches RPG_RT regardless. Covered by
+   a new `scripts/rpg2k_logic_check.rb` check (an actor whose current exceeds
+   its recomputed max reports that current as the displayed ceiling, the
+   recomputed maximum untouched, and a current below it keeps the max).
   ✅ **Change System BGM (10660) / Change System SFX (10670) overrides now
   round-trip through the `.lsd` too**, not just the portable `Marshal` save.
   `Game::State#system_bgm`/`#system_sfx` (populated by

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1318,6 +1318,16 @@ module Game
     # Hero Name screen and, once a message picks it explicitly, by Show Text.
     attr_reader :face_name, :face_index
     attr_accessor :hp, :mp
+    # The HP/MP maximum a status panel should display for this actor: the larger
+    # of the live current value and the recomputed stat maximum. A resumed real
+    # save (docs/TODO.md's "Save & Continue" entry) can carry a current HP/MP
+    # that exceeds this engine's own growth-curve figure -- RPG_RT shows the
+    # saved current as both value and ceiling, so a panel reads e.g. 600/600
+    # rather than 600/<smaller max>. Display only: it must never feed the
+    # damage/heal clamping in #change_hp / #change_mp / #recompute_stats, which
+    # keep using the genuine recomputed maximum.
+    def display_max_hp; hp && hp > max_hp ? hp : max_hp; end
+    def display_max_mp; mp && mp > max_mp ? mp : max_mp; end
     # Name and title (the status-screen subtitle) are mutable via the Change
     # Actor Name / Title event commands. `transparent` hides the actor's map
     # sprite (the Change Sprite Association transparency flag).
@@ -8408,6 +8418,12 @@ module Game
                            # through #refill_queue first.
                            :queued_no_act) do
       def dead?; hp <= 0; end
+
+      # The HP/MP ceiling a status panel should show for this combatant: the
+      # larger of the live current value and the recomputed maximum (see
+      # Game::Actor's identical helper, shared by the battle status windows).
+      def display_max_hp; hp && hp > max_hp ? hp : max_hp; end
+      def display_max_mp; mp && mp > max_mp ? mp : max_mp; end
 
       # Swings per basic attack: 2 with a 二刀流 weapon, 1 otherwise. Struct
       # members start nil, so the reader normalises.

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2550,9 +2550,9 @@ class RPG2k
       # condition, then the HP / SP gauges.
       def battle_status_row(b)
         hp = b.hp < 0 ? 0 : b.hp
-        [[b.name, STATUS_NAME_X, 0], battle_state_segment(b),
-         ["HP #{hp}/#{b.max_hp}", STATUS_HP_X, 0],
-         ["MP #{b.mp}/#{b.max_mp}", STATUS_MP_X, 0]]
+         [[b.name, STATUS_NAME_X, 0], battle_state_segment(b),
+          ["HP #{hp}/#{b.display_max_hp}", STATUS_HP_X, 0],
+          ["MP #{b.mp}/#{b.display_max_mp}", STATUS_MP_X, 0]]
       end
 
       # The condition column, as a status-panel segment: the same reading the
@@ -2622,8 +2622,8 @@ class RPG2k
         x += 25
         c.blt x, y, system2, Rect.new(32, 32, 16, 48)
         hp = ally.hp < 0 ? 0 : ally.hp
-        draw_gauge_system2(c, system2, fill_x, y, hp, ally.max_hp, 0)
-        draw_gauge_system2(c, system2, fill_x, y + 16, ally.mp, ally.max_mp, 1)
+        draw_gauge_system2(c, system2, fill_x, y, hp, ally.display_max_hp, 0)
+        draw_gauge_system2(c, system2, fill_x, y + 16, ally.mp, ally.display_max_mp, 1)
         num_x = 40 + 80 * i
         draw_number_system2(c, system2, num_x, y, hp)
         draw_number_system2(c, system2, num_x, y + 12 + 4, ally.mp)
@@ -2859,7 +2859,7 @@ class RPG2k
       def draw_battle_ally_target
         @ui[:ally_win].dispose if @ui[:ally_win]
         labels = battle_ally_targets.map do |a|
-          "#{a.name}  #{a.hp < 0 ? 0 : a.hp}/#{a.max_hp}"
+          "#{a.name}  #{a.hp < 0 ? 0 : a.hp}/#{a.display_max_hp}"
         end
         @ui[:ally_win] =
           battle_list_window(0, BATTLE_STATUS_W, labels, @ui[:ally_i], 335)

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -234,8 +234,8 @@ class RPG2k
         a = actor
         c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}  #{term(:level_short, 'Lv')} #{a.level}"
         c.draw_text 0, LINE_H, inner_w, LINE_H,
-                    "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
-                    "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
+                    "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
+                    "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
         c.draw_text 0, LINE_H * 2, inner_w, LINE_H,
                     "#{term(:attack, 'Atk')} #{a.atk}  #{term(:defense, 'Def')} #{a.def}  " \
                     "#{term(:mind, 'Int')} #{a.int}  #{term(:agility, 'Agi')} #{a.agi}"

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -467,8 +467,8 @@ class RPG2k
           # list, since it is where you pick who to use an antidote on.
           draw_actor_state c, a, 0, y, inner_w, LINE_H, @skin, 2
           c.draw_text 0, y + LINE_H, inner_w, LINE_H,
-                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
-                      "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
+                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
+                      "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
         end
         @target_window.contents = c
         refresh_target_cursor

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -243,8 +243,8 @@ class RPG2k
           draw_actor_state sc, a, 0, y, sc.width, 14, @skin, 2
           sc.draw_text 0, y + 16, sc.width, 14,
                        "#{term(:level_short, 'Lv')} #{a.level}  " \
-                       "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
-                       "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
+                        "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
+                        "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
         end
         @status.contents = sc
         # No cursor of its own until Skill/Equip/Status hands it focus (see

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -360,7 +360,7 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         a = caster
         mp_term = term(:mp_short, 'MP')
-        c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}   #{mp_term} #{a.mp}/#{a.max_mp}"
+        c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}   #{mp_term} #{a.mp}/#{a.display_max_mp}"
         # An empty skill list draws no placeholder text -- matching the fix
         # for the analogous Item screen (see item_menu.rb), confirmed there
         # against genuine RPG_RT under wine: a blank list row with a visible,
@@ -410,8 +410,8 @@ class RPG2k
           # list, since it is where you pick who to use an antidote on.
           draw_actor_state c, a, 0, y, inner_w, LINE_H, @skin, 2
           c.draw_text 0, y + LINE_H, inner_w, LINE_H,
-                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
-                      "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
+                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
+                      "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
         end
         @target_window.contents = c
         refresh_target_cursor

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -104,8 +104,8 @@ class RPG2k
           header,
           "#{term(:level_short, 'Lv')} #{a.level}    " \
           "#{term(:exp_short, 'EXP')} #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
-          "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}    " \
-          "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}",
+          "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}    " \
+          "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}",
           "#{term(:attack, 'Atk')} #{a.atk}   #{term(:defense, 'Def')} #{a.def}   " \
           "#{term(:mind, 'Int')} #{a.int}   #{term(:agility, 'Agi')} #{a.agi}",
           # The condition gets a labelled row of its own, as on RPG_RT's status

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6176,6 +6176,24 @@ check 'a field heal skill restores HP by the RPG2000 formula and spends SP' do
   eq 25, hero.mp                               # 30 - 5
 end
 
+check 'Actor#display_max_hp / #display_max_mp lift the shown ceiling to the live ' \
+      'current when it exceeds the recomputed max (a resumed real save)' do
+  # docs/TODO.md's "Save & Continue" entry: a resumed real RPG_RT save (Nepheshel
+  # under wine) carries an actor whose saved HP/MP exceeds this engine's own
+  # growth-curve figure, so the status panels must show the saved current as the
+  # ceiling (e.g. 600/600) rather than 600/<smaller computed max>. #display_max_*
+  # is display-only -- it must not change the genuine recomputed maximum.
+  st = skill_party({}, {})
+  hero = st.party.actor_by_id(1)
+  max = hero.max_hp
+  hero.hp = max + 100
+  eq max + 100, hero.display_max_hp, 'a current above the recomputed max lifts the shown ceiling'
+  eq max, hero.max_hp, 'the genuine recomputed max is untouched'
+  hero.hp = max - 1
+  eq max, hero.display_max_hp, 'a current below the max keeps the recomputed max'
+  eq hero.max_mp, hero.display_max_mp, 'MP is unaffected when only HP was changed'
+end
+
 check 'field_skills lists only known field-usable ally skills; can_cast? checks SP' do
   # What keeps an ordinary skill out of the field menu is its *scope* and whether
   # it does anything at all — not `occasion_field`, which RPG2000 only reads for

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2357,12 +2357,14 @@ end
 
 # A lightweight party for the inn tests: resume_inn only needs gold + a party
 # roster whose members respond to full_heal, and Scene::Map reads party.leader.
-class InnStubActor
+ class InnStubActor
   attr_accessor :hp, :mp
   attr_reader :max_hp, :max_mp, :name
   def initialize(name); @name = name; @hp = 1; @mp = 0; @max_hp = 100; @max_mp = 30; end
   def full_heal; @hp = @max_hp; @mp = @max_mp; end
-end
+  def display_max_hp; hp && hp > max_hp ? hp : max_hp; end
+  def display_max_mp; mp && mp > max_mp ? mp : max_mp; end
+ end
 
 class InnStubParty
   attr_reader :actors, :gold
@@ -13231,7 +13233,10 @@ class MenuStubActor
   # exercising that needs its own richer stub, same as the item/skill tables
   # below.
   def two_handed?(_item_id); false; end
-end
+  # Mirror Game::Actor#display_max_hp / #display_max_mp for the RGSS stubs.
+  def display_max_hp; hp && hp > max_hp ? hp : max_hp; end
+  def display_max_mp; mp && mp > max_mp ? mp : max_mp; end
+ end
 
 class MenuStubParty
   attr_reader :actors, :gold, :revision


### PR DESCRIPTION
## Summary
- A resumed real RPG_RT save (Nepheshel under wine) carries an actor whose saved HP/MP exceeds this engine's own growth-curve figure — RPG_RT shows the saved current as the ceiling (600/600 at level 50) while this engine's recomputed max is smaller (245/254). The load path already preserved the saved current (`Game::Actor#hp`/`#mp` are the unclamped `attr_accessor`, set straight from the save), so the panel read e.g. `600/245`; the displayed ceiling now uses `max(current, computed_max)`, so it reads `600/600` like RPG_RT.
- Added `Game::Actor#display_max_hp` / `#display_max_mp` (and the `Game::Battle::Combatant` twins). Every HP/MP maximum draw — the field/menu party status row, the Item/Skill/Equip/Status screens, and the battle status windows, gauges and ally-target list — now calls them. The genuine recomputed maximum still drives all damage / heal / recalc clamping (display-only, per docs/TODO.md's recommended fix).
- The underlying growth-curve discrepancy is left as a separate research question (would need another actor's data point to settle; the display now matches RPG_RT regardless). Resolves the "Left open" item and flips the Save & Continue header to done.
- Covered by a new `scripts/rpg2k_logic_check.rb` check.

## Test plan
- `cmake --build build -t test` (8/8)
- `ruby scripts/rpg2k_scene_check.rb` (659)
- `ruby scripts/rpg2k_logic_check.rb` (974)
- `pre-commit run --all-files`

🤖 Generated with [opencode](https://opencode.ai)