### PR TITLE
rpg2003: align the row mechanic with EasyRPG's Algo row adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@
   party as face/bars gauge cards from the project's System2 graphic, seats
   each member's battle sprite on the automatic placement grid the project
   configures (`battlecommands.placement` 1, keyed by the encounter terrain),
-  and applies RPG2003's front/back row accuracy, while the traditional and
+  and applies RPG2003's front/back row mechanic (a back-row defender is harder
+  to hit and takes less damage, a front-row actor deals more — ported from
+  EasyRPG's `Algo` row adjustments), while the traditional and
   alternative presentations inherit the unchanged turn-based machine. The 2003
   test beds ship no encounters, so a `--rpg2k_battle_troop=<id>` flag drives a
   real project straight into a fight against a chosen database troop after New

--- a/changelog.d/rpg2003-battle-row-reference.fixed.md
+++ b/changelog.d/rpg2003-battle-row-reference.fixed.md
@@ -1,0 +1,12 @@
+- Correct the RPG2003 front/back **row** mechanic to match the actual RPG_RT
+  2003 behaviour (EasyRPG's `Algo::IsRowAdjusted` / `CalcNormalAttackToHit` /
+  `CalcNormalAttackEffect`, src/algo.cpp) instead of the earlier guess: a
+  back-row defender is now a **flat 25 harder to hit** (was a 50% multiplier)
+  and takes **-25% damage**, and a **front-row actor deals +25% damage** (the
+  previously-deferred attacker-side adjustment; an enemy attacker is never
+  row-adjusted). Physical skills are no longer row-adjusted at all — the
+  reference gates skill rows behind an EasyRPG-only field absent from real
+  RPG Maker 2003 files. The attack hit/damage terms apply in the reference's
+  own order (`Game::Battle#row_adjusted?`). RPG2000, which never sets a row,
+  is untouched. Covered by reworked checks in
+  `scripts/rpg2k3_battle_row_check.rb` (ADR 0053).

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -83,25 +83,35 @@ Landed in `mruby-rpg2k/mrblib/game.rb`:
   `battlecommands.placement` (field 2) + the actor's `battle_x`/`battle_y` is
   the remaining data step and is intentionally **not** guessed here — the
   placement→row mapping is an RPG_RT 2003 presentation rule that needs the spec.
-- `Game::Battle#row_hit_modifier` / `Game::Party#row_hit_modifier` apply a
-  fixed `ROW_BACK_DEFENDER_HIT_MULT` (currently 50) to the attacker's hit rate
-  when the **target** stands in the back row. Wired into both physical hit
-  paths: `Battle#to_hit` (basic attack) and `Party#skill_to_hit` (the 2003
-  physical-skill branch). RPG2000 never sets a row, so both return 100
-  unchanged there.
-- **Open within Phase 1:** the *attacker*-side back-row reach penalty (a
-  melee back-row attacker cannot reach a front-row target / suffers reduced
-  accuracy unless the weapon is ranged) is **not** yet modelled — it needs the
-  attacker's weapon range, which this sim does not currently carry. The exact
-  `ROW_BACK_DEFENDER_HIT_MULT` value is the RPG_RT 2003 documented back-row
-  evasion and is flagged TODO against the RPG_RT 2003 specification (still
-  inaccessible; see the LCF schema work's same blocker).
+- **Row adjustments are ported from EasyRPG's `Algo` (src/algo.cpp)**, once
+  that source became reachable, which resolved the earlier guesses. The row
+  mechanic is richer than "back-row is hard to hit": `Algo::IsRowAdjusted`
+  decides whether a battler's row matters at all, by *battle condition* and
+  *role*. This engine models no battle conditions, so only the normal (`none`)
+  branch holds, and `Game::Battle#row_adjusted?(battler, offense)` is that
+  branch: an actor standing on the offense row is row-adjusted (a **front-row
+  attacker deals +25% damage** — the deferred attacker-side piece; an *enemy*
+  attacker is never row-adjusted, `allow_enemy=false`), and a **back-row
+  defender is 25 harder to hit and takes -25% damage**. This replaces the
+  pre-reference `row_hit_modifier` guess of a flat **50% multiplier**: the
+  reference's `CalcNormalAttackToHit` subtracts a flat 25 (`to_hit -= 25`,
+  `ROW_HIT_PENALTY`), and `CalcNormalAttackEffect` scales damage by 125/100
+  (attacker, before the weapon's elemental multiplier) and 75/100 (defender,
+  after it). RPG2000 never sets a row, so every term is a no-op there.
+- **Skills are deliberately not row-adjusted.** EasyRPG's `CalcSkillToHit` /
+  `CalcSkillEffect` gate their row terms behind `skill.easyrpg_affected_by_row_
+  modifiers`, an EasyRPG-only field the RPG Maker 2003 editor cannot set
+  (absent from every real 2003 file), so vanilla skills are untouched by rows;
+  the earlier `Party#skill_to_hit` row penalty is removed to match.
 
-Verification: `scripts/rpg2k3_battle_row_check.rb` (8 checks) exercises the
-row model, both `row_hit_modifier` definitions, and the back-row reduction in
-both `to_hit` and `skill_to_hit`; wired into the `ruby-checks` CI job. The
-existing 976-check `rpg2k_logic_check.rb` stays green because no fixture sets
-a back row.
+Verification: `scripts/rpg2k3_battle_row_check.rb` (13 checks) exercises the
+row model, `#row_adjusted?` (front-row ally attacker adjusted, back-row / enemy
+attacker not, back-row defender adjusted), the flat 25 hit reduction in
+`Battle#to_hit`, the 125/75 damage adjustments in `Battle#deal_attack` in the
+reference's order, that a physical skill is *not* row-adjusted, and `from_actor`
+front-row default; wired into the `ruby-checks` CI job. The existing
+`rpg2k_logic_check.rb` and `rpg2k_scene_check.rb` suites stay green because no
+fixture sets a back row.
 
 ## Phase 2 — implementation notes (2026-08-16)
 
@@ -241,6 +251,9 @@ fatal). Scene checks pin the `headless_battle_troop` flag plumbing and
   path: a gauge fight now runs on per-combatant gauges instead of the 2000
   sequential round machine, with every other 2003 fight untouched.
 - Follow-up work (battle-event pages already parsed; 2003-specific battle
-  commands beyond the four this engine drives; the Special command handler;
-  the attacker-side back-row reach penalty) stays out of scope for these three
-  phases and is tracked separately.
+  commands beyond the four this engine drives; the Special command handler)
+  stays out of scope for these three phases and is tracked separately. The
+  attacker-side row adjustment is now implemented (ADR 0053 Phase 1 notes,
+  2026-08-17); the per-battler row derivation from `battlecommands.placement`
+  and the condition-gated `IsRowAdjusted` branches (back-attack / surround)
+  remain open until the battle conditions are modelled.

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -123,5 +123,6 @@ Behavioral notes and deliberate simplifications:
   derivation and battle conditions this runtime does not model); `mtf-
   meido-action` uses placement 1, so its real gauge battle exercises it.
 - Follow-ups: Wait-off (active) mode and the database wait toggle; the
-  Special command handler;
-  the attacker-side back-row reach penalty.
+  Special command handler. The attacker-side row adjustment (a front-row actor
+  dealing +25% damage and the flat-25 back-row defender hit penalty) landed
+  with ADR 0053 Phase 1's reference-aligned row model (2026-08-17).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4760,18 +4760,14 @@ module Game
     # databases, but RPG_RT still honours the bit whenever it is set (see the
     # "Not implemented: CalcSkillToHit" note in docs/TODO.md). `source` is the
     # caster, `target` the first foe the skill lands on.
-    # RPG2003 row accuracy for physical skills: mirrors Battle#row_hit_modifier
-    # -- a back-row defender is harder to hit. Defined here too because
-    # #skill_to_hit (the physical-skill hit path) lives on Party, not Battle,
-    # and both classes keep their own copy of the shared hit-chance helpers
-    # (#hit_modifier, #do_nothing_restricted?, #effective_agi). See ADR 0053.
-    ROW_BACK_DEFENDER_HIT_MULT = 50
-
-    def row_hit_modifier(_attacker, target)
-      return 100 unless target.respond_to?(:back_row?) && target.back_row?
-      ROW_BACK_DEFENDER_HIT_MULT
-    end
-
+    # RPG2003 row accuracy does **not** extend to physical skills. EasyRPG's
+    # `CalcSkillToHit` (algo.cpp) gates both its row hit and row damage terms
+    # behind `skill.easyrpg_affected_by_row_modifiers`, an EasyRPG-only field
+    # the RPG Maker 2003 editor cannot set (absent from every real 2003 file),
+    # so a vanilla skill is never row-adjusted -- only a basic attack (#to_hit /
+    # #deal_attack on Game::Battle) is. A prior draft applied the same back-row
+    # penalty a pre-reference guess had used for attacks; the reference settles
+    # it: skills are untouched by rows. See ADR 0053/0054.
     def skill_to_hit(sk, source, target)
       return skill_hit(sk) unless sk.respond_to?(:failure_message) && sk.failure_message == 3
       # The physical formula is enemy-only: an ally/self-scoped skill (scope 2/3/4)
@@ -4799,8 +4795,6 @@ module Game
       # 物理回避率アップ: a shield/armour/helmet/accessory flagged
       # `raise_evasion` subtracts a flat 25, after the AGI term.
       agi_adjusted -= 25 if target.evasion_up
-      # RPG2003 row: a back-row defender is harder to hit.
-      agi_adjusted = agi_adjusted * row_hit_modifier(source, target) / 100
       Game.clamp(agi_adjusted, 0, 100)
     end
 
@@ -8340,10 +8334,11 @@ module Game
   # elemental attributes, damage variance) into a live fight.
   class Battle
     # RPG2003 front/back row. A purely RPG2003 concept (RPG2000 never sets it):
-    # a back-row battler is harder to hit and, when attacking with a melee
-    # weapon, cannot reach a front-row target. The exact row-derived accuracy
-    # is an RPG_RT 2003 battle-system constant -- see #row_hit_modifier and
-    # ADR 0053 (the placement field that decides a battler's row for a given
+    # the row changes a battler's hit and damage the way EasyRPG's
+    # `Algo::IsRowAdjusted` / `CalcNormalAttackToHit` / `CalcNormalAttackEffect`
+    # (src/algo.cpp) describe -- a back-row defender is harder to hit and takes
+    # reduced damage, a front-row actor deals more. See #row_adjusted? and ADR
+    # 0053 (the placement field that decides a battler's row for a given
     # battle is the RPG2003 Battle Commands table, 0x1D, field 2).
     ROW_FRONT = 0
     ROW_BACK = 1
@@ -8457,8 +8452,10 @@ module Game
                             # The RPG2003 front/back row this battler stands
                             # in (see the `ROW_FRONT`/`ROW_BACK` constants
                             # above); nil defaults to the front row, the only
-                            # row RPG2000 knows. A back-row battler is harder
-                            # to hit (#row_hit_modifier) -- the row is an
+                            # row RPG2000 knows. The row changes how the fight
+                            # treats the battler (#row_adjusted?): a back-row
+                            # defender is harder to hit and takes less damage,
+                            # a front-row actor deals more -- the row is an
                             # RPG2003-only concept, so this stays front for
                             # every 2000 fight.
                             :row,
@@ -9112,17 +9109,38 @@ module Game
     # term down and always gets hit -- `CalcNormalAttackToHit`'s `if
     # (!target.CanAct()) return 100;`, ahead of every accuracy term below it.
     # RPG2003 row accuracy: a back-row defender is harder to hit by a physical
-    # attack. RPG_RT 2003 applies a fixed hit-rate reduction to any attack aimed
-    # at a back-row battler; the front/back row is an RPG2003-only concept, so
-    # RPG2000 (which never sets a row) returns 100 unconditionally here. The
-    # exact percentage is an RPG_RT 2003 battle-system constant -- TODO(ADR
-    # 0053): confirm against the RPG_RT 2003 specification (currently
-    # inaccessible); 50% is the documented behaviour.
-    ROW_BACK_DEFENDER_HIT_MULT = 50
+    # attack. EasyRPG's `CalcNormalAttackToHit` (algo.cpp) applies a flat 25 to
+    # the already agility-adjusted chance when the *defender* is row-adjusted
+    # (`to_hit -= 25`), not the 50% multiplier a pre-reference draft guessed
+    # here -- see #row_adjusted? for what "row-adjusted" means and the ADR 0053
+    # note that originally flagged the multiplier as unconfirmed. The front/
+    # back row is an RPG2003-only concept, so RPG2000 (which never sets a row)
+    # has no adjusted defender and this term is a no-op there.
+    ROW_HIT_PENALTY = 25
 
-    def row_hit_modifier(_attacker, target)
-      return 100 unless target.respond_to?(:back_row?) && target.back_row?
-      ROW_BACK_DEFENDER_HIT_MULT
+    # Port of EasyRPG's `Algo::IsRowAdjusted` (src/algo.cpp) for the only
+    # battle condition this runtime models. RPG_RT 2003's row mechanic decides
+    # whether a battler's row changes its hit / damage by the *battle condition*
+    # (normal / initiative / back-attack / surround) and by the battler's role;
+    # this engine models no battle conditions, so the normal (`none`) branch is
+    # what holds: a battler standing on the "offense" row is row-adjusted.
+    #
+    # For an attacker (`offense` true) the offense row is the front: an actor
+    # standing in the front row deals +25% damage, and an *enemy* attacker is
+    # never row-adjusted -- EasyRPG consults only the actor row there
+    # (`IsRowAdjusted(source, cond, true, /*allow_enemy=*/false)`). For a
+    # defender (`offense` false) the offense row is the back: a back-row
+    # defender is 25 harder to hit and takes -25% damage (allow_enemy true, but
+    # an enemy defaulting to the front row is never adjusted). The `row` is
+    # read through Combatant#row (nil defaults to the front row, the only row
+    # RPG2000 knows).
+    def row_adjusted?(battler, offense)
+      row = battler.respond_to?(:row) ? battler.row : ROW_FRONT
+      if offense
+        ally?(battler) && row == ROW_FRONT
+      else
+        row == ROW_BACK
+      end
     end
 
     # RPG2003 active-time (gauge) battle timing (ADR 0053, Phase 2). The gauge
@@ -9258,8 +9276,9 @@ module Game
         # term, and never reached at all by a 必中 attacker (the branch
         # above already returned).
         agi_adjusted -= 25 if target.evasion_up
-        # RPG2003 row: a back-row defender is harder to hit.
-        agi_adjusted = agi_adjusted * row_hit_modifier(attacker, target) / 100
+        # RPG2003 row: a back-row defender is harder to hit (a flat 25, after
+        # the AGI term -- EasyRPG's CalcNormalAttackToHit `to_hit -= 25`).
+        agi_adjusted -= ROW_HIT_PENALTY if row_adjusted?(target, false)
         Game.clamp(agi_adjusted, 0, 100)
       end
     end
@@ -10395,11 +10414,14 @@ module Game
     # attack_variance: false, skill_variance: true, emulate_bugs: true)` --
     # the one real, un-patched RPG_RT always runs; EasyRPG's other two named
     # algorithms, `AttackOnly` and `RpgRtImproved`, are its own optional,
-    # non-default customizations and are not modelled here). Row-based
-    # battle-formation modifiers (`Feature::HasRow()` in every formula this
-    # ports) are never applicable: this codebase has no row/formation system
-    # of any kind, so every such branch in the source is dead code for any
-    # database this build can load, not a simplification made on our end.
+    # non-default customizations and are not modelled here). The ranking
+    # deliberately mirrors EasyRPG's `CalcNormalAttackAutoBattleTargetRank` /
+    # `CalcSkillAutoBattleTargetRank` at `apply_variance: false` and does not
+    # layer the RPG2003 row modifiers (#row_adjusted?) into its per-target
+    # score -- the actual hit/damage a thrown attack lands (#deal_attack /
+    # #to_hit) is where those apply, and a ranking heuristic need not double-
+    # count them, so a front-row actor's +25% shows up in the damage it deals
+    # rather than being pre-empted in its auto-battle preference.
     def choose_auto_battle_command(b)
       best_skill = nil
       best_sid = nil
@@ -10778,9 +10800,19 @@ module Game
                  attack_animation_id: anim, target_index: target_index }
       end
       dmg = Battle.attack_damage(effective_atk(b), effective_def(target))
+      # RPG2003 row: an actor attacking from the offense (front) row deals
+      # +25% damage -- EasyRPG's CalcNormalAttackEffect attacker adjustment,
+      # applied *before* the weapon's elemental scaling (the reference's own
+      # order). An enemy attacker is never row-adjusted. The front row is the
+      # only row RPG2000 knows, so this is a no-op there.
+      dmg = 125 * dmg / 100 if row_adjusted?(b, true)
       # An elemental weapon scales its damage by the target's resistance before
       # variance / criticals (EasyRPG's ApplyAttributeNormalAttackMultiplier).
       dmg = apply_attr_multiplier(dmg, b.atk_attrs, target)
+      # RPG2003 row: a back-row defender takes -25% damage -- the reference's
+      # defender adjustment, applied *after* the elemental scaling, again in
+      # CalcNormalAttackEffect's own order.
+      dmg = 75 * dmg / 100 if row_adjusted?(target, false)
       # No critical on a same-side hit (e.g. a confused ally striking an ally) or
       # against a target whose gear prevents criticals, matching EasyRPG.
       crit = critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit

--- a/scripts/rpg2k3_battle_row_check.rb
+++ b/scripts/rpg2k3_battle_row_check.rb
@@ -2,10 +2,15 @@
 # encoding: UTF-8
 #
 # Host-side unit checks for the RPG2003 front/back row battle mechanic
-# (ADR 0053, Phase 1). The row is an RPG2003-only concept: a back-row
-# defender is harder to hit by a physical attack. RPG2000 never sets a row,
-# so the path is a no-op there and these checks exercise the 2003 behaviour
-# directly on the shared hit-chance helpers in mruby-rpg2k/mrblib/game.rb.
+# (ADR 0053 Phase 1, resolved against EasyRPG's Algo::IsRowAdjusted /
+# CalcNormalAttackToHit / CalcNormalAttackEffect, src/algo.cpp). The row is an
+# RPG2003-only concept: it changes how the fight treats a battler -- a back-row
+# defender is 25 harder to hit and takes -25% damage, a front-row actor deals
+# +25% damage, and an enemy attacker (or a back-row attacker) is not row-
+# adjusted at all. RPG2000 never sets a row, so the path is a no-op there and
+# these checks exercise the 2003 behaviour directly on the shared helpers in
+# mruby-rpg2k/mrblib/game.rb. Skills are deliberately NOT row-adjusted (the
+# reference gates that behind an EasyRPG-only field absent from real files).
 #
 # Usage: ruby scripts/rpg2k3_battle_row_check.rb   (exits non-zero on failure)
 
@@ -69,7 +74,7 @@ def combatant(name, atk, dfn, agi, hp)
   Game::Battle::Combatant.new(name, atk, dfn, agi, hp, hp)
 end
 
-# A minimal Party (no roster needed for the row helper / skill_to_hit).
+# A minimal Party (no roster needed for the skill_to_hit checks).
 def fake_party
   db = Object.new
   def db.system; Struct.new(:party).new([]); end
@@ -92,32 +97,84 @@ check 'setting ROW_BACK makes back_row? true' do
   eq false, front.back_row?
 end
 
-# -- Battle#to_hit integration ----------------------------------------------
+# -- row_adjusted? (the Algo::IsRowAdjusted port) ----------------------------
+# An actor-backed attacker in the front row is row-adjusted; a back-row actor
+# attacker and every enemy attacker are not; a back-row defender is.
+def actor_combatant(name, atk, dfn, agi)
+  c = combatant(name, atk, dfn, agi, 10_000)
+  c.actor = Object.new # ally?(battler) keys on a non-nil #actor
+  c
+end
+
 bat = Game::Battle.new([front], [front], Game::Rng.new(1))
-attacker = bat.allies[0]
+attacker = actor_combatant('Atk', 100, 0, 20)
 target_front = bat.enemies[0]
 target_back = target_front.dup
 target_back.row = Game::Battle::ROW_BACK
 
-check 'Battle#row_hit_modifier: 100 for a front defender' do
-  eq 100, bat.row_hit_modifier(attacker, target_front)
+check 'row_adjusted?: front-row ally attacker is adjusted' do
+  eq true, bat.row_adjusted?(attacker, true)
 end
 
-check 'Battle#row_hit_modifier: 50 for a back defender' do
-  eq Game::Battle::ROW_BACK_DEFENDER_HIT_MULT, bat.row_hit_modifier(attacker, target_back)
+check 'row_adjusted?: back-row ally attacker is not adjusted' do
+  back_attacker = attacker.dup
+  back_attacker.row = Game::Battle::ROW_BACK
+  eq false, bat.row_adjusted?(back_attacker, true)
 end
 
-check 'back-row defender is strictly harder to hit (basic attack)' do
+check 'row_adjusted?: an enemy attacker is never adjusted' do
+  eq false, bat.row_adjusted?(target_front, true)
+end
+
+check 'row_adjusted?: a back-row defender is adjusted' do
+  eq true, bat.row_adjusted?(target_back, false)
+end
+
+check 'row_adjusted?: a front-row defender is not adjusted' do
+  eq false, bat.row_adjusted?(target_front, false)
+end
+
+# -- Battle#to_hit integration ----------------------------------------------
+check 'a back-row defender is exactly 25 harder to hit (flat, not a multiplier)' do
   front_hit = bat.to_hit(attacker, target_front)
   back_hit = bat.to_hit(attacker, target_back)
   ok back_hit < front_hit, "expected back-row hit (#{back_hit}) < front hit (#{front_hit})"
-  eq (front_hit * Game::Battle::ROW_BACK_DEFENDER_HIT_MULT / 100), back_hit,
-      'back-row hit should be the front hit scaled by the row multiplier'
+  eq [front_hit - Game::Battle::ROW_HIT_PENALTY, 0].max, back_hit,
+      'back-row hit should be the front hit less the flat 25 row penalty'
 end
 
-# -- Party#skill_to_hit integration (the 2003 physical-skill path) -----------
+# -- deal_attack damage integration (CalcNormalAttackEffect order) -----------
+# Variance and criticals off so the integer damage is deterministic:
+#   attack_damage(100, 0) = 100/2 - 0/4 = 50
+#   front-row attacker: 125 * 50 / 100 = 62   (attacker row, before attribute)
+#   front defender: unchanged 62
+#   back  defender: 75 * 62 / 100 = 46        (defender row, after attribute)
+dmg_bat = Game::Battle.new([attacker], [target_front], Game::Rng.new(1),
+                           nil, false, false, false)
+
+check 'a front-row attacker deals +25% damage vs a front-row defender' do
+  entry = dmg_bat.send(:deal_attack, attacker, target_front)
+  eq 62, entry[:damage]
+end
+
+check 'a back-row defender takes -25% damage from the same swing' do
+  entry = dmg_bat.send(:deal_attack, attacker, target_back)
+  eq 46, entry[:damage]
+end
+
+check 'a back-row attacker loses the +25% bonus' do
+  back_attacker = attacker.dup
+  back_attacker.row = Game::Battle::ROW_BACK
+  front_entry = dmg_bat.send(:deal_attack, attacker, target_front) # 50 *125/100 = 62
+  back_entry = dmg_bat.send(:deal_attack, back_attacker, target_front) # base 50, no bonus
+  eq 62, front_entry[:damage]
+  eq 50, back_entry[:damage]
+end
+
+# -- skills are NOT row-adjusted (reference: gated behind an EasyRPG-only
+#    field absent from real files) -------------------------------------------
 party = fake_party
-src = combatant('Src', 50, 0, 20, 10_000)
+src = actor_combatant('Src', 50, 0, 20)
 sk = Object.new
 def sk.hit; 90; end
 def sk.failure_message; 3; end   # physical skill -> agility/evasion branch
@@ -127,14 +184,11 @@ tgt_front = combatant('TgtF', 0, 0, 5, 10_000)
 tgt_back = combatant('TgtB', 0, 0, 5, 10_000)
 tgt_back.row = Game::Battle::ROW_BACK
 
-check 'Party#row_hit_modifier: 50 for a back defender' do
-  eq Game::Battle::ROW_BACK_DEFENDER_HIT_MULT, party.row_hit_modifier(src, tgt_back)
-end
-
-check 'back-row defender is harder to hit by a physical skill' do
+check 'a physical skill is not harder to land on a back-row defender' do
   front_hit = party.skill_to_hit(sk, src, tgt_front)
   back_hit = party.skill_to_hit(sk, src, tgt_back)
-  ok back_hit < front_hit, "expected back-row skill hit (#{back_hit}) < front (#{front_hit})"
+  eq front_hit, back_hit,
+      'vanilla RPG_RT skills are not row-adjusted; the hits should match'
 end
 
 # -- from_actor defaults to the front row ------------------------------------


### PR DESCRIPTION
Closes the ADR 0053 TODO on the front/back row mechanic's 50% multiplier by
aligning it with EasyRPG's actual RPG_RT 2003 port (`Algo::IsRowAdjusted` /
`CalcNormalAttackToHit` / `CalcNormalAttackEffect`, src/algo.cpp), which also
turns out to resolve the "attacker-side reach penalty" follow-up: the row
mechanic keys purely on a battler's row and the battle condition, never on
weapon range.

- `Game::Battle#row_adjusted?(battler, offense)` — faithful `IsRowAdjusted`
  port for the `none` battle condition this runtime models: a front-row
  **actor** attacker deals +25% damage (enemy attackers are never adjusted),
  a back-row defender is a flat **25 harder to hit** and takes -25% damage.
- `to_hit`: the 50% multiplier is replaced by the reference's `to_hit -= 25`.
- `deal_attack_with_current_weapon`: attacker +25% and defender -25% damage
  terms, in `CalcNormalAttackEffect`'s own order (attacker before the weapon
  attribute, defender after).
- `Party#skill_to_hit`: skills are no longer row-adjusted — the reference
  gates skill rows behind the EasyRPG-only `easyrpg_affected_by_row_modifiers`
  field, absent from real RPG Maker 2003 files.

RPG2000 (never sets a row) is untouched. Checks: `rpg2k3_battle_row_check.rb`
reworked to 13 checks; logic/scene/gauge/testbed-logic/render all green;
rpg2k coverage 93.2%. Docs: ADR 0053/0054 corrected, README updated,
changelog fragment added.