### PR TITLE
interpreter: resolve vehicle refs in Conditional Branch's orientation check

### DIFF
--- a/changelog.d/conditional-branch-orientation-vehicle.fixed.md
+++ b/changelog.d/conditional-branch-orientation-vehicle.fixed.md
@@ -1,0 +1,4 @@
+- **Conditional Branch's character-orientation condition (type 6) now
+  resolves a vehicle reference** (10002 boat / 10003 ship / 10004 airship),
+  matching Control Variables' identical operand 6 attr 3 lookup. Previously
+  a vehicle ref fell through to `nil` and the condition always read false.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2617,9 +2617,9 @@ module Game
         cmd.param(2) == 0 ? has : !has
       when 5 # actor: param1 id, param2 sub-condition (see actor_condition)
         actor_condition(cmd)
-      when 6 # orientation: is character param1 (10001 the hero, 0 / 10005 this
-             # event, any other positive id a map event) facing direction param2
-             # (0 up / 1 right / 2 down / 3 left)?
+      when 6 # orientation: is character param1 (10001 the hero, 10002-10004 a
+             # vehicle, 0 / 10005 this event, any other positive id a map
+             # event) facing direction param2 (0 up / 1 right / 2 down / 3 left)?
         facing = character_facing(cmd.param(1))
         !facing.nil? && facing == FACING_NUMPAD[cmd.param(2)]
       when 7 # vehicle: true when the party is riding vehicle param1 (0 boat /
@@ -2673,6 +2673,13 @@ module Game
       return nil if id.nil?
       if id == CHAR_PLAYER
         @state.direction
+      elsif id >= CHAR_BOAT && id <= CHAR_AIRSHIP
+        # A vehicle ref, mirroring #vehicle_operand's identical lookup
+        # (Control Variables operand 6 attr 3) -- read straight off
+        # `Game::State` rather than through `@map_info`, since a vehicle is
+        # tracked independently of whatever map is currently loaded.
+        v = @state.vehicle(Vehicle::TYPES[id - CHAR_BOAT])
+        v && v.direction
       elsif id > 0 && id < 10000 && @map_info.respond_to?(:event_position)
         pos = @map_info.event_position(id)
         pos && pos[:direction]

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7433,6 +7433,21 @@ check 'Conditional Branch orientation: "this event" (type 6, ref 10005 / 0)' do
   eq true, run_cond_with_mapinfo([6, 10005, 1]).switches[2]
 end
 
+check 'Conditional Branch orientation: a vehicle ref (type 6, ref 10002-10004)' do
+  # #character_facing used to only resolve CHAR_PLAYER and a map event id --
+  # a vehicle ref (10002 boat / 10003 ship / 10004 airship) fell through to
+  # nil and the condition silently read false, unlike Control Variables'
+  # identical operand 6 attr 3 (#vehicle_operand, already correct). Mirrors
+  # that check's own vehicle setup.
+  st = run_actor_cond([6, 10002, 2]) { |s| s.vehicle(:boat).direction = 2 } # boat facing down
+  eq true, st.switches[1]                             # facing down -> if-branch
+  st = run_actor_cond([6, 10003, 0]) { |s| s.vehicle(:ship).direction = 2 } # ship facing down, asked up
+  eq true, st.switches[2]                             # not facing up -> else
+  # An unplaced vehicle defaults to facing down (numpad 2, direction 8's
+  # own #new default) -- reads a real direction, not nil/false regardless.
+  eq true, run_actor_cond([6, 10004, 2]).switches[1]  # airship, never placed, still faces down
+end
+
 # -- Input Number -------------------------------------------------------------
 
 check 'Input Number pauses with a :number request, resume stores the value' do


### PR DESCRIPTION
## Summary

- `character_facing` (Conditional Branch condition type 6) only handled `CHAR_PLAYER` and a map event id — a vehicle ref (10002 boat / 10003 ship / 10004 airship) fell through to `nil`, so the condition silently read false regardless of the vehicle's real facing.
- Control Variables' identical operand 6 attr 3 lookup (`vehicle_operand`) already resolves this correctly; `character_facing` now mirrors it exactly.
- A changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 990 checks passed (1 new, next to the existing orientation-condition checks)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 687 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_