### PR TITLE
battle: a transformed monster pays out its new form's rewards

### DIFF
--- a/changelog.d/transform-rewards-sync.fixed.md
+++ b/changelog.d/transform-rewards-sync.fixed.md
@@ -1,0 +1,6 @@
+- **A monster that Transforms mid-fight now pays out its new form's
+  EXP/gold/item drop on defeat, not its original form's.** The battle math
+  already repointed the combatant at the new monster; the troop's own
+  reward bookkeeping (a separate object at the same slot) was never told,
+  matching EasyRPG's single repointed database-row pointer instead of this
+  engine's two independent objects.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1623,6 +1623,24 @@ The work below is roughly ordered by the critical path to a walkable game
   combatant carries its `battler_name`, and `Scene::Map#refresh_battle_sprites`
   rebuilds any sprite whose battler no longer matches the one it was drawn from
   (an unchanged battler is left alone, so the field does not churn every frame).
+  ✅ **A transformed monster now also pays out its new form's EXP/gold/drop
+  on defeat, not its original form's (2026-08-18).** The battle math runs on
+  a `Game::Battle::Combatant` (`enemy_transform_action` already repointed
+  its stats and `battler_name`/`battler_hue`), but `#total_exp`/`#total_gold`/
+  `#drops` read `exp`/`gold`/`drop_id`/`drop_prob` off a separate object --
+  the troop's own `Game::Enemy` at the same slot -- that nothing ever told
+  about the transform. EasyRPG's actual `Game_Enemy::Transform`
+  (`src/game_enemy.cpp`) repoints a single backing database-row pointer, so
+  every accessor, combat and reward alike, reads the new monster from that
+  one point on; this port's parallel Combatant/`Troop::Enemy` split needs an
+  explicit mirror instead. `#refresh_battle_sprites`'s existing battler-swap
+  detection (the same signal that already triggers a sprite rebuild) now
+  also calls a new `#sync_troop_member_rewards`, which re-seeds the troop
+  member's reward fields (`Game::Enemy#reseed_rewards`) from a fresh
+  `Game::Enemy` built off the combatant's own already-updated `enemy_id` --
+  position, `levitate` and `hidden` are untouched, since a Transform keeps
+  its place and never revives a hidden member. One new
+  `rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix code.
   ✅ **Charge was only ever spent by the enemy's own next Attack, not by
   anything else it might do first (2026-08-18).** `Game_BattleAlgorithm::
   AlgorithmBase::Start()` (`src/game_battlealgorithm.cpp`, confirmed against

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7821,6 +7821,21 @@ module Game
     def attack_hit_rate; @miss ? 70 : 90; end
 
     def dead?; @hp <= 0; end
+
+    # Re-seeds this troop member's own reward fields from `into` (a fresh
+    # `Enemy` for whatever database row a mid-fight Transform just repointed
+    # the parallel `Game::Battle::Combatant` at) -- what `RPG2k::Scene::
+    # Battle#sync_troop_member_rewards` calls once it notices a combatant's
+    # battler no longer matches the sprite it was drawn from. Only the fields
+    # `#total_exp`/`#total_gold`/`#drops` actually read; everything else this
+    # class carries (position, `levitate`, `hidden`) is transform-invariant --
+    # a Transform keeps its place and never revives a hidden member.
+    def reseed_rewards(into)
+      @exp = into.exp
+      @gold = into.gold
+      @drop_id = into.drop_id
+      @drop_prob = into.drop_prob
+    end
   end
 
   # An enemy troop (敵グループ, chunk 15) instantiated for a battle: the live

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -930,7 +930,20 @@ class RPG2k
         hues = (@ui[:sprite_hues] ||= [])
         @ui[:foes].each_with_index do |foe, i|
           changed = names[i] != foe.battler_name || hues[i] != (foe.battler_hue || 0)
-          rebuild_battler_sprite(i, foe) if sprites[i] && changed
+          next unless changed
+          rebuild_battler_sprite(i, foe) if sprites[i]
+          # Recorded here rather than only inside #rebuild_battler_sprite, so a
+          # transformed slot with no sprite object to rebuild (a bare fixture,
+          # say) still stops re-triggering this every frame.
+          names[i] = foe.battler_name
+          hues[i] = foe.battler_hue || 0
+          # The battler swap is this method's only signal that a Transform ran
+          # (Game::Battle#enemy_transform_action updates the combatant's stats
+          # including battler_name/hue, but has no other hook into the scene) --
+          # sync the troop's own Enemy object's reward fields off it too, same
+          # as #total_exp/#total_gold/#drops' `hidden` mirroring a few lines
+          # below.
+          sync_troop_member_rewards(i, foe)
         end
         @ui[:foes].each_with_index do |foe, i|
           spr = sprites[i]
@@ -968,8 +981,27 @@ class RPG2k
         spr.visible = !foe.out_of_play?
         sprites[i] = spr
         dispose_battle_sprite(old)
-        @ui[:sprite_names][i] = foe.battler_name
-        @ui[:sprite_hues][i] = foe.battler_hue || 0
+      end
+
+      # A Transform repoints the combatant at a new database enemy row
+      # (#enemy_transform_action already updates its combat stats), but the
+      # troop's own Enemy object at the same slot -- the one #total_exp/
+      # #total_gold/#drops actually read exp/gold/drop_id/drop_prob from,
+      # entirely separate from the Combatant this scene fights with -- is
+      # never told: EasyRPG's own `Game_Enemy::Transform` (src/game_enemy.cpp)
+      # repoints a single backing data pointer, so every accessor, combat and
+      # reward alike, reads the new monster from that one point on; this port
+      # keeps two parallel objects for one troop slot instead, and only the
+      # combat side was ever kept in sync. Re-seeds the troop member's reward
+      # fields (position/levitate/hidden are untouched -- a Transform keeps
+      # its place, and never revives a hidden member) from a fresh
+      # `Game::Enemy` built off the combatant's own already-updated
+      # `enemy_id`, the identical constructor `EnemyAi#enemy` used to resolve
+      # what the combatant just turned into.
+      def sync_troop_member_rewards(i, foe)
+        member = @ui[:troop].members[i]
+        return unless member && foe.respond_to?(:enemy_id) && foe.enemy_id
+        member.reseed_rewards(Game::Enemy.new(db, foe.enemy_id))
       end
 
       def living_allies; @ui[:allies].reject(&:dead?); end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16791,6 +16791,40 @@ check 'a transformed monster is redrawn with its new battler graphic' do
   ok ui[:enemy_sprites][0].equal?(same), 'an unchanged battler is left alone'
 end
 
+# A Transform repoints the combatant at a new database enemy row
+# (Game::Battle#enemy_transform_action), but the troop's own Enemy object at
+# the same slot -- the one #total_exp/#total_gold/#drops actually read
+# exp/gold/drop_id/drop_prob from -- is a separate object nothing else keeps
+# in sync. EasyRPG's own Game_Enemy::Transform repoints a single backing
+# data pointer, so reward accessors read the new monster too; this port's
+# parallel Combatant/Troop::Enemy split needs an explicit mirror, which
+# #refresh_battle_sprites now performs (#sync_troop_member_rewards) right
+# alongside its existing battler-swap detection.
+check 'a transformed monster pays out its new form\'s EXP/gold/drop, not its original form\'s' do
+  scene, _st = battle_scene_with_pages(nil)
+  90.times do
+    ui = battle_ui(scene)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
+    scene.update
+    RGSS::Input.triggered = []
+    ui = battle_ui(scene)
+    break if ui && ui[:phase] == :command
+  end
+  ui = battle_ui(scene)
+  member = ui[:troop].members[0]
+  eq 5, member.exp, "starts as the default fixture's Slime (id 2)"
+  eq 10, member.gold
+  # What Game::Battle's transform action does to the combatant: repoint it at
+  # enemy id 3, the default fixture's own Bat (exp 4, gold 8, no drop).
+  ui[:foes][0].battler_name = 'Bat'
+  ui[:foes][0].name = 'Bat'
+  ui[:foes][0].enemy_id = 3
+  scene.instance_variable_get(:@battle).send(:refresh_battle_sprites)
+  eq 4, member.exp, "the troop member's own reward fields follow the transform"
+  eq 8, member.gold
+  eq 0, member.drop_id, 'Bat carries no drop, unlike Slime'
+end
+
 # -- random ("wandering monster") encounters ----------------------------------
 #
 # Map-tree node field 41 (enemy_groups) / 44 (encount_steps), read the same


### PR DESCRIPTION
## Summary

- `Game::Battle#enemy_transform_action` rewrites the acting `Combatant`'s combat stats and battler graphic when a monster Transforms mid-fight, but `Game::Troop::Enemy` — a *separate* object at the same troop slot, the one `#total_exp`/`#total_gold`/`#drops` actually read `exp`/`gold`/`drop_id`/`drop_prob` from at battle end — was never told. Those fields are `attr_reader`-only; nothing wrote them after construction.
- Confirmed against EasyRPG's actual source: `Game_Enemy::Transform` (`src/game_enemy.cpp`) repoints a *single* backing database-row pointer (`enemy = lcf::ReaderUtil::GetElement(lcf::Data::enemies, new_enemy_id)`), so every subsequent accessor — combat stats and reward numbers alike — reads the new monster through that one pointer. This port instead keeps two independently-constructed objects for one troop slot; only the combat-facing one (`Combatant`) was ever updated.
- `scene/battle.rb`'s `#refresh_battle_sprites` already detects a Transform (a combatant's `battler_name`/`battler_hue` no longer matching what its sprite was built from) to trigger a sprite rebuild — the exact same signal now also drives a new `#sync_troop_member_rewards`, which re-seeds the troop member's reward fields (a new `Game::Enemy#reseed_rewards`) from a fresh `Game::Enemy` built off the combatant's own already-updated `enemy_id` (the identical constructor `EnemyAi#enemy` already uses to resolve what a Transform turns into). Position/`levitate`/`hidden` are untouched — a Transform keeps its place and never revives a hidden member.
- The battler-name/hue bookkeeping (`names[i]`/`hues[i]`) moves out of `#rebuild_battler_sprite` into `#refresh_battle_sprites` itself, so a transformed slot with no sprite object to rebuild still stops re-detecting the same change every frame.
- `docs/TODO.md`'s transform entry gets a dated follow-up note; changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 694 checks passed (1 new: a monster transformed from the default fixture's Slime (exp 5/gold 10) into its Bat (exp 4/gold 8, no drop) pays out the Bat's numbers, not the Slime's — confirmed to fail against the pre-fix code before landing the fix)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 998 checks passed (unchanged)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_