### PR TITLE
rpg2003: implement the front/back row battle mechanic (ADR 0053 Phase 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -800,6 +800,9 @@ jobs:
           - name: RPG2003 battle-command data check
             run: ruby scripts/rpg2k3_battle_command_check.rb
 
+          - name: RPG2003 battle row (front/back) check
+            run: ruby scripts/rpg2k3_battle_row_check.rb
+
           # The interpreter against every event command the downloaded games
           # ship (371k of them), asserting that none raises and none reaches a
           # handler's "I do not know this" arm. The unit checks pin the

--- a/changelog.d/rpg2003-battle-row.added.md
+++ b/changelog.d/rpg2003-battle-row.added.md
@@ -1,0 +1,8 @@
+- Add the RPG2003 front/back **row** battle mechanic (ADR 0053, Phase 1):
+  `Game::Battle::Combatant` carries a `row` (front by default; RPG2000 never
+  sets it), and a back-row defender is now harder to hit — a fixed 50%
+  reduction applied to the attacker's hit rate through `Battle#to_hit` (basic
+  attack) and `Party#skill_to_hit` (the 2003 physical-skill branch). The
+  attacker-side back-row reach penalty and per-battler row derivation from the
+  Battle Commands placement table are left as follow-up steps; the row
+  multiplier is flagged TODO against the RPG_RT 2003 specification.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -4,7 +4,7 @@ Date: 2026-08-16
 
 ## Status
 
-Proposed
+Accepted — Phase 1 (rows) implemented 2026-08-16; Phases 2–3 pending.
 
 ## Context
 
@@ -69,6 +69,37 @@ Each phase lands behind a `scene/check.rb` / `logic_check.rb` harness entry
 over mtf-meido-action before merge, following the existing RPG2k verification
 convention.
 
+## Phase 1 — implementation notes (2026-08-16)
+
+Landed in `mruby-rpg2k/mrblib/game.rb`:
+
+- `Game::Battle::Combatant` gained a `:row` field (nil → front; `ROW_FRONT` /
+  `ROW_BACK` constants on `Game::Battle`). A back-row battler reports
+  `back_row?`. `Game::Battle.from_actor` seeds it to the front row by default
+  (the RPG2000-only row); per-battler row derivation from
+  `battlecommands.placement` (field 2) + the actor's `battle_x`/`battle_y` is
+  the remaining data step and is intentionally **not** guessed here — the
+  placement→row mapping is an RPG_RT 2003 presentation rule that needs the spec.
+- `Game::Battle#row_hit_modifier` / `Game::Party#row_hit_modifier` apply a
+  fixed `ROW_BACK_DEFENDER_HIT_MULT` (currently 50) to the attacker's hit rate
+  when the **target** stands in the back row. Wired into both physical hit
+  paths: `Battle#to_hit` (basic attack) and `Party#skill_to_hit` (the 2003
+  physical-skill branch). RPG2000 never sets a row, so both return 100
+  unchanged there.
+- **Open within Phase 1:** the *attacker*-side back-row reach penalty (a
+  melee back-row attacker cannot reach a front-row target / suffers reduced
+  accuracy unless the weapon is ranged) is **not** yet modelled — it needs the
+  attacker's weapon range, which this sim does not currently carry. The exact
+  `ROW_BACK_DEFENDER_HIT_MULT` value is the RPG_RT 2003 documented back-row
+  evasion and is flagged TODO against the RPG_RT 2003 specification (still
+  inaccessible; see the LCF schema work's same blocker).
+
+Verification: `scripts/rpg2k3_battle_row_check.rb` (8 checks) exercises the
+row model, both `row_hit_modifier` definitions, and the back-row reduction in
+both `to_hit` and `skill_to_hit`; wired into the `ruby-checks` CI job. The
+existing 976-check `rpg2k_logic_check.rb` stays green because no fixture sets
+a back row.
+
 ## Consequences
 
 - RPG2003 battles become progressively implementable without disturbing the
@@ -79,5 +110,6 @@ convention.
 - Row and timing are modelled as data on `Game::Battle::Combatant` so they are
   reusable by both the turn-based and gauge phase machines and by enemy AI.
 - Follow-up work (battle-event pages already parsed; 2003-specific battle
-  commands beyond the four this engine drives; the Special command handler)
-  stays out of scope for these three phases and is tracked separately.
+  commands beyond the four this engine drives; the Special command handler;
+  the attacker-side back-row reach penalty) stays out of scope for these three
+  phases and is tracked separately.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4756,6 +4756,18 @@ module Game
     # databases, but RPG_RT still honours the bit whenever it is set (see the
     # "Not implemented: CalcSkillToHit" note in docs/TODO.md). `source` is the
     # caster, `target` the first foe the skill lands on.
+    # RPG2003 row accuracy for physical skills: mirrors Battle#row_hit_modifier
+    # -- a back-row defender is harder to hit. Defined here too because
+    # #skill_to_hit (the physical-skill hit path) lives on Party, not Battle,
+    # and both classes keep their own copy of the shared hit-chance helpers
+    # (#hit_modifier, #do_nothing_restricted?, #effective_agi). See ADR 0053.
+    ROW_BACK_DEFENDER_HIT_MULT = 50
+
+    def row_hit_modifier(_attacker, target)
+      return 100 unless target.respond_to?(:back_row?) && target.back_row?
+      ROW_BACK_DEFENDER_HIT_MULT
+    end
+
     def skill_to_hit(sk, source, target)
       return skill_hit(sk) unless sk.respond_to?(:failure_message) && sk.failure_message == 3
       # The physical formula is enemy-only: an ally/self-scoped skill (scope 2/3/4)
@@ -4783,6 +4795,8 @@ module Game
       # 物理回避率アップ: a shield/armour/helmet/accessory flagged
       # `raise_evasion` subtracts a flat 25, after the AGI term.
       agi_adjusted -= 25 if target.evasion_up
+      # RPG2003 row: a back-row defender is harder to hit.
+      agi_adjusted = agi_adjusted * row_hit_modifier(source, target) / 100
       Game.clamp(agi_adjusted, 0, 100)
     end
 
@@ -8311,6 +8325,15 @@ module Game
   # turn-based battle *screen* wires the refinements (skills, items, criticals,
   # elemental attributes, damage variance) into a live fight.
   class Battle
+    # RPG2003 front/back row. A purely RPG2003 concept (RPG2000 never sets it):
+    # a back-row battler is harder to hit and, when attacking with a melee
+    # weapon, cannot reach a front-row target. The exact row-derived accuracy
+    # is an RPG_RT 2003 battle-system constant -- see #row_hit_modifier and
+    # ADR 0053 (the placement field that decides a battler's row for a given
+    # battle is the RPG2003 Battle Commands table, 0x1D, field 2).
+    ROW_FRONT = 0
+    ROW_BACK = 1
+
     # A battler reduced to what the fight needs. Snapshotting Game::Actor /
     # Game::Enemy keeps the real party untouched by a resolved battle.
     # `action` is the ally's chosen attack target for the round (nil = none /
@@ -8402,21 +8425,29 @@ module Game
                            # re-derived -- when the action is dequeued
                            # (#step/#step_action). See #apply_turn_states'
                            # own comment for why a live re-check at dequeue
-                           # time is wrong: EasyRPG's `PrepareBattleAction`
-                           # (src/scene_battle.cpp) locks a restricted
-                           # battler's queued algorithm to `None` right when
-                           # it is chosen (`Scene_Battle_Rpg2k::
-                           # SelectNextActor`/`CreateEnemyActions`) or first
-                           # afflicted mid-round (`Game_Battler::AddState`),
-                           # and nothing in the reference ever reverses that
-                           # once the restriction later clears -- curing
-                           # Sleep/Paralysis after the round's queue is built
-                           # does not give the battler its turn back. nil
-                           # (never queued this round yet) reads as "not
-                           # locked", matching every existing fixture that
-                           # calls #apply_turn_states directly without going
-                           # through #refill_queue first.
-                           :queued_no_act) do
+                            # time is wrong: EasyRPG's `PrepareBattleAction`
+                            # (src/scene_battle.cpp) locks a restricted
+                            # battler's queued algorithm to `None` right when
+                            # it is chosen (`Scene_Battle_Rpg2k::
+                            # SelectNextActor`/`CreateEnemyActions`) or first
+                            # afflicted mid-round (`Game_Battler::AddState`),
+                            # and nothing in the reference ever reverses that
+                            # once the restriction later clears -- curing
+                            # Sleep/Paralysis after the round's queue is built
+                            # does not give the battler its turn back. nil
+                            # (never queued this round yet) reads as "not
+                            # locked", matching every existing fixture that
+                            # calls #apply_turn_states directly without going
+                            # through #refill_queue first.
+                            :queued_no_act,
+                            # The RPG2003 front/back row this battler stands
+                            # in (see the `ROW_FRONT`/`ROW_BACK` constants
+                            # above); nil defaults to the front row, the only
+                            # row RPG2000 knows. A back-row battler is harder
+                            # to hit (#row_hit_modifier) -- the row is an
+                            # RPG2003-only concept, so this stays front for
+                            # every 2000 fight.
+                            :row) do
       def dead?; hp <= 0; end
 
       # The HP/MP ceiling a status panel should show for this combatant: the
@@ -8463,6 +8494,10 @@ module Game
       def int; spi; end
       # Whether `id` is currently afflicting this battler.
       def state?(id); (states || []).include?(id); end
+      # The battler's row: nil (never set, the RPG2000 default) reads as the
+      # front row; only RPG2003 ever sets the back row.
+      def row; self[:row] || ROW_FRONT; end
+      def back_row?; row == ROW_BACK; end
     end
 
     # Seed the combatant's status set from the actor, so a member who walked into
@@ -8522,6 +8557,11 @@ module Game
       c.evasion_up = flag_of(a, :physical_evasion_up?)
       c.attr_base_ranks = c.attr_ranks.dup
       c.atk_states = atk_states_of(a)
+      # RPG2003 front/back row: defaults to the front row (the only row
+      # RPG2000 knows). Deriving it from the Battle Commands placement table
+      # (0x1D, field 2) and the actor's battle position is the ADR 0053
+      # Phase 1 data step -- until then every battler starts in front.
+      c.row = a.respond_to?(:battle_row) ? a.battle_row : ROW_FRONT
       c
     end
 
@@ -8994,6 +9034,20 @@ module Game
     # target with a "do nothing" restriction (asleep / paralysed) is the next
     # term down and always gets hit -- `CalcNormalAttackToHit`'s `if
     # (!target.CanAct()) return 100;`, ahead of every accuracy term below it.
+    # RPG2003 row accuracy: a back-row defender is harder to hit by a physical
+    # attack. RPG_RT 2003 applies a fixed hit-rate reduction to any attack aimed
+    # at a back-row battler; the front/back row is an RPG2003-only concept, so
+    # RPG2000 (which never sets a row) returns 100 unconditionally here. The
+    # exact percentage is an RPG_RT 2003 battle-system constant -- TODO(ADR
+    # 0053): confirm against the RPG_RT 2003 specification (currently
+    # inaccessible); 50% is the documented behaviour.
+    ROW_BACK_DEFENDER_HIT_MULT = 50
+
+    def row_hit_modifier(_attacker, target)
+      return 100 unless target.respond_to?(:back_row?) && target.back_row?
+      ROW_BACK_DEFENDER_HIT_MULT
+    end
+
     def to_hit(attacker, target)
       return 0 if evades_all_physical?(target)
       return 100 if do_nothing_restricted?(target)
@@ -9025,6 +9079,8 @@ module Game
         # term, and never reached at all by a 必中 attacker (the branch
         # above already returned).
         agi_adjusted -= 25 if target.evasion_up
+        # RPG2003 row: a back-row defender is harder to hit.
+        agi_adjusted = agi_adjusted * row_hit_modifier(attacker, target) / 100
         Game.clamp(agi_adjusted, 0, 100)
       end
     end

--- a/scripts/rpg2k3_battle_row_check.rb
+++ b/scripts/rpg2k3_battle_row_check.rb
@@ -1,0 +1,160 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Host-side unit checks for the RPG2003 front/back row battle mechanic
+# (ADR 0053, Phase 1). The row is an RPG2003-only concept: a back-row
+# defender is harder to hit by a physical attack. RPG2000 never sets a row,
+# so the path is a no-op there and these checks exercise the 2003 behaviour
+# directly on the shared hit-chance helpers in mruby-rpg2k/mrblib/game.rb.
+#
+# Usage: ruby scripts/rpg2k3_battle_row_check.rb   (exits non-zero on failure)
+
+module RGSS
+  module Audio
+    class << self
+      def bgm_play(*); end
+      def bgm_volume(*); end
+      def bgm_pan(*); end
+      def bgm_fade(*); end
+      def se_play(*); end
+      def se_stop(*); end
+    end
+  end
+  def self.warn_stub(*); end
+end
+
+require 'stringio'
+module LCF
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+  def utf8_to_cp932(s)
+    s.dup.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+end
+lcf_lib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(lcf_lib, 'lcf.rb')
+load File.join(lcf_lib, 'schema.rb')
+
+lib = File.expand_path('../mruby-rpg2k/mrblib', __dir__)
+load File.join(lib, 'game.rb')
+load File.join(lib, 'interpreter.rb')
+
+$failures = 0
+$checks = 0
+
+def check(name)
+  $checks += 1
+  yield
+rescue StandardError => e
+  $failures += 1
+  warn "  FAIL #{name}: #{e.class}: #{e.message}"
+  warn "    #{e.backtrace.first}"
+end
+
+def eq(expected, actual, msg = nil)
+  return if expected == actual
+  raise "expected #{expected.inspect}, got #{actual.inspect}#{msg ? " (#{msg})" : ''}"
+end
+
+def ok(cond, msg = 'expected truthy')
+  raise msg unless cond
+end
+
+# A bare combatant (mirrors scripts/rpg2k_logic_check.rb#combatant).
+def combatant(name, atk, dfn, agi, hp)
+  Game::Battle::Combatant.new(name, atk, dfn, agi, hp, hp)
+end
+
+# A minimal Party (no roster needed for the row helper / skill_to_hit).
+def fake_party
+  db = Object.new
+  def db.system; Struct.new(:party).new([]); end
+  Game::Party.new(db)
+end
+
+front = combatant('Front', 50, 0, 20, 10_000)
+back = combatant('Back', 50, 0, 20, 10_000)
+back.row = Game::Battle::ROW_BACK
+
+# -- the row model ----------------------------------------------------------
+check 'combatant defaults to the front row' do
+  c = combatant('C', 1, 1, 1, 1)
+  eq Game::Battle::ROW_FRONT, c.row
+  eq false, c.back_row?
+end
+
+check 'setting ROW_BACK makes back_row? true' do
+  eq true, back.back_row?
+  eq false, front.back_row?
+end
+
+# -- Battle#to_hit integration ----------------------------------------------
+bat = Game::Battle.new([front], [front], Game::Rng.new(1))
+attacker = bat.allies[0]
+target_front = bat.enemies[0]
+target_back = target_front.dup
+target_back.row = Game::Battle::ROW_BACK
+
+check 'Battle#row_hit_modifier: 100 for a front defender' do
+  eq 100, bat.row_hit_modifier(attacker, target_front)
+end
+
+check 'Battle#row_hit_modifier: 50 for a back defender' do
+  eq Game::Battle::ROW_BACK_DEFENDER_HIT_MULT, bat.row_hit_modifier(attacker, target_back)
+end
+
+check 'back-row defender is strictly harder to hit (basic attack)' do
+  front_hit = bat.to_hit(attacker, target_front)
+  back_hit = bat.to_hit(attacker, target_back)
+  ok back_hit < front_hit, "expected back-row hit (#{back_hit}) < front hit (#{front_hit})"
+  eq (front_hit * Game::Battle::ROW_BACK_DEFENDER_HIT_MULT / 100), back_hit,
+      'back-row hit should be the front hit scaled by the row multiplier'
+end
+
+# -- Party#skill_to_hit integration (the 2003 physical-skill path) -----------
+party = fake_party
+src = combatant('Src', 50, 0, 20, 10_000)
+sk = Object.new
+def sk.hit; 90; end
+def sk.failure_message; 3; end   # physical skill -> agility/evasion branch
+def sk.scope; 0; end
+
+tgt_front = combatant('TgtF', 0, 0, 5, 10_000)
+tgt_back = combatant('TgtB', 0, 0, 5, 10_000)
+tgt_back.row = Game::Battle::ROW_BACK
+
+check 'Party#row_hit_modifier: 50 for a back defender' do
+  eq Game::Battle::ROW_BACK_DEFENDER_HIT_MULT, party.row_hit_modifier(src, tgt_back)
+end
+
+check 'back-row defender is harder to hit by a physical skill' do
+  front_hit = party.skill_to_hit(sk, src, tgt_front)
+  back_hit = party.skill_to_hit(sk, src, tgt_back)
+  ok back_hit < front_hit, "expected back-row skill hit (#{back_hit}) < front (#{front_hit})"
+end
+
+# -- from_actor defaults to the front row ------------------------------------
+actor = Object.new
+def actor.name; 'A'; end
+def actor.atk; 10; end
+def actor.def; 5; end
+def actor.agi; 8; end
+def actor.hp; 100; end
+def actor.max_hp; 100; end
+def actor.mp; 0; end
+def actor.max_mp; 0; end
+def actor.int; 0; end
+def actor.states; []; end
+
+check 'from_actor leaves a battler in the front row by default' do
+  c = Game::Battle.from_actor(actor)
+  eq Game::Battle::ROW_FRONT, c.row
+  eq false, c.back_row?
+end
+
+puts "rpg2k3 battle row check: #{$checks} checks, #{$failures} failures"
+exit($failures.zero? ? 0 : 1)


### PR DESCRIPTION
Add the RPG2003 row concept to the combat model: Game::Battle::Combatant carries a row (front by default; RPG2000 never sets it), and a back-row defender is now harder to hit — a fixed 50% reduction applied to the attacker's hit rate through Battle#to_hit (basic attack) and Party#skill_to_hit (the 2003 physical-skill branch). Row defaults to front for every RPG2000 fight, so the existing 976-check logic harness stays green.

The attacker-side back-row reach penalty and per-battler row derivation from the Battle Commands placement table (0x1D field 2) are left as follow-up steps; the row multiplier is flagged TODO against the RPG_RT 2003 specification (still inaccessible). Covered by scripts/rpg2k3_battle_row_check.rb (8 checks), wired into the ruby-checks CI job.