### PR TITLE
psp: cut the memory footprint of the embedded builds (ADR 0047)

### DIFF
--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -58,8 +58,18 @@ set(LV_BUILD_CONF_DIR
 # even when they did compile, every byte of them is RAM-resident on the PSP (the
 # whole EBOOT is loaded into memory at launch). The RGSS runtime and the idle
 # status screen need none of them, so keep both out of the EBOOT.
-set(CONFIG_LV_BUILD_EXAMPLES OFF)
-set(CONFIG_LV_BUILD_DEMOS OFF)
+#
+# These must be set as CACHE variables: LVGL's os_desktop.cmake gates its
+# examples/demos behind `option(CONFIG_LV_BUILD_EXAMPLES ...)`, and with CMP0077
+# unset (the project does not raise cmake_minimum_required past 3.12) option()
+# only honours cache variables -- a plain set() is silently ignored, which is
+# exactly how the examples leaked back into the PSP build's link.
+set(CONFIG_LV_BUILD_EXAMPLES
+    OFF
+    CACHE BOOL "" FORCE)
+set(CONFIG_LV_BUILD_DEMOS
+    OFF
+    CACHE BOOL "" FORCE)
 add_subdirectory(${REPO_ROOT}/3rd/lvgl 3rd/lvgl EXCLUDE_FROM_ALL)
 
 # mruby-rgss and mruby-lcf both link uni-algo (Unicode normalisation / CP932

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -52,6 +52,14 @@ endif()
 set(LV_BUILD_CONF_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}
     CACHE PATH "lv_conf.h location" FORCE)
+# LVGL's desktop CMake builds its examples and demos into the `lvgl` library
+# itself (they are PUBLIC-linked), and their sources call widget constructors
+# that app/psp/lv_conf.h disables -- so building them would fail to compile, and
+# even when they did compile, every byte of them is RAM-resident on the PSP (the
+# whole EBOOT is loaded into memory at launch). The RGSS runtime and the idle
+# status screen need none of them, so keep both out of the EBOOT.
+set(CONFIG_LV_BUILD_EXAMPLES OFF)
+set(CONFIG_LV_BUILD_DEMOS OFF)
 add_subdirectory(${REPO_ROOT}/3rd/lvgl 3rd/lvgl EXCLUDE_FROM_ALL)
 
 # mruby-rgss and mruby-lcf both link uni-algo (Unicode normalisation / CP932

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -136,12 +136,15 @@ The pieces below are scaffolded but **not** part of the EBOOT yet:
   equivalent of the desktop build's `--game_dir` flag or the browser build's
   runtime project loader, since the PSP EBOOT has no command line and no
   way to be told a different location after it starts.
-- **ADR 0047's P2 (the mruby/LVGL allocator split).** `main.cxx` still opens
-  mruby with its own default allocator (plain `malloc`), not routed through
-  `lv_malloc` the way the desktop build's `mrb_basic_alloc_func` override
-  does. Starting a real game didn't require deciding this either; it needs
-  real on-device numbers from an actual game running at `kGameDir` first (see
-  "Memory budget" below).
+- **Validating ADR 0047's P2 numbers.** The mruby/LVGL allocator split itself
+  is decided and wired (mruby's whole heap lives in its own 8 MB arena, see
+  `main.cxx`'s `mrb_basic_alloc_func` — LVGL's pool only aligns to 4 bytes on
+  32-bit, too weak for mruby's word boxing, so sharing it is not an option
+  the way it is on desktop). What still needs a real game running at
+  `kGameDir` is confirming the arena size is right: the `RPG2K_PSP_BRINGUP`
+  heartbeat reports free RAM and LVGL's pool high-water mark, and the
+  mruby arena's own usage is the gap between `sceKernelTotalFreeMemSize` and
+  those two, once a title actually runs on hardware or an emulator.
 - **Accelerated rendering.** The bring-up flushes with a CPU `memcpy` into the
   framebuffer. Moving the blit onto the `sceGu` GPU is a later optimisation,
   and the natural place to also do real scaling (above) instead of clipping.
@@ -153,12 +156,26 @@ answering how the game's live heap, LVGL's pool and decoded assets actually
 fit inside the PSP's ~24 MB of RAM still needs a real game run on real
 hardware or an emulator with a Memory Stick image, not just CI's `psp-smoke`.
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)
-works through that, including a real risk: mruby 4.0's global allocator hook
-defaults to sharing LVGL's pool (as it does on desktop) if `main.cxx` ever
-installs that override the way the desktop build's `mrb_basic_alloc_func`
-does — which it does not yet (see "Not yet wired" above) — so `lv_conf.h`'s
-4 MB `LV_MEM_SIZE` may need to cover the entire mruby object graph, not just
-LVGL widgets, unless a PSP-specific allocator exception is added instead.
+works through that, including the P2 allocator split, which is now decided and
+wired: mruby's entire heap lives in a fixed 8 MB arena of its own
+(`main.cxx`'s `mrb_basic_alloc_func`) rather than sharing LVGL's pool (whose
+TLSF only 4-byte-aligns on 32-bit — too weak for mruby's word boxing) or
+growing unbounded on plain malloc, so the interpreter OOMs into a catchable
+`NoMemoryError` instead of colliding with the decoded-bitmap heap. `lv_conf.h`'s
+4 MB `LV_MEM_SIZE` therefore covers only LVGL's own widgets and internals, and
+the decoded bitmaps stay in a third, uncapped pool as before.
+
+Beyond the arena, this port also shrinks the live footprint in three smaller
+ways: the LVGL partial-render buffers are sized to the game's own canvas
+(RPG2k's 320×240 fits ~38 KB per buffer instead of the fixed panel-width 64 KB
+each — see `psp.cxx`), the EBOOT links none of LVGL's examples/demos and only
+the widgets the RGSS layer actually uses (canvas/image/label; the default theme
+that pulled every widget into the link is off), and the mruby cross-build runs
+the embedded tuning knobs (`MRB_HEAP_PAGE_SIZE`/`KHASH_INITIAL_SIZE` — see
+`build_config.rb`). The `RPG2K_PSP_BRINGUP` heartbeat is the place to read the
+result: `free`/`maxfree` from `sceKernelTotalFreeMemSize` are the device's real
+free RAM, `lvgl_used`/`lvgl_max` are LVGL's pool, and the mruby arena's usage is
+the gap between them once a game is actually running.
 
 For a packed RPG Maker XP/VX/VX Ace title,
 [`scripts/rgssad_unpack.rb`](../../scripts/rgssad_unpack.rb) unpacks

--- a/app/psp/lv_conf.h
+++ b/app/psp/lv_conf.h
@@ -1,13 +1,16 @@
 // LVGL configuration for the PSP EBOOT.
 //
-// The desktop build's include/lv_conf.h hardcodes a 16 MB LVGL heap pool, which
+// The desktop build's include/lv_conf.h hardcodes a 64 MB LVGL heap pool, which
 // does not fit the PSP's ~24 MB of user RAM once mruby and game assets are
 // added later. This config keeps the same shape but a PSP-sized heap. LVGL v9
 // fills every option not set here with the default from lv_conf_internal.h, so
 // this only overrides what the port needs.
 //
 // Selected via -DLV_CONF_INCLUDE_SIMPLE plus this directory on the include path
-// (see app/psp/CMakeLists.txt).
+// (see app/psp/CMakeLists.txt). The same config is seen by the psp mruby
+// cross-build that compiles mruby-rgss (mruby-rgss/mrbgem.rake adds this dir to
+// its include path when build.name == 'psp'), so the two agree on what LVGL
+// compiled in.
 
 #ifndef LV_CONF_H
 #define LV_CONF_H
@@ -23,9 +26,12 @@
 /* RGB565, matching the display framebuffer set up in psp.cxx. */
 #define LV_COLOR_DEPTH 16
 
-/* Built-in allocator with a static pool. Comfortable on the PSP's RAM, but far
- * from the desktop's 16 MB so it leaves room for the mruby heap and whole-file
- * assets in later slices. */
+/* Built-in allocator with a static pool. Covers only LVGL's own widgets and
+ * internals: mruby's heap lives in its own fixed arena (app/psp/main.cxx's
+ * mrb_basic_alloc_func, ADR 0047's P2) and decoded bitmaps in the plain C
+ * heap, so this pool no longer needs to double as mruby's. 4 MB is generous
+ * for the widget tree alone; the BRINGUP heartbeat's lvgl_max high-water mark
+ * is the number to size it against on-device. */
 #define LV_USE_STDLIB_MALLOC  LV_STDLIB_BUILTIN
 #define LV_USE_STDLIB_STRING  LV_STDLIB_BUILTIN
 #define LV_USE_STDLIB_SPRINTF LV_STDLIB_BUILTIN
@@ -71,6 +77,83 @@
 /* The panel is driven directly from psp.cxx's flush callback (sceDisplay), so
  * LVGL's own display drivers stay off. */
 #define LV_USE_SDL 0
+
+/*====================
+   WIDGETS
+ *====================*/
+
+/* The RGSS runtime renders through lv_canvas (every Bitmap is a canvas buffer)
+ * and base lv_obj containers; the idle bring-up status screen uses lv_label and
+ * lv_image is a canvas dependency. Every other widget is dead weight on the
+ * PSP: the whole EBOOT is loaded into RAM at launch, so a widget file that is
+ * compiled in is RAM-resident for the process lifetime, not just flash. Each
+ * unused widget is also dragged into the link by the default theme's styles
+ * (see THEMES below), so trimming here is what actually lets the linker drop
+ * them. */
+#define LV_USE_CANVAS     1
+#define LV_USE_IMAGE      1
+#define LV_USE_LABEL      1
+
+#define LV_USE_ANIMIMG    0
+#define LV_USE_ARC        0
+#define LV_USE_ARCLABEL   0
+#define LV_USE_BAR        0
+#define LV_USE_BUTTON     0
+#define LV_USE_BUTTONMATRIX 0
+#define LV_USE_CALENDAR   0
+#define LV_USE_CHART      0
+#define LV_USE_CHECKBOX   0
+#define LV_USE_DROPDOWN   0
+#define LV_USE_IMAGEBUTTON 0
+#define LV_USE_KEYBOARD   0
+#define LV_USE_LED        0
+#define LV_USE_LINE       0
+#define LV_USE_LIST       0
+#define LV_USE_MENU       0
+#define LV_USE_MSGBOX     0
+#define LV_USE_ROLLER     0
+#define LV_USE_SCALE      0
+#define LV_USE_SLIDER     0
+#define LV_USE_SPAN       0
+#define LV_USE_SPINBOX    0
+#define LV_USE_SPINNER    0
+#define LV_USE_SWITCH     0
+#define LV_USE_TABLE      0
+#define LV_USE_TABVIEW    0
+#define LV_USE_TEXTAREA   0
+#define LV_USE_TILEVIEW   0
+#define LV_USE_WIN        0
+
+/*====================
+   THEMES
+ *====================*/
+
+/* No theme at all: the default theme is auto-initialised by lv_display_create
+ * (LV_USE_THEME_DEFAULT) and its styles reference every widget, which is what
+ * pulls all those widget object files into the link in the first place. The
+ * RGSS runtime styles every object it creates explicitly (lv_obj_remove_style_all
+ * + lv_obj_set_style_*), so dropping the theme changes nothing for the game
+ * path -- labels on the idle status screen set their own text colour too. */
+#define LV_USE_THEME_DEFAULT 0
+#define LV_USE_THEME_SIMPLE 0
+#define LV_USE_THEME_MONO 0
+
+/*====================
+   LAYOUTS
+ *====================*/
+
+/* The RGSS runtime positions objects with lv_obj_align / lv_obj_set_pos, never
+ * flex/grid layouts. */
+#define LV_USE_FLEX 0
+#define LV_USE_GRID 0
+
+/*====================
+   OTHERS
+ *====================*/
+
+/* The RGSS runtime neither observes nor reads objects via the property API. */
+#define LV_USE_OBSERVER 0
+#define LV_USE_OBJ_PROPERTY 0
 
 /* clang-format on */
 

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -40,11 +40,18 @@
 //
 // mrb_open() here uses mruby's own default allocator (plain malloc) rather
 // than routing through lv_malloc the way the desktop build does -- ADR 0047's
-// P2 (share LVGL's pool vs. a separate arena) is still an open decision that
-// this slice does not need to make just to prove the interpreter boots and a
-// game can start.
+// P2 (share LVGL's pool vs. a separate arena) is now decided for this target
+// (see below): the interpreter's whole live heap is routed through a
+// fixed-size arena of its own (mrb_basic_alloc_func) instead of LVGL's pool
+// -- which only aligns to 4 bytes on a 32-bit build, too weak for mruby's word
+// boxing, the same reason the wasm build opts out -- and instead of the
+// unbounded default malloc. When the arena is exhausted the allocator returns
+// NULL and mruby raises a catchable NoMemoryError rather than the interpreter
+// growing until it collides with the decoded-bitmap heap.
 
+#include <cstddef>
 #include <cstdio>
+#include <cstring>
 
 #include <lvgl.h>
 #include <mruby.h>
@@ -65,6 +72,134 @@ PSP_MAIN_THREAD_ATTR(THREAD_ATTR_USER | THREAD_ATTR_VFPU);
 namespace {
 
 lv_obj_t* g_status_label = nullptr;
+
+// ADR 0047's P2 (the mruby/LVGL allocator split), decided for this target:
+// mruby gets its own bounded arena instead of sharing LVGL's pool or running
+// unbounded on plain malloc. Sharing LVGL's pool is not an option here the way
+// it is on desktop -- LVGL's builtin TLSF pool only aligns to 4 bytes on a
+// 32-bit build (lv_mem_core_builtin.c's ALIGN_MASK), which breaks mruby's word
+// boxing, the same reason the wasm build opts out -- and an unbounded malloc
+// lets the interpreter eat the whole ~24 MB until it collides with the
+// decoded-bitmap heap. A fixed arena bounds it: when the pool is exhausted
+// mrb_basic_alloc_func returns NULL and mruby raises a catchable NoMemoryError
+// (mrb_realloc -> mrb_raise_nomemory) instead of corrupting RAM.
+//
+// This is a first-fit free-list allocator with splitting and coalescing; every
+// block is 16-byte aligned (enough for the 8-byte RVALUE alignment mruby's
+// word boxing needs on 32-bit). The size should be validated against a real
+// game on-device -- the BRINGUP heartbeat below already reports free RAM --
+// but 8 MB is generous: the rpg2k+lcf+rgss mrblib costs ~1.4 MB of class
+// definitions on a 64-bit host (roughly half on the PSP's 32-bit MIPS), and a
+// real LCF database (Nepheshel's 1.3 MB .ldb) plus the maps and scene objects
+// fit well inside, while still leaving most of the ~24 MB for the LVGL pool,
+// the draw buffers and the decoded-bitmap heap.
+constexpr size_t kMrbArenaSize = 8u * 1024u * 1024u;
+alignas(16) uint8_t g_mrb_arena[kMrbArenaSize];
+
+constexpr size_t kMrbAlign = 16;
+struct MrbBlock {
+  size_t size;     // payload bytes, a multiple of kMrbAlign
+  MrbBlock* next;  // next free block in ascending address order (free blocks)
+};
+static_assert(sizeof(MrbBlock) <= kMrbAlign,
+              "block header must fit one alignment unit");
+
+MrbBlock* g_mrb_free = nullptr;
+
+size_t mrb_align_up(size_t n) {
+  return (n + kMrbAlign - 1) & ~(kMrbAlign - 1);
+}
+
+// The arena starts as one free block spanning everything after its own header.
+void mrb_arena_init() {
+  if (g_mrb_free)
+    return;
+  MrbBlock* first = reinterpret_cast<MrbBlock*>(g_mrb_arena);
+  first->size = kMrbArenaSize - kMrbAlign;
+  first->next = nullptr;
+  g_mrb_free = first;
+}
+
+void* mrb_arena_alloc(size_t n) {
+  mrb_arena_init();
+  const size_t need = mrb_align_up(n);
+  MrbBlock* prev = nullptr;
+  for (MrbBlock* b = g_mrb_free; b; prev = b, b = b->next) {
+    if (b->size < need)
+      continue;
+    // Split when the leftover can hold another block (header + 16 B payload).
+    if (b->size - need >= 2 * kMrbAlign) {
+      MrbBlock* rest = reinterpret_cast<MrbBlock*>(
+          reinterpret_cast<uint8_t*>(b) + kMrbAlign + need);
+      rest->size = b->size - need - kMrbAlign;
+      rest->next = b->next;
+      b->size = need;
+      if (prev)
+        prev->next = rest;
+      else
+        g_mrb_free = rest;
+    } else {
+      if (prev)
+        prev->next = b->next;
+      else
+        g_mrb_free = b->next;
+    }
+    return reinterpret_cast<uint8_t*>(b) + kMrbAlign;
+  }
+  return nullptr;  // arena exhausted -> mruby raises NoMemoryError
+}
+
+void mrb_arena_free(void* p) {
+  if (!p)
+    return;
+  mrb_arena_init();
+  MrbBlock* b =
+      reinterpret_cast<MrbBlock*>(reinterpret_cast<uint8_t*>(p) - kMrbAlign);
+  // Insert back into the address-ordered free list.
+  MrbBlock* prev = nullptr;
+  MrbBlock* cur = g_mrb_free;
+  while (cur && cur < b) {
+    prev = cur;
+    cur = cur->next;
+  }
+  b->next = cur;
+  if (prev)
+    prev->next = b;
+  else
+    g_mrb_free = b;
+  // Coalesce with the physically-next block when it is free and adjacent.
+  if (cur && reinterpret_cast<uint8_t*>(b) + kMrbAlign + b->size ==
+                 reinterpret_cast<uint8_t*>(cur)) {
+    b->size += kMrbAlign + cur->size;
+    b->next = cur->next;
+  }
+  // Coalesce with the physically-previous block when it is free and adjacent.
+  if (prev && reinterpret_cast<uint8_t*>(prev) + kMrbAlign + prev->size ==
+                  reinterpret_cast<uint8_t*>(b)) {
+    prev->size += kMrbAlign + b->size;
+    prev->next = b->next;
+  }
+}
+
+void* mrb_arena_realloc(void* p, size_t n) {
+  if (n == 0) {
+    mrb_arena_free(p);
+    return nullptr;
+  }
+  if (!p)
+    return mrb_arena_alloc(n);
+  MrbBlock* b =
+      reinterpret_cast<MrbBlock*>(reinterpret_cast<uint8_t*>(p) - kMrbAlign);
+  const size_t need = mrb_align_up(n);
+  if (b->size >= need)
+    return p;  // already fits; no move
+  void* nbuf = mrb_arena_alloc(need);
+  if (!nbuf)
+    return nullptr;
+  std::memcpy(nbuf, p, b->size < n ? b->size : n);
+  mrb_arena_free(p);
+  return nbuf;
+}
 
 // Names for the RGSS key ids, indexed by PspKey, for the on-screen echo.
 const char* const kKeyNames[PSP_INPUT_KEY_COUNT] = {
@@ -219,6 +354,21 @@ void show_keys(uint32_t mask) {
 }
 
 }  // namespace
+
+// mruby 4.0 has no per-state allocator hook; a program overrides the global
+// mrb_basic_alloc_func to supply its own allocator. Defining it here means the
+// linker never pulls mruby's default (plain realloc) from libmruby.a -- the
+// same pattern src/main.cxx uses to route mruby through LVGL's pool on
+// desktop. On the PSP every mruby allocation (the whole live object graph,
+// strings, the parsed LCF database) comes out of the fixed arena above, so the
+// interpreter's footprint is bounded regardless of what a game does.
+extern "C" void* mrb_basic_alloc_func(void* p, size_t size) {
+  if (size == 0) {
+    mrb_arena_free(p);
+    return nullptr;
+  }
+  return mrb_arena_realloc(p, size);
+}
 
 int main(void) {
   // Emitted before any LVGL/display init so the CI smoke test can tell "the

--- a/app/wio/lv_conf.h
+++ b/app/wio/lv_conf.h
@@ -66,6 +66,77 @@
  * callback, so LVGL's own display drivers stay off. */
 #define LV_USE_SDL 0
 
+/*====================
+   WIDGETS
+ *====================*/
+
+/* The bring-up firmware renders through base lv_obj containers and the lv_label
+ * status screen; lv_canvas/lv_image are kept on to match the PSP config (the
+ * same minimal set the RGSS runtime needs once mruby is layered on) rather than
+ * churning this file per slice. Every other widget is dead weight on a 192 KB
+ * board, so it is compiled out -- and each one is also dragged into the link by
+ * the default theme's styles, so trimming here is what lets the linker drop it
+ * (see THEMES below). */
+#define LV_USE_CANVAS     1
+#define LV_USE_IMAGE      1
+#define LV_USE_LABEL      1
+
+#define LV_USE_ANIMIMG    0
+#define LV_USE_ARC        0
+#define LV_USE_ARCLABEL   0
+#define LV_USE_BAR        0
+#define LV_USE_BUTTON     0
+#define LV_USE_BUTTONMATRIX 0
+#define LV_USE_CALENDAR   0
+#define LV_USE_CHART      0
+#define LV_USE_CHECKBOX   0
+#define LV_USE_DROPDOWN   0
+#define LV_USE_IMAGEBUTTON 0
+#define LV_USE_KEYBOARD   0
+#define LV_USE_LED        0
+#define LV_USE_LINE       0
+#define LV_USE_LIST       0
+#define LV_USE_MENU       0
+#define LV_USE_MSGBOX     0
+#define LV_USE_ROLLER     0
+#define LV_USE_SCALE      0
+#define LV_USE_SLIDER     0
+#define LV_USE_SPAN       0
+#define LV_USE_SPINBOX    0
+#define LV_USE_SPINNER    0
+#define LV_USE_SWITCH     0
+#define LV_USE_TABLE      0
+#define LV_USE_TABVIEW    0
+#define LV_USE_TEXTAREA   0
+#define LV_USE_TILEVIEW   0
+#define LV_USE_WIN        0
+
+/*====================
+   THEMES
+ *====================*/
+
+/* No theme: the default theme is auto-initialised by lv_display_create and its
+ * styles reference every widget, pulling all those object files into the link.
+ * The firmware styles what it draws explicitly (lv_obj_set_style_*), so nothing
+ * changes visually. */
+#define LV_USE_THEME_DEFAULT 0
+#define LV_USE_THEME_SIMPLE 0
+#define LV_USE_THEME_MONO 0
+
+/*====================
+   LAYOUTS
+ *====================*/
+
+#define LV_USE_FLEX 0
+#define LV_USE_GRID 0
+
+/*====================
+   OTHERS
+ *====================*/
+
+#define LV_USE_OBSERVER 0
+#define LV_USE_OBJ_PROPERTY 0
+
 /* clang-format on */
 
 #endif  // LV_CONF_H

--- a/build_config.rb
+++ b/build_config.rb
@@ -167,6 +167,17 @@ if wio
       # mruby already does for free on Linux/macOS/BSD. Actual RAM fit is a
       # separate concern handled by the streaming rework (P3).
       t.defines << 'MRB_STR_LENGTH_MAX=0'
+      # The micro-controller tuning knobs from mruby's own mrbconf.h (the
+      # MRB_CONSTRAINED_BASELINE_PROFILE set, minus MRB_NO_METHOD_CACHE which
+      # costs dispatch speed on a CPU-bound handheld): a smaller GC heap page
+      # (256 vs 1024 objects) cuts the slack an under-filled last page wastes,
+      # and a smaller initial khash bucket count (16 vs 32) shrinks the symbol
+      # and instance-variable tables that start nearly empty. Both are pure
+      # footprint wins with no behaviour change -- the same object graph just
+      # allocates in smaller, tighter units. See
+      # docs/adr/0047-psp-memory-budget.md.
+      t.defines << 'MRB_HEAP_PAGE_SIZE=256'
+      t.defines << 'KHASH_INITIAL_SIZE=16'
     end
     conf.linker.flags += cpu_flags
 
@@ -245,6 +256,12 @@ if psp
       # the wasm/Wio builds and what mruby already does for free on
       # Linux/macOS/BSD.
       t.defines << 'MRB_STR_LENGTH_MAX=0'
+      # Same micro-controller knobs as the Wio build above (see its comment):
+      # a 256-object GC heap page and 16-entry initial khash buckets cut the
+      # interpreter's live footprint on the PSP's ~24 MB without any
+      # behaviour change.
+      t.defines << 'MRB_HEAP_PAGE_SIZE=256'
+      t.defines << 'KHASH_INITIAL_SIZE=16'
     end
     conf.linker.flags += cpu_flags
 

--- a/changelog.d/psp-draw-buffers-canvas-sized.changed.md
+++ b/changelog.d/psp-draw-buffers-canvas-sized.changed.md
@@ -1,0 +1,8 @@
+- **PSP: LVGL draw buffers are sized to the game's canvas instead of the
+  panel.** The two partial-render buffers in `mruby-rgss/src/psp.cxx` were
+  fixed 480×68×2 (64 KB each, 128 KB total) regardless of the logical display
+  resolution. They are now computed at display-create time from the canvas
+  (RPG2k's 320×240 fits 60 rows → ~38 KB per buffer, ~76 KB total), capped at
+  the old 64 KB per buffer so an XP/VX canvas wider than the panel keeps
+  fewer rows per flush rather than growing. See
+  `docs/adr/0047-psp-memory-budget.md`.

--- a/changelog.d/psp-lvgl-widget-trim.changed.md
+++ b/changelog.d/psp-lvgl-widget-trim.changed.md
@@ -1,0 +1,11 @@
+- **PSP/Wio: LVGL is trimmed to the widgets the runtime actually uses.** The
+  EBOOT's `app/psp/lv_conf.h` (and the Wio firmware's `app/wio/lv_conf.h`)
+  now compile out every widget beyond the RGSS layer's real set
+  (canvas/image/label), the three default themes, and the flex/grid layouts —
+  the default theme is what `lv_display_create` auto-installs and whose styles
+  reference every widget, so disabling it is what lets the linker drop the
+  unused widget object files. The PSP EBOOT also stops linking LVGL's
+  examples/demos (`CONFIG_LV_BUILD_EXAMPLES/DEMOS OFF` in
+  `app/psp/CMakeLists.txt`), which its CMake PUBLIC-links into `liblvgl.a` by
+  default. On the PSP every byte of the EBOOT is loaded into RAM at launch, so
+  this is live memory, not just flash. See `docs/adr/0047-psp-memory-budget.md`.

--- a/changelog.d/psp-mruby-heap-arena.added.md
+++ b/changelog.d/psp-mruby-heap-arena.added.md
@@ -1,0 +1,11 @@
+- **PSP: the mruby heap now lives in a bounded 8 MB arena (ADR 0047's P2).**
+  `app/psp/main.cxx` overrides `mrb_basic_alloc_func` with a fixed-size,
+  16-byte-aligned first-fit free-list allocator (with splitting and
+  coalescing), so the interpreter can no longer grow unbounded across the
+  PSP's ~24 MB and collide with the decoded-bitmap heap. Sharing LVGL's pool
+  the way the desktop build does was not an option: LVGL's builtin TLSF pool
+  only aligns to 4 bytes on 32-bit, which breaks mruby's word boxing. When
+  the arena is exhausted the allocator returns NULL and mruby raises a
+  catchable `NoMemoryError` instead of corrupting RAM. `app/psp/lv_conf.h`'s
+  comment now states that its pool covers LVGL only. See
+  `docs/adr/0047-psp-memory-budget.md`.

--- a/changelog.d/psp-mruby-profile-tuning.changed.md
+++ b/changelog.d/psp-mruby-profile-tuning.changed.md
@@ -1,0 +1,10 @@
+- **PSP/Wio: mruby builds with the embedded tuning knobs.** The `psp` and
+  `wio` mruby cross-builds in `build_config.rb` now pass
+  `MRB_HEAP_PAGE_SIZE=256` (down from 1024 objects) and
+  `KHASH_INITIAL_SIZE=16` (down from 32), the footprint-relevant half of
+  mruby's own `MRB_CONSTRAINED_BASELINE_PROFILE` micro-controller set —
+  `MRB_NO_METHOD_CACHE`, the third piece, is deliberately left out because it
+  costs method-dispatch speed on a CPU-bound handheld. Smaller GC heap pages
+  cut the slack an under-filled last page wastes, and smaller initial khash
+  buckets shrink the symbol and instance-variable tables that start nearly
+  empty, with no behaviour change. See `docs/adr/0047-psp-memory-budget.md`.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -248,13 +248,41 @@ the interpreter-linking slice, in this order:
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none
   either (file size only). This is Decision work that shipped as code rather
   than staying a P-item — see Consequences.
-- **P2 — decide the allocator split explicitly.** Either accept the default
-  (mruby shares `LV_MEM_SIZE` with LVGL, matching desktop) and size that one
-  pool generously enough for both from the P1 measurements, or add a PSP
-  exception next to Emscripten's in `src/main.cxx`/the PSP entry point so
-  mruby gets its own bounded arena. Whichever is chosen, fix
-  `app/psp/lv_conf.h`'s comment to state it accurately instead of describing
-  the un-taken option.
+- **P2 — decided for this target: mruby gets its own bounded arena.** Sharing
+  LVGL's pool the way desktop does is not viable on the PSP: the builtin TLSF
+  pool only aligns to 4 bytes on a 32-bit build (`lv_mem_core_builtin.c`'s
+  `ALIGN_MASK`), which breaks mruby's word boxing — the same reason the
+  Emscripten build opts out — and plain `malloc` lets the interpreter grow
+  unbounded until it collides with the decoded-bitmap heap. `app/psp/main.cxx`
+  now overrides `mrb_basic_alloc_func` (the mruby 4.0 global allocator hook)
+  with a fixed 8 MB first-fit arena (16-byte aligned, with splitting and
+  coalescing; the same "linker never pulls the default from libmruby.a"
+  pattern desktop uses). When the arena is exhausted the allocator returns
+  NULL and mruby raises a catchable `NoMemoryError` instead of corrupting RAM.
+  `app/psp/lv_conf.h`'s comment now states this accurately (the pool covers
+  LVGL only) instead of describing the un-taken shared-pool option. The 8 MB
+  figure is a generous placeholder to be validated against a real game
+  on-device, exactly as the BRINGUP heartbeat (P1) measures.
+- **P6 — drawn from Finding 3's "third pool" and the EBOOT's own size,
+  landed as three smaller reductions in the same slice:**
+  - The LVGL partial-render draw buffers are sized to the *logical* canvas at
+    display-create time (`mruby-rgss/src/psp.cxx`), capped at the old
+    panel-width 64 KB per buffer: RPG2k's 320×240 canvas needs ~38 KB per
+    buffer (~76 KB total vs the old fixed 128 KB), while an XP/VX canvas
+    (wider than the panel) keeps fewer rows per flush instead of growing.
+  - The EBOOT no longer links LVGL's examples/demos (they are PUBLIC-linked
+    into `liblvgl.a` by default) or any widget beyond the RGSS layer's actual
+    set (canvas/image/label) — the default theme, which `lv_display_create`
+    auto-installs and whose styles reference every widget, is disabled so the
+    unused widget object files are no longer pulled into the link. On the PSP
+    every byte of the EBOOT is loaded into RAM at launch, so this is live
+    memory, not just flash.
+  - The `psp` mruby cross-build (and the `wio` one) now sets mruby's
+    micro-controller tuning knobs `MRB_HEAP_PAGE_SIZE=256` and
+    `KHASH_INITIAL_SIZE=16` (the `MRB_CONSTRAINED_BASELINE_PROFILE` set minus
+    `MRB_NO_METHOD_CACHE`, which would cost dispatch speed), shrinking GC heap
+    page granularity and the initial khash bucket counts with no behaviour
+    change.
 - **P3 — done (the tool; the deployment step itself is still per-release).**
   `scripts/rgssad_unpack.rb` unpacks a `Game.rgssad`/`.rgss2a`/`.rgss3a`
   (desktop-side, reusing the existing `RPGXP::RGSSAD` reader rather than
@@ -290,19 +318,22 @@ the interpreter-linking slice, in this order:
   lands, this revision ships small, self-contained changes alongside the ADR
   update: P1a (stripping mrbc's `-g` for the `psp` cross-build), half of P1
   (the bring-up EBOOT's heartbeat now reports real device memory numbers),
-  and the tool half of P3 (`scripts/rgssad_unpack.rb`). None of these is a
-  pool-sizing or allocator decision — those still depend on numbers only the
-  interpreter-linking slice can produce (a real database and map actually
-  loaded) — so the rest of the Decision items remain design record only.
+  the tool half of P3 (`scripts/rgssad_unpack.rb`), and now the P2 allocator
+  split plus P6's three reductions (draw buffers sized to the canvas, the
+  LVGL widget/theme/example trim, and the mruby embedded tuning knobs). The
+  one pool-sizing number that still depends on the interpreter-linking slice
+  (a real database and map actually loaded) is the mruby arena's 8 MB
+  figure, which the heartbeat is now in place to validate.
 - ADR 0010's "the full gem set should fit" is narrowed: it holds for gem
   *code* size, but says nothing about per-title asset memory, which Finding 2
   shows can exceed the entire 24 MB budget for an RGSSAD-packed game even
   though the Wio Terminal's port needed the same warning at a much smaller
   scale.
-- **Risk register:** P2 (allocator split / pool sizing) is soft-blocking the
-  interpreter-linking slice — the slice can land without it decided, but
-  `LV_MEM_SIZE` will be guessed rather than sized until it is. P3 (RGSSAD
-  whole-archive loads) is hard-blocking for any future XP/VX PSP target; the
+- **Risk register:** P2 is now decided (a bounded 8 MB mruby arena, see the
+  Decision) rather than soft-blocking, but its *size* is still a placeholder
+  awaiting on-device numbers — the BRINGUP heartbeat measures it, so that is a
+  measurement follow-up, not an architectural one. P3 (RGSSAD whole-archive
+  loads) is hard-blocking for any future XP/VX PSP target; the
   tool to close it is done, but running it and excluding the packed archive
   is still a manual step per release, not something CI or the build enforces
   — that's the remaining risk, not the unpack logic itself. P4/P5 are

--- a/mruby-rgss/src/psp.cxx
+++ b/mruby-rgss/src/psp.cxx
@@ -6,7 +6,9 @@
 
 #include "psp.hxx"
 
+#include <cstddef>
 #include <cstring>
+#include <vector>
 
 #include <pspctrl.h>
 #include <pspdisplay.h>
@@ -40,13 +42,16 @@ uint16_t* g_fb = nullptr;
 int32_t g_offset_x = 0;
 int32_t g_offset_y = 0;
 
-// LVGL partial-render draw buffers, in main RAM. Quarter-screen each
-// (480 * 68 * 2 = ~64 KB); two buffers let LVGL render one while the other is
-// being copied out. The PSP has ~24 MB of user RAM, so unlike the Wio backend
-// these are comfortable -- kept partial only to bound peak working set.
-constexpr int32_t kBufRows = PSP_SCR_HEIGHT / 4;
-uint8_t g_buf1[PSP_SCR_WIDTH * kBufRows * 2];
-uint8_t g_buf2[PSP_SCR_WIDTH * kBufRows * 2];
+// LVGL partial-render draw buffers, in main RAM, sized at display-create time
+// to the *logical* canvas rather than the panel (see psp_display_create):
+// RPG2k's 320x240 canvas needs ~38 KB per buffer (320 * 60 * 2) instead of the
+// old fixed panel-width 64 KB, while the idle 480x272 case keeps the full 64 KB
+// and an XP/VX canvas wider than the panel is capped at 64 KB by dropping rows.
+// Two buffers let LVGL render one while the other is being copied out. The PSP
+// has ~24 MB of user RAM, so unlike the Wio backend these are comfortable --
+// kept partial only to bound peak working set.
+std::vector<uint8_t> g_buf1;
+std::vector<uint8_t> g_buf2;
 
 // LVGL needs a millisecond tick and a delay without SDL. The pspsdk system
 // timer is microseconds; wrap it so the function-pointer types match exactly
@@ -134,7 +139,30 @@ lv_display_t* psp_display_create(int32_t hor_res, int32_t ver_res) {
     return nullptr;
 
   lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
-  lv_display_set_buffers(disp, g_buf1, g_buf2, sizeof(g_buf1),
+
+  // Size the partial-render buffers to the canvas instead of the panel. Each
+  // buffer covers a quarter-screen strip of `ver_res / 4` rows at the canvas's
+  // own width; the strip is capped at the old panel-width budget (480 * 68 * 2
+  // = 64 KB) so a canvas wider than the panel (RPG XP 640 / VX 544) keeps
+  // fewer rows per flush rather than growing the buffers, while RPG2k's
+  // 320-wide canvas fits the same strip in ~38 KB. LVGL derives the strip
+  // height from buf_size / (hor_res * bpp), so a narrower buffer just means
+  // more, smaller flushes -- never a correctness change.
+  constexpr size_t kBufBytesCap =
+      static_cast<size_t>(PSP_SCR_WIDTH) * (PSP_SCR_HEIGHT / 4) * 2;
+  constexpr size_t kBpp = 2;  // RGB565
+  size_t rows = static_cast<size_t>(ver_res) / 4;
+  const size_t rows_cap = kBufBytesCap / (static_cast<size_t>(hor_res) * kBpp);
+  if (rows > rows_cap)
+    rows = rows_cap;
+  if (rows == 0)
+    rows = 1;
+  const size_t buf_bytes = rows * static_cast<size_t>(hor_res) * kBpp;
+  g_buf1.assign(buf_bytes, 0);
+  g_buf2.assign(buf_bytes, 0);
+
+  lv_display_set_buffers(disp, g_buf1.data(), g_buf2.data(),
+                         static_cast<uint32_t>(buf_bytes),
                          LV_DISPLAY_RENDER_MODE_PARTIAL);
   lv_display_set_flush_cb(disp, flush_cb);
   return disp;


### PR DESCRIPTION
## What

Reduces live RAM on the PSP (and Wio) embedded builds, closing ADR 0047's P2 and adding P6. Four changes:

### 1. Bounded mruby heap — ADR 0047 P2, decided
`app/psp/main.cxx` overrides `mrb_basic_alloc_func` with a fixed **8 MB** first-fit arena (16-byte aligned, splitting + coalescing). Sharing LVGL's pool like desktop is not viable on the PSP — LVGL's builtin TLSF pool only aligns to 4 bytes on 32-bit, which breaks mruby's word boxing (the same reason the wasm build opts out) — and plain `malloc` let the interpreter grow unbounded across the ~24 MB. When the arena is exhausted the allocator returns NULL and mruby raises a **catchable `NoMemoryError`** instead of colliding with the decoded-bitmap heap.

### 2. LVGL draw buffers sized to the canvas
`mruby-rgss/src/psp.cxx` sizes the two partial-render buffers at display-create time: RPG2k's 320×240 canvas needs ~38 KB per buffer instead of the fixed panel-width 64 KB (~76 KB vs 128 KB total). XP/VX canvases (wider than the panel) are capped at the old 64 KB by dropping rows per flush.

### 3. LVGL widget/theme/example trim
`app/psp/lv_conf.h` (and `app/wio/lv_conf.h`) keep only canvas/image/label, disable the three default themes (the default theme is what `lv_display_create` auto-installs and whose styles reference every widget — disabling it is what lets the linker drop the unused widget object files), plus flex/grid/observer. The PSP EBOOT also stops building LVGL's examples/demos, which its CMake PUBLIC-links into `liblvgl.a`. On the PSP every EBOOT byte is loaded into RAM at launch, so this is live memory, not just flash.

### 4. mruby embedded tuning knobs
The `psp` and `wio` cross-builds now pass `MRB_HEAP_PAGE_SIZE=256` (from 1024) and `KHASH_INITIAL_SIZE=16` (from 32) — the perf-neutral half of `MRB_CONSTRAINED_BASELINE_PROFILE` (`MRB_NO_METHOD_CACHE` is deliberately left out, as it costs dispatch speed).

## Verification

- Both trimmed LVGL configs build cleanly for the host (`-DLV_BUILD_CONF_DIR=app/psp`, `-DLV_BUILD_CONF_DIR=app/wio`).
- The mruby defines compile; `build_config.rb` is syntax-valid and the desktop/host rake build is untouched (changes are gated behind `MRUBY_TARGET=psp`/`wio`).
- The arena allocator passes a host stress test under UBSan (alignment, splitting, coalesce-to-full, realloc-as-copy, exhaustion → NULL, mruby-like alloc/free churn).
- `pre-commit` passes on all changed files.
- The EBOOT itself builds/boots in CI (`psp` job is the required gate; `psp-smoke` boots under PPSSPP). I could not run those locally (no pspdev toolchain / Docker daemon on this machine).

The 8 MB arena figure is a documented placeholder: `RPG2K_PSP_BRINGUP`'s heartbeat already reports `sceKernelTotalFreeMemSize`/`lv_mem_monitor` and the arena's usage is the gap between them, so the number gets validated against a real game on-device.

## Docs

ADR 0047 Decision updated (P2 decided + new P6), `app/psp/README.md` refreshed, four changelog fragments.