### PR TITLE
terminal: restore the cursor and normal screen when a terminal backend exits

### DIFF
--- a/changelog.d/terminal-restore-cursor.fixed.md
+++ b/changelog.d/terminal-restore-cursor.fixed.md
@@ -1,0 +1,10 @@
+- The terminal backends (`--iterm` / `--sixel`) now hand the shell back a
+  visible cursor and the normal screen. Their teardown emits show-cursor
+  (`ESC [ ? 25 h`) and leave-alternate-screen (`ESC [ ? 1049 l`) through
+  `terminal_write`, which the async stdout writer had quietly swallowed since
+  it landed: `restore_terminal` stops the writer thread *before* writing them,
+  and `writer_enqueue` drops every byte once the writer is down (and, before
+  that, only buffers into `g_encode_buf`, which nothing drains after the final
+  frame). Only the `tcsetattr` raw-mode restore -- a direct syscall -- survived,
+  so quitting a terminal-mode game left the prompt cursorless on top of the last
+  game frame. Teardown now clears the writer hook and writes straight to stdout.

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -153,6 +153,12 @@ std::atomic<bool> g_has_frame{false};   // true when a frame is enqueued
 std::thread g_writer_thread;
 std::atomic<bool> g_writer_running{false};
 
+// Where terminal_write sends its bytes.  Null until a terminal display exists
+// (and again once restore_terminal has torn the writer down), in which case
+// terminal_write falls back to writing stdout directly.
+using enqueue_fn = void (*)(const char* p, size_t n);
+enqueue_fn g_enqueue = nullptr;
+
 // Accumulate `n` bytes from `p` into g_encode_buf.  Called during encoding via
 // terminal_write → g_enqueue.  All writes on the render thread; no contention.
 void writer_enqueue(const char* p, size_t n) {
@@ -307,6 +313,15 @@ void restore_terminal() {
     if (g_writer_thread.joinable())
       g_writer_thread.join();
   }
+
+  // Send the teardown sequences below straight to stdout.  They must not go
+  // through the writer any more: writer_enqueue drops everything once
+  // g_writer_running is false (just cleared above), and even before that it
+  // only appends to g_encode_buf, which nothing drains after the last frame --
+  // either way the show-cursor and leave-alt-screen bytes would never reach the
+  // terminal, leaving the shell with an invisible cursor on the alternate
+  // screen.
+  g_enqueue = nullptr;
 
   // Undo the visual state first (while still in raw mode), then hand the
   // terminal back to the shell.  Leaving the alternate screen buffer restores
@@ -597,11 +612,6 @@ void terminal_append_console(std::string& s) {
     s += "\x1b[0m\r\n";
   }
 }
-
-// Callback wired during init: routes encoder output to the async writer instead
-// of direct ::write calls.
-using enqueue_fn = void (*)(const char* p, size_t n);
-enqueue_fn g_enqueue = nullptr;
 
 void terminal_write(const char* p, size_t n) {
   if (g_stats)


### PR DESCRIPTION
## Problem

After playing in `--iterm` (or `--sixel`) mode, the shell comes back with **no cursor**, still sitting on the alternate screen over the last game frame.

`init_terminal()` hides the cursor (`ESC[?25l`) and enters the alt screen (`ESC[?1049h`); `restore_terminal()` is supposed to undo both. It doesn't, and hasn't since the async stdout writer landed in 967d153c:

1. `restore_terminal()` clears `g_writer_running` and joins the writer thread first (`terminal.cxx:305`).
2. It then calls `show_cursor()` / writes the leave-alt sequence via `terminal_write` (`terminal.cxx:316`).
3. `terminal_write` routes through `g_enqueue`, which `terminal_display_create` installed permanently as `writer_enqueue` — and `writer_enqueue` returns immediately when `g_writer_running` is false, so the bytes are dropped.

Reordering alone wouldn't help: `writer_enqueue` only appends to `g_encode_buf`, which is drained solely by `flush_cb` per frame, and no frame follows the teardown.

Only the `tcsetattr` raw-mode restore — a direct syscall — survived, which is why input/echo look normal while the cursor stays gone. Both quit paths (`q`/Ctrl-C, and the `atexit`/signal handlers) and both terminal backends are affected.

## Fix

Clear the writer hook in `restore_terminal()` once the thread is joined, so `terminal_write` falls back to its direct `::write` path for the teardown sequences. The `enqueue_fn`/`g_enqueue` declaration moves up into the writer's state block so it is visible there (it was file-scope with external linkage and is only used in this translation unit).

## Verification

Run under a pty with `script(1)`, `--iterm --timeout_ms=3000` against Nepheshel, checking the tail of the captured stream:

```
before: ...4sLoKRzz++AEAyCc/rC+0ndcAAAAASUVORK5CYII=^G
after:  ...4sLoKRzz++AEAyCc/rC+0ndcAAAAASUVORK5CYII=^G^[[?25h^[[2J^[[?1049l
```

Before, the stream stops at the BEL terminating the last inline image; after, it ends with show-cursor, erase and leave-alt-screen.

`cmake --build build -t test` passes except for a pre-existing, unrelated macOS failure (`RGSS::Audio finds an upper-case extension on disk` — case-insensitive APFS returns `test-upper-se.wav` where the test expects `.WAV`); it fails the same way on `master`, and this diff touches only `mruby-rgss/src/terminal.cxx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)