### PR TITLE
sdl: keep the #449 framebuffer hint off macOS

### DIFF
--- a/changelog.d/sdl-window-macos-framebuffer.fixed.md
+++ b/changelog.d/sdl-window-macos-framebuffer.fixed.md
@@ -1,0 +1,11 @@
+- The main SDL window opens again on macOS instead of aborting on
+  `Check failed: display` at startup. The `SDL_HINT_FRAMEBUFFER_ACCELERATION=0`
+  workaround added for the X11 `GLXBadContext` crash (#449) only leaves a
+  working fallback where the video backend implements a window framebuffer of
+  its own — X11's XImage/MIT-SHM path, Wayland's `wl_shm` one, Emscripten's
+  canvas one. SDL3's Cocoa backend has none, so `SDL_GetWindowSurface()` there
+  can only go through `SDL_CreateWindowTexture`; turning that companion
+  renderer off left it with nothing and `SDL_CreateRenderer()` failed with
+  `Window framebuffer support not available`, taking the whole process down.
+  The hint is now skipped on macOS, which keeps the #449 fix intact everywhere
+  it actually helps.

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -1166,8 +1166,19 @@ int main(int argc, char** argv) {
     // server with no working GLX. SDL_HINT_FRAMEBUFFER_ACCELERATION=0 turns
     // that companion renderer off, so SDL_GetWindowSurface() falls back to a
     // plain CPU blit instead -- see issue #449.
+    //
+    // That "plain CPU blit" only exists where the video backend implements a
+    // window framebuffer of its own (X11 has the XImage/MIT-SHM path, Wayland
+    // the wl_shm one, and Emscripten its canvas one). SDL3's Cocoa backend has
+    // none: SDL_GetWindowSurface() there can *only* go through
+    // SDL_CreateWindowTexture, so switching the companion renderer off leaves
+    // it with nothing and the software renderer fails to come up at all
+    // ("Window framebuffer support not available"), taking the CHECK below and
+    // the whole process with it. Keep the #449 workaround off macOS.
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+#ifndef __APPLE__
     SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION, "0");
+#endif
     display = std::shared_ptr<lv_display_t>(
         lv_sdl_window_create(FLAGS_width, FLAGS_height),
         [](lv_display_t*) { lv_sdl_quit(); });


### PR DESCRIPTION
## Problem

The SDL window aborts at startup on macOS — the app is unusable in SDL mode:

```
[Error] init_display: Failed to create SDL renderer 'Parameter 'renderer' is invalid' lv_sdl_sw.c:103
[Error] window_create: Failed to initialize SDL backend lv_sdl_window.c:308
[Error] lv_sdl_window_create: Failed to initialize window lv_sdl_window.c:88
F main.cxx:1174] Check failed: display
```

## Root cause

The renderer error text is a red herring — sdl2-compat overwrites SDL's real error with `Parameter 'renderer' is invalid`. `SDL_LOGGING="*=verbose"` shows the actual one:

```
WARN: Couldn't create renderer software: Window framebuffer support not available
```

LVGL's software renderer (`LV_SDL_ACCELERATED 0`) presents through `SDL_GetWindowSurface()`, which needs a window framebuffer. `SDL_HINT_FRAMEBUFFER_ACCELERATION=0` — added for the X11 `X_GLXMakeCurrent` (`GLXBadContext`) crash in #449 — switches off the `SDL_CreateWindowTexture` path.

That only leaves a working fallback where the video backend implements a window framebuffer of its own: X11 has the XImage/MIT-SHM path, Wayland the `wl_shm` one, Emscripten its canvas one. **SDL3's Cocoa backend has none** — `SDL_GetWindowSurface()` there can only go through `SDL_CreateWindowTexture`. Disabling it leaves nothing, so the renderer never comes up and the `CHECK(display)` takes the process down.

## Fix

Skip the hint on macOS. #449 stays fixed on every target where its fallback actually exists; Linux, Wayland and the wasm build are untouched.

## Verification

- Isolated to the hint alone with a standalone SDL2 program: `FRAMEBUFFER_ACCELERATION=0` alone reproduces the failure, and without it `SDL_CreateRenderer` returns a working `software` renderer.
- Not a version regression — reproduces against both sdl2-compat 2.32.68 / SDL3 3.4.10 (nix) and 2.32.70 / SDL3 3.4.14 (homebrew).
- With the fix the app boots and runs `data/Nepheshel206beta/Nepheshel206Nbeta`: window opens, title set from the game, fonts and MIDI instruments load, no crash.
- `pre-commit run` clean; `cmake --build build -t test` → 1779 OK, 7/8 CTest suites.

## Note on the one failing test

`RGSS::Audio finds an upper-case extension on disk` (`mruby-rgss/test/test.rb:1344`) fails, but it is **pre-existing and unrelated** — `src/main.cxx` is only in the `rpg_maker_clone` target, never linked into `mrbtest`. It fails on macOS because case-insensitive APFS lets the lower-case probe match first, so the resolved path comes back `test-upper-se.wav` where the test expects `test-upper-se.WAV`. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)