### PR TITLE
rpg2003: model the active-time gauge turn cycle (ADR 0053 Phase 2)

### DIFF
--- a/changelog.d/rpg2003-battle-gauge.added.md
+++ b/changelog.d/rpg2003-battle-gauge.added.md
@@ -13,6 +13,12 @@
   is now plumbed into `Game::Battle` at construction via a `battle_type:`
   keyword (default 0); `Scene::Battle` passes `db.battlecommands.battle_type`
   (0 for every RPG2000 project, which has no Battle Commands table). This is
-  the first Phase-3 (boot) slice: it selects the gauge engine for a 2003
-  gauge battle the moment one is reached, without touching the turn-based
-  path.
+   the first Phase-3 (boot) slice: it selects the gauge engine for a 2003
+   gauge battle the moment one is reached, without touching the turn-based
+   path.
+
+   The active-time turn cycle is modelled too: `Game::Battle#reset_gauge(c)`
+   empties a combatant's gauge after it acts, and `Game::Battle#pop_ready`
+   returns the highest-gauge ready combatant and resets it -- the fill ->
+   ready -> act -> refill loop the per-frame `Scene::Battle` picker will drive
+   in Phase 3. Both are nil / no-op for a turn-based battle.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -4,8 +4,8 @@ Date: 2026-08-16
 
 ## Status
 
-Accepted — Phase 1 (rows) and the Phase 2 gauge model implemented
-2026-08-16; Phase 2 scene integration and Phase 3 pending.
+Accepted — Phase 1 (rows) and the Phase 2 gauge model (fill + ready + turn
+cycle) implemented 2026-08-16; Phase 2 scene integration and Phase 3 pending.
 
 ## Context
 
@@ -119,6 +119,11 @@ once a 2003 project reaches a fight.
   - `ready_combatants` returns the full-gauge battlers in descending gauge
     order — the pool the active-time turn picker draws from. `all_combatants`
     joins allies + enemies for bookkeeping.
+  - The active-time turn cycle is modelled too: `reset_gauge(c)` empties a
+    combatant's gauge after it acts, and `pop_ready` returns the highest-gauge
+    ready combatant and resets it — the "fill → ready → act → refill" loop the
+    per-frame `Scene::Battle` picker will drive (Phase 3). Both are nil / no-op
+    for a turn-based battle.
 - The database's battle-setup `battle_type` (Battle Setup chunk 0x1D field 7,
   already decoded into the schema) is now plumbed into `Game::Battle` at
   construction: `Game::Battle.new` takes a `battle_type:` keyword (default 0),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9113,6 +9113,26 @@ module Game
       (@allies || []) + (@enemies || [])
     end
 
+    # Reset a combatant's gauge to empty after it has taken its active-time
+    # turn, so it must refill from zero before acting again (RPG_RT 2003's
+    # gauge behaviour). The per-frame Scene::Battle loop calls this from the
+    # turn picker; exposed here so the gauge cycle is unit-testable without
+    # the 2003 boot path (Phase 3).
+    def reset_gauge(c)
+      c.gauge = 0
+    end
+
+    # The active-time turn picker: return the next ready combatant (highest
+    # gauge; see #ready_combatants) and reset its gauge so the loop can advance
+    # and refill it. Returns nil when nobody is ready. A turn-based battle
+    # (battle_type != 2) never has a ready combatant, so this is nil there too.
+    def pop_ready
+      c = ready_combatants.first
+      return nil unless c
+      reset_gauge(c)
+      c
+    end
+
     def to_hit(attacker, target)
       return 0 if evades_all_physical?(target)
       return 100 if do_nothing_restricted?(target)

--- a/scripts/rpg2k3_battle_gauge_check.rb
+++ b/scripts/rpg2k3_battle_gauge_check.rb
@@ -126,5 +126,34 @@ check 'a dead battler does not charge or become ready' do
   eq false, dead.gauge_full?
 end
 
+# -- the active-time turn cycle: pop_ready consumes and resets --------------
+cycle_fast = combatant('CFast', 1, 1, 20, 1)
+cycle_slow = combatant('CSlow', 1, 1, 10, 1)
+cbat = Game::Battle.new([cycle_fast], [cycle_slow], Game::Rng.new(1))
+cbat.battle_type = 2
+cbat.advance_gauges(6)   # fast full (100), slow at 60
+
+check 'pop_ready returns the highest-gauge combatant and resets its gauge' do
+  taken = cbat.pop_ready
+  eq cycle_fast, taken
+  eq 0, cycle_fast.gauge
+  eq false, cycle_fast.gauge_full?
+  # slow is still charging, so nothing else is ready yet
+  eq [], cbat.ready_combatants
+end
+
+check 'after the taker refills it becomes ready again (the ATB loop repeats)' do
+  cbat.advance_gauges(5)   # fast: 0 -> 100 (agi 20 * 5); slow: 60 -> 110 -> 100
+  eq 2, cbat.ready_combatants.size
+  taken = cbat.pop_ready
+  eq cycle_fast, taken   # fast reached full first again
+  eq 0, cycle_fast.gauge
+end
+
+check 'pop_ready is nil for a turn-based battle' do
+  tbat = Game::Battle.new([combatant('A', 1, 1, 20, 1)], [combatant('B', 1, 1, 10, 1)], Game::Rng.new(1))
+  eq nil, tbat.pop_ready
+end
+
 puts "rpg2k3 battle gauge check: #{$checks} checks, #{$failures} failures"
 exit($failures.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary
Completes the RPG2003 gauge timing **model** (ADR 0053, Phase 2), stacked on the gauge-engine PR #939. The active-time turn cycle is now modelled: after a combatant acts its gauge is emptied and it must refill before acting again (RPG_RT 2003 gauge behaviour).

- `Game::Battle#reset_gauge(c)` empties a combatant's gauge.
- `Game::Battle#pop_ready` returns the highest-gauge ready combatant (see `ready_combatants`) and resets it — the fill → ready → act → refill loop the per-frame `Scene::Battle` picker will drive in Phase 3. Both are nil / no-op for a turn-based battle (`battle_type != 2`).

## Deliberately out of scope
The per-frame wiring into `Scene::Battle#update` that actually drives turns off `pop_ready` is deferred to Phase 3 (the 2003 boot path), so this stays fixture-verifiable only. The `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve, the Phase-1 row multiplier, and the attacker-side reach penalty remain flagged TODO against the RPG_RT 2003 specification (still inaccessible).

## Test plan
- `ruby scripts/rpg2k3_battle_gauge_check.rb` — now 10 checks, including the cycle repeating after a combatant refills and `pop_ready` being nil for a turn-based battle. Wired into the `ruby-checks` CI job.
- `ruby scripts/rpg2k_logic_check.rb` — still 976 checks green.

Co-authored-by: opencode <noreply@opencode.ai>