### PR TITLE
rpg2003: implement the Wait/active ATB toggle (SaveSystem.atb_mode)

### DIFF
--- a/changelog.d/rpg2003-battle-atb-wait-toggle.added.md
+++ b/changelog.d/rpg2003-battle-atb-wait-toggle.added.md
@@ -1,0 +1,14 @@
+- The **RPG2003 Wait/active toggle is implemented** (ADR 0054's follow-up).
+  The switch is the save-system `SaveSystem.atb_mode` field (LSD chunk 140),
+  not a Battle Commands database field — liblcf's `fields.csv` has no `wait`
+  entry on that table — so the schema now decodes it and `Game::State`
+  carries it, writing the 2003-only chunk out only when non-zero. The field
+  menu's **Wait command (id 8)** now appears for RPG2003 games that list it,
+  showing the current mode via the `wait_on` / `wait_off` terms and flipping
+  `atb_mode` on confirm. In a gauge battle, wait mode (the default) freezes
+  the charge gauges while a command menu is open, while active mode keeps
+  them filling and lets a ready non-controllable combatant's action
+  **interrupt** the menu — mirroring EasyRPG's `IsAtbAccumulating` and
+  `ProcessSceneActionCommand`. Covered by new `rpg2k_scene_check.rb` checks
+  (freeze / active-fill / menu-interrupt / Wait-row toggle) and an
+  `rpg2k_save_load_check.rb` round-trip.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1656,9 +1656,12 @@ The work below is roughly ordered by the critical path to a walkable game
   window cannot change mode. Still open here: **Toggle ATB Mode** (5003), which
   would switch a gauge fight between this engine's active-time turn cycle (ADR
   0054 — the gauge-driven battle now modelled for the gauge presentation) and
-  the round-based machine; the command itself toggles a per-battle flag the
-  battle still never reads, so it stays a reported gap rather than a silent
-  no-op. The opcodes were read out of liblcf's `EventCommand::Code` enum, which
+  the round-based machine; the field-menu Wait command already flips the
+  `atb_mode` save-system field the event command would target (see the `Wait`
+  command paragraph in the field-menu section), but the battle still never
+  reads a per-fight toggle, so the *event* command stays a reported gap rather
+  than a silent no-op. The opcodes were read out of liblcf's
+  `EventCommand::Code` enum, which
   also corrected `analyze_game.rb` — it had Change Class / Change Battle Commands
   at 12610 / 12710, numbers the enum does not define at all.
   **Battle-event pages now run too**: a troop's pages (`enemy_group` chunk 11)
@@ -2397,8 +2400,10 @@ The work below is roughly ordered by the critical path to a walkable game
 #### Menus, save, battle
 - ✅ Menu scene — opens over the map (cancel button); shows party status and a
   command list. Save, End Game, **Item**, **Skill**, **Equip**, **Status** and
-  **Order** all work. (The RPG2003 Row and Wait commands stay blocked on the
-  unmodelled RPG2003 battle system; see the body.)
+  **Order** all work, and **Wait** (id 8) now does too: it flips the save-system
+  `atb_mode` field that freezes (wait) or keeps running (active) a gauge
+  battle's command menu — the RPG2003 Wait toggle, see the body. (Row alone
+  stays blocked on the unmodelled RPG2003 battle system; see the body.)
   ✅ **The command list itself now matches the editor that wrote the game**,
   rather than always showing the same fixed six. This line used to claim
   Item/Skill/Equip/Status/Save/End Game was simply "the full main-menu set,"
@@ -2440,8 +2445,12 @@ The work below is roughly ordered by the critical path to a walkable game
   ✅ **Order (id 7) has since gained its own entry too** — unlike Row and
   Wait it turned out to have no battle-system dependency at all, just party
   reordering; see the `Order` paragraph further down for the follow-up.
-  Row and Wait remain genuinely blocked on the unmodelled RPG2003 battle
-  system. The **Item** command opens
+  ✅ **Wait (id 8) has since gained its own entry too** — the toggle turned out
+  to live on the save system, not the Battle Commands table: it flips the
+  `SaveSystem.atb_mode` field (LSD chunk 140) that makes a gauge battle's
+  command menu freeze (wait) or keep running (active); see the `Wait` paragraph
+  further down for the follow-up. Row alone remains genuinely blocked on the
+  unmodelled RPG2003 battle system. The **Item** command opens
   `Scene::ItemMenu`: it lists the party's usable **medicines** (database item type
   6), **skill books** (type 7) and **seeds** (type 8) with their held counts. A
   medicine heals its target — a single-target item a chosen ally, an all-ally item
@@ -2653,8 +2662,10 @@ The work below is roughly ordered by the critical path to a walkable game
   Of the three ids `RPG2K3_COMMAND_IDS` used to skip wholesale (Row, Order,
   Wait), Order turned out to have no dependency on the unmodelled battle
   system at all — it is pure party-array reordering, so it was pulled out and
-  built standalone while Row (battle front/back rank) and Wait (the ATB
-  toggle) stay genuinely blocked on that gap. The interaction model was
+  built standalone while Row (battle front/back rank) stays genuinely blocked
+  on that gap (Wait is now implemented too — its toggle turned out to live on
+  the save system, not the battle system; see its own paragraph above). The
+  interaction model was
   confirmed against EasyRPG Player's own `Scene_Order` rather than guessed:
   it is a **pick-and-place build, not a swap or drag-drop** — the player picks
   party members one at a time from a left column (`UpdateOrder`'s
@@ -2687,6 +2698,31 @@ The work below is roughly ordered by the critical path to a walkable game
   time or leaves the screen with none picked; Confirm applies the picked
   order to the party and closes; Redo clears every pick without touching the
   party)
+  ✅ **Wait (RPG2003 `menu_commands` id 8, the ATB toggle) is implemented.** Of
+  the three ids `RPG2K3_COMMAND_IDS` used to skip wholesale (Row, Order,
+  Wait), the toggle turned out to live on the **save system**, not the Battle
+  Commands table: liblcf's `fields.csv` has no `wait` entry on
+  `BattleCommands`, and RPG_RT stores the wait/active choice as
+  `SaveSystem.atb_mode` (LSD chunk 140, default 0 = wait, 1 = active,
+  RPG2003-only). The schema now decodes it, `Game::State` carries it
+  (`attr_accessor :atb_mode`, written to the save only when non-zero so an
+  RPG2000 save never gains the 2003-only chunk), and `Scene::Menu`'s Wait row
+  flips it — ported from EasyRPG's own `Scene_Menu` Wait branch: the label
+  shows the *current* mode (`wait_on` / `wait_off`, `Terms` fields 121/122),
+  confirming plays the Decision SE and relabels the row. In the battle scene
+  (ADR 0054) wait mode freezes the gauges while a command menu is open;
+  active mode keeps them filling and a ready non-controllable combatant's
+  action **interrupts** the menu — `active_atb?` / `atb_accumulating?` /
+  `drive_battle_command`'s interrupt gate mirror EasyRPG's
+  `IsAtbAccumulating` and `ProcessSceneActionCommand` (`GetAtbMode() ==
+  active && IsBattleActionPending()`, with SelectActor/AutoBattle always
+  accumulating). Covered by new `scripts/rpg2k_scene_check.rb` checks (wait
+  mode freezes an enemy's gauge behind the menu; active mode keeps it filling
+  and a ready enemy's action interrupts and returns to the menu; a ready
+  enemy waits in wait mode; the menu Wait row toggles and relabels) and a
+  `scripts/rpg2k_save_load_check.rb` round-trip (`atb_mode` 1 survives).
+  Row alone remains genuinely blocked on the unmodelled RPG2003 battle
+  system.
   ✅ **A weapon/shield/armour/helmet/accessory item flagged `use_skill`
   (schema field 71) is now usable directly from the field and battle Item
   menus too, invoking its `skill_id` skill without being equipped.** The

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -65,8 +65,9 @@ Behavioral notes and deliberate simplifications:
 - The command menu **pauses the fight** while it is open — RPG2003's Wait-mode
   behaviour — so other ready combatants queue behind the committing actor
   rather than acting mid-deliberation. The active-during-menu (Wait-off)
-  presentation, and the database's wait toggle itself (a Battle Commands field
-  the schema does not decode yet), are follow-ups.
+  presentation is the follow-up below; the wait toggle itself turns out to
+  live on the **save system**, not the Battle Commands table (the original
+  guess here was wrong — see the follow-up).
 - A gauge battle shows **no Fight/Auto/Escape options window**: the first ready
   actor's menu opens on its own. The gauge fill runs on EasyRPG's real RPG_RT
   2003 curve — `GAUGE_MAX` 300000, per-frame increment
@@ -122,9 +123,24 @@ Behavioral notes and deliberate simplifications:
   back-row `row_x_offset` and the pincer/surround enemy tables need the row
   derivation and battle conditions this runtime does not model); `mtf-
   meido-action` uses placement 1, so its real gauge battle exercises it.
-- Follow-ups: Wait-off (active) mode and the database wait toggle. The
-  Special command handler (a chosen Special forfeits the actor's turn,
-  EasyRPG's DoNothing) landed 2026-08-17, and the attacker-side row
-  adjustment (a front-row actor dealing +25% damage and the flat-25 back-row
-  defender hit penalty) landed with ADR 0053 Phase 1's reference-aligned row
-  model (2026-08-17).
+- Follow-ups: Wait-off (active) mode and the wait toggle. The Special command
+  handler (a chosen Special forfeits the actor's turn, EasyRPG's DoNothing)
+  landed 2026-08-17, and the attacker-side row adjustment (a front-row actor
+  dealing +25% damage and the flat-25 back-row defender hit penalty) landed
+  with ADR 0053 Phase 1's reference-aligned row model (2026-08-17).
+- **Wait-off (active) mode landed 2026-08-17.** The toggle is the save-system
+  `SaveSystem.atb_mode` field (LSD chunk 140; the earlier "Battle Commands
+  field" guess above was wrong — liblcf's `fields.csv` has no `wait` entry on
+  `BattleCommands`, and RPG_RT stores the mode in the save's System chunk,
+  default 0 = wait, 1 = active, RPG2003-only). The schema decodes it
+  (`SAVE_SYSTEM` field 140), `Game::State` carries it and writes it out only
+  when non-zero (an RPG2000 save never gains the 2003-only chunk), and the
+  field menu's Wait command (id 8, `Terms wait_on`/`wait_off` labels) flips
+  it. In the battle scene, wait mode freezes the gauges while a command
+  menu is open; active mode keeps them filling and a ready non-controllable
+  combatant's action **interrupts** the menu — EasyRPG's
+  `ProcessSceneActionCommand`'s `GetAtbMode() == active &&
+  IsBattleActionPending()` gate (`IsAtbAccumulating` returns `active_atb`
+  during SelectCommand/Item/Skill/EnemyTarget/AllyTarget). The field-menu
+  Toggle ATB Mode event command (5003) remains unmodelled (its menu entry is
+  the interactive path to the same field).

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1453,8 +1453,17 @@ module LCF
       123 => { name: :save_allowed, type: :bool },
       124 => { name: :menu_allowed, type: :bool },
       125 => { name: :battle_background, type: :string },
-      131 => { name: :save_count, type: :int },
-      132 => { name: :save_slot, type: :int, default: 1 },
+       131 => { name: :save_count, type: :int },
+       132 => { name: :save_slot, type: :int, default: 1 },
+      # liblcf's `SaveSystem.atb_mode` (0x8C == 140): the RPG2003 wait/active
+      # toggle. 0 = wait (the command menu pauses the fight), 1 = active
+      # (gauges keep filling while a menu is open and a ready non-controllable
+      # combatant interrupts it). This is a *save-system* runtime field, not a
+      # Battle Commands database field -- liblcf's BattleCommands has no wait
+      # field at all, correcting the premise ADR 0054 recorded -- and it is
+      # what the field menu's Wait command (id 8) flips. RPG2000 saves never
+      # carry it (the chunk is 2003-only), so an absent chunk reads 0 (wait).
+      140 => { name: :atb_mode, type: :int, default: 0 },
     }
 
     # Fields shown on the file-select screen (chunk 100 of the save file). The

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11880,6 +11880,13 @@ module Game
     # chunks 21 / 23); Scene::Map reloads the windowskin when the override
     # changes.
     attr_accessor :system_graphic, :font_id
+    # RPG2003's active-time wait/active toggle (`SaveSystem.atb_mode`, LSD
+    # SAVE_SYSTEM chunk 140): 0 = wait (a gauge battle's command menu pauses
+    # the fight), 1 = active (gauges keep filling while a menu is open and a
+    # ready non-controllable combatant's action interrupts it). The field
+    # menu's Wait command (id 8) flips it and the gauge battle scene reads it;
+    # default 0 (wait), matching liblcf. RPG2000 saves never carry the chunk.
+    attr_accessor :atb_mode
     # Last known-good resume position of each running Common Event Parallel
     # Process, id => a command-list index (see Game::Interpreter
     # #resumable_index). Unlike a Map Event's parallel process (which always
@@ -11971,6 +11978,8 @@ module Game
       @screen_transitions = Array.new(SCREEN_TRANSITION_SLOTS, nil)
       @system_graphic = nil
       @font_id = 0
+      # RPG2003's wait/active toggle; wait mode (0) is the default.
+      @atb_mode = 0
       @weather = Weather.new
       # The three vehicles' saved locations (boat / ship / airship), persisted in
       # `.lsd` chunks 105-107. Unplaced until a save restores them.
@@ -12340,6 +12349,10 @@ module Game
       # System windowskin / font override (Change System Graphics).
       sys[21] = @system_graphic if @system_graphic
       sys[23] = @font_id
+      # RPG2003's wait/active toggle (chunk 140). Written only when it leaves
+      # the default 0 (wait) -- the chunk is 2003-only, so an RPG2000 save
+      # must not gain a stray 0 here.
+      sys[140] = @atb_mode if @atb_mode && @atb_mode != 0
       sys[131] = save_count
       sys[132] = 1
       save[101] = sys
@@ -12657,6 +12670,9 @@ module Game
       sg = sys.system_graphic
       state.system_graphic = sg unless sg.nil? || sg.empty?
       state.font_id = sys.font || 0
+      # RPG2003's wait/active toggle. The chunk's own default is 0 (wait), so
+      # an absent chunk (RPG2000 saves, or a wait-mode 2003 save) reads wait.
+      state.atb_mode = sys.atb_mode || 0
       # The leader's display name from the file-screen title chunk. This used
       # to be treated as always redundant with chunk 109's own party list
       # (field 1: "both hold the same live name in a genuine save"), so a

--- a/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
+++ b/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
@@ -11,15 +11,46 @@ module RPG2k3
     # per-frame turn cycle here): every combatant's gauge fills each frame, the
     # moment one is full decides *whose turn it is* instead of the 2000
     # sequential round order, and acting resets it so it refills. A
-    # controllable party member whose gauge is full opens the command menu
-    # (the battle pauses on it -- Wait-mode behaviour); everyone else acts
-    # automatically the instant their gauge fires, enemy AI included.
+    # controllable party member whose gauge is full opens the command menu;
+    # everyone else acts automatically the instant their gauge fires, enemy AI
+    # included. How long that command menu lets the fight run is the RPG2003
+    # Wait/active toggle (`SaveSystem.atb_mode`, LSD chunk 140): in wait mode
+    # (the default) the gauges freeze while the menu is open, in active mode
+    # they keep filling and a ready non-controllable combatant's action
+    # interrupts the menu (#atb_accumulating? / #drive_battle_command's
+    # override).
     #
     # The traditional (0) and alternative (1) presentations run the inherited
     # turn-based machine unchanged -- every override below is gated on
     # `battle_type == 2`, so routing every 2003 fight through this scene stays
     # safe for them.
     class Battle < RPG2k::Scene::Battle
+      # The gauge phases that count as "the command menu is open" for the
+      # wait/active toggle (EasyRPG's State_SelectCommand / SelectItem /
+      # SelectSkill / SelectEnemyTarget / SelectAllyTarget): in wait mode
+      # gauges freeze here, in active mode they keep filling.
+      ATB_MENU_PHASES = [:command, :target, :skill, :item, :ally_target].freeze
+
+      # Whether this fight runs in RPG2003's active-during-menu (Wait-off)
+      # presentation -- the save-system `atb_mode` toggle (LSD chunk 140),
+      # flipped by the field menu's Wait command (id 8). Wait mode (the
+      # default) freezes the gauges while a command menu is open.
+      def active_atb?
+        gauge_battle? && @state.atb_mode == 1
+      end
+
+      # Whether the active-time gauges advance this frame -- EasyRPG's
+      # `IsAtbAccumulating` (src/scene_battle_rpg2k3.cpp): always in the
+      # idle loop (SelectActor / AutoBattle), only in active mode while a
+      # command/target/skill/item menu is open, and never during action
+      # resolution, the encounter banner or a battle event.
+      def atb_accumulating?
+        phase = @ui[:phase]
+        return true if phase == :atb
+        return active_atb? if ATB_MENU_PHASES.include?(phase)
+        false
+      end
+
       # Advance the active-time gauge every frame for a gauge battle, then
       # dispatch on the phase. A turn-based or alternative battle leaves the
       # gauge at 0 and runs the inherited update (and with it the whole 2000
@@ -27,7 +58,7 @@ module RPG2k3
       def update
         battle = @ui && @ui[:battle]
         if battle && battle.battle_type == 2
-          battle.advance_gauges
+          battle.advance_gauges if atb_accumulating?
           update_enemy_flashes
           update_enemy_positions
           update_enemy_shakes
@@ -138,6 +169,36 @@ module RPG2k3
       def advance_actor
         return start_gauge_action(current_actor) if gauge_battle? && current_actor
         super
+      end
+
+      # A gauge battle's command menu, with the Wait/active toggle honoured:
+      # in active mode a ready combatant whose action would fire on its own
+      # (an enemy, or a restricted / Forced-AI actor -- anyone the idle loop
+      # would act automatically rather than prompt) interrupts the menu
+      # instead of waiting behind it. EasyRPG's own `ProcessSceneActionCommand`
+      # does exactly this: `if (GetAtbMode() == AtbMode_atb_active &&
+      # IsBattleActionPending()) SetState(State_Battle)`. The interrupting
+      # turn plays out, then -- because the commanded actor's gauge is still
+      # held full -- the idle loop reopens its menu. In wait mode this check
+      # is skipped and the menu stays up until the player commits, matching
+      # the reference's `IsBattleActionPending` gate being ANDed with active
+      # mode only.
+      def drive_battle_command
+        if gauge_battle? && active_atb? && (b = interrupting_ready_combatant)
+          start_gauge_action(b)
+          return
+        end
+        super
+      end
+
+      # The ready combatant whose action is pending behind the command menu in
+      # active mode: the first full-gauge battler the idle loop would act
+      # automatically -- i.e. not the actor whose menu is up and not one a
+      # controllable party member whose own menu would simply wait its turn.
+      def interrupting_ready_combatant
+        battle = @ui[:battle]
+        cur = current_actor
+        battle.ready_combatants.find { |c| c != cur && !controllable?(c) }
       end
 
       # The gauge battle's counterpart to #start_round_animation: begin the one

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -44,14 +44,20 @@ class RPG2k
       # Skill=2, Equipment=3, Save=4, Status=5, Row=6, Order=7, Wait=8; Quit=9
       # is never itself in the list -- `Scene_Menu` appends it unconditionally
       # after the loop, which #build_commands mirrors below). Row (battle
-      # front/back rank) and Wait (the ATB toggle) have no entry here and are
-      # silently skipped: they are RPG2003 battle-system features this runtime
-      # does not model, the same reported-gap precedent the Toggle ATB Mode
-      # (5003) event command entry already establishes elsewhere. Order
-      # (party reordering, id 7) *is* modelled -- unlike Row/Wait it has no
-      # battle-system dependency at all, just Game::Party#reorder and
-      # Scene::Order (see #select_command's :order branch). A real RPG2003
-      # game's array (mtf-meido-action's is `[1, 2, 3, 4, 5, 6, 7, 8]`,
+      # front/back rank) has no entry here and is silently skipped: it is an
+      # RPG2003 battle-system feature this runtime does not model, the same
+      # reported-gap precedent the Toggle ATB Mode (5003) event command entry
+      # already establishes elsewhere. Wait (id 8) *is* modelled: it flips the
+      # save-system `atb_mode` toggle (LSD chunk 140) that makes a gauge
+      # battle's command menu freeze (wait) or keep running (active) -- the
+      # Wait-off (active) mode follow-up ADR 0054 named -- and its label
+      # shows the *current* mode via the `wait_on` / `wait_off` terms, exactly
+      # as EasyRPG's own Wait row does (`GetAtbMode() == wait ? wait_on :
+      # wait_off`, and #select_command's :wait branch relabels it after
+      # flipping). Order (party reordering, id 7) is also modelled -- unlike
+      # Row it has no battle-system dependency at all, just Game::Party#
+      # reorder and Scene::Order (see #select_command's :order branch). A real
+      # RPG2003 game's array (mtf-meido-action's is `[1, 2, 3, 4, 5, 6, 7, 8]`,
       # confirmed by `db.rpg2003?` and reading chunk 22 by id under the CRuby
       # host harness, where `db.system` itself collides with Kernel#system)
       # can both omit a command (hiding it, e.g. a game with no Save on
@@ -63,7 +69,8 @@ class RPG2k
         3 => [:equip, :battle_equipment, "Equip"],
         4 => [:save, :battle_save, "Save"],
         5 => [:status, :status, "Status"],
-        7 => [:order, :order, "Order"]
+        7 => [:order, :order, "Order"],
+        8 => [:wait, :wait, "Wait"]
       }.freeze
 
       def initialize parent, state
@@ -206,6 +213,11 @@ class RPG2k
       # (falsy) on the RPG2000-shaped fixtures the scene-check harness builds,
       # which is the correct reading for them too: they carry no `menu_commands`
       # chunk any more than a genuine RPG2000 database does.
+      #
+      # The Wait command's label is live: it shows the *current* active-time
+      # mode (`wait_on` when wait, `wait_off` when active), the same reading
+      # EasyRPG's own menu uses, so the row the player just picked reads
+      # "Wait On" while they are about to turn wait mode *off*.
       def build_commands
         keys = if db.rpg2003?
                  ids = db.system.menu_commands || []
@@ -213,7 +225,21 @@ class RPG2k
                else
                  RPG2K_COMMAND_KEYS
                end
-        keys.map { |key, term_name, fallback| [key, term(term_name, fallback)] }
+        keys.map { |key, term_name, fallback| [key, wait_term_for(key, term_name, fallback)] }
+      end
+
+      # The label for a command row: the Wait row is dynamic (the current
+      # mode's term), every other row is a plain Term lookup.
+      def wait_term_for(key, term_name, fallback)
+        return wait_label if key == :wait
+        term(term_name, fallback)
+      end
+
+      # The Wait command row's label: `wait_on` while the fight is set to
+      # pause on its command menu (wait mode), `wait_off` once it is active.
+      # Defaults match the terms' own RPG2003 defaults ("Wait: On" / "Wait: Off").
+      def wait_label
+        @state.atb_mode == 1 ? term(:wait_off, 'Wait Off') : term(:wait_on, 'Wait On')
       end
 
       def build_windows
@@ -257,6 +283,23 @@ class RPG2k
       def refresh_cursor
         @command.cursor_rect =
           Rect.new(0, @index * LINE_H, @command.contents.width, LINE_H)
+      end
+
+      # Redraw the command window's label list. The Wait row's label is live
+      # (see #wait_label), so flipping the toggle (#select_command's :wait
+      # branch) has to repaint it -- the same redraw EasyRPG's
+      # `SetItemText(index, ...)` performs for the relabelled row, applied to
+      # the whole list here since this engine draws the command window as one
+      # bitmap rather than per-row windows. Clears and re-draws the existing
+      # contents bitmap in place, so the window object and cursor stay put.
+      def redraw_command_labels
+        cc = @command.contents
+        cc.clear
+        cc.font.color = Color.new(255, 255, 255, 255)
+        @commands.each_with_index do |(_key, label), i|
+          cc.draw_text 0, i * LINE_H + 2, cc.width, LINE_H, label
+        end
+        refresh_cursor
       end
 
       # Height of one party-status row (see #build_windows's own `y = i *
@@ -313,6 +356,16 @@ class RPG2k
             play_system_se(SFX_DECISION)
             @parent.push Scene::Order.new(@parent, @state)
           end
+        when :wait
+          # The active-time Wait/active toggle, ported from EasyRPG's own
+          # `Scene_Menu::UpdateCommand` Wait branch: play the Decision SE,
+          # flip `SaveSystem.atb_mode` (0 wait <-> 1 active), and relabel the
+          # row to the other mode's term. The gauge battle scene reads the
+          # same field (#atb_accumulating? in battle_rpg2k3.rb).
+          play_system_se(SFX_DECISION)
+          @state.atb_mode = @state.atb_mode == 1 ? 0 : 1
+          @commands[@index] = [:wait, wait_label]
+          redraw_command_labels
         when :save
           # A disabled Save command (Change Save Access off) just refuses the
           # selection outright -- confirmed against EasyRPG's own

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -238,6 +238,11 @@ def check_game(dir)
   state.teleport_access = true
   state.escape_access = true
   state.save_count = 7
+  # Wait-off (active) ATB: the save-system toggle (LSD chunk 140, ADR 0054's
+  # follow-up). Set it non-default so the round-trip proves it is written and
+  # read back; the default (0, wait mode) is pinned by the scene check's
+  # fresh-state assertion ("a fresh state starts in wait mode").
+  state.atb_mode = 1
   if state.party.leader
     state.party.leader.set_charset('HeroAlt', 5)
     state.party.leader.name = 'Renamed'
@@ -314,6 +319,7 @@ def check_game(dir)
   eq true, round.teleport_access, 'to_lsd: teleport_access'
   eq true, round.escape_access, 'to_lsd: escape_access'
   eq 7, round.save_count, 'to_lsd: save_count'
+  eq 1, round.atb_mode, 'to_lsd: the wait-off atb_mode survives the round-trip'
   if round.party.leader
     eq 'HeroAlt', round.party.leader.charset_name, 'to_lsd: leader sprite override'
     eq 5, round.party.leader.charset_index, 'to_lsd: leader sprite index'

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13026,6 +13026,81 @@ check 'a ready but restricted (asleep) party member\'s gauge fires a silent no-o
   eq true, hero.queued_no_act, 'the do-nothing restriction was locked in for the turn'
 end
 
+# -- Wait-off (active) mode: the command menu and the atb_mode toggle --------
+#
+# ADR 0054's follow-up: the gauge fight's Wait/active presentation. The toggle
+# is the save-system `atb_mode` field (LSD chunk 140), flipped by the field
+# menu's Wait command -- *not* a Battle Commands database field, correcting
+# the ADR's own premise. In wait mode (default) the gauges freeze while any
+# command menu is open; in active mode they keep filling and a ready
+# non-controllable combatant's action interrupts the menu (EasyRPG's
+# `ProcessSceneActionCommand`'s `GetAtbMode() == active && IsBattleActionPending()`
+# gate). These checks drive both through the 2003 scene.
+
+check 'wait mode: the command menu freezes every gauge, enemy gauges included' do
+  scene, st = battle_scene_with_pages({}, rpg2003: true,
+                                      battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
+  st.atb_mode = 0 # wait mode -- also the default
+  ui = battle_until_phase(scene, :command, 250)
+  ok ui, 'the battle opened to the ready actor\'s menu'
+  hero = ui[:allies][0]
+  eq true, hero.gauge_full?, 'the commanded actor\'s gauge is held full'
+  enemy = ui[:battle].enemy(0)
+  # Park the enemy mid-fill so the freeze is measurable: under wait mode its
+  # gauge must not move while the menu stays up.
+  enemy.gauge = Game::Battle::GAUGE_MAX / 2
+  20.times { scene.update }
+  eq Game::Battle::GAUGE_MAX / 2, enemy.gauge,
+     'wait mode: the enemy\'s gauge does not fill while the command menu is open'
+end
+
+check 'active mode: the command menu keeps the gauges filling, and a ready ' \
+      'enemy\'s action interrupts it' do
+  scene, st = battle_scene_with_pages({}, rpg2003: true,
+                                      battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
+  st.atb_mode = 1 # Wait-off (active)
+  ui = battle_until_phase(scene, :command, 250)
+  ok ui, 'the battle opened to the ready actor\'s menu'
+  enemy = ui[:battle].enemy(0)
+  enemy.gauge = Game::Battle::GAUGE_MAX / 2
+  20.times { scene.update }
+  ok enemy.gauge > Game::Battle::GAUGE_MAX / 2,
+     'active mode: the enemy\'s gauge keeps filling while the command menu is open'
+  ui = battle_ui(scene)
+  eq :command, ui[:phase], 'the menu is still up (no interrupt yet -- the enemy is not ready)'
+  # Make the enemy ready: in active mode its full gauge fires *now*, mid-menu.
+  enemy.gauge = Game::Battle::GAUGE_MAX
+  scene.update
+  ui = battle_ui(scene)
+  eq :animate, ui[:phase], 'a ready enemy\'s action interrupts the open command menu'
+  eq 0, enemy.gauge, 'the interrupting enemy\'s gauge was consumed'
+  # The interrupting turn plays out -- its action banner holds for
+  # BATTLE_ANIM_FRAMES (90) frames -- then, because the commanded actor's
+  # gauge is still held full, the idle loop reopens its menu.
+  ui = nil
+  150.times do
+    scene.update
+    ui = battle_ui(scene)
+    break if ui && ui[:phase] == :command
+  end
+  eq :command, ui[:phase], 'after the interrupt resolves, the ready actor\'s menu returns'
+end
+
+check 'wait mode: a ready enemy waits behind the command menu, no interrupt' do
+  scene, st = battle_scene_with_pages({}, rpg2003: true,
+                                      battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
+  st.atb_mode = 0 # wait mode
+  ui = battle_until_phase(scene, :command, 250)
+  ok ui, 'the battle opened to the ready actor\'s menu'
+  enemy = ui[:battle].enemy(0)
+  enemy.gauge = Game::Battle::GAUGE_MAX
+  scene.update
+  ui = battle_ui(scene)
+  eq :command, ui[:phase], 'wait mode: a ready enemy does not interrupt the open menu'
+  eq Game::Battle::GAUGE_MAX, enemy.gauge,
+     'and its gauge is left full, waiting for the menu to close'
+end
+
 check 'an RPG2003 battle_type 0 (traditional) fight still runs the round machine, never the gauge idle loop' do
   scene, = battle_scene_with_pages({}, rpg2003: true,
                                    battlecommands: OpenStruct.new(battle_type: 0, placement: 1))
@@ -13941,16 +14016,41 @@ check 'Scene::Menu: an RPG2003 database drives the command list from ' \
       'System.menu_commands, Status and Order included' do
   # mtf-meido-action's own array, id-for-id (confirmed by loading its real
   # RPG_RT.ldb): every one of RPG2003's eight customizable ids, in ascending
-  # order. Row (6) and Wait (8) are RPG2003 battle-system features this
-  # runtime does not model (the same reported-gap precedent as Toggle ATB
-  # Mode, 5003) and are silently skipped; Order (7) has no such dependency and
-  # is offered, same as Status; End Game is appended unconditionally, matching
+  # order. Row (6) is an RPG2003 battle-system feature this runtime does not
+  # model (the same reported-gap precedent as Toggle ATB Mode, 5003) and is
+  # silently skipped; Wait (8) -- the ATB toggle -- *is* modelled (it flips
+  # the save-system `atb_mode` field, ADR 0054's follow-up) and is offered
+  # with its current-mode label; Order (7) has no such dependency and is
+  # offered, same as Status; End Game is appended unconditionally, matching
   # EasyRPG's own unconditional Quit push outside the customized loop.
   db = fake_db(rpg2003: true, menu_commands: [1, 2, 3, 4, 5, 6, 7, 8])
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)
   keys = scene.instance_variable_get(:@commands).map(&:first)
-  eq [:item, :skill, :equip, :save, :status, :order, :end_game], keys,
-     'Status (id 5) and Order (id 7) are offered, Row/Wait (6/8) are dropped rather than crashing'
+  eq [:item, :skill, :equip, :save, :status, :order, :wait, :end_game], keys,
+     'Status (id 5), Order (id 7) and Wait (id 8) are offered, Row (6) is dropped rather than crashing'
+end
+
+check 'Scene::Menu: the Wait command shows the current atb_mode, and toggling ' \
+      'it flips the field and relabels the row' do
+  db = fake_db(rpg2003: true, menu_commands: [1, 8])
+  st = wrap_menu_state
+  eq 0, st.atb_mode, 'a fresh state starts in wait mode'
+  scene = menu_scene(RPG2k::Scene::Menu, st, db)
+  cmds = scene.instance_variable_get(:@commands)
+  eq :wait, cmds[1].first, 'the Wait command (id 8) is offered'
+  eq ['Wait On'], [cmds[1][1]], 'wait mode labels the row with wait_on'
+  scene.instance_variable_set(:@index, 1)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq 1, st.atb_mode, 'confirming Wait flips atb_mode to active'
+  cmds = scene.instance_variable_get(:@commands)
+  eq ['Wait Off'], [cmds[1][1]], 'the row relabels to wait_off after the flip'
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq 0, st.atb_mode, 'confirming again flips back to wait'
+  eq ['Wait On'], [cmds[1][1]], 'and the row relabels back to wait_on'
 end
 
 check 'Scene::Menu: RPG2003 System.menu_commands can reorder and omit commands' do


### PR DESCRIPTION
Implements ADR 0054's follow-up: the RPG2003 Wait/active toggle.

**What changed**

- The wait toggle lives on the **save system**, not the Battle Commands table
  (liblcf's `fields.csv` has no `wait` field there, correcting the ADR's own
  premise). The schema now decodes `SaveSystem.atb_mode` (LSD chunk 140) and
  `Game::State` carries it, writing the 2003-only chunk out only when non-zero
  so RPG2000 saves stay untouched.
- The field menu's **Wait command (id 8)** now appears for RPG2003 games that
  list it: the row shows the current mode via the `wait_on`/`wait_off` terms
  and confirming flips `atb_mode` and relabels the row.
- In a gauge battle (ADR 0054), **wait mode (default) freezes the charge
  gauges while a command menu is open**; **active mode keeps them filling and
  lets a ready non-controllable combatant's action interrupt the menu** —
  mirroring EasyRPG's `IsAtbAccumulating` and `ProcessSceneActionCommand`
  (`GetAtbMode() == active && IsBattleActionPending()`).

**Tests**

- New `rpg2k_scene_check.rb` checks: wait freezes an enemy's gauge behind the
  menu; active keeps it filling and a ready enemy's action interrupts and
  returns to the menu; a ready enemy waits in wait mode; the menu Wait row
  toggles and relabels.
- `rpg2k_save_load_check.rb` round-trips `atb_mode = 1` through `.lsd`.
- Full scene/logic/test-bed/gauge/command/row suites pass; native `mruby_test`
  and the rest of CTest pass; coverage and pre-commit clean.