### PR TITLE
rpg2003: wire the RPG2003 battle scene into the gauge engine (ADR 0053 Phase 2)

### DIFF
--- a/changelog.d/rpg2003-battle-gauge-scene.added.md
+++ b/changelog.d/rpg2003-battle-gauge-scene.added.md
@@ -1,0 +1,10 @@
+- Route a fight to the RPG2003 battle scene (RPG2k3::Scene::Battle) whenever the
+  database was authored in 2003, via a new `RPG2k::Scene.battle_scene_class(db)`
+  factory that Scene::Map#drive_battle now uses instead of constructing
+  `RPG2k::Scene::Battle` directly (ADR 0053, Phase 2 scene integration). The 2003
+  scene subclasses the 2000 battle scene and overrides `#update` to advance the
+  active-time gauge every frame for a gauge (battle_type 2) presentation; the
+  traditional (0) and alternative (1) presentations inherit the unchanged
+  turn-based machine, so routing every 2003 fight through it is safe. This is the
+  first 2003-boot slice that actually drives the 2003 gauge engine the moment a
+  fight is reached, without touching the 2000 path.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -4,8 +4,9 @@ Date: 2026-08-16
 
 ## Status
 
-Accepted — Phase 1 (rows) and the Phase 2 gauge model (fill + ready + turn
-cycle) implemented 2026-08-16; Phase 2 scene integration and Phase 3 pending.
+Accepted — Phase 1 (rows), the Phase 2 gauge model (fill + ready + turn cycle)
+and the Phase 2 scene integration all implemented 2026-08-16; Phase 3 (the
+remaining 2003 boot path) pending.
 
 ## Context
 
@@ -144,6 +145,34 @@ Verification: `scripts/rpg2k3_battle_gauge_check.rb` (6 checks) exercises the
 inert turn-based path, AGI-proportional fill, full/ready selection, ordering,
 and that a dead battler neither charges nor becomes ready; wired into the
 `ruby-checks` CI job.
+
+## Phase 2 — scene integration notes (2026-08-16)
+
+The per-frame gauge advance is now driven from the battle scene rather than
+left as a fixture-only model. A new `RPG2k::Scene.battle_scene_class(db)`
+factory (`mruby-rpg2k/mrblib/scene/base.rb`) selects the scene class for a
+fight: `RPG2k3::Scene::Battle` (a new `mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb`)
+when the database was authored in 2003 (`db.rpg2003?`), else the plain
+`RPG2k::Scene::Battle`. `Scene::Map#drive_battle` now constructs the battle
+through this factory instead of `Scene::Battle.new` directly, so the 2003 scene
+is reached the moment a 2003 project opens a fight.
+
+- `RPG2k3::Scene::Battle` subclasses the 2000 scene and overrides `#update` to
+  call `Game::Battle#advance_gauges` once per frame **before** `#super`, gated on
+  `battle_type == 2`. `advance_gauges` is itself a no-op for `battle_type != 2`,
+  so the traditional (0) and alternative (1) presentations run the unchanged
+  turn-based machine — routing every 2003 fight through this scene is safe and
+  future-proof for the 2003-specific presentation work.
+- The factory is referenced at call time (not load time), and `RPG2k3::Scene::Battle`
+  only needs to exist when the method runs, so scene-file load order does not
+  matter for correctness. `battle_rpg2k3.rb` sorts after `battle.rb` in the
+  mrblib glob, so its superclass is defined before it is parsed.
+
+Verification: `scripts/rpg2k_scene_check.rb` adds checks that `battle_scene_class`
+returns `RPG2k3::Scene::Battle` for a 2003 database, `RPG2k::Scene::Battle` for
+an RPG2000 database, and the 2000 scene for a database that implements no
+`#rpg2003?` at all (a bare fixture) — keeping the gauge engine dark for every
+fixture-driven check. The existing 660-check scene harness stays green.
 
 ## Consequences
 

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -329,5 +329,21 @@ class RPG2k
       end
     end
 
+    # The battle scene class for a fight in `db`'s edition: the RPG2003 scene
+    # (RPG2k3::Scene::Battle, mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb) when
+    # the database was authored in 2003, else the plain RPG2000 turn-based
+    # scene. The 2003 scene subclasses the 2000 one and only overrides #update
+    # to advance the active-time gauge when battle_type == 2, so routing every
+    # 2003 fight through it is safe even for the traditional (0) and
+    # alternative (1) presentations, which inherit the unchanged turn-based
+    # machine. Referenced at call time (not load time), so the RPG2k3 constant
+    # resolves however the files happen to be loaded.
+    def self.battle_scene_class(db)
+      if db.respond_to?(:rpg2003?) && db.rpg2003?
+        RPG2k3::Scene::Battle
+      else
+        Battle
+      end
+    end
   end
 end

--- a/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
+++ b/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
@@ -1,0 +1,27 @@
+module RPG2k3
+  module Scene
+    # RPG2003 battle scene. It subclasses the RPG2000 Scene::Battle so it
+    # inherits the entire command / target-cursor / animation machinery --
+    # which is already edition-agnostic, since the RPG2003 battle commands are
+    # ported (ADR 0048) and the database decode is id-driven. Only the *timing*
+    # layer is overridden, keeping the 2000 battle completely untouched.
+    #
+    # For a gauge (active-time) presentation (battle_type 2) #update advances
+    # every combatant's gauge each frame; the next step (ADR 0054) replaces the
+    # 2000 sequential round order with gauge-readiness-driven actor selection.
+    # The traditional (0) and alternative (1) presentations run the inherited
+    # turn-based machine unchanged.
+    class Battle < RPG2k::Scene::Battle
+      # Advance the active-time gauge every frame for a gauge battle, then run
+      # the inherited update (enemy flashes / phase dispatch / ...). A
+      # turn-based or alternative battle leaves the gauge at 0, so
+      # Game::Battle#advance_gauges is a no-op there and 2000 behaviour is
+      # preserved exactly.
+      def update
+        battle = @ui && @ui[:battle]
+        battle.advance_gauges if battle && battle.battle_type == 2
+        super
+      end
+    end
+  end
+end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4830,7 +4830,7 @@ class RPG2k
         req = it.battle_request
         return it.resume_battle(:victory) unless req
         if @battle.nil?
-          @battle = Scene::Battle.new(self, req, it)
+          @battle = RPG2k::Scene.battle_scene_class(db).new(self, req, it)
           @battle.start # opened this frame; take input from the next one
           return
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16497,6 +16497,26 @@ check 'the window title comes from RPG_RT.ini, decoded from CP932' do
   end
 end
 
+check 'battle_scene_class routes a 2003 database to the RPG2k3 battle scene' do
+  rpg2003_db = OpenStruct.new
+  def rpg2003_db.rpg2003?; true; end
+  eq RPG2k3::Scene::Battle, RPG2k::Scene.battle_scene_class(rpg2003_db),
+     'an RPG2003 database boots the gauge-capable 2003 scene'
+
+  rpg2000_db = OpenStruct.new
+  def rpg2000_db.rpg2003?; false; end
+  eq RPG2k::Scene::Battle, RPG2k::Scene.battle_scene_class(rpg2000_db),
+     'an RPG2000 database keeps the turn-based 2000 scene'
+end
+
+# A database that does not implement #rpg2003? at all (a bare fixture) is
+# treated as RPG2000, never as the 2003 scene, so the gauge engine stays dark
+# for every fixture-driven check.
+check 'battle_scene_class treats an edition-less database as RPG2000' do
+  eq RPG2k::Scene::Battle, RPG2k::Scene.battle_scene_class(OpenStruct.new),
+     'a fixture database with no #rpg2003? keeps the 2000 scene'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
- Route a 2003 fight through `RPG2k3::Scene::Battle` the moment one opens: `Scene::Map#drive_battle` now builds the battle via a new `RPG2k::Scene.battle_scene_class(db)` factory (returns `RPG2k3::Scene::Battle` for an RPG2003 database, else the plain RPG2000 turn-based scene) instead of constructing `RPG2k::Scene::Battle` directly.
- `RPG2k3::Scene::Battle` (new `mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb`) subclasses the 2000 battle scene and overrides `#update` to advance the active-time gauge every frame for a gauge (`battle_type` 2) presentation; the traditional (0) and alternative (1) presentations inherit the unchanged turn-based machine, so routing every 2003 fight through it is safe and keeps the 2000 path untouched.
- The gauge engine itself (fill / ready / turn cycle) is already on `master` (PRs #939/#940). This is the Phase 2 scene-integration slice of ADR 0053.

## Verification
- `scripts/rpg2k_scene_check.rb`: 662 checks pass (2 new checks assert `battle_scene_class` returns the 2003 scene for a 2003 database and the 2000 scene for an RPG2000 / edition-less database).
- `scripts/rpg2k3_battle_gauge_check.rb`: 10 checks, `scripts/rpg2k3_battle_row_check.rb`: 8 checks — unaffected.
- `mrbc` compiles the scene files in the native build order; pre-commit hooks clean.

🤖 Generated with [opencode](https://opencode.ai)

Co-authored-by: opencode <noreply@opencode.ai>