### PR TITLE
rpg2003: charge the gauge battle at the real RPG_RT 2003 fill curve (ADR 0053/0054)

### DIFF
--- a/changelog.d/rpg2003-battle-gauge-fill-curve.changed.md
+++ b/changelog.d/rpg2003-battle-gauge-fill-curve.changed.md
@@ -1,0 +1,12 @@
+- The **RPG2003 gauge battle now charges at the real RPG_RT 2003 pace**, not
+  the placeholder linear curve: `Game::Battle#advance_gauges` ports EasyRPG's
+  `Game_Battle::UpdateAtbGauges` (src/game_battle.cpp) exactly —
+  `GAUGE_MAX` is 300000, and each battler's per-frame increment is
+  `GAUGE_MAX / (sum_agi / (agi + 1))` over every non-hidden battler's AGI
+  (all integer-truncated), so the whole field charges together on a common
+  pace scaled by relative AGI rather than each battler charging at its own
+  absolute rate, a do-nothing-restricted ally never charges (`CanAct()`),
+  and faster battlers still reach full first. Covered by reworked
+  `rpg2k3_battle_gauge_check.rb` checks pinning the exact increments, the
+  143-vs-273-tick fill ordering, full-and-stays, and the dead/restricted
+  no-charge rules.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -114,8 +114,12 @@ once a 2003 project reaches a fight.
   empty) with `gauge` / `gauge_full?` readers.
 - `Game::Battle` gained `battle_type` (0 traditional / 1 alternative / 2
   gauge; defaults to 0) and the gauge engine:
-  - `advance_gauges(ticks)` fills every living, in-play battler's gauge at
-    `effective_agi * GAUGE_AGI_RATE * ticks`, clamped to `GAUGE_MAX`. It is a
+  - `advance_gauges(ticks)` fills every charging battler's gauge, clamped to
+    `GAUGE_MAX`. The exact curve was settled later, in the ADR 0054 follow-on,
+    as EasyRPG's `Game_Battle::UpdateAtbGauges` port (`GAUGE_MAX` 300000,
+    per-frame increment `GAUGE_MAX / (sum_agi / (agi + 1))` over every
+    non-hidden battler's AGI) — the original placeholder (`effective_agi *
+    GAUGE_AGI_RATE * ticks`, max 100) is gone. It is a
     **no-op unless `battle_type == 2`**, so RPG2000 and the 2003 traditional
     presentation keep running the turn-based machine untouched.
   - `ready_combatants` returns the full-gauge battlers in descending gauge
@@ -138,13 +142,13 @@ once a 2003 project reaches a fight.
   resets its gauge (replacing "whose turn is it" in the round machine) is
   intentionally **not** wired yet — doing so requires the per-frame
   `Scene::Battle#update` loop and a 2003 project to run it (Phase 3). The
-  exact `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve is the RPG_RT 2003
-  constant, flagged TODO against the RPG_RT 2003 specification (still
-  inaccessible).
+  exact fill curve was also deferred — the ADR 0054 follow-on resolved it
+  against EasyRPG's own RPG_RT 2003 port once that source was reachable.
 
-Verification: `scripts/rpg2k3_battle_gauge_check.rb` (6 checks) exercises the
-inert turn-based path, AGI-proportional fill, full/ready selection, ordering,
-and that a dead battler neither charges nor becomes ready; wired into the
+Verification: `scripts/rpg2k3_battle_gauge_check.rb` (14 checks) exercises the
+inert turn-based path, the real relative fill curve, full/ready selection,
+ordering, that a dead battler neither charges nor becomes ready, and that a
+do-nothing-restricted ally never charges; wired into the
 `ruby-checks` CI job.
 
 ## Phase 2 — scene integration notes (2026-08-16)

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -68,8 +68,11 @@ Behavioral notes and deliberate simplifications:
   presentation, and the database's wait toggle itself (a Battle Commands field
   the schema does not decode yet), are follow-ups.
 - A gauge battle shows **no Fight/Auto/Escape options window**: the first ready
-  actor's menu opens on its own. The `GAUGE_MAX` / `GAUGE_AGI_RATE` fill curve
-  remains ADR 0053's flagged-placeholder constants.
+  actor's menu opens on its own. The gauge fill runs on EasyRPG's real RPG_RT
+  2003 curve — `GAUGE_MAX` 300000, per-frame increment
+  `GAUGE_MAX / (sum_agi / (agi + 1))` over every non-hidden battler's AGI, so
+  the field charges together and a do-nothing-restricted ally never charges —
+  replacing the earlier placeholder constants.
 - The **battle combo** (Enable Combo / 1007) is spent: the scene records the
   chosen battle command onto the Combatant (`last_battle_action`), and
   `Game::Battle#combo_hits` multiplies the hits of an attack or skill command
@@ -92,7 +95,9 @@ Behavioral notes and deliberate simplifications:
   and the model addition is additive.
 - Verification is fixture-driven: `rpg2k3_battle_gauge_check.rb` pins
   `begin_gauge_turn` (single-battler queue, gauge consumption, per-battler turn
-  bump, silent no-op turn for a restricted battler) and `rpg2k_scene_check.rb`
+  bump, silent no-op turn for a restricted battler) and the real fill curve
+  (exact increments, faster-fills-first, full-and-stays, a dead or
+  do-nothing-restricted ally never charging) and `rpg2k_scene_check.rb`
   drives real gauge battles through the 2003 scene (menu-on-own, commit →
   action → idle, ready enemy auto-fires, restricted member's silent turn, and a
   battle_type 0 fight never entering the gauge loop). The combo's model math is
@@ -103,4 +108,6 @@ Behavioral notes and deliberate simplifications:
 - Follow-ups: Wait-off (active) mode and the database wait toggle; the
   source-threading that makes `command_actor` pages satisfiable; the Special
   command handler;
-  the attacker-side back-row reach penalty; the exact RPG_RT 2003 fill curve.
+  the attacker-side back-row reach penalty; the automatic battler-placement
+  grid (`Calculate2k3BattlePosition`, whose reference source this ADR's work
+  also surfaced).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9086,33 +9086,45 @@ module Game
     end
 
     # RPG2003 active-time (gauge) battle timing (ADR 0053, Phase 2). The gauge
-    # is a 0..GAUGE_MAX charge each living battler accumulates every frame at a
-    # rate proportional to its AGI; the moment it is full the battler may act
-    # (see #ready_combatants). This is the RPG2003 presentation-2 ("gauge")
-    # time system -- RPG2000 (battle_type 0) and the 2003 traditional
-    # presentation (1) never advance it and keep running the turn-based
-    # machine, so #advance_gauges is a no-op for them.
+    # is a 0..GAUGE_MAX charge each battler accumulates every frame; the moment
+    # it is full the battler may act (see #ready_combatants). This is the
+    # RPG2003 presentation-2 ("gauge") time system -- RPG2000 (battle_type 0)
+    # and the 2003 traditional presentation (1) never advance it and keep
+    # running the turn-based machine, so #advance_gauges is a no-op for them.
     #
-    # GAUGE_MAX and the AGI-to-fill relationship are RPG_RT 2003 constants;
-    # the exact fill curve is flagged TODO against the RPG_RT 2003
-    # specification (still inaccessible, the same blocker as the row
-    # multiplier / LCF schema work). The model below is the structure RPG_RT
-    # uses, with a linear AGI-proportional fill chosen as the documented
-    # default.
-    GAUGE_MAX = 100
-    GAUGE_AGI_RATE = 1   # gauge points gained per AGI per tick
+    # GAUGE_MAX and the fill curve are EasyRPG's RPG_RT 2003 port
+    # (Game_Battler::GetMaxAtbGauge / Game_Battle::UpdateAtbGauges,
+    # src/game_battle.cpp), replacing the earlier placeholder constants
+    # (100 max, one gauge point per AGI per frame) that were flagged TODO
+    # against the then-inaccessible RPG_RT specification. The real curve is
+    # *relative*, not linear in AGI: every non-hidden battler's AGI is summed
+    # (times 100), each battler's per-frame increment is
+    # `GAUGE_MAX / (sum_agi / (agi + 1))`, and all the integer division is
+    # truncating -- so a battler with double another's AGI fills nearly twice
+    # as fast, and the whole field charges together (a bigger party shares a
+    # slower common pace rather than each battler charging at its own absolute
+    # rate). A do-nothing-restricted *ally* does not charge (`CanAct()`, and an
+    # enemy always charges -- EasyRPG's `CanAct() || Type_Enemy`), and a dead /
+    # hidden / not-a-member battler neither contributes to the sum nor charges.
+    GAUGE_MAX = 300_000
 
     attr_accessor :battle_type
 
-    # Advance every living, in-play battler's gauge by `ticks` frames, gated on
-    # battle_type (only the gauge presentation advances it). AGI drives the
-    # fill rate so faster battlers reach a full gauge sooner, the RPG_RT 2003
-    # behaviour. Dead / hidden / not-a-member combatants do not charge.
+    # Advance every charging battler's gauge by `ticks` frames, gated on
+    # battle_type (only the gauge presentation advances it). Ported verbatim
+    # from EasyRPG's `Game_Battle::UpdateAtbGauges` (src/game_battle.cpp): the
+    # sum over non-hidden battlers decides each one's share, so faster battlers
+    # reach a full gauge sooner but nobody charges at an independent absolute
+    # rate.
     def advance_gauges(ticks = 1)
       return unless @battle_type == 2
+      visible = all_combatants.reject { |c| c.hidden }
+      return if visible.empty?
+      sum_agi = visible.reduce(0) { |s, c| s + effective_agi(c) } * 100
       all_combatants.each do |c|
         next if c.out_of_play?
-        add = effective_agi(c) * GAUGE_AGI_RATE * ticks
+        next if do_nothing_restricted?(c) && side_of(c) != :enemy
+        add = GAUGE_MAX / (sum_agi / (effective_agi(c) + 1)) * ticks
         c.gauge = [c.gauge + add, GAUGE_MAX].min
       end
     end

--- a/scripts/rpg2k3_battle_gauge_check.rb
+++ b/scripts/rpg2k3_battle_gauge_check.rb
@@ -80,8 +80,9 @@ check 'Game::Battle.new accepts battle_type: and activates the gauge' do
                          Game::Rng.new(1), nil, false, false, false, false, nil, nil,
                          battle_type: 2)
   eq 2, bat.battle_type
-  bat.advance_gauges(6)
-  eq Game::Battle::GAUGE_MAX, bat.all_combatants[0].gauge
+  bat.advance_gauges(1)
+  eq 2112, bat.all_combatants[0].gauge, 'A (agi 20, half the field\'s agi sum) gains 2112/frame'
+  eq 1102, bat.all_combatants[1].gauge, 'B (agi 10) gains 1102/frame'
 end
 
 check 'advance_gauges is a no-op for battle_type 0' do
@@ -91,23 +92,30 @@ check 'advance_gauges is a no-op for battle_type 0' do
   eq 0, bat.ready_combatants.size
 end
 
-# -- gauge fills proportional to AGI for the 2003 gauge presentation ---------
-fast = combatant('Fast', 1, 1, 20, 1)   # 20 gauge/tick -> full in 5 ticks
-slow = combatant('Slow', 1, 1, 10, 1)   # 10 gauge/tick -> full in 10 ticks
+# -- gauge fills by EasyRPG's relative curve for the 2003 gauge presentation ---
+# Port of Game_Battle::UpdateAtbGauges (src/game_battle.cpp): every non-hidden
+# battler's AGI is summed (times 100), and each battler's per-frame increment
+# is GAUGE_MAX / (sum_agi / (agi + 1)), all integer-truncated -- so the faster
+# battler fills first but the field charges together, not at independent rates.
+fast = combatant('Fast', 1, 1, 20, 1)   # 300000 / (3000/21) = 2112/frame
+slow = combatant('Slow', 1, 1, 10, 1)   # 300000 / (3000/11) = 1102/frame
 bat = Game::Battle.new([fast], [slow], Game::Rng.new(1))
 bat.battle_type = 2
 
-check 'after 6 ticks the faster battler is full, the slower is not' do
-  bat.advance_gauges(6)
-  eq Game::Battle::GAUGE_MAX, fast.gauge
-  eq 60, slow.gauge
-  ready = bat.ready_combatants
-  eq [fast], ready
+check 'after one tick the faster battler is ahead by exactly the relative curve' do
+  bat.advance_gauges(1)
+  eq 2112, fast.gauge
+  eq 1102, slow.gauge
+  eq [], bat.ready_combatants, 'neither is anywhere near full at one tick (max 300000)'
 end
 
-check 'after 10 ticks both are full' do
-  bat.advance_gauges(4)
-  eq Game::Battle::GAUGE_MAX, slow.gauge
+check 'the faster battler fills before the slower, and both reach full (143 vs 273 ticks)' do
+  bat.advance_gauges(142) # 143 ticks total
+  eq Game::Battle::GAUGE_MAX, fast.gauge, 'fast crosses 300000 first (143 ticks)'
+  ok slow.gauge < Game::Battle::GAUGE_MAX, 'slow is still charging (273 ticks to fill)'
+  eq [fast], bat.ready_combatants, 'only the fast one is ready'
+  bat.advance_gauges(130) # 273 ticks total
+  eq Game::Battle::GAUGE_MAX, slow.gauge, 'slow crosses too (273 ticks)'
   eq 2, bat.ready_combatants.size
 end
 
@@ -127,24 +135,36 @@ check 'a dead battler does not charge or become ready' do
   eq false, dead.gauge_full?
 end
 
+check 'a do-nothing-restricted ally never charges, matching EasyRPG\'s CanAct() gate' do
+  asleep = combatant('Asleep', 1, 1, 20, 1)
+  asleep.states = [4] # Sleep: restriction 1
+  states = { 4 => OpenStruct.new(restriction: Game::Battle::RESTRICTION_DO_NOTHING) }
+  abat = Game::Battle.new([asleep], [combatant('Awake', 1, 1, 5, 1)],
+                          Game::Rng.new(1), states, false, false, false, false,
+                          nil, nil, battle_type: 2)
+  abat.advance_gauges(300)
+  eq 0, asleep.gauge, 'a restricted ally cannot take a turn, so it does not charge'
+  ok abat.all_combatants[1].gauge > 0, 'the awake enemy charges normally'
+end
+
 # -- the active-time turn cycle: pop_ready consumes and resets --------------
 cycle_fast = combatant('CFast', 1, 1, 20, 1)
 cycle_slow = combatant('CSlow', 1, 1, 10, 1)
 cbat = Game::Battle.new([cycle_fast], [cycle_slow], Game::Rng.new(1))
 cbat.battle_type = 2
-cbat.advance_gauges(6)   # fast full (100), slow at 60
+cbat.advance_gauges(143) # fast full (300000), slow at 143 * 1102 = 157586
 
 check 'pop_ready returns the highest-gauge combatant and resets its gauge' do
   taken = cbat.pop_ready
   eq cycle_fast, taken
   eq 0, cycle_fast.gauge
   eq false, cycle_fast.gauge_full?
-  # slow is still charging, so nothing else is ready yet
+  # slow is still charging (157586 < 300000), so nothing else is ready yet
   eq [], cbat.ready_combatants
 end
 
 check 'after the taker refills it becomes ready again (the ATB loop repeats)' do
-  cbat.advance_gauges(5)   # fast: 0 -> 100 (agi 20 * 5); slow: 60 -> 110 -> 100
+  cbat.advance_gauges(143) # fast: 0 -> 300000; slow: 157586 + 157586 -> 300000
   eq 2, cbat.ready_combatants.size
   taken = cbat.pop_ready
   eq cycle_fast, taken   # fast reached full first again
@@ -163,7 +183,7 @@ turn_hero = combatant('THero', 30, 0, 20, 1000)
 turn_slime = combatant('TSlime', 0, 0, 5, 1000)
 tbat = Game::Battle.new([turn_hero], [turn_slime], Game::Rng.new(1))
 tbat.battle_type = 2
-tbat.advance_gauges(5) # the hero's gauge is full
+tbat.advance_gauges(120) # the hero's gauge is full: 300000 / (2500/21) = 2521/frame
 
 check 'begin_gauge_turn queues one battler: step_action plays its turn, then nothing remains' do
   tbat.command_attack(turn_hero, turn_slime)
@@ -188,7 +208,10 @@ check 'a do-nothing-restricted battler\'s gauge turn is consumed as a silent no-
   abat = Game::Battle.new([asleep], [combatant('Awake', 0, 0, 5, 1000)],
                           Game::Rng.new(1), states, false, false, false, false,
                           nil, nil, battle_type: 2)
-  abat.advance_gauges(5)
+  # A restricted ally never *charges* (see the check above), but a full gauge
+  # one somehow has still fires its turn -- and the restriction resolves it to
+  # a silent no-op, exactly as if it could act.
+  asleep.gauge = Game::Battle::GAUGE_MAX
   eq Game::Battle::GAUGE_MAX, asleep.gauge, 'ready to act'
   abat.begin_gauge_turn(asleep)
   eq 0, asleep.gauge, 'the turn consumed the gauge even though it cannot act'

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12803,7 +12803,7 @@ check 'a gauge battle opens the ready actor\'s command menu on its own -- no Fig
   scene = gauge_battle_scene
   seen_options = false
   ui = nil
-  120.times do
+  250.times do
     scene.update
     ui = battle_ui(scene)
     seen_options = true if ui && ui[:phase] == :battle_options
@@ -12820,7 +12820,7 @@ end
 
 check 'committing the ready actor\'s command starts that one action, consuming its gauge' do
   scene = gauge_battle_scene
-  ui = battle_until_phase(scene, :command, 120)
+  ui = battle_until_phase(scene, :command, 250)
   ok ui, 'the battle opened to the ready actor\'s menu'
   # Empty every gauge so the fight has nothing else queued behind this action.
   ui[:battle].all_combatants.each { |c| c.gauge = 0 }
@@ -12841,7 +12841,7 @@ end
 check 'canceling the ready actor\'s menu returns to the active-time idle loop, and ' \
       'a ready enemy\'s gauge fires its action automatically there' do
   scene = gauge_battle_scene
-  ui = battle_until_phase(scene, :command, 120)
+  ui = battle_until_phase(scene, :command, 250)
   ok ui, 'the battle opened to the ready actor\'s menu'
   ui[:battle].all_combatants.each { |c| c.gauge = 0 }
   RGSS::Input.triggered = [RGSS::Input::B] # cancel the menu
@@ -12859,9 +12859,16 @@ end
 
 check 'a ready but restricted (asleep) party member\'s gauge fires a silent no-op, never a command prompt' do
   scene = gauge_battle_scene(BattleStubParty.new(BattleStubActor.new(id: 1, states: [4])))
-  ui = battle_until_phase(scene, :animate, 120)
-  ok ui, 'the battle opened'
+  ui = battle_until_phase(scene, :atb, 150)
+  ok ui, 'the battle opened to the active-time idle loop'
   hero = ui[:battle].all_combatants.first
+  # The restricted ally never *charges* under the real fill curve (EasyRPG's
+  # CanAct() gate -- the new rpg2k3_battle_gauge_check.rb check pins that), so
+  # seed its gauge directly: a full gauge it somehow holds still fires its
+  # turn, and the restriction resolves it to a silent no-op, never a prompt.
+  hero.gauge = Game::Battle::GAUGE_MAX
+  scene.update
+  ui = battle_ui(scene)
   eq 0, hero.gauge, 'the asleep member\'s ready gauge was consumed by its (no-op) turn'
   eq true, hero.queued_no_act, 'the do-nothing restriction was locked in for the turn'
 end


### PR DESCRIPTION
The gauge fill was ADR 0053/0054's placeholder constants (100 max, one gauge point per AGI per frame), flagged TODO against the then-inaccessible RPG_RT 2003 specification. EasyRPG's own port is now reachable, so this replaces it with the real curve.

**What changed**
- `Game::Battle#advance_gauges` ports `Game_Battle::UpdateAtbGauges` (src/game_battle.cpp) exactly: `GAUGE_MAX` is 300000 (`GetMaxAtbGauge`), every non-hidden battler's AGI is summed (×100), and each charging battler's per-frame increment is `GAUGE_MAX / (sum_agi / (agi + 1))` — all integer-truncated. The field charges together on a common pace scaled by relative AGI (double AGI fills nearly twice as fast, nobody charges at an independent absolute rate), a do-nothing-restricted ally never charges (EasyRPG's `CanAct()` gate; enemies always do), and a dead/hidden/non-member neither contributes to the sum nor charges.
- `rpg2k3_battle_gauge_check.rb` reworked for the real curve: exact increments (2112/1102 per frame for a 20/10 field), the 143-vs-273-tick fill ordering, full-and-stays, dead no-charge, and a new restricted-ally-never-charges check. Scene checks that relied on the old 5-frame fill get wider budgets (the real pace is seconds, not frames); the restricted member's silent-turn check now seeds the gauge directly.

**Verify:** `rpg2k3_battle_gauge_check.rb` (14), `rpg2k_scene_check.rb` (673), `rpg2k_logic_check.rb` (983), `cmake --build build -t test` (8/8), native boot check keeps the real 2003 gauge battle green, pre-commit clean.