### PR TITLE
game: a skill's hit -1 sentinel now uses the caster's weapon hit rate

### DIFF
--- a/changelog.d/skill-hit-minus-one-sentinel.fixed.md
+++ b/changelog.d/skill-hit-minus-one-sentinel.fixed.md
@@ -1,0 +1,5 @@
+- **A skill with `hit` set to -1 (a RPG_RT sentinel meaning "use the
+  caster's own weapon-based hit chance") no longer misses unconditionally.**
+  The raw -1 was flowing straight into the roll comparison, which can never
+  succeed against a 0..99 die; it now resolves to the caster's `hit_rate`,
+  matching EasyRPG's `Algo::CalcSkillToHit`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5661,6 +5661,21 @@ not yet verified:
    losing 25, a `do_nothing`-restricted target always hit, and an
    evasion-ignoring caster skipping the AGI term), each confirmed to fail
    against the pre-fix code.
+   ✅ **`skill.hit == -1` ("use the caster's own weapon-based hit chance"
+   instead of a fixed rate) is now honoured too (2026-08-18).** `Algo::
+   CalcSkillToHit`'s very first line, unconditional for every skill (not
+   gated behind an EasyRPG-only extension flag the way the row terms are):
+   `skill.hit == -1 ? source.GetHitChance(WeaponAll) : skill.hit`.
+   `Game::Party#skill_hit` previously read the raw `-1` through unchanged,
+   which flowed into `cmd[:chance]` and then `@rng.random(100) < -1` --
+   always false, so such a skill missed every affect_hp/affect_sp/state roll
+   unconditionally instead of using the caster's real weapon hit rate.
+   `#skill_hit` now takes the caster too, resolving the sentinel to a
+   `Combatant`'s own `hit_rate` (the identical field `Game::Battle#to_hit`
+   reads for an ordinary Attack), falling back to `Battle.hit_rate_of` for
+   the bare-Actor/-Enemy case no current caller actually reaches. Two new
+   `rpg2k_logic_check.rb` checks (one non-physical, one physical-flagged),
+   both confirmed to fail against the pre-fix code.
 - ✅ **`Game::Battle#fatigue` (the RPG2003 `fatigue` page condition) now
   rounds an exact tie to the nearest *even* whole percent, not always up.**
   A prior version of this method's own comment claimed it used "the same

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4777,8 +4777,25 @@ module Game
       sk.respond_to?(:absorb_damage) ? (sk.absorb_damage ? true : false) : false
     end
 
-    def skill_hit(sk)
+    # `sk.hit == -1` is a sentinel meaning "use the caster's own weapon-based
+    # hit chance" rather than a fixed rate -- EasyRPG's `Algo::CalcSkillToHit`
+    # (`src/algo.cpp`) reads it as its very first line, unconditionally, for
+    # every skill (not gated behind any EasyRPG-only extension flag the way
+    # the row terms a few lines further down are): `skill.hit == -1 ?
+    # source.GetHitChance(Game_Battler::WeaponAll) : skill.hit`. A `Combatant`
+    # snapshot (every real caller today) already carries that merged figure
+    # as its own `hit_rate` -- the same field `Game::Battle#to_hit` reads for
+    # an ordinary Attack; a bare `Game::Actor`/`Game::Enemy`, should one ever
+    # reach this, falls back to `Battle.hit_rate_of` instead, the identical
+    # `attack_hit_rate`-reading helper a fresh `Combatant` is seeded from.
+    def skill_hit(sk, source)
+      return skill_hit_weapon_fallback(source) if sk.respond_to?(:hit) && sk.hit == -1
       sk.respond_to?(:hit) ? (sk.hit || 100) : 100
+    end
+
+    def skill_hit_weapon_fallback(source)
+      return source.hit_rate || 90 if source.respond_to?(:hit_rate)
+      Battle.hit_rate_of(source)
     end
 
     # A Skill's to-hit chance, ported from EasyRPG's `Algo::CalcSkillToHit`
@@ -4801,7 +4818,7 @@ module Game
     # penalty a pre-reference guess had used for attacks; the reference settles
     # it: skills are untouched by rows. See ADR 0053/0054.
     def skill_to_hit(sk, source, target)
-      return skill_hit(sk) unless sk.respond_to?(:failure_message) && sk.failure_message == 3
+      return skill_hit(sk, source) unless sk.respond_to?(:failure_message) && sk.failure_message == 3
       # The physical formula is enemy-only: an ally/self-scoped skill (scope 2/3/4)
       # always falls back to the flat rate regardless of the flag — EasyRPG's
       # `CalcSkillToHit` guards the whole physical branch behind
@@ -4809,9 +4826,9 @@ module Game
       # can no longer even set the flag, so the branch is reached only by skills
       # that still target the opposing side (scope 0 single / 1 all enemy).
       scope = sk.respond_to?(:scope) ? sk.scope.to_i : 0
-      return skill_hit(sk) unless scope == 0 || scope == 1
+      return skill_hit(sk, source) unless scope == 0 || scope == 1
 
-      to_hit = skill_hit(sk)
+      to_hit = skill_hit(sk, source)
       # A do-nothing-restricted target cannot dodge: the attack always connects.
       return 100 if do_nothing_restricted?(target)
       # The caster's own statuses (e.g. Blind) sour its aim first, before the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10359,6 +10359,34 @@ end
    eq 90, c[:chance]                            # no agility term, just skill.hit
  end
 
+ # `hit == -1` is a sentinel meaning "use the caster's own weapon-based hit
+ # chance" -- EasyRPG's Algo::CalcSkillToHit reads it unconditionally, as its
+ # very first line, for every skill (not gated behind any EasyRPG-only
+ # extension flag, unlike the row terms). Previously read literally: -1 as a
+ # flat percent compares false against every possible `@rng.random(100)`
+ # roll (0..99), so such a skill missed unconditionally instead of using the
+ # caster's real hit rate.
+ check "a skill with hit -1 uses the caster's own weapon-based hit rate, not a literal -1" do
+   skills = { 7 => fake_skill(name: 'Bolt', scope: 0, hit: -1, failure_message: 0) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.hit_rate = 77
+   foe = combatant('Foe', 0, 0, 10, 100)
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   eq 77, c[:chance], "the caster's hit_rate, not a literal -1 that would always miss"
+ end
+
+ check 'a physical-flagged (failure_message 3) skill with hit -1 also uses the weapon hit rate as its base' do
+   skills = { 7 => fake_skill(name: 'Punch', scope: 0, hit: -1, failure_message: 3) }
+   st = skill_party(skills)
+   hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+   hero.hit_rate = 80
+   hero.agi = 7
+   foe = combatant('Foe', 0, 0, 7, 100) # equal agility -> AGI term reduces to identity
+   c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+   eq 80, c[:chance], 'the -1 sentinel resolves before the agility-adjusted physical formula runs'
+ end
+
  check 'an ally-scoped physical-flagged skill stays on the flat hit rate' do
    skills = { 7 => fake_skill(name: 'Mend', scope: 3, hit: 90, failure_message: 3) }
    st = skill_party(skills)


### PR DESCRIPTION
## Summary

- `Game::Party#skill_hit` read a skill's `hit` field (liblcf field 0x19) as a literal percentage. `hit == -1` is a real RPG_RT/RPG2003 sentinel meaning "use the caster's own weapon-based hit chance" instead of a fixed rate — confirmed against EasyRPG's actual `Algo::CalcSkillToHit` (`src/algo.cpp`), whose very first line is `skill.hit == -1 ? source.GetHitChance(WeaponAll) : skill.hit`, unconditional for every skill (not gated behind any EasyRPG-only extension flag, unlike the row terms this same function checks a few lines later, which this codebase already correctly excludes).
- The raw `-1` flowed straight into `cmd[:chance]` and then into `Game::Battle`'s roll comparison (`@rng.random(100) < (cmd[:chance] || 100)`). Since `@rng.random(100)` only ever returns `0..99`, `x < -1` is always false — a skill authored with this sentinel missed every affect_hp/affect_sp/state roll unconditionally, instead of using the caster's real weapon hit rate.
- `skill_hit` now takes the caster and resolves the sentinel to the caster's own hit chance: a `Combatant`'s `hit_rate` (the identical field `Game::Battle#to_hit` reads for an ordinary Attack) for every real caller today, falling back to `Battle.hit_rate_of` (the `attack_hit_rate`-reading helper a fresh `Combatant` is itself seeded from) for a bare `Game::Actor`/`Game::Enemy`, should one ever reach this — no current caller does, `battle_skill_command`'s own doc comment confirms caster/target are always `Combatant` snapshots.
- `docs/TODO.md`'s existing `CalcSkillToHit` entry gets a dated follow-up note; changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 998 checks passed (2 new: a non-physical skill and a physical-flagged skill, both with `hit: -1`, resolve to the caster's `hit_rate` rather than always missing — both confirmed to fail against the pre-fix code before landing the fix)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 693 checks passed (unchanged)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_