### PR TITLE
interpreter: Control Variables' Other operand reads the BGM play position

### DIFF
--- a/changelog.d/control-variables-bgm-position.added.md
+++ b/changelog.d/control-variables-bgm-position.added.md
@@ -1,0 +1,6 @@
+- **Control Variables' "Other" operand now supports selector 8 (BGM play
+  position)**, reading `RGSS::Audio#bgm_pos` (milliseconds into the current
+  track, already used by the "BGM played once" Conditional Branch) the same
+  way EasyRPG's `ControlVariables::Other` reads `Audio().BGM_GetTicks()` --
+  base-engine behaviour, not gated behind the Maniac Patch like the
+  selectors above it. Previously read as 0, silently.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1758,8 +1758,18 @@ module Game
 
     # Operand type 7: a miscellaneous game quantity selected by param5 (0 party
     # gold, 1 timer seconds, 2 party members, 3 save count, 4 battle count,
-    # 5 win count, 6 defeat count, 7 escape/run count). Remaining RPG2003-only
-    # selectors are not modelled and read as 0.
+    # 5 win count, 6 defeat count, 7 escape/run count, 8 BGM play position).
+    # Selector 8 is not RPG2003-only despite reading that way at a glance --
+    # EasyRPG's `ControlVariables::Other` (src/game_interpreter_control_
+    # variables.cpp) gates cases 10+ behind the Maniac Patch but not this one,
+    # so it is base-engine behaviour. It reads `Audio().BGM_GetTicks()`
+    # there, milliseconds into the current track; `RGSS::Audio#bgm_pos` is
+    # this engine's own millisecond BGM clock (src/sdl_audio.cxx's `bgm_pos`,
+    # already read the same way by Scene::Map#watch_bgm_loop for the "BGM
+    # played once" branch), so it is read the same defensive way here --
+    # `respond_to?`-gated for a backend that cannot report one. Remaining
+    # selectors (9+ other than the RPG2003 second timer below) are not
+    # modelled and read as 0.
     def other_operand(cmd)
       case cmd.param(5)
       when 0 then party.gold
@@ -1770,6 +1780,7 @@ module Game
       when 5 then @state.win_count
       when 6 then @state.defeat_count
       when 7 then @state.escape_count
+      when 8 then RGSS::Audio.respond_to?(:bgm_pos) ? RGSS::Audio.bgm_pos.to_i : 0
       when 9 then @state.timer(1).seconds # RPG2003's second timer
       else 0
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -20,7 +20,7 @@
 module RGSS
   module Audio
     class << self
-      attr_accessor :log
+      attr_accessor :log, :bgm_pos
       def bgm_play(*a); (@log ||= []) << [:bgm, *a]; end
       def bgm_volume(*a); (@log ||= []) << [:bgm_volume, *a]; end
       def bgm_pan(*a); (@log ||= []) << [:bgm_pan, *a]; end
@@ -6979,6 +6979,22 @@ check 'Control Variables reads the save / battle / win / defeat / escape counts'
   eq 6, st.variables[3]
   eq 1, st.variables[4]
   eq 2, st.variables[5]
+end
+
+check 'Control Variables reads the BGM play position (operand type 7, selector 8)' do
+  # Not RPG2003/Maniac-Patch-only despite the "remaining selectors" doc
+  # comment's general framing -- EasyRPG's ControlVariables::Other gates
+  # cases 10+ behind the Maniac Patch but not this one. RGSS::Audio#bgm_pos
+  # is this engine's own millisecond BGM clock (already read the same
+  # `respond_to?`-gated way by Scene::Map#watch_bgm_loop).
+  st = new_state
+  it = Game::Interpreter.new(st)
+  RGSS::Audio.bgm_pos = 1234
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 7, 8])])
+  it.update
+  eq 1234, st.variables[1]
+ensure
+  RGSS::Audio.bgm_pos = nil
 end
 
 check 'battle counters advance: Enemy Encounter and its outcome' do


### PR DESCRIPTION
## Summary

- Control Variables' "Other" operand (type 7) fell through to `else 0` for selector 8, with a doc comment implying every remaining selector was RPG2003-only and unmodelled.
- Checked against EasyRPG's actual `ControlVariables::Other` (`src/game_interpreter_control_variables.cpp`): case 8 resolves to `Audio().BGM_GetTicks()`, and — unlike cases 10+ — is **not** gated behind the Maniac Patch, so it's genuine base-engine behavior (e.g. for rhythm-timed puzzles branching on BGM playback position), not an RPG2003/patch-only extension as the old comment implied.
- `Game::Interpreter#other_operand` now reads `RGSS::Audio#bgm_pos` for selector 8, `respond_to?`-gated for a backend that can't report a position — the same defensive pattern and the same underlying millisecond BGM clock (`src/sdl_audio.cxx`'s `bgm_pos`) that `Scene::Map#watch_bgm_loop` already polls for the unrelated "BGM played once" Conditional Branch.
- The doc comment above `other_operand` is corrected accordingly.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 994 checks passed (1 new: selector 8 reads the stubbed `RGSS::Audio.bgm_pos` value through Control Variables)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 693 checks passed (unchanged)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_