### PR TITLE
rpg2003: draw a knocked-out actor's Dead battle sprite pose

### DIFF
--- a/changelog.d/rpg2003-actor-dead-pose.fixed.md
+++ b/changelog.d/rpg2003-actor-dead-pose.fixed.md
@@ -1,0 +1,7 @@
+- **A knocked-out party member's alternate-layout battle sprite now shows its
+  Dead pose** (Battler Animation table Pose id 4) instead of drawing no
+  sprite at all, matching EasyRPG's `Sprite_Actor::DoIdleAnimation`, whose
+  monster branch resolves the Knockout state to `AnimationState_Dead` rather
+  than hiding it. The sprite swaps the instant a round (or, in a gauge fight,
+  an individual turn) ends with the member felled, and a member already KO'd
+  when the fight opens gets the pose immediately.

--- a/docs/adr/0053-rpg2003-battle-scene-mechanics.md
+++ b/docs/adr/0053-rpg2003-battle-scene-mechanics.md
@@ -300,3 +300,32 @@ fatal). Scene checks pin the `headless_battle_troop` flag plumbing and
   `rpg2k_scene_check.rb` check proving the menu dispatch reaches it (focus
   moves to the actor panel, confirming toggles with no scene pushed, focus
   returns to the command list).
+- **A knocked-out party member's battle sprite landed (2026-08-18).** Idle
+  and Defend were the only two poses `#build_actor_sprite` picked between; a
+  dead member fell through to no sprite at all, `next nil if ally.dead?`
+  right alongside a hidden troop member never getting one either. EasyRPG's
+  `Sprite_Actor::DoIdleAnimation` (`src/sprite_actor.cpp`, confirmed against
+  the reference source) checks `IsDefending()` first, then resolves the
+  battler's `GetSignificantState()`: for a monster (no battler-animation
+  table to consult) that is a direct `state->ID == 1 ? AnimationState_Dead :
+  AnimationState_Idle`, still drawn rather than hidden. A defeated party
+  member is now treated the same unambiguous way -- `#build_actor_sprite`
+  gained a `dead:` keyword selecting Pose id 4 (Dead), alongside the
+  existing `defending:` -> Pose id 7, both falling back to Idle when the
+  entry defines no such pose of its own. The reference's *other* branch --
+  an actor's own active state (not just Death) swapping in that state's own
+  `situation.battler_animation_id` pose (`+1`/the `101` "no override" ->
+  `AnimationState_BadStatus` sentinel, worked out from `sprite_actor.h`'s
+  `AnimationState` enum but not yet exercised here) -- stays unimplemented,
+  same deferral this ADR's Phase 1 notes already used for the condition-gated
+  row rules. `Game::Battle::Combatant#states` is not itself kept in sync with
+  the Knockout state id the way `Game::Actor#states` is (nothing here needed
+  it to be, since `Combatant#dead?` is plain `hp <= 0`), so the new code
+  reads `dead?` directly rather than through `Game::States.significant`.
+  Wired into `#build_actor_sprites` (initial build), `#add_battle_actor_sprite`
+  (mid-battle rejoin) and both scenes' `#finish_round_animation` (a felled
+  ally's sprite catches up once the round/turn that killed them ends, the
+  same targeted-repositioning shape the Defend-pose landing above already
+  established for its own snapshot-then-revert). Three new
+  `rpg2k_scene_check.rb` checks cover the already-KO'd-at-open case and both
+  scenes' round-end catch-up.

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -448,36 +448,37 @@ class RPG2k
         refresh_battle_sprites
       end
 
-      # RPG2003's alternative/gauge battle layouts draw each living party
-      # member as a sprite too (unlike RPG2000's status-window-only layout --
-      # see Game::Party#alternate_battle_layout?), sourced from the
-      # database's Battler Animation table (chunk 32, db.battleranimations --
-      # decoded in a prior change, nothing read it until now). Scoped to the
-      # plain Idle pose only (Pose id 0): no active state, not defending --
-      # EasyRPG's Sprite_Actor::DoIdleAnimation (src/sprite_actor.cpp) swaps
-      # in a Defend or state-mapped pose in those two cases, which is
-      # follow-up work for a later change, not this one. A dead party member
-      # gets no sprite (mirrors a hidden troop member never getting one
-      # either in #build_battle_sprites above); the party status window keeps
-      # showing everyone regardless, so a member left spriteless here (dead,
-      # or any of the gaps #build_actor_sprite itself documents) is never
-      # invisible to the player. A traditional-layout database (or a bare
-      # test fixture whose party doesn't even answer #alternate_battle_layout?)
-      # builds nothing, matching current behaviour exactly.
+      # RPG2003's alternative/gauge battle layouts draw each party member as
+      # a sprite too (unlike RPG2000's status-window-only layout -- see
+      # Game::Party#alternate_battle_layout?), sourced from the database's
+      # Battler Animation table (chunk 32, db.battleranimations). Idle,
+      # Defend and Dead are the three poses #build_actor_sprite picks
+      # between (EasyRPG's Sprite_Actor::DoIdleAnimation, src/sprite_actor.cpp
+      # -- its remaining branch, any *other* active state swapping in its own
+      # `situation.battler_animation_id` pose, is still unimplemented here).
+      # A fallen member still gets a sprite (the Dead pose, or Idle when the
+      # entry defines no Dead pose of its own) rather than none at all -- the
+      # party status window shows everyone regardless either way, so this
+      # only changes what a downed member's own battler sprite looks like.
+      # A traditional-layout database (or a bare test fixture whose party
+      # doesn't even answer #alternate_battle_layout?) builds nothing,
+      # matching current behaviour exactly.
       def build_actor_sprites
         @ui[:actor_sprites] = nil
         return unless @state.party.respond_to?(:alternate_battle_layout?) &&
                       @state.party.alternate_battle_layout?
         @ui[:actor_sprites] = @ui[:allies].each_with_index.map do |ally, i|
-          next nil if ally.dead?
-          build_actor_sprite(ally.actor, i, defending: ally.defending)
+          build_actor_sprite(ally.actor, i, defending: ally.defending, dead: ally.dead?)
         end
       end
 
-      # Idle and Defend pose ids within a `db.battleranimations` entry's
-      # `poses` table (lcf::rpg::BattlerAnimation::Pose_Idle/Pose_Defend --
-      # schema.rb's own comment on chunk 32 lists the full 12-pose order).
+      # Idle, Dead and Defend pose ids within a `db.battleranimations` entry's
+      # `poses` table (lcf::rpg::BattlerAnimation::Pose_Idle/Pose_Dead/
+      # Pose_Defend -- schema.rb's own comment on chunk 32 lists the full
+      # 12-pose order, and matches EasyRPG's own `AnimationState` enum once
+      # its one-off `AnimationState_Null` head element is subtracted out).
       ACTOR_IDLE_POSE = 0
+      ACTOR_DEAD_POSE = 4
       ACTOR_DEFEND_POSE = 7
       # `poses[id].animation_type` values: 0 a BattleCharSet sprite sheet
       # (implemented below), 1 a full Battle/<name> (CBA) animation sequence
@@ -496,45 +497,58 @@ class RPG2k
         200 + i
       end
 
-      # A living party member's Idle- or Defend-pose sprite, or nil when this
+      # A party member's Idle-, Defend- or Dead-pose sprite, or nil when this
       # step cannot draw one: `actor.battler_animation_id` names no
       # `db.battleranimations` entry (Game::Actor#battler_animation_id
       # already logs that diagnostic itself), the resolved entry defines
-      # neither pose at all (silent -- an entry legitimately covering only
-      # some of the 12 poses is normal authoring, not a dangling reference),
-      # or the pose uses the `animation_type == 1` battle/CBA format this
-      # step does not implement (logged below, matching this codebase's
-      # "reported gap, not silently invented" convention for unimplemented
-      # behaviour).
+      # none of the three poses at all (silent -- an entry legitimately
+      # covering only some of the 12 poses is normal authoring, not a
+      # dangling reference), or the pose uses the `animation_type == 1`
+      # battle/CBA format this step does not implement (logged below,
+      # matching this codebase's "reported gap, not silently invented"
+      # convention for unimplemented behaviour).
       #
-      # `defending:` selects Pose id 7 (Defend, schema.rb's own comment on
-      # chunk 32 lists the full 12-pose order) over Idle -- ported from
-      # EasyRPG's `Sprite_Actor::DoIdleAnimation`, whose very first check is
-      # `battler->IsDefending()`, ahead of every state-mapped pose (the
-      # other half of that function's own idle-vs-something dispatch, still
-      # unimplemented here -- this only ever picks Idle or Defend). Falls
-      # back to Idle when the entry defines no Defend pose of its own,
-      # exactly like an entry with no Idle pose falls back to no sprite at
-      # all: a partially-authored table is normal, not an error.
+      # `defending:`/`dead:` select Pose id 7 (Defend) / 4 (Dead) over Idle
+      # -- ported from EasyRPG's `Sprite_Actor::DoIdleAnimation`, whose very
+      # first check is `battler->IsDefending()`, ahead of every state-mapped
+      # pose, and whose monster branch (the one unambiguous case without a
+      # `situation.battler_animation_id` table to consult) resolves the
+      # Knockout state straight to `AnimationState_Dead`; a defeated actor
+      # is treated the same way here rather than through its own state's
+      # configurable pose (the other, still-unimplemented half of that
+      # function's dispatch -- see #build_actor_sprites). Defending wins
+      # over dead, matching the reference's check order, though the two
+      # never actually coincide (a downed actor never has a command to
+      # defend with). Either falls back to Idle when the entry defines no
+      # pose of its own for it, exactly like an entry with no Idle pose
+      # falls back to no sprite at all: a partially-authored table is normal,
+      # not an error.
       #
       # Position is either `battlecommands.placement` manual (0)'s raw
       # database `battle_x`/`battle_y` (Game_Actor::GetOriginalPosition) or
       # automatic (1)'s computed grid slot (#automatic_battle_position, the
       # EasyRPG Calculate2k3BattlePosition port) -- confirmed against
       # EasyRPG's actual C++ source, which splits exactly this way.
-      def build_actor_sprite(actor, i, defending: false)
+      def build_actor_sprite(actor, i, defending: false, dead: false)
         anim_id = actor.respond_to?(:battler_animation_id) ? (actor.battler_animation_id || 0) : 0
         table = db.respond_to?(:battleranimations) ? db.battleranimations : nil
         entry = (table && anim_id > 0) ? table[anim_id] : nil
         return nil unless entry
         poses = entry.respond_to?(:poses) ? entry.poses : nil
         return nil unless poses
-        used_defend_pose = defending && poses[ACTOR_DEFEND_POSE] ? true : false
-        pose = used_defend_pose ? poses[ACTOR_DEFEND_POSE] : poses[ACTOR_IDLE_POSE]
+        pose_id = if defending && poses[ACTOR_DEFEND_POSE]
+                    ACTOR_DEFEND_POSE
+                  elsif dead && poses[ACTOR_DEAD_POSE]
+                    ACTOR_DEAD_POSE
+                  else
+                    ACTOR_IDLE_POSE
+                  end
+        pose = poses[pose_id]
         return nil unless pose
 
         if pose.animation_type == ACTOR_POSE_TYPE_BATTLE
-          $stderr.puts "[RPG2k] actor ##{actor.id}: #{used_defend_pose ? 'defend' : 'idle'} pose " \
+          label = { ACTOR_DEFEND_POSE => 'defend', ACTOR_DEAD_POSE => 'dead' }.fetch(pose_id, 'idle')
+          $stderr.puts "[RPG2k] actor ##{actor.id}: #{label} pose " \
                        "uses a battle-animation (CBA) sheet, not a BattleCharSet -- not yet " \
                        "implemented, sprite not drawn"
           return nil
@@ -680,7 +694,7 @@ class RPG2k
         @ui[:allies].push(combatant)
         return unless @ui[:actor_sprites]
         i = @ui[:allies].length - 1
-        @ui[:actor_sprites].push(combatant.dead? ? nil : build_actor_sprite(combatant.actor, i, defending: combatant.defending))
+        @ui[:actor_sprites].push(build_actor_sprite(combatant.actor, i, defending: combatant.defending, dead: combatant.dead?))
         reset_actor_battler_z
       end
 
@@ -701,22 +715,25 @@ class RPG2k
         reset_actor_battler_z
       end
 
-      # `combatant`'s row just changed (the in-battle Row command) and its
-      # on-screen alternate-layout sprite needs to reflect the new
+      # `combatant`'s row, Defend or Dead status just changed and its
+      # on-screen alternate-layout sprite needs to catch up -- the new
       # automatic-placement X (`#automatic_battle_position`'s `row_x_offset`)
-      # -- rebuild it in place at the same index/Z, the same dispose-then-
-      # #build_actor_sprite-fresh shape #remove_battle_actor_sprite/
-      # #add_battle_actor_sprite already use for a roster change. A no-op
-      # when the fight draws no actor sprites at all (a traditional-layout
-      # database), or manual placement (its `battle_x`/`battle_y` never
-      # depend on row -- see `Combatant.from_actor`'s own row comment).
+      # for a row change, or the Idle/Defend/Dead pose #build_actor_sprite
+      # picks between otherwise -- rebuilt in place at the same index/Z, the
+      # same dispose-then-#build_actor_sprite-fresh shape
+      # #remove_battle_actor_sprite/#add_battle_actor_sprite already use for
+      # a roster change. A no-op when the fight draws no actor sprites at
+      # all (a traditional-layout database); manual placement's row_x_offset
+      # is a no-op too, since its `battle_x`/`battle_y` never depend on row
+      # (see `Combatant.from_actor`'s own row comment) -- only the pose can
+      # still change there.
       def reposition_actor_sprite(combatant)
         sprites = @ui[:actor_sprites]
         return unless sprites
         i = @ui[:allies].index { |c| c.equal?(combatant) }
         return unless i && sprites[i]
         dispose_battle_sprite(sprites[i])
-        sprites[i] = build_actor_sprite(combatant.actor, i, defending: combatant.defending)
+        sprites[i] = build_actor_sprite(combatant.actor, i, defending: combatant.defending, dead: combatant.dead?)
       end
 
       # Re-derive every surviving actor sprite's Z from its current index in
@@ -2076,10 +2093,14 @@ class RPG2k
         # revert any sprite still showing the Defend pose from the round
         # that just ended, snapshotted here since `#end_round` itself wipes
         # the flag this reads (#reposition_actor_sprite is a no-op when
-        # there are no alternate-layout actor sprites to begin with).
+        # there are no alternate-layout actor sprites to begin with). Anyone
+        # felled during the round just gone needs the same catch-up onto
+        # the Dead pose -- `dead?` itself survives `#end_round` untouched,
+        # so it is read after rather than snapshotted before.
         defenders = @ui[:allies].select(&:defending)
         battle.end_round
-        defenders.each { |ally| reposition_actor_sprite(ally) }
+        (defenders + @ui[:allies].select(&:dead?)).uniq { |a| a.object_id }
+          .each { |ally| reposition_actor_sprite(ally) }
         close_battle_action
         if battle.finished?
           enter_battle_result(battle.result)

--- a/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
+++ b/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
@@ -232,10 +232,12 @@ module RPG2k3
         battle = @ui[:battle]
         # See the base #finish_round_animation's identical comment: snapshot
         # who is showing the Defend pose before `end_round` clears the flag,
-        # so their sprite can revert to Idle.
+        # so their sprite can revert to Idle, and catch up anyone felled
+        # this action onto the Dead pose.
         defenders = @ui[:allies].select(&:defending)
         battle.end_round
-        defenders.each { |ally| reposition_actor_sprite(ally) }
+        (defenders + @ui[:allies].select(&:dead?)).uniq { |a| a.object_id }
+          .each { |ally| reposition_actor_sprite(ally) }
         close_battle_action
         if battle.finished?
           enter_battle_result(battle.result)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9994,6 +9994,34 @@ check 'Enemy Encounter scene: the alternative/gauge layout draws a positioned Id
   ok spr.z < 300, 'sits below the UI windows (z >= 300)'
 end
 
+# EasyRPG's Sprite_Actor::DoIdleAnimation resolves a monster's Knockout state
+# straight to AnimationState_Dead rather than hiding it; a party member is
+# treated the same way here (#build_actor_sprite's `dead:` keyword, Pose id
+# 4) -- so a member already KO'd the instant the fight opens gets that pose
+# rather than no sprite at all, the gap this check pins.
+check "Enemy Encounter scene: a party member already KO'd going into the fight draws the Dead pose, not no sprite" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose(battler_name: 'Hero', battler_index: 2),
+                                          4 => battle_pose(battler_name: 'Hero', battler_index: 6) }) }
+  scene = new_scene({ 1 => event(2, 2, auto) }, battleranimations: anims)
+  st = scene.instance_variable_get(:@state)
+  fallen = BattleStubActor.new(id: 1, battler_animation_id: 5, hp: 0)
+  alive = BattleStubActor.new(id: 2, battler_animation_id: 5)
+  st.instance_variable_set(:@party, BattleStubParty.new(actors: [fallen, alive], alternate_layout: true))
+  ui = battle_to_command(scene)
+
+  sprites = ui[:actor_sprites]
+  ok sprites, 'built when the layout is alternative/gauge'
+  eq 2, sprites.compact.length, 'both members get a sprite, including the already-fallen one'
+  cell = RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+  eq RGSS::Rect.new(0, 6 * cell, cell, cell), sprites[0].src_rect,
+     "the fallen member's sprite uses the entry's Dead pose cell (battler_index 6), not Idle"
+  eq RGSS::Rect.new(0, 2 * cell, cell, cell), sprites[1].src_rect,
+     'the living member still gets the Idle pose'
+end
+
 check 'Enemy Encounter scene: the traditional (RPG2000) layout draws no actor sprites' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
@@ -11328,6 +11356,45 @@ check 'a gauge battle: Defend swaps the sprite too, via the RPG2k3 scene\'s own 
   scene.instance_variable_get(:@battle).send(:finish_round_animation)
   eq idle_y, placement_sprites(scene)[0].src_rect.y,
      "the RPG2k3 scene's own override reverts it once the gauge turn ends"
+end
+
+check 'a party member killed mid-round switches to the Dead pose once the round ends' do
+  # #finish_round_animation's own dead-select-after-#end_round addition
+  # (mirrors its existing defenders snapshot, but read after rather than
+  # before since `dead?` survives `#end_round` untouched) is what catches a
+  # felled ally's sprite up -- `hp` is set directly here rather than driving
+  # a full damage exchange, the same "simulate the moment, not the whole
+  # pipeline" idiom the Defend checks above use for `defending`.
+  poses = { 0 => battle_pose(battler_name: 'Party', battler_index: 0),
+           4 => battle_pose(battler_name: 'Party', battler_index: 6) }
+  scene = placement_battle([1, 2], placement: 0, battle_type: 0, poses: poses)
+  idle_y = 0 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+  dead_y = 6 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+
+  sprites = placement_sprites(scene)
+  eq [idle_y, idle_y], [sprites[0].src_rect.y, sprites[1].src_rect.y], 'both start on the Idle pose'
+
+  ui = battle_ui(scene)
+  ui[:allies][1].hp = 0 # felled mid-round
+  scene.instance_variable_get(:@battle).send(:finish_round_animation)
+  sprites = placement_sprites(scene)
+  eq idle_y, sprites[0].src_rect.y, 'the survivor stays on the Idle pose'
+  eq dead_y, sprites[1].src_rect.y, 'the felled member switches to the Dead pose'
+end
+
+check 'a gauge battle: a felled ally switches to the Dead pose too, via the RPG2k3 scene\'s own #finish_round_animation' do
+  poses = { 0 => battle_pose(battler_name: 'Party', battler_index: 0),
+           4 => battle_pose(battler_name: 'Party', battler_index: 6) }
+  scene = placement_battle([1, 2], battle_type: 2, poses: poses)
+  idle_y = 0 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+  dead_y = 6 * RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+
+  ui = battle_ui(scene)
+  ui[:allies][0].hp = 0 # the other member stays alive, so the fight (and @ui) survives
+  scene.instance_variable_get(:@battle).send(:finish_round_animation)
+  sprites = placement_sprites(scene)
+  eq dead_y, sprites[0].src_rect.y, "the RPG2k3 scene's own override catches the Dead pose up too"
+  eq idle_y, sprites[1].src_rect.y, 'the survivor is untouched'
 end
 
 # yado.tk / 01_shoshin's 011_siyou: "Empty party doesn't itself Game Over, but


### PR DESCRIPTION
## Summary

- A downed party member drew **no** alternate-layout battle sprite at all (`next nil if ally.dead?`) — the same treatment as a hidden troop member, but not what the reference does. EasyRPG's `Sprite_Actor::DoIdleAnimation` (`src/sprite_actor.cpp`, confirmed against the actual source) checks `IsDefending()` first, then resolves `GetSignificantState()`; for a monster (no battler-animation table to consult) that's a direct `state->ID == 1 ? AnimationState_Dead : AnimationState_Idle` — still drawn, never hidden.
- `#build_actor_sprite` gains a `dead:` keyword selecting Pose id 4 (Dead), alongside the existing `defending:` → Pose id 7, both falling back to Idle when the entry defines no such pose of its own. Defending still wins over dead in the (never-actually-co-occurring) tie, matching the reference's check order.
- The reference's *other* branch — an actor's own active state (not just Death) swapping in that state's own `situation.battler_animation_id` pose (worked out from `sprite_actor.h`'s `AnimationState` enum, including its `+1`/the raw-`100` "no override" → `AnimationState_BadStatus` sentinel) — stays unimplemented, the same phased deferral this ADR's Phase 1 notes already use for the condition-gated row rules.
- `Game::Battle::Combatant#states` is not itself kept in sync with the Knockout state id the way `Game::Actor#states` is, so the new code reads `Combatant#dead?` (`hp <= 0`) directly rather than through `Game::States.significant`.
- Wired into `#build_actor_sprites` (initial build), `#add_battle_actor_sprite` (mid-battle rejoin) and both scenes' `#finish_round_animation` — a felled ally's sprite now catches up once the round (or, in a gauge fight, the individual turn) that killed them ends, the same targeted-repositioning shape the earlier Defend-pose landing established for its own snapshot-then-revert.
- ADR 0053 updated and a changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 993 checks passed (unchanged)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 693 checks passed (3 new: already-KO'd-at-battle-open draws Dead not nil; a mid-round death catches up to Dead once the round ends in both the base and RPG2003 gauge scenes)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_