### PR TITLE
audio: never resolve a track name to a directory

### DIFF
--- a/changelog.d/audio-directory-shadows-track.fixed.md
+++ b/changelog.d/audio-directory-shadows-track.fixed.md
@@ -1,0 +1,14 @@
+- A BGM/ME/BGS/SE whose name matches one of the game's own asset **folders** now
+  plays instead of failing to load. `RGSS::Audio`'s disk search probed each
+  candidate with `File.exist?`, which is also true for a directory — and because
+  `EXT_SPELLINGS` leads with the empty extension and `MUSIC_DIRS`/`SOUND_DIRS`
+  with the empty folder, the very first candidate for a track called `title` is
+  the bare `#{GAME_DIR}/title`, right where a released game keeps `Title/`,
+  `Battle/`, `Movie/` and friends. Nepheshel ships its title-screen graphics in
+  `Title/` beside its title theme in `Music/title.mid`; on a case-insensitive
+  filesystem (macOS, Windows) the folder matched first, the search stopped on it,
+  and `Mix_LoadMUS` was handed a directory — `Audio: failed to load music
+  '.../title'` for a MIDI sitting right there, so the title screen was silent.
+  The search now requires a regular file (`File.file?`), in both the plain and
+  the NFD spelling, and keeps looking past a directory. Covered by a new
+  `mruby-rgss` test.

--- a/mruby-rgss/mrbgem.rake
+++ b/mruby-rgss/mrbgem.rake
@@ -9,6 +9,11 @@ MRuby::Gem::Specification.new('mruby-rgss') do |spec|
   # File, so the standalone mrbtest build needs mruby-io. The loader itself
   # reads files through C stdio, so this is only needed for the tests.
   add_test_dependency 'mruby-io'
+  # The audio loader's directory-shadowing test (a folder named like a track,
+  # as Nepheshel's `Title/` sits beside its `Music/title.mid`) has to create a
+  # real directory to stand in for it, and Dir lives in its own core gem.
+  # Nothing in the engine's own code needs Dir, so this is test-only.
+  add_test_dependency 'mruby-dir'
   # The wave_blt test computes its expected phase with Math::PI. Math is part
   # of the full game's gem set (build_config.rb's rpg_maker_gems), but the
   # standalone mrbtest build only pulls this gem plus its declared

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1178,7 +1178,7 @@ module RGSS
       # is retried in NFD form, as Bitmap does.
       # Timed as `audio.resolve`: every Play SE/BGM/BGS/ME goes through here,
       # and a miss walks two roots x the kind's directories x EXT_SPELLINGS
-      # (each also in its NFD spelling), so the cost is a burst of File.exist?
+      # (each also in its NFD spelling), so the cost is a burst of File.file?
       # syscalls on the game-loop thread rather than anything audio-related.
       def resolve(filename, dirs)
         RGSS::Profiler.section("audio.resolve") { search_for(filename, dirs) }
@@ -1200,13 +1200,25 @@ module RGSS
       end
 
       # First of +base+ with each known extension appended that exists on disk
-      # (also trying the decomposed NFD form), or nil.
+      # as a *file* (also trying the decomposed NFD form), or nil.
+      #
+      # File.file?, not File.exist?: EXT_SPELLINGS leads with the empty
+      # extension and MUSIC_DIRS/SOUND_DIRS lead with the empty folder, so the
+      # very first candidate for a track named "title" is the bare
+      # `#{GAME_DIR}/title` -- and a game's asset folders sit right there.
+      # Nepheshel keeps its title-screen graphics in `Title/` beside its
+      # `Music/title.mid`, and on a case-insensitive filesystem (macOS, Windows)
+      # that directory answered File.exist? first. The search stopped on it and
+      # handed a directory to Mix_LoadMUS, which of course could not open it:
+      # "Audio: failed to load music '.../title'" on a game whose MIDI is right
+      # there in Music/. A directory is never a playable asset, so skip it and
+      # keep looking.
       def exist_with_ext(base)
         EXT_SPELLINGS.each do |ext|
           cand = "#{base}#{ext}"
-          return cand if File.exist?(cand)
+          return cand if File.file?(cand)
           nfd = RGSS.to_nfd(cand)
-          return nfd if nfd != cand && File.exist?(nfd)
+          return nfd if nfd != cand && File.file?(nfd)
         end
         nil
       end

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1370,6 +1370,41 @@ assert "RGSS::Audio finds an upper-case extension on disk" do
   end
 end
 
+assert "RGSS::Audio skips a directory that shadows a track name" do
+  # EXT_SPELLINGS leads with the empty extension and MUSIC_DIRS/SOUND_DIRS with
+  # the empty folder, so the first candidate for a track called "X" is the bare
+  # name "X" under the game root -- exactly where a released game keeps its
+  # asset *folders*. Nepheshel ships `Title/` (title-screen graphics) beside
+  # `Music/title.mid`, and on a case-insensitive filesystem that folder matched
+  # the bare candidate first: the search stopped on a directory, handed it to
+  # Mix_LoadMUS, and the title MIDI was silent ("failed to load music
+  # '.../title'") for a file sitting right there in Music/. A directory is never
+  # a playable asset.
+  dir = "test-shadowed-se"
+  path = "test-shadowed-se.wav"
+  Dir.mkdir(dir) unless Dir.exist?(dir)
+  File.open(path, "wb") { |io| io.write("RIFFtestWAVEfixture") }
+  class << RGSS::Audio
+    alias _se_play_orig4 _se_play
+    def _se_play(p, v, pi)
+      $audio_se_capture = [p, v, pi]
+      nil
+    end
+  end
+  begin
+    $audio_se_capture = nil
+    RGSS::Audio.se_play("test-shadowed-se")
+    assert_false $audio_se_capture.nil?, "the .wav should have resolved"
+    assert_equal path, $audio_se_capture[0]
+  ensure
+    class << RGSS::Audio
+      alias _se_play _se_play_orig4
+    end
+    File.delete(path) if File.exist?(path)
+    Dir.delete(dir) if Dir.exist?(dir)
+  end
+end
+
 assert "RGSS::Audio finds an upper-case extension in the archive" do
   # The same for a packed release: an archive entry name is whatever the editor
   # wrote, so it carries the same mixed-case extensions the disk tree does.


### PR DESCRIPTION
## The bug

Nepheshel's title screen is silent, and the log says its title MIDI could not be opened:

```
W sdl_audio.cxx:295] Audio: failed to load music
  '.../Nepheshel206Rbeta/title': Couldn't open '.../Nepheshel206Rbeta/title'
```

…for a file that is right there in `Music/title.mid`. Note the resolved path: no folder, no extension. The engine never looked in `Music/`.

`RGSS::Audio.exist_with_ext` probed each candidate with `File.exist?`, which is **also true for a directory**. `EXT_SPELLINGS` leads with the empty extension and `MUSIC_DIRS`/`SOUND_DIRS` with the empty folder, so the very first candidate `search_for` tries for a track called `title` is the bare `#{GAME_DIR}/title` — right where a released game keeps its asset folders. Nepheshel ships `Title/` (title-screen graphics) beside `Music/title.mid`, and on a case-insensitive filesystem (macOS, Windows) that folder matched. The search stopped on it and handed a directory to `Mix_LoadMUS`.

The miss did not even fall through to the archive lookup, because `resolve` returned a truthy path.

Verified against the engine's own mruby:

```
exist? true      directory? true      file? false
music exist? true   # Music/title.mid
```

Nothing to do with TiMidity (`Audio: MIDI instruments from '.../assets/timidity/timidity.cfg'` resolves fine) or with the Shift_JIS → UTF-8 / NFD retry path — the Japanese-named tracks were always fine. Scanning Nepheshel's `Music/` and `Sound/` against its root folders, `Music/title.mid` ↔ `Title/` is the only collision in that game, so exactly one track was affected. `SOUND_DIRS` has the same shape, so SE carried the same exposure.

## The fix

Require a regular file (`File.file?`) in both the plain and the NFD spelling, and keep looking past a directory. A directory is never a playable asset.

MV/MZ audio reaches the same function (`mruby-mvjs/mrblib/mv.rb` builds `"audio/bgm/#{name}"` and calls `RGSS::Audio.bgm_play`) and is covered by the same change, though no MV/MZ project has a directory inside `audio/bgm/` to collide with.

## Audit of the other resolvers

I checked every other asset resolver for the same defect. None have it, and the reason is uniform: **they decide by opening and reading the bytes, not by stat**, and a read of a directory fails.

| Resolver | Verdict |
| --- | --- |
| `Bitmap#initialize` (`mruby-rgss/mrblib/lib.rb:526`) — does probe a bare, extension-less candidate | Safe: acceptance is a successful full `fread` in `slurp_file` |
| `RPG::Cache` (XP/VX, `rgss_library.rb:102`) | Safe: no filesystem work at all; empty names short-circuit to `blank` |
| `mv_resolve_path` (`mvjs.cxx:1095`) | Safe: pure string join, no existence test, no extension probing |
| `find_font_path` (`lib.cxx:2201`) / `default_font.cxx` | Safe: `readdir` + extension filter; `default_font.cxx:88` already rules a directory out explicitly, with a comment saying why |
| `rgssad.rb:55`, `rgss_data.rb:296`/`:115` | Same directory-blind `File.exist?`, but every candidate carries a mandatory extension (`Game.rgssad`, `Data/System.rxdata`) so no bare-name probe exists, and each caller degrades through a `rescue`. Left alone to keep this diff to one logical change. |

## Verification

- New `mruby-rgss` test, `RGSS::Audio skips a directory that shadows a track name`: creates a directory and a `.wav` sharing a base name and asserts the `.wav` resolves. Confirmed to be a real guard — with the predicate reverted to `File.exist?` it fails with `expected "test-shadowed-se.wav", got "test-shadowed-se"`.
- `ruby scripts/rgss_cruby_test_check.rb` — passes.
- `./build/mruby/host/bin/mrbtest` — the new test passes. One pre-existing failure on this machine, `RGSS::Audio finds an upper-case extension on disk`, which needs a case-sensitive filesystem and fails on macOS APFS on `master` too; `scripts/rgss_cruby_test_check.rb:33-46` documents and skips it for exactly that reason. Unrelated to this change — both predicates are true for that real file.
- End to end on the real game: the warning is gone, and `RGSS::Audio.resolve("title", MUSIC_DIRS)` now answers `.../Nepheshel206Rbeta/Music/title.mid`.
- `pre-commit run --all-files` — passes.

`mruby-dir` is added as a **test** dependency of `mruby-rgss`: the new test has to create a real directory, and `Dir` lives in its own core gem. Nothing in the engine's own code needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
