### PR TITLE
flake: export LD_LIBRARY_PATH for libstdc++/zlib in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,25 @@
                 pkgs.winePackages.staging
                 pkgs.winePackages.fonts
               ];
+            # `.envrc`'s `layout python3` puts the project venv's bin/ ahead of
+            # everything else on PATH, so the venv's `python3` -- a symlink into
+            # this flake's nix store closure -- is what any `#!/usr/bin/env
+            # python3` script resolves to for the lifetime of the shell. That
+            # interpreter's loader is nix's own glibc (a hardcoded nix-store
+            # path, not /lib64/ld-linux-x86-64.so.2), which never reads the
+            # host distro's ld.so.cache or /usr/lib -- only its own RPATH
+            # closure and LD_LIBRARY_PATH. Binary wheels pulled into the venv
+            # with plain pip (numpy, which piper-tts depends on) expect the
+            # host's libstdc++/libz to be reachable the normal FHS way and
+            # fail with "cannot open shared object file" without them, as does
+            # any *other* `env python3` script picked up while cd'd into this
+            # directory (e.g. the system's /opt/rocm `amd-smi`, which needs
+            # libstdc++ the same way). Exporting these two nix-store lib dirs
+            # on LD_LIBRARY_PATH covers both cases without touching the host
+            # system.
+            shellHook = old.shellHook + ''
+              export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            '';
           });
         }
       );


### PR DESCRIPTION
## Summary
- `.envrc`'s `layout python3` prepends the project venv's `bin/` onto `PATH`, so any `#!/usr/bin/env python3` script picked up while cd'd into this repo — including the venv's own binaries and unrelated system tools like `amd-smi` — resolves to the venv's `python3`, a symlink into this flake's nix store closure.
- That interpreter's dynamic loader is nix's own glibc, which never reads the host distro's `ld.so.cache`/`/usr/lib` — only its RPATH closure and `LD_LIBRARY_PATH`. Binary wheels installed into the venv with plain pip (e.g. `numpy`, pulled in by `piper-tts`) then fail with `libstdc++.so.6: cannot open shared object file`, as does any other PATH-shadowed `env python3` script needing the same library.
- Adds a `shellHook` line to the `default` devShell exporting `LD_LIBRARY_PATH` to include the flake's `stdenv.cc.cc.lib` (libstdc++) and `zlib`, fixing both cases without any host/system changes.

## Test plan
- [x] `nix flake check --no-build` evaluates cleanly
- [x] `direnv reload` in the repo, then confirmed both `amd-smi version` and `piper --help` run without the missing-library error (previously both failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)