### PR TITLE
lcf: declare the remaining database sections and battle-command fields

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -794,6 +794,9 @@ jobs:
           - name: LCF test-bed smoke check
             run: ruby scripts/lcf_testbed_check.rb
 
+          - name: LCF schema coverage
+            run: ruby scripts/lcf_schema_coverage.rb
+
           # The interpreter against every event command the downloaded games
           # ship (371k of them), asserting that none raises and none reaches a
           # handler's "I do not know this" arm. The unit checks pin the

--- a/changelog.d/lcf-schema-completeness.added.md
+++ b/changelog.d/lcf-schema-completeness.added.md
@@ -1,0 +1,14 @@
+- **LCF schema completeness.** The parser now names every chunk the real
+  test beds actually write, so no game data is left as an unnamed raw blob.
+  The four RPG2003-only top-level database sections between the 2000
+  common-events table and the 2003 battle-commands list and between Classes
+  and Battler-Animation (chunks 26/27/28 and 31) are declared as bare
+  `Array2D` tables (present-but-empty in the mtf-meido-action test bed, so
+  their record layout is not yet transcribed — they preserve any real bytes a
+  non-empty project writes and stay nameable instead of raising on access),
+  and the two top-level `battlecommands` (chunk 29) fields 9 and 24 —
+  single-byte ints in the test bed — are declared as plain `:int` so they
+  round-trip and are nameable rather than guessed at their RPG_RT meaning. A
+  new `scripts/lcf_schema_coverage.rb` walks every test-bed `.ldb`/`.lmt`/
+  `Map*.lmu` and fails if any chunk the parser stores is left unnamed, making
+  schema completeness a checked invariant instead of an eyeball audit.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,11 +26,26 @@
   the whole block from its defaults. `lcf_testbed_check.rb` now asserts the
   shape (nine coordinates, eighteen tile ids, every field materialising), and
   that guard was checked by mis-declaring chunk 62 and watching it fail. These
-  remain editor-only details off the walkable-game critical path — nothing reads
-  them at run time, RPG_RT included
-- ✅ Show window component for title scene
-- ✅ Implement New Game functionality — builds the party, loads the start map
-  and enters a walkable `Scene::Map` with events
+   remain editor-only details off the walkable-game critical path — nothing reads
+   them at run time, RPG_RT included
+ - 🚧 **Declare the remaining database sections / battle-command fields.** The
+   schema now names every chunk the real test beds actually write: the four
+   RPG2003-only top-level database sections that sit between the 2000 common-events
+   table and the 2003 battle-commands list and between Classes and Battler-Animation
+   (chunks 26/27/28 and 31) are declared as bare `Array2D` tables (present-but-empty
+   in the mtf-meido-action test bed, so their record layout is not yet transcribed
+   — they keep any real bytes a non-empty project writes and stay nameable instead
+   of raising on access), and the two top-level `battlecommands` (chunk 29) fields 9
+   and 24 — single-byte ints in the test bed — are declared as plain `:int` so they
+   round-trip and are nameable rather than guessed at their RPG_RT meaning. A new
+   `scripts/lcf_schema_coverage.rb` walks every test-bed `.ldb`/`.lmt`/`Map*.lmu` and
+   fails if any chunk the parser stores is left unnamed, so completeness is now a
+   checked invariant instead of an eyeball audit. The CBA/pose/animation and
+   2003 battle-command *semantics* are still unimplemented at run time; this TODO
+   is the schema surface, not the battle system.
+ - ✅ Show window component for title scene
+ - ✅ Implement New Game functionality — builds the party, loads the start map
+   and enters a walkable `Scene::Map` with events
 - ✅ Implement Continue functionality — loads a saved game (portable `Marshal`
   save; the LCF `.lsd` format is a later refinement)
 

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -749,12 +749,24 @@ module LCF
             1 => { name: :name, type: :string, default: '' },
           }
         },
-        25 => {
-          # https://wikiwiki.jp/viprpg-dev/200X%E5%85%B1%E9%80%9A/%E8%A7%A3%E6%9E%90%E3%81%BE%E3%81%A8%E3%82%81/%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9/%E3%82%B3%E3%83%A2%E3%83%B3%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88
-          name: :common_event, type: :Array2D,
-          elements: COMMON_EVENT
-        },
-        29 => {
+         25 => {
+           # https://wikiwiki.jp/viprpg-dev/200X%E5%85%B1%E9%80%9A/%E8%A7%A3%E6%9E%90%E3%81%BE%E3%81%A8%E3%82%81/%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9/%E3%82%B3%E3%83%A2%E3%83%B3%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88
+           name: :common_event, type: :Array2D,
+           elements: COMMON_EVENT
+         },
+         # RPG2003-only database sections (chunks 26/27/28 sit between the 2000
+         # common-events table and the 2003 battle-commands list; 31 sits between
+         # the 2003 Classes table and the Battler-Animation table). They are
+         # present-but-empty in the only 2003 test bed (mtf-meido-action), so the
+         # record layout is not yet transcribed from the RPG_RT specification.
+         # Declared as bare Array2D tables -- every top-level database section is a
+         # record table, so this is structurally correct and preserves any real
+         # bytes that a non-empty project writes, while making the sections
+         # nameable instead of raising on access.
+         26 => { name: :section_26, type: :Array2D, elements: {} },
+         27 => { name: :section_27, type: :Array2D, elements: {} },
+         28 => { name: :section_28, type: :Array2D, elements: {} },
+         29 => {
           # RPG2003's database-wide "Battle Commands" list (0x1D on liblcf's
           # own rpg::Database, not on the VIPRPG 200X wiki this file otherwise
           # transcribes -- confirmed against liblcf's generator/csv/fields.csv
@@ -782,6 +794,11 @@ module LCF
             # gauges). RPG2000's editor has no such option, so an RPG2000
             # database never sets this and correctly reads back as 0.
             7 => { name: :battle_type, type: :int, default: 0 },
+            # RPG2003-only BattleCommands field (chunk 9). A single byte (0 in the
+            # mtf-meido-action test bed); the RPG_RT semantic is not yet
+            # transcribed from the specification, so it is declared as a plain int
+            # to keep the value round-tripping and nameable rather than guessed.
+            9 => { name: :section_flags_9, type: :int, default: 0 },
             10 => {
               name: :commands, type: :Array2D,
               elements: {
@@ -804,6 +821,11 @@ module LCF
             # the same way every other RPG2003-only flag in this codebase is.
             15 => { name: :death_handler, type: :bool, default: false },
             16 => { name: :death_event, type: :int, default: 1 },
+            # RPG2003-only BattleCommands field (chunk 24). A single byte (1 in the
+            # mtf-meido-action test bed); the RPG_RT semantic is not yet
+            # transcribed from the specification, so it is declared as a plain int
+            # to keep the value round-tripping and nameable rather than guessed.
+            24 => { name: :section_flags_24, type: :int, default: 0 },
             # `death_teleport_face` follows the same 1-based up/right/down/
             # left-with-0-meaning-"keep the current facing" layout as the
             # Teleport event command's own facing parameter (liblcf's
@@ -836,10 +858,16 @@ module LCF
             72 => { name: :state_ranks, type: :int8_array },
             73 => { name: :attribute_ranks_size, type: :int, default: 0 },
             74 => { name: :attribute_ranks, type: :int8_array },
-            80 => { name: :battle_commands, type: :int32_array },
-          }
-        },
-        32 => {
+             80 => { name: :battle_commands, type: :int32_array },
+           }
+         },
+         # RPG2003-only database section (chunk 31) between the 2003 Classes
+         # table and the Battler-Animation table. Present-but-empty in the only
+         # 2003 test bed (mtf-meido-action); declared as a bare Array2D table --
+         # structurally correct and preserves any real bytes a non-empty project
+         # writes, matching the 26/27/28 sections above.
+         31 => { name: :section_31, type: :Array2D, elements: {} },
+         32 => {
           # RPG2003's database-wide "Battler Animation" table (0x20 on
           # liblcf's ChunkDatabase, `rpg::BattlerAnimation`) -- a named set of
           # up to 12 poses an actor's battle sprite can show, one entry per

--- a/scripts/lcf_schema_coverage.rb
+++ b/scripts/lcf_schema_coverage.rb
@@ -1,0 +1,137 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# LCF schema coverage: load every real test-bed RPG_RT.ldb / .lmt / Map*.lmu and
+# report any chunk id the parser stores but the schema does not name. A named
+# schema entry is what makes a chunk accessible to game code and what the
+# test-bed walker validates; an undeclared chunk is preserved as raw bytes but is
+# invisible to the runtime. This is the measuring stick for the "Support all data
+# schema of LCF" TODO -- run it after editing mruby-lcf/mrblib/schema.rb to make
+# sure no real-game chunk is left unnamed.
+#
+# Usage: ruby scripts/lcf_schema_coverage.rb [GAME_DIR ...]
+# With no arguments it scans ./data for directories that contain an RPG_RT.ldb.
+# Exits non-zero if any undeclared chunk is found.
+
+require 'stringio'
+require 'set'
+
+module LCF
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
+  end
+  module_function :cp932_to_utf8
+
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+mrblib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(mrblib, 'lcf.rb')
+load File.join(mrblib, 'schema.rb')
+
+def present_ids(obj)
+  root = obj.respond_to?(:instance_variable_get) ? obj.instance_variable_get(:@root) : obj
+  root = obj if root.nil?
+  if root.is_a?(LCF::Sections)
+    return root.instance_variable_get(:@list).flat_map { |s| present_ids(s) }.to_set
+  end
+  d = root.instance_variable_get(:@data) rescue nil
+  d ? d.each_with_index.filter_map { |v, i| i if v }.to_set : Set.new
+end
+
+def declared_ids(schema)
+  if schema.is_a?(Array)
+    schema.flat_map { |s| declared_ids(s) }.to_set
+  elsif schema && schema[:elements]
+    schema[:elements].keys.to_set
+  else
+    Set.new
+  end
+end
+
+$gaps = Hash.new { |h, k| h[k] = Set.new }
+
+# Recursively compare present vs declared chunk ids at every Array1D/Array2D
+# level and record undeclared ids with a path.
+def scan(obj, schema, path)
+  return unless schema
+  if schema.is_a?(Array)
+    list = obj.respond_to?(:instance_variable_get) ? obj.instance_variable_get(:@root) : obj
+    list = list.instance_variable_get(:@list) if list.is_a?(LCF::Sections)
+    list.each_with_index { |entry, i| scan(entry, schema[i], "#{path}/#{i}") }
+    return
+  end
+  return if schema[:type] == :Tree
+  return unless schema[:elements]
+  # An Array2D is a table of records: its "present" ids are table entry keys, not
+  # chunk ids, so do not compare them -- descend into each record instead.
+  if schema[:type] == :Array2D
+    begin
+      obj.each { |_id, entry| scan(entry, schema[:elements], "#{path}[]") }
+    rescue
+    end
+    return
+  end
+  # Array1D node: its indices are chunk ids -- compare against declared fields.
+  present = present_ids(obj)
+  declared = declared_ids(schema)
+  (present - declared).sort.each { |id| $gaps[path] << id }
+  schema[:elements].each do |idx, e|
+    next unless e[:type] == :Array1D || e[:type] == :Array2D
+    begin
+      v = obj[idx]
+    rescue
+      next
+    end
+    next unless v
+    if e[:type] == :Array2D
+      v.each { |_id, entry| scan(entry, e[:elements], "#{path}.#{e[:name]}[]") }
+    else
+      scan(v, e, "#{path}.#{e[:name]}")
+    end
+  end
+end
+
+def schema_for(base)
+  case base
+  when 'RPG_RT.ldb' then LCF::Schema::DATABASE
+  when 'RPG_RT.lmt' then LCF::Schema::MAP_TREE
+  else LCF::Schema::MAP_UNIT
+  end
+end
+
+def klass_for(base)
+  case base
+  when 'RPG_RT.ldb' then LCF::Database
+  when 'RPG_RT.lmt' then LCF::MapTree
+  else LCF::MapUnit
+  end
+end
+
+games = ARGV.dup
+games = Dir.glob(File.join(File.expand_path('../data', __dir__), '**', 'RPG_RT.ldb')) if games.empty?
+games += Dir.glob(File.join(File.expand_path('../data', __dir__), '**', 'RPG_RT.lmt'))
+games += Dir.glob(File.join(File.expand_path('../data', __dir__), '**', 'Map*.lmu'))
+
+errors = 0
+games.sort.uniq.each do |f|
+  base = File.basename(f)
+  begin
+    obj = klass_for(base).new(File.open(f, 'rb'))
+    scan(obj, schema_for(base), base)
+  rescue => ex
+    warn "ERROR #{f}: #{ex.class}: #{ex.message}"
+    errors += 1
+  end
+end
+
+if $gaps.empty?
+  puts 'OK: every chunk in the test-bed data is named by the LCF schema'
+else
+  $gaps.sort.each do |path, ids|
+    puts "#{path}: UNDECLARED #{ids.sort.inspect}"
+  end
+  errors += 1
+end
+exit(errors.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary
- The LCF schema now names **every chunk the real test beds actually write**, so no game data is left as an unnamed raw blob invisible to game code.
- The four RPG2003-only top-level database sections between the 2000 common-events table and the 2003 battle-commands list and between Classes and Battler-Animation (chunks **26/27/28 and 31**) are declared as bare `Array2D` tables. They are present-but-empty in the only 2003 test bed (mtf-meido-action), so their record layout is not yet transcribed; declaring them this way preserves any real bytes a non-empty project writes and makes the sections nameable instead of raising on access.
- The two top-level `battlecommands` (chunk 29) fields **9 and 24** — single-byte ints in the test bed — are declared as plain `:int` so they round-trip and are nameable rather than guessed at their RPG_RT meaning.

## Test plan
- `ruby scripts/lcf_testbed_check.rb` — 1099 maps / 3 games parse cleanly.
- `ruby scripts/lcf_schema_coverage.rb` — new; reports zero undeclared chunks across all test-bed data.
- Wired into the `ruby-checks` CI job as a parallel step, so schema completeness is now a checked invariant.

## Notes
The 2003 battle-command / CBA / pose *semantics* are still unimplemented at run time; this TODO is the schema surface, not the battle system. The remaining LCF-completeness work (fully transcribing the 26/27/28/31 record layouts, and the 9/24 field meanings) is blocked on the RPG_RT specification reference, which is currently inaccessible.

Co-authored-by: opencode <noreply@opencode.ai>