### PR TITLE
rpg2003: seat party battle sprites on the automatic placement grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@
   combatant's charge gauge fills each frame, the first one full opens the
   command menu for a controllable party member or fires the action of anyone
   else (enemy AI included) automatically, and acting resets it — draws the
-  party as face/bars gauge cards from the project's System2 graphic, and
-  applies RPG2003's front/back row accuracy, while the traditional and
+  party as face/bars gauge cards from the project's System2 graphic, seats
+  each member's battle sprite on the automatic placement grid the project
+  configures (`battlecommands.placement` 1, keyed by the encounter terrain),
+  and applies RPG2003's front/back row accuracy, while the traditional and
   alternative presentations inherit the unchanged turn-based machine. The 2003
   test beds ship no encounters, so a `--rpg2k_battle_troop=<id>` flag drives a
   real project straight into a fight against a chosen database troop after New

--- a/changelog.d/rpg2003-battle-automatic-placement.added.md
+++ b/changelog.d/rpg2003-battle-automatic-placement.added.md
@@ -1,0 +1,14 @@
+- The **RPG2003 automatic battler placement** (`battlecommands.placement == 1`)
+  now seats each party member's battle sprite on the grid slot from EasyRPG's
+  `CalculateBaseGridPosition` / `Calculate2k3BattlePosition`
+  (src/game_battle.cpp) — keyed by the member's party index/size and the
+  encounter terrain's grid fields (terrain chunks 46-48), with the reference's
+  own no-terrain defaults (112 / 392 / 16000) when no terrain is named —
+  instead of falling back to the manual `battle_x`/`battle_y` (that fallback
+  is now reserved for `placement == 0`). Ported with EasyRPG's grid table 0
+  and its integer-truncation; the front-row actor path is done (the back-row
+  offset and the pincer/surround enemy tables need the row derivation and
+  battle conditions this runtime does not model). mtf-meido-action uses
+  placement 1, so its real gauge battle exercises it. Covered by new
+  `rpg2k_scene_check.rb` checks (lone and two-member grid slots; manual
+  placement unchanged).

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -112,8 +112,16 @@ Behavioral notes and deliberate simplifications:
   the source) are pinned by `rpg2k_logic_check.rb`, and the command-id
   recording by the scene checks.
   The native boot check keeps the real 2003 battle green.
+- The **automatic battler placement** (`battlecommands.placement == 1`) is
+  implemented: each party member's battle sprite sits on the grid slot from
+  EasyRPG's `CalculateBaseGridPosition` / `Calculate2k3BattlePosition`
+  (src/game_battle.cpp), keyed by party index/size and the encounter terrain's
+  grid fields (terrain chunks 46-48), replacing the manual battle_x/battle_y —
+  ported with the reference's own grid table 0 and its no-terrain defaults
+  (112 / 392 / 16000). Only the ordinary front-row actor path is done (the
+  back-row `row_x_offset` and the pincer/surround enemy tables need the row
+  derivation and battle conditions this runtime does not model); `mtf-
+  meido-action` uses placement 1, so its real gauge battle exercises it.
 - Follow-ups: Wait-off (active) mode and the database wait toggle; the
   Special command handler;
-  the attacker-side back-row reach penalty; the automatic battler-placement
-  grid (`Calculate2k3BattlePosition`, whose reference source this ADR's work
-  also surfaced).
+  the attacker-side back-row reach penalty.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3467,10 +3467,10 @@ module Game
     # RPG2003's battle-sprite placement choice (`battlecommands.placement`,
     # chunk 29 field 2 -- 0 manual, 1 automatic; see schema.rb). Manual is
     # `Game::Actor#battle_x`/`#battle_y` read as literal screen coordinates;
-    # automatic computes a grid formula this runtime does not implement yet
-    # (see the alternate-battle-sprite renderer in scene/battle.rb), so callers
-    # use this to know when to fall back to the raw coordinates and log a
-    # diagnostic instead of guessing at the formula. A bare test fixture with
+    # automatic computes a grid formula (the EasyRPG
+    # CalculateBaseGridPosition / Calculate2k3BattlePosition port in
+    # scene/battle.rb's #automatic_battle_position) keyed by party index/size
+    # and the encounter terrain. A bare test fixture with
     # no `#battlecommands` table, or an RPG2000 database (which never sets
     # this field), reads false/manual, same as `#alternate_battle_layout?`.
     def automatic_battle_placement?

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -505,13 +505,11 @@ class RPG2k
       # does not implement (logged below, matching this codebase's "reported
       # gap, not silently invented" convention for unimplemented behaviour).
       #
-      # Position is the raw database `battle_x`/`battle_y`
-      # (Game_Actor::GetOriginalPosition) -- confirmed against EasyRPG's
-      # actual C++ source this is only what `battlecommands.placement`
-      # manual (0) uses; automatic (1) instead computes a real grid formula
-      # (`CalculateBaseGridPosition`, src/game_battle.cpp) this step does not
-      # implement either, so that case also just logs and falls back to the
-      # same raw coordinates rather than guessing at the formula.
+      # Position is either `battlecommands.placement` manual (0)'s raw
+      # database `battle_x`/`battle_y` (Game_Actor::GetOriginalPosition) or
+      # automatic (1)'s computed grid slot (#automatic_battle_position, the
+      # EasyRPG Calculate2k3BattlePosition port) -- confirmed against
+      # EasyRPG's actual C++ source, which splits exactly this way.
       def build_actor_sprite(actor, i)
         anim_id = actor.respond_to?(:battler_animation_id) ? (actor.battler_animation_id || 0) : 0
         table = db.respond_to?(:battleranimations) ? db.battleranimations : nil
@@ -529,20 +527,97 @@ class RPG2k
         bmp = actor_battlecharset_bitmap(pose.battler_name)
         return nil unless bmp
 
-        if @state.party.respond_to?(:automatic_battle_placement?) &&
-           @state.party.automatic_battle_placement?
-          $stderr.puts "[RPG2k] actor ##{actor.id}: automatic battler placement not yet " \
-                       "implemented, using the database's manual battle_x/battle_y"
+        x, y = automatic_battle_position(i)
+        if x.nil?
+          # Manual placement: the database's own battle_x/battle_y.
+          x = actor.respond_to?(:battle_x) ? (actor.battle_x || 0) : 0
+          y = actor.respond_to?(:battle_y) ? (actor.battle_y || 0) : 0
         end
 
         spr = Sprite.new
         spr.bitmap = bmp
         spr.src_rect = Rect.new(0, (pose.battler_index || 0) * ACTOR_CHARSET_CELL,
                                 ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL)
-        spr.x = actor.respond_to?(:battle_x) ? (actor.battle_x || 0) : 0
-        spr.y = actor.respond_to?(:battle_y) ? (actor.battle_y || 0) : 0
+        spr.x = x
+        spr.y = y
         spr.z = actor_sprite_z(i)
         spr
+      end
+
+      # -- automatic battler placement (`battlecommands.placement == 1`) --------
+      #
+      # Port of EasyRPG's `CalculateBaseGridPosition` /
+      # `Calculate2k3BattlePosition` (src/game_battle.cpp): when the database
+      # asks for automatic placement, each party member's sprite sits on a grid
+      # slot computed from its party index, the party size and the encounter's
+      # terrain (the `grid_top_y` / `grid_elongation` / `grid_inclination`
+      # database-terrain fields 46-48), instead of the manual battle_x/battle_y.
+      # Only grid table 0 is used -- the ordinary actor path indexes table_x 0
+      # and table_y 0 (the other tables are the pincer/surround enemy paths this
+      # runtime does not model), and only the front row (the one row this
+      # runtime derives; the per-battler back-row derivation is a separate
+      # step), so `row_x_offset` is always a half-width.
+      #
+      # Returns [x, y] for the `i`-th member of `@ui[:allies]`, or nil when
+      # the database asks for manual placement (the caller falls back to
+      # battle_x/battle_y) or the party outgrows the reference grid (8 rows).
+      def automatic_battle_position(i)
+        return nil unless @state.party.respond_to?(:automatic_battle_placement?) &&
+                          @state.party.automatic_battle_placement?
+        pos = battle_grid_position(i, @ui[:allies].length)
+        return nil unless pos
+        half = ACTOR_CHARSET_CELL / 2
+        # EasyRPG's actor-path x/y for the normal battle condition, with a
+        # front-row `row_x_offset` of a half-width, then the same x clamp
+        # (y is deliberately unclamped for actors -- the reference doesn't).
+        x = SCREEN_W - (pos[0] + half + half)
+        y = pos[1] - half
+        [Game.clamp(x, half, SCREEN_W - half), y]
+      end
+
+      # EasyRPG's `CalculateBaseGridPosition` grid table 0 (src/game_battle.cpp)
+      # -- the only table the ordinary actor path indexes (table_x 0, table_y
+      # 0), one row per party size, one fraction per member index.
+      GRID_TABLE_0 = [
+        [0.5],
+        [0.0, 1.0],
+        [0.0, 0.5, 1.0],
+        [0.0, 0.33, 0.66, 1.0],
+        [0.0, 0.25, 0.5, 0.75, 1.0],
+        [0.0, 0.0, 0.5, 0.5, 1.0, 1.0],
+        [0.0, 0.25, 0.33, 0.5, 0.66, 0.75, 1.0],
+        [0.0, 0.0, 0.33, 0.33, 0.66, 0.66, 1.0, 1.0]
+      ].freeze
+      # EasyRPG's no-terrain defaults (the editor's database-terrain fields
+      # default to 0 / 375 / 16400, but the reference falls back to these when
+      # no terrain is named, not to the editor defaults).
+      GRID_TOP_Y_DEFAULT = 112
+      GRID_ELONGATION_DEFAULT = 392
+      GRID_INCLINATION_DEFAULT = 16000
+
+      # The grid slot for the `i`-th of `party_size` members, or nil when the
+      # party outgrows the table. Integer-truncated like the reference's
+      # `(int)` casts.
+      def battle_grid_position(i, party_size)
+        row = GRID_TABLE_0[party_size - 1]
+        return nil unless row && row[i]
+        t = row[i]
+        grid = battle_grid_params
+        x = ((1.0 - t) * (grid[:inclination] / 1000.0)).to_i
+        y = grid[:top_y] + (Math.sin(grid[:elongation] / 1000.0) * 120.0 * t).to_i
+        [x, y]
+      end
+
+      # The encounter terrain's grid fields (database terrain chunks 46-48), or
+      # EasyRPG's no-terrain defaults when the party's tile names no terrain.
+      def battle_grid_params
+        tid = @map.respond_to?(:terrain_id) ? @map.terrain_id(@state.x, @state.y) : 0
+        row = tid && tid > 0 && db.respond_to?(:terrain) && db.terrain ? db.terrain[tid] : nil
+        return { top_y: GRID_TOP_Y_DEFAULT, elongation: GRID_ELONGATION_DEFAULT,
+                 inclination: GRID_INCLINATION_DEFAULT } unless row
+        { top_y: row.respond_to?(:grid_top_y) ? (row.grid_top_y || 0) : 0,
+          elongation: row.respond_to?(:grid_elongation) ? (row.grid_elongation || 0) : 0,
+          inclination: row.respond_to?(:grid_inclination) ? (row.grid_inclination || 0) : 0 }
       end
 
       # Interpreter#do_change_party's hook (via `@ui[:events].

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11056,6 +11056,76 @@ check 'a command_actor troop page fires at the acting battler\'s turn in a gauge
   eq true, st.switches[5], 'the command_actor page fired at the acting hero\'s turn'
 end
 
+# -- automatic battler placement (`battlecommands.placement == 1`) -------------
+#
+# Port of EasyRPG's Calculate2k3BattlePosition (src/game_battle.cpp): a
+# placement-1 database computes each party member's battle sprite position
+# from a grid keyed by party index/size and the encounter terrain, instead of
+# the manual battle_x/battle_y. The fixture terrain (fake_db's tile tag 42)
+# names no grid fields, so the reference's no-terrain defaults (112 / 392 /
+# 16000) apply; half a 48px BattleCharSet cell (24) is the row/width offset.
+
+# A placement-1 gauge battle whose actor sprites build, for the placement
+# checks. `ids` become the party (one BattleStubActor each, carrying its own
+# BattlerAnimation id so `build_actor_sprite` draws a sprite -- the harness
+# Bitmap stub stands in for the BattleCharSet sheet). The fixture terrain the
+# party stands on (tag 42) is given the reference's own no-terrain grid
+# parameters (112 / 392 / 16000) so the checks' expected coordinates are
+# explicit; `battle_xy:` supplies per-actor manual coordinates for the
+# placement-0 check.
+def placement_battle(ids, placement: 1, battle_xy: {})
+  members = ids.map do |id|
+    xy = battle_xy[id] || [0, 0]
+    BattleStubActor.new(id: id, agi: 20, battler_animation_id: id,
+                        battle_x: xy[0], battle_y: xy[1])
+  end
+  anims = {}
+  members.each do |a|
+    anims[a.id] = battle_pose_set(name: 'Fighter',
+                                  poses: { 0 => battle_pose(battler_name: 'Party', battler_index: 0) })
+  end
+  party = BattleStubParty.new(members.first, alternate_layout: true,
+                              automatic_placement: placement == 1, actors: members)
+  scene, = battle_scene_with_pages({}, party: party, rpg2003: true,
+                                   battlecommands: OpenStruct.new(placement: placement, battle_type: 2),
+                                   battleranimations: anims)
+  grid = scene.db.terrain[42]
+  grid.grid_top_y = 112
+  grid.grid_elongation = 392
+  grid.grid_inclination = 16000
+  # Drive the battle open (the actor sprites are built in Scene::Battle#start).
+  battle_until_phase(scene, :command, 250)
+  scene
+end
+
+def placement_sprites(scene)
+  ui = battle_ui(scene)
+  ui && ui[:actor_sprites]
+end
+
+check 'automatic battler placement seats a lone party member on the grid, not battle_x/battle_y' do
+  scene = placement_battle([1])
+  sprites = placement_sprites(scene)
+  ok sprites && sprites[0], 'the actor sprite was built'
+  eq [264, 110], [sprites[0].x, sprites[0].y],
+     'the no-terrain grid for a party of one: 320 - (grid.x 8 + 24 + 24), grid.y 134 - 24'
+end
+
+check 'automatic battler placement seats a two-member party on its two grid slots' do
+  scene = placement_battle([1, 2])
+  sprites = placement_sprites(scene)
+  eq [[256, 88], [272, 133]],
+     [[sprites[0].x, sprites[0].y], [sprites[1].x, sprites[1].y]],
+     'member 0 at grid slot (16, 112), member 1 at (0, 157), each minus a 24px half-cell'
+end
+
+check 'manual battler placement keeps the database battle_x/battle_y, unchanged' do
+  scene = placement_battle([1], placement: 0, battle_xy: { 1 => [120, 90] })
+  sprites = placement_sprites(scene)
+  eq [120, 90], [sprites[0].x, sprites[0].y],
+     'placement 0 reads the actor\'s own coordinates, no grid involved'
+end
+
 # yado.tk / 01_shoshin's 011_siyou: "Empty party doesn't itself Game Over, but
 # battling with one is instant defeat; all-KO'd ... is instant Game Over the
 # same way." #draw_battle_command's current_actor (living_allies[actor_i]) is


### PR DESCRIPTION
`battlecommands.placement == 1` (automatic) used to log "not yet implemented" and fall back to the manual `battle_x`/`battle_y`. Now it computes each party member's sprite slot from EasyRPG's `CalculateBaseGridPosition` / `Calculate2k3BattlePosition` (src/game_battle.cpp), surfaced as the reference by this ADR's work.

**What changed**
- `Scene::Battle#automatic_battle_position` resolves a member's slot: the grid table 0 fraction keyed by party index/size, the encounter terrain's grid fields (terrain chunks 46–48, or the reference's no-terrain defaults 112 / 392 / 16000), then the actor-path x/y (front-row offset of a half-cell, x clamped, y unclamped) — integer-truncated like the reference's casts. Manual placement (0) keeps the DB `battle_x`/`battle_y`.
- Only the ordinary front-row actor path is done; the back-row offset and pincer/surround enemy tables need the row derivation and battle conditions this runtime doesn't model.

**Verify:** `rpg2k_scene_check.rb` (677) pins the lone/two-member grid slots and that manual placement is unchanged; `rpg2k_logic_check.rb` (985), CTest (8/8), native boot check keep the real 2003 gauge battle (mtf-meido-action uses placement 1) green; pre-commit clean.