### PR TITLE
rpg2003: wire the Toggle ATB Mode event command (5003)

### DIFF
--- a/changelog.d/rpg2003-toggle-atb-mode-command.added.md
+++ b/changelog.d/rpg2003-toggle-atb-mode-command.added.md
@@ -1,0 +1,10 @@
+- The **Toggle ATB Mode event command (5003) is implemented**: it flips the
+  same save-system `atb_mode` field the field menu's Wait command targets, so
+  a gauge battle switches live between wait and active mid-fight — EasyRPG's
+  `Game_System::ToggleAtbMode()` (`data.atb_mode = !data.atb_mode`). The
+  opcode now has a `Cmd::TOGGLE_ATB_MODE` constant (the last of liblcf's
+  2k3e 500x block to be wired) and a `do_toggle_atb_mode` handler that runs
+  the event straight on. Covered by new `rpg2k_logic_check.rb` checks
+  (the constant matches the LCF Code enum; the command flips the field both
+  ways and does not pause) and a `rpg2k_scene_check.rb` check driving a
+  5003-bearing battle page through a live gauge fight.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1653,14 +1653,12 @@ The work below is roughly ordered by the critical path to a walkable game
   Game** (5002) leave the map for the loader / quit; **Toggle Fullscreen** (5004)
   and **Open Video Options** (5005) are logged no-ops because this build's
   display backend has neither, the same answer EasyRPG gives on a platform whose
-  window cannot change mode. Still open here: **Toggle ATB Mode** (5003), which
-  would switch a gauge fight between this engine's active-time turn cycle (ADR
-  0054 — the gauge-driven battle now modelled for the gauge presentation) and
-  the round-based machine; the field-menu Wait command already flips the
-  `atb_mode` save-system field the event command would target (see the `Wait`
-  command paragraph in the field-menu section), but the battle still never
-  reads a per-fight toggle, so the *event* command stays a reported gap rather
-  than a silent no-op. The opcodes were read out of liblcf's
+  window cannot change mode. ✅ **Toggle ATB Mode (5003) is now implemented
+  too**: it flips the same save-system `atb_mode` field the field-menu Wait
+  command targets (see the `Wait` command paragraph in the field-menu
+  section), so a gauge battle switches live between wait and active mid-fight
+  — EasyRPG's `Game_System::ToggleAtbMode()` (`data.atb_mode =
+  !data.atb_mode`). The opcodes were read out of liblcf's
   `EventCommand::Code` enum, which
   also corrected `analyze_game.rb` — it had Change Class / Change Battle Commands
   at 12610 / 12710, numbers the enum does not define at all.
@@ -2432,12 +2430,12 @@ The work below is roughly ordered by the critical path to a walkable game
   through `RPG2K3_COMMAND_IDS` — a small id→command table that (at the time)
   had **no** entry for Row (battle front/back rank), Order (party reordering)
   or Wait (the ATB toggle), so a 2003 game listing them simply did not offer
-  them, the identical reported-gap precedent the Toggle ATB Mode (5003) event
-  command entry above already establishes for the same unmodelled RPG2003
-  battle system — rather than crashing or inventing a screen. Covered by new
+  them, the same reported-gap discipline the Toggle ATB Mode (5003) event
+  command followed for the same unmodelled RPG2003 battle system — rather
+  than crashing or inventing a screen. Covered by new
   `scripts/rpg2k_scene_check.rb` checks (a non-2003 fixture never offers
   Status at all; a 2003 fixture's full eight-id array offers Status and drops
-  Row/Order/Wait; a 2003 fixture that reorders and omits commands is honoured
+  Row; a 2003 fixture that reorders and omits commands is honoured
   end to end, including actually opening the reordered Status screen),
   confirmed to fail against the pre-fix code (Status always offered
   regardless of edition; a 2003 reorder/omission silently ignored) before the

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -141,6 +141,9 @@ Behavioral notes and deliberate simplifications:
   combatant's action **interrupts** the menu — EasyRPG's
   `ProcessSceneActionCommand`'s `GetAtbMode() == active &&
   IsBattleActionPending()` gate (`IsAtbAccumulating` returns `active_atb`
-  during SelectCommand/Item/Skill/EnemyTarget/AllyTarget). The field-menu
-  Toggle ATB Mode event command (5003) remains unmodelled (its menu entry is
-  the interactive path to the same field).
+  during SelectCommand/Item/Skill/EnemyTarget/AllyTarget). The Toggle ATB Mode
+  event command (5003) is the event-driven path to the same field: it flips
+  `atb_mode` just like the menu Wait command, so a gauge battle switches live
+  between wait and active mid-fight — `Cmd::TOGGLE_ATB_MODE` /
+  `do_toggle_atb_mode`, matching EasyRPG's `Game_System::ToggleAtbMode()`
+  (`data.atb_mode = !data.atb_mode`).

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -24,6 +24,7 @@ module Game
       CHANGE_BATTLE_COMMANDS = 1009
       OPEN_LOAD_MENU         = 5001
       EXIT_GAME              = 5002
+      TOGGLE_ATB_MODE        = 5003
       TOGGLE_FULLSCREEN      = 5004
       OPEN_VIDEO_OPTIONS     = 5005
       SHOW_MESSAGE     = 10110
@@ -953,6 +954,7 @@ module Game
       when Cmd::CALL_COMMON_EVENT then do_call_common_event cmd
       when Cmd::OPEN_LOAD_MENU   then do_open_load_menu cmd
       when Cmd::EXIT_GAME        then do_exit_game cmd
+      when Cmd::TOGGLE_ATB_MODE  then do_toggle_atb_mode cmd
       when Cmd::TOGGLE_FULLSCREEN then do_toggle_fullscreen cmd
       when Cmd::OPEN_VIDEO_OPTIONS then do_open_video_options cmd
       when Cmd::ERASE_EVENT      then @erase_requested = true
@@ -3001,6 +3003,18 @@ module Game
     def do_exit_game(_cmd)
       @wait_kind = :exit_game
       @waiting = true
+    end
+
+    # Toggle ATB Mode (5003): flip the save-system wait/active toggle
+    # (`SaveSystem.atb_mode`, LSD chunk 140) between wait (0) and active (1) —
+    # the same field the field menu's Wait command (id 8) flips, so a gauge
+    # battle's command menu starts freezing / keeping the gauges running
+    # accordingly (RPG2k3::Scene::Battle#atb_accumulating? reads it live).
+    # EasyRPG's own `Game_System::ToggleAtbMode()` does exactly this
+    # (`data.atb_mode = !data.atb_mode`), and RPG_RT's 2k3e "Toggle ATB Mode"
+    # command is the event-driven path to the same setting. The event runs on.
+    def do_toggle_atb_mode(_cmd)
+      @state.atb_mode = @state.atb_mode == 1 ? 0 : 1
     end
 
     # Toggle Fullscreen (5004) / Open Video Options (5005): the 2k3e display

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -45,9 +45,10 @@ class RPG2k
       # is never itself in the list -- `Scene_Menu` appends it unconditionally
       # after the loop, which #build_commands mirrors below). Row (battle
       # front/back rank) has no entry here and is silently skipped: it is an
-      # RPG2003 battle-system feature this runtime does not model, the same
-      # reported-gap precedent the Toggle ATB Mode (5003) event command entry
-      # already establishes elsewhere. Wait (id 8) *is* modelled: it flips the
+      # RPG2003 battle-system feature this runtime does not model (Row's
+      # front/back mechanic itself is modelled -- ADR 0053 -- but the
+      # per-actor row *assignment* in the menu is not). Wait (id 8) *is*
+      # modelled: it flips the
       # save-system `atb_mode` toggle (LSD chunk 140) that makes a gauge
       # battle's command menu freeze (wait) or keep running (active) -- the
       # Wait-off (active) mode follow-up ADR 0054 named -- and its label

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15012,6 +15012,7 @@ check 'RPG2003 event opcodes match the LCF Code enum' do
   eq 1009, IC::CHANGE_BATTLE_COMMANDS
   eq 5001, IC::OPEN_LOAD_MENU
   eq 5002, IC::EXIT_GAME
+  eq 5003, IC::TOGGLE_ATB_MODE
   eq 5004, IC::TOGGLE_FULLSCREEN
   eq 5005, IC::OPEN_VIDEO_OPTIONS
 end
@@ -15199,6 +15200,22 @@ check 'Toggle Fullscreen / Open Video Options run on without pausing' do
   it.update
   ok !it.waiting?, 'neither command blocks the event'
   eq true, st.switches[1]
+end
+
+check 'Toggle ATB Mode (5003) flips the wait/active atb_mode and runs on' do
+  st = new_state(rpg2003: true)
+  eq 0, st.atb_mode, 'a fresh state starts in wait mode'
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::TOGGLE_ATB_MODE, []),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'the toggle does not block the event'
+  eq 1, st.atb_mode, 'the toggle flipped wait mode to active'
+  eq true, st.switches[1], 'the event ran straight on past the toggle'
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::TOGGLE_ATB_MODE, [])])
+  it2.update
+  eq 0, st.atb_mode, 'a second toggle flips back to wait'
 end
 
 check 'Show Battle Animation (battle form) waits like the map form' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13101,6 +13101,26 @@ check 'wait mode: a ready enemy waits behind the command menu, no interrupt' do
      'and its gauge is left full, waiting for the menu to close'
 end
 
+check 'a battle-page Toggle ATB Mode (5003) flips the live fight to active' do
+  ic = Game::Interpreter::Cmd
+  # A TURN-gated page runs at the first turn boundary; its 5003 flips the
+  # same save-system `atb_mode` the field menu Wait command flips, live.
+  pages = { 1 => troop_page([ECmd.new(ic::TOGGLE_ATB_MODE, [])]) }
+  scene, st = battle_scene_with_pages(pages, rpg2003: true,
+                                      battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
+  eq 0, st.atb_mode, 'the fight begins in wait mode'
+  ui = battle_until_phase(scene, :command, 250)
+  ok ui, 'the gauge battle opened to the ready actor\'s menu'
+  eq 1, st.atb_mode, 'the 5003 page flipped the fight to active'
+  # And the flip is live: the enemy gauge now fills behind the menu, the
+  # active-mode behaviour pinned by the checks above.
+  enemy = ui[:battle].enemy(0)
+  enemy.gauge = Game::Battle::GAUGE_MAX / 2
+  20.times { scene.update }
+  ok enemy.gauge > Game::Battle::GAUGE_MAX / 2,
+     'and the flipped-to-active fight keeps the gauges filling behind the menu'
+end
+
 check 'an RPG2003 battle_type 0 (traditional) fight still runs the round machine, never the gauge idle loop' do
   scene, = battle_scene_with_pages({}, rpg2003: true,
                                    battlecommands: OpenStruct.new(battle_type: 0, placement: 1))
@@ -14017,11 +14037,10 @@ check 'Scene::Menu: an RPG2003 database drives the command list from ' \
   # mtf-meido-action's own array, id-for-id (confirmed by loading its real
   # RPG_RT.ldb): every one of RPG2003's eight customizable ids, in ascending
   # order. Row (6) is an RPG2003 battle-system feature this runtime does not
-  # model (the same reported-gap precedent as Toggle ATB Mode, 5003) and is
-  # silently skipped; Wait (8) -- the ATB toggle -- *is* modelled (it flips
-  # the save-system `atb_mode` field, ADR 0054's follow-up) and is offered
-  # with its current-mode label; Order (7) has no such dependency and is
-  # offered, same as Status; End Game is appended unconditionally, matching
+  # model and is silently skipped; Wait (8) -- the ATB toggle -- *is* modelled
+  # (it flips the save-system `atb_mode` field, ADR 0054's follow-up) and is
+  # offered with its current-mode label; Order (7) has no such dependency and
+  # is offered, same as Status; End Game is appended unconditionally, matching
   # EasyRPG's own unconditional Quit push outside the customized loop.
   db = fake_db(rpg2003: true, menu_commands: [1, 2, 3, 4, 5, 6, 7, 8])
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)


### PR DESCRIPTION
Wires the last unimplemented opcode of liblcf's 2k3e 500x block.

**What changed**

- Adds `Cmd::TOGGLE_ATB_MODE = 5003` (the constant the LCF Code enum defines;
  `analyze_game.rb` already knew it as `ToggleAtbMode`).
- Adds a `do_toggle_atb_mode` handler that flips the same save-system
  `atb_mode` field (LSD chunk 140) the field menu's Wait command (id 8)
  targets — EasyRPG's `Game_System::ToggleAtbMode()` (`data.atb_mode =
  !data.atb_mode`). Since `RPG2k3::Scene::Battle#atb_accumulating?` reads that
  field live, a gauge battle now switches between wait and active mid-fight
  when an event toggles it.

**Tests**

- `rpg2k_logic_check.rb`: the constant matches the LCF Code enum; the command
  flips the field both ways and runs the event straight on without pausing.
- `rpg2k_scene_check.rb`: a battle-page 5003 flips a live gauge fight to
  active — the enemy gauge fills behind the open command menu, the active-mode
  behaviour.
- Full scene (684) / logic (986) / test-bed suites pass; coverage and
  pre-commit clean.