### PR TITLE
game: a medicine's reverse_state_effect never inflicts, only cures

### DIFF
--- a/changelog.d/medicine-reverse-state-effect-dead.fixed.md
+++ b/changelog.d/medicine-reverse-state-effect-dead.fixed.md
@@ -1,0 +1,7 @@
+- **A medicine's `reverse_state_effect` flag no longer inflicts states
+  instead of curing them.** EasyRPG's `Game_BattleAlgorithm::Item::vExecute`
+  never reads that field for a medicine (unlike a weapon's own, RPG2003-only
+  flip, or a skill's) -- the editor's checkbox does nothing for an item in
+  the real engine. `state_set` is always a cure list now, regardless of the
+  flag, matching the reference exactly rather than mirroring the skill
+  side's mechanism on an assumption that turned out not to hold.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -732,6 +732,29 @@ The work below is roughly ordered by the critical path to a walkable game
   checks built the same way the mirrored skill-side inflict behaviour already
   was, confirmed to fail against the pre-fix code (a `NoMethodError` for the
   missing accessor, then a wrong-effective-flag failure) before the fix.
+  ❌ **The inflict half above was itself wrong, and has been removed
+  (2026-08-18).** It assumed `Item::vExecute` mirrors the skill side's
+  `reverse_state_effect` branch "the same way" without the reference
+  function ever actually being read — once EasyRPG's real
+  `Game_BattleAlgorithm::Item::vExecute` (`src/game_battlealgorithm.cpp`)
+  became reachable, its `Type_medicine` branch turned out to apply
+  `state_set` as an unconditional cure list with **no** `reverse_state_effect`
+  check at all; the field is real data an item row carries (chunk 13 field
+  68), but the editor's checkbox does nothing for a medicine in the real
+  engine. Exhaustively confirmed: the whole of `game_battlealgorithm.cpp`
+  references the field exactly twice, once in the weapon block of
+  `Normal::vExecute` (RPG2003 only) and once in `Skill::vExecute` — never in
+  `Item::vExecute`. `Game::Party#item_inflicted_states` is deleted;
+  `#item_cured_states` no longer checks the flag at all, curing
+  unconditionally regardless of it (matching what the reference actually
+  does, not what its own comment assumed); `#use_medicine`'s inflict branch
+  and `#item_effective?`'s inflict-side offer clause are gone with it.
+  `rpg2k_logic_check.rb`'s two checks proving the (wrong) inflict mechanism
+  are replaced with checks proving the flag is inert on a medicine either
+  way. The weapon-side flip above (`is2k3 && w->reverse_state_effect`,
+  RPG2003 only) and the field-skill flip (`Game_Battler::UseSkill`) are
+  untouched — both really are read by the reference, just not by the item
+  algorithm.
   The **death state (戦闘不能, id 1)** is **coupled to HP** (EasyRPG's
   `kDeathID`): lethal `change_hp` knocks the actor out and inflicts state 1
   (zeroing HP), a downed actor can't be healed by HP changes, and curing the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1989,11 +1989,14 @@ module Game
     # state, or the same one at a different chance -- EasyRPG takes the
     # higher chance when both weapons flag the same state ("we take the max
     # probability as RPG_RT does"), which is what the `< chance` compare
-    # below does per state id. `reverse_state_effect` (field 20) flips a
+    # below does per state id. `reverse_state_effect` (field 68) flips a
     # weapon's own states from inflicting to curing, but **only on RPG2003**
     # (`is2k3 && w->reverse_state_effect`) -- on RPG2000 the field has no
-    # effect here, matching the flag's own item-menu/skill-menu handling
-    # elsewhere in this file (`#item_inflicted_states`, `#skill_state_ids`).
+    # effect here. This is the one place the item table's `reverse_state_
+    # effect` field actually does anything at all: a *medicine*'s identical
+    # field (same chunk, same field number, read only when `item.type` is
+    # medicine rather than weapon) is dead in the real engine --
+    # `Item::vExecute` never once reads it (see #item_cured_states).
     #
     # No item table (a fixture) or an unarmed actor carries none of either.
     def weapon_states
@@ -3670,49 +3673,41 @@ module Game
 
     # The status-condition ids a medicine cures. RPG2000 items list affected
     # states in `state_set` (a 0/1 byte per state, index i -> state id i+1), and a
-    # medicine **cures** them; `reverse_state_effect` is what flips it into
-    # inflicting them, exactly as it does for a skill (see #skill_state_ids).
-    # Curing is unconditional, matching EasyRPG's item algorithm.
+    # medicine **cures** them, unconditionally, matching EasyRPG's own item
+    # algorithm exactly: `Game_BattleAlgorithm::Item::vExecute`
+    # (src/game_battlealgorithm.cpp, confirmed against the actual source)
+    # calls `State::Remove` for every flagged bit inside its `Type_medicine`
+    # branch with no other condition attached at all -- unlike a weapon's own
+    # `state_set` (#weapon_states) or a skill's (#skill_cured_states/
+    # #skill_inflicted_states), `item.reverse_state_effect` (field 68) is
+    # never once read there. `reverse_state_effect` is real data an item row
+    # can carry, but it is a dead field for a medicine in the real engine --
+    # the editor exposes the checkbox, RPG_RT/EasyRPG simply never consult it
+    # for this item type. This method previously mirrored it into an
+    # inflict/cure split anyway (see #item_inflicted_states, since removed);
+    # nothing in either test bed sets the flag on an item, so nothing was
+    # ever known to depend on that behaviour.
     #
-    # The polarity used to be read the other way round -- cures only when the
-    # flag is *set* -- which meant no shipped curative item cured anything.
-    # Neither test bed sets the flag on any item at all, while Nepheshel has 13
-    # medicines naming states without it and mtf-meido-action one: アンチドーテ
-    # and ユニコーンの角 name all fifteen states, and 気付け薬 / ドラゴンブラッド
-    # name state 1 alone, which is 戦闘不能 -- they are revives. Reading those as
-    # "cures nothing" made every antidote and every revive item in both games
-    # inert, in the menu and in a fight alike.
-    #
-    # A medicine that really does *inflict* (the flag set): see
-    # #item_inflicted_states below, which mirrors this the same way
-    # #skill_inflicted_states mirrors #skill_cured_states for a field skill.
+    # The polarity used to be read backwards too, at one point -- cures only
+    # when the flag was *set* -- which meant no shipped curative item cured
+    # anything. Neither test bed sets the flag on any item at all, while
+    # Nepheshel has 13 medicines naming states without it and mtf-meido-action
+    # one: アンチドーテ and ユニコーンの角 name all fifteen states, and 気付け薬 /
+    # ドラゴンブラッド name state 1 alone, which is 戦闘不能 -- they are revives.
+    # Reading those as "cures nothing" made every antidote and every revive
+    # item in both games inert, in the menu and in a fight alike.
     def item_cured_states(it)
-      return [] if it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
       item_state_ids(it)
     end
 
     # The states item `it` names in its `state_set` (a 0/1 byte per state, index
-    # i -> state id i+1), regardless of polarity. Shared by #item_cured_states
-    # and #item_inflicted_states, mirroring #skill_state_ids.
+    # i -> state id i+1). Shared by #item_cured_states, mirroring #skill_state_ids.
     def item_state_ids(it)
       set = it.state_set
       return [] unless set
       out = []
       set.each_index { |i| out.push(i + 1) if set[i] && set[i] != 0 }
       out
-    end
-
-    # The states item `it` inflicts (the reverse case, `reverse_state_effect`
-    # set): the opposite polarity to #item_cured_states, exactly as
-    # #skill_inflicted_states is to #skill_cured_states for a field skill (both
-    # port EasyRPG's identical `reverse_state_effect` branch, `Item::vExecute`
-    # for an item and `Game_Battler::UseSkill` for a skill). No item in either
-    # test bed sets the flag, so this was previously left unbuilt entirely --
-    # unlike the skill side, which already has the mechanism -- even though
-    # using the item this way was reachable and silently did nothing at all.
-    def item_inflicted_states(it)
-      return [] unless it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
-      item_state_ids(it)
     end
 
     # 蘇生専用 (`ko_only`): an item that does nothing at all to a target who is
@@ -3809,8 +3804,7 @@ module Game
         return false if ko_only_blocked?(it, actor)
         hp, mp = item_recovery(it, actor)
         (hp > 0 && actor.hp < actor.max_hp) || (mp > 0 && actor.mp < actor.max_mp) ||
-          item_cured_states(it).any? { |s| actor.state?(s) } ||
-          item_inflicted_states(it).any? { |s| !actor.state?(s) }
+          item_cured_states(it).any? { |s| actor.state?(s) }
       when ITEM_SKILL_BOOK
         s = it.skill_id
         !s.nil? && s != 0 && !actor.knows_skill?(s)
@@ -3997,7 +3991,6 @@ module Game
     def use_medicine(it, id, actor)
       targets = it.scope == 1 ? @actors : [actor].compact
       cured = item_cured_states(it)
-      inflicted = item_inflicted_states(it)
       affected = []
       targets.each do |t|
         # A 蘇生専用 item passes over anyone still standing without touching
@@ -4015,20 +4008,6 @@ module Game
             changed = true
           end
         end
-        landed = false
-        inflicted.each do |s|
-          unless t.state?(s)
-            t.add_state(s)
-            changed = true
-            landed = true
-          end
-        end
-        # RPG_RT's crowding-out rule (see Game::States::PRUNE_GAP): a state a
-        # poison item just inflicted may itself immediately push out one
-        # already held, or be pushed out by one already held that outranks it
-        # -- the same prune #cast_skill applies for a skill's own inflicted
-        # states.
-        t.states = Game::States.prune(t.states, state_table) if landed
         hp, mp = item_recovery(it, t)
         before_hp = t.hp
         before_mp = t.mp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5742,33 +5742,37 @@ check 'a heal+cure item counts either the heal or the cure as a use' do
   eq 1, st.party.item_count(5)
 end
 
-check 'a reverse medicine inflicts its listed states instead of curing them' do
-  # The flag flips a medicine from curing to inflicting, the same way it already
-  # does for a field skill (#skill_inflicted_states / #cast_skill) -- the same
-  # EasyRPG reverse_state_effect branch, just on the item side. No item in
-  # either test bed sets it, but the mechanism is the identical, already-tested
-  # one the skill side runs.
+check "reverse_state_effect is dead on a medicine -- it still cures, the flag does nothing" do
+  # Unlike a weapon's own `state_set` (RPG2003, #weapon_states) or a skill's
+  # (#skill_cured_states/#skill_inflicted_states), EasyRPG's
+  # Game_BattleAlgorithm::Item::vExecute (Type_medicine branch,
+  # src/game_battlealgorithm.cpp) never once reads item.reverse_state_effect
+  # -- confirmed against the actual source, exhaustively (the whole file has
+  # exactly two occurrences of the field, one in the weapon block of
+  # ::Normal::vExecute, one in ::Skill::vExecute; Item::vExecute has none). A
+  # medicine's `state_set` is always a cure list, full stop -- the flag is
+  # real data an item row can carry, but the editor's checkbox just does
+  # nothing for a medicine in the real engine, so this codebase's own
+  # previous inflict/cure split on the flag (#item_inflicted_states, since
+  # removed) modelled behaviour that was never actually real.
   st = item_party({})
   it = fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true)
-  eq [], st.party.item_cured_states(it)
-  eq [3], st.party.item_inflicted_states(it)
+  eq [3], st.party.item_cured_states(it), 'the flag makes no difference -- still a cure list'
   eq [3], st.party.item_cured_states(fake_item(type: 6, state_set: [0, 0, 1])),
-     'the same row without the flag does cure'
-  eq [], st.party.item_inflicted_states(fake_item(type: 6, state_set: [0, 0, 1])),
-     'and does not also inflict'
+     'the same row without the flag cures identically'
 end
 
-check 'a reverse medicine actually inflicts on use, and is greyed out once landed' do
+check 'a medicine flagged reverse_state_effect still cures on use, exactly like an unflagged one' do
   items = { 5 => fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true) }
   st = item_party(items)
   st.party.gain_item(5, 2)
   hero = st.party.leader
-  eq false, hero.state?(3)
+  hero.add_state(3)
   eq true, st.party.item_effective?(5, hero)
   eq [hero], st.party.use_item(5, hero)
-  eq true, hero.state?(3)                       # inflicted
+  eq false, hero.state?(3)                      # cured, not inflicted
   eq 1, st.party.item_count(5)                  # consumed
-  eq false, st.party.item_effective?(5, hero), 'already afflicted -> no longer effective'
+  eq false, st.party.item_effective?(5, hero), 'already cured -> no longer effective'
   eq [], st.party.use_item(5, hero)
   eq 1, st.party.item_count(5), 'a no-op use does not consume another'
 end
@@ -10432,8 +10436,9 @@ end
 check "battle: an RPG2003 weapon's reverse_state_effect heals instead of inflicts" do
   # Same weapon, `reverse_state_effect` set: on RPG2003 this flips the weapon
   # from inflicting its named states to curing them (EasyRPG's
-  # `is2k3 && w->reverse_state_effect` branch) -- the same flip
-  # `#item_inflicted_states`/`#skill_state_ids` already model for items/skills.
+  # `is2k3 && w->reverse_state_effect` branch) -- a weapon-only flip; the
+  # identical field on a *medicine* item is dead in the real engine (see
+  # `Game::Party#item_cured_states`'s own comment).
   items = { 7 => fake_item(type: 1, atk: 10, state_set: [0, 0, 1],
                             state_chance: 100, reverse_state: true) }
   st = skill_party({}, items, rpg2003: true)

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -1015,11 +1015,13 @@ def check_bush(dir)
   end
 end
 
-# Curative items, against the real item table. A fixture cannot catch a field
-# read with the wrong polarity — it is written to match whatever the code does —
-# so only a real game's antidotes can say which way round `reverse_state_effect`
-# goes. Nepheshel's アンチドーテ and ユニコーンの角 name all fifteen states and
-# 気付け薬 names 戦闘不能 alone; none of them sets the flag.
+# Curative items, against the real item table. `reverse_state_effect` is dead
+# on a medicine in the real engine (EasyRPG's `Item::vExecute` never reads it
+# -- see `Game::Party#item_cured_states`'s own comment), so every medicine
+# naming states cures them regardless of the flag; `reversed` below is only
+# tallied for visibility; the assertions apply equally to it. Nepheshel's
+# アンチドーテ and ユニコーンの角 name all fifteen states and 気付け薬 names
+# 戦闘不能 alone; none of them actually sets the flag either way.
 def check_items(dir)
   name = File.basename(dir)
   db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))


### PR DESCRIPTION
## Summary

- A prior change added `Game::Party#item_inflicted_states`, flipping a medicine's `state_set` from curing to inflicting when `reverse_state_effect` is set — reasoning that it "mirrors #item_cured_states the same way #skill_inflicted_states mirrors #skill_cured_states for a field skill", both assumed to "port the identical EasyRPG `reverse_state_effect` branch". That assumption was never checked against the actual reference function.
- Fetched EasyRPG's real `Game_BattleAlgorithm::Item::vExecute` (`src/game_battlealgorithm.cpp`): its `Type_medicine` branch applies `state_set` as an **unconditional cure list**, calling `State::Remove` for every flagged bit with **no** `reverse_state_effect` check anywhere in the function.
- Confirmed exhaustively: the entire `game_battlealgorithm.cpp` file references `reverse_state_effect` exactly twice — once in the weapon block of `Normal::vExecute` (RPG2003-gated), once in `Skill::vExecute`. Never in `Item::vExecute`. The field is real data an item row carries (chunk 13, field 68 — the editor exposes the checkbox), but the item algorithm simply never reads it. It's a skill-only and weapon-only mechanic, not an item one.
- `item_cured_states` now cures unconditionally, dropping the flag check entirely. `item_inflicted_states` is removed, along with `use_medicine`'s inflict branch and `item_effective?`'s inflict-side offer clause — none of that behavior is real.
- The two `rpg2k_logic_check.rb` checks that pinned the (wrong) inflict mechanism are replaced with checks proving the flag is inert on a medicine either way. A stale comment on the unrelated weapon-`reverse_state_effect` path (which *is* real, RPG2003-only) is also corrected — it referenced the wrong LCF field number and the now-removed method.
- `docs/TODO.md`'s original entry is left in place with a dated correction note explaining what was wrong and why, rather than rewritten in place.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 994 checks passed (2 checks rewritten to prove the flag is inert on a medicine, replacing 2 that pinned the wrong inflict behavior)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 693 checks passed (unchanged)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_