### PR TITLE
lcf: validate the RPG2003 battle-command list against real 2k3 data

### DIFF
--- a/changelog.d/rpg2003-battlecommands-real-testbed.added.md
+++ b/changelog.d/rpg2003-battlecommands-real-testbed.added.md
@@ -1,0 +1,11 @@
+- The RPG2003 battle-command schema is now **validated against a real 2003
+  database the way the rest of the 2003-specific table is**, closing the ADR 0048
+  follow-up: `scripts/lcf_testbed_check.rb` gains a `check_battlecommands` pass
+  (alongside its existing chunk-30 Classes check) that proves a 2003 database's
+  database-wide Battle Commands list (chunk 29) is present with a non-empty
+  `commands` table, that every positive reference in each actor's and class's
+  own `battle_commands` list names one of those commands, and that an RPG2000
+  database never carries the list at all (its editor has no such tab). Verified
+  against mtf-meido-action (12 commands covering every type value 0–6, with all
+  of its 12 actors' and 18 classes' positive references resolving) alongside the
+  RPG2000 Nepheshel data.

--- a/docs/adr/0048-rpg2003-battle-command-customization.md
+++ b/docs/adr/0048-rpg2003-battle-command-customization.md
@@ -4,7 +4,8 @@ Date: 2026-08-15
 
 ## Status
 
-Accepted
+Accepted — the open chunk-29 test-bed validation follow-up is now closed
+(2026-08-17, see the Consequences below).
 
 ## Context
 
@@ -32,11 +33,14 @@ data" section, ADR 0009/0011). Chunk 29 has no page on that wiki and no test
 game close at hand to diff against here. Its field/enum ids are instead
 transcribed from liblcf's own `generator/csv/{fields,enums}.csv` — the
 reference C++ implementation's declared format, not a byte-level guess — and
-checked against a hand-built synthetic blob the same way every other chunk in
-`mruby-lcf/test/lcf_test.rb` is (`db.battlecommands.commands[id].name/.type`).
-It has **not** been validated against a real 2k3 `RPG_RT.ldb` the way
-`lcf_testbed_check.rb` validates the rest of the 2003-specific schema; that
-remains a follow-up once a customized test-bed database is available.
+ checked against a hand-built synthetic blob the same way every other chunk in
+ `mruby-lcf/test/lcf_test.rb` is (`db.battlecommands.commands[id].name/.type`).
+It
+has **now** been validated against the real 2k3 test bed (mtf-meido-action)
+the way `lcf_testbed_check.rb` validates the rest of the 2003-specific schema
+— the "customized test-bed database" that was outstanding at the ADR's writing
+is mtf-meido-action itself, whose database-wide list carries twelve commands
+and whose actors/classes reference them (see the Consequences below).
 
 ## Decision
 
@@ -79,16 +83,31 @@ RPG2000 file, and any fixture built before this change) is unaffected —
 `battle_command_row` returns nil for every id, so `custom_battle_commands`
 always returns nil and the fixed four still draws exactly as before.
 
-Chunk 29's structural correctness rests on liblcf's own declared format plus
-a synthetic round-trip test, not a real save/database byte-diff — the
-weaker of the two forms of evidence this project otherwise insists on for
-LCF chunks. `lcf_testbed_check.rb` should pick up `db.battlecommands` once a
-2003 test-bed project that actually uses this tab is available, closing that
-gap the way the rest of the 2003-specific schema is already closed.
+Chunk 29's structural correctness rested on liblcf's own declared format plus
+a synthetic round-trip test, not a real save/database byte-diff — the weaker
+of the two forms of evidence this project otherwise insists on for LCF
+chunks. **That gap is now closed (2026-08-17).** The customized test bed the
+ADR was waiting for turned out to be the engine's existing RPG2003 test bed,
+mtf-meido-action: its database-wide Battle Commands list carries twelve
+commands whose types span the whole 0–6 range (Attack/Defend/Item/Escape and
+the skill/subskill rows — Holy Magic, Magic, Special, Ninpou, Nature,
+Atmosphere), `placement` 1 (automatic) and `battle_type` 2 (gauge); and its
+actors and classes reference them through their own `battle_commands` — all
+eighteen classes name a command, while the actor table is mostly the empty
+all-`-1` state with only actor 1 carrying a real list (a genuine edge case: no
+assertion may require an actor to have one). `lcf_testbed_check.rb` now proves
+the real 2003 bytes the way it already does for the Classes (chunk 30) table:
+the list is present with a non-empty `commands` field, every positive reference
+in any actor's or class's `battle_commands` names a command in that list (0
+Row and -1 empty slot are caller-handled sentinels and correctly name no entry),
+and an RPG2000 database (Nepheshel) never carries the list at all.
 
 Covered by `mruby-lcf/test/lcf_test.rb` (chunk 29 decode), new
 `scripts/rpg2k_logic_check.rb` checks (`battle_command_row` resolving a real
-entry, an undefined id, and a database with no chunk 29 at all), and new
+entry, an undefined id, and a database with no chunk 29 at all), new
 `scripts/rpg2k_scene_check.rb` checks (a skill-only customized list; a
 shortened, reordered Item/Defense list drawing and dispatching in its own
-order; Row alone falling back to the fixed four).
+order; Row alone falling back to the fixed four), `scripts/rpg2k3_battle_
+command_check.rb` (the chunk's top-level decode against mtf), and — since the
+cross-reference was what the synthetic test could not express — the new
+`check_battlecommands` pass in `scripts/lcf_testbed_check.rb` described above.

--- a/scripts/lcf_testbed_check.rb
+++ b/scripts/lcf_testbed_check.rb
@@ -104,12 +104,47 @@ class Checker
     end
   end
 
+  # The RPG2003 database-wide Battle Commands list (chunk 29): present in a 2003
+  # database with a non-empty `commands` table (field 10), and every actor's /
+  # class's own `battle_commands` (field 80) positive reference actually naming
+  # one of those commands. 0 (Row) and -1 (empty slot) name no entry -- they are
+  # caller-handled sentinels (per the chunk-29 schema) -- and are skipped here,
+  # the way #check_maker skips a zero class_id. A 2000 database must never carry
+  # the list at all (its editor has no such tab), mirroring the Classes-section
+  # (chunk 30) assertion above. This is the cross-reference, plus the 2000
+  # negative, that the structural pass in #walk and rpg2k3_battle_command_check
+  # .rb's top-level decode do not assert -- the "second form of evidence" ADR
+  # 0048 deferred, closing the gap the way every other 2003-specific table here
+  # is closed.
+  def check_battlecommands(db)
+    if db.rpg2003?
+      bc = db.battlecommands
+      fail 'ldb: 2003 database has no Battle Commands list (chunk 29)' unless bc
+      cmds = bc && bc.commands
+      fail 'ldb: 2003 Battle Commands list has no commands (field 10)' unless cmds
+      ids = {}
+      cmds&.each { |id, _c| ids[id] = true }
+      %w[player job].each do |table|
+        db.send(table)&.each do |id, row|
+          row.battle_commands&.each do |rid|
+            next unless rid.is_a?(Integer) && rid.positive?
+            fail "ldb.#{table}[#{id}].battle_commands reference #{rid} has no matching command" unless ids[rid]
+          end
+        end
+      end
+      puts "  battlecommands: #{ids.size} commands"
+    elsif db.battlecommands
+      fail 'ldb: RPG2000 database unexpectedly carries a Battle Commands list (chunk 29)'
+    end
+  end
+
   def check_game(dir)
     puts "== #{dir} =="
 
     db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
     walk(db, LCF::Schema::DATABASE, 'ldb')
     check_maker(db)
+    check_battlecommands(db)
 
     lmt = LCF::MapTree.new(File.open(File.join(dir, 'RPG_RT.lmt'), 'rb'))
     fail 'map tree has no start map' if lmt.initial.initial_map_id.to_i <= 0


### PR DESCRIPTION
Validate the engine's own 2003 test bed: the chunk-29 cross-reference

Closes the ADR 0048 follow-up the way the Classes (chunk 30) table is already
held to real 2k3 data.

**What changed**

- `scripts/lcf_testbed_check.rb` gains `check_battlecommands`, called
  alongside the existing `check_maker`, with the same positive+negative
  shape that chunk 30 gets inside `check_maker`:
    - a 2003 database must carry chunk 29 with a non-empty `commands`
      (field 10) table;
    - every positive reference in each actor's and class's own
      `battle_commands` (field 80) list must name one of those commands,
      the way `check_maker`'s existing `class_id` cross-reference does;
    - an RPG2000 database must not carry the list at all (its editor has
      no such tab), mirroring the chunk-30 absence assertion above it.
  0 (Row) and -1 (empty slot) are caller-handled sentinels and correctly
  name no entry, so they are skipped — the existing `walk` pass and
  `rpg2k3_battle_command_check.rb`'s top-level decode already prove the
  chunk parses, but the cross-reference between an actor's/class's own
  list and the shared table was what the synthetic test could not
  express.

- `docs/adr/0048-...md`: Status, one Context sentence and the two
  Consequences paragraphs now point at the real test-bed validation
  (mtf-meido-action's 12 commands, the full 0-6 type range, placement
  1 / battle_type 2, and its actors + classes referencing them, including
  the all-`-1` empty-actor edge case) and list the new check as coverage.

- `changelog.d/rpg2003-battlecommands-real-testbed.added.md` added.

**Tests**

- `ruby scripts/lcf_testbed_check.rb` — mtf (2003) now prints
  `battlecommands: 12 commands` and Nepheshel (2000, 2x) passes with no
  chunk 29; full run (all 1099 maps) exits 0.
- Non-vacuity: a throwaway script confirms the new predicate flags a
  bogus reference id (999) while accepting a real one (7), and that every
  positive reference in the real test bed resolves — i.e. the pass
  discriminates, not vacuous-passes.
- `rpg2k3_battle_command_check.rb` + `lcf_schema_coverage.rb` still green.
- `pre-commit run` on the touched files (trailing-whitespace,
  end-of-file-fixer, check-added-large-files) all pass.
