### PR TITLE
interpreter: level-up/skill-learned lines now read the database's terms

### DIFF
--- a/changelog.d/interpreter-level-up-terms.fixed.md
+++ b/changelog.d/interpreter-level-up-terms.fixed.md
@@ -1,0 +1,5 @@
+- **Change EXP/Change Level/Change Class's level-up and skill-learned
+  messages now read the database's own `level_up`/`level`/`skill_learned`
+  terms**, matching the battle-result screen's identical lines. A database
+  that leaves the terms blank still falls back to the same composed English
+  as before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11316,6 +11316,22 @@ above are repeated here)
   EXP threshold and one learn-table entry line up with the two-Slime troop's
   10 total EXP; a blank database falls back to the composed English for
   both), both confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-18): the interpreter path caught up too.**
+  `#level_up_message`/`#skill_learned_message` (Change EXP/Change Level/
+  Change Class's own map-side lines) had stayed on the "plain English line
+  for now" simplification this entry itself documented as left untouched --
+  now ported from `#battle_level_up_message`/`#battle_skill_learned_message`
+  exactly, down to the same "は"/term/space composition and the same
+  falls-back-to-English-when-blank rule. `Game::Party` gains a `#term(name,
+  fallback)` reader (mirroring every scene's own `Scene::Base#term`, since
+  `Game::Interpreter` has no scene of its own to ask -- it can run inside a
+  common event, outside any scene at all) that `Game::Interpreter` reads
+  through a `respond_to?`-guarded `#party_term` helper, so a bare fixture
+  party with no `#term` still falls back to English rather than raising.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (a database
+  setting `level`/`level_up`/`skill_learned` composes the same line the
+  battle-result screen would; a blank database falls back to the identical
+  English both methods already used).
 - ✅ **Sell price = `floor(list price / 2)`; price 0 = unsellable in a shop
   but free if placed in a shop's own buy list — confirmed already
   correct**, all three facts, no code change needed. `Game::Shop#sell_price`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4207,6 +4207,19 @@ module Game
       @db.skill[id]
     end
 
+    # `db.term.<name>`, or `fallback` when the field is blank or the database
+    # carries no term table at all -- mirrors every scene's own `#term`
+    # (`Scene::Base`), the shared reader for vocabulary a project can rename.
+    # `Game::Interpreter` has no scene of its own to ask (it can run outside
+    # one entirely, e.g. a common event), so it reads the database's words
+    # through its party instead.
+    def term(name, fallback)
+      t = @db.respond_to?(:term) ? @db.term : nil
+      s = t && t.respond_to?(name) ? t.send(name) : nil
+      s = s.to_s
+      s.empty? ? fallback : s
+    end
+
     # The database's state (`situation`) table, for Game::States lookups --
     # priority, display name/colour, message text. nil for a fixture without
     # one, which every Game::States accessor already tolerates.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1973,18 +1973,39 @@ module Game
     end
 
     # The one line a level-up announces. RPG_RT phrases it from the database
-    # terms; this build uses a plain English line for now.
+    # terms -- ported from Scene::Battle's identical #battle_level_up_message
+    # (mruby-rpg2k/mrblib/scene/battle.rb), which already reads them for the
+    # post-battle result screen; this map-side path (Change EXP / Change
+    # Level / Change Class) used to stay on a plain English line regardless
+    # of the database. Falls back to English when the database leaves
+    # `level_up` blank (a raw `level_up` term with no `level` term set still
+    # gets the 'Lv' stand-in rather than losing the whole line).
     def level_up_message(actor, level)
-      "#{actor.name} is now level #{level}!"
+      up = party_term(:level_up, nil)
+      return "#{actor.name} is now level #{level}!" unless up
+      "#{actor.name}は#{party_term(:level, 'Lv')} #{level} #{up}"
     end
 
     # The one line a newly-learned skill announces, immediately following its
-    # level's own level-up line. RPG_RT glues the skill's own name onto the
-    # `skill_learned` database term (EasyRPG's ActorMessage::GetLearningMessage,
-    # `src/game_message_terms.cpp`); this build uses a plain English line for
-    # now, matching #level_up_message's own documented simplification.
+    # level's own level-up line -- ported from Scene::Battle's identical
+    # #battle_skill_learned_message the same way #level_up_message is.
+    # EasyRPG's stock/CP932 `GetLearningMessage` branch names only the skill,
+    # never the actor, since it always trails that actor's own level-up line
+    # the way it does here too. Falls back to composed English (which does
+    # name the actor, since a database leaving `skill_learned` blank gets no
+    # level-up line's context to lean on either) when the term is blank.
     def skill_learned_message(actor, sk)
-      "#{actor.name} learned #{sk.name}!"
+      learned = party_term(:skill_learned, nil)
+      return "#{actor.name} learned #{sk.name}!" unless learned
+      "#{sk.name}#{learned}"
+    end
+
+    # `@state.party.term`, or `fallback` when the live party is a bare
+    # fixture that implements no `#term` at all (this codebase's usual
+    # optional-interface guard, matching `db.respond_to?(:term)` elsewhere).
+    def party_term(name, fallback)
+      party = @state.party
+      party.respond_to?(:term) ? party.term(name, fallback) : fallback
     end
 
     # Enter the next queued level-up message as a :message wait; returns false

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3384,7 +3384,7 @@ end
 
 class FakeActorDB
   attr_reader :player, :system, :item, :skill, :job, :situation, :property, :battlecommands,
-              :enemy_group, :battleranimations
+              :enemy_group, :battleranimations, :term
   # `enemy_group` defaults to "every id exists" (Hash.new(true)) since most
   # checks using this fixture have nothing to do with troop validity; pass an
   # explicit hash (e.g. {}) to exercise the missing-troop-id diagnostic path.
@@ -3395,7 +3395,7 @@ class FakeActorDB
   def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil,
                  property = nil, rpg2003: false, battlecommands: nil,
                  enemy_group: Hash.new(true), battleranimations: nil,
-                 equipment_setting: nil)
+                 equipment_setting: nil, term: nil)
     @player = players
     @system = FakeActorSystem.new(party_ids, equipment_setting)
     @item = items
@@ -3407,6 +3407,7 @@ class FakeActorDB
     @battlecommands = battlecommands
     @enemy_group = enemy_group
     @battleranimations = battleranimations
+    @term = term
   end
 
   # Mirrors LCF::Schema::Database#rpg2003? (Classes-chunk presence) for tests
@@ -4600,6 +4601,29 @@ check 'Change Class shows one level-up line when it taught skills' do
   it.resume
   it.update
   ok !it.waiting?, 'a class change announces one line, not one per level'
+end
+
+check "level_up_message/skill_learned_message compose from the database's own terms" do
+  # Ported from Scene::Battle's identical battle_level_up_message/
+  # battle_skill_learned_message (already term-based for the post-battle
+  # result screen) -- these map-side lines (Change EXP/Level/Class) used to
+  # stay on a plain English line regardless of the database.
+  terms = Struct.new(:level_up, :level, :skill_learned).new('になった！', 'Lv', 'を覚えた！')
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1], term: terms)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  it = Game::Interpreter.new(st)
+  hero = st.party.actors.first
+  eq 'HeroはLv 5 になった！', it.send(:level_up_message, hero, 5)
+  eq 'Fireballを覚えた！', it.send(:skill_learned_message, hero, fake_skill(name: 'Fireball'))
+end
+
+check 'level_up_message/skill_learned_message fall back to English when the database leaves the terms blank' do
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  it = Game::Interpreter.new(st)
+  hero = st.party.actors.first
+  eq 'Hero is now level 5!', it.send(:level_up_message, hero, 5)
+  eq 'Hero learned Fireball!', it.send(:skill_learned_message, hero, fake_skill(name: 'Fireball'))
 end
 
 check 'Change Class stays quiet when the level held and no skills moved' do


### PR DESCRIPTION
## Summary

- `level_up_message`/`skill_learned_message` (Change EXP/Change Level/Change Class's own map-side lines) stayed on a plain English line regardless of the database, unlike `Scene::Battle`'s identical `battle_level_up_message`/`battle_skill_learned_message`, which already read real terms for the post-battle result screen — the interpreter path was the one place still marked "documented simplification, left untouched" when that fix landed.
- Ported the exact same composition here: `Game::Party` gains a `#term(name, fallback)` reader (mirroring every scene's own `Scene::Base#term`, since `Game::Interpreter` has no scene of its own to ask — it can run inside a common event, outside any scene at all), read through a `respond_to?`-guarded `#party_term` helper so a bare fixture party with no `#term` still falls back to English rather than raising.
- `docs/TODO.md` updated with a dated follow-up on the original entry, and a changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 992 checks passed (2 new: a database setting `level`/`level_up`/`skill_learned` composes the same line the battle-result screen would; a blank database falls back to the identical English both methods already used)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 689 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_