### PR TITLE
rpg2003: spend the battle combo an Enable Combo arms (ADR 0054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@
   curve from the class row and honouring the command's skill and parameter modes
   (keep / reset / add, keep / halve / reset); **Change Battle Commands** (1009)
   edits an actor's battle-command list; **Force Flee** (1006), **Enable Combo**
-  (1007) and **Call Common Event** (1005) act inside a battle-event page; and the
+  (1007) — an armed combo now multiplies the hits of the named battle command
+  when the actor uses it (attack and skill commands; an Item or Defend is
+  never combo'd, matching RPG_RT) — and **Call Common Event** (1005) act
+  inside a battle-event page; and the
   English-release **Open Load Menu** (5001) opens the same save/load
   file-select screen the field menu's Save command and the title's Continue
   use, and **Exit Game** (5002) quits

--- a/changelog.d/rpg2003-battle-combo-spent.added.md
+++ b/changelog.d/rpg2003-battle-combo-spent.added.md
@@ -1,0 +1,12 @@
+- The **RPG2003 battle combo is now spent** — the one Enable Combo (1007)
+  arming that was recorded but never acted on. The scene records the battle
+  command an actor chooses (`Combatant#last_battle_action`, the fixed four
+  mapping to EasyRPG's default ids 1-4, a customized list to its own refs),
+  and `Game::Battle#combo_hits` multiplies the hits of that command when an
+  armed combo names it exactly — a combo'd basic Attack lands its full combo
+  count, a combo'd skill repeats its effect with the SP spent once, and (like
+  real RPG_RT/EasyRPG) a Defend / Item / Escape command is never combo'd. The
+  combo stays armed for the whole fight, matching EasyRPG's
+  `ProcessBattleActionCombo`. Covered by new `rpg2k_logic_check.rb` checks
+  (armed/wrong-command/Item cases, single- and all-target skill SP-spent-once)
+  and `rpg2k_scene_check.rb` checks pinning the command-id recording.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1658,9 +1658,7 @@ The work below is roughly ordered by the critical path to a walkable game
   0054 — the gauge-driven battle now modelled for the gauge presentation) and
   the round-based machine; the command itself toggles a per-battle flag the
   battle still never reads, so it stays a reported gap rather than a silent
-  no-op. And the combo
-  an Enable Combo arms is recorded on the actor but never spent, for the same
-  reason. The opcodes were read out of liblcf's `EventCommand::Code` enum, which
+  no-op. The opcodes were read out of liblcf's `EventCommand::Code` enum, which
   also corrected `analyze_game.rb` — it had Change Class / Change Battle Commands
   at 12610 / 12710, numbers the enum does not define at all.
   **Battle-event pages now run too**: a troop's pages (`enemy_group` chunk 11)

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -70,9 +70,17 @@ Behavioral notes and deliberate simplifications:
 - A gauge battle shows **no Fight/Auto/Escape options window**: the first ready
   actor's menu opens on its own. The `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve
   remains ADR 0053's flagged-placeholder constants.
-- A `command_actor`-gated battle page still never fires: the turn cycle hands
-  the picker a concrete battler but never records which command it chose
-  (`Game::Battle#actor_command` stays nil).
+- The **battle combo** (Enable Combo / 1007) is spent: the scene records the
+  chosen battle command onto the Combatant (`last_battle_action`), and
+  `Game::Battle#combo_hits` multiplies the hits of an attack or skill command
+  when an armed combo names that exact command — never a Defend/Item/Escape.
+  The combo stays armed for the fight (no decrement), matching EasyRPG.
+- A `command_actor`-gated battle page still never fires: the scene now records
+  which command the battler chose (`Combatant#last_battle_action`), but the
+  source-threading that lets the page test *the acting battler's* command at
+  its action boundary — EasyRPG's `ScheduleNextPage(flags, source)` — is not
+  wired, so `Game::Battle#actor_command` stays nil (never satisfiable, the
+  same answer RPG_RT's RPG2000 scene gives).
 
 ## Consequences
 
@@ -87,8 +95,12 @@ Behavioral notes and deliberate simplifications:
   bump, silent no-op turn for a restricted battler) and `rpg2k_scene_check.rb`
   drives real gauge battles through the 2003 scene (menu-on-own, commit →
   action → idle, ready enemy auto-fires, restricted member's silent turn, and a
-  battle_type 0 fight never entering the gauge loop). The native boot check
-  keeps the real 2003 battle green.
-- Follow-ups: Wait-off (active) mode and the database wait toggle; recording
-  the chosen command for `command_actor` pages; the Special command handler;
+  battle_type 0 fight never entering the gauge loop). The combo's model math is
+  pinned by `rpg2k_logic_check.rb` (armed Attack combos to its full count,
+  wrong-command and Item combos never apply, a combo'd skill repeats with SP
+  spent once, all-target too) and the command-id recording by the scene checks.
+  The native boot check keeps the real 2003 battle green.
+- Follow-ups: Wait-off (active) mode and the database wait toggle; the
+  source-threading that makes `command_actor` pages satisfiable; the Special
+  command handler;
   the attacker-side back-row reach penalty; the exact RPG_RT 2003 fill curve.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2789,13 +2789,17 @@ module Game
     def battle_commands_changed?; !@battle_commands.nil?; end
 
     # The RPG2003 battle combo an Enable Combo (1007) armed: the battle command
-    # to repeat and how many times. nil until a battle page arms one.
+    # to repeat and how many times. nil until a battle page arms one. Stored on
+    # the actor the way RPG_RT keeps it (EasyRPG's Game_Actor::SetBattleCombo);
+    # the battle resolution spends it -- Battle#combo_hits multiplies the hits
+    # of the armed command when it is the one the actor chose (ADR 0054).
     attr_reader :battle_combo
 
     # Enable Combo (event command 1007): make `command_id` repeat `multiple`
     # times when this actor uses it. Stored on the actor the way RPG_RT keeps it
-    # (EasyRPG's Game_Actor::SetBattleCombo); the ATB battle system that spends
-    # it is not modelled here, so this records the arming rather than acting.
+    # (EasyRPG's Game_Actor::SetBattleCombo); the combo is not decremented by a
+    # use -- it stays armed for the whole fight until another Enable Combo
+    # overwrites it, matching EasyRPG.
     def set_battle_combo(command_id, multiple)
       @battle_combo = { command_id: command_id, multiple: multiple }
     end
@@ -8455,7 +8459,18 @@ module Game
                             # advances it -- RPG2000 (battle_type 0) and the
                             # 2003 traditional presentation (1) leave it at 0
                             # and run the turn-based machine instead.
-                            :gauge) do
+                            :gauge,
+                            # The ref of the battle command (into
+                            # `db.battlecommands.commands`, 1..4 for the fixed
+                            # four) this actor last chose in the command window,
+                            # recorded by the scene (#select_battle_command) the
+                            # way EasyRPG's Scene_Battle_Rpg2k3 sets
+                            # `SetLastBattleAction(command->ID)`. Read by the
+                            # RPG2003 battle combo (#combo_hits) and, in time,
+                            # the battle-page `command_actor` condition. nil
+                            # until an actor picks a command (an enemy, or an
+                            # auto-battling ally, never records one).
+                            :last_battle_action) do
       def dead?; hp <= 0; end
 
       # The HP/MP ceiling a status panel should show for this combatant: the
@@ -8831,16 +8846,17 @@ module Game
 
     # The `command_actor` page condition (which battle command an actor just
     # chose) is answered "unknown" (nil), which Game::BattlePage reads as
-    # "fails the page" rather than firing it unchecked — and this is not a
-    # gap to close, it is what RPG_RT itself does for RPG2000's battle system.
-    # EasyRPG's `AreConditionsMet` only evaluates the condition when it is
-    # handed a `source` battler (`if (!source) return false;`), and
-    # `Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents` — the *only* call
-    # site `Scene_Battle_Rpg2k` has — always calls `ScheduleNextPage(nullptr)`.
-    # A per-actor `source` only ever exists in `Scene_Battle_Rpg2k3`, the
-    # separate ATB scene this runtime does not model (see the Toggle ATB Mode
-    # note); a page gated on `command_actor` is therefore *never satisfiable*
-    # under RPG2000's own battle system, not merely unimplemented here.
+    # "fails the page" rather than firing it unchecked. The *data* is now in
+    # place -- the scene records the chosen command onto the Combatant
+    # (`last_battle_action`, recorded at command selection) -- but EasyRPG's
+    # `AreConditionsMet` only evaluates the condition when handed a `source`
+    # battler (`if (!source) return false;`), and `Scene_Battle_Rpg2k::
+    # CheckBattleEndAndScheduleEvents` — the only page-scheduling call site
+    # RPG2000's own battle scene has — always calls with a null source. The
+    # source-threading that lets a page test *the acting battler's* command
+    # (rather than anyone's recorded one, at any boundary) is the remaining
+    # piece; until then a page gated on `command_actor` stays never satisfiable
+    # here, matching real RPG_RT's RPG2000 behaviour by keeping the answer nil.
     def actor_command(_id); nil; end
 
     # Force Flee (1006), target 0: let the party leave whenever it next tries.
@@ -9880,10 +9896,14 @@ module Game
         # one, same as an unforced Attack would (デフォ戦botまとめ: "Berserk
         # additionally collapses an 'attack all' weapon down to a single
         # target").
-        return swing_side(b, side_targets(target)) if r == RESTRICTION_ATTACK_ALLY && b.attack_all
-        return swing(b, target)
+        hits = combo_hits(b, :attack)
+        return swing_side(b, side_targets(target), hits) if r == RESTRICTION_ATTACK_ALLY && b.attack_all
+        return swing(b, target, hits)
       end
-      return apply_command(b) if b.command
+      # A combo multiplies a skill's hits (SP paid once), never an item's --
+      # #combo_hits resolves the chosen command's type, and an Item command
+      # reads 1.
+      return apply_command(b, combo_hits(b, :skill)) if b.command
       return nil if side_of(b) == :ally && b.defending # defending = no attack
       # An enemy with a 行動パターン chooses from it rather than always swinging.
       if side_of(b) == :enemy
@@ -9895,8 +9915,66 @@ module Game
       end
       target = attack_target(b)
       return nil unless target
-      return swing_side(b, side_targets(target)) if b.attack_all
-      swing(b, target)
+      hits = combo_hits(b, :attack)
+      return swing_side(b, side_targets(target), hits) if b.attack_all
+      swing(b, target, hits)
+    end
+
+    # -- RPG2003 battle combo (Enable Combo / 1007) -----------------------------
+    #
+    # A combo armed by Enable Combo (event 1007) multiplies the hits of the
+    # battle command it names. Port of EasyRPG's `ProcessBattleActionCombo`
+    # (src/scene_battle_rpg2k3.cpp): the armed `{ command_id:, multiple: }`
+    # (Game::Actor#battle_combo) applies only when `command_id` is the command
+    # the actor actually chose this turn (Combatant#last_battle_action,
+    # recorded by the scene at command selection), and only to attack / skill /
+    # subskill commands -- "RPG_RT doesn't allow combo for item or other
+    # actions other than attack and skills" (their comment). Like EasyRPG, the
+    # combo is not decremented by a use: it stays armed (until battle end or
+    # another Enable Combo overwrites it), so every matching use of the command
+    # during the fight hits `multiple` times.
+    #
+    # The fixed-four command ids (1 attack, 2 skill, 3 defense, 4 item) are
+    # EasyRPG's `GetDefaultBattleCommands`; a customized actor's ids are refs
+    # into `db.battlecommands.commands`, whose rows this resolves through the
+    # actor the same way the scene's command menu does.
+    DEFAULT_BATTLE_COMMAND_TYPES = {
+      1 => Game::Actor::BATTLE_COMMAND_ATTACK,
+      2 => Game::Actor::BATTLE_COMMAND_SKILL,
+      3 => Game::Actor::BATTLE_COMMAND_DEFENSE,
+      4 => Game::Actor::BATTLE_COMMAND_ITEM
+    }.freeze
+
+    # The RPG2003 battle-command type for `cmd_id` on battler `b`: the actor's
+    # own customized list's row when it has one, else the fixed-four default
+    # table (a 2000 actor, or one whose list does not reach this id).
+    def battle_command_type(b, cmd_id)
+      actor = b.respond_to?(:actor) ? b.actor : nil
+      row = actor && actor.respond_to?(:battle_command_row) ? actor.battle_command_row(cmd_id) : nil
+      return row.type if row && row.respond_to?(:type)
+      DEFAULT_BATTLE_COMMAND_TYPES[cmd_id]
+    end
+
+    # The combo hit multiplier for `b`'s current `kind` (:attack or :skill)
+    # of action, or 1 when no matching combo is armed -- see the section
+    # comment above for the exact matching rules. Enemies and auto-battling
+    # allies never record a `last_battle_action`, so they never combo.
+    def combo_hits(b, kind)
+      actor = b.respond_to?(:actor) ? b.actor : nil
+      return 1 unless actor && actor.respond_to?(:battle_combo)
+      combo = actor.battle_combo
+      multiple = combo && combo[:multiple]
+      return 1 unless multiple && multiple > 1
+      return 1 unless combo[:command_id] && combo[:command_id] == b.last_battle_action
+      case kind
+      when :attack
+        battle_command_type(b, combo[:command_id]) == Game::Actor::BATTLE_COMMAND_ATTACK ? multiple : 1
+      when :skill
+        type = battle_command_type(b, combo[:command_id])
+        type == Game::Actor::BATTLE_COMMAND_SKILL || type == Game::Actor::BATTLE_COMMAND_SUBSKILL ? multiple : 1
+      else
+        1
+      end
     end
 
     # The living members of `target`'s own side -- what an `attack_all`
@@ -9912,11 +9990,11 @@ module Game
     # attack_all under an ordinary Attack: every target swings (dual-wield
     # included, matching a single-target #swing), flattened into one array of
     # log entries for #record_action to drain one hit at a time.
-    def swing_side(b, targets)
+    def swing_side(b, targets, hits = 1)
       # Not Array(swing(...)) -- Array() on a Hash (an ordinary single swing's
       # log entry) explodes it into [key, value] pairs rather than wrapping
       # it, since Hash is Enumerable. Same guard #record_action already uses.
-      targets.flat_map { |t| r = swing(b, t); r.is_a?(Array) ? r : [r] }
+      targets.flat_map { |t| r = swing(b, t, hits); r.is_a?(Array) ? r : [r] }
     end
 
     # -- enemy AI (行動パターン) ------------------------------------------------
@@ -10575,10 +10653,17 @@ module Game
     # handed to `#deal_attack`, which resolves a two-weapon actor's specific
     # governing weapon for that swing (`Actor#swing_weapon_data`) rather than
     # reusing the same merged hit/attribute/state/crit data for every swing.
-    def swing(b, target)
+    def swing(b, target, hits = 1)
       entries = []
-      b.strike_count.times do |i|
-        entries << deal_attack(b, target, i)
+      # A combo multiplies the whole swing count: each base swing round runs
+      # `hits` times (so a two-weapon actor's weapon rotation repeats intact),
+      # and a swing that fells the target stops the whole attack, matching the
+      # single-round rule below and EasyRPG's repeat loop.
+      hits.times do
+        b.strike_count.times do |i|
+          entries << deal_attack(b, target, i)
+          break if target.dead?
+        end
         break if target.dead?
       end
       entries.size == 1 ? entries.first : entries
@@ -10976,14 +11061,25 @@ module Game
     # landing on. Scoped to this single-target path only: an all-enemies-scope
     # Skill's own reflect handling is a materially different shape in real
     # RPG_RT -- see #apply_command_all, where it is now implemented too.
-    def apply_command(b)
+    def apply_command(b, combo = 1)
       cmd = b.command
-      return apply_command_all(b, cmd) if cmd[:all]
+      return apply_command_all(b, cmd, combo) if cmd[:all]
       target = cmd[:target]
       return nil if target.nil? || target.dead?
       target = b if reflects_skill?(b, target, cmd)
       b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
-      apply_skill_hit(b, target, cmd[:hp] || 0, cmd[:mp] || 0, cmd)
+      # A combo'd skill repeats its effect `combo` times against the same
+      # target, the SP spent once -- EasyRPG's repeat loop over the algorithm
+      # (which also pays its cost once, in vStart). Each repeat is its own
+      # log entry (buffered by #record_action), and one that fells the target
+      # stops the repeats, matching the swing rule.
+      entries = []
+      combo.times do
+        entry = apply_skill_hit(b, target, cmd[:hp] || 0, cmd[:mp] || 0, cmd)
+        entries << entry if entry
+        break if target.dead?
+      end
+      entries.size == 1 ? entries.first : (entries.empty? ? nil : entries)
     end
 
     # The first already-computed `{target:, hp:, mp:}` entry in `live` whose
@@ -11026,7 +11122,7 @@ module Game
     # queued against), while #apply_skill_hit still recomputes each hit's
     # own elemental multiplier/variance/absorb fresh against whichever new
     # target it actually lands on.
-    def apply_command_all(b, cmd)
+    def apply_command_all(b, cmd, combo = 1)
       live = (cmd[:targets] || []).select { |t| t[:target] && !t[:target].dead? }
       return nil if live.empty?
       reflected = reflecting_target_all(b, live, cmd)
@@ -11035,7 +11131,15 @@ module Game
         live = own_side.map { |t| { target: t, hp: reflected[:hp], mp: reflected[:mp] } }
       end
       b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
-      entries = live.map { |t| apply_skill_hit(b, t[:target], t[:hp] || 0, t[:mp] || 0, cmd) }
+      # A combo'd all-target skill repeats the whole volley `combo` times (one
+      # entry per hit, buffered by #record_action), the SP spent once -- the
+      # same rule as #apply_command's single-target repeat.
+      entries = []
+      combo.times do
+        live.each do |t|
+          entries << apply_skill_hit(b, t[:target], t[:hp] || 0, t[:mp] || 0, cmd)
+        end
+      end
       # An all-ally item is consumed once for the whole volley: keep item_id on
       # the first hit only, so the scene's per-entry bag deduction fires once.
       entries.each_with_index { |e, i| e[:item_id] = nil unless i.zero? } if cmd[:item_id]

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2444,9 +2444,10 @@ module Game
 
     # Enable Combo (1007), RPG2003-only: arm actor param0's battle command param1
     # to repeat param2 times. The actor is named by id, so it resolves through the
-    # roster like the other fixed-id commands. Recorded on the actor; the ATB
-    # battle system that spends a combo is not modelled here, so nothing acts on
-    # it yet. Matches EasyRPG's own `Game_Interpreter_Battle::
+    # roster like the other fixed-id commands. Recorded on the actor; the battle
+    # resolution spends it -- a combo'd attack or skill hits `multiple` times
+    # (Game::Battle#combo_hits, ADR 0054's combo work; EasyRPG's
+    # `ProcessBattleActionCombo`). Matches EasyRPG's own `Game_Interpreter_Battle::
     # CommandEnableCombo` (src/game_interpreter_battle.cpp), the same
     # `IsRPG2k3Commands()` gate as Force Flee above.
     def do_enable_combo(cmd)

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -887,8 +887,15 @@ class RPG2k
       end
 
       # The per-actor commands, in menu order (the cursor row is 1 + index,
-      # below the actor-name header): each a `{ label:, action: }` pair, drawn
-      # by `#battle_commands` below and dispatched by `#select_battle_command`.
+      # below the actor-name header): each a `{ label:, action:,
+      # command_id: }` pair, drawn by `#battle_commands` below and dispatched
+      # by `#select_battle_command`. `command_id` is the ref into the
+      # database's Battle-Commands table (`db.battlecommands.commands`) the
+      # row came from -- the fixed four map to EasyRPG's default command ids
+      # 1..4 (attack, skill, defense, item), a customized list to its own
+      # refs -- which the scene records onto the acting Combatant when the
+      # row is chosen, for the RPG2003 battle combo and the battle-page
+      # `command_actor` condition.
       #
       # An acting actor whose own RPG2003 battle-command list
       # (`Game::Actor#battle_commands`, edited by Change Battle Commands (1009)
@@ -902,16 +909,23 @@ class RPG2k
       # it substitutes the acting actor's own RPG2000 rename
       # (`#skill_command_label` below) when the database sets one, so it can
       # change from one actor's turn to the next.
+      #
+      # The fixed-four ids (1 attack, 2 skill, 3 defense, 4 item) are
+      # EasyRPG's `GetDefaultBattleCommands`, which builds exactly these four
+      # entries in this order for an actor with no customized list -- the same
+      # ids a real 2003 database's own Battle-Commands table conventionally
+      # numbers its first four entries, and the ids the Enable Combo (1007)
+      # command and the `command_actor` page condition refer to.
       def battle_command_rows
         actor = current_actor_row
         custom = actor && custom_battle_commands(actor)
         return custom if custom
 
         [
-          { label: term(:battle_attack, 'Attack'), action: :attack },
-          { label: skill_command_label, action: :skill },
-          { label: term(:battle_defend, 'Defend'), action: :defend },
-          { label: term(:battle_item, 'Item'), action: :item }
+          { label: term(:battle_attack, 'Attack'), action: :attack, command_id: 1 },
+          { label: skill_command_label, action: :skill, command_id: 2 },
+          { label: term(:battle_defend, 'Defend'), action: :defend, command_id: 3 },
+          { label: term(:battle_item, 'Item'), action: :item, command_id: 4 }
         ]
       end
 
@@ -945,13 +959,17 @@ class RPG2k
 
           case row.type
           when Game::Actor::BATTLE_COMMAND_ATTACK
-            out << { label: nonblank(row.name, term(:battle_attack, 'Attack')), action: :attack }
+            out << { label: nonblank(row.name, term(:battle_attack, 'Attack')), action: :attack,
+                     command_id: cmd_id }
           when Game::Actor::BATTLE_COMMAND_SKILL, Game::Actor::BATTLE_COMMAND_SUBSKILL
-            out << { label: nonblank(row.name, skill_command_label), action: :skill }
+            out << { label: nonblank(row.name, skill_command_label), action: :skill,
+                     command_id: cmd_id }
           when Game::Actor::BATTLE_COMMAND_DEFENSE
-            out << { label: nonblank(row.name, term(:battle_defend, 'Defend')), action: :defend }
+            out << { label: nonblank(row.name, term(:battle_defend, 'Defend')), action: :defend,
+                     command_id: cmd_id }
           when Game::Actor::BATTLE_COMMAND_ITEM
-            out << { label: nonblank(row.name, term(:battle_item, 'Item')), action: :item }
+            out << { label: nonblank(row.name, term(:battle_item, 'Item')), action: :item,
+                     command_id: cmd_id }
           end
           # Escape / Special: no menu row (see the method comment above).
         end
@@ -1180,7 +1198,16 @@ class RPG2k
       # RPG_RT's own Decision-on-opening-the-submenu and Buzzer-on-nothing-
       # to-pick are both conditional on that submenu's own state there.
       def select_battle_command
-        case battle_command_rows[@ui[:cmd]][:action]
+        # Record the chosen battle command (its `command_id` ref into
+        # `db.battlecommands.commands`, 1..4 for the fixed four -- see
+        # #battle_command_rows) onto the acting Combatant, the way EasyRPG's
+        # Scene_Battle_Rpg2k3 sets `SetLastBattleAction(command->ID)` when the
+        # command window confirms. The RPG2003 battle combo (Enable Combo) and
+        # the battle-page `command_actor` condition both read it; RPG2000 never
+        # consults either, so recording it for every battle is harmless.
+        row = battle_command_rows[@ui[:cmd]]
+        current_actor.last_battle_action = row[:command_id] if current_actor && row[:command_id]
+        case row[:action]
         when :attack
           play_system_se(SFX_DECISION)
           @ui[:pending] = { kind: :attack }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10826,6 +10826,131 @@ check 'battle_skill_command carries the skill variance on its heal branch too' d
   eq 7, c[:variance], 'the heal branch reports the skill row variance, not 0'
 end
 
+# -- RPG2003 battle combo (Enable Combo / 1007) --------------------------------
+#
+# A combo armed by Enable Combo (event 1007) makes the named battle command hit
+# `multiple` times. Port of EasyRPG's ProcessBattleActionCombo
+# (src/scene_battle_rpg2k3.cpp): the armed combo applies only when `command_id`
+# is the command the actor actually chose this turn (Combatant#last_battle_action,
+# recorded by the scene's #select_battle_command) and only to attack / skill /
+# subskill commands -- never Defend, Item or Escape. Like EasyRPG the combo is
+# not decremented by a use; it stays armed for the whole fight.
+
+# A party whose battle-commands table carries the fixed four (attack 1, skill
+# 2, defend 3, item 4 -- EasyRPG's GetDefaultBattleCommands ids) so a combo's
+# command id resolves to a real type the way the scene menu's would.
+def combo_party(skills = {})
+  commands = {
+    1 => FakeBattleCommand.new('Attack', Game::Actor::BATTLE_COMMAND_ATTACK),
+    2 => FakeBattleCommand.new('Skill', Game::Actor::BATTLE_COMMAND_SKILL),
+    3 => FakeBattleCommand.new('Defend', Game::Actor::BATTLE_COMMAND_DEFENSE),
+    4 => FakeBattleCommand.new('Item', Game::Actor::BATTLE_COMMAND_ITEM)
+  }
+  table = FakeBattleCommandsTable.new(commands, 0, 0)
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8, int: 12, agi: 7),
+  }
+  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1], {}, skills, {}, nil, nil,
+                                                 rpg2003: true, battlecommands: table)),
+                  1, 0, 0)
+end
+
+def strike_entries(bat, attacker)
+  r = bat.send(:strike, attacker)
+  r.is_a?(Array) ? r : [r]
+end
+
+check 'an armed Attack combo makes a basic Attack land its full combo count' do
+  st = combo_party
+  hero = st.party.actor_by_id(1)
+  hero.set_battle_combo(1, 3) # Attack (command 1) hits 3 times
+  attacker = Game::Battle.from_actor(hero)
+  attacker.last_battle_action = 1 # the scene recorded "Attack" at command selection
+  slime = combatant('Slime', 0, 0, 5, 100_000) # tanky so every swing lands
+  bat = Game::Battle.new([attacker], [slime], Game::Rng.new(1))
+  entries = strike_entries(bat, attacker)
+  eq 3, entries.size, 'three swings for the 3x combo'
+  eq ['Slime'], entries.map { |e| e[:target] }.uniq, 'all aimed at the commanded target'
+end
+
+check 'a basic Attack with no armed combo stays a single hit' do
+  st = combo_party
+  attacker = Game::Battle.from_actor(st.party.actor_by_id(1))
+  attacker.last_battle_action = 1
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([attacker], [slime], Game::Rng.new(1))
+  entries = strike_entries(bat, attacker)
+  eq 1, entries.size, 'one swing, one log entry'
+end
+
+check 'a combo armed for one command does not multiply a different chosen command' do
+  st = combo_party
+  hero = st.party.actor_by_id(1)
+  hero.set_battle_combo(2, 3) # a Skill combo
+  attacker = Game::Battle.from_actor(hero)
+  attacker.last_battle_action = 1 # but the actor chose Attack this turn
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([attacker], [slime], Game::Rng.new(1))
+  entries = strike_entries(bat, attacker)
+  eq 1, entries.size, 'the Attack is not combo\'d -- only the armed Skill command is'
+end
+
+check 'a combo armed for the Item command never multiplies anything, matching RPG_RT' do
+  st = combo_party
+  hero = st.party.actor_by_id(1)
+  hero.set_battle_combo(4, 3) # Item is the armed command
+  attacker = Game::Battle.from_actor(hero)
+  attacker.last_battle_action = 4 # and the actor chose Item
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([attacker], [slime], Game::Rng.new(1))
+  eq 1, bat.send(:combo_hits, attacker, :skill), 'the skill path reads no combo for an Item command'
+  eq 1, bat.send(:combo_hits, attacker, :attack), 'nor does the attack path'
+end
+
+check 'a combo\'d skill repeats its effect with the SP spent once' do
+  skills = { 8 => fake_skill(name: 'Fire', scope: 0, sp_cost: 4, power: 10,
+                             mrate: 0, hp: true, type: 0) }
+  st = combo_party(skills)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(8)
+  hero.set_battle_combo(2, 3) # the Skill command (2) combo
+  caster = Game::Battle.from_actor(hero)
+  caster.last_battle_action = 2 # chose the Skill command
+  caster.mp = 20
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([caster], [slime], Game::Rng.new(1))
+  c = st.party.battle_skill_command(st.party.db_skill(8), caster, slime)
+  bat.command_skill(caster, slime, name: 'Fire', cost: c[:cost], hp: c[:hp],
+                    mp: c[:mp], variance: c[:variance])
+  entries = strike_entries(bat, caster)
+  eq 3, entries.size, 'the combo\'d skill casts three times'
+  eq 16, caster.mp, 'but the SP is spent once (20 - 4), not three times'
+end
+
+check 'a combo\'d all-target skill repeats the whole volley, SP spent once' do
+  skills = { 9 => fake_skill(name: 'Gale', scope: 1, sp_cost: 6, power: 10,
+                             mrate: 0, hp: true, type: 0) }
+  st = combo_party(skills)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(9)
+  hero.set_battle_combo(2, 2) # the Skill command (2) combo
+  caster = Game::Battle.from_actor(hero)
+  caster.last_battle_action = 2
+  caster.mp = 30
+  slime_a = combatant('SlimeA', 0, 0, 5, 100_000)
+  slime_b = combatant('SlimeB', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([caster], [slime_a, slime_b], Game::Rng.new(1))
+  c = st.party.battle_skill_command(st.party.db_skill(9), caster, slime_a)
+  bat.command_skill_all(caster,
+                        [slime_a, slime_b].map { |t| { target: t, hp: c[:hp], mp: c[:mp] } },
+                        name: 'Gale', cost: c[:cost], inflict: c[:inflict],
+                        chance: c[:chance], variance: c[:variance])
+  entries = strike_entries(bat, caster)
+  eq 4, entries.size, 'two targets times the 2x combo = four hits'
+  eq 24, caster.mp, 'but the SP is spent once (30 - 6)'
+end
+
 check 'battle_skill_command carries the skill elemental attributes on its heal branch too, ' \
      'and a target that partly resists them heals for less than the raw base' do
   # EasyRPG's `Algo::CalcSkillEffect` runs `Attribute::

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9620,6 +9620,41 @@ check "Enemy Encounter scene: a reordered Defense command still commits at once,
      "cmd 1's own action (:defend) drove this, not the fixed four's cmd-2-is-Defend rule"
 end
 
+check 'selecting a battle command records its command id on the acting Combatant, ' \
+      'the way EasyRPG sets SetLastBattleAction' do
+  # The fixed four map to EasyRPG's default command ids 1..4 (attack, skill,
+  # defense, item) -- what the RPG2003 battle combo (Enable Combo) and the
+  # `command_actor` page condition compare against. This pins the recording,
+  # not the spending (the model-side combo math lives in rpg2k_logic_check.rb).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(BattleStubActor.new(agi: 20)))
+  ui = battle_to_command(scene)
+  hero = ui[:allies][0]
+  eq nil, hero.last_battle_action, 'nothing recorded before a command is chosen'
+  press_key(scene, RGSS::Input::C) # Attack (cmd 0, the default cursor row)
+  eq 1, hero.last_battle_action, 'the fixed Attack row records command id 1'
+end
+
+check 'selecting a customized battle command records its own command-table ref' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  actor = BattleStubActor.new(agi: 20,
+    battle_commands: [10, 0, -1, -1, -1, -1, -1],
+    battle_command_table: { 10 => BattleCommandDef.new('Cast Magic', Game::Actor::BATTLE_COMMAND_SUBSKILL) })
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(actor))
+  ui = battle_to_command(scene)
+  hero = ui[:allies][0]
+  press_key(scene, RGSS::Input::C) # the only row, cmd 0: the Subskill at ref 10
+  eq 10, hero.last_battle_action, 'a customized row records its own db.commands ref'
+end
+
 check "Enemy Encounter scene: a battle-command list of Row alone falls back to the fixed four" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
Enable Combo (event 1007) arms an actor's battle command to hit `multiple` times; the arming was recorded but never acted on. Now the battle resolution spends it, ported from EasyRPG's `ProcessBattleActionCombo`.

**What changed**
- The scene records the chosen battle command onto the acting Combatant (`last_battle_action`): the fixed four map to EasyRPG's default ids 1–4 (attack, skill, defense, item), a customized list to its own refs into `db.battlecommands.commands`.
- `Game::Battle#combo_hits` resolves the armed combo's multiplier (command match + attack/skill/subskill type eligibility — never Defend/Item/Escape, matching RPG_RT), and `#strike` threads it into `#swing` (combo'd basic Attack lands its full swing count, dual-wield rotation repeated intact) and `#apply_command`/`#apply_command_all` (combo'd skill repeats its effect, single- and all-target, with the SP spent once). Like EasyRPG the combo is not decremented by a use — it stays armed for the fight.
- The command-id recording is also the data foundation the `command_actor` page condition reads (still not satisfiable — the source threading that tests the *acting* battler is a documented follow-up).

**Verify:** `rpg2k_logic_check.rb` (983) pins the model math, `rpg2k_scene_check.rb` (673) pins the command-id recording, native boot check keeps the real 2003 gauge battle green, `cmake --build build -t test` (8/8), pre-commit all green.