### PR TITLE
Use nixpkgs PPSSPP for psp-smoke CI job instead of source build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1329,9 +1329,11 @@ jobs:
     # renderer) and look for the bring-up markers it writes via sceIoWrite --
     # RPG2K_PSP_BOOT (a libc-free string literal, emitted before any init) and
     # the per-second RPG2K_PSP_BRINGUP heartbeat. This exercises the EBOOT on an
-    # emulator, beyond the compile-only `psp` job. PPSSPP is built from source
-    # (no stable prebuilt headless binary) and cached by tag, so only the first
-    # run pays the build cost.
+    # emulator, beyond the compile-only `psp` job. The emulator comes from
+    # nixpkgs (`packages.ppsspp` in flake.nix) rather than a source build: the
+    # channel this flake pins has it prebuilt on cache.nixos.org, so the job
+    # substitutes a closure in place of a from-source PPSSPP compile plus the
+    # hand-rolled tree cache that used to carry it between runs.
     #
     # NON-BLOCKING (continue-on-error): PPSSPP's headless HLE only partially
     # implements pspsdk's libc stdio (printf/strlen resolve to firmware stubs),
@@ -1342,64 +1344,41 @@ jobs:
     needs: psp
     runs-on: ubuntu-24.04
     continue-on-error: true
-    env:
-      PPSSPP_TAG: v1.17.1
     steps:
+      - uses: actions/checkout@v7
+        with:
+          # flake.nix / flake.lock are all this job reads from the checkout --
+          # they are what pin the emulator -- so no submodules here (and hence
+          # no test262-skip step; see the `build` job). Same two quiet-checkout
+          # settings as every other checkout in this workflow.
+          submodules: false
+          show-progress: false
+          persist-credentials: false
+
       - name: Download EBOOT
         uses: actions/download-artifact@v8
         with:
           name: psp-eboot
           path: eboot
 
-      - name: Install PPSSPP build deps
-        # PPSSPP compiles its GL/Vulkan backends even for HEADLESS: its bundled
-        # GLEW pulls in GL/glu.h, so libglu is required on top of libgl. Vulkan
-        # and fontconfig headers are needed for the SDL/Linux frontend it links.
-        # -qq keeps apt to warnings and errors: the per-index "Get:N ..." and
-        # per-package "Selecting/Unpacking/Setting up ..." lines are noise on a
-        # step whose only interesting outcome is its exit code.
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            build-essential cmake ninja-build pkg-config \
-            libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev libvulkan-dev \
-            libfontconfig1-dev zlib1g-dev
+      - uses: nixbuild/nix-quick-install-action@v35
 
-      # Restore/save are split so a failed (partial) build is never cached: the
-      # save runs only on success. The build step below always runs and lets
-      # ninja finish incrementally on top of whatever the restore brought back.
-      - name: Restore PPSSPP cache
-        id: cache-ppsspp
-        uses: actions/cache/restore@v6
-        with:
-          path: ppsspp
-          key: ppsspp-${{ env.PPSSPP_TAG }}-headless-v2-${{ runner.os }}
-
-      - name: Build PPSSPP headless
-        run: |
-          if [ ! -d ppsspp/.git ]; then
-            git clone --quiet --recursive --depth 1 -b "$PPSSPP_TAG" \
-              https://github.com/hrydgard/ppsspp
-          fi
-          cmake -S ppsspp -B ppsspp/build -GNinja \
-            -DHEADLESS=ON -DUNITTEST=OFF -DCMAKE_BUILD_TYPE=Release
-          cmake --build ppsspp/build --target PPSSPPHeadless -j"$(nproc)"
-
-      - name: Save PPSSPP cache
-        if: success() && steps.cache-ppsspp.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: ppsspp
-          key: ppsspp-${{ env.PPSSPP_TAG }}-headless-v2-${{ runner.os }}
+      # Deliberately no cache-nix-action here, unlike the jobs that enter the
+      # dev shell: the only thing this job realises is PPSSPP, which
+      # cache.nixos.org already has built for the pinned channel. Pushing its
+      # ~1 GiB closure through the Actions cache every run would cost more than
+      # substituting it, and would evict the caches that do earn their keep.
+      - name: Fetch PPSSPP
+        # `packages.ppsspp` is nixpkgs' default (non-Qt) build, which configures
+        # with -DHEADLESS=ON and ships `bin/ppsspp-headless`; see flake.nix. The
+        # emulator finds its assets relative to its own store path, so unlike
+        # the old source tree it can be run from anywhere.
+        run: nix build -L --out-link ppsspp '.#ppsspp'
 
       - name: Run headless smoke test
         run: |
           EBOOT="$GITHUB_WORKSPACE/eboot/EBOOT.PBP"
           ls -l "$EBOOT"
-          cd ppsspp
-          # Run from the PPSSPP tree so it finds its assets/ (fonts, etc.).
           # The bring-up writes its markers with sceIoWrite(fd 1 and 2); PPSSPP
           # logs those, but below the default headless level, so --log is needed
           # to surface them (plain printf is an unimplemented HLE import under
@@ -1411,7 +1390,7 @@ jobs:
           # the log file rather than the console: the whole file is uploaded as
           # the `psp-smoke` artifact below, and the lines that decide this step
           # (the markers, or the tail when they are missing) are echoed here.
-          ./build/PPSSPPHeadless --log --graphics=software --timeout=15 \
+          ./ppsspp/bin/ppsspp-headless --log --graphics=software --timeout=15 \
             "$EBOOT" > "$GITHUB_WORKSPACE/headless.log" 2>&1 || true
           echo "=== asserting the EBOOT booted (and ideally pumped frames) ==="
           # RPG2K_PSP_BOOT proves it booted with output captured; RPG2K_PSP_BRINGUP

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -108,10 +108,14 @@ PPSSPP only partially implements
 pspsdk's libc stdio (plain `printf` is an unimplemented HLE import there), so
 emulator capture can be fragile — the required build gate is the `psp` job. To
 reproduce locally, run PPSSPP's headless binary with `--log` (needed to surface
-the `sceIoWrite` output):
+the `sceIoWrite` output). CI takes that binary from nixpkgs instead of building
+it, and the same package works locally — `nix build '.#ppsspp'` puts it at
+`./result/bin/ppsspp-headless` (it finds its own assets, so the working
+directory does not matter):
 
 ```sh
-PPSSPPHeadless --log --graphics=software --timeout=15 EBOOT.PBP
+nix build '.#ppsspp'
+./result/bin/ppsspp-headless --log --graphics=software --timeout=15 EBOOT.PBP
 ```
 
 ## Not yet wired (later slices)

--- a/changelog.d/psp-smoke-nixpkgs-ppsspp.changed.md
+++ b/changelog.d/psp-smoke-nixpkgs-ppsspp.changed.md
@@ -1,0 +1,8 @@
+- The `psp-smoke` CI job now runs the EBOOT under the PPSSPP that nixpkgs
+  ships (`packages.ppsspp` in `flake.nix`, pinned by `flake.lock` and
+  substituted prebuilt from `cache.nixos.org`) instead of cloning and compiling
+  the emulator itself. The apt build-deps step, the source build and the
+  hand-rolled `ppsspp-<tag>` tree cache are gone, along with the `cd` into that
+  tree — the packaged binary resolves its own `assets/`, so the smoke test runs
+  it from anywhere as `./ppsspp/bin/ppsspp-headless`. Same flags, same markers;
+  the job stays non-blocking.

--- a/docs/adr/0010-psp-port.md
+++ b/docs/adr/0010-psp-port.md
@@ -78,11 +78,14 @@ and CI-checked before the interpreter and assets are layered on:
   markers it writes via `sceIoWrite` — a libc-free `RPG2K_PSP_BOOT` literal
   emitted before any init, plus the per-second `RPG2K_PSP_BRINGUP` heartbeat — so
   CI verifies the EBOOT actually runs on an emulator, not just that it links.
-  PPSSPP is built from source (no stable prebuilt headless binary exists) and
-  cached by tag. The job is **non-blocking** (`continue-on-error`): PPSSPP only
-  partially HLE-implements pspsdk's libc stdio (plain `printf`/`strlen` resolve
-  to firmware stubs), so the markers deliberately avoid libc where possible, but
-  emulator capture can still be fragile; the required gate is the `psp` build.
+  PPSSPP comes from nixpkgs (`packages.ppsspp` in `flake.nix`, whose default
+  non-Qt build configures `-DHEADLESS=ON` and installs `bin/ppsspp-headless`),
+  pinned by `flake.lock` and substituted prebuilt from `cache.nixos.org` rather
+  than compiled in CI. The job is **non-blocking** (`continue-on-error`):
+  PPSSPP only partially HLE-implements pspsdk's libc stdio (plain
+  `printf`/`strlen` resolve to firmware stubs), so the markers deliberately
+  avoid libc where possible, but emulator capture can still be fragile; the
+  required gate is the `psp` build.
 
 ## Consequences
 

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,25 @@
             '';
           };
         }
+        // nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          # The emulator the `psp-smoke` CI job boots the EBOOT under, taken
+          # from nixpkgs instead of built from source: cache.nixos.org has it
+          # prebuilt for the channel this flake pins, so the job substitutes a
+          # closure rather than compiling PPSSPP (and hand-caching the tree)
+          # itself.
+          #
+          # The default (non-Qt) build is the one that carries what the smoke
+          # test needs: it configures with -DHEADLESS=ON and installs the
+          # headless binary as `$out/bin/ppsspp-headless`, next to the SDL
+          # frontend. Its assets are found without a working directory dance --
+          # the real binary sits in $out/share/ppsspp/bin, and PPSSPP's headless
+          # entry point walks up from the executable looking for assets/flash0,
+          # which lands on $out/share/ppsspp/assets one level up.
+          #
+          # Linux-only, matching the package's own meta.platforms: forcing this
+          # attribute on darwin (e.g. `nix flake show`) would otherwise throw.
+          ppsspp = pkgs.ppsspp;
+        }
       );
 
       # `devShells.default`, the current flake schema's spelling of what used to


### PR DESCRIPTION
## Summary
Replace the manual PPSSPP source build in the `psp-smoke` CI job with the prebuilt binary from nixpkgs, pinned via `flake.nix` and substituted from `cache.nixos.org`.

## Key Changes

- **CI workflow (`build.yml`)**: Removed the PPSSPP build dependency installation, source cloning, CMake compilation, and manual caching logic. Replaced with a simple `nix build` invocation that fetches the prebuilt package.

- **Flake configuration (`flake.nix`)**: Added `packages.ppsspp` attribute (Linux-only) that exposes nixpkgs' default PPSSPP build, which is configured with `-DHEADLESS=ON` and installs the headless binary as `bin/ppsspp-headless`.

- **Smoke test execution**: Updated the test to run the emulator from its nix store path (`./ppsspp/bin/ppsspp-headless`) instead of from a local build tree. Removed the `cd ppsspp` directory change since the packaged binary resolves its own assets relative to its store path.

- **Documentation**: Updated `docs/adr/0010-psp-port.md` and `app/psp/README.md` to reflect that PPSSPP now comes from nixpkgs and can be built locally with `nix build '.#ppsspp'`.

## Implementation Details

- The job now uses `nix build -L --out-link ppsspp '.#ppsspp'` to fetch the prebuilt closure, eliminating ~50 lines of build infrastructure code.
- Removed the `PPSSPP_TAG` environment variable and all associated caching logic (`actions/cache`).
- The nixpkgs package finds its assets automatically via relative paths from the executable location, so no working directory setup is needed.
- Job remains non-blocking (`continue-on-error: true`) with the same test markers and timeout behavior.
- Added a changelog entry documenting the removal of build dependencies and manual caching.

https://claude.ai/code/session_01HG9rTBjhWHcMceF6PoV3Mi