### PR TITLE
Cache Nix store in psp-smoke job for patched PPSSPP build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1350,11 +1350,14 @@ jobs:
     # renderer) and look for the bring-up markers it writes via sceIoWrite --
     # RPG2K_PSP_BOOT (a libc-free string literal, emitted before any init) and
     # the per-second RPG2K_PSP_BRINGUP heartbeat. This exercises the EBOOT on an
-    # emulator, beyond the compile-only `psp` job. The emulator comes from
-    # nixpkgs (`packages.ppsspp` in flake.nix) rather than a source build: the
-    # channel this flake pins has it prebuilt on cache.nixos.org, so the job
-    # substitutes a closure in place of a from-source PPSSPP compile plus the
-    # hand-rolled tree cache that used to carry it between runs.
+    # emulator, beyond the compile-only `psp` job. The emulator is nixpkgs'
+    # `packages.ppsspp` (see flake.nix) carrying one local patch, so it no
+    # longer matches what cache.nixos.org has prebuilt for the pinned channel
+    # -- every `nix build '.#ppsspp'` compiles PPSSPP from source rather than
+    # substituting a closure. The Nix store cache below (same
+    # `cache-nix-action` step every other job in this file uses) is what turns
+    # that from a from-source PPSSPP compile on every run into a one-time cost,
+    # replacing the hand-rolled tree cache PPSSPP used to be built from.
     #
     # NON-BLOCKING (continue-on-error): PPSSPP's headless HLE only partially
     # implements pspsdk's libc stdio (printf/strlen resolve to firmware stubs),
@@ -1384,11 +1387,19 @@ jobs:
 
       - uses: nixbuild/nix-quick-install-action@v35
 
-      # Deliberately no cache-nix-action here, unlike the jobs that enter the
-      # dev shell: the only thing this job realises is PPSSPP, which
-      # cache.nixos.org already has built for the pinned channel. Pushing its
-      # ~1 GiB closure through the Actions cache every run would cost more than
-      # substituting it, and would evict the caches that do earn their keep.
+      # The patched `ppsspp` (see flake.nix) no longer matches nixpkgs'
+      # prebuilt closure, so every `nix build` here compiles PPSSPP from
+      # source -- a multi-minute C++ build -- unless the result is cached.
+      # Keyed on the patch alongside flake.*: the patch changes PPSSPP's
+      # output hash without touching either flake file, and a key that missed
+      # that would silently keep restoring the pre-patch closure's build
+      # instead of ever caching the patched one.
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-ppsspp-${{ runner.os }}-${{ hashFiles('flake.*', 'nix/patches/ppsspp-lwmutex-workarea-validate.patch') }}
+          restore-prefixes-first-match: nix-ppsspp-${{ runner.os }}-
+
       - name: Fetch PPSSPP
         # `packages.ppsspp` is nixpkgs' default (non-Qt) build, which configures
         # with -DHEADLESS=ON and ships `bin/ppsspp-headless`; see flake.nix. The

--- a/changelog.d/psp-smoke-ppsspp-cache.changed.md
+++ b/changelog.d/psp-smoke-ppsspp-cache.changed.md
@@ -1,0 +1,9 @@
+- The `psp-smoke` CI job now caches the Nix store across runs. `flake.nix`'s
+  `ppsspp` package carries a local patch (see
+  `ppsspp-lwmutex-nix-patch.fixed.md`), so its output no longer matches
+  nixpkgs' prebuilt closure on `cache.nixos.org` and every `nix build
+  '.#ppsspp'` compiled PPSSPP from source — a multi-minute cost the job used
+  to pay on every push. It now restores/saves that store with the same
+  `cache-nix-action` step the rest of `.github/workflows/build.yml` already
+  uses, keyed on `flake.*` plus the patch file itself (the patch changes
+  PPSSPP's build without touching either flake file).

--- a/flake.nix
+++ b/flake.nix
@@ -112,11 +112,15 @@
           };
         }
         // nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-          # The emulator the `psp-smoke` CI job boots the EBOOT under, taken
-          # from nixpkgs instead of built from source: cache.nixos.org has it
-          # prebuilt for the channel this flake pins, so the job substitutes a
-          # closure rather than compiling PPSSPP (and hand-caching the tree)
-          # itself.
+          # The emulator the `psp-smoke` CI job boots the EBOOT under. Based on
+          # nixpkgs' own package, but the local patch below changes its output
+          # hash, so it no longer matches what cache.nixos.org has prebuilt for
+          # the channel this flake pins -- every `nix build '.#ppsspp'` compiles
+          # PPSSPP from source instead of substituting a closure. That is a
+          # multi-minute C++ build, so the `psp-smoke` job caches the Nix store
+          # across runs (the same `cache-nix-action` step every other job in
+          # `.github/workflows/build.yml` already uses) to avoid paying it on
+          # every push.
           #
           # The default (non-Qt) build is the one that carries what the smoke
           # test needs: it configures with -DHEADLESS=ON and installs the


### PR DESCRIPTION
## Summary
The `psp-smoke` CI job now caches the Nix store across runs to avoid recompiling PPSSPP from source on every push. This is necessary because `flake.nix` applies a local patch to the PPSSPP package, which changes its output hash and prevents using nixpkgs' prebuilt closure from `cache.nixos.org`.

## Key Changes

- **build.yml**: Added `cache-nix-action` step to the `psp-smoke` job with a cache key that includes both `flake.*` files and the PPSSPP patch file. Updated comments to explain why caching is now necessary (the patched PPSSPP no longer matches nixpkgs' prebuilt closure).

- **flake.nix**: Updated comments for the `ppsspp` package to document that it carries a local patch, explain that this prevents using prebuilt closures, and note that the `psp-smoke` job now caches the compiled result across runs.

- **changelog.d/psp-smoke-ppsspp-cache.changed.md**: Added changelog entry documenting the caching improvement and its rationale.

## Implementation Details

The cache key is carefully constructed to include:
- `flake.*` files (to invalidate when dependencies change)
- `nix/patches/ppsspp-lwmutex-workarea-validate.patch` (to invalidate when the patch changes)

This ensures the cache is only reused when both the flake configuration and the patch remain unchanged, preventing stale builds from being restored when the patch is modified.

https://claude.ai/code/session_019wk14fey1o7C5NryVhkjvr