### PR TITLE
rpg2003: active-time (gauge) turn cycle in the battle scene (ADR 0054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,17 @@
   back the frame it ends
 - A fight in an **RPG2003 project** runs through the 2003 battle scene
   (`RPG2k3::Scene::Battle`, selected by the database's edition): a gauge
-  (`battle_type` 2) presentation draws the party as face/bars gauge cards from
-  the project's System2 graphic and advances each battler's active-time charge
-  every frame, while the traditional and alternative presentations inherit the
-  unchanged turn-based machine. The 2003 test beds ship no encounters, so a
-  `--rpg2k_battle_troop=<id>` flag drives a real project straight into a fight
-  against a chosen database troop after New Game — the boot check uses it to
-  exercise the 2003 battle path end to end against real data
+  (`battle_type` 2) presentation runs on the active-time turn cycle — every
+  combatant's charge gauge fills each frame, the first one full opens the
+  command menu for a controllable party member or fires the action of anyone
+  else (enemy AI included) automatically, and acting resets it — draws the
+  party as face/bars gauge cards from the project's System2 graphic, and
+  applies RPG2003's front/back row accuracy, while the traditional and
+  alternative presentations inherit the unchanged turn-based machine. The 2003
+  test beds ship no encounters, so a `--rpg2k_battle_troop=<id>` flag drives a
+  real project straight into a fight against a chosen database troop after New
+  Game — the boot check uses it to exercise the 2003 battle path end to end
+  against real data
 - The **field windows show a condition too** — the menu party list, the item and
   skill target lists, and the status screen, which are the three RPG_RT draws one
   in. The target lists are the point: they are where you pick who to use an

--- a/changelog.d/rpg2003-battle-gauge-turn-cycle.added.md
+++ b/changelog.d/rpg2003-battle-gauge-turn-cycle.added.md
@@ -1,0 +1,16 @@
+- The **RPG2003 gauge battle now runs on its active-time turn cycle** (ADR
+  0054): a gauge presentation (battle_type 2) fight replaces the 2000
+  sequential round order with "whose gauge is full" — every combatant's charge
+  gauge fills each frame, the first one full opens the command menu for a
+  controllable party member (the fight pauses on it, Wait-mode behaviour) or
+  fires the action of anyone else (enemy AI included) automatically, and acting
+  resets the gauge so it refills. `Game::Battle#begin_gauge_turn` queues one
+  battler per action (bumping its own per-battler turn counter for the
+  RPG2003 page conditions, never the round count), and `RPG2k3::Scene::Battle`
+  runs the whole cycle through an `:atb` idle loop — with every override gated
+  on battle_type 2, so the traditional and alternative 2003 presentations and
+  every RPG2000 fight keep the unchanged round machine. A gauge fight no longer
+  shows the Fight/Auto/Escape options window; its once-per-fight menu opens for
+  the first ready actor instead. Covered by new `rpg2k3_battle_gauge_check.rb`
+  and `rpg2k_scene_check.rb` checks driving a real gauge battle through the
+  2003 scene; the native boot check's 2003 battle pass stays green.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1654,8 +1654,11 @@ The work below is roughly ordered by the critical path to a walkable game
   and **Open Video Options** (5005) are logged no-ops because this build's
   display backend has neither, the same answer EasyRPG gives on a platform whose
   window cannot change mode. Still open here: **Toggle ATB Mode** (5003), which
-  needs the RPG2003 ATB battle system this runtime does not model, so it is
-  deliberately left as a reported gap rather than a silent no-op; and the combo
+  would switch a gauge fight between this engine's active-time turn cycle (ADR
+  0054 — the gauge-driven battle now modelled for the gauge presentation) and
+  the round-based machine; the command itself toggles a per-battle flag the
+  battle still never reads, so it stays a reported gap rather than a silent
+  no-op. And the combo
   an Enable Combo arms is recorded on the actor but never spent, for the same
   reason. The opcodes were read out of liblcf's `EventCommand::Code` enum, which
   also corrected `analyze_game.rb` — it had Change Class / Change Battle Commands
@@ -1691,11 +1694,13 @@ The work below is roughly ordered by the critical path to a walkable game
   *only* page-scheduling call site RPG2000's own battle scene has, always
   calls `ScheduleNextPage(nullptr)`. A real `source` only ever exists in
   `Scene_Battle_Rpg2k3`, whose active-time turn cycle — the gauge-readiness
-  driver that hands the picker a concrete acting battler, still the one
-  unmodelled piece of the 2003 battle scene this runtime routes to (see ADR
-  0053 and the Toggle ATB Mode note below) — this runtime does not model, so
-  a page gated on `command_actor` is
-  *never satisfiable* under RPG2000's own battle system — not a once-per-turn
+  driver this runtime now runs for gauge battles (ADR 0054; see the Toggle
+  ATB Mode note below) — hands the picker a concrete acting battler, but the
+  *chosen command* is still never recorded onto it (`Game::Battle#
+  actor_command` stays nil: the scene drives a gauge turn through the same
+  action queue a round does, and nothing in that path notes which command was
+  picked), so a page gated on `command_actor` remains
+  *never satisfiable* here — not a once-per-turn
   evaluation standing in for a future per-actor one. Still open: video
   playback for Play Movie (no decoder is linked in; the request is logged). **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -6,7 +6,8 @@ Date: 2026-08-16
 
 Accepted — Phase 1 (rows), the Phase 2 gauge model (fill + ready + turn cycle),
 the Phase 2 scene integration and Phase 3 (boot-to-battle) all implemented
-2026-08-16.
+2026-08-16. The active-time turn cycle itself — the per-frame picker that
+consumes a full gauge — is implemented as the follow-on ADR 0054.
 
 ## Context
 
@@ -230,11 +231,11 @@ fatal). Scene checks pin the `headless_battle_troop` flag plumbing and
   mruby/CRuby divergence class the CRuby harnesses cannot see.
 - Row and timing are modelled as data on `Game::Battle::Combatant` so they are
   reusable by both the turn-based and gauge phase machines and by enemy AI.
-- The active-time turn cycle — consuming a full gauge with a command/AI action
-  and resetting it — is the remaining 2003 battle piece: the scene integration
-  advances gauges and Phase 3 reaches a real 2003 fight, but turns still run on
-  the 2000 sequential round machine. See the "next step" note on
-  `RPG2k3::Scene::Battle`.
+- The active-time turn cycle — the gauge-readiness-driven picker that consumes
+  a full gauge with a command/AI action and resets it — is implemented as the
+  follow-on ADR 0054, on top of the Phase 2 scene integration and Phase 3 boot
+  path: a gauge fight now runs on per-combatant gauges instead of the 2000
+  sequential round machine, with every other 2003 fight untouched.
 - Follow-up work (battle-event pages already parsed; 2003-specific battle
   commands beyond the four this engine drives; the Special command handler;
   the attacker-side back-row reach penalty) stays out of scope for these three

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -1,0 +1,94 @@
+# 54. RPG2003 gauge battle — the active-time turn cycle
+
+Date: 2026-08-16
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0053 scoped the RPG2003 battle work in three phases and landed them: the
+row mechanic (Phase 1), the per-combatant gauge model — `advance_gauges` /
+`ready_combatants` / `pop_ready` / `reset_gauge` on `Game::Battle` (Phase 2) —
+and the boot path that drives a real 2003 project into the battle scene (Phase
+3). The scene integration that routes 2003 fights to `RPG2k3::Scene::Battle`
+(Phase 2's final slice) advanced every combatant's gauge every frame, but the
+**turn picker was never wired**: the battle still decided *whose turn it is*
+with the 2000 sequential round machine (`begin_round` / `step_action` /
+`end_round` over an agility-ordered queue), so a gauge battle charged gauges
+that nothing consumed. The remaining piece, called out as "the next step (ADR
+0054)" in `battle_rpg2k3.rb`, is the active-time turn cycle itself.
+
+RPG_RT 2003's gauge presentation (EasyRPG's `Scene_Battle_Rpg2k3`) replaces
+"whose turn is it" with "whose gauge is full": every combatant's gauge fills
+every frame at a rate proportional to its AGI; the instant one is full it
+acts — a controllable party member opens the command menu, everyone else
+(enemy AI included) fires automatically — and acting resets the gauge so it
+must refill. Turns are thus per-combatant and continuous rather than
+all-combatants-per-round.
+
+## Decision
+
+Drive the gauge battle's turns from gauge readiness in `RPG2k3::Scene::Battle`,
+on top of the unchanged action-resolution machinery:
+
+- **A new idle phase `:atb`** is the gauge battle's "whose turn" loop.
+  `drive_battle_atb` runs the troop battle-event page check, settles a decided
+  fight, then polls `Game::Battle#ready_combatants` (the full-gauge
+  combatants, highest gauge first). A living, in-play party member free to be
+  handed a manual command — `controllable?`: an ally, not
+  `command_restricted?`, not Forced-AI — opens the command menu with its gauge
+  held full; anyone else's ready gauge fires its action automatically.
+- **`Game::Battle#begin_gauge_turn(b)`** is the model-side counterpart to
+  `begin_round`: it queues `b` as the sole battler of the coming action, resets
+  its gauge, locks in its round-level do-nothing restriction, and bumps its
+  per-battler turn counter (the RPG2003 `turn_enemy`/`turn_actor` page
+  condition count). It deliberately does **not** touch `@rounds` — a gauge
+  battle has no RPG2000-style rounds, so the global turn number stays 0 and the
+  pages read per-battler counters. From there the existing `step_action` /
+  `strike` / `@pending` machinery runs the action unchanged.
+- **The round-flow method overrides are all gated on `battle_type == 2`**
+  (`gauge_battle?`): `enter_command_phase` and `open_battle_options` route to
+  the idle loop instead of the once-per-fight Fight/Auto/Escape window,
+  `prev_commandable_actor_index` returns nil (canceling a ready actor's menu
+  returns it to the idle loop, its gauge still full), `advance_actor` starts
+  the committing actor's action instead of the next actor's menu, and
+  `finish_round_animation` returns to the idle loop instead of opening the next
+  round. The traditional (0) and alternative (1) presentations inherit the
+  untouched 2000 machine.
+- **`update`** advances the gauges and dispatches the phases itself for a gauge
+  battle (adding the `:atb` case); everything else delegates to `super`.
+
+Behavioral notes and deliberate simplifications:
+
+- The command menu **pauses the fight** while it is open — RPG2003's Wait-mode
+  behaviour — so other ready combatants queue behind the committing actor
+  rather than acting mid-deliberation. The active-during-menu (Wait-off)
+  presentation, and the database's wait toggle itself (a Battle Commands field
+  the schema does not decode yet), are follow-ups.
+- A gauge battle shows **no Fight/Auto/Escape options window**: the first ready
+  actor's menu opens on its own. The `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve
+  remains ADR 0053's flagged-placeholder constants.
+- A `command_actor`-gated battle page still never fires: the turn cycle hands
+  the picker a concrete battler but never records which command it chose
+  (`Game::Battle#actor_command` stays nil).
+
+## Consequences
+
+- The gauge presentation's core timing — per-combatant, AGI-paced turns instead
+  of rounds — is now playable, and a real 2003 gauge project (mtf-meido-action
+  via `--rpg2k_battle_troop`) boots into it and runs stably.
+- The existing round machine, the row mechanic and the traditional/alternative
+  presentations are untouched: every override is gated on `battle_type == 2`,
+  and the model addition is additive.
+- Verification is fixture-driven: `rpg2k3_battle_gauge_check.rb` pins
+  `begin_gauge_turn` (single-battler queue, gauge consumption, per-battler turn
+  bump, silent no-op turn for a restricted battler) and `rpg2k_scene_check.rb`
+  drives real gauge battles through the 2003 scene (menu-on-own, commit →
+  action → idle, ready enemy auto-fires, restricted member's silent turn, and a
+  battle_type 0 fight never entering the gauge loop). The native boot check
+  keeps the real 2003 battle green.
+- Follow-ups: Wait-off (active) mode and the database wait toggle; recording
+  the chosen command for `command_actor` pages; the Special command handler;
+  the attacker-side back-row reach penalty; the exact RPG_RT 2003 fill curve.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9133,6 +9133,31 @@ module Game
       c
     end
 
+    # Begin `b`'s active-time turn: its gauge fired, so it acts on its own
+    # schedule rather than as one slot of an agility-ordered round. This queues
+    # `b` as the sole battler of the coming action the way #begin_round queues a
+    # whole round, so the existing per-action machinery (#step_action / #strike /
+    # the @pending multi-hit buffer / #end_round) runs unchanged for it -- the
+    # scene's per-frame picker (RPG2k3::Scene::Battle#drive_battle_atb) calls
+    # this once per ready combatant instead of #begin_round once per round.
+    #
+    # The battler's gauge is reset here (it must refill before acting again),
+    # and its own per-battler turn counter is bumped -- RPG2003's
+    # turn_enemy / turn_actor page-condition count, the same #next_battle_turn
+    # #step bumps when the *round* machine runs one -- so a page's per-battler
+    # turn conditions tick in a gauge battle too. A "do nothing" restriction is
+    # locked in for the turn the same way #refill_queue locks it at the start of
+    # a round. Deliberately does NOT touch @rounds: a gauge battle has no
+    # RPG2000-style rounds, so the global turn number (#turn) stays 0 for it and
+    # the pages read the per-battler counters instead.
+    def begin_gauge_turn(b)
+      @pending = []
+      b.next_battle_turn
+      b.queued_no_act = do_nothing_restricted?(b)
+      reset_gauge(b)
+      @queue = [b]
+    end
+
     def to_hit(attacker, target)
       return 0 if evades_all_physical?(target)
       return 100 if do_nothing_restricted?(target)

--- a/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
+++ b/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
@@ -6,21 +6,199 @@ module RPG2k3
     # ported (ADR 0048) and the database decode is id-driven. Only the *timing*
     # layer is overridden, keeping the 2000 battle completely untouched.
     #
-    # For a gauge (active-time) presentation (battle_type 2) #update advances
-    # every combatant's gauge each frame; the next step (ADR 0054) replaces the
-    # 2000 sequential round order with gauge-readiness-driven actor selection.
+    # For a gauge (active-time) presentation (battle_type 2) the fight runs on
+    # the per-combatant charge gauge (ADR 0053 Phase 2's model, driven by the
+    # per-frame turn cycle here): every combatant's gauge fills each frame, the
+    # moment one is full decides *whose turn it is* instead of the 2000
+    # sequential round order, and acting resets it so it refills. A
+    # controllable party member whose gauge is full opens the command menu
+    # (the battle pauses on it -- Wait-mode behaviour); everyone else acts
+    # automatically the instant their gauge fires, enemy AI included.
+    #
     # The traditional (0) and alternative (1) presentations run the inherited
-    # turn-based machine unchanged.
+    # turn-based machine unchanged -- every override below is gated on
+    # `battle_type == 2`, so routing every 2003 fight through this scene stays
+    # safe for them.
     class Battle < RPG2k::Scene::Battle
-      # Advance the active-time gauge every frame for a gauge battle, then run
-      # the inherited update (enemy flashes / phase dispatch / ...). A
-      # turn-based or alternative battle leaves the gauge at 0, so
-      # Game::Battle#advance_gauges is a no-op there and 2000 behaviour is
-      # preserved exactly.
+      # Advance the active-time gauge every frame for a gauge battle, then
+      # dispatch on the phase. A turn-based or alternative battle leaves the
+      # gauge at 0 and runs the inherited update (and with it the whole 2000
+      # round machine) untouched.
       def update
         battle = @ui && @ui[:battle]
-        battle.advance_gauges if battle && battle.battle_type == 2
+        if battle && battle.battle_type == 2
+          battle.advance_gauges
+          update_enemy_flashes
+          update_enemy_positions
+          update_enemy_shakes
+          case @ui[:phase]
+          when :encounter_message then drive_battle_encounter_message
+          # The active-time idle loop -- the phase the gauge battle lives in
+          # between actions, and the replacement for the round machine's
+          # :command/:battle_options pair (see #enter_command_phase).
+          when :atb         then drive_battle_atb
+          when :command     then drive_battle_command
+          when :target      then drive_battle_target
+          when :skill       then drive_battle_skill
+          when :item        then drive_battle_item
+          when :ally_target then drive_battle_ally_target
+          when :animate     then drive_battle_animate
+          when :result      then drive_battle_result
+          when :event       then drive_battle_event
+          end
+          @map.try_open_debug_menu
+        else
+          super
+        end
+      end
+
+      # Whether this fight is the gauge presentation -- the gate every override
+      # here checks, so the 2003 scene's traditional (0) and alternative (1)
+      # battles inherit the untouched 2000 machine. A bare fixture battle that
+      # never set a battle_type reads 0 (false), like every other optional
+      # field in this codebase.
+      def gauge_battle?
+        battle = @ui && @ui[:battle]
+        !!(battle && battle.battle_type == 2)
+      end
+
+      # The gauge battle's "whose turn is it": poll the ready combatants (the
+      # full-gauge ones, highest first) and hand the frame to whichever one
+      # fires. A living, in-play party member free to take a manual command
+      # opens the command menu for it -- its gauge stays full, held, until it
+      # commits -- and anyone else (an enemy, an asleep/paralysed or Forced-AI
+      # actor) acts automatically right away. Battle-event pages are checked
+      # once per acting battler the way the round machine checks them between
+      # battlers, and a decided fight settles to its result.
+      def drive_battle_atb
+        battle = @ui[:battle]
+        return if run_battle_events(:atb)
+        if battle.finished?
+          # #finish_round_animation settles the result before returning here,
+          # but the per-frame loop should not trust that: settle it defensively
+          # (end_round is idempotent) so a fight that became decided another
+          # way -- a battle-event page, say -- lands on its result, never on a
+          # nil one.
+          battle.end_round
+          enter_battle_result(battle.result)
+          return
+        end
+        b = battle.ready_combatants.first
+        return unless b
+        if controllable?(b)
+          # Point the command flow at the ready actor (`current_actor` reads
+          # @ui[:actor_i]) and open its menu; the gauge stays full while the
+          # player chooses.
+          idx = living_allies.index(b)
+          @ui[:actor_i] = idx if idx
+          @ui[:cmd] = 0
+          @ui[:phase] = :command
+          draw_battle_command
+        else
+          # A Forced-AI actor's ready gauge gets the same AI pick the round
+          # machine's skip logic would have queued for it; a restricted actor
+          # just fires its turn (which #step_action resolves to a no-op).
+          battle.choose_auto_battle_command(b) if force_ai_actor?(b)
+          start_gauge_action(b)
+        end
+      end
+
+      # The gauge battle's replacement for the once-per-fight Fight/Auto/Escape
+      # options window: there is none -- the first ready controllable actor's
+      # command menu opens on its own the moment its gauge fills. Both the
+      # battle-start entry (#start's own final step) and the between-actions
+      # re-entry route here.
+      def enter_command_phase
+        return enter_atb_phase if gauge_battle?
         super
+      end
+
+      # The command menu's cancel lands here too: a gauge battle offers no
+      # Fight/Auto/Escape window to fall back to, so canceling the ready
+      # actor's menu simply returns it to the idle loop -- its gauge stays full
+      # and it is offered the menu again.
+      def open_battle_options
+        return enter_atb_phase if gauge_battle?
+        super
+      end
+
+      # A gauge battle's command-cancel never re-commands a *previous* party
+      # member the way the round machine does (only the ready actor is ever
+      # offered a menu); it always returns to the active-time idle loop. The
+      # base #drive_battle_command reads this to decide where B lands.
+      def prev_commandable_actor_index
+        return nil if gauge_battle?
+        super
+      end
+
+      # The command flow's "next actor" is the round machine's job. A gauge
+      # battle instead starts the ready actor's action the moment its command
+      # commits -- every command path (Attack/Skill/Defend/Item, each of the
+      # target/skill/item sub-menus) funnels through this one method.
+      def advance_actor
+        return start_gauge_action(current_actor) if gauge_battle? && current_actor
+        super
+      end
+
+      # The gauge battle's counterpart to #start_round_animation: begin the one
+      # ready combatant's action (its gauge already consumed by the model) in
+      # place of a whole agility-ordered round. From here #drive_battle_animate
+      # plays it out exactly as it plays a round -- banner, SE, animation,
+      # battle-page checks at the action boundary -- then the queue emptying
+      # returns the fight to the idle loop (#finish_round_animation's override).
+      def start_gauge_action(b)
+        if @ui[:cmd_win]
+          @ui[:cmd_win].dispose
+          @ui[:cmd_win] = nil
+        end
+        @ui[:battle].begin_gauge_turn(b)
+        @ui[:phase] = :animate
+        @ui[:anim_timer] = 0 # land the action next frame
+      end
+
+      # A gauge action is its own "round": when the queue empties, return to
+      # the active-time idle loop rather than opening the next round's command
+      # window. The per-action `pages_run` reset matches the base's per-round
+      # reset -- each battler's turn re-arms the troop's pages.
+      def finish_round_animation
+        return super unless gauge_battle?
+        battle = @ui[:battle]
+        battle.end_round
+        close_battle_action
+        if battle.finished?
+          enter_battle_result(battle.result)
+        else
+          @ui[:actor_i] = 0
+          @ui[:cmd] = 0
+          @ui[:pages_run] = {}
+          enter_atb_phase
+        end
+      end
+
+      # Enter the active-time idle loop and give it the rest of this frame, so
+      # an action ending and the next ready combatant firing never costs a
+      # whole extra frame -- the same "spend this frame's step budget
+      # immediately" idiom the base's own #finish_round_animation uses to open
+      # the next command window. #drive_battle_atb runs the page/finished/ready
+      # checks itself, so this just points the phase at it.
+      def enter_atb_phase
+        @ui[:phase] = :atb
+        return if settle_already_finished_battle
+        drive_battle_atb
+      end
+
+      # Whether `b` is a living, in-play *party member* free to be handed a
+      # manual command right now -- an enemy is never offered a menu (its ready
+      # gauge always fires its own AI action), and the "commandable" test the
+      # round machine's own skip logic uses for the allies it does offer one to
+      # (`#command_restricted?` + the scene's Forced-AI test) decides the rest,
+      # so an asleep / paralysed / Forced-AI actor's ready gauge fires its
+      # action automatically instead of pausing the fight for a prompt the
+      # action resolution would discard or override anyway.
+      def controllable?(b)
+        return false unless @ui[:allies].include?(b)
+        battle = @ui[:battle]
+        !battle.command_restricted?(b) && !force_ai_actor?(b)
       end
     end
   end

--- a/scripts/rpg2k3_battle_gauge_check.rb
+++ b/scripts/rpg2k3_battle_gauge_check.rb
@@ -24,6 +24,7 @@ module RGSS
 end
 
 require 'stringio'
+require 'ostruct'
 module LCF
   def cp932_to_utf8(s)
     s.dup.force_encoding('Windows-31J')
@@ -153,6 +154,46 @@ end
 check 'pop_ready is nil for a turn-based battle' do
   tbat = Game::Battle.new([combatant('A', 1, 1, 20, 1)], [combatant('B', 1, 1, 10, 1)], Game::Rng.new(1))
   eq nil, tbat.pop_ready
+end
+
+# -- begin_gauge_turn: the per-ready-combatant action the scene's picker primes
+# -- (RPG2k3::Scene::Battle#drive_battle_atb), the single-battler counterpart
+# -- to begin_round's whole agility-ordered queue ----------------------------
+turn_hero = combatant('THero', 30, 0, 20, 1000)
+turn_slime = combatant('TSlime', 0, 0, 5, 1000)
+tbat = Game::Battle.new([turn_hero], [turn_slime], Game::Rng.new(1))
+tbat.battle_type = 2
+tbat.advance_gauges(5) # the hero's gauge is full
+
+check 'begin_gauge_turn queues one battler: step_action plays its turn, then nothing remains' do
+  tbat.command_attack(turn_hero, turn_slime)
+  tbat.begin_gauge_turn(turn_hero)
+  eq 0, turn_hero.gauge, 'the fired gauge was consumed'
+  entry = tbat.step_action
+  ok entry, 'the queued battler acted'
+  eq 'TSlime', entry[:target], 'against the commanded target'
+  eq nil, tbat.step_action, 'no second battler is in the queue -- the turn is done'
+end
+
+check 'begin_gauge_turn bumps the battler\'s per-battler turn counter, not the round count' do
+  eq 1, turn_hero.turns_taken, 'the battler\'s own page-condition turn counter ticks'
+  eq 0, tbat.turn, 'but the RPG2000-style round count stays 0 -- a gauge battle has no rounds'
+  eq nil, tbat.ready_combatants.first, 'and the consumed gauge is no longer ready'
+end
+
+check 'a do-nothing-restricted battler\'s gauge turn is consumed as a silent no-op' do
+  asleep = combatant('Asleep', 30, 0, 20, 1000)
+  asleep.states = [4] # Sleep: restriction 1
+  states = { 4 => OpenStruct.new(restriction: Game::Battle::RESTRICTION_DO_NOTHING) }
+  abat = Game::Battle.new([asleep], [combatant('Awake', 0, 0, 5, 1000)],
+                          Game::Rng.new(1), states, false, false, false, false,
+                          nil, nil, battle_type: 2)
+  abat.advance_gauges(5)
+  eq Game::Battle::GAUGE_MAX, asleep.gauge, 'ready to act'
+  abat.begin_gauge_turn(asleep)
+  eq 0, asleep.gauge, 'the turn consumed the gauge even though it cannot act'
+  eq 1, asleep.turns_taken, 'the skipped turn still counts as the battler\'s turn'
+  eq nil, abat.step_action, 'the restriction resolved the turn to no action at all'
 end
 
 puts "rpg2k3 battle gauge check: #{$checks} checks, #{$failures} failures"

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -357,7 +357,7 @@ end
 def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
             airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
             rpg2003: false, menu_commands: nil, footstep: '', on_damage_se: false,
-            battleranimations: nil)
+            battleranimations: nil, battlecommands: nil)
   OpenStruct.new(
     rpg2003?: rpg2003,
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
@@ -573,7 +573,15 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
     # nil (the default, an RPG2000 database never carries chunk 32) unless a
     # check passes its own id => entry hash (#battle_pose, #battle_pose_set
     # below build the shape #build_actor_sprite reads).
-    battleranimations: battleranimations
+    battleranimations: battleranimations,
+    # RPG2003's Battle Commands table (chunk 0x1D, db.battlecommands) -- nil
+    # (the default, an RPG2000 database never carries it) unless a check passes
+    # its own table, e.g. `OpenStruct.new(battle_type: 2, placement: 1)` for a
+    # gauge-presentation fight. Scene::Battle#start reads
+    # `db.battlecommands.battle_type` off it to seed the fight's timing, and
+    # `battle_scene_class(db)` routes the fight to RPG2k3::Scene::Battle on
+    # `db.rpg2003?` -- so the two must agree in a gauge check.
+    battlecommands: battlecommands
   )
 end
 
@@ -804,12 +812,13 @@ def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: n
               members: [], terrain_damage: 0, bush_depth: 0,
               airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
               map_tree: nil, test_play: false, rpg2003: false,
-              footstep: '', on_damage_se: false, battleranimations: nil)
+              footstep: '', on_damage_se: false, battleranimations: nil,
+              battlecommands: nil)
   db = fake_db(common, troop_pages, terrain_damage, bush_depth,
                airship_land: airship_land, airship_pass: airship_pass,
                boat_pass: boat_pass, ship_pass: ship_pass, rpg2003: rpg2003,
                footstep: footstep, on_damage_se: on_damage_se,
-               battleranimations: battleranimations)
+               battleranimations: battleranimations, battlecommands: battlecommands)
   state = Game::State.new(fake_party(members, rpg2003: rpg2003), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   parent = fake_parent(db)
@@ -10971,12 +10980,14 @@ end
 # check predating the gauge-card status panel used; a check exercising a
 # non-default battle-screen presentation (BattleStubParty's `gauge_layout:`)
 # passes its own instead.
-def battle_scene_with_pages(pages, party: BattleStubParty.new, battleranimations: nil)
+def battle_scene_with_pages(pages, party: BattleStubParty.new, battleranimations: nil,
+                            rpg2003: false, battlecommands: nil)
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic)
   scene = new_scene({ 1 => event(2, 2, auto) }, troop_pages: pages,
-                    battleranimations: battleranimations)
+                    battleranimations: battleranimations,
+                    rpg2003: rpg2003, battlecommands: battlecommands)
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, party)
   [scene, st]
@@ -12731,6 +12742,115 @@ check 'DrawNumberSystem2 leading-zero cascade matches EasyRPG exactly (7, 42, 10
   eq [[8, 1], [16, 0], [24, 0]], glyphs.call(100),
      'a hundreds digit that carries down still draws its own zero tens/ones cells'
   eq [[8, 9], [16, 9], [24, 9]], glyphs.call(999), 'three 9s, still no (blank) thousands cell'
+end
+
+# -- the active-time (gauge) turn cycle (ADR 0053 Phase 2, scene integration) --
+#
+# A gauge-presentation battle (battle_type 2, routed to RPG2k3::Scene::Battle
+# by `battle_scene_class`) replaces "whose turn is it" with "whose gauge is
+# full": every combatant's gauge fills each frame, a full gauge opens the
+# command menu for a controllable party member or fires the action of anyone
+# else (enemy AI included) automatically, and acting resets it. These checks
+# drive a real gauge battle through the 2003 scene and poke the gauges
+# directly to control whose turn is up.
+
+# A real gauge battle for the turn-cycle checks: the fixture database is
+# RPG2003 with a Battle Commands table asking for the gauge presentation, so
+# the fight opens in RPG2k3::Scene::Battle (not the 2000 scene) and its model
+# is seeded battle_type 2.
+def gauge_battle_scene(party = BattleStubParty.new, pages = {})
+  scene, = battle_scene_with_pages(pages, party: party, rpg2003: true,
+                                   battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
+  scene
+end
+
+check 'a gauge battle opens the ready actor\'s command menu on its own -- no Fight/Auto/Escape window' do
+  scene = gauge_battle_scene
+  seen_options = false
+  ui = nil
+  120.times do
+    scene.update
+    ui = battle_ui(scene)
+    seen_options = true if ui && ui[:phase] == :battle_options
+    break if ui && ui[:phase] == :command
+  end
+  ok ui, 'the battle opened'
+  ok scene.instance_variable_get(:@battle).is_a?(RPG2k3::Scene::Battle),
+     'the gauge database routes the fight to the 2003 scene'
+  eq :command, ui[:phase], 'the first full-gauge party member\'s menu appears on its own'
+  eq ui[:allies][0], scene.instance_variable_get(:@battle).send(:current_actor),
+     'and it is that ready member being commanded'
+  eq false, seen_options, 'the once-per-fight Fight/Auto/Escape window never shows for a gauge battle'
+end
+
+check 'committing the ready actor\'s command starts that one action, consuming its gauge' do
+  scene = gauge_battle_scene
+  ui = battle_until_phase(scene, :command, 120)
+  ok ui, 'the battle opened to the ready actor\'s menu'
+  # Empty every gauge so the fight has nothing else queued behind this action.
+  ui[:battle].all_combatants.each { |c| c.gauge = 0 }
+  RGSS::Input.triggered = [RGSS::Input::C] # Attack
+  scene.update
+  RGSS::Input.triggered = []
+  ui = battle_ui(scene)
+  eq :target, ui[:phase], 'Attack opens the target cursor'
+  RGSS::Input.triggered = [RGSS::Input::C] # the first Slime
+  scene.update
+  RGSS::Input.triggered = []
+  ui = battle_ui(scene)
+  eq :animate, ui[:phase], 'confirming the target starts the action'
+  eq 0, ui[:battle].all_combatants.first.gauge,
+     'the committed actor\'s gauge was consumed the moment its turn began'
+end
+
+check 'canceling the ready actor\'s menu returns to the active-time idle loop, and ' \
+      'a ready enemy\'s gauge fires its action automatically there' do
+  scene = gauge_battle_scene
+  ui = battle_until_phase(scene, :command, 120)
+  ok ui, 'the battle opened to the ready actor\'s menu'
+  ui[:battle].all_combatants.each { |c| c.gauge = 0 }
+  RGSS::Input.triggered = [RGSS::Input::B] # cancel the menu
+  scene.update
+  RGSS::Input.triggered = []
+  ui = battle_ui(scene)
+  eq :atb, ui[:phase], 'cancel returns to the active-time idle loop, not to a Fight/Auto/Escape window'
+  # Make a Slime ready: its gauge fires the enemy's action with no menu.
+  ui[:battle].enemy(0).gauge = Game::Battle::GAUGE_MAX
+  scene.update
+  ui = battle_ui(scene)
+  eq :animate, ui[:phase], 'a ready enemy acts immediately instead of opening a menu'
+  eq 0, ui[:battle].enemy(0).gauge, 'the acting enemy\'s gauge was consumed'
+end
+
+check 'a ready but restricted (asleep) party member\'s gauge fires a silent no-op, never a command prompt' do
+  scene = gauge_battle_scene(BattleStubParty.new(BattleStubActor.new(id: 1, states: [4])))
+  ui = battle_until_phase(scene, :animate, 120)
+  ok ui, 'the battle opened'
+  hero = ui[:battle].all_combatants.first
+  eq 0, hero.gauge, 'the asleep member\'s ready gauge was consumed by its (no-op) turn'
+  eq true, hero.queued_no_act, 'the do-nothing restriction was locked in for the turn'
+end
+
+check 'an RPG2003 battle_type 0 (traditional) fight still runs the round machine, never the gauge idle loop' do
+  scene, = battle_scene_with_pages({}, rpg2003: true,
+                                   battlecommands: OpenStruct.new(battle_type: 0, placement: 1))
+  seen_atb = false
+  ui = nil
+  120.times do
+    ui = battle_ui(scene)
+    # The same tap-before-update pattern #battle_at_command uses: dismissing
+    # the Fight/Auto/Escape window is the only way the round machine gets to
+    # its :command phase, and the tap must survive into the update that reads it.
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
+    seen_atb = true if ui && ui[:phase] == :atb
+    scene.update
+    RGSS::Input.triggered = []
+    ui = battle_ui(scene)
+    break if ui && ui[:phase] == :command
+  end
+  ok ui, 'the battle opened'
+  eq :command, ui[:phase], 'the traditional 2003 fight opens the ordinary round command phase'
+  eq false, seen_atb, 'and never enters the active-time idle loop'
 end
 
 # -- mid-battle party roster sync: the screen (step 2 of the roster-sync ------


### PR DESCRIPTION
The last piece of the RPG2003 gauge battle: a gauge-presentation fight (`battle_type` 2) now decides *whose turn it is* with *whose gauge is full* instead of the 2000 sequential round machine.

**What changed**
- `Game::Battle#begin_gauge_turn(b)` — queues one battler as the sole action of its gauge-fired turn (the existing `step_action`/`strike` machinery runs unchanged), resets its gauge, locks its round-level do-nothing restriction, and bumps its per-battler turn counter (never the RPG2000-style round count).
- `RPG2k3::Scene::Battle` — a new `:atb` idle phase (`drive_battle_atb`) polls `ready_combatants`: a controllable party member (an ally, unrestricted, not Forced-AI) opens the command menu with its gauge held full; everyone else (enemy AI, asleep/paralysed/Forced-AI actors) fires automatically. `enter_command_phase`/`open_battle_options` route to the idle loop (no Fight/Auto/Escape window in a gauge fight), `advance_actor` starts the committing actor's action, `finish_round_animation` returns to the idle loop. **Every override is gated on `battle_type == 2`**, so the traditional/alternative 2003 presentations and all RPG2000 fights keep the unchanged round machine.
- Menu-open pauses the fight (RPG2003 Wait-mode); the active-during-menu mode and the DB wait toggle are documented follow-ups in ADR 0054.

**Verify:** `rpg2k3_battle_gauge_check.rb` (13), `rpg2k_scene_check.rb` (671), `rpg2k_logic_check.rb` (977), `cmake --build build -t test` (8/8), native boot check (real 2003 gauge battle reaches `[RPG2k-BATTLE]` and runs stably), pre-commit all green.