### PR TITLE
rpg2003: implement the field-menu Row command

### DIFF
--- a/changelog.d/rpg2003-menu-row-command.added.md
+++ b/changelog.d/rpg2003-menu-row-command.added.md
@@ -1,0 +1,5 @@
+- **RPG2003's field-menu Row command** (`menu_commands` id 6) is implemented:
+  picking it hands focus to the party-status panel like Skill/Equipment/
+  Status, and confirming an actor toggles their front/back row in place
+  (`Game::Party#toggle_actor_row`) with no sub-scene opened, refusing to
+  leave the whole party in the back row the way real RPG_RT does.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -275,8 +275,27 @@ fatal). Scene checks pin the `headless_battle_troop` flag plumbing and
   refusing a toggle that would empty the front row
   (`#can_leave_front_row?`, ported from EasyRPG's `RowSelected` guard) with
   the reference's own Buzzer SE. `scripts/rpg2k3_battle_row_check.rb` and
-  `rpg2k_scene_check.rb` stay green. Still open: the field menu's own Row
-  screen (id 6 of `RPG2K3_COMMAND_IDS`, a pre-battle per-actor row picker,
-  EasyRPG's `Scene_Row`) and the automatic-placement `row_x_offset` /
-  pincer-surround grid tables, both noted in `scene/menu.rb` and ADR 0054
-  respectively.
+  `rpg2k_scene_check.rb` stay green. Still open: the automatic-placement
+  `row_x_offset` (ADR 0054) and the pincer-surround grid tables, which need
+  the battle conditions this runtime does not model.
+- **The field-menu Row command landed (2026-08-18).** There is no separate
+  `Scene_Row` in the reference after all -- that earlier guess was wrong too:
+  EasyRPG's `Scene_Menu::UpdateActorSelection` handles Row inline, on the
+  exact same party-status actor-selection panel Skill/Equipment/Status
+  already share (confirmed against the reference source), just toggling the
+  picked actor's row and falling straight back to the command list instead of
+  pushing a sub-scene. `RPG2K3_COMMAND_IDS` gains id 6 (`:row`), `select_command`
+  folds `:row` into the existing Skill/Equip/Status actor-selection branch
+  (same empty-party Buzzer gate -- unlike Order's `size <= 1`, a solo
+  character's row still matters), and `confirm_actor_selection` dispatches it
+  to a new `Game::Party#toggle_actor_row` -- the field-menu counterpart to
+  `Game::Battle#toggle_row`, with the identical "don't empty the front row"
+  guard restated over the live party's actors (EasyRPG's own field-menu Row
+  case has no `IsDirectionFlipped` term and, unlike the in-battle version,
+  always plays Decision -- never Buzzer -- even when the toggle is silently
+  refused; ported exactly rather than unified with the in-battle asymmetry).
+  Covered by a new `rpg2k_logic_check.rb` check pinning the guard directly
+  against real `Game::Party`/`Game::Actor` objects, and a new
+  `rpg2k_scene_check.rb` check proving the menu dispatch reaches it (focus
+  moves to the actor panel, confirming toggles with no scene pushed, focus
+  returns to the command list).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3186,6 +3186,29 @@ module Game
       @revision += 1
     end
 
+    # RPG2003's field-menu **Row** command (`RPG2K3_COMMAND_IDS` id 6,
+    # `scene/menu.rb`): flip `actor`'s front/back row (`Game::Actor
+    # #battle_row=`), refusing to leave the whole live party in the back row
+    # -- EasyRPG's `Scene_Menu::UpdateActorSelection` Row case counts how
+    # many of `@actors` (the current party, not the full roster) are already
+    # back-row and blocks only the toggle that would push the last front-row
+    # member back, exactly `Game::Battle#can_leave_front_row?`'s in-battle
+    # guard restated the other way around (no `IsDirectionFlipped` term here
+    # -- the reference's field-menu Row case never has one either). Unlike
+    # the in-battle Row command, the reference plays its Decision SE
+    # regardless of whether the toggle actually took -- the caller's job, not
+    # this method's; this only ever silently no-ops a refused toggle.
+    def toggle_actor_row(actor)
+      return unless actor.respond_to?(:battle_row) && actor.respond_to?(:battle_row=)
+      if actor.battle_row == Battle::ROW_FRONT
+        back_count = @actors.count { |a| a != actor && a.respond_to?(:battle_row) && a.battle_row == Battle::ROW_BACK }
+        return if back_count >= @actors.size - 1
+        actor.battle_row = Battle::ROW_BACK
+      else
+        actor.battle_row = Battle::ROW_FRONT
+      end
+    end
+
     def include_actor?(id); @actors.any? { |a| a.id == id }; end
     def actor_by_id(id); @actors.find { |a| a.id == id }; end
 

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -1,21 +1,23 @@
 class RPG2k
   module Scene
     # Main menu, opened over the map with the cancel button. Shows party status
-    # and a command list. Item, Save and Order act immediately; Skill, Equip
-    # and Status instead hand input focus to the party-status panel so the
-    # player picks *which actor* first (UP/DOWN, confirmed with C) before
-    # the corresponding scene (Scene::SkillMenu / EquipMenu / StatusMenu)
-    # opens for that one -- confirmed against EasyRPG's own
-    # `Scene_Menu::UpdateCommand`/`UpdateActorSelection` (`Skill`/
-    # `Equipment`/`Status`/`Row` all share this shape; RPG2003's Row, the
-    # battle front/back toggle, is not modelled here, but Order -- which acts
-    # on the whole party at once, not one actor -- pushes Scene::Order
-    # directly, the same `UpdateCommand` shape Item/Save already use).
-    # Cancelling back out of actor selection returns focus to the command
-    # list. End Game opens a Yes/No confirmation (see #open_end_game_confirm);
-    # only confirming "Yes" there returns to the title. Any further command
-    # (there are none left in the built command list today) falls back to a
-    # "not implemented yet" message.
+    # and a command list. Item, Save and Order act immediately; Skill, Equip,
+    # Status and Row instead hand input focus to the party-status panel so the
+    # player picks *which actor* first (UP/DOWN, confirmed with C) -- Skill/
+    # Equip/Status then open the corresponding scene (Scene::SkillMenu /
+    # EquipMenu / StatusMenu) for that one, while Row instead toggles the
+    # picked actor's front/back row right there and returns to the command
+    # list without opening anything -- confirmed against EasyRPG's own
+    # `Scene_Menu::UpdateCommand`/`UpdateActorSelection`, where all four cases
+    # share this one actor-selection panel (there is no separate `Scene_Row`;
+    # the Row toggle is inline in `UpdateActorSelection`'s own `switch`).
+    # Order -- which acts on the whole party at once, not one actor -- pushes
+    # Scene::Order directly instead, the same `UpdateCommand` shape Item/Save
+    # already use. Cancelling back out of actor selection returns focus to
+    # the command list. End Game opens a Yes/No confirmation (see
+    # #open_end_game_confirm); only confirming "Yes" there returns to the
+    # title. Any further command (there are none left in the built command
+    # list today) falls back to a "not implemented yet" message.
     class Menu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
@@ -43,14 +45,12 @@ class RPG2k
       # arranges them -- matching EasyRPG's `CommandOptionType` enum (Item=1,
       # Skill=2, Equipment=3, Save=4, Status=5, Row=6, Order=7, Wait=8; Quit=9
       # is never itself in the list -- `Scene_Menu` appends it unconditionally
-      # after the loop, which #build_commands mirrors below). Row (battle
-      # front/back rank) has no entry here and is silently skipped: this
-      # field-menu screen (a per-actor row picker, EasyRPG's `Scene_Row`) is
-      # not modelled, even though row assignment itself now is -- the
-      # in-battle Row command flips `Game::Actor#battle_row`
-      # (`scene/battle.rb`'s `:row` command, ADR 0053) the same
-      # `Game::Battle#toggle_row` a field-menu Row screen would eventually
-      # drive too, just without this menu's own dedicated entry point yet.
+      # after the loop, which #build_commands mirrors below). Row (id 6, the
+      # battle front/back toggle) is modelled the same actor-selection-panel
+      # way Skill/Equipment/Status are (see the class comment) -- picking an
+      # actor there flips `Game::Actor#battle_row` via `Game::Party
+      # #toggle_actor_row`, the field-menu counterpart to the in-battle Row
+      # command's `Game::Battle#toggle_row` (`scene/battle.rb`, ADR 0053).
       # Wait (id 8) *is* modelled: it flips the
       # save-system `atb_mode` toggle (LSD chunk 140) that makes a gauge
       # battle's command menu freeze (wait) or keep running (active) -- the
@@ -73,6 +73,7 @@ class RPG2k
         3 => [:equip, :battle_equipment, "Equip"],
         4 => [:save, :battle_save, "Save"],
         5 => [:status, :status, "Status"],
+        6 => [:row, :row, "Row"],
         7 => [:order, :order, "Order"],
         8 => [:wait, :wait, "Wait"]
       }.freeze
@@ -200,6 +201,14 @@ class RPG2k
         when :skill  then @parent.push Scene::SkillMenu.new(@parent, @state, index)
         when :equip  then @parent.push Scene::EquipMenu.new(@parent, @state, index)
         when :status then @parent.push Scene::StatusMenu.new(@parent, @state, index)
+        when :row
+          # No sub-scene: EasyRPG's own Row case toggles the picked actor's
+          # row right on the actor-selection panel and falls straight back to
+          # the command list, playing Decision regardless of whether the
+          # toggle actually took (`Game::Party#toggle_actor_row` silently
+          # no-ops a refused one -- see its own comment on the "don't empty
+          # the front row" guard).
+          @state.party.toggle_actor_row(actor) if @state.party.respond_to?(:toggle_actor_row)
         end
       end
 
@@ -342,7 +351,14 @@ class RPG2k
             play_system_se(SFX_DECISION)
             @parent.push Scene::ItemMenu.new(@parent, @state)
           end
-        when :skill, :equip, :status
+        when :skill, :equip, :status, :row
+          # Row shares the exact same empty-party gate as Skill/Equipment/
+          # Status here -- EasyRPG's `UpdateCommand` groups all four cases
+          # under one `if (actors.empty()) Buzzer else { Decision; activate
+          # the actor panel }` block. Unlike Order's `size <= 1` gate, a
+          # single-member party's Row toggle is still meaningful (front vs.
+          # back matters for a solo character), so it is not specially
+          # blocked here.
           if @state.party.actors.empty?
             play_system_se(SFX_BUZZER)
           else

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3905,6 +3905,35 @@ check 'Party#reorder applies a picked front-to-back permutation, ' \
   eq [3, 1, 2, 4], party.actors.map(&:id), 'the identity permutation (by current index) is a no-op order'
 end
 
+check "Party#toggle_actor_row flips an actor's row and refuses to empty the front row" do
+  # RPG2003's field-menu Row command (scene/menu.rb's :row branch) --
+  # EasyRPG's own `Scene_Menu::UpdateActorSelection` Row case, restated:
+  # blocks only the toggle that would leave every live party member in the
+  # back row (no `IsDirectionFlipped` term here -- that quirk is specific to
+  # the in-battle `Scene_Battle_Rpg2k3::RowSelected`, see
+  # Game::Battle#can_leave_front_row?).
+  players = (1..3).to_h { |i| [i, FakePlayerRow.new("Actor#{i}", '', 0, 1, max_hp: 10)] }
+  db = FakeActorDB.new(players, [1, 2, 3])
+  party = Game::Party.new(db)
+  a1, a2, a3 = party.actors
+
+  eq Game::Battle::ROW_FRONT, a1.battle_row, 'a fresh actor starts front row'
+  party.toggle_actor_row(a1)
+  eq Game::Battle::ROW_BACK, a1.battle_row, 'the first toggle moves it to the back'
+  party.toggle_actor_row(a1)
+  eq Game::Battle::ROW_FRONT, a1.battle_row, 'toggling again moves it back to the front'
+
+  party.toggle_actor_row(a1)
+  party.toggle_actor_row(a2)
+  eq [Game::Battle::ROW_BACK, Game::Battle::ROW_BACK, Game::Battle::ROW_FRONT],
+     [a1.battle_row, a2.battle_row, a3.battle_row],
+     'two of three back-row is still fine -- a3 alone keeps the front row occupied'
+
+  party.toggle_actor_row(a3)
+  eq Game::Battle::ROW_FRONT, a3.battle_row,
+     'refused: moving the last front-row member back would empty the front row entirely'
+end
+
 check 'Actors builds each id once and reports a missing row as nil' do
   roster = Game::Actors.new(roster_db)
   a = roster[1]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9577,8 +9577,11 @@ check "Enemy Encounter scene: an actor's RPG2003 skill-only battle-command list 
   ui = battle_to_command(scene)
   labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
   eq ['Cast Magic'], labels,
-     "a customized list of just one Subskill entry (plus Row, still unimplemented) " \
-     'shows that one row alone, not the fixed four'
+     "a customized list of just one Subskill entry (plus id 0, Row -- skipped " \
+     "within the customizable list itself, see #custom_battle_commands) " \
+     'shows that one row alone, not the fixed four (this fixture is not ' \
+     'rpg2003?-flagged, so the appended Row row -- #row_command_available? -- ' \
+     'never shows either)'
   press_key(scene, RGSS::Input::C) # the only row, cmd 0, is a Skill-type command
   eq :skill, ui[:phase], 'a Subskill entry opens the Skill list the same as the generic Skill command'
 end
@@ -13785,6 +13788,9 @@ end
 class MenuStubActor
   attr_reader :name, :title, :level, :hp, :max_hp, :mp, :max_mp,
               :atk, :def, :int, :agi, :exp, :states, :equipment
+  # Mirrors Game::Actor's own RPG2003 battle-row state, for the field-menu
+  # Row command check below (Game::Party#toggle_actor_row reads/writes this).
+  attr_accessor :battle_row
   attr_accessor :faceset_name, :faceset_index
   def initialize
     @name = 'Hero'; @title = 'Wanderer'; @level = 5
@@ -13793,6 +13799,7 @@ class MenuStubActor
     @states = []
     @equipment = [0, 0, 0, 0, 0]
     @faceset_name = ''; @faceset_index = 0
+    @battle_row = Game::Battle::ROW_FRONT
   end
   def exp_to_next; 120; end
   def add_state(id); @states.push(id) unless @states.include?(id); end
@@ -13820,6 +13827,18 @@ class MenuStubParty
   def field_items(_state = nil); []; end
   def field_skills(_actor, _state = nil); []; end
   def reorder(new_order); @actors = new_order.map { |i| @actors[i] }; end
+  # Mirrors Game::Party#toggle_actor_row's own guard (see rpg2k_logic_check.rb
+  # for that method's own coverage) -- this scene-check only needs to prove
+  # Scene::Menu's `:row` dispatch actually reaches it, not re-prove the guard.
+  def toggle_actor_row(actor)
+    if actor.battle_row == Game::Battle::ROW_FRONT
+      back = @actors.count { |a| a != actor && a.battle_row == Game::Battle::ROW_BACK }
+      return if back >= @actors.size - 1
+      actor.battle_row = Game::Battle::ROW_BACK
+    else
+      actor.battle_row = Game::Battle::ROW_FRONT
+    end
+  end
 end
 
 def menu_scene(klass, state, db = fake_db)
@@ -14095,20 +14114,21 @@ check 'Scene::Menu: RPG2000 (no rpg2003? flag) never offers Status at all' do
 end
 
 check 'Scene::Menu: an RPG2003 database drives the command list from ' \
-      'System.menu_commands, Status and Order included' do
+      'System.menu_commands, Status, Row and Order included' do
   # mtf-meido-action's own array, id-for-id (confirmed by loading its real
   # RPG_RT.ldb): every one of RPG2003's eight customizable ids, in ascending
-  # order. Row (6) is an RPG2003 battle-system feature this runtime does not
-  # model and is silently skipped; Wait (8) -- the ATB toggle -- *is* modelled
-  # (it flips the save-system `atb_mode` field, ADR 0054's follow-up) and is
-  # offered with its current-mode label; Order (7) has no such dependency and
-  # is offered, same as Status; End Game is appended unconditionally, matching
+  # order. Every id is modelled now: Row (6) toggles the picked actor's row
+  # on the same actor-selection panel Skill/Equipment/Status use
+  # (`Game::Party#toggle_actor_row`); Wait (8) -- the ATB toggle -- flips the
+  # save-system `atb_mode` field (ADR 0054's follow-up) and is offered with
+  # its current-mode label; Order (7) has no battle-system dependency at all,
+  # just party reordering; End Game is appended unconditionally, matching
   # EasyRPG's own unconditional Quit push outside the customized loop.
   db = fake_db(rpg2003: true, menu_commands: [1, 2, 3, 4, 5, 6, 7, 8])
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)
   keys = scene.instance_variable_get(:@commands).map(&:first)
-  eq [:item, :skill, :equip, :save, :status, :order, :wait, :end_game], keys,
-     'Status (id 5), Order (id 7) and Wait (id 8) are offered, Row (6) is dropped rather than crashing'
+  eq [:item, :skill, :equip, :save, :status, :row, :order, :wait, :end_game], keys,
+     'Status (id 5), Row (id 6), Order (id 7) and Wait (id 8) are all offered'
 end
 
 check 'Scene::Menu: the Wait command shows the current atb_mode, and toggling ' \
@@ -14171,6 +14191,35 @@ check 'Scene::Menu: choosing Order pushes Scene::Order directly, no actor-' \
   ok pushed.is_a?(RPG2k::Scene::Order), "Order pushes a live Scene::Order, got #{pushed.class}"
   eq :command, scene.instance_variable_get(:@focus),
      'no actor-selection focus change, unlike Skill/Equip/Status'
+end
+
+check 'Scene::Menu: choosing Row hands focus to the actor-selection panel, ' \
+      'and confirming an actor toggles their row with no scene pushed' do
+  # Unlike Order, Row shares Skill/Equipment/Status' actor-selection shape
+  # (the class comment, and EasyRPG's own UpdateCommand grouping) -- but
+  # unlike those three, confirming an actor never opens anything: the toggle
+  # happens right on the panel and focus falls straight back to the command
+  # list (EasyRPG's UpdateActorSelection Row case ends with the same
+  # SetActive/SetIndex(-1) every other case does).
+  db = fake_db(rpg2003: true, menu_commands: [6])
+  st = wrap_menu_state
+  scene = menu_scene(RPG2k::Scene::Menu, st, db)
+  hero, ally = st.party.actors
+  eq Game::Battle::ROW_FRONT, hero.battle_row
+
+  RGSS::Input.triggered = [RGSS::Input::C]  # Row -> actor-selection panel
+  scene.update
+  RGSS::Input.reset
+  eq :actors, scene.instance_variable_get(:@focus), 'Row hands focus to the party-status panel'
+
+  RGSS::Input.triggered = [RGSS::Input::C]  # confirm the first (highlighted) actor
+  scene.update
+  RGSS::Input.reset
+  eq Game::Battle::ROW_BACK, hero.battle_row, 'the picked actor toggled to the back row'
+  eq Game::Battle::ROW_FRONT, ally.battle_row, 'the other party member is untouched'
+  ok scene.parent.pushed.empty?, 'no sub-scene opens for Row, unlike Skill/Equip/Status'
+  eq :command, scene.instance_variable_get(:@focus),
+     'focus returns to the command list after one toggle, not another pick'
 end
 
 check 'Scene::Menu: Order refuses a single-member party with the buzzer, ' \


### PR DESCRIPTION
## Summary

- `RPG2K3_COMMAND_IDS` had no entry for id 6 (Row), so a real game listing it in `System.menu_commands` silently dropped it — the last of the eight customizable field-menu commands still unmodelled, now that the in-battle Row command, Order and Wait have all landed (#965).
- There is no separate `Scene_Row` in the reference after all (an earlier code comment guessed there was): EasyRPG's `Scene_Menu::UpdateActorSelection` handles Row inline, on the exact same party-status actor-selection panel Skill/Equipment/Status already share — picking an actor there toggles their row directly and falls back to the command list, rather than opening a sub-scene.
- `select_command` folds `:row` into that existing actor-selection branch (same empty-party Buzzer gate — unlike Order's `size <= 1` check, a solo character's row still matters), and `confirm_actor_selection` dispatches it to a new `Game::Party#toggle_actor_row`: the field-menu counterpart to `Game::Battle#toggle_row`, with the same "don't empty the front row" guard restated over the live party (no `IsDirectionFlipped` term here, and always plays Decision — never Buzzer — even on a refused toggle, matching the reference's own asymmetry with the in-battle version rather than unifying it away).
- ADR 0053 updated and a changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 987 checks passed (1 new: `Party#toggle_actor_row` pinned directly against real `Game::Party`/`Game::Actor`)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 687 checks passed (1 new: the menu dispatch reaches the toggle with no scene pushed; the existing "eight customizable ids" check updated since Row is no longer dropped)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_