### PR TITLE
rpg2003: make the command_actor battle page fire at the acting battler's turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@
   ambushed by RPG2000's 1-in-32 first-strike roll. Flying past it on the
   airship, or being marched by a forced move route, never rolls
 - A troop's **battle-event pages** run during a fight: their conditions (switch,
-  variable, turn, enemy/actor HP, plus RPG2003's per-battler turn counters and
-  party fatigue) are re-checked each turn, and a matching page runs the ordinary
+  variable, turn, enemy/actor HP, plus RPG2003's per-battler turn counters, the
+  chosen battle command and party fatigue) are re-checked each turn, and a
+  matching page runs the ordinary
   command set plus the battle-only commands — Change Monster HP / MP / Condition,
   Show Hidden Monster, Change Battle Background, the battle Show Battle
   Animation, the battle Conditional Branch and Terminate Battle. A page whose

--- a/changelog.d/rpg2003-battle-command-actor-page.fixed.md
+++ b/changelog.d/rpg2003-battle-command-actor-page.fixed.md
@@ -1,0 +1,15 @@
+- The **`command_actor` battle-page condition now fires in a gauge battle**,
+  closing the "never satisfiable" gap that the ADR 0054 turn-cycle work left
+  open. The battle tracks the acting battler (`Game::Battle#acting_battler`,
+  set as each turn resolves), the per-battler boundary page check passes it as
+  the `source` the way EasyRPG's `ScheduleNextPage(flags, source)` does, and
+  `Game::Battle#actor_command` answers that battler's recorded command
+  (`Combatant#last_battle_action`) — so the page fires for the battler who
+  actually chose the command, and only its own. The same source gates the
+  `turn_enemy` / `turn_actor` conditions (a per-battler check never fires off
+  a different battler's counter), while a no-source round-boundary check stays
+  ungated and a turn-based (RPG2000) battle leaves `command_actor` unmet,
+  matching real RPG_RT. Covered by new `rpg2k_logic_check.rb` checks
+  (satisfiable at the acting battler's turn, wrong-source/different-battler
+  failures, turn_enemy/turn_actor source gating) and a `rpg2k_scene_check.rb`
+  check driving a real gauge battle whose `command_actor` troop page fires.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1684,23 +1684,20 @@ The work below is roughly ordered by the critical path to a walkable game
   which is RPG_RT's reading of "no trigger" and the opposite of how every other
   RPG2000 page kind treats vacuous conditions; both test beds carry such pages
   (446 of Nepheshel's 3265, all 88 of mtf-meido-action's) and every one is empty,
-  so no real game changes behaviour. **The `command_actor` (chosen battle
-  command) condition never firing is confirmed correct, not a gap**: it needs
-  the battler whose action triggered the check, and EasyRPG's
-  `AreConditionsMet` only evaluates it when handed one (`if (!source) return
-  false;`) — but `Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents`, the
-  *only* page-scheduling call site RPG2000's own battle scene has, always
-  calls `ScheduleNextPage(nullptr)`. A real `source` only ever exists in
-  `Scene_Battle_Rpg2k3`, whose active-time turn cycle — the gauge-readiness
-  driver this runtime now runs for gauge battles (ADR 0054; see the Toggle
-  ATB Mode note below) — hands the picker a concrete acting battler, but the
-  *chosen command* is still never recorded onto it (`Game::Battle#
-  actor_command` stays nil: the scene drives a gauge turn through the same
-  action queue a round does, and nothing in that path notes which command was
-  picked), so a page gated on `command_actor` remains
-  *never satisfiable* here — not a once-per-turn
-  evaluation standing in for a future per-actor one. Still open: video
-  playback for Play Movie (no decoder is linked in; the request is logged). **Show Battle Animation** (11210) now plays on the map — the
+   so no real game changes behaviour. **The `command_actor` (chosen battle
+   command) condition now fires in a gauge battle**: it needs the battler
+   whose action triggered the check — EasyRPG's `AreConditionsMet` only
+   evaluates it when handed one (`if (!source) return false;`) — and this
+   runtime's 2003 scene hands exactly that over (ADR 0054): the battle tracks
+   the acting battler, the boundary page check passes it as the source, and
+   `Game::Battle#actor_command` answers its recorded command
+   (`Combatant#last_battle_action`). RPG2000's own battle scene
+   (`Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents`) always schedules
+   with a null source, so a page gated on `command_actor` stays unsatisfiable
+   in a turn-based fight, matching real RPG_RT. The same source also gates the
+   `turn_enemy`/`turn_actor` conditions so a per-battler check never fires off
+   a different battler's counter. Still open: video
+   playback for Play Movie (no decoder is linked in; the request is logged). **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the
   target frame by frame and fires its screen flashes, holding the event with the
   wait flag. **Target-only flashes are precisely implemented, not an

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -78,12 +78,17 @@ Behavioral notes and deliberate simplifications:
   `Game::Battle#combo_hits` multiplies the hits of an attack or skill command
   when an armed combo names that exact command — never a Defend/Item/Escape.
   The combo stays armed for the fight (no decrement), matching EasyRPG.
-- A `command_actor`-gated battle page still never fires: the scene now records
-  which command the battler chose (`Combatant#last_battle_action`), but the
-  source-threading that lets the page test *the acting battler's* command at
-  its action boundary — EasyRPG's `ScheduleNextPage(flags, source)` — is not
-  wired, so `Game::Battle#actor_command` stays nil (never satisfiable, the
-  same answer RPG_RT's RPG2000 scene gives).
+- A `command_actor`-gated battle page now fires: the battle tracks the acting
+  battler (`Combatant#acting_battler`, set as each turn resolves), the
+  boundary page check passes it as the per-battler `source` the way EasyRPG's
+  `ScheduleNextPage(flags, source)` does, and `Game::Battle#actor_command`
+  answers that battler's recorded command (`Combatant#last_battle_action`) —
+  so the condition tests the acting battler's choice, and only its own. The
+  same source also gates the `turn_enemy`/`turn_actor` conditions (`source !=
+  enemy/actor` fails the page), so a per-battler check never fires off a
+  *different* battler's counter. A no-source round-boundary check leaves
+  those ungated (turn_* read the named battler's counter, command_actor
+  fails), matching EasyRPG's RPG2000 scene.
 
 ## Consequences
 
@@ -99,15 +104,16 @@ Behavioral notes and deliberate simplifications:
   (exact increments, faster-fills-first, full-and-stays, a dead or
   do-nothing-restricted ally never charging) and `rpg2k_scene_check.rb`
   drives real gauge battles through the 2003 scene (menu-on-own, commit →
-  action → idle, ready enemy auto-fires, restricted member's silent turn, and a
-  battle_type 0 fight never entering the gauge loop). The combo's model math is
-  pinned by `rpg2k_logic_check.rb` (armed Attack combos to its full count,
-  wrong-command and Item combos never apply, a combo'd skill repeats with SP
-  spent once, all-target too) and the command-id recording by the scene checks.
+  action → idle, ready enemy auto-fires, restricted member's silent turn, a
+  battle_type 0 fight never entering the gauge loop, and a `command_actor`
+  troop page firing at the acting battler's turn). The combo's model math and
+  the per-battler page-condition gating (command_actor satisfiable only for
+  the acting battler who chose the command; turn_enemy/turn_actor gated on
+  the source) are pinned by `rpg2k_logic_check.rb`, and the command-id
+  recording by the scene checks.
   The native boot check keeps the real 2003 battle green.
 - Follow-ups: Wait-off (active) mode and the database wait toggle; the
-  source-threading that makes `command_actor` pages satisfiable; the Special
-  command handler;
+  Special command handler;
   the attacker-side back-row reach penalty; the automatic battler-placement
   grid (`Calculate2k3BattlePosition`, whose reference source this ADR's work
   also surfaced).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6008,7 +6008,16 @@ module Game
     # `turn`, `enemy(index)`, `ally_by_actor_id(id)`, `enemy_turn(index)`,
     # `actor_turn(id)`, `fatigue` and `actor_command(id)`. A context that cannot
     # answer a tested sub-condition fails the page.
-    def self.active?(cond, switches, variables, ctx)
+    #
+    # `source` is the battler a per-battler check runs *for* -- the scene passes
+    # the battle's #acting_battler at a battler's action boundary. It gates the
+    # turn_enemy / turn_actor / command_actor conditions the way EasyRPG's
+    # `AreConditionsMet(source, ...)` does: a page checked at one battler's turn
+    # only fires off that battler's own counter/command, and a command_actor
+    # page needs a source at all. A no-source round-boundary check leaves those
+    # conditions ungated (turn_* test the named battler regardless, command_actor
+    # fails), matching the reference.
+    def self.active?(cond, switches, variables, ctx, source = nil)
       # A page whose condition box is entirely unticked never runs — RPG_RT
       # treats "no trigger" as "never", not as "always" (EasyRPG's
       # AreConditionsMet opens with exactly this test). Worth stating because the
@@ -6044,17 +6053,17 @@ module Game
       # the same silent-pass-through class of bug the map-event TIMER2
       # condition (Game::EventPage.active?, this file) was already fixed for.
       if (flags & TURN_ENEMY) != 0 && ctx.rpg2003?
-        t = ctx.enemy_turn(cond.turn_enemy_id)
+        t = ctx.enemy_turn(cond.turn_enemy_id, source)
         return false if t.nil?
         return false unless check_turns(t, cond.turn_enemy_b, cond.turn_enemy_a)
       end
       if (flags & TURN_ACTOR) != 0 && ctx.rpg2003?
-        t = ctx.actor_turn(cond.turn_actor_id)
+        t = ctx.actor_turn(cond.turn_actor_id, source)
         return false if t.nil?
         return false unless check_turns(t, cond.turn_actor_b, cond.turn_actor_a)
       end
       if (flags & COMMAND_ACTOR) != 0 && ctx.rpg2003?
-        return false unless ctx.actor_command(cond.command_actor_id) == cond.command_id
+        return false unless ctx.actor_command(cond.command_actor_id, source) == cond.command_id
       end
       if (flags & FATIGUE) != 0 && ctx.rpg2003?
         f = ctx.fatigue
@@ -6066,11 +6075,12 @@ module Game
 
     # Every [id, page] whose condition currently holds, in page order — unlike
     # a map event (where the highest active page wins) RPG2000 runs *each*
-    # matching battle page.
-    def self.select_all(pages, switches, variables, ctx)
+    # matching battle page. `source` threads to #active? (the battler a
+    # per-battler check runs for, see there).
+    def self.select_all(pages, switches, variables, ctx, source = nil)
       out = []
       return out if pages.nil?
-      pages.each { |id, page| out << [id, page] if active?(page.condition, switches, variables, ctx) }
+      pages.each { |id, page| out << [id, page] if active?(page.condition, switches, variables, ctx, source) }
       out
     end
   end
@@ -8739,6 +8749,11 @@ module Game
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
       @pending = []  # extra hits of an all-target action, drained one per #step
+      # The battler whose turn is currently resolving (set by #step / #step_action
+      # as each one is dequeued, and by #begin_gauge_turn for a gauge-fired
+      # action). nil between turns. Exposed as #acting_battler for the per-battler
+      # battle-page checks (#enemy_turn/#actor_turn/#actor_command's `source`).
+      @acting = nil
     end
 
     # RPG2000 normal-attack damage variance on the 0-10 `var` scale.
@@ -8778,6 +8793,15 @@ module Game
     # battle turn number, which the pages' turn conditions are written against.
     def turn; @rounds; end
 
+    # The battler whose turn is currently resolving -- set as each battler is
+    # dequeued to act (#step / #step_action) or queued for a gauge-fired turn
+    # (#begin_gauge_turn), nil between turns. The `source` the per-battler
+    # battle-page checks (#enemy_turn / #actor_turn / #actor_command) gate on:
+    # the scene passes this at a battler's action boundary, so a
+    # turn_enemy / turn_actor / command_actor page tests the battler it is
+    # checked for rather than anyone's counter.
+    def acting_battler; @acting; end
+
     # The live combatant for troop member `index`, or nil when out of range.
     def enemy(index)
       return nil unless index.is_a?(Integer) && index >= 0
@@ -8801,14 +8825,26 @@ module Game
     # turn_enemy / turn_actor conditions test (Combatant#turns_taken). nil for a
     # battler that is not in this fight, which fails the page rather than
     # answering a condition about someone who is not here.
-    def enemy_turn(index)
+    #
+    # `source` is the battler a per-battler page check is running *for*
+    # (the scene passes #acting_battler at a battler's action boundary): when
+    # one is given, the named battler's counter only answers if the source *is*
+    # that battler — EasyRPG's `AreConditionsMet`'s
+    # `if (source && source != enemy) return false;` — so a page checked at one
+    # battler's turn never fires off a *different* battler's counter. A
+    # no-source round-boundary check stays ungated, matching the reference.
+    def enemy_turn(index, source = nil)
       foe = enemy(index)
-      foe && foe.turns_taken
+      return nil unless foe
+      return nil if source && !source.equal?(foe)
+      foe.turns_taken
     end
 
-    def actor_turn(id)
+    def actor_turn(id, source = nil)
       ally = ally_by_actor_id(id)
-      ally && ally.turns_taken
+      return nil unless ally
+      return nil if source && !source.equal?(ally)
+      ally.turns_taken
     end
 
     # The party's exhaustion, 0 (untouched) to 100 (wiped out) — the RPG2003
@@ -8844,20 +8880,23 @@ module Game
       100 - Game.round_half_even(num, den)
     end
 
-    # The `command_actor` page condition (which battle command an actor just
-    # chose) is answered "unknown" (nil), which Game::BattlePage reads as
-    # "fails the page" rather than firing it unchecked. The *data* is now in
-    # place -- the scene records the chosen command onto the Combatant
-    # (`last_battle_action`, recorded at command selection) -- but EasyRPG's
-    # `AreConditionsMet` only evaluates the condition when handed a `source`
-    # battler (`if (!source) return false;`), and `Scene_Battle_Rpg2k::
-    # CheckBattleEndAndScheduleEvents` — the only page-scheduling call site
-    # RPG2000's own battle scene has — always calls with a null source. The
-    # source-threading that lets a page test *the acting battler's* command
-    # (rather than anyone's recorded one, at any boundary) is the remaining
-    # piece; until then a page gated on `command_actor` stays never satisfiable
-    # here, matching real RPG_RT's RPG2000 behaviour by keeping the answer nil.
-    def actor_command(_id); nil; end
+    # The `command_actor` page condition: which battle command the *acting*
+    # battler chose (Combatant#last_battle_action, recorded by the scene at
+    # command selection). Port of EasyRPG's `AreConditionsMet` (src/
+    # game_interpreter_battle.cpp): the condition only evaluates when handed a
+    # `source` battler (`if (!source) return false;`), the source must *be* the
+    # named actor (`if (source != actor) return false;`), and then the actor's
+    # chosen command is compared. `source` is the battler a per-battler page
+    # check runs for (the scene passes #acting_battler at a battler's action
+    # boundary); a no-source round-boundary check — the only kind RPG2000's own
+    # battle scene ever has — answers nil and the condition fails, matching
+    # real RPG_RT's RPG2000 behaviour.
+    def actor_command(actor_id, source = nil)
+      return nil unless source
+      a = source.actor
+      return nil unless a && a.respond_to?(:id) && a.id == actor_id
+      source.last_battle_action
+    end
 
     # Force Flee (1006), target 0: let the party leave whenever it next tries.
     # RPG_RT grants the escape rather than performing it, so the player still has
@@ -8926,6 +8965,7 @@ module Game
         refill_queue if @queue.empty?
         return nil if @queue.empty? # hit MAX_ROUNDS
         b = @queue.shift
+        @acting = b
         sync_allies_from_party if @party # see #step_action's own comment on why
         next if b.dead? || !b.member?
         # The battler's own turn starts here, whether or not it ends up able to
@@ -9180,6 +9220,7 @@ module Game
     # the pages read the per-battler counters instead.
     def begin_gauge_turn(b)
       @pending = []
+      @acting = b
       b.next_battle_turn
       b.queued_no_act = do_nothing_restricted?(b)
       reset_gauge(b)
@@ -9560,6 +9601,7 @@ module Game
       loop do
         return nil if finished? || @queue.empty?
         b = @queue.shift
+        @acting = b
         sync_allies_from_party if @party
         next if b.dead? || !b.member?
         # Afflicted states act at the start of the battler's turn: slip damage

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1715,9 +1715,12 @@ class RPG2k
         # the previous #step_action call left nothing buffered (a dual-wield
         # swing or an all-target Skill/Item queues several hits from *one*
         # battler; the check belongs between battlers, not between hits).
+        # The acting battler rides along as the per-battler check's source, so
+        # the turn_enemy / turn_actor / command_actor conditions test the
+        # battler the check is for (Game::BattlePage.active?).
         if @ui[:battler_boundary]
           @ui[:battler_boundary] = false
-          return if run_battle_events(:animate)
+          return if run_battle_events(:animate, @ui[:battle].acting_battler)
         end
         entry = @ui[:battle].step_action
         if entry
@@ -1906,16 +1909,22 @@ class RPG2k
       # command menu), `:animate` for the between-battlers check
       # (#drive_battle_animate), which needs to pick back up mid-round rather
       # than restart the command phase.
-      def run_battle_events(return_phase = :command)
+      #
+      # `source` is the battler this page check runs *for* -- the battle's
+      # #acting_battler at a battler's action boundary (see
+      # Game::BattlePage.active?), which gates the per-battler turn_* /
+      # command_actor conditions on that battler. A round-boundary check (the
+      # default, no source) leaves them ungated.
+      def run_battle_events(return_phase = :command, source = nil)
         ui = @ui
         return false unless ui && ui[:troop].pages
         matched = Game::BattlePage.select_all(ui[:troop].pages, @state.switches,
-                                              @state.variables, ui[:battle])
+                                              @state.variables, ui[:battle], source)
         entry = matched.find { |(id, _)| !ui[:pages_run][id] }
         return false unless entry
         ui[:pages_run][entry[0]] = true
         cmds = entry[1].event
-        return run_battle_events(return_phase) if cmds.nil? || cmds.empty? # empty page: try the next
+        return run_battle_events(return_phase, source) if cmds.nil? || cmds.empty? # empty page: try the next
         ui[:events].battle = ui[:battle]
         ui[:events].start(cmds)
         ui[:event_return_phase] = return_phase

--- a/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
+++ b/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
@@ -146,12 +146,18 @@ module RPG2k3
       # plays it out exactly as it plays a round -- banner, SE, animation,
       # battle-page checks at the action boundary -- then the queue emptying
       # returns the fight to the idle loop (#finish_round_animation's override).
+      #
+      # `battler_boundary` is armed so the *first* gauge action of a turn gets
+      # the per-battler page check too: #drive_battle_animate only runs that
+      # check on a set boundary, and a fresh gauge action has none of its own
+      # yet (the flag is normally set by the *previous* action's step_action).
       def start_gauge_action(b)
         if @ui[:cmd_win]
           @ui[:cmd_win].dispose
           @ui[:cmd_win] = nil
         end
         @ui[:battle].begin_gauge_turn(b)
+        @ui[:battler_boundary] = true
         @ui[:phase] = :animate
         @ui[:anim_timer] = 0 # land the action next frame
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14497,12 +14497,11 @@ check 'BattlePage.active? ignores command_actor on a non-RPG2003 battle, same as
 end
 
 check 'BattlePage.active? fails a command_actor condition the runtime cannot answer, on RPG2003' do
-  # On a genuine RPG2003 battle the gate now lets the check run -- but this
-  # codebase's own #actor_command (Game::Battle) always answers nil, since
-  # there is no per-battler "last chosen command" tracking implemented yet,
-  # so a command_actor condition can never be satisfied here regardless of
-  # what real RPG_RT's own 2k3 ATB scene would say for a battler that just
-  # chose that exact command.
+  # On a genuine RPG2003 battle the gate now lets the check run -- but without
+  # a `source` battler (a round-boundary check; see the source-gating checks
+  # below) Game::Battle#actor_command answers nil, so a command_actor
+  # condition is unsatisfiable there, exactly as RPG_RT's own RPG2000 scene
+  # (which never passes a source) would leave it.
   b2003 = battle_with(rpg2003: true)
   st = new_state
   eq false, BP.active?(battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1,
@@ -14513,6 +14512,58 @@ check 'BattlePage.active? fails a command_actor condition the runtime cannot ans
                        st.switches, st.variables, b2003)
   eq false, BP.active?(battle_cond(BP::TURN_ACTOR, turn_actor_id: 99),
                        st.switches, st.variables, b2003)
+end
+
+# -- the per-battler source: BattlePage checks at an action boundary -----------
+#
+# A per-battler check runs *for* a concrete battler -- the scene passes the
+# battle's #acting_battler. Port of EasyRPG's AreConditionsMet(source, ...):
+# the source gates turn_enemy/turn_actor (a page checked at one battler's turn
+# never fires off a different battler's counter) and command_actor (needs a
+# source at all, and that source must be the named actor, whose chosen command
+# is then compared against the condition).
+
+check 'a command_actor condition is satisfiable at the acting battler\'s own turn' do
+  b2003 = battle_with(rpg2003: true)
+  st = new_state
+  hero = b2003.ally_by_actor_id(1)
+  cond = battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1, command_id: 3)
+  # No source (a round-boundary check) -> the condition cannot be answered.
+  eq false, BP.active?(cond, st.switches, st.variables, b2003)
+  # The acting hero chose command 3 (e.g. the fixed-four Defend id): the
+  # condition fires for that battler.
+  hero.last_battle_action = 3
+  eq true, BP.active?(cond, st.switches, st.variables, b2003, hero),
+     'the acting battler who chose the command satisfies the page'
+  # A different battler as the source does not: the source must BE the actor.
+  eq false, BP.active?(cond, st.switches, st.variables, b2003, b2003.enemy(0)),
+     'an enemy source (not the named actor) fails the condition'
+end
+
+check 'a turn_enemy / turn_actor condition is gated on the source being that battler' do
+  b2003 = battle_with(rpg2003: true)
+  st = new_state
+  foe = b2003.enemy(0)
+  hero = b2003.ally_by_actor_id(1)
+  foe.next_battle_turn # the foe has taken one turn
+  econd = battle_cond(BP::TURN_ENEMY, turn_enemy_id: 0, turn_enemy_b: 1, turn_enemy_a: 0)
+  # Ungated round-boundary check: the named foe's counter answers.
+  eq true, BP.active?(econd, st.switches, st.variables, b2003),
+     'a no-source check reads the named foe\'s own counter'
+  # Checked at the foe's own boundary: fires.
+  eq true, BP.active?(econd, st.switches, st.variables, b2003, foe),
+     'checked at the foe\'s own turn, its counter fires'
+  # Checked at the hero's boundary (the hero is the source): the foe's
+  # counter must not answer -- EasyRPG's `if (source && source != enemy)`.
+  eq false, BP.active?(econd, st.switches, st.variables, b2003, hero),
+     'checked at a different battler\'s turn, the foe\'s counter does not fire'
+
+  hero.next_battle_turn # the hero has taken one turn
+  acond = battle_cond(BP::TURN_ACTOR, turn_actor_id: 1, turn_actor_b: 1, turn_actor_a: 0)
+  eq true, BP.active?(acond, st.switches, st.variables, b2003, hero),
+     'the actor\'s own turn_actor counter fires at its boundary'
+  eq false, BP.active?(acond, st.switches, st.variables, b2003, foe),
+     'but not at the foe\'s boundary'
 end
 
 # turn_enemy / turn_actor / fatigue are RPG2003-only page conditions --

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11028,6 +11028,34 @@ def battle_scene_with_pages(pages, party: BattleStubParty.new, battleranimations
   [scene, st]
 end
 
+# The per-battler `source` the boundary page check runs with: a troop page
+# gated on `command_actor` fires when the *acting* battler chose the command
+# (Game::Battle#actor_command with the scene-passed #acting_battler) -- the
+# ADR 0054 follow-up that made the condition satisfiable at all. The
+# model-side gating is pinned in rpg2k_logic_check.rb; this drives a real
+# gauge battle through the 2003 scene so the boundary check actually hands
+# the acting battler over.
+check 'a command_actor troop page fires at the acting battler\'s turn in a gauge battle' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])],
+                            Game::BattlePage::COMMAND_ACTOR,
+                            command_actor_id: 1, command_id: 1) }
+  scene, st = battle_scene_with_pages(pages, rpg2003: true,
+                                      battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(BattleStubActor.new(agi: 20)))
+  ui = battle_until_phase(scene, :command, 250)
+  ok ui, 'the gauge battle opened to the ready actor\'s menu'
+  eq false, st.switches[5], 'the page has not fired yet'
+  press_key(scene, RGSS::Input::C) # Attack -- the fixed-four command id 1
+  eq :target, ui[:phase], 'Attack opens the target cursor'
+  press_key(scene, RGSS::Input::C) # the first Slime: the action begins
+  # The action's boundary check runs the troop's pages for the acting battler
+  # (the hero, who chose Attack = command id 1), so the command_actor page
+  # fires and its event toggles switch 5.
+  5.times { scene.update }
+  eq true, st.switches[5], 'the command_actor page fired at the acting hero\'s turn'
+end
+
 # yado.tk / 01_shoshin's 011_siyou: "Empty party doesn't itself Game Over, but
 # battling with one is instant defeat; all-KO'd ... is instant Game Over the
 # same way." #draw_battle_command's current_actor (living_allies[actor_i]) is


### PR DESCRIPTION
The `command_actor` battle-page condition was "never satisfiable" — the data (`Combatant#last_battle_action`) existed, but nothing handed the page check the battler it ran *for*. This ports EasyRPG's `AreConditionsMet(source, ...)` / `ScheduleNextPage(flags, source)`.

**What changed**
- `Game::Battle` tracks the acting battler (`#acting_battler`, set as each turn resolves in `step`/`step_action`/`begin_gauge_turn`), and `#actor_command` answers that battler's recorded command — but only when a `source` is given and it *is* the named actor (`if (!source) return false; source != actor`). `#enemy_turn`/`#actor_turn` gate on the source the same way, so a per-battler check never fires off a *different* battler's counter.
- `BattlePage.active?`/`select_all` thread the source through; the scene's `run_battle_events` passes `battle.acting_battler` at the per-battler boundary check, and a gauge action's first boundary is armed so its own check runs (`start_gauge_action`). A no-source round-boundary check stays ungated, and a turn-based (RPG2000) battle leaves `command_actor` unmet — matching real RPG_RT.

**Verify:** `rpg2k_logic_check.rb` (985) pins the gating, `rpg2k_scene_check.rb` (674) drives a real gauge battle whose `command_actor` troop page fires, `cmake --build build -t test` (8/8), native boot check keeps the real 2003 gauge battle green, pre-commit clean.