### PR TITLE
rpg2003: automatic placement now honours battler row

### DIFF
--- a/changelog.d/rpg2003-battle-row-command.added.md
+++ b/changelog.d/rpg2003-battle-row-command.added.md
@@ -1,0 +1,7 @@
+- **RPG2003's in-battle Row command** is implemented: an actor's front/back
+  row (`Game::Actor#battle_row`, persisted across Save/Continue via LSD
+  SaveActor field `0x5B`/91) can now be flipped mid-fight through the Row
+  battle-menu entry, feeding the existing hit/damage row adjustments (ADR
+  0053). RPG_RT's own "can't empty the front row" guard is ported too — a
+  blocked toggle plays the Buzzer SE and stays on the command menu instead of
+  spending the actor's turn.

--- a/changelog.d/rpg2003-battle-row-x-offset.added.md
+++ b/changelog.d/rpg2003-battle-row-x-offset.added.md
@@ -1,0 +1,5 @@
+- **RPG2003's automatic battler placement now honours row.** A back-row
+  actor's grid-computed sprite X drops its `row_x_offset` to 0 (was always a
+  front-row half-width), matching EasyRPG's `Calculate2k3BattlePosition`, and
+  the in-battle Row command repositions the sprite in place the instant a
+  toggle succeeds, instead of leaving the pre-toggle position on screen.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -255,6 +255,28 @@ fatal). Scene checks pin the `headless_battle_troop` flag plumbing and
   three phases and is tracked separately. The Special command handler landed
   with the command-customization follow-up (2026-08-17), and the attacker-side
   row adjustment is implemented (ADR 0053 Phase 1 notes, 2026-08-17); the
-  per-battler row derivation from `battlecommands.placement` and the
   condition-gated `IsRowAdjusted` branches (back-attack / surround) remain
   open until the battle conditions are modelled.
+- **The in-battle Row command landed (2026-08-18).** The earlier framing above
+  ("per-battler row derivation from `battlecommands.placement`") turned out to
+  be the wrong model once EasyRPG's actual `Game_Actor` source was reachable:
+  row is not derived from the placement table or the actor's manual
+  `battle_x`/`battle_y` at all -- it is its own persisted field
+  (`data.row`/`GetBattleRow`/`SetBattleRow`, liblcf's `SaveActor` field
+  `0x5B`), defaulting to the front row and changed only by the player, via the
+  Row battle-menu command. `Game::Actor#battle_row`/`#battle_row=` now carry
+  that state (schema.rb's `SAVE_PARTY_ACTOR` field 91, both the LCF `.lsd`
+  round-trip and the portable Marshal save), `Combatant.from_actor` seeds a
+  fight's row from it, and `Scene::Battle`'s command window appends a fixed
+  Row entry (`#row_command_available?`, gated on `battle.rpg2003?` since the
+  EasyRPG-only `easyrpg_disable_row_feature` opt-out this mirrors has no real
+  LCF field for a vanilla database to set) that flips it via the new
+  `Game::Battle#toggle_row`, a `DoNothing` turn like the Special command,
+  refusing a toggle that would empty the front row
+  (`#can_leave_front_row?`, ported from EasyRPG's `RowSelected` guard) with
+  the reference's own Buzzer SE. `scripts/rpg2k3_battle_row_check.rb` and
+  `rpg2k_scene_check.rb` stay green. Still open: the field menu's own Row
+  screen (id 6 of `RPG2K3_COMMAND_IDS`, a pre-battle per-actor row picker,
+  EasyRPG's `Scene_Row`) and the automatic-placement `row_x_offset` /
+  pincer-surround grid tables, both noted in `scene/menu.rb` and ADR 0054
+  respectively.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -275,8 +275,9 @@ fatal). Scene checks pin the `headless_battle_troop` flag plumbing and
   refusing a toggle that would empty the front row
   (`#can_leave_front_row?`, ported from EasyRPG's `RowSelected` guard) with
   the reference's own Buzzer SE. `scripts/rpg2k3_battle_row_check.rb` and
-  `rpg2k_scene_check.rb` stay green. Still open: the field menu's own Row
-  screen (id 6 of `RPG2K3_COMMAND_IDS`, a pre-battle per-actor row picker,
-  EasyRPG's `Scene_Row`) and the automatic-placement `row_x_offset` /
-  pincer-surround grid tables, both noted in `scene/menu.rb` and ADR 0054
-  respectively.
+  `rpg2k_scene_check.rb` stay green. The automatic-placement `row_x_offset`
+  landed the same day too (ADR 0054's own follow-up note). Still open: the
+  field menu's own Row screen (id 6 of `RPG2K3_COMMAND_IDS`, a pre-battle
+  per-actor row picker, EasyRPG's `Scene_Row`, noted in `scene/menu.rb`) and
+  the pincer-surround grid tables, which need the battle conditions this
+  runtime does not model.

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -119,20 +119,27 @@ Behavioral notes and deliberate simplifications:
   (src/game_battle.cpp), keyed by party index/size and the encounter terrain's
   grid fields (terrain chunks 46-48), replacing the manual battle_x/battle_y —
   ported with the reference's own grid table 0 and its no-terrain defaults
-  (112 / 392 / 16000). Only the ordinary front-row actor path is done (the
-  back-row `row_x_offset` needs the row-adjusted grid X once an actor's row
-  can actually change, landed below; the pincer/surround enemy tables still
-  need the battle conditions this runtime does not model); `mtf-
-  meido-action` uses placement 1, so its real gauge battle exercises it.
+  (112 / 392 / 16000). Only the ordinary front-row actor path is done -- the
+  pincer/surround enemy tables still need the battle conditions this runtime
+  does not model; `mtf-meido-action` uses placement 1, so its real gauge
+  battle exercises it.
 - Follow-ups: Wait-off (active) mode and the wait toggle. The Special command
   handler (a chosen Special forfeits the actor's turn, EasyRPG's DoNothing)
   landed 2026-08-17, and the attacker-side row adjustment (a front-row actor
   dealing +25% damage and the flat-25 back-row defender hit penalty) landed
   with ADR 0053 Phase 1's reference-aligned row model (2026-08-17). The
   in-battle Row command itself (the only thing that ever moves an actor off
-  the front-row default) landed 2026-08-18 — see ADR 0053's own follow-up
-  note; `row_x_offset` is still not wired into the automatic-placement sprite
-  X this ADR's grid code computes.
+  the front-row default) landed 2026-08-18 -- see ADR 0053's own follow-up
+  note. **`row_x_offset` landed the same day**: `automatic_battle_position`
+  now reads the `i`-th ally's own `Combatant#back_row?` (a half-width for
+  front, 0 for back, matching EasyRPG's `row_x_offset = actor.GetBattleRow()
+  == RowType_front ? half_width : 0` exactly), and a successful Row toggle
+  calls the scene's new `#reposition_actor_sprite` to rebuild that one
+  alternate-layout sprite in place rather than leaving the pre-toggle
+  position on screen until an unrelated redraw catches it up.
+  `scripts/rpg2k_scene_check.rb`'s placement-check fixture gained a
+  `battle_type:` knob (round-based, so the command phase's actor order is
+  deterministic) and a new check pinning the exact before/after sprite X.
 - **Wait-off (active) mode landed 2026-08-17.** The toggle is the save-system
   `SaveSystem.atb_mode` field (LSD chunk 140; the earlier "Battle Commands
   field" guess above was wrong — liblcf's `fields.csv` has no `wait` entry on

--- a/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
+++ b/docs/adr/0054-rpg2003-battle-gauge-turn-cycle.md
@@ -120,14 +120,19 @@ Behavioral notes and deliberate simplifications:
   grid fields (terrain chunks 46-48), replacing the manual battle_x/battle_y —
   ported with the reference's own grid table 0 and its no-terrain defaults
   (112 / 392 / 16000). Only the ordinary front-row actor path is done (the
-  back-row `row_x_offset` and the pincer/surround enemy tables need the row
-  derivation and battle conditions this runtime does not model); `mtf-
+  back-row `row_x_offset` needs the row-adjusted grid X once an actor's row
+  can actually change, landed below; the pincer/surround enemy tables still
+  need the battle conditions this runtime does not model); `mtf-
   meido-action` uses placement 1, so its real gauge battle exercises it.
 - Follow-ups: Wait-off (active) mode and the wait toggle. The Special command
   handler (a chosen Special forfeits the actor's turn, EasyRPG's DoNothing)
   landed 2026-08-17, and the attacker-side row adjustment (a front-row actor
   dealing +25% damage and the flat-25 back-row defender hit penalty) landed
-  with ADR 0053 Phase 1's reference-aligned row model (2026-08-17).
+  with ADR 0053 Phase 1's reference-aligned row model (2026-08-17). The
+  in-battle Row command itself (the only thing that ever moves an actor off
+  the front-row default) landed 2026-08-18 — see ADR 0053's own follow-up
+  note; `row_x_offset` is still not wired into the automatic-placement sprite
+  X this ADR's grid code computes.
 - **Wait-off (active) mode landed 2026-08-17.** The toggle is the save-system
   `SaveSystem.atb_mode` field (LSD chunk 140; the earlier "Battle Commands
   field" guess above was wrong — liblcf's `fields.csv` has no `wait` entry on

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1260,6 +1260,15 @@ module LCF
       # legitimate Change Class target in its own right, distinct from
       # "unset").
       90 => { name: :class_id, type: :int, default: -1 }, # 職業ID (Change Class)
+
+      # RPG2003 battle front/back row (Game::Actor#battle_row), toggled by the
+      # in-battle Row command (ADR 0053's row mechanic). liblcf's own
+      # `ChunkSaveActor` enum (lsd/chunks.h) numbers this field 0x5B, right
+      # after class_id (0x5A) and before the two_weapon/lock_equipment/
+      # auto_battle/super_guard/battler_animation fields this schema does not
+      # declare yet -- 0 (RowType_front) is both liblcf's own default and the
+      # only row RPG2000 ever writes.
+      91 => { name: :row, type: :int, default: 0 }, # 隊列 (2003)
     }
 
     # https://w.atwiki.jp/rpg2kpsp/pages/37.html

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1416,6 +1416,13 @@ module Game
       @battler_animation_override = 0
       @class_changed = false
       @battle_commands = nil # lazily taken from the database on the first change
+      # RPG2003 battle front/back row (ADR 0053): purely runtime/save state,
+      # never derived from the database's own `battle_x`/`battle_y` manual
+      # placement -- EasyRPG's `Game_Actor` seeds a fresh actor's
+      # `data.row`/`GetOriginalPosition()` from separate fields entirely, and
+      # only the in-battle Row command (Combatant#toggle_row) or a restored
+      # save (SAVE_PARTY_ACTOR field 0x5B/91) ever moves it off the front row.
+      @row = Battle::ROW_FRONT
       @battle_combo = nil
       @exp = 0
       @equipment = normalize_equipment(a.respond_to?(:initial_equipment) ? a.initial_equipment : nil)
@@ -2770,6 +2777,12 @@ module Game
     # class id.
     def class_changed?; @class_changed; end
 
+    # This actor's current RPG2003 battle row (Battle::ROW_FRONT /
+    # Battle::ROW_BACK), read by Combatant.from_actor when a fight starts and
+    # written by the in-battle Row command / a restored save.
+    def battle_row; @row; end
+    def battle_row=(row); @row = row == Battle::ROW_BACK ? Battle::ROW_BACK : Battle::ROW_FRONT; end
+
     # Replace the battle-command list (Continue restoring a saved one). nil keeps
     # whatever the database / class defines.
     def battle_commands=(ids)
@@ -3080,7 +3093,10 @@ module Game
                        # permanent edit, so it has to outlive Save / Continue the
                        # way the name and sprite overrides do.
                        class_id: a.class_id,
-                       battle_commands: a.battle_commands.dup }
+                       battle_commands: a.battle_commands.dup,
+                       # RPG2003 battle row (ADR 0053's Row command): outlives
+                       # Save/Continue the same way a live Change Class does.
+                       row: a.battle_row }
       end
       { actor_ids: @actors.map { |a| a.id }, items: @items,
         # Half-spent 使用回数 rides along with the bag, the way the save format
@@ -3147,6 +3163,7 @@ module Game
       actor.transparent = m[:transparent] unless m[:transparent].nil?
       actor.states = m[:states] if m[:states]
       actor.battle_commands = m[:battle_commands] if m[:battle_commands]
+      actor.battle_row = m[:row] if m[:row]
     end
 
     def each(&blk); @actors.each(&blk); end
@@ -8591,10 +8608,16 @@ module Game
       c.evasion_up = flag_of(a, :physical_evasion_up?)
       c.attr_base_ranks = c.attr_ranks.dup
       c.atk_states = atk_states_of(a)
-      # RPG2003 front/back row: defaults to the front row (the only row
-      # RPG2000 knows). Deriving it from the Battle Commands placement table
-      # (0x1D, field 2) and the actor's battle position is the ADR 0053
-      # Phase 1 data step -- until then every battler starts in front.
+      # RPG2003 front/back row: seeded from the actor's own persisted
+      # `#battle_row` (a fresh actor's own default -- RPG2000 never sets it,
+      # so this stays front there too). Confirmed against EasyRPG's own
+      # `Game_Actor`: row is runtime/save state (`data.row`, SaveActor field
+      # 0x5B) that the in-battle Row command toggles, not something derived
+      # from the Battle Commands placement table (0x1D field 2) or the
+      # actor's manual `battle_x`/`battle_y` -- `GetOriginalPosition()` reads
+      # those two independently of row, and `Calculate2k3BattlePosition`'s
+      # `row_x_offset` only ever *reads* the already-set row back, for the
+      # automatic-placement sprite's own on-screen X (still unmodelled here).
       c.row = a.respond_to?(:battle_row) ? a.battle_row : ROW_FRONT
       c
     end
@@ -9023,6 +9046,34 @@ module Game
     # commands at #end_round.
     def command_skip(ally)
       ally.action = nil; ally.defending = false; ally.command = nil; ally.skip = true
+    end
+
+    # Whether `ally` may leave the front row right now: RPG2003 refuses to
+    # empty the front row entirely (real RPG_RT buzzes and stays on the
+    # command menu if the player tries), ported from EasyRPG's own
+    # `Scene_Battle_Rpg2k3::RowSelected` guard. That guard also folds in
+    # `IsDirectionFlipped()` (a battler-mirroring mechanic this engine does
+    # not model, and which no ordinary actor ever sets in the reference
+    # either -- it always reads false there), so the surviving, always-true
+    # part of the condition is exactly "at least one *other* in-play ally is
+    # still in front" -- moving from back to front never needs this check at
+    # all, since it can only ever add to the front row.
+    def can_leave_front_row?(ally)
+      allies.reject(&:out_of_play?).count { |a| a != ally && !a.back_row? } >= 1
+    end
+
+    # The RPG2003 **Row** battle command: flip `ally` between front and back
+    # row (ADR 0053's row mechanic), refusing a front-row ally's toggle that
+    # would leave the front row empty (#can_leave_front_row?). Returns
+    # whether the row actually changed, so the scene can play the reference's
+    # Buzzer SE instead of committing a turn when it did not. A successful
+    # toggle still costs the ally's turn -- EasyRPG's `RowSelected` queues a
+    # `DoNothing` action the same way the Special command does -- which is
+    # the scene's job (`#command_skip`) once this returns true.
+    def toggle_row(ally)
+      return false if !ally.back_row? && !can_leave_front_row?(ally)
+      ally.row = ally.back_row? ? ROW_FRONT : ROW_BACK
+      true
     end
 
     # Average agility of every battler on `side` (EasyRPG's
@@ -12397,6 +12448,12 @@ module Game
           e[80] = a.battle_commands
           e[83] = true
         end
+        # RPG2003 battle row (0x5B/91, liblcf's `ChunkSaveActor::row`) --
+        # only written off the front-row default, the same eliding-writer
+        # convention `class_id`/`battle_commands` follow above, so an
+        # RPG2000 save (or a 2003 save whose party never touched Row) never
+        # gains the field.
+        e[91] = a.battle_row if a.battle_row != Battle::ROW_FRONT
         actors[a.id] = e
       end
       save[108] = actors
@@ -12567,6 +12624,11 @@ module Game
           # present", since an empty list is schema.rb's own declared
           # default rather than a real Change Battle Commands to nothing.
           actor.battle_commands = sa.battle_commands if sa.changed_battle_commands
+          # RPG2003 battle row (0x5B/91) -- the schema default (0/front)
+          # restores the same as never having touched it, so no changed-flag
+          # gating is needed the way battle_commands' own nil-vs-empty
+          # ambiguity requires above.
+          actor.battle_row = sa.row if sa.respond_to?(:row)
           # A Change Actor Name override on *any* roster member, not just the
           # leader (whose name chunk 100's title also carries below). ADR
           # 0014 already flagged this field's other case when it was first

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -991,17 +991,35 @@ class RPG2k
       # ids a real 2003 database's own Battle-Commands table conventionally
       # numbers its first four entries, and the ids the Enable Combo (1007)
       # command and the `command_actor` page condition refer to.
+      #
+      # RPG2003 also appends a fixed **Row** row after whichever list this
+      # resolves to (#row_command_available?), the front/back toggle
+      # (`#select_battle_command`'s `:row` arm) -- not itself a Battle-
+      # Commands table entry (see #custom_battle_commands' own comment on why
+      # id 0 is skipped there), so it always carries a nil `command_id`.
       def battle_command_rows
         actor = current_actor_row
         custom = actor && custom_battle_commands(actor)
-        return custom if custom
-
-        [
+        rows = custom || [
           { label: term(:battle_attack, 'Attack'), action: :attack, command_id: 1 },
           { label: skill_command_label, action: :skill, command_id: 2 },
           { label: term(:battle_defend, 'Defend'), action: :defend, command_id: 3 },
           { label: term(:battle_item, 'Item'), action: :item, command_id: 4 }
         ]
+        rows += [{ label: term(:row, 'Row'), action: :row, command_id: nil }] if row_command_available?
+        rows
+      end
+
+      # RPG2003's Row entry is not one of the customizable Battle-Commands
+      # list's own rows -- confirmed above and by EasyRPG's own
+      # `Game_Actor::GetBattleCommands` comment marking it "not impl" there
+      # too -- it is a fixed extra row `Scene_Battle_Rpg2k3` appends after
+      # whatever list a project customized, present on every RPG2003 fight
+      # (`Feature::HasRow`'s own `easyrpg_disable_row_feature` opt-out is an
+      # EasyRPG-only editor extension with no real LCF field, so there is
+      # nothing for a vanilla database to gate this on beyond the edition).
+      def row_command_available?
+        @ui[:battle] && @ui[:battle].respond_to?(:rpg2003?) && @ui[:battle].rpg2003?
       end
 
       # `actor`'s own RPG2003 battle-command list resolved to menu rows, or nil
@@ -1287,7 +1305,14 @@ class RPG2k
         # the battle-page `command_actor` condition both read it; RPG2000 never
         # consults either, so recording it for every battle is harmless.
         row = battle_command_rows[@ui[:cmd]]
-        current_actor.last_battle_action = row[:command_id] if current_actor && row[:command_id]
+        # Row carries no real command_id (it is not a Battle-Commands table
+        # entry -- see #battle_command_rows), so it clears any previously
+        # recorded command instead of leaving a stale one behind, mirroring
+        # EasyRPG's own `SetLastBattleAction(-1)` right before `RowSelected`.
+        if current_actor
+          current_actor.last_battle_action = row[:command_id] if row[:command_id]
+          current_actor.last_battle_action = nil if row[:action] == :row
+        end
         case row[:action]
         when :attack
           play_system_se(SFX_DECISION)
@@ -1312,6 +1337,29 @@ class RPG2k
           play_system_se(SFX_DECISION)
           @ui[:battle].command_skip(current_actor)
           advance_actor
+        when :row
+          # RPG2003's Row battle command: flip the acting ally's front/back
+          # row (ADR 0053), refused with a Buzzer if it would empty the front
+          # row (`Game::Battle#toggle_row`/`#can_leave_front_row?`, ported
+          # from EasyRPG's `Scene_Battle_Rpg2k3::RowSelected` guard) -- real
+          # RPG_RT stays on the command menu rather than committing a turn
+          # when that happens, so this only advances on success. A
+          # successful toggle is written back onto the real `Game::Actor`
+          # (`#battle_row=`) so it survives past this battle -- Combatant#row
+          # is a fight-scoped snapshot the same way #attr_ranks is (see the
+          # Combatant Struct's own field comment) -- and, like Special,
+          # consumes the turn as a `DoNothing` action
+          # (`Game::Battle#command_skip`).
+          if @ui[:battle].toggle_row(current_actor)
+            if current_actor_row && current_actor_row.respond_to?(:battle_row=)
+              current_actor_row.battle_row = current_actor.row
+            end
+            play_system_se(SFX_DECISION)
+            @ui[:battle].command_skip(current_actor)
+            advance_actor
+          else
+            play_system_se(SFX_BUZZER)
+          end
         end
       end
 

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -554,9 +554,11 @@ class RPG2k
       # database-terrain fields 46-48), instead of the manual battle_x/battle_y.
       # Only grid table 0 is used -- the ordinary actor path indexes table_x 0
       # and table_y 0 (the other tables are the pincer/surround enemy paths this
-      # runtime does not model), and only the front row (the one row this
-      # runtime derives; the per-battler back-row derivation is a separate
-      # step), so `row_x_offset` is always a half-width.
+      # runtime does not model). `row_x_offset` reads the `i`-th ally's own
+      # row (`Combatant#back_row?`, ADR 0053 -- the in-battle Row command is
+      # what actually moves it off the front-row default): a half-width for
+      # front, 0 for back, exactly EasyRPG's own `row_x_offset = actor.
+      # GetBattleRow() == RowType_front ? half_width : 0`.
       #
       # Returns [x, y] for the `i`-th member of `@ui[:allies]`, or nil when
       # the database asks for manual placement (the caller falls back to
@@ -567,10 +569,12 @@ class RPG2k
         pos = battle_grid_position(i, @ui[:allies].length)
         return nil unless pos
         half = ACTOR_CHARSET_CELL / 2
-        # EasyRPG's actor-path x/y for the normal battle condition, with a
-        # front-row `row_x_offset` of a half-width, then the same x clamp
-        # (y is deliberately unclamped for actors -- the reference doesn't).
-        x = SCREEN_W - (pos[0] + half + half)
+        ally = @ui[:allies][i]
+        row_x_offset = ally && ally.back_row? ? 0 : half
+        # EasyRPG's actor-path x/y for the normal battle condition, then the
+        # same x clamp (y is deliberately unclamped for actors -- the
+        # reference doesn't).
+        x = SCREEN_W - (pos[0] + half + row_x_offset)
         y = pos[1] - half
         [Game.clamp(x, half, SCREEN_W - half), y]
       end
@@ -679,6 +683,24 @@ class RPG2k
         return unless sprites
         dispose_battle_sprite(sprites.delete_at(idx))
         reset_actor_battler_z
+      end
+
+      # `combatant`'s row just changed (the in-battle Row command) and its
+      # on-screen alternate-layout sprite needs to reflect the new
+      # automatic-placement X (`#automatic_battle_position`'s `row_x_offset`)
+      # -- rebuild it in place at the same index/Z, the same dispose-then-
+      # #build_actor_sprite-fresh shape #remove_battle_actor_sprite/
+      # #add_battle_actor_sprite already use for a roster change. A no-op
+      # when the fight draws no actor sprites at all (a traditional-layout
+      # database), or manual placement (its `battle_x`/`battle_y` never
+      # depend on row -- see `Combatant.from_actor`'s own row comment).
+      def reposition_actor_sprite(combatant)
+        sprites = @ui[:actor_sprites]
+        return unless sprites
+        i = @ui[:allies].index { |c| c.equal?(combatant) }
+        return unless i && sprites[i]
+        dispose_battle_sprite(sprites[i])
+        sprites[i] = build_actor_sprite(combatant.actor, i)
       end
 
       # Re-derive every surviving actor sprite's Z from its current index in
@@ -1354,6 +1376,11 @@ class RPG2k
             if current_actor_row && current_actor_row.respond_to?(:battle_row=)
               current_actor_row.battle_row = current_actor.row
             end
+            # The alternate-layout sprite's automatic-placement X depends on
+            # row (#automatic_battle_position) -- move it now rather than
+            # leaving the old position on screen until some unrelated
+            # roster-change redraw happens to catch it up.
+            reposition_actor_sprite(current_actor)
             play_system_se(SFX_DECISION)
             @ui[:battle].command_skip(current_actor)
             advance_actor

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -44,11 +44,14 @@ class RPG2k
       # Skill=2, Equipment=3, Save=4, Status=5, Row=6, Order=7, Wait=8; Quit=9
       # is never itself in the list -- `Scene_Menu` appends it unconditionally
       # after the loop, which #build_commands mirrors below). Row (battle
-      # front/back rank) has no entry here and is silently skipped: it is an
-      # RPG2003 battle-system feature this runtime does not model (Row's
-      # front/back mechanic itself is modelled -- ADR 0053 -- but the
-      # per-actor row *assignment* in the menu is not). Wait (id 8) *is*
-      # modelled: it flips the
+      # front/back rank) has no entry here and is silently skipped: this
+      # field-menu screen (a per-actor row picker, EasyRPG's `Scene_Row`) is
+      # not modelled, even though row assignment itself now is -- the
+      # in-battle Row command flips `Game::Actor#battle_row`
+      # (`scene/battle.rb`'s `:row` command, ADR 0053) the same
+      # `Game::Battle#toggle_row` a field-menu Row screen would eventually
+      # drive too, just without this menu's own dedicated entry point yet.
+      # Wait (id 8) *is* modelled: it flips the
       # save-system `atb_mode` toggle (LSD chunk 140) that makes a gauge
       # battle's command menu freeze (wait) or keep running (active) -- the
       # Wait-off (active) mode follow-up ADR 0054 named -- and its label

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2409,7 +2409,7 @@ end
 BattleCommandDef = Struct.new(:name, :type)
 
 class BattleStubActor
-  attr_accessor :exp, :hp, :mp
+  attr_accessor :exp, :hp, :mp, :battle_row
   attr_reader :id, :name, :atk, :def, :agi, :int, :max_hp, :max_mp, :skills, :states,
               :level, :learn_table
   # Defaults are strong enough to beat the two-Slime troop the scene db defines;
@@ -2449,6 +2449,10 @@ class BattleStubActor
     @battler_animation_id = battler_animation_id
     @battle_x = battle_x; @battle_y = battle_y
     @faceset_name = faceset_name; @faceset_index = faceset_index
+    # Mirrors Game::Actor's own RPG2003 battle-row state (#battle_row/
+    # #battle_row=): front by default, flipped by the in-battle Row command
+    # the same way a real actor's would be.
+    @battle_row = Game::Battle::ROW_FRONT
   end
   attr_reader :battler_animation_id, :battle_x, :battle_y
   # RPG2003 gauge-card status panel fixture (#draw_battle_gauge_face,
@@ -9684,6 +9688,64 @@ check "Enemy Encounter scene: a Special battle command draws a row and forfeits 
   8.times { scene.update }
   hero_attacked = ui[:battle].log.any? { |e| e[:attacker] == 'Hero' }
   eq false, hero_attacked, 'the Special turn produced no attack entry for the hero'
+end
+
+check "Enemy Encounter scene: an RPG2003 fight offers Row after the fixed four " \
+      "and refuses to empty the front row" do
+  # A lone party member can never leave the front row (Game::Battle
+  # #can_leave_front_row?, ported from EasyRPG's `RowSelected` guard) --
+  # RPG_RT buzzes and stays on the command menu rather than spending the
+  # turn, exactly like the reference's own "nothing to pick" Buzzer cases.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) }, rpg2003: true)
+  st = scene.instance_variable_get(:@state)
+  actor = BattleStubActor.new(agi: 20)
+  st.instance_variable_set(:@party, BattleStubParty.new(actor, rpg2003: true))
+  ui = battle_to_command(scene)
+  labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
+  eq %w[Attack Skill Defend Item Row], labels,
+     'a 2003 fight appends the fixed Row row after the ordinary fixed four'
+  4.times { press_key(scene, RGSS::Input::DOWN) } # Attack -> Skill -> Defend -> Item -> Row
+  eq 4, ui[:cmd], 'the cursor lands on the appended Row row'
+  hero = ui[:allies][0]
+  press_key(scene, RGSS::Input::C)
+  eq :command, ui[:phase], 'a refused toggle stays on the command menu, not a committed turn'
+  eq Game::Battle::ROW_FRONT, hero.row, 'the sole ally is still front row'
+  eq Game::Battle::ROW_FRONT, actor.battle_row, 'the real actor was never written back to either'
+end
+
+check 'Enemy Encounter scene: Row flips a front-row ally to the back and spends the turn' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) }, rpg2003: true)
+  st = scene.instance_variable_get(:@state)
+  a1 = BattleStubActor.new(id: 1, name: 'Hero', agi: 20)
+  a2 = BattleStubActor.new(id: 2, name: 'Ally', agi: 15)
+  st.instance_variable_set(:@party, BattleStubParty.new(rpg2003: true, actors: [a1, a2]))
+  ui = battle_to_command(scene)
+  labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
+  eq %w[Attack Skill Defend Item Row], labels
+  4.times { press_key(scene, RGSS::Input::DOWN) } # Attack -> Skill -> Defend -> Item -> Row
+  hero = ui[:allies][0]
+  press_key(scene, RGSS::Input::C)
+  # Row commits at once, like Special -- no target/skill/item submenu -- but
+  # with a second party member still to command, that only advances to
+  # *their* menu, not straight to the round's animation.
+  eq :command, ui[:phase], "Row spends only the acting ally's turn, moving on to the next ally's menu"
+  eq Game::Battle::ROW_BACK, hero.row, 'the fight-scoped Combatant moved to the back row'
+  eq Game::Battle::ROW_BACK, a1.battle_row, 'the real actor is written back so it outlives the battle'
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::C)    # Ally defends, committing the round
+  eq :animate, ui[:phase], "the round animates once both allies have committed"
+  # The row change cost Hero's own turn like Special does: only Ally's
+  # attacks show up in the round's log.
+  8.times { scene.update }
+  hero_attacked = ui[:battle].log.any? { |e| e[:attacker] == 'Hero' }
+  eq false, hero_attacked, 'the Row turn produced no attack entry for the hero'
 end
 
 check "Enemy Encounter scene: a battle-command list of Row alone falls back to the fixed four" do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11190,7 +11190,7 @@ end
 # parameters (112 / 392 / 16000) so the checks' expected coordinates are
 # explicit; `battle_xy:` supplies per-actor manual coordinates for the
 # placement-0 check.
-def placement_battle(ids, placement: 1, battle_xy: {})
+def placement_battle(ids, placement: 1, battle_xy: {}, battle_type: 2)
   members = ids.map do |id|
     xy = battle_xy[id] || [0, 0]
     BattleStubActor.new(id: id, agi: 20, battler_animation_id: id,
@@ -11204,14 +11204,17 @@ def placement_battle(ids, placement: 1, battle_xy: {})
   party = BattleStubParty.new(members.first, alternate_layout: true,
                               automatic_placement: placement == 1, actors: members)
   scene, = battle_scene_with_pages({}, party: party, rpg2003: true,
-                                   battlecommands: OpenStruct.new(placement: placement, battle_type: 2),
+                                   battlecommands: OpenStruct.new(placement: placement, battle_type: battle_type),
                                    battleranimations: anims)
   grid = scene.db.terrain[42]
   grid.grid_top_y = 112
   grid.grid_elongation = 392
   grid.grid_inclination = 16000
   # Drive the battle open (the actor sprites are built in Scene::Battle#start).
-  battle_until_phase(scene, :command, 250)
+  # A round-based (battle_type 0) command phase commands actor 0 first and
+  # deterministically, unlike a gauge fight's ready-first ordering, which is
+  # what the Row/row_x_offset check below needs.
+  battle_type == 0 ? battle_to_command(scene) : battle_until_phase(scene, :command, 250)
   scene
 end
 
@@ -11241,6 +11244,28 @@ check 'manual battler placement keeps the database battle_x/battle_y, unchanged'
   sprites = placement_sprites(scene)
   eq [120, 90], [sprites[0].x, sprites[0].y],
      'placement 0 reads the actor\'s own coordinates, no grid involved'
+end
+
+check 'the Row command moves an automatic-placement actor sprite by row_x_offset' do
+  # A two-member party's own grid slots (the "seats a two-member party"
+  # check above): member 0 starts front row at x=256 (320 - (grid.x 16 + a
+  # 24px half-cell + the front-row row_x_offset, also 24)). Flipping it to
+  # the back row drops row_x_offset to 0, moving the sprite to x=280 -- the
+  # same reposition #reposition_actor_sprite now drives right when the Row
+  # command's toggle succeeds, rather than leaving the old front-row sprite
+  # on screen until an unrelated redraw happens to catch it up.
+  scene = placement_battle([1, 2], battle_type: 0)
+  sprites = placement_sprites(scene)
+  eq [256, 88], [sprites[0].x, sprites[0].y], 'member 0 starts on its front-row grid slot'
+  ui = battle_ui(scene)
+  eq %w[Attack Skill Defend Item Row], ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
+  4.times { press_key(scene, RGSS::Input::DOWN) } # Attack -> Skill -> Defend -> Item -> Row
+  press_key(scene, RGSS::Input::C)
+  hero = ui[:allies][0]
+  eq Game::Battle::ROW_BACK, hero.row, 'member 0 moved to the back row'
+  sprites = placement_sprites(scene)
+  eq [280, 88], [sprites[0].x, sprites[0].y],
+     'the sprite followed the row change: same grid slot, row_x_offset now 0 instead of 24'
 end
 
 # yado.tk / 01_shoshin's 011_siyou: "Empty party doesn't itself Game Over, but


### PR DESCRIPTION
## Summary

Stacked on #965 (the in-battle Row command) — this diff will shrink to just the commit below once that merges.

- `Calculate2k3BattlePosition`'s `row_x_offset` always assumed the front row (a half-width offset), since nothing could move a battler off it yet. Now that the in-battle Row command can (#965), `automatic_battle_position` reads the `i`-th ally's own `Combatant#back_row?` and drops the offset to 0 for the back row, matching EasyRPG's `row_x_offset = actor.GetBattleRow() == RowType_front ? half_width : 0` exactly.
- A successful Row toggle now calls a new `#reposition_actor_sprite` to rebuild that one alternate-layout sprite in place, so the on-screen position actually follows the row change instead of showing the stale front-row spot until an unrelated redraw happens to catch it up.
- ADRs 0053/0054 updated and a changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 687 checks passed (1 new: a round-based, automatic-placement, two-member fight selects Row and the sprite's exact before/after X is pinned)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures
- [x] `ruby scripts/rpg2k_logic_check.rb` — 986 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_