### PR TITLE
desktop: trim LVGL to the widgets the runtime actually uses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,18 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(LV_BUILD_CONF_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     CACHE PATH "lv_conf.h location" FORCE)
+# LVGL's CMake builds its examples and demos into the `lvgl` library itself
+# (they are PUBLIC-linked), and their sources call widget constructors that
+# include/lv_conf.h disables -- so building them would fail to compile. The
+# runtime uses none of them, and matching app/psp's EBOOT keeps the configs
+# aligned. Set as cache variables so they override LVGL's `option(...)` defaults
+# even with CMP0077 unset (see app/psp/CMakeLists.txt).
+set(CONFIG_LV_BUILD_EXAMPLES
+    OFF
+    CACHE BOOL "" FORCE)
+set(CONFIG_LV_BUILD_DEMOS
+    OFF
+    CACHE BOOL "" FORCE)
 add_subdirectory(3rd/lvgl EXCLUDE_FROM_ALL)
 
 set(WITH_GTEST OFF)

--- a/changelog.d/desktop-lvgl-widget-trim.changed.md
+++ b/changelog.d/desktop-lvgl-widget-trim.changed.md
@@ -1,0 +1,12 @@
+- **Desktop LVGL config now matches the embedded builds.** `include/lv_conf.h`
+  compiles out every widget beyond the RGSS layer's real set
+  (canvas/image/label), the three default themes, and the flex/grid layouts —
+  the default theme is what `lv_display_create` auto-installs and whose styles
+  reference every widget, so disabling it lets the linker drop the unused
+  widget object files. The root `CMakeLists.txt` also stops building LVGL's
+  examples/demos (PUBLIC-linked into `liblvgl.a` by default), the same
+  `CONFIG_LV_BUILD_EXAMPLES/DEMOS OFF` as `app/psp` — set as cache variables
+  because LVGL's `option()` only honours cache variables with CMP0077 unset.
+  All three targets now compile the same minimal LVGL, so the render path
+  cannot drift between desktop and the embedded builds. See
+  `docs/adr/0047-psp-memory-budget.md`.

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -472,125 +472,73 @@
 
 #define LV_WIDGETS_HAS_DEFAULT_VALUE  1
 
-#define LV_USE_ANIMIMG    1
-
-#define LV_USE_ARC        1
-
-#define LV_USE_BAR        1
-
-#define LV_USE_BUTTON        1
-
-#define LV_USE_BUTTONMATRIX  1
-
-#define LV_USE_CALENDAR   1
-#if LV_USE_CALENDAR
-    #define LV_CALENDAR_WEEK_STARTS_MONDAY 0
-    #if LV_CALENDAR_WEEK_STARTS_MONDAY
-        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
-    #else
-        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
-    #endif
-
-    #define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
-    #define LV_USE_CALENDAR_HEADER_ARROW 1
-    #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
-#endif  /*LV_USE_CALENDAR*/
-
+/* The RGSS runtime renders through lv_canvas (every Bitmap is a canvas buffer)
+ * and base lv_obj containers, with lv_image's transform calls for sprite
+ * zoom/rotation; nothing else is ever instantiated, so every other widget is
+ * dead weight. Keeping the exact same minimal set (and the same disabled
+ * themes/layouts below) as the PSP and Wio configs (app/psp/lv_conf.h,
+ * app/wio/lv_conf.h) means all targets build the same LVGL, so the render path
+ * cannot drift between desktop and the embedded builds. */
+#define LV_USE_ANIMIMG    0
+#define LV_USE_ARC        0
+#define LV_USE_ARCLABEL   0
+#define LV_USE_BAR        0
+#define LV_USE_BUTTON     0
+#define LV_USE_BUTTONMATRIX 0
+#define LV_USE_CALENDAR   0
 #define LV_USE_CANVAS     1
-
-#define LV_USE_CHART      1
-
-#define LV_USE_CHECKBOX   1
-
-#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
-
-#define LV_USE_IMAGE      1   /*Requires: lv_label*/
-
-#define LV_USE_IMAGEBUTTON     1
-
-#define LV_USE_KEYBOARD   1
-
+#define LV_USE_CHART      0
+#define LV_USE_CHECKBOX   0
+#define LV_USE_DROPDOWN   0
+#define LV_USE_IMAGE      1
+#define LV_USE_IMAGEBUTTON     0
+#define LV_USE_KEYBOARD   0
 #define LV_USE_LABEL      1
 #if LV_USE_LABEL
     #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
     #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
     #define LV_LABEL_WAIT_CHAR_COUNT 3  /*The count of wait chart*/
 #endif
-
-#define LV_USE_LED        1
-
-#define LV_USE_LINE       1
-
-#define LV_USE_LIST       1
-
-#define LV_USE_MENU       1
-
-#define LV_USE_MSGBOX     1
-
-#define LV_USE_ROLLER     1   /*Requires: lv_label*/
-
-#define LV_USE_SCALE      1
-
-#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
-
-#define LV_USE_SPAN       1
-#if LV_USE_SPAN
-    /*A line text can contain maximum num of span descriptor */
-    #define LV_SPAN_SNIPPET_STACK_SIZE 64
-#endif
-
-#define LV_USE_SPINBOX    1
-
-#define LV_USE_SPINNER    1
-
-#define LV_USE_SWITCH     1
-
-#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
-#if LV_USE_TEXTAREA != 0
-    #define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
-#endif
-
-#define LV_USE_TABLE      1
-
-#define LV_USE_TABVIEW    1
-
-#define LV_USE_TILEVIEW   1
-
-#define LV_USE_WIN        1
+#define LV_USE_LED        0
+#define LV_USE_LINE       0
+#define LV_USE_LIST       0
+#define LV_USE_MENU       0
+#define LV_USE_MSGBOX     0
+#define LV_USE_ROLLER     0
+#define LV_USE_SCALE      0
+#define LV_USE_SLIDER     0
+#define LV_USE_SPAN       0
+#define LV_USE_SPINBOX    0
+#define LV_USE_SPINNER    0
+#define LV_USE_SWITCH     0
+#define LV_USE_TEXTAREA   0
+#define LV_USE_TABLE      0
+#define LV_USE_TABVIEW    0
+#define LV_USE_TILEVIEW   0
+#define LV_USE_WIN        0
 
 /*==================
  * THEMES
  *==================*/
 
-/*A simple, impressive and very complete theme*/
-#define LV_USE_THEME_DEFAULT 1
-#if LV_USE_THEME_DEFAULT
-
-    /*0: Light mode; 1: Dark mode*/
-    #define LV_THEME_DEFAULT_DARK 0
-
-    /*1: Enable grow on press*/
-    #define LV_THEME_DEFAULT_GROW 1
-
-    /*Default transition time in [ms]*/
-    #define LV_THEME_DEFAULT_TRANSITION_TIME 80
-#endif /*LV_USE_THEME_DEFAULT*/
-
-/*A very simple theme that is a good starting point for a custom theme*/
-#define LV_USE_THEME_SIMPLE 1
-
-/*A theme designed for monochrome displays*/
-#define LV_USE_THEME_MONO 1
+/* No theme: the default theme is auto-initialised by lv_display_create and its
+ * styles reference every widget, which is what pulls all those widget object
+ * files into the link in the first place. The RGSS runtime styles every object
+ * it creates explicitly (lv_obj_remove_style_all + lv_obj_set_style_*), so
+ * dropping the theme changes nothing visually -- and matches the PSP/Wio
+ * configs, which need it gone to shrink the EBOOT. */
+#define LV_USE_THEME_DEFAULT 0
+#define LV_USE_THEME_SIMPLE 0
+#define LV_USE_THEME_MONO 0
 
 /*==================
  * LAYOUTS
  *==================*/
 
-/*A layout similar to Flexbox in CSS.*/
-#define LV_USE_FLEX 1
-
-/*A layout similar to Grid in CSS.*/
-#define LV_USE_GRID 1
+/* The RGSS runtime positions objects with lv_obj_align / lv_obj_set_pos, never
+ * flex/grid layouts. */
+#define LV_USE_FLEX 0
+#define LV_USE_GRID 0
 
 /*====================
  * 3RD PARTS LIBRARIES
@@ -804,7 +752,9 @@
 #define LV_USE_IMGFONT 0
 
 /*1: Enable an observer pattern implementation*/
-#define LV_USE_OBSERVER 1
+/* The RGSS runtime never registers observers; off to match the PSP/Wio
+ * configs. */
+#define LV_USE_OBSERVER 0
 
 /*1: Enable Pinyin input method*/
 /*Requires: lv_keyboard*/


### PR DESCRIPTION
## What

Extends the LVGL config trim from `app/psp`/`app/wio` to the desktop config (`include/lv_conf.h`), so all three targets build the same minimal LVGL and the render path cannot drift between desktop and the embedded builds.

- **Widgets**: only `lv_canvas` (every Bitmap is a canvas buffer), base `lv_obj` containers, and `lv_image`'s transform calls are used by the RGSS layer. Every other widget is compiled out.
- **Themes**: the three default themes are off. `lv_display_create` auto-installs the default theme, whose styles reference every widget — disabling it is what lets the linker drop the unused widget object files.
- **Layouts/observer**: flex/grid/observer off (the runtime positions with `lv_obj_align`/`lv_obj_set_pos`).
- **Examples/demos**: the root `CMakeLists.txt` stops building LVGL's examples/demos, which its CMake PUBLIC-links into `liblvgl.a`. Set as **cache variables with FORCE** — with CMP0077 unset, LVGL's `option()` only honours cache variables, so a plain `set()` would be silently ignored (exactly what broke the PSP build in PR #944, fixed there first).

Desktop-specific settings are kept: the SDL driver, `LV_USE_SNAPSHOT 1` (`Graphics.snap_to_bitmap`/freeze), `LV_USE_LOG`, asserts, and the 64 MB pool.

## Verification

- The trimmed desktop LVGL builds; the `lvgl_examples`/`lvgl_demos` targets no longer exist in the configured build.
- Booted `data/Nepheshel206beta` through the `--iterm` backend: a 320×240 frame renders through the trimmed LVGL (canvas path works without the theme).
- `pre-commit` passes.
- The SDL render path can't be exercised headless on this machine (pre-existing SDL3 duplicate-dylib conflict, same for `render_probe`/`exe_open` locally) — CI's `build` job (xvfb + wine frame-diff harness) is the gate.

## Docs

Changelog fragment added; ADR 0047's P6 already covers the trim (now applies to desktop too).