### PR TITLE
game: an enemy's charge is spent by any action, not only its next attack

### DIFF
--- a/changelog.d/enemy-charge-spent-by-any-action.fixed.md
+++ b/changelog.d/enemy-charge-spent-by-any-action.fixed.md
@@ -1,0 +1,8 @@
+- **An enemy's Charge bonus is now spent by whatever it does next, not only
+  by its own next Attack.** EasyRPG's `AlgorithmBase::Start()` clears the
+  charge unconditionally for every action kind (skill, defend, observe,
+  transform, self-destruct, everything), so a charge previously survived
+  untouched through any number of non-attack turns and still doubled a much
+  later attack. Also fixed: both swings of a charged dual attack now double
+  (EasyRPG models it as one action with a repeat count of 2, not two
+  independent attacks), where only the first used to.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1623,6 +1623,28 @@ The work below is roughly ordered by the critical path to a walkable game
   combatant carries its `battler_name`, and `Scene::Map#refresh_battle_sprites`
   rebuilds any sprite whose battler no longer matches the one it was drawn from
   (an unchanged battler is left alone, so the field does not churn every frame).
+  ✅ **Charge was only ever spent by the enemy's own next Attack, not by
+  anything else it might do first (2026-08-18).** `Game_BattleAlgorithm::
+  AlgorithmBase::Start()` (`src/game_battlealgorithm.cpp`, confirmed against
+  the actual source) calls `source->SetCharged(false)` unconditionally, for
+  every algorithm kind — Skill, SelfDestruct, Defend, Transform, Normal, all
+  of them — not only the plain-attack one that reads it. This codebase had
+  only ever cleared `b.charged` from inside the attack path
+  (`#deal_attack_with_current_weapon`), so a charge set one turn silently
+  survived any number of intervening skill casts, Defends or Observes and
+  still doubled whatever ordinary attack eventually happened, turns later.
+  `#perform_enemy_action` now snapshots and clears `b.charged` once, up
+  front, before dispatching to any action kind, and threads the snapshot
+  explicitly into `#deal_attack` for every path that can still substitute an
+  attack (the basic Attack/dual-attack arms, and `#enemy_fallback_attack`'s
+  degrade-on-unresolved-skill-or-transform). Fixed the same investigation
+  turned up a second, narrower bug in the same mechanism: EasyRPG's own
+  dual attack is *one* `Normal` algorithm with a repeat count of 2
+  (`enemyai.cpp`'s `MakeAttack(enemy, 2)`), so `Init()` captures the charge
+  flag once for the whole action and both swings see it — this codebase's
+  two independent `#deal_attack` calls each re-read (and the first one
+  cleared) `b.charged`, so only the first swing of a charged dual attack
+  ever doubled.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10270,13 +10270,27 @@ module Game
 
     # Run the action `b` chose and return its log entry (or entries). Any switch
     # the action flips is applied once it has run.
+    #
+    # `b.charged` is snapshotted and cleared right here, before dispatching to
+    # any action kind -- EasyRPG's `Game_BattleAlgorithm::AlgorithmBase::
+    # Start()` calls `source->SetCharged(false)` unconditionally, for every
+    # algorithm (Skill, SelfDestruct, Defend, Transform, Normal, all of them),
+    # confirmed against the actual `game_battlealgorithm.cpp` source -- not
+    # only in the Normal (plain-attack) algorithm this codebase previously
+    # cleared it from inside. A charge is spent (or simply wasted) by
+    # whatever this enemy does next, attack or not; it never survives to a
+    # later turn. The snapshot rides along as the `charged:` a plain-attack
+    # branch below hands to #deal_attack explicitly, since by the time any of
+    # them would run, `b.charged` here has already been cleared.
     def perform_enemy_action(b, act)
+      charged = b.charged ? true : false
+      b.charged = false
       entry = if act.skill?
-                enemy_skill_action(b, act)
+                enemy_skill_action(b, act, charged)
               elsif act.transform?
-                enemy_transform_action(b, act)
+                enemy_transform_action(b, act, charged)
               else
-                enemy_basic_action(b, act)
+                enemy_basic_action(b, act, charged)
               end
       apply_action_switches(act)
       entry
@@ -10293,15 +10307,23 @@ module Game
     # The basic actions (kind 0). Attack and dual attack go through the ordinary
     # attack path (so accuracy, criticals, elements and variance all apply);
     # the rest have no damage of their own and read as a plain note on the log.
-    def enemy_basic_action(b, act)
+    # `charged` is #perform_enemy_action's already-snapshotted-and-cleared
+    # `b.charged` -- handed to #deal_attack explicitly rather than read off
+    # `b` again here, since it is already gone by this point either way.
+    def enemy_basic_action(b, act, charged)
       case act.basic
       when EnemyAction::BASIC_DUAL_ATTACK
         target = attack_target(b)
         return nil unless target
-        first = deal_attack(b, target)
+        # EasyRPG's own dual attack is one `Normal` algorithm with a repeat
+        # count of 2 (`enemyai.cpp`'s `MakeAttack(enemy, 2)`), not two
+        # separate algorithm instances -- `Init()` (and so `charged_attack`)
+        # runs once for the whole action, so a charge doubles *both* swings,
+        # not only the one that happens to run first.
+        first = deal_attack(b, target, 0, charged: charged)
         # The second swing only lands if the first did not fell the target.
         return [first] if target.dead?
-        second = deal_attack(b, target)
+        second = deal_attack(b, target, 1, charged: charged)
         # RPG_RT's enemy-attack SE plays once per action (at its very start),
         # not once per swing -- EasyRPG's ProcessBattleActionUsage calls
         # GetStartSe only before the first Execute, a repeat re-enters at
@@ -10316,7 +10338,8 @@ module Game
         { attacker: b.name, observe: true }
       when EnemyAction::BASIC_CHARGE
         # The next attack this enemy lands does double damage (EasyRPG's
-        # IsCharged, spent in #deal_attack).
+        # IsCharged, spent in #deal_attack) -- any stale charge already spent
+        # by #perform_enemy_action above starts fresh here regardless.
         b.charged = true
         { attacker: b.name, charge: true }
       when EnemyAction::BASIC_AUTODESTRUCT
@@ -10330,7 +10353,7 @@ module Game
         { attacker: b.name, nothing: true }
       else
         target = attack_target(b)
-        target ? deal_attack(b, target) : nil
+        target ? deal_attack(b, target, 0, charged: charged) : nil
       end
     end
 
@@ -10385,13 +10408,13 @@ module Game
     # states exactly like a hero's — which is what finally lets an enemy poison or
     # sleep the party. A skill whose scope names the caster's own side heals /
     # buffs a fellow monster instead.
-    def enemy_skill_action(b, act)
+    def enemy_skill_action(b, act, charged)
       sk = @ai && @ai.skill(act.skill_id)
-      return enemy_fallback_attack(b) unless sk
+      return enemy_fallback_attack(b, charged) unless sk
       targets = enemy_skill_targets(b, sk)
-      return enemy_fallback_attack(b) if targets.empty?
+      return enemy_fallback_attack(b, charged) if targets.empty?
       cmd = @ai.skill_command(sk, b, targets.first)
-      return enemy_fallback_attack(b) unless cmd
+      return enemy_fallback_attack(b, charged) unless cmd
       b.command = skill_command_hash(sk, cmd, targets.first)
       b.command[:skill_id] = act.skill_id
       if targets.size > 1
@@ -10401,7 +10424,7 @@ module Game
           c = @ai.skill_command(sk, b, t)
           c ? { target: t, hp: c[:hp] || 0, mp: c[:mp] || 0 } : nil
         end.compact
-        return enemy_fallback_attack(b) if per.empty?
+        return enemy_fallback_attack(b, charged) if per.empty?
         b.command[:all] = true
         b.command[:targets] = per
         b.command[:target] = nil
@@ -10474,9 +10497,9 @@ module Game
     # "damage carries across a transformation" design this build's own
     # clamp made impossible by silently full-healing every downward
     # transform.
-    def enemy_transform_action(b, act)
+    def enemy_transform_action(b, act, charged)
       into = @ai && @ai.enemy(act.enemy_id)
-      return enemy_fallback_attack(b) unless into
+      return enemy_fallback_attack(b, charged) unless into
       b.name = into.name
       b.atk = into.atk; b.def = into.def; b.agi = into.agi; b.spi = into.spi
       b.max_hp = into.max_hp; b.max_mp = into.max_sp
@@ -10493,9 +10516,11 @@ module Game
 
     # A skill / transformation that could not be resolved (no database to hand)
     # degrades to a plain attack rather than costing the enemy its turn.
-    def enemy_fallback_attack(b)
+    # `charged` (already snapshotted by #perform_enemy_action) rides along
+    # into the substituted attack, same as an ordinary chosen one.
+    def enemy_fallback_attack(b, charged)
       target = attack_target(b)
-      target ? deal_attack(b, target) : nil
+      target ? deal_attack(b, target, 0, charged: charged) : nil
     end
 
     # -- forced AI (強制AI) ---------------------------------------------------
@@ -10855,7 +10880,14 @@ module Game
     # most one equipped weapon) has no override to make, so this is a no-op
     # for them -- the merged fields already correctly describe their one
     # weapon.
-    def deal_attack(b, target, swing_index = 0)
+    # `charged:` lets a caller that has already resolved whether this attack
+    # is charged (#perform_enemy_action, which must snapshot-and-clear
+    # `b.charged` before dispatching to any action kind -- see its own
+    # comment) hand the value in explicitly, rather than have this method
+    # read (and clear) `b.charged` itself. nil -- every other caller,
+    # including an ally's own #swing, which never sets `b.charged` at all --
+    # keeps the old self-contained behaviour.
+    def deal_attack(b, target, swing_index = 0, charged: nil)
       wdata = b.respond_to?(:actor) && b.actor.respond_to?(:swing_weapon_data) ? b.actor.swing_weapon_data(swing_index) : nil
       saved = wdata ? [b.hit_rate, b.atk_attrs, b.atk_states, b.crit_chance] : nil
       if wdata
@@ -10864,12 +10896,12 @@ module Game
         b.atk_states = wdata[:atk_states]
         b.crit_chance = wdata[:crit_chance]
       end
-      deal_attack_with_current_weapon(b, target)
+      deal_attack_with_current_weapon(b, target, charged: charged)
     ensure
       b.hit_rate, b.atk_attrs, b.atk_states, b.crit_chance = saved if saved
     end
 
-    def deal_attack_with_current_weapon(b, target)
+    def deal_attack_with_current_weapon(b, target, charged: nil)
       # `attacker_ally` (unlike `target_ally`, which every hit already carries)
       # only appears on a plain Attack's own entry -- it is how
       # Scene::Map#play_battle_action_se tells a normal swing apart from a
@@ -10915,9 +10947,14 @@ module Game
       crit = critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit
       # A charged-up attack (the enemy's Charge basic action) hits twice as hard,
       # but a critical takes precedence over it — EasyRPG's CalcNormalAttackEffect
-      # applies one or the other, never both. The charge is spent either way.
-      charged = b.charged ? true : false
-      b.charged = false if charged
+      # applies one or the other, never both. `charged` (the parameter) already
+      # carries the resolved answer when the caller passed one; otherwise fall
+      # back to reading (and spending) `b.charged` directly, matching the old
+      # self-contained behaviour.
+      if charged.nil?
+        charged = b.charged ? true : false
+        b.charged = false if charged
+      end
       if crit
         dmg *= 3
       elsif charged

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15573,6 +15573,54 @@ check 'a charge doubles the enemy next attack, then is spent' do
   ok !foe.charged, 'and the charge is spent'
 end
 
+check 'a charge is wasted by an intervening non-attack action, not just an attack' do
+  # EasyRPG's Game_BattleAlgorithm::AlgorithmBase::Start() calls
+  # source->SetCharged(false) unconditionally, for every algorithm kind, not
+  # only inside Normal (the plain-attack algorithm) -- confirmed against
+  # game_battlealgorithm.cpp. #perform_enemy_action ports that: it
+  # snapshots-and-clears `b.charged` before dispatching, so an intervening
+  # Defend spends the charge exactly as an intervening Attack would, and it
+  # never survives to a later turn.
+  foe = combatant('Slime', 40, 0, 5, 500)
+  charge = enemy_action(kind: 0, basic: 4)
+  defend = enemy_action(kind: 0, basic: 2)
+  attack = enemy_action(kind: 0, basic: 0)
+  b = ai_battle([charge], nil, foe: foe)
+  b.begin_round; b.step_action
+  eq true, b.step_action[:charge], 'the monster gathers strength'
+  ok foe.charged, 'the charge is held'
+  foe.actions = [defend]
+  b.end_round; b.begin_round; b.step_action
+  eq true, b.step_action[:defend], 'a Defend runs instead of an Attack'
+  ok !foe.charged, 'and the charge is already gone, spent by the Defend'
+  foe.actions = [attack]
+  b.end_round; b.begin_round; b.step_action
+  e = b.step_action
+  eq 20, e[:damage], 'the later attack lands at base damage -- no stale charge left to double it'
+  ok !e[:charged]
+end
+
+check 'a charged dual attack doubles both swings, not only the first' do
+  # EasyRPG's own dual attack is one Normal algorithm with a repeat count of
+  # 2 (enemyai.cpp's MakeAttack(enemy, 2)), not two separate algorithm
+  # instances -- Init() (and so the captured charged_attack flag) runs once
+  # for the whole action, so a charge doubles every swing it covers.
+  foe = combatant('Slime', 40, 0, 5, 500)
+  charge = enemy_action(kind: 0, basic: 4)
+  dual = enemy_action(kind: 0, basic: 1)
+  b = ai_battle([charge], nil, foe: foe)
+  b.begin_round; b.step_action
+  b.step_action
+  ok foe.charged, 'the charge is held'
+  foe.actions = [dual]
+  b.end_round; b.begin_round; b.step_action
+  first = b.step_action
+  second = b.step_action
+  eq 40, first[:damage], 'first swing doubled'
+  eq 40, second[:damage], 'second swing doubled too'
+  ok !foe.charged, 'spent by the action as a whole, not per swing'
+end
+
 check 'a dual attack strikes twice in one turn' do
   b = ai_battle([enemy_action(kind: 0, basic: 1)])
   b.begin_round


### PR DESCRIPTION
## Summary

- `b.charged` (the enemy Charge basic action's damage-doubling flag) was only ever read and cleared inside `#deal_attack_with_current_weapon` — reachable solely via a plain Attack, dual attack, or the skill/transform degrade-to-attack fallback. Every other action an enemy can take (Skill, Transform, Self-destruct, Defend, Observe, Escape, Nothing, re-Charge) left it untouched.
- Checked against EasyRPG's actual `Game_BattleAlgorithm::AlgorithmBase::Start()` (`src/game_battlealgorithm.cpp`): it calls `source->SetCharged(false)` **unconditionally**, for every algorithm kind, before that action executes — not only inside the plain-attack (`Normal`) algorithm, which is the only one that ever reads `IsCharged()`. So in the reference, a charge is spent (and simply wasted, if the next action isn't an attack) by whatever the enemy does next — it never survives to a later turn.
- `#perform_enemy_action` now snapshots and clears `b.charged` once, up front, before dispatching to any action kind, and threads the snapshot explicitly into `#deal_attack` for every path that can still produce an attack (`enemy_basic_action`'s Attack/dual-attack arms, and `enemy_fallback_attack`'s degrade-on-unresolved-skill-or-transform). `#deal_attack`/`#deal_attack_with_current_weapon` gain an optional `charged:` override — nil (every other caller, including an ally's own `#swing`, which never sets `b.charged` at all) keeps the old self-contained read-and-clear behavior.
- Along the way, found and fixed a second, narrower bug in the same mechanism: EasyRPG's own dual attack is **one** `Normal` algorithm with a repeat count of 2 (`enemyai.cpp`'s `MakeAttack(enemy, 2)`), so `Init()` captures the charge flag once for the whole action and it applies to every repeat. This codebase's two independent `deal_attack` calls each re-read `b.charged` — the first call cleared it, so only the first swing of a charged dual attack ever doubled. Both calls now receive the same snapshotted value.
- `docs/TODO.md`'s original charge entry gets a dated follow-up note; changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 996 checks passed (2 new: a Defend between Charge and the eventual Attack wastes the charge; a charged dual attack doubles both swings, not only the first — both checks confirmed to fail against the pre-fix code before landing the fix)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 693 checks passed (unchanged)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_