### PR TITLE
rpg2003: add the active-time (gauge) battle-timing model + battle_type plumbing (ADR 0053 Phase 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -803,6 +803,9 @@ jobs:
           - name: RPG2003 battle row (front/back) check
             run: ruby scripts/rpg2k3_battle_row_check.rb
 
+          - name: RPG2003 battle gauge (active-time) check
+            run: ruby scripts/rpg2k3_battle_gauge_check.rb
+
           # The interpreter against every event command the downloaded games
           # ship (371k of them), asserting that none raises and none reaches a
           # handler's "I do not know this" arm. The unit checks pin the

--- a/changelog.d/rpg2003-battle-gauge.added.md
+++ b/changelog.d/rpg2003-battle-gauge.added.md
@@ -1,0 +1,18 @@
+- Add the RPG2003 active-time (gauge) battle-timing model (ADR 0053, Phase 2
+  foundation): `Game::Battle::Combatant` carries a `gauge` (0..`GAUGE_MAX`),
+  and `Game::Battle` advances every living battler's gauge at an AGI-proportional
+  rate via `advance_gauges` / exposes `ready_combatants` (full-gauge battlers,
+  gauge-descending). The engine is a no-op unless `battle_type == 2`, so
+  RPG2000 and the 2003 traditional presentation keep the turn-based machine
+  untouched. The per-frame `Scene::Battle` turn-picker that actually drives
+  turns off the gauge is deferred to Phase 3 (the 2003 boot path); the
+  `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve is flagged TODO against the RPG_RT
+  2003 specification.
+
+  The database's battle-setup `battle_type` (Battle Setup chunk 0x1D field 7)
+  is now plumbed into `Game::Battle` at construction via a `battle_type:`
+  keyword (default 0); `Scene::Battle` passes `db.battlecommands.battle_type`
+  (0 for every RPG2000 project, which has no Battle Commands table). This is
+  the first Phase-3 (boot) slice: it selects the gauge engine for a 2003
+  gauge battle the moment one is reached, without touching the turn-based
+  path.

--- a/changelog.d/rpg2003-battle-gauge.added.md
+++ b/changelog.d/rpg2003-battle-gauge.added.md
@@ -13,6 +13,12 @@
   is now plumbed into `Game::Battle` at construction via a `battle_type:`
   keyword (default 0); `Scene::Battle` passes `db.battlecommands.battle_type`
   (0 for every RPG2000 project, which has no Battle Commands table). This is
-  the first Phase-3 (boot) slice: it selects the gauge engine for a 2003
-  gauge battle the moment one is reached, without touching the turn-based
-  path.
+   the first Phase-3 (boot) slice: it selects the gauge engine for a 2003
+   gauge battle the moment one is reached, without touching the turn-based
+   path.
+
+   The active-time turn cycle is modelled too: `Game::Battle#reset_gauge(c)`
+   empties a combatant's gauge after it acts, and `Game::Battle#pop_ready`
+   returns the highest-gauge ready combatant and resets it -- the fill ->
+   ready -> act -> refill loop the per-frame `Scene::Battle` picker will drive
+   in Phase 3. Both are nil / no-op for a turn-based battle.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -4,8 +4,8 @@ Date: 2026-08-16
 
 ## Status
 
-Accepted — Phase 1 (rows) and the Phase 2 gauge model implemented
-2026-08-16; Phase 2 scene integration and Phase 3 pending.
+Accepted — Phase 1 (rows) and the Phase 2 gauge model (fill + ready + turn
+cycle) implemented 2026-08-16; Phase 2 scene integration and Phase 3 pending.
 
 ## Context
 
@@ -119,6 +119,11 @@ once a 2003 project reaches a fight.
   - `ready_combatants` returns the full-gauge battlers in descending gauge
     order — the pool the active-time turn picker draws from. `all_combatants`
     joins allies + enemies for bookkeeping.
+  - The active-time turn cycle is modelled too: `reset_gauge(c)` empties a
+    combatant's gauge after it acts, and `pop_ready` returns the highest-gauge
+    ready combatant and resets it — the "fill → ready → act → refill" loop the
+    per-frame `Scene::Battle` picker will drive (Phase 3). Both are nil / no-op
+    for a turn-based battle.
 - The database's battle-setup `battle_type` (Battle Setup chunk 0x1D field 7,
   already decoded into the schema) is now plumbed into `Game::Battle` at
   construction: `Game::Battle.new` takes a `battle_type:` keyword (default 0),

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -4,7 +4,8 @@ Date: 2026-08-16
 
 ## Status
 
-Accepted — Phase 1 (rows) implemented 2026-08-16; Phases 2–3 pending.
+Accepted — Phase 1 (rows) and the Phase 2 gauge model implemented
+2026-08-16; Phase 2 scene integration and Phase 3 pending.
 
 ## Context
 
@@ -99,6 +100,45 @@ row model, both `row_hit_modifier` definitions, and the back-row reduction in
 both `to_hit` and `skill_to_hit`; wired into the `ruby-checks` CI job. The
 existing 976-check `rpg2k_logic_check.rb` stays green because no fixture sets
 a back row.
+
+## Phase 2 — implementation notes (2026-08-16)
+
+The active-time (gauge) model is in place in `mruby-rpg2k/mrblib/game.rb`;
+the per-frame `Scene::Battle` integration that actually drives turns off it is
+**deferred to Phase 3** (the 2003 boot path), because the gauge only matters
+once a 2003 project reaches a fight.
+
+- `Game::Battle::Combatant` gained a `:gauge` field (0..`GAUGE_MAX`, default
+  empty) with `gauge` / `gauge_full?` readers.
+- `Game::Battle` gained `battle_type` (0 traditional / 1 alternative / 2
+  gauge; defaults to 0) and the gauge engine:
+  - `advance_gauges(ticks)` fills every living, in-play battler's gauge at
+    `effective_agi * GAUGE_AGI_RATE * ticks`, clamped to `GAUGE_MAX`. It is a
+    **no-op unless `battle_type == 2`**, so RPG2000 and the 2003 traditional
+    presentation keep running the turn-based machine untouched.
+  - `ready_combatants` returns the full-gauge battlers in descending gauge
+    order — the pool the active-time turn picker draws from. `all_combatants`
+    joins allies + enemies for bookkeeping.
+- The database's battle-setup `battle_type` (Battle Setup chunk 0x1D field 7,
+  already decoded into the schema) is now plumbed into `Game::Battle` at
+  construction: `Game::Battle.new` takes a `battle_type:` keyword (default 0),
+  and `Scene::Battle` passes `db.battlecommands.battle_type` (0 when the
+  database has no Battle Commands table, i.e. every RPG2000 project). This is
+  the first Phase-3 (boot) slice — it makes the gauge engine actually select
+  for a 2003 gauge battle the moment one is reached — without touching the
+  turn-based path.
+- **Open within Phase 2:** the turn picker that consumes a ready combatant and
+  resets its gauge (replacing "whose turn is it" in the round machine) is
+  intentionally **not** wired yet — doing so requires the per-frame
+  `Scene::Battle#update` loop and a 2003 project to run it (Phase 3). The
+  exact `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve is the RPG_RT 2003
+  constant, flagged TODO against the RPG_RT 2003 specification (still
+  inaccessible).
+
+Verification: `scripts/rpg2k3_battle_gauge_check.rb` (6 checks) exercises the
+inert turn-based path, AGI-proportional fill, full/ready selection, ordering,
+and that a dead battler neither charges nor becomes ready; wired into the
+`ruby-checks` CI job.
 
 ## Consequences
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9113,6 +9113,26 @@ module Game
       (@allies || []) + (@enemies || [])
     end
 
+    # Reset a combatant's gauge to empty after it has taken its active-time
+    # turn, so it must refill from zero before acting again (RPG_RT 2003's
+    # gauge behaviour). The per-frame Scene::Battle loop calls this from the
+    # turn picker; exposed here so the gauge cycle is unit-testable without
+    # the 2003 boot path (Phase 3).
+    def reset_gauge(c)
+      c.gauge = 0
+    end
+
+    # The active-time turn picker: return the next ready combatant (highest
+    # gauge; see #ready_combatants) and reset its gauge so the loop can advance
+    # and refill it. Returns nil when nobody is ready. A turn-based battle
+    # (battle_type != 2) never has a ready combatant, so this is nil there too.
+    def pop_ready
+      c = ready_combatants.first
+      return nil unless c
+      reset_gauge(c)
+      c
+    end
+
     def to_hit(attacker, target)
       return 0 if evades_all_physical?(target)
       return 100 if do_nothing_restricted?(target)

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8447,7 +8447,15 @@ module Game
                             # to hit (#row_hit_modifier) -- the row is an
                             # RPG2003-only concept, so this stays front for
                             # every 2000 fight.
-                            :row) do
+                            :row,
+                            # The RPG2003 active-time (gauge) charge for this
+                            # battler (ADR 0053, Phase 2). 0..GAUGE_MAX; a
+                            # battler whose gauge is full may act. Only the
+                            # 2003 gauge presentation (battle_type 2) actually
+                            # advances it -- RPG2000 (battle_type 0) and the
+                            # 2003 traditional presentation (1) leave it at 0
+                            # and run the turn-based machine instead.
+                            :gauge) do
       def dead?; hp <= 0; end
 
       # The HP/MP ceiling a status panel should show for this combatant: the
@@ -8498,6 +8506,10 @@ module Game
       # front row; only RPG2003 ever sets the back row.
       def row; self[:row] || ROW_FRONT; end
       def back_row?; row == ROW_BACK; end
+      # The battler's active-time gauge: nil (never advanced, the RPG2000 /
+      # traditional-2003 default) reads as empty.
+      def gauge; self[:gauge] || 0; end
+      def gauge_full?; gauge >= GAUGE_MAX; end
     end
 
     # Seed the combatant's status set from the actor, so a member who walked into
@@ -8674,7 +8686,8 @@ module Game
     # its own, unchanged from before this parameter existed.
     def initialize(allies, enemies, rng = nil, states = nil, variance = false,
                    criticals = false, accuracy = false, first_strike = false,
-                   attributes = nil, ai = nil, rpg2003: false, party: nil)
+                   attributes = nil, ai = nil, rpg2003: false, party: nil,
+                   battle_type: 0)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
@@ -8687,6 +8700,14 @@ module Game
       @ai = ai
       @rpg2003 = rpg2003 ? true : false
       @party = party
+      # RPG2003 battle timing presentation (database Battle Setup chunk 0x1D
+      # field 7): 0 traditional (RPG2000-style, turn-based), 1 alternative
+      # (actor sprites, no ATB), 2 gauge (per-combatant active-time charge).
+      # Only presentation 2 advances the active-time gauge (#advance_gauges);
+      # the rest run the existing turn-based machine untouched. Seeded from the
+      # database's battle setup when the battle is constructed (see
+      # Scene::Battle), defaulting to 0 so every RPG2000 fight is turn-based.
+      @battle_type = battle_type || 0
       @rounds = 0
       @result = nil
       @escaped = false # set once the party successfully flees (#attempt_escape)
@@ -9046,6 +9067,50 @@ module Game
     def row_hit_modifier(_attacker, target)
       return 100 unless target.respond_to?(:back_row?) && target.back_row?
       ROW_BACK_DEFENDER_HIT_MULT
+    end
+
+    # RPG2003 active-time (gauge) battle timing (ADR 0053, Phase 2). The gauge
+    # is a 0..GAUGE_MAX charge each living battler accumulates every frame at a
+    # rate proportional to its AGI; the moment it is full the battler may act
+    # (see #ready_combatants). This is the RPG2003 presentation-2 ("gauge")
+    # time system -- RPG2000 (battle_type 0) and the 2003 traditional
+    # presentation (1) never advance it and keep running the turn-based
+    # machine, so #advance_gauges is a no-op for them.
+    #
+    # GAUGE_MAX and the AGI-to-fill relationship are RPG_RT 2003 constants;
+    # the exact fill curve is flagged TODO against the RPG_RT 2003
+    # specification (still inaccessible, the same blocker as the row
+    # multiplier / LCF schema work). The model below is the structure RPG_RT
+    # uses, with a linear AGI-proportional fill chosen as the documented
+    # default.
+    GAUGE_MAX = 100
+    GAUGE_AGI_RATE = 1   # gauge points gained per AGI per tick
+
+    attr_accessor :battle_type
+
+    # Advance every living, in-play battler's gauge by `ticks` frames, gated on
+    # battle_type (only the gauge presentation advances it). AGI drives the
+    # fill rate so faster battlers reach a full gauge sooner, the RPG_RT 2003
+    # behaviour. Dead / hidden / not-a-member combatants do not charge.
+    def advance_gauges(ticks = 1)
+      return unless @battle_type == 2
+      all_combatants.each do |c|
+        next if c.out_of_play?
+        add = effective_agi(c) * GAUGE_AGI_RATE * ticks
+        c.gauge = [c.gauge + add, GAUGE_MAX].min
+      end
+    end
+
+    # The combatants whose gauge is full, in descending gauge order (ties broken
+    # by side then by the order they were added), so the active-time turn picker
+    # can pull the next actor off the front. Empty for a turn-based battle.
+    def ready_combatants
+      all_combatants.reject(&:out_of_play?).select(&:gauge_full?).sort_by { |c| -c.gauge }
+    end
+
+    # Every combatant in the fight (allies then enemies), for gauge bookkeeping.
+    def all_combatants
+      (@allies || []) + (@enemies || [])
     end
 
     def to_hit(attacker, target)

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -179,8 +179,19 @@ class RPG2k
                                                 # (see #apply_attr_multiplier)
                                                 # is handled differently per
                                                 # edition.
-                                                rpg2003: db.respond_to?(:rpg2003?) && db.rpg2003?,
-                                                # Mid-battle roster sync
+                                                 rpg2003: db.respond_to?(:rpg2003?) && db.rpg2003?,
+                                                 # RPG2003 battle timing
+                                                 # presentation (Battle Setup
+                                                 # chunk 0x1D field 7): 0
+                                                 # traditional / 1 alternative /
+                                                 # 2 gauge. Drives whether the
+                                                 # active-time gauge engine
+                                                 # (#advance_gauges) ever runs;
+                                                 # RPG2000 has no battlecommands
+                                                 # table, so this reads 0 and the
+                                                 # turn-based machine is used.
+                                                 battle_type: db.respond_to?(:battlecommands) && db.battlecommands ? (db.battlecommands.battle_type || 0) : 0,
+                                                 # Mid-battle roster sync
                                                 # (Game::Battle#sync_allies_from_party):
                                                 # a Change Party Member command
                                                 # run from a battle event page

--- a/scripts/rpg2k3_battle_gauge_check.rb
+++ b/scripts/rpg2k3_battle_gauge_check.rb
@@ -1,0 +1,130 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Host-side unit checks for the RPG2003 active-time (gauge) battle timing
+# (ADR 0053, Phase 2). The gauge is an RPG2003 presentation-2 concept; this
+# harness exercises the pure gauge-accumulation / ready-selection model in
+# mruby-rpg2k/mrblib/game.rb. RPG2000 (battle_type 0) and the 2003
+# traditional presentation (1) never advance the gauge.
+#
+# Usage: ruby scripts/rpg2k3_battle_gauge_check.rb   (exits non-zero on failure)
+
+module RGSS
+  module Audio
+    class << self
+      def bgm_play(*); end
+      def bgm_volume(*); end
+      def bgm_pan(*); end
+      def bgm_fade(*); end
+      def se_play(*); end
+      def se_stop(*); end
+    end
+  end
+  def self.warn_stub(*); end
+end
+
+require 'stringio'
+module LCF
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+  def utf8_to_cp932(s)
+    s.dup.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+end
+lcf_lib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(lcf_lib, 'lcf.rb')
+load File.join(lcf_lib, 'schema.rb')
+
+lib = File.expand_path('../mruby-rpg2k/mrblib', __dir__)
+load File.join(lib, 'game.rb')
+load File.join(lib, 'interpreter.rb')
+
+$failures = 0
+$checks = 0
+
+def check(name)
+  $checks += 1
+  yield
+rescue StandardError => e
+  $failures += 1
+  warn "  FAIL #{name}: #{e.class}: #{e.message}"
+  warn "    #{e.backtrace.first}"
+end
+
+def eq(expected, actual, msg = nil)
+  return if expected == actual
+  raise "expected #{expected.inspect}, got #{actual.inspect}#{msg ? " (#{msg})" : ''}"
+end
+
+def ok(cond, msg = 'expected truthy')
+  raise msg unless cond
+end
+
+def combatant(name, atk, dfn, agi, hp)
+  Game::Battle::Combatant.new(name, atk, dfn, agi, hp, hp)
+end
+
+# -- gauge is inert for turn-based battles (battle_type 0) -------------------
+check 'default battle_type is 0 (turn-based)' do
+  bat = Game::Battle.new([combatant('A', 1, 1, 10, 1)], [combatant('B', 1, 1, 5, 1)], Game::Rng.new(1))
+  eq 0, bat.battle_type
+end
+
+check 'Game::Battle.new accepts battle_type: and activates the gauge' do
+  bat = Game::Battle.new([combatant('A', 1, 1, 20, 1)], [combatant('B', 1, 1, 10, 1)],
+                         Game::Rng.new(1), nil, false, false, false, false, nil, nil,
+                         battle_type: 2)
+  eq 2, bat.battle_type
+  bat.advance_gauges(6)
+  eq Game::Battle::GAUGE_MAX, bat.all_combatants[0].gauge
+end
+
+check 'advance_gauges is a no-op for battle_type 0' do
+  bat = Game::Battle.new([combatant('A', 1, 1, 10, 1)], [combatant('B', 1, 1, 5, 1)], Game::Rng.new(1))
+  bat.advance_gauges(100)
+  eq 0, bat.all_combatants.map(&:gauge).max
+  eq 0, bat.ready_combatants.size
+end
+
+# -- gauge fills proportional to AGI for the 2003 gauge presentation ---------
+fast = combatant('Fast', 1, 1, 20, 1)   # 20 gauge/tick -> full in 5 ticks
+slow = combatant('Slow', 1, 1, 10, 1)   # 10 gauge/tick -> full in 10 ticks
+bat = Game::Battle.new([fast], [slow], Game::Rng.new(1))
+bat.battle_type = 2
+
+check 'after 6 ticks the faster battler is full, the slower is not' do
+  bat.advance_gauges(6)
+  eq Game::Battle::GAUGE_MAX, fast.gauge
+  eq 60, slow.gauge
+  ready = bat.ready_combatants
+  eq [fast], ready
+end
+
+check 'after 10 ticks both are full' do
+  bat.advance_gauges(4)
+  eq Game::Battle::GAUGE_MAX, slow.gauge
+  eq 2, bat.ready_combatants.size
+end
+
+check 'ready_combatants is ordered by gauge descending' do
+  # Bump the slower one past max so it sorts first, then re-check ordering.
+  slow.gauge = Game::Battle::GAUGE_MAX + 5
+  eq [slow, fast], bat.ready_combatants
+end
+
+check 'a dead battler does not charge or become ready' do
+  dead = combatant('Dead', 1, 1, 50, 1)
+  dead.hp = 0
+  bat2 = Game::Battle.new([dead], [combatant('Live', 1, 1, 10, 1)], Game::Rng.new(1))
+  bat2.battle_type = 2
+  bat2.advance_gauges(100)
+  eq 0, dead.gauge
+  eq false, dead.gauge_full?
+end
+
+puts "rpg2k3 battle gauge check: #{$checks} checks, #{$failures} failures"
+exit($failures.zero? ? 0 : 1)

--- a/scripts/rpg2k3_battle_gauge_check.rb
+++ b/scripts/rpg2k3_battle_gauge_check.rb
@@ -126,5 +126,34 @@ check 'a dead battler does not charge or become ready' do
   eq false, dead.gauge_full?
 end
 
+# -- the active-time turn cycle: pop_ready consumes and resets --------------
+cycle_fast = combatant('CFast', 1, 1, 20, 1)
+cycle_slow = combatant('CSlow', 1, 1, 10, 1)
+cbat = Game::Battle.new([cycle_fast], [cycle_slow], Game::Rng.new(1))
+cbat.battle_type = 2
+cbat.advance_gauges(6)   # fast full (100), slow at 60
+
+check 'pop_ready returns the highest-gauge combatant and resets its gauge' do
+  taken = cbat.pop_ready
+  eq cycle_fast, taken
+  eq 0, cycle_fast.gauge
+  eq false, cycle_fast.gauge_full?
+  # slow is still charging, so nothing else is ready yet
+  eq [], cbat.ready_combatants
+end
+
+check 'after the taker refills it becomes ready again (the ATB loop repeats)' do
+  cbat.advance_gauges(5)   # fast: 0 -> 100 (agi 20 * 5); slow: 60 -> 110 -> 100
+  eq 2, cbat.ready_combatants.size
+  taken = cbat.pop_ready
+  eq cycle_fast, taken   # fast reached full first again
+  eq 0, cycle_fast.gauge
+end
+
+check 'pop_ready is nil for a turn-based battle' do
+  tbat = Game::Battle.new([combatant('A', 1, 1, 20, 1)], [combatant('B', 1, 1, 10, 1)], Game::Rng.new(1))
+  eq nil, tbat.pop_ready
+end
+
 puts "rpg2k3 battle gauge check: #{$checks} checks, #{$failures} failures"
 exit($failures.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary
The RPG2003 battle-scene work continues (ADR 0053). This PR delivers **Phase 2** — the active-time (gauge) timing model — plus a first **Phase 3** slice that makes it actually selectable. It builds on the merged row PR #938.

- `Game::Battle::Combatant` carries a `gauge` (0..`GAUGE_MAX`) with `gauge` / `gauge_full?` readers.
- `Game::Battle#advance_gauges(ticks)` fills every living, in-play battler's gauge at an AGI-proportional rate (the RPG_RT 2003 behaviour), clamped to `GAUGE_MAX`; a **no-op unless `battle_type == 2`**, so RPG2000 and the 2003 traditional presentation keep the turn-based machine untouched. `Game::Battle#ready_combatants` returns the full-gauge battlers in descending gauge order — the pool the active-time turn picker will draw from.
- The database's battle-setup `battle_type` (Battle Setup chunk 0x1D field 7, already decoded) is plumbed into `Game::Battle` at construction via a `battle_type:` keyword (default 0); `Scene::Battle` passes `db.battlecommands.battle_type` (0 for every RPG2000 project, which has no Battle Commands table). This selects the gauge engine for a 2003 gauge battle the moment one is reached, without touching the turn-based path.

## Deliberately out of scope
- The per-frame `Scene::Battle` turn-picker that consumes a ready combatant and resets its gauge is **deferred to the full Phase 3** (2003 boot-to-battle), since the gauge only matters once a 2003 project reaches a fight.
- `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve, and the Phase-1 row multiplier / attacker-side reach penalty, remain flagged TODO against the RPG_RT 2003 specification (still inaccessible, same blocker as the LCF schema work).

## Test plan
- `ruby scripts/rpg2k3_battle_gauge_check.rb` — 7 checks: inert turn-based path, construction-time `battle_type:`, AGI-proportional fill, full/ready selection, ordering, dead-battler exclusion. Wired into the `ruby-checks` CI job (after #938's row check).
- `ruby scripts/rpg2k_logic_check.rb` — still 976 checks green (no fixture sets a gauge / back row, so the 2000 path is untouched).

## Notes
Phase 3 (2003 boot-to-battle) is the remaining large step that makes Phases 1–2 verifiable against real gameplay; until then this is fixture-only.

Co-authored-by: opencode <noreply@opencode.ai>