### PR TITLE
psp: cut LVGL's pool from 4 MB to 256 KB (ADR 0047's P2a)

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -185,8 +185,21 @@ wired: mruby's entire heap lives in a fixed 8 MB arena of its own
 TLSF only 4-byte-aligns on 32-bit — too weak for mruby's word boxing) or
 growing unbounded on plain malloc, so the interpreter OOMs into a catchable
 `NoMemoryError` instead of colliding with the decoded-bitmap heap. `lv_conf.h`'s
-4 MB `LV_MEM_SIZE` therefore covers only LVGL's own widgets and internals, and
-the decoded bitmaps stay in a third, uncapped pool as before.
+`LV_MEM_SIZE` therefore covers only LVGL's own widgets and internals, and the
+decoded bitmaps stay in a third, uncapped pool as before. That pool is 256 KB,
+cut down from an original 4 MB once P2 established what is actually left for
+it to cover: neither the decoded bitmaps nor the LVGL partial-render draw
+buffers (`psp.cxx`'s `g_buf1`/`g_buf2`, plain `std::vector`) come from it, and
+the real game draws all of its own text through the RGSS `Bitmap`'s shinonome
+blitter rather than LVGL's font system — only the idle bring-up screen's two
+labels ever touch that. What is left is `lv_obj_t`/style bookkeeping for the
+canvas/image/label widgets this port uses, plausibly tens of KB even for a
+busy screen. Unlike the arena, LVGL's own default failure mode for pool
+exhaustion (`LV_ASSERT_HANDLER`) is a silent `while(1);`, indistinguishable
+from any other hang — `lv_conf.h` now points it at `psp_lvgl_assert_halt`
+(`psp.cxx`), which writes an `RPG2K_PSP_LVGL_ASSERT` marker via `sceIoWrite`
+before halting, so a pool that turns out too small shows up in the log
+instead of as an unexplained stall.
 
 Beyond the arena, this port also shrinks the live footprint in four smaller
 ways: the LVGL partial-render buffers are sized to the game's own canvas

--- a/app/psp/lv_assert_handler.h
+++ b/app/psp/lv_assert_handler.h
@@ -1,0 +1,32 @@
+// LV_ASSERT_HANDLER_INCLUDE target for app/psp/lv_conf.h.
+//
+// Deliberately NOT psp.hxx: this header is pulled into LVGL's own plain-C
+// translation units (lv_conf.h is included from both C and C++ code), and
+// psp.hxx uses C++-only syntax (constexpr). This file has to compile as
+// either language, so it is nothing but a bare function declaration.
+
+#ifndef PSP_LV_ASSERT_HANDLER_H
+#define PSP_LV_ASSERT_HANDLER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Called in place of LVGL's own default LV_ASSERT_HANDLER (an unconditional
+// `while(1);`) whenever LV_USE_ASSERT_MALLOC/LV_USE_ASSERT_NULL trips --
+// chiefly lv_malloc() returning NULL because LV_MEM_SIZE's pool is exhausted.
+// The stock handler halts silently: nothing distinguishes that failure from
+// any other hang, which is exactly the class of bug this port spent real
+// effort chasing (ADR 0047). This one writes a libc-free marker via
+// sceIoWrite -- the same reasoning app/psp/main.cxx's StrBuf/psp_write
+// already use, since pspsdk's sysclib_snprintf is not to be trusted here
+// either -- so the log names the failure before it halts. Defined in
+// mruby-rgss/src/psp.cxx, which already owns the PSP LVGL HAL and links into
+// both the CMake EBOOT and the psp mruby cross-build.
+void psp_lvgl_assert_halt(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PSP_LV_ASSERT_HANDLER_H

--- a/app/psp/lv_conf.h
+++ b/app/psp/lv_conf.h
@@ -28,14 +28,24 @@
 
 /* Built-in allocator with a static pool. Covers only LVGL's own widgets and
  * internals: mruby's heap lives in its own fixed arena (app/psp/main.cxx's
- * mrb_basic_alloc_func, ADR 0047's P2) and decoded bitmaps in the plain C
- * heap, so this pool no longer needs to double as mruby's. 4 MB is generous
- * for the widget tree alone; the BRINGUP heartbeat's lvgl_max high-water mark
- * is the number to size it against on-device. */
+ * mrb_basic_alloc_func, ADR 0047's P2), decoded bitmaps live in the plain C
+ * heap, and the LVGL partial-render draw buffers are plain std::vector
+ * (mruby-rgss/src/psp.cxx's g_buf1/g_buf2) -- none of that touches this pool,
+ * so what is actually left for it to cover is just lv_obj_t/style/internal
+ * bookkeeping for the canvas/image/label widgets this port uses (WIDGETS
+ * below), and only two lv_label objects (the idle bring-up screen) ever come
+ * from LVGL's own font/text system -- the real game draws all of its own
+ * text through the RGSS Bitmap's shinonome blitter, bypassing LVGL entirely.
+ * 256 KB is a comfortable multiple of what that object graph plausibly needs
+ * (dozens to a couple hundred live objects at a few hundred bytes each); the
+ * BRINGUP heartbeat's lvgl_max high-water mark is still the number to
+ * validate this against on-device once a real game can run there. Unlike the
+ * mruby arena, exhaustion here is not a catchable error by default -- see
+ * ASSERTS below for why that matters and what closes the gap. */
 #define LV_USE_STDLIB_MALLOC  LV_STDLIB_BUILTIN
 #define LV_USE_STDLIB_STRING  LV_STDLIB_BUILTIN
 #define LV_USE_STDLIB_SPRINTF LV_STDLIB_BUILTIN
-#define LV_MEM_SIZE (4 * 1024U * 1024U)
+#define LV_MEM_SIZE (256U * 1024U)
 
 /*====================
    HAL / TICK
@@ -62,6 +72,19 @@
 #define LV_USE_LOG 0
 #define LV_USE_ASSERT_NULL 1
 #define LV_USE_ASSERT_MALLOC 1
+
+/* LVGL's own default LV_ASSERT_HANDLER is an unconditional `while(1);`: a
+ * silent halt that looks identical to any other hang. That is a real risk
+ * specifically for LV_MEM_SIZE (above): unlike the mruby arena, which raises
+ * a catchable NoMemoryError when its own fixed arena is exhausted, an
+ * lv_malloc() failure here would otherwise just stop the EBOOT with nothing
+ * in the log to say why -- exactly the class of bug ADR 0047 spent real
+ * effort chasing down for this port. Route it through a marker-writing halt
+ * instead (mruby-rgss/src/psp.cxx's psp_lvgl_assert_halt) so a shrunk pool
+ * that turns out too small is diagnosable from the heartbeat log rather than
+ * indistinguishable from any other stall. */
+#define LV_ASSERT_HANDLER_INCLUDE <lv_assert_handler.h>
+#define LV_ASSERT_HANDLER psp_lvgl_assert_halt();
 
 /*====================
    FONTS

--- a/changelog.d/psp-lvgl-pool-shrink.changed.md
+++ b/changelog.d/psp-lvgl-pool-shrink.changed.md
@@ -1,0 +1,23 @@
+- **PSP: LVGL's memory pool cut from 4 MB to 256 KB.** ADR 0047's P2 already
+  moved mruby's heap onto its own separate arena and established that decoded
+  bitmaps never touch LVGL's pool; checking what was actually left for that
+  pool to cover found the LVGL partial-render draw buffers don't either
+  (`mruby-rgss/src/psp.cxx`'s `g_buf1`/`g_buf2` are plain `std::vector`, not
+  `lv_malloc`'d) and the real game never reaches LVGL's own font/text system —
+  every game screen draws through the RGSS `Bitmap`'s shinonome blitter,
+  bypassing LVGL entirely. What the pool actually covers is `lv_obj_t`/style
+  bookkeeping for the canvas/image/label widgets this port uses (already
+  trimmed to those three), plausibly tens of KB even for a busy screen. 4 MB
+  was never validated against anything; 256 KB is a comfortable multiple of
+  that estimate, freeing ~3.75 MB of the PSP's ~24 MB budget.
+
+  Because LVGL's own default `LV_ASSERT_HANDLER` (enabled here via
+  `LV_USE_ASSERT_MALLOC`) is an unconditional `while(1);` — a silent halt
+  indistinguishable from any other hang — `app/psp/lv_conf.h` now points it at
+  a new `psp_lvgl_assert_halt` (`mruby-rgss/src/psp.cxx`), which writes a
+  libc-free `RPG2K_PSP_LVGL_ASSERT` marker via `sceIoWrite` before halting, so
+  a pool that turns out too small in practice is diagnosable from the log
+  instead of an unexplained stall. Verified the shrunk pool builds clean and
+  the idle-HAL screen (title + status label) does not trip that marker;
+  validating it against a real game's widget count still needs an on-device
+  run, same as the mruby arena's 8 MB figure.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -280,6 +280,33 @@ the interpreter-linking slice, in this order:
   LVGL only) instead of describing the un-taken shared-pool option. The 8 MB
   figure is a generous placeholder to be validated against a real game
   on-device, exactly as the BRINGUP heartbeat (P1) measures.
+- **P2a — `LV_MEM_SIZE` cut from 4 MB to 256 KB.** Once P2 moved mruby onto
+  its own arena, checked what is actually left for LVGL's pool to cover:
+  decoded bitmaps bypass it (Finding 3), the LVGL partial-render draw buffers
+  are plain `std::vector` (`psp.cxx`'s `g_buf1`/`g_buf2`, not `lv_malloc`'d
+  either), and the real game never reaches LVGL's own font/text system at
+  all — every game screen draws through the RGSS `Bitmap`'s shinonome
+  blitter; only the idle bring-up screen's two `lv_label`s ever touch it. So
+  the pool's only job is `lv_obj_t`/style/internal bookkeeping for the
+  canvas/image/label widgets this port actually uses (already trimmed to
+  those three by P6 below) — plausibly tens of KB even for a busy screen, not
+  megabytes. 4 MB was never validated against anything; 256 KB is a
+  comfortable multiple of that estimate, still awaiting the same on-device
+  BRINGUP validation P2's 8 MB arena figure does.
+
+  This one has a sharper failure mode than the arena, though: LVGL's default
+  `LV_ASSERT_HANDLER` (fired by `LV_USE_ASSERT_MALLOC`, on for this target)
+  is an unconditional `while(1);` — pool exhaustion would have looked like
+  any other silent hang, which is exactly the class of bug the rest of this
+  ADR's Consequences spent real effort chasing. `app/psp/lv_conf.h` now
+  points `LV_ASSERT_HANDLER` at `psp_lvgl_assert_halt`
+  (`mruby-rgss/src/psp.cxx`), which writes a libc-free `RPG2K_PSP_LVGL_ASSERT`
+  marker via `sceIoWrite` before halting — the same `StrBuf`/`psp_write`
+  reasoning `main.cxx` already uses, since `sysclib_snprintf` is not to be
+  trusted here either. Verified the shrunk pool builds clean and the idle-HAL
+  screen (title + status label) does not trip that marker under
+  PPSSPP-headless; validating it against a real game's widget count still
+  needs the same on-device run P1/P2 do.
 - **P6 — drawn from Finding 3's "third pool" and the EBOOT's own size,
   landed as four smaller reductions:**
   - The uni-algo modules nothing in this project calls are switched off, so
@@ -362,13 +389,14 @@ the interpreter-linking slice, in this order:
   update: P1a (stripping mrbc's `-g` for the `psp` cross-build), half of P1
   (the bring-up EBOOT's heartbeat now reports real device memory numbers),
   the tool half of P3 (`scripts/rgssad_unpack.rb`), the P2 allocator
-  split plus P6's reductions (draw buffers sized to the canvas, the LVGL
-  widget/theme/example trim, the mruby embedded tuning knobs, and the
-  uni-algo table trim), and P5's explicit main-thread stack size plus its
-  heartbeat fields. The
-  two sizing numbers that still depend on a real database and map actually
-  being loaded are the mruby arena's 8 MB and the stack's 256 KB, both of
-  which the heartbeat is now in place to validate.
+  split plus P2a's LVGL pool cut (4 MB to 256 KB, with a marker-writing
+  assert handler replacing LVGL's silent-halt default) plus P6's reductions
+  (draw buffers sized to the canvas, the LVGL widget/theme/example trim, the
+  mruby embedded tuning knobs, and the uni-algo table trim), and P5's
+  explicit main-thread stack size plus its heartbeat fields. The three sizing
+  numbers that still depend on a real database and map actually being loaded
+  are the mruby arena's 8 MB, LVGL's 256 KB, and the stack's 256 KB, all
+  three of which the heartbeat is now in place to validate.
 - ADR 0010's "the full gem set should fit" is narrowed: it holds for gem
   *code* size, but says nothing about per-title asset memory, which Finding 2
   shows can exceed the entire 24 MB budget for an RGSSAD-packed game even

--- a/mruby-rgss/src/psp.cxx
+++ b/mruby-rgss/src/psp.cxx
@@ -13,6 +13,7 @@
 #include <pspctrl.h>
 #include <pspdisplay.h>
 #include <pspge.h>
+#include <pspiofilemgr.h>
 #include <pspkernel.h>
 
 namespace {
@@ -227,6 +228,18 @@ uint64_t psp_input_scan(void) {
     mask |= (1ull << PSP_INPUT_N4);
 
   return mask;
+}
+
+// app/psp/lv_conf.h's LV_ASSERT_HANDLER. See lv_assert_handler.h for why this
+// exists instead of LVGL's own default `while(1);`: a marker naming the
+// failure (rather than a silent halt) before this loops forever, matching the
+// libc-free-write reasoning app/psp/main.cxx's StrBuf/psp_write already use.
+extern "C" void psp_lvgl_assert_halt(void) {
+  static const char kMarker[] = "RPG2K_PSP_LVGL_ASSERT\n";
+  sceIoWrite(1, kMarker, sizeof(kMarker) - 1);
+  sceIoWrite(2, kMarker, sizeof(kMarker) - 1);
+  for (;;)
+    sceKernelDelayThread(1000000);  // 1s; never returns.
 }
 
 #endif  // PSP_BUILD


### PR DESCRIPTION
ADR 0047's **P2a** — a follow-up to P2 (the mruby/LVGL allocator split).

## What

Once P2 moved mruby's own heap onto a separate 8 MB arena, checked what was actually left for LVGL's `LV_MEM_SIZE` pool to cover:

- Decoded bitmaps bypass it (already established, Finding 3).
- The LVGL partial-render draw buffers **also** bypass it — `mruby-rgss/src/psp.cxx`'s `g_buf1`/`g_buf2` are plain `std::vector<uint8_t>`, not `lv_malloc`'d.
- The real game never reaches LVGL's own font/text system at all — every game screen draws through the RGSS `Bitmap`'s shinonome blitter. Only the idle bring-up screen's two `lv_label`s ever touch this pool.

What's left is `lv_obj_t`/style/internal bookkeeping for the canvas/image/label widgets this port already trims to (P6) — plausibly tens of KB even for a busy screen, nowhere near megabytes. 4 MB was a placeholder that was never validated against anything. Cut to **256 KB**, a comfortable multiple of that estimate, freeing ~3.75 MB of the PSP's ~24 MB budget.

## The one wrinkle

LVGL's own default `LV_ASSERT_HANDLER` (fired by `LV_USE_ASSERT_MALLOC`, already on for this target) is an unconditional `while(1);` on pool exhaustion — a **silent halt indistinguishable from any other hang**. Unlike the mruby arena (which raises a catchable `NoMemoryError`), a shrunk-too-far LVGL pool would fail exactly the way this port's own bring-up investigation has spent real effort chasing down.

Added `app/psp/lv_assert_handler.h` (a bare, C-compatible declaration — `lv_conf.h` is included from LVGL's own plain-C translation units too, so it can't pull in `psp.hxx`'s C++-only syntax) and `psp_lvgl_assert_halt` (`mruby-rgss/src/psp.cxx`, which already owns this port's LVGL HAL). It writes a libc-free `RPG2K_PSP_LVGL_ASSERT` marker via `sceIoWrite` before halting, so a pool that turns out too small in practice shows up in the log instead of as an unexplained stall.

## Verification

- Builds clean — both the CMake LVGL build and the `psp` mruby cross-build's compile of `psp.cxx` pick up the new header from the same `app/psp` include path they already share for `lv_conf.h` (`mruby-rgss/mrbgem.rake`'s existing `build.name == 'psp'` conditional).
- Booted under PPSSPP-headless: the idle-HAL screen (title + status label) builds and never trips the new `RPG2K_PSP_LVGL_ASSERT` marker — 256 KB comfortably covers it.

Like the mruby arena's 8 MB figure, validating 256 KB against a real game's widget count still needs an on-device run — that's the open item, not something this PR claims to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWRDFncfXqFhx7Uw23SJR3