### PR TITLE
rpg2003: draw a defending actor's Defend pose

### DIFF
--- a/changelog.d/rpg2003-actor-defend-pose.added.md
+++ b/changelog.d/rpg2003-actor-defend-pose.added.md
@@ -1,0 +1,5 @@
+- **A defending party member's alternate-layout battle sprite now shows its
+  Defend pose** (Battler Animation table Pose id 7) instead of staying on
+  Idle, matching EasyRPG's `Sprite_Actor::DoIdleAnimation`. The sprite swaps
+  the instant Defend commits and reverts to Idle once the round (or, in a
+  gauge fight, the individual turn) ends.

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -470,14 +470,15 @@ class RPG2k
                       @state.party.alternate_battle_layout?
         @ui[:actor_sprites] = @ui[:allies].each_with_index.map do |ally, i|
           next nil if ally.dead?
-          build_actor_sprite(ally.actor, i)
+          build_actor_sprite(ally.actor, i, defending: ally.defending)
         end
       end
 
-      # Idle pose id within a `db.battleranimations` entry's `poses` table
-      # (lcf::rpg::BattlerAnimation::Pose_Idle -- schema.rb's own comment on
-      # chunk 32 lists the full 12-pose order).
+      # Idle and Defend pose ids within a `db.battleranimations` entry's
+      # `poses` table (lcf::rpg::BattlerAnimation::Pose_Idle/Pose_Defend --
+      # schema.rb's own comment on chunk 32 lists the full 12-pose order).
       ACTOR_IDLE_POSE = 0
+      ACTOR_DEFEND_POSE = 7
       # `poses[id].animation_type` values: 0 a BattleCharSet sprite sheet
       # (implemented below), 1 a full Battle/<name> (CBA) animation sequence
       # played in place of a static sprite (not implemented here -- see
@@ -495,32 +496,47 @@ class RPG2k
         200 + i
       end
 
-      # A living party member's Idle-pose sprite, or nil when this step
-      # cannot draw one: `actor.battler_animation_id` names no
+      # A living party member's Idle- or Defend-pose sprite, or nil when this
+      # step cannot draw one: `actor.battler_animation_id` names no
       # `db.battleranimations` entry (Game::Actor#battler_animation_id
-      # already logs that diagnostic itself), the resolved entry defines no
-      # Idle pose at all (silent -- an entry legitimately covering only some
-      # of the 12 poses is normal authoring, not a dangling reference), or
-      # the pose uses the `animation_type == 1` battle/CBA format this step
-      # does not implement (logged below, matching this codebase's "reported
-      # gap, not silently invented" convention for unimplemented behaviour).
+      # already logs that diagnostic itself), the resolved entry defines
+      # neither pose at all (silent -- an entry legitimately covering only
+      # some of the 12 poses is normal authoring, not a dangling reference),
+      # or the pose uses the `animation_type == 1` battle/CBA format this
+      # step does not implement (logged below, matching this codebase's
+      # "reported gap, not silently invented" convention for unimplemented
+      # behaviour).
+      #
+      # `defending:` selects Pose id 7 (Defend, schema.rb's own comment on
+      # chunk 32 lists the full 12-pose order) over Idle -- ported from
+      # EasyRPG's `Sprite_Actor::DoIdleAnimation`, whose very first check is
+      # `battler->IsDefending()`, ahead of every state-mapped pose (the
+      # other half of that function's own idle-vs-something dispatch, still
+      # unimplemented here -- this only ever picks Idle or Defend). Falls
+      # back to Idle when the entry defines no Defend pose of its own,
+      # exactly like an entry with no Idle pose falls back to no sprite at
+      # all: a partially-authored table is normal, not an error.
       #
       # Position is either `battlecommands.placement` manual (0)'s raw
       # database `battle_x`/`battle_y` (Game_Actor::GetOriginalPosition) or
       # automatic (1)'s computed grid slot (#automatic_battle_position, the
       # EasyRPG Calculate2k3BattlePosition port) -- confirmed against
       # EasyRPG's actual C++ source, which splits exactly this way.
-      def build_actor_sprite(actor, i)
+      def build_actor_sprite(actor, i, defending: false)
         anim_id = actor.respond_to?(:battler_animation_id) ? (actor.battler_animation_id || 0) : 0
         table = db.respond_to?(:battleranimations) ? db.battleranimations : nil
         entry = (table && anim_id > 0) ? table[anim_id] : nil
         return nil unless entry
-        pose = entry.respond_to?(:poses) && entry.poses ? entry.poses[ACTOR_IDLE_POSE] : nil
+        poses = entry.respond_to?(:poses) ? entry.poses : nil
+        return nil unless poses
+        used_defend_pose = defending && poses[ACTOR_DEFEND_POSE] ? true : false
+        pose = used_defend_pose ? poses[ACTOR_DEFEND_POSE] : poses[ACTOR_IDLE_POSE]
         return nil unless pose
 
         if pose.animation_type == ACTOR_POSE_TYPE_BATTLE
-          $stderr.puts "[RPG2k] actor ##{actor.id}: idle pose uses a battle-animation (CBA) " \
-                       "sheet, not a BattleCharSet -- not yet implemented, sprite not drawn"
+          $stderr.puts "[RPG2k] actor ##{actor.id}: #{used_defend_pose ? 'defend' : 'idle'} pose " \
+                       "uses a battle-animation (CBA) sheet, not a BattleCharSet -- not yet " \
+                       "implemented, sprite not drawn"
           return nil
         end
 
@@ -664,7 +680,7 @@ class RPG2k
         @ui[:allies].push(combatant)
         return unless @ui[:actor_sprites]
         i = @ui[:allies].length - 1
-        @ui[:actor_sprites].push(combatant.dead? ? nil : build_actor_sprite(combatant.actor, i))
+        @ui[:actor_sprites].push(combatant.dead? ? nil : build_actor_sprite(combatant.actor, i, defending: combatant.defending))
         reset_actor_battler_z
       end
 
@@ -700,7 +716,7 @@ class RPG2k
         i = @ui[:allies].index { |c| c.equal?(combatant) }
         return unless i && sprites[i]
         dispose_battle_sprite(sprites[i])
-        sprites[i] = build_actor_sprite(combatant.actor, i)
+        sprites[i] = build_actor_sprite(combatant.actor, i, defending: combatant.defending)
       end
 
       # Re-derive every surviving actor sprite's Z from its current index in
@@ -1346,6 +1362,13 @@ class RPG2k
         when :defend
           play_system_se(SFX_DECISION)
           @ui[:battle].command_defend(current_actor)
+          # The alternate-layout sprite swaps to its Defend pose the instant
+          # the command commits (EasyRPG's own Sprite_Actor::DoIdleAnimation
+          # checks IsDefending() continuously; this codebase rebuilds
+          # instead, so the trigger has to be explicit) -- #finish_round_
+          # animation reverts it once Game::Battle#end_round clears
+          # `defending` back to false for the next round.
+          reposition_actor_sprite(current_actor)
           advance_actor
         when :item then open_battle_item
         when :special
@@ -2047,7 +2070,14 @@ class RPG2k
       # and branch to the result window or the next command phase.
       def finish_round_animation
         battle = @ui[:battle]
+        # `end_round` clears every ally's `defending` for the new round --
+        # revert any sprite still showing the Defend pose from the round
+        # that just ended, snapshotted here since `#end_round` itself wipes
+        # the flag this reads (#reposition_actor_sprite is a no-op when
+        # there are no alternate-layout actor sprites to begin with).
+        defenders = @ui[:allies].select(&:defending)
         battle.end_round
+        defenders.each { |ally| reposition_actor_sprite(ally) }
         close_battle_action
         if battle.finished?
           enter_battle_result(battle.result)

--- a/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
+++ b/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
@@ -230,7 +230,12 @@ module RPG2k3
       def finish_round_animation
         return super unless gauge_battle?
         battle = @ui[:battle]
+        # See the base #finish_round_animation's identical comment: snapshot
+        # who is showing the Defend pose before `end_round` clears the flag,
+        # so their sprite can revert to Idle.
+        defenders = @ui[:allies].select(&:defending)
         battle.end_round
+        defenders.each { |ally| reposition_actor_sprite(ally) }
         close_battle_action
         if battle.finished?
           enter_battle_result(battle.result)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11190,7 +11190,7 @@ end
 # parameters (112 / 392 / 16000) so the checks' expected coordinates are
 # explicit; `battle_xy:` supplies per-actor manual coordinates for the
 # placement-0 check.
-def placement_battle(ids, placement: 1, battle_xy: {}, battle_type: 2)
+def placement_battle(ids, placement: 1, battle_xy: {}, battle_type: 2, poses: nil)
   members = ids.map do |id|
     xy = battle_xy[id] || [0, 0]
     BattleStubActor.new(id: id, agi: 20, battler_animation_id: id,
@@ -11199,7 +11199,7 @@ def placement_battle(ids, placement: 1, battle_xy: {}, battle_type: 2)
   anims = {}
   members.each do |a|
     anims[a.id] = battle_pose_set(name: 'Fighter',
-                                  poses: { 0 => battle_pose(battler_name: 'Party', battler_index: 0) })
+                                  poses: poses || { 0 => battle_pose(battler_name: 'Party', battler_index: 0) })
   end
   party = BattleStubParty.new(members.first, alternate_layout: true,
                               automatic_placement: placement == 1, actors: members)
@@ -11266,6 +11266,65 @@ check 'the Row command moves an automatic-placement actor sprite by row_x_offset
   sprites = placement_sprites(scene)
   eq [280, 88], [sprites[0].x, sprites[0].y],
      'the sprite followed the row change: same grid slot, row_x_offset now 0 instead of 24'
+end
+
+check 'a defending actor draws the Defend pose, reverting to Idle once the round ends' do
+  # EasyRPG's Sprite_Actor::DoIdleAnimation checks IsDefending() before
+  # anything else -- ported as #build_actor_sprite's `defending:` keyword
+  # (Pose id 7), driven by #reposition_actor_sprite right when Defend
+  # commits and again once Game::Battle#end_round clears the flag.
+  poses = { 0 => battle_pose(battler_name: 'Party', battler_index: 0),
+           7 => battle_pose(battler_name: 'Party', battler_index: 3) }
+  scene = placement_battle([1, 2], placement: 0, battle_type: 0, poses: poses)
+  ui = battle_ui(scene)
+  # The sprite's src_rect Y is `pose.battler_index * ACTOR_CHARSET_CELL`
+  # (the sheet row the pose itself names, `poses` above) -- not the pose id
+  # (7 for Defend) directly.
+  idle_y = 0 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+  defend_y = 3 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+
+  sprites = placement_sprites(scene)
+  eq [idle_y, idle_y], [sprites[0].src_rect.y, sprites[1].src_rect.y], 'both start on the Idle pose'
+
+  2.times { press_key(scene, RGSS::Input::DOWN) } # Attack -> Skill -> Defend
+  press_key(scene, RGSS::Input::C)                # member 0 defends
+  sprites = placement_sprites(scene)
+  eq defend_y, sprites[0].src_rect.y, "member 0's sprite swaps to Defend the instant it commits"
+  eq idle_y, sprites[1].src_rect.y, "member 1 hasn't acted yet, still Idle"
+
+  # #finish_round_animation itself (not the many real frames a full round of
+  # message banners and enemy turns takes to animate out) is what reverts
+  # the sprite -- called directly, the same way other checks drive a scene's
+  # private step methods rather than re-proving the whole round machine's
+  # own timing here.
+  ui[:allies][1].defending = true # member 1 defends too, without driving its own menu
+  scene.instance_variable_get(:@battle).send(:finish_round_animation)
+  sprites = placement_sprites(scene)
+  eq [idle_y, idle_y], [sprites[0].src_rect.y, sprites[1].src_rect.y],
+     "both revert to Idle once the round ends and Game::Battle#end_round clears defending"
+end
+
+check 'a gauge battle: Defend swaps the sprite too, via the RPG2k3 scene\'s own #finish_round_animation' do
+  # `RPG2k3::Scene::Battle#finish_round_animation` fully overrides the base
+  # (calling `super` only when `!gauge_battle?`) and calls `Game::Battle
+  # #end_round` itself -- needs the identical defenders-snapshot fix, not
+  # just the base class.
+  poses = { 0 => battle_pose(battler_name: 'Party', battler_index: 0),
+           7 => battle_pose(battler_name: 'Party', battler_index: 3) }
+  scene = placement_battle([1], battle_type: 2, poses: poses)
+  ui = battle_ui(scene)
+  idle_y = 0 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+  defend_y = 3 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+
+  eq idle_y, placement_sprites(scene)[0].src_rect.y
+
+  2.times { press_key(scene, RGSS::Input::DOWN) } # Attack -> Skill -> Defend
+  press_key(scene, RGSS::Input::C)
+  eq defend_y, placement_sprites(scene)[0].src_rect.y, 'Defend swaps the pose in a gauge fight too'
+
+  scene.instance_variable_get(:@battle).send(:finish_round_animation)
+  eq idle_y, placement_sprites(scene)[0].src_rect.y,
+     "the RPG2k3 scene's own override reverts it once the gauge turn ends"
 end
 
 # yado.tk / 01_shoshin's 011_siyou: "Empty party doesn't itself Game Over, but


### PR DESCRIPTION
## Summary

- `build_actor_sprite` (the RPG2003 alternate-layout party sprite) only ever looked up Pose id 0 (Idle) from the Battler Animation table — every defending actor kept showing Idle. Pose id 7 is Defend (schema.rb's own chunk 32 comment, verified against liblcf's `fields.csv`/`chunks.h`), so a defending Combatant's sprite now looks it up instead, falling back to Idle when an entry defines no Defend pose of its own — ported from EasyRPG's `Sprite_Actor::DoIdleAnimation`, whose very first check is `battler->IsDefending()`, ahead of every state-mapped pose (still out of scope here).
- Since actor sprites are built once and never polled per frame, the new pose needs an explicit trigger: the Defend command's own dispatch now repositions the acting actor's sprite the instant it commits, and `finish_round_animation` (both the base round machine and the RPG2k3 gauge override, which fully replaces rather than calling `super`) snapshots who was defending before `Game::Battle#end_round` clears the flag, so their sprite reverts to Idle once the round/turn ends.
- A changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 689 checks passed (2 new: round-based — the sprite swaps on commit and both members revert once the round ends; gauge — the RPG2k3 scene's own override reverts it too)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 986 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_