### PR TITLE
build: trim uni-algo to the Unicode tables this project uses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,10 @@ add_subdirectory(3rd/ng-log EXCLUDE_FROM_ALL)
 set(BUILD_TESTING ${old_build_testing})
 
 add_subdirectory(3rd/uni-algo EXCLUDE_FROM_ALL)
+# Drop the Unicode tables for the uni-algo modules nothing here calls -- see
+# cmake/uni-algo-trim.cmake for what is kept and why.
+include(cmake/uni-algo-trim.cmake)
+rpg2k_trim_uni_algo()
 
 # quickjs-ng: the embedded JavaScript engine for RPG Maker MV support (see
 # docs/adr/0004-javascript-maker-mv-quickjs.md). Only the `qjs` static library

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -76,6 +76,11 @@ add_subdirectory(${REPO_ROOT}/3rd/lvgl 3rd/lvgl EXCLUDE_FROM_ALL)
 # conversion). See the LVGL comment above for why the binary dir must be
 # "3rd/uni-algo".
 add_subdirectory(${REPO_ROOT}/3rd/uni-algo 3rd/uni-algo EXCLUDE_FROM_ALL)
+# Drop the Unicode tables for the uni-algo modules nothing here calls. On the
+# PSP this is live RAM, not just image size: every PT_LOAD segment of the EBOOT
+# is mapped into the console's ~24 MB at launch. See cmake/uni-algo-trim.cmake.
+include(${REPO_ROOT}/cmake/uni-algo-trim.cmake)
+rpg2k_trim_uni_algo()
 
 # Build libmruby.a for the psp target via mruby's own rake-based build system
 # (build_config.rb's `psp` MRuby::CrossBuild), the same way the root

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -170,14 +170,18 @@ growing unbounded on plain malloc, so the interpreter OOMs into a catchable
 4 MB `LV_MEM_SIZE` therefore covers only LVGL's own widgets and internals, and
 the decoded bitmaps stay in a third, uncapped pool as before.
 
-Beyond the arena, this port also shrinks the live footprint in three smaller
+Beyond the arena, this port also shrinks the live footprint in four smaller
 ways: the LVGL partial-render buffers are sized to the game's own canvas
 (RPG2k's 320×240 fits ~38 KB per buffer instead of the fixed panel-width 64 KB
 each — see `psp.cxx`), the EBOOT links none of LVGL's examples/demos and only
 the widgets the RGSS layer actually uses (canvas/image/label; the default theme
-that pulled every widget into the link is off), and the mruby cross-build runs
+that pulled every widget into the link is off), the mruby cross-build runs
 the embedded tuning knobs (`MRB_HEAP_PAGE_SIZE`/`KHASH_INITIAL_SIZE` — see
-`build_config.rb`). The `RPG2K_PSP_BRINGUP` heartbeat is the place to read the
+`build_config.rb`), and the uni-algo Unicode tables are cut to the modules this
+project calls (`cmake/uni-algo-trim.cmake`), which alone is ~506 KB — on the
+PSP every PT_LOAD segment of the EBOOT is mapped into RAM at launch, so a
+read-only table is live memory, not just file size. The
+`RPG2K_PSP_BRINGUP` heartbeat is the place to read the
 result: `free`/`maxfree` from `sceKernelTotalFreeMemSize` are the device's real
 free RAM, `lvgl_used`/`lvgl_max` are LVGL's pool, and the mruby arena's usage is
 the gap between them once a game is actually running.

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,3 +1,28 @@
+# The uni-algo modules this project never calls, switched off so their Unicode
+# tables are never compiled in. This is the mirror of
+# cmake/uni-algo-trim.cmake's RPG2K_UNI_ALGO_TRIM_DEFINES -- that file applies
+# the same list to the CMake `uni-algo` target (which compiles the tables
+# themselves, in its src/data.cpp), this one applies it to the mruby gems that
+# include uni-algo's headers, so the two agree about which modules exist.
+# **Keep the two lists in sync**; the reasoning, the measured sizes and which
+# three uni-algo features this repo does use are all documented there rather
+# than duplicated here. Note that the NFKC/NFKD define in that file is
+# deliberately *not* mirrored here -- it is scoped to uni-algo's own data
+# translation unit because uni-algo 1.2.0 cannot compile `impl_norm.h` with it
+# set; see the comment beside RPG2K_UNI_ALGO_TRIM_DEFINES_DATA_ONLY.
+#
+# Called from rpg_maker_gems below rather than from each build block: the gems
+# that include uni-algo's headers (mruby-rgss, mruby-lcf) are exactly the ones
+# that method declares, so every build with those gems gets the flags and no
+# build block can forget them.
+UNI_ALGO_TRIM_DEFINES = %w[
+  UNI_ALGO_DISABLE_CASE
+  UNI_ALGO_DISABLE_PROP
+  UNI_ALGO_DISABLE_SCRIPT
+  UNI_ALGO_DISABLE_SEGMENT_GRAPHEME
+  UNI_ALGO_DISABLE_SEGMENT_WORD
+].freeze
+
 # Gems shared by every build variant (the actual game libraries).
 #
 # include_mvjs: false drops mruby-mvjs (RPG Maker MV/MZ via embedded
@@ -11,6 +36,9 @@
 # to port quickjs and a software GL stack to the PSP as a side effect of
 # wiring RPG2k up.
 def rpg_maker_gems(conf, include_mvjs: true)
+  # uni-algo is C++-only, so only the C++ compiler needs these.
+  conf.cxx.defines += UNI_ALGO_TRIM_DEFINES
+
   conf.gem core: 'mruby-array-ext'
   conf.gem core: 'mruby-hash-ext'
   # Enumerable#sort_by / min_by / max_by / group_by etc. mruby-array-ext does not

--- a/changelog.d/uni-algo-table-trim.changed.md
+++ b/changelog.d/uni-algo-table-trim.changed.md
@@ -1,0 +1,20 @@
+- **The uni-algo Unicode tables are trimmed to the modules this project
+  actually calls.** The whole codebase uses exactly three uni-algo features —
+  UTF conversion (`una::utf32to8` / `una::utf8to32u`), the UTF-8 decoding view
+  (`una::views::utf8`) and NFD normalisation (`una::norm::to_nfd_utf8`) — but
+  every build was compiling in the case-mapping, collation, code-point
+  property, script, grapheme/word segmentation and compatibility (NFKC/NFKD)
+  normalisation tables alongside them. `cmake/uni-algo-trim.cmake` switches
+  those modules off on the CMake `uni-algo` target and `build_config.rb`
+  mirrors the same list into the mruby cross-builds, so the gems that include
+  uni-algo's headers agree with the library they link. Measured on the PSP
+  EBOOT: the `una::detail::*` tables fall from 663 KB to 145 KB and the
+  loaded read/execute segment by 517,920 B — on that target this is **~506 KB
+  of live RAM**, not just image size, because the loader maps every PT_LOAD
+  segment into the console's ~24 MB at launch (ADR 0047's P6). Desktop and
+  wasm shed the same tables from their binaries, and it is the `uni-algo` half
+  of ADR 0007's P2 flash-fitting lever for the Wio Terminal, which takes
+  effect there once that port links `libmruby.a`. No behaviour change: the
+  disabled modules are `#ifdef`-gated in uni-algo's own headers, so a call to
+  one would be a compile or link error rather than a silent difference, and
+  the `RGSS.to_nfd` test still passes.

--- a/cmake/uni-algo-trim.cmake
+++ b/cmake/uni-algo-trim.cmake
@@ -1,0 +1,70 @@
+# Turn off the uni-algo modules this project never calls, so their Unicode
+# tables are never compiled into any target's read-only data.
+#
+# This repo uses exactly three things from uni-algo: UTF conversion
+# (`una::utf32to8` / `una::utf8to32u` in mruby-lcf/src/lcf.cxx), the UTF-8
+# decoding view (`s | una::views::utf8` in mruby-rgss/src/lib.cxx) and NFD
+# normalisation (`una::norm::to_nfd_utf8`, likewise). Conversion and the view
+# carry no tables at all; NFD needs only the decomposition/combining-class data.
+# Everything else uni-algo ships -- case mapping, collation, code-point
+# properties, script lookup, grapheme/word segmentation and the compatibility
+# (NFKC/NFKD) normalisation forms -- is dead weight here, and each one is a
+# large static table rather than a little code.
+#
+# Measured on the PSP EBOOT (psp-gcc, `nm --size-sort`): the `una::detail::*`
+# tables account for 663 KB of a 2.24 MB `.rodata`, and the modules disabled
+# below are most of that. On the PSP that is live RAM, not just image size --
+# the loader maps every PT_LOAD segment of the EBOOT into the console's ~24 MB
+# at launch -- which makes it ADR 0047 (P6) work; it is also the `uni-algo` half
+# of ADR 0007's P2 lever for the Wio Terminal, whose 512 KB of internal flash
+# cannot hold the full table set at all. Desktop and wasm get the same reduction
+# for free, since the modules are equally unused there.
+#
+# Every one of these is gated in uni-algo's own headers (see its
+# `include/uni_algo/config.h`, which documents the size each one saves), so
+# disabling a module the project does call would be a compile error at the call
+# site -- `norm.h` `#error`s outright on `UNI_ALGO_DISABLE_NORM` -- not a silent
+# behaviour change.
+#
+# The defines have to reach two different build systems, because the library and
+# its callers are compiled separately: this list applies to the CMake `uni-algo`
+# target (PUBLIC, so it covers both `src/data.cpp` -- where the tables live --
+# and every CMake target that links it), while build_config.rb applies the same
+# list to the mruby cross-builds' own C++ flags so the gem sources that include
+# uni-algo's headers agree with the library they link. Keep the two lists in
+# sync.
+set(RPG2K_UNI_ALGO_TRIM_DEFINES
+    UNI_ALGO_DISABLE_CASE # case mapping + collation, ~300 KB
+    UNI_ALGO_DISABLE_PROP # code-point properties, ~35 KB
+    UNI_ALGO_DISABLE_SCRIPT # script lookup, ~70 KB
+    UNI_ALGO_DISABLE_SEGMENT_GRAPHEME # grapheme breaking, ~25 KB
+    UNI_ALGO_DISABLE_SEGMENT_WORD) # word breaking, ~35 KB
+
+# The compatibility normalisation forms (~100 KB of decomposition tables) are
+# switched off for the data translation unit *only*, deliberately, rather than
+# joining the PUBLIC list above -- uni-algo 1.2.0 cannot compile its own
+# `impl_norm.h` with `UNI_ALGO_DISABLE_NFKC_NFKD` defined. The define guards
+# both the NFKD tables and the plain `constexpr norm_bound_nfkd = 0x00A0` beside
+# them (`impl_norm.h:204`), but `stages_qc_yes_ns` (`:254`) reads that constant
+# unconditionally -- it needs the NFKD lower bound to count non-starters for
+# Stream-Safe Text Process even on the *NFD* path, as its own comment says. So
+# any caller that includes `norm.h` with the define set fails to compile, which
+# is an upstream over-gating bug, not something this project is doing wrong.
+#
+# Scoping it to `src/data.cpp` sidesteps that cleanly, because data.cpp never
+# includes `impl_norm.h` at all: it includes `internal/data_inl.h`, which pulls
+# in only `impl/impl_data.h` (the tables) and the locale glue. The tables are
+# plain `extern const` arrays, so dropping their definitions while callers still
+# see the declarations costs nothing as long as nothing calls a compatibility
+# normalisation function -- and if something ever does, it is an
+# undefined-reference link error naming the missing table, not a silent
+# behaviour change.
+set(RPG2K_UNI_ALGO_TRIM_DEFINES_DATA_ONLY UNI_ALGO_DISABLE_NFKC_NFKD)
+
+# Apply the lists to the vendored uni-algo target. Call this straight after the
+# add_subdirectory that creates it, before anything links it.
+function(rpg2k_trim_uni_algo)
+  target_compile_definitions(uni-algo PUBLIC ${RPG2K_UNI_ALGO_TRIM_DEFINES})
+  target_compile_definitions(uni-algo
+                             PRIVATE ${RPG2K_UNI_ALGO_TRIM_DEFINES_DATA_ONLY})
+endfunction()

--- a/docs/adr/0007-wio-terminal-port.md
+++ b/docs/adr/0007-wio-terminal-port.md
@@ -168,6 +168,19 @@ Phase 1** rather than assumed:
 - Drop `mruby-onig-regexp` if the target games' scripts don't require regex, or
   swap in a much smaller matcher.
 - Slim `uni-algo` (only the normalization/case tables actually used).
+  **Done** — `cmake/uni-algo-trim.cmake` switches off every uni-algo module
+  this project never calls, and `build_config.rb` mirrors the same list into
+  the mruby cross-builds (the `wio` one included) so the gems that include
+  uni-algo's headers agree with the library they link. Only three uni-algo
+  features are used anywhere here — UTF conversion, the UTF-8 decoding view
+  and NFD normalisation — so the case/collation, code-point property, script,
+  grapheme/word segmentation and compatibility-normalisation tables all go.
+  Measured on the PSP EBOOT, which is the target that links uni-algo today:
+  the `una::detail::*` tables drop from 663 KB to 145 KB. The Wio firmware
+  does not link `libmruby.a` (and so uni-algo) yet, so the saving lands here
+  the moment the P1 image grows into P2 rather than being a Wio number today
+  — but the trim is in the shared build config, not a PSP-only switch, so it
+  cannot be forgotten at that point.
 - Place read-only bytecode, rodata and — importantly — the game assets in the
   **4 MB external QSPI flash** (XIP / a read-only FS), keeping internal flash for
   hot code.
@@ -214,7 +227,9 @@ are the tuning levers.
   `RGSS::Input` — with **real flash/RAM `size` numbers captured** to replace the
   estimates above.
 - **P2 — fit flash.** Trim gems (regex/uni-algo), and move rodata/bytecode/assets
-  to QSPI as needed, until the image links within budget.
+  to QSPI as needed, until the image links within budget. The `uni-algo` half is
+  done and lives in the shared build config (see the Flash budget above); the
+  regex and QSPI halves are still open.
 - **P3 — asset streaming.** Rework LCF and bitmap loading so game data is read
   from SD on demand instead of whole-file strings; target the title screen
   rendering from a real game folder.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -264,7 +264,21 @@ the interpreter-linking slice, in this order:
   figure is a generous placeholder to be validated against a real game
   on-device, exactly as the BRINGUP heartbeat (P1) measures.
 - **P6 — drawn from Finding 3's "third pool" and the EBOOT's own size,
-  landed as three smaller reductions in the same slice:**
+  landed as four smaller reductions:**
+  - The uni-algo modules nothing in this project calls are switched off, so
+    their Unicode tables are never compiled in (`cmake/uni-algo-trim.cmake`,
+    mirrored into the mruby cross-builds by `build_config.rb`). The repo uses
+    exactly three uni-algo features — UTF conversion, the UTF-8 decoding view,
+    and NFD normalisation — none of which need the case/collation, code-point
+    property, script, grapheme/word segmentation or compatibility-normalisation
+    tables. Measured on the EBOOT with `nm --size-sort`: the `una::detail::*`
+    tables fall from 663 KB to 145 KB, `.rodata` from 2,238,894 B to
+    1,723,798 B, and the loaded R/E segment by 517,920 B — **~506 KB of live
+    RAM**, since the loader maps every PT_LOAD segment into the console's
+    ~24 MB at launch. Desktop and wasm shrink by the same tables for free.
+    This is also ADR 0007's P2 lever for the Wio Terminal (whose 512 KB of
+    internal flash cannot hold the full set at all), where it takes effect
+    when that port links `libmruby.a`.
   - The LVGL partial-render draw buffers are sized to the *logical* canvas at
     display-create time (`mruby-rgss/src/psp.cxx`), capped at the old
     panel-width 64 KB per buffer: RPG2k's 320×240 canvas needs ~38 KB per
@@ -331,9 +345,10 @@ the interpreter-linking slice, in this order:
   update: P1a (stripping mrbc's `-g` for the `psp` cross-build), half of P1
   (the bring-up EBOOT's heartbeat now reports real device memory numbers),
   the tool half of P3 (`scripts/rgssad_unpack.rb`), the P2 allocator
-  split plus P6's three reductions (draw buffers sized to the canvas, the
-  LVGL widget/theme/example trim, and the mruby embedded tuning knobs), and
-  now P5's explicit main-thread stack size plus its heartbeat fields. The
+  split plus P6's reductions (draw buffers sized to the canvas, the LVGL
+  widget/theme/example trim, the mruby embedded tuning knobs, and the
+  uni-algo table trim), and P5's explicit main-thread stack size plus its
+  heartbeat fields. The
   two sizing numbers that still depend on a real database and map actually
   being loaded are the mruby arena's 8 MB and the stack's 256 KB, both of
   which the heartbeat is now in place to validate.


### PR DESCRIPTION
ADR 0047's **P6** (PSP) and the `uni-algo` half of ADR 0007's **P2** (Wio Terminal).

## What

This codebase calls exactly three uni-algo features:

| feature | where | tables |
|---|---|---|
| `una::utf32to8` / `una::utf8to32u` | `mruby-lcf/src/lcf.cxx` | none |
| `una::views::utf8` | `mruby-rgss/src/lib.cxx` | none |
| `una::norm::to_nfd_utf8` | `mruby-rgss/src/lib.cxx` | decomposition + combining class |

Every build was nonetheless compiling in the case-mapping, collation, code-point property, script, grapheme/word segmentation and compatibility (NFKC/NFKD) normalisation tables alongside them — nothing here can reach any of it.

`cmake/uni-algo-trim.cmake` carries the disable list and applies it to the CMake `uni-algo` target (where `src/data.cpp` actually defines the tables); `build_config.rb` mirrors it into the mruby cross-builds so the gems that include uni-algo's headers agree with the library they link.

## Numbers (PSP EBOOT, `psp-gcc`, `nm --size-sort` / `readelf -l`)

| | before | after | delta |
|---|---|---|---|
| `una::detail::*` tables | 663,120 B | 144,684 B | −518,436 B |
| `.rodata` | 2,238,894 B | 1,723,798 B | −515,096 B |
| loaded R/E segment | 4,852,485 B | 4,334,565 B | **−517,920 B** |

On the PSP that last row is **live RAM, ~506 KB of it** — the loader maps every `PT_LOAD` segment of the EBOOT into the console's ~24 MB at launch, so a read-only table costs memory, not just file size. Desktop and wasm shed the same tables from their binaries (verified: the desktop binary's table total lands on the same 144,684 B).

The Wio Terminal firmware does not link `libmruby.a` (and so uni-algo) yet, so it collects this when P2's link happens. The trim lives in the shared build config rather than a PSP-only switch specifically so it can't be forgotten at that point.

## The one wrinkle

`UNI_ALGO_DISABLE_NFKC_NFKD` is scoped to uni-algo's own data translation unit rather than joining the rest of the list, because **uni-algo 1.2.0 cannot compile its own `impl_norm.h` with that define set**: it gates the plain `constexpr norm_bound_nfkd = 0x00A0` behind it (`impl_norm.h:204`) but `stages_qc_yes_ns` (`:254`) reads that constant unconditionally — it needs the NFKD lower bound to count non-starters for Stream-Safe Text Process even on the *NFD* path, as its own comment says. Upstream over-gating, not something this project is doing wrong.

Scoping it to `src/data.cpp` sidesteps it cleanly: that TU never includes `impl_norm.h` (only `impl/impl_data.h` and the locale glue), and the tables are plain `extern const` arrays, so dropping their definitions while callers still see the declarations costs nothing unless something calls a compatibility form — which would be an undefined-reference link error naming the missing table, not a silent behaviour change. It's commented in full at the definition.

## Verification

- PSP EBOOT rebuilt in the `pspdev/pspdev` container (same image and commands as the `psp` CI job); numbers above are from the resulting ELF.
- Desktop build links; `mruby_test` passes 1821 tests including `RGSS.to_nfd("Ŵ") == "Ŵ"` — the one kept table-backed feature. The 4 remaining KOs are this machine's headless WebGL/EGL (`MV::JS`), identical before the change.

No behaviour change: every disabled module is `#ifdef`-gated in uni-algo's own headers, so calling into one is a compile or link error rather than a silent difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWRDFncfXqFhx7Uw23SJR3