### PR TITLE
rpg2003: drive the Special battle command as a do-nothing turn

### DIFF
--- a/changelog.d/rpg2003-battle-special-command.added.md
+++ b/changelog.d/rpg2003-battle-special-command.added.md
@@ -1,0 +1,13 @@
+- The RPG2003 **Special** battle command (type 6 in the Battle Commands table)
+  is now driven: a customized menu that names a Special entry offers it as a
+  row, and choosing it forfeits the actor's turn — EasyRPG's
+  `Scene_Battle_Rpg2k3::SpecialSelected` queues `Game_BattleAlgorithm::
+  DoNothing`, so the actor spends its turn (and, in a gauge battle, its held
+  charge) with no action, message or animation (`Game::Battle#command_skip`,
+  the same no-op a failed escape produces). The chosen command is still
+  recorded for the battle-page `command_actor` condition and the Enable Combo
+  matching (which never multiplies a Special). Previously the handler was
+  skipped along with Escape. Covered by new `rpg2k_scene_check.rb` checks (a
+  Special-only customized list drawing and committing at once in a round
+  battle, and the gauge-battle counterpart spending the ready actor's gauge
+  and returning to the ATB loop).

--- a/docs/adr/0048-rpg2003-battle-command-customization.md
+++ b/docs/adr/0048-rpg2003-battle-command-customization.md
@@ -52,11 +52,14 @@ remains a follow-up once a customized test-bed database is available.
   a fixture without chunk 29, or an id the table doesn't define.
 - **`Scene::Map#custom_battle_commands(actor)`** (`scene/map.rb`) walks
   `actor.battle_commands`, skipping `0`/`-1`/unresolvable refs, and turns
-  each resolved entry into a `{ label:, action: }` row for the four types
+  each resolved entry into a `{ label:, action: }` row for the five types
   this engine actually drives (Attack, Skill — Subskill folds into the same
   Skill submenu, there being no single-skill quick-cast modelled — Defense,
-  Item). Escape (already offered as Cancel on the first actor) and Special
-  (no handler anywhere in this engine) are skipped, the same "reported gap,
+  Item, Special). Special is the RPG2003 "does nothing this turn" command
+  (EasyRPG's `Game_BattleAlgorithm::DoNothing`): it is offered as a row and
+  `#select_battle_command` forfeits the actor's turn, spending it (and, in a
+  gauge battle, the charge) with no action. Escape (already offered as Cancel
+  on the first actor) is skipped, the same "reported gap,
   not silently invented" precedent the rest of this file already follows for
   unmodelled RPG2003 features. A list with nothing usable in it — no data at
   all, which reads back as `[0]`, Row alone, same as

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -251,9 +251,10 @@ fatal). Scene checks pin the `headless_battle_troop` flag plumbing and
   path: a gauge fight now runs on per-combatant gauges instead of the 2000
   sequential round machine, with every other 2003 fight untouched.
 - Follow-up work (battle-event pages already parsed; 2003-specific battle
-  commands beyond the four this engine drives; the Special command handler)
-  stays out of scope for these three phases and is tracked separately. The
-  attacker-side row adjustment is now implemented (ADR 0053 Phase 1 notes,
-  2026-08-17); the per-battler row derivation from `battlecommands.placement`
-  and the condition-gated `IsRowAdjusted` branches (back-attack / surround)
-  remain open until the battle conditions are modelled.
+  commands beyond the five this engine drives) stays out of scope for these
+  three phases and is tracked separately. The Special command handler landed
+  with the command-customization follow-up (2026-08-17), and the attacker-side
+  row adjustment is implemented (ADR 0053 Phase 1 notes, 2026-08-17); the
+  per-battler row derivation from `battlecommands.placement` and the
+  condition-gated `IsRowAdjusted` branches (back-attack / surround) remain
+  open until the battle conditions are modelled.

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -122,7 +122,9 @@ Behavioral notes and deliberate simplifications:
   back-row `row_x_offset` and the pincer/surround enemy tables need the row
   derivation and battle conditions this runtime does not model); `mtf-
   meido-action` uses placement 1, so its real gauge battle exercises it.
-- Follow-ups: Wait-off (active) mode and the database wait toggle; the
-  Special command handler. The attacker-side row adjustment (a front-row actor
-  dealing +25% damage and the flat-25 back-row defender hit penalty) landed
-  with ADR 0053 Phase 1's reference-aligned row model (2026-08-17).
+- Follow-ups: Wait-off (active) mode and the database wait toggle. The
+  Special command handler (a chosen Special forfeits the actor's turn,
+  EasyRPG's DoNothing) landed 2026-08-17, and the attacker-side row
+  adjustment (a front-row actor dealing +25% damage and the flat-25 back-row
+  defender hit penalty) landed with ADR 0053 Phase 1's reference-aligned row
+  model (2026-08-17).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9015,8 +9015,12 @@ module Game
     end
 
     # Forfeit `ally`'s action for the round — it neither attacks nor gains a
-    # defend's damage cut — used when a failed escape costs the party its turn.
-    # Cleared with the other commands at #end_round.
+    # defend's damage cut — used when a failed escape costs the party its turn
+    # and for the RPG2003 **Special** battle command, whose turn resolves to
+    # exactly this (EasyRPG's `Game_BattleAlgorithm::DoNothing`: the actor
+    # spends its turn doing nothing, no message, no animation — see the
+    # scene's `select_battle_command` `:special` arm). Cleared with the other
+    # commands at #end_round.
     def command_skip(ally)
       ally.action = nil; ally.defending = false; ally.command = nil; ally.skip = true
     end

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1016,12 +1016,14 @@ class RPG2k
       # "not impl" and skips it the same way), -1 (an empty padding slot,
       # likewise skipped), or a positive ref into the database's own
       # Battle-Commands table (`Game::Actor#battle_command_row`) naming one
-      # entry's `name` + `type`. Only the four types this engine actually
-      # drives -- Attack, (sub)Skill, Defense, Item -- become a row; Escape
-      # (the first actor's own Cancel already offers it) and Special (no
-      # handler modelled anywhere in this engine) are skipped, same as an
-      # unresolvable ref (a project whose database has no Battle-Commands
-      # table decoded, or an id it doesn't define).
+      # entry's `name` + `type`. The five types this engine actually drives --
+      # Attack, (sub)Skill, Defense, Item and Special -- become a row; Escape
+      # (the first actor's own Cancel already offers it) is skipped, same as
+      # an unresolvable ref (a project whose database has no Battle-Commands
+      # table decoded, or an id it doesn't define). Special is a turn that
+      # does nothing (EasyRPG's `Game_BattleAlgorithm::DoNothing`, queued by
+      # `Scene_Battle_Rpg2k3::SpecialSelected`) -- #select_battle_command
+      # resolves it to a forfeited turn.
       def custom_battle_commands(actor)
         return nil unless actor.respond_to?(:battle_commands)
         cmds = actor.battle_commands
@@ -1045,8 +1047,12 @@ class RPG2k
           when Game::Actor::BATTLE_COMMAND_ITEM
             out << { label: nonblank(row.name, term(:battle_item, 'Item')), action: :item,
                      command_id: cmd_id }
+          when Game::Actor::BATTLE_COMMAND_SPECIAL
+            out << { label: nonblank(row.name, 'Special'), action: :special,
+                     command_id: cmd_id }
           end
-          # Escape / Special: no menu row (see the method comment above).
+          # Escape: no menu row (see the method comment above) -- Special has
+          # one now, since #select_battle_command drives it.
         end
         rows.empty? ? nil : rows
       end
@@ -1295,6 +1301,17 @@ class RPG2k
           @ui[:battle].command_defend(current_actor)
           advance_actor
         when :item then open_battle_item
+        when :special
+          # RPG2003's Special battle command is a turn that does nothing:
+          # EasyRPG's `Scene_Battle_Rpg2k3::SpecialSelected` plays the
+          # Decision SE and queues `Game_BattleAlgorithm::DoNothing`, which
+          # consumes the actor's turn (and, in a gauge battle, its charge)
+          # with no action, message or animation -- exactly what
+          # `Game::Battle#command_skip` resolves to here (#strike returns nil
+          # for a skipped battler and the turn is passed).
+          play_system_se(SFX_DECISION)
+          @ui[:battle].command_skip(current_actor)
+          advance_actor
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9655,6 +9655,37 @@ check 'selecting a customized battle command records its own command-table ref' 
   eq 10, hero.last_battle_action, 'a customized row records its own db.commands ref'
 end
 
+check "Enemy Encounter scene: a Special battle command draws a row and forfeits the actor's turn" do
+  # RPG2003's Special (type 6) command resolves to a turn that does nothing --
+  # EasyRPG's `Scene_Battle_Rpg2k3::SpecialSelected` queues
+  # `Game_BattleAlgorithm::DoNothing`. It must be offered as a menu row (this
+  # engine used to skip it along with Escape) and, once chosen, commit at once
+  # like Defend -- no target/skill/item submenu -- and pass the actor's turn
+  # with no action: `Game::Battle#command_skip` sets the Combatant's skip
+  # flag, #strike returns nil for it, and the round machine moves on.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  actor = BattleStubActor.new(agi: 20,
+    battle_commands: [12, 0, -1, -1, -1, -1, -1],
+    battle_command_table: { 12 => BattleCommandDef.new('Stall', Game::Actor::BATTLE_COMMAND_SPECIAL) })
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(actor))
+  ui = battle_to_command(scene)
+  labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
+  eq ['Stall'], labels, 'a customized list with just a Special entry shows that one row, not the fixed four'
+  hero = ui[:allies][0]
+  press_key(scene, RGSS::Input::C) # the only row, cmd 0: the Special at ref 12
+  eq 12, hero.last_battle_action, 'a Special row records its own db.commands ref (never multiplied by a combo)'
+  eq :animate, ui[:phase], 'Special commits at once -- no target/skill/item submenu, like Defend'
+  # The hero's turn is skipped, so after the round resolves the only log
+  # entries are the Slimes' attacks, never a Hero one.
+  8.times { scene.update }
+  hero_attacked = ui[:battle].log.any? { |e| e[:attacker] == 'Hero' }
+  eq false, hero_attacked, 'the Special turn produced no attack entry for the hero'
+end
+
 check "Enemy Encounter scene: a battle-command list of Row alone falls back to the fixed four" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
@@ -11054,6 +11085,30 @@ check 'a command_actor troop page fires at the acting battler\'s turn in a gauge
   # fires and its event toggles switch 5.
   5.times { scene.update }
   eq true, st.switches[5], 'the command_actor page fired at the acting hero\'s turn'
+end
+
+# The Special command in a gauge fight: choosing it forfeits the ready actor's
+# turn (EasyRPG's DoNothing), spending the held gauge and returning to the ATB
+# idle loop without any action -- the active-time counterpart to the round-
+# based Special check above.
+check "a gauge battle: the Special command spends the ready actor's turn and returns to the ATB loop" do
+  scene, st = battle_scene_with_pages({}, rpg2003: true,
+                                      battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
+  actor = BattleStubActor.new(agi: 20,
+    battle_commands: [12, 0, -1, -1, -1, -1, -1],
+    battle_command_table: { 12 => BattleCommandDef.new('Stall', Game::Actor::BATTLE_COMMAND_SPECIAL) })
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(actor))
+  ui = battle_until_phase(scene, :command, 250)
+  ok ui, 'the gauge battle opened to the ready actor\'s menu'
+  hero = ui[:allies][0]
+  eq true, hero.gauge_full?, 'the actor\'s gauge is held full while the menu is open'
+  press_key(scene, RGSS::Input::C) # the only row: the Special at ref 12
+  eq :animate, ui[:phase], 'Special commits at once -- no target/skill/item submenu'
+  scene.update
+  eq :atb, ui[:phase], 'the consumed turn returns to the active-time idle loop'
+  ok !hero.gauge_full?, 'the Special turn spent the hero\'s held-full gauge (it refills from the ATB loop)'
+  hero_attacked = ui[:battle].log.any? { |e| e[:attacker] == 'Hero' }
+  eq false, hero_attacked, 'the Special turn produced no action entry'
 end
 
 # -- automatic battler placement (`battlecommands.placement == 1`) -------------


### PR DESCRIPTION
Implements the RPG2003 **Special** battle command (type 6 in the Battle
Commands table), which `custom_battle_commands` previously skipped along
with Escape ("no handler modelled anywhere in this engine"). EasyRPG's
`Scene_Battle_Rpg2k3::SpecialSelected` queues `Game_BattleAlgorithm::
DoNothing`: the actor spends its turn doing nothing.

- `Scene::Battle#custom_battle_commands` now turns a Special entry into a
  menu row (database command name, literal `'Special'` fallback).
- `Scene::Battle#select_battle_command` dispatches `:special` by playing
  the Decision SE and forfeiting the turn via `Game::Battle#command_skip`
  (`#strike` resolves a skipped battler to a no-op) — exactly the
  DoNothing behaviour. The command id is still recorded as
  `last_battle_action`, so the `command_actor` page condition and the
  Enable Combo matching both see it (`combo_hits` never multiplies a
  Special).
- Works in round-based and gauge battles (a gauge fight consumes the
  ready actor's held-full gauge and returns to the ATB idle loop).

Checks: two new `rpg2k_scene_check.rb` checks (round-based Special-only
list committing at once; gauge counterpart spending the gauge and
returning to the ATB loop). Logic/scene/gauge/row/render suites green,
rpg2k coverage 93.3%. Docs: ADR 0048/0053/0054 updated, changelog
fragment added.