### PR TITLE
psp: fix psp-fixup-imports stub misordering with a JAL-relocation-aware patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1323,7 +1323,18 @@ jobs:
         # MRuby::CrossBuild also builds a native "host" mruby (to produce mrbc,
         # which then compiles the target .rb sources to bytecode), and that
         # half runs the ambient `gcc`, not psp-gcc -- confirmed missing by a
-        # real CI run ("sh: gcc: not found") once Ruby alone was installed.
+        # real CI run ("sh: gcc: not found") once Ruby alone was installed;
+        # `git` is for scripts/build_psp_fixup_imports.bash, below.
+        #
+        # That script replaces the image's own /usr/local/pspdev/bin/
+        # psp-fixup-imports (a host tool `cmake --build` invokes automatically
+        # after linking, as part of `create_pbp_file`) with a patched build
+        # before configuring -- see the script and patches/
+        # psp-fixup-imports-jal-relocation-aware.patch for why: the stock tool
+        # silently mis-links several of this EBOOT's own genuine PSP imports,
+        # which is what stops it booting to completion under PPSSPP-headless
+        # (see docs/adr/0047-psp-memory-budget.md's P1).
+        #
         # Pull the image up front with -q: an implicit pull from `docker run`
         # prints a per-layer download/extract progress block, which `-q`
         # reduces to the resolved digest.
@@ -1333,7 +1344,8 @@ jobs:
             -e cp932_table=/src/.native-build-tables/bestfit932.txt \
             -e jis0208_table=/src/.native-build-tables/JIS0208.TXT \
             pspdev/pspdev:latest sh -euc '
-            apk add --no-cache ruby ruby-rake build-base
+            apk add --no-cache ruby ruby-rake build-base git
+            bash scripts/build_psp_fixup_imports.bash
             psp-cmake -S app/psp -B build-psp
             cmake --build build-psp -j"$(nproc)"
           '

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -70,9 +70,14 @@ What runs today:
 ## Building
 
 Requires the [pspdev toolchain](https://github.com/pspdev/pspdev) with `$PSPDEV`
-set (it provides `psp-gcc`, the CMake toolchain file and `create_pbp_file`):
+set (it provides `psp-gcc`, the CMake toolchain file and `create_pbp_file`).
+Run `scripts/build_psp_fixup_imports.bash` first — it replaces the
+toolchain's own `psp-fixup-imports` (normally at `$PSPDEV/bin/`) with a
+patched build; see the seven-bug trail lower in this section for why this
+EBOOT needs it to actually boot:
 
 ```sh
+scripts/build_psp_fixup_imports.bash "$PSPDEV/bin/psp-fixup-imports"
 cmake -S app/psp -B build-psp \
   -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake
 cmake --build build-psp          # -> build-psp/EBOOT.PBP
@@ -109,8 +114,8 @@ marker appears, so a regression that links but fails to boot is caught
 automatically; it has no project at `kGameDir`, so it only ever exercises the
 idle path (`RPG2K_PSP_GAME_START none not_found`). The job is
 **non-blocking** — the required build gate is the `psp` job, because the
-EBOOT still does not boot to completion under PPSSPP-headless. Six
-independent bugs have been found and root-caused chasing that, three of
+EBOOT still does not boot to completion under PPSSPP-headless. Seven
+independent bugs have been found and root-caused chasing that, five of
 them fixed:
 
 - pspsdk's `sysclib_snprintf`/`sysclib_sprintf` HLE stubs are only partially
@@ -153,20 +158,40 @@ longer reachable on this boot path: it only ever triggered because of the
 `malloc()` for the affected lock struct no longer fails. Worth reporting
 upstream, not worth working around here.
 
-What's still actually blocking boot is a fourth bug, found but **not**
-fixed: `psp-fixup-imports` (pspsdk's post-link import tool) requires every
-call site referencing a given PSP module to be physically contiguous in the
-linked binary, and traced to its source (not just the "stubs out of order"
-symptom) this turns out to reflect genuinely necessary separation in
-`main.cxx`'s own control flow — e.g. `setup_callbacks()`'s one-time
-`ThreadManForUser` calls versus the ongoing per-second heartbeat's own,
-much later call into the same module — not an accidental ordering slip a
-reorder could fix. See
+- A fourth bug, also fixed: `psp-fixup-imports` (pspsdk's post-link import
+  tool) requires every call site referencing a given PSP module to be
+  physically contiguous in the linked binary, and traced to its source (not
+  just the "stubs out of order" symptom it prints) this turns out to
+  reflect genuinely necessary separation in `main.cxx`'s own control flow —
+  e.g. `setup_callbacks()`'s one-time `ThreadManForUser` calls versus the
+  ongoing per-second heartbeat's own, much later call into the same module
+  — not an accidental ordering slip a source reorder could fix. A patch
+  that just regroups the tool's metadata by module was tried first and
+  found unsafe (it silently misdirects syscalls — confirmed: it produced a
+  binary where `sceKernelCreateThread` and `sceIoRemove` resolved to the
+  same trampoline address); the real fix additionally scans every
+  executable section for `jal` instructions targeting a moved slot and
+  repoints them, the same relocation work a real ET_EXEC loader would do
+  and this prebuilt-binary tool skips.
+  `scripts/build_psp_fixup_imports.bash` fetches pspsdk at the pinned
+  commit `patches/psp-fixup-imports-jal-relocation-aware.patch` targets,
+  applies it, and drops the rebuilt tool in place of the container's own —
+  wired into the `psp` CI job ahead of `psp-cmake`/`cmake --build`. Not yet
+  upstreamed to `pspdev/pspsdk`.
+
+With that fixed, this EBOOT now boots dramatically further than at any
+earlier point on this whole trail — past `RPG2K_PSP_BOOT`, through
+`_sbrk`'s heap init, through `mrb_open`, into real LVGL widget creation —
+and hits a **seventh bug, found and not yet fixed**: LVGL's builtin TLSF
+allocator asserts `block already marked as free` inside `lv_tlsf_realloc`,
+most plausibly reached from `build_ui()`'s per-frame
+`lv_label_set_text(g_status_label, ...)` update. Confirmed not a sizing
+issue (bumping `LV_MEM_SIZE` 8x made no difference), so more likely
+something elsewhere corrupting a TLSF block's free/used bit than a bug in
+the allocator itself — matching this whole trail's running theme of memory
+corruption over logic bugs. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
-P1 for the full trail, including why a tempting-looking `psp-fixup-imports`
-metadata patch was written, tested, and reverted (it silently misdirects
-syscalls rather than failing cleanly) rather than merged. To reproduce any
-of this locally, run
+P1 for the full seven-bug trail. To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched
 `ppsspp` package output (see above) rather than nixpkgs' unpatched one —

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -146,13 +146,27 @@ them fixed:
   `RPG2K_PSP_BOOT` (`_sbrk`'s heap-init probe re-ran forever). Linking
   `pspuser` first fixed it.
 
-Two more bugs are found but **not** fixed, one of them genuinely
-pspsdk-side and real, the other a build-toolchain limitation this session
-tried and failed to patch around safely — see
+A third bug — a real one, in pspsdk's own `__retarget_lock_init_recursive`
+(missing a null-check after `malloc()`) — is confirmed present but no
+longer reachable on this boot path: it only ever triggered because of the
+`_sbrk`/`sceKernelMaxFreeMemSize` bug just above, and with that fixed,
+`malloc()` for the affected lock struct no longer fails. Worth reporting
+upstream, not worth working around here.
+
+What's still actually blocking boot is a fourth bug, found but **not**
+fixed: `psp-fixup-imports` (pspsdk's post-link import tool) requires every
+call site referencing a given PSP module to be physically contiguous in the
+linked binary, and traced to its source (not just the "stubs out of order"
+symptom) this turns out to reflect genuinely necessary separation in
+`main.cxx`'s own control flow — e.g. `setup_callbacks()`'s one-time
+`ThreadManForUser` calls versus the ongoing per-second heartbeat's own,
+much later call into the same module — not an accidental ordering slip a
+reorder could fix. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
-P1 for the full trail on both, including why the tempting-looking
-`psp-fixup-imports` metadata patch was reverted (it silently misdirects
-syscalls rather than failing cleanly). To reproduce any of this locally, run
+P1 for the full trail, including why a tempting-looking `psp-fixup-imports`
+metadata patch was written, tested, and reverted (it silently misdirects
+syscalls rather than failing cleanly) rather than merged. To reproduce any
+of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched
 `ppsspp` package output (see above) rather than nixpkgs' unpatched one —

--- a/changelog.d/psp-fixup-imports-jal-relocation.fixed.md
+++ b/changelog.d/psp-fixup-imports-jal-relocation.fixed.md
@@ -1,0 +1,28 @@
+- **The `psp` CI job now builds the PSP EBOOT with a patched
+  `psp-fixup-imports`, fixing a real boot blocker.** pspsdk's post-link
+  import-table tool requires every call site referencing a given PSP module
+  to already be physically contiguous in the linked binary — a requirement
+  this EBOOT's own `main.cxx` doesn't satisfy, since it calls into several
+  PSP modules in ordinary control-flow order (confirmed: this reflects
+  genuinely necessary separation in the program's own logic, not an
+  accidental ordering slip a source reorder could fix). When out of order,
+  the stock tool silently assigned several genuine, correctly-named imports
+  the wrong `(module, function)` index, so calls into them returned
+  `SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED` unchecked — this was what
+  actually stopped the EBOOT booting to completion under PPSSPP-headless
+  even after every other known bug on that path was fixed. A metadata-only
+  regroup patch was tried first and found unsafe (confirmed to silently
+  misdirect syscalls to the wrong function); the real fix additionally scans
+  every executable section for `jal` instructions targeting a moved import
+  slot and repoints them — the relocation work an ET_EXEC binary's loader
+  would need but this prebuilt tool skips.
+  `patches/psp-fixup-imports-jal-relocation-aware.patch` (pinned against a
+  specific pspsdk commit) carries the fix;
+  `scripts/build_psp_fixup_imports.bash` fetches pspsdk at that pin, applies
+  it, and drops the rebuilt tool in place of the toolchain's own, wired into
+  the `psp` CI job ahead of `psp-cmake`/`cmake --build`. Not yet upstreamed
+  to `pspdev/pspsdk`. With this fixed, the EBOOT now boots dramatically
+  further under PPSSPP-headless than at any earlier point — past
+  `RPG2K_PSP_BOOT`, through `mrb_open`, into real LVGL widget creation —
+  before hitting a new, separate, not-yet-fixed bug; see
+  `docs/adr/0047-psp-memory-budget.md`'s P1 for the full trail.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -314,18 +314,17 @@ the interpreter-linking slice, in this order:
      it — confirmed via PPSSPP's syscall log: the "unknown syscall"/failed
      LwMutex counts, which used to run into the hundreds of thousands over
      a 15s boot attempt, dropped to zero.
-  6. **Found, not fixed — inherent to this EBOOT's control flow, not a
-     quick patch.** With bug 5 fixed, `psp-fixup-imports` (pspsdk's
-     post-link import-table tool) warns `stubs out of order` on this
-     binary. It requires every stub reference to a given PSP module to be
-     physically contiguous in the linked binary's import metadata. When
-     out of order, the tool still marks entries processed but assigns some
-     of them the wrong `(module, function)` index, so PPSSPP resolves
-     several genuine, correctly-named imports (confirmed present as real
-     `ForUser`-module NIDs) as if they belonged to an unrelated module, and
-     calls into them return `SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED` —
-     again silently, and this is what's now hanging boot just past bug 5's
-     fix.
+  6. **Fixed, via a patched pspsdk host tool.** With bug 5 fixed,
+     `psp-fixup-imports` (pspsdk's post-link import-table tool) warned
+     `stubs out of order` on this binary. It requires every stub reference
+     to a given PSP module to be physically contiguous in the linked
+     binary's import metadata. When out of order, the tool still marked
+     entries processed but assigned some of them the wrong
+     `(module, function)` index, so PPSSPP resolved several genuine,
+     correctly-named imports (confirmed present as real `ForUser`-module
+     NIDs) as if they belonged to an unrelated module, and calls into them
+     returned `SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED` — again silently,
+     and this was what hung boot just past bug 5's fix.
 
      Traced to its actual source, not just its symptom: `app/psp/main.cxx`
      alone accounts for the overwhelming majority of this EBOOT's ~88
@@ -336,8 +335,8 @@ the interpreter-linking slice, in this order:
      `main.cxx` and 7 are unique to it. A minimal, hand-written pspsdk
      homebrew calling into three different modules (`ThreadManForUser`,
      `sceDisplay`, `sceCtrl`) from a single file — deliberately structured
-     like `main.cxx`'s own mix — built clean with no warning, which rules
-     out "any file touching multiple modules" as the trigger, and matches
+     like `main.cxx`'s own mix — built clean with no warning, which ruled
+     out "any file touching multiple modules" as the trigger, and matched
      `psp.cxx`'s own 7 module-unique calls also causing no trouble on
      their own. The actual splits are things like `ThreadManForUser`:
      `setup_callbacks()` calls `sceKernelCreateThread`/`sceKernelStartThread`
@@ -346,26 +345,65 @@ the interpreter-linking slice, in this order:
      from inside the main loop — two genuinely different call sites,
      necessarily far apart in `main.cxx`'s own control flow, with unrelated
      modules' calls (`IoFileMgrForUser`, `SysMemUserForUser`, ...) between
-     them. Re-linking `main.cxx` at `-O0` does not change the warning
-     either (rules out compiler reordering). So this isn't an accident
+     them. Re-linking `main.cxx` at `-O0` did not change the warning either
+     (ruled out compiler reordering). So this was never an accident
      reorder-away-able fix: it reflects how this EBOOT's own logic is
-     actually laid out, not a stray ordering slip.
+     actually laid out, not a stray ordering slip — no restructuring of
+     which compilation units call which PSP modules would have avoided it
+     either, only deferred it to the next place two calls to the same
+     module happen to land far apart.
 
-     A patch that stably regroups the tool's `(stub_addr, nid)` metadata by
-     owning module was written and tested, but is **unsafe and was not
-     merged**: `stub_addr` doubles as the fixed trampoline address every
+     A patch that just stably regroups the tool's `(stub_addr, nid)`
+     metadata by owning module was written and tested first, and found
+     **unsafe**: `stub_addr` doubles as the fixed trampoline address every
      `jal` instruction elsewhere in the binary already targets at link
      time, so moving which function's metadata occupies which slot
      decouples the two — confirmed by testing it, which produced a binary
      where `sceKernelCreateThread` and `sceIoRemove` both resolved to the
      same trampoline address, and the guest's own crt0 sequence ended up
-     calling `sceIoRemove("user_main")`. A correct fix needs a full
-     relocation-aware rewrite (scan `.text` for every `jal` targeting a
-     moved slot and repoint it) — a substantially bigger undertaking than
-     the fixes above, not attempted.
+     calling `sceIoRemove("user_main")`. The actual fix does the full
+     relocation-aware rewrite that implies: after grouping, scan every
+     executable section for `jal` instructions targeting a slot that
+     moved, and repoint each one at the function's new address (an
+     ET_EXEC binary carries no relocation entries left to do this through
+     any other way). `patches/psp-fixup-imports-jal-relocation-aware.patch`
+     (pinned against a specific pspsdk commit, matching what
+     `pspdev/pspdev:latest`'s own prebuilt tool was built from) carries the
+     fix; `scripts/build_psp_fixup_imports.bash` fetches pspsdk at that
+     pin, applies it, and drops the rebuilt tool in place of the
+     toolchain's own copy — wired into the `psp` CI job
+     (`.github/workflows/build.yml`) ahead of `psp-cmake`/`cmake --build`.
+     Confirmed on this project's own EBOOT: 88 imports across 15 modules,
+     78 of which needed to move, 1620–1625 `jal` instructions repointed to
+     match (the exact count moves slightly run to run with unrelated
+     binary layout changes, e.g. bug 5's fix shrinking the .bss zero-fill
+     shifted a few unrelated addresses), zero `stubs out of order`
+     warnings afterward.
 
-  Whether real hardware shares bug 6 is unknown (bug 3 is now moot on this
-  boot path either way); the P1 device numbers above remain unconfirmed on
+  With bug 6 fixed, this EBOOT boots dramatically further than at any
+  earlier point on this whole P1 trail: past `RPG2K_PSP_BOOT`, through
+  `_sbrk`'s heap init (correctly allocating the full requested size this
+  time, confirmed via PPSSPP's own memory-partition log line), through
+  `mrb_open`, into real LVGL widget creation in `build_ui()`. It then hits
+  a **seventh bug, found and not yet fixed**: LVGL's builtin TLSF
+  allocator's `lv_tlsf_realloc` (`3rd/lvgl/src/stdlib/builtin/lv_tlsf.c`)
+  asserts `block already marked as free` — a use-after-free/double-free
+  detector, not a sizing issue (confirmed: bumping `LV_MEM_SIZE` 8x, from
+  256 KB to 2 MB, made no difference at all to whether or where the assert
+  fired, which a genuine capacity problem would not do). Traced to its
+  caller via a temporary `__builtin_return_address(0)` capture in
+  `psp_lvgl_assert_halt` (not kept — diagnostic only): `lv_tlsf_realloc`
+  itself, most plausibly reached from `build_ui()`'s second
+  `lv_label_set_text(g_status_label, ...)` call (the per-frame pressed-keys
+  status update; LVGL labels reallocate their internal text buffer on
+  change) reallocating a block some other write already corrupted the
+  free/used bit of, rather than a bug in LVGL's own allocator itself
+  (matching this whole trail's running theme of memory corruption over
+  logic bugs). Not yet root-caused further.
+
+  Whether real hardware shares bug 7 is unknown (bugs 3 and 6 are moot on
+  this boot path either way, one because it stopped triggering, the other
+  because it's fixed); the P1 device numbers above remain unconfirmed on
   the emulator and untried on hardware.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -263,9 +263,11 @@ the interpreter-linking slice, in this order:
      `hrydgard/ppsspp`; `flake.nix`'s `ppsspp` package output carries the
      fix as a local patch (`nix/patches/
      ppsspp-lwmutex-workarea-validate.patch`).
-  3. **Real, confirmed, not yet fixed.** With bugs 1–2 out of the way, a
-     `workareaPtr=0` genuinely comes from the guest side, not host memory
-     corruption — traced to pspsdk's own `src/libcglue/lock.c`, where
+  3. **Real bug, confirmed present in pspsdk, but no longer reachable on
+     this boot path — not fixed, and no longer blocking anything by
+     itself.** With bugs 1–2 out of the way, a `workareaPtr=0` genuinely
+     came from the guest side, not host memory corruption — traced to
+     pspsdk's own `src/libcglue/lock.c`, where
      `__retarget_lock_init_recursive` calls `malloc()` for a new lock
      struct with no null-check before dereferencing it, triggered by
      `global_stdio_init`'s lazy lock creation on this EBOOT's very first
@@ -275,10 +277,15 @@ the interpreter-linking slice, in this order:
      container library as the cause — an earlier, since-retracted theory
      in this section blamed a stale library and a downstream JIT/heap
      crash; both were artifacts of this investigation's own diagnostic
-     instrumentation perturbing timing, not genuine behavior. The real,
-     confirmed behavior with a clean toolchain is that execution continues
-     past this bug — the three affected LwMutex creates simply fail and are
-     otherwise unused early in boot — into bug 4 below).
+     instrumentation perturbing timing, not genuine behavior). That
+     `malloc()` was failing because of bug 5 below (the same broken
+     `_sbrk()` heap init) — with bug 5 fixed, `malloc()` for the lock
+     struct now succeeds and this null-check gap simply never triggers on
+     this boot path anymore (confirmed: re-tested the full boot with bug
+     5's fix applied, zero `ILLEGAL_ADDR=sceKernelCreateLwMutex` calls,
+     versus dozens before). The missing null-check is still a real latent
+     bug in pspsdk itself and worth reporting upstream, but it is not
+     something this repo needs to work around right now.
   4. **Fixed, PPSSPP-side.** The interpreter's `mfic`/`mtic` (Allegrex "move
      from/to interrupt controller", `Core/MIPS/MIPSInt.cpp`) were pure
      no-ops. pspsdk's `pspSdkDisableInterrupts()`/`EnableInterrupts()`
@@ -307,39 +314,59 @@ the interpreter-linking slice, in this order:
      it — confirmed via PPSSPP's syscall log: the "unknown syscall"/failed
      LwMutex counts, which used to run into the hundreds of thousands over
      a 15s boot attempt, dropped to zero.
-  6. **Found, not fixed — a toolchain limitation, not a quick patch.** With
-     bug 5 fixed, `psp-fixup-imports` (pspsdk's post-link import-table
-     tool) warns `stubs out of order` on this binary. It requires every
-     stub reference to a given PSP module to be physically contiguous in
-     the linked binary's import metadata; this project's `main.cxx` and
-     LVGL's PSP display driver each call into several different PSP
-     modules in ordinary control-flow order, so the linker's relocation
-     order doesn't group by module. When out of order, the tool still
-     marks entries processed but assigns some of them the wrong
-     `(module, function)` index, so PPSSPP resolves several genuine,
-     correctly-named imports (confirmed present as real `ForUser`-module
-     NIDs) as if they belonged to an unrelated module, and calls into them
-     return `SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED` — again silently, and
-     this is what's now hanging boot just past bug 5's fix. Re-linking
-     `main.cxx` at `-O0` does not change the warning (ruled out compiler
-     reordering as the cause; it's inherent to the source's own call
-     order). A patch that stably regroups the tool's `(stub_addr, nid)`
-     metadata by owning module was written and tested, but is **unsafe and
-     was not merged**: `stub_addr` doubles as the fixed trampoline address
-     every `jal` instruction elsewhere in the binary already targets at
-     link time, so moving which function's metadata occupies which slot
+  6. **Found, not fixed — inherent to this EBOOT's control flow, not a
+     quick patch.** With bug 5 fixed, `psp-fixup-imports` (pspsdk's
+     post-link import-table tool) warns `stubs out of order` on this
+     binary. It requires every stub reference to a given PSP module to be
+     physically contiguous in the linked binary's import metadata. When
+     out of order, the tool still marks entries processed but assigns some
+     of them the wrong `(module, function)` index, so PPSSPP resolves
+     several genuine, correctly-named imports (confirmed present as real
+     `ForUser`-module NIDs) as if they belonged to an unrelated module, and
+     calls into them return `SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED` —
+     again silently, and this is what's now hanging boot just past bug 5's
+     fix.
+
+     Traced to its actual source, not just its symptom: `app/psp/main.cxx`
+     alone accounts for the overwhelming majority of this EBOOT's ~88
+     total PSP imports across 15 modules; `mruby-rgss/src/psp.cxx` (built
+     into `libmruby.a`, the only other object file in the whole archive —
+     all 160 of them — that calls a raw PSP syscall at all) contributes
+     just 9, of which 2 (`sceIoWrite`, `sceKernelDelayThread`) overlap with
+     `main.cxx` and 7 are unique to it. A minimal, hand-written pspsdk
+     homebrew calling into three different modules (`ThreadManForUser`,
+     `sceDisplay`, `sceCtrl`) from a single file — deliberately structured
+     like `main.cxx`'s own mix — built clean with no warning, which rules
+     out "any file touching multiple modules" as the trigger, and matches
+     `psp.cxx`'s own 7 module-unique calls also causing no trouble on
+     their own. The actual splits are things like `ThreadManForUser`:
+     `setup_callbacks()` calls `sceKernelCreateThread`/`sceKernelStartThread`
+     once, early, and the separate, ongoing `RPG2K_PSP_BRINGUP` heartbeat
+     calls `sceKernelGetThreadStackFreeSize` (same module) once per second
+     from inside the main loop — two genuinely different call sites,
+     necessarily far apart in `main.cxx`'s own control flow, with unrelated
+     modules' calls (`IoFileMgrForUser`, `SysMemUserForUser`, ...) between
+     them. Re-linking `main.cxx` at `-O0` does not change the warning
+     either (rules out compiler reordering). So this isn't an accident
+     reorder-away-able fix: it reflects how this EBOOT's own logic is
+     actually laid out, not a stray ordering slip.
+
+     A patch that stably regroups the tool's `(stub_addr, nid)` metadata by
+     owning module was written and tested, but is **unsafe and was not
+     merged**: `stub_addr` doubles as the fixed trampoline address every
+     `jal` instruction elsewhere in the binary already targets at link
+     time, so moving which function's metadata occupies which slot
      decouples the two — confirmed by testing it, which produced a binary
      where `sceKernelCreateThread` and `sceIoRemove` both resolved to the
      same trampoline address, and the guest's own crt0 sequence ended up
      calling `sceIoRemove("user_main")`. A correct fix needs a full
      relocation-aware rewrite (scan `.text` for every `jal` targeting a
-     moved slot and repoint it), a substantially bigger undertaking than
-     the fixes above; the alternative is restructuring which compilation
-     units call which PSP modules so each object file's own stubs are
-     naturally contiguous. Neither has been attempted.
+     moved slot and repoint it) — a substantially bigger undertaking than
+     the fixes above, not attempted.
 
-  Whether real hardware shares any of bugs 3 or 6 is unknown; the P1 device
-  numbers above remain unconfirmed on the emulator and untried on hardware.
+  Whether real hardware shares bug 6 is unknown (bug 3 is now moot on this
+  boot path either way); the P1 device numbers above remain unconfirmed on
+  the emulator and untried on hardware.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/patches/psp-fixup-imports-config.h
+++ b/patches/psp-fixup-imports-config.h
@@ -1,0 +1,14 @@
+// Hand-written stand-in for the config.h that pspsdk's own `./bootstrap &&
+// ./configure` would normally autoconf-generate. Building the patched
+// psp-fixup-imports (see psp-fixup-imports-jal-relocation-aware.patch and
+// scripts/build_psp_fixup_imports.bash) needs *a* config.h to exist --
+// tools/types.h includes it unconditionally, not guarded by HAVE_CONFIG_H --
+// but grep across tools/psp-fixup-imports.c, tools/types.h, and everything
+// else that file pulls in shows only these three HAVE_* macros are ever
+// actually tested by a preprocessor conditional. Running the full pspsdk
+// autotools bootstrap just to generate the other several dozen unused
+// HAVE_*/PACKAGE_* defines a real ./configure run would produce isn't worth
+// the extra CI dependencies (autoconf, automake) for three #defines.
+#define HAVE_CONFIG_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_INTTYPES_H 1

--- a/patches/psp-fixup-imports-jal-relocation-aware.patch
+++ b/patches/psp-fixup-imports-jal-relocation-aware.patch
@@ -1,0 +1,295 @@
+pspsdk bug: psp-fixup-imports (tools/psp-fixup-imports.c) requires every
+stub call site referencing a given PSP module to already be physically
+contiguous in the linked binary's import metadata (g_stubtext/g_nid) --
+it assigns each module's PspModuleImport::nids/funcs to the position of
+its *first* entry, then trusts func_count more entries for that module
+immediately follow. That's only true if every object file's relocations
+happen to reference imports in module-grouped order. A single
+translation unit calling into several different PSP modules in ordinary
+control-flow order (this project's app/psp/main.cxx does, driven by its
+own legitimate control flow -- see docs/adr/0047-psp-memory-budget.md's
+P1 for the trail) breaks that assumption. No amount of reordering the
+*linked libraries* on the command line can fix it either: link order
+only decides which .o files get pulled in, not the relocation order
+already recorded inside any one already-compiled .o.
+
+When out of order, the tool still marks every entry processed (so the
+build doesn't fail outright) but silently assigns some of them the
+wrong (module, function) index. The PSP loader (PPSSPP or real
+firmware) then resolves genuine, correctly-named imports as if they
+belonged to an unrelated module, and calls into them return
+SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED -- again silently, since nothing
+in this codebase's own PSP glue checks for it. This is what stopped this
+project's PSP EBOOT from booting to completion under PPSSPP-headless (or
+presumably on real hardware) even after every other known bug on that
+path was fixed.
+
+This patch makes psp-fixup-imports self-heal instead of just warning:
+
+  - Before the existing per-entry accounting pass, stably group
+    g_stubtext/g_nid by owning module (same relative order within each
+    module's run, groups in first-appearance order). Entries the tool
+    can't resolve to a module (already-processed sentinels, or bad
+    addresses the existing pass already rejects) form their own
+    singleton groups and keep their original position.
+  - Grouping alone corrupts the binary rather than fixing it: each
+    entry's own trampoline -- the fixed address every `jal` instruction
+    elsewhere in the program already targets, baked in at link time (an
+    ET_EXEC binary carries no relocation entries left to update it
+    through) -- lives at g_stubtext->iAddr + itsIndex*8, purely a
+    function of its position. Moving an entry to a new index moves its
+    real, callable address without moving any of the JAL instructions
+    that call it, so callers of a moved function keep hitting whichever
+    *other* function the reorder left sitting at the address they still
+    target. Confirmed by testing the grouping-only version of this idea
+    in isolation: it produced a binary where sceKernelCreateThread and
+    sceIoRemove both resolved to the same trampoline address, and the
+    guest's own crt0 sequence ended up calling sceIoRemove("user_main").
+  - So this patch also scans every SHF_EXECINSTR section (.text/.init/
+    .fini -- real code only, so a stray matching bit pattern in a data
+    section can't cause a false match) for `jal` instructions whose
+    target is one of the addresses that just moved, and repoints each
+    one at the function's new address. Confirmed on this project's own
+    EBOOT: 88 imports across 15 modules, 78 of which needed to move,
+    1620 `jal` instructions repointed to match, zero "stubs out of
+    order" warnings afterward, and the resulting EBOOT boots
+    dramatically further under PPSSPP-headless than it ever did before
+    this patch -- past RPG2K_PSP_BOOT, through the mruby interpreter
+    opening, into real LVGL widget creation.
+
+Pinned against pspdev/pspsdk commit 314b2083f2e1eaf145fc5de342736336fe1f0148
+(2026-07-28), the commit confirmed to match what pspdev/pspdev:latest's
+prebuilt psp-fixup-imports binary was itself built from at the time this
+was written (verified by disassembling and comparing object files
+between the container's shipped binary and a from-scratch rebuild of
+this exact commit). scripts/build_psp_fixup_imports.bash fetches
+pspsdk at this pin, applies this patch, and builds a replacement native
+tool; see that script and app/psp/README.md for how it's wired into the
+`psp` CI job and local reproduction. Not upstreamed to
+https://github.com/pspdev/pspsdk -- worth reporting there, since nothing
+about this fix is specific to this project's binary, but applied locally
+here in the meantime the same way this repo's own PPSSPP patches are
+(nix/patches/).
+
+--- a/tools/psp-fixup-imports.c
++++ b/tools/psp-fixup-imports.c
+@@ -648,6 +648,105 @@
+ #define MIPS_JR_31 0x03e00008
+ #define MIPS_NOP   0x0
+
++/* Resolve which PspModuleImport a (stub_addr, stub_nid) entry belongs to for
++ * grouping purposes, or NULL if it's an already-processed sentinel or an
++ * address the entry-processing loop below will reject. Deliberately silent
++ * (no error print/return) -- that loop re-validates every entry itself and
++ * is what actually reports a bad address. */
++static struct PspModuleImport *group_key(unsigned int stub_addr, unsigned int stub_nid)
++{
++	if((stub_addr == MIPS_JR_31) && (stub_nid == MIPS_NOP))
++	{
++		return NULL;
++	}
++
++	if((stub_addr < g_libstub->iAddr) || (stub_addr > (g_libstub->iAddr + g_libstub->iSize)) || (stub_addr & 3))
++	{
++		return NULL;
++	}
++
++	return (struct PspModuleImport *) (g_libstub->pData + (stub_addr - g_libstub->iAddr));
++}
++
++#define MIPS_OP_JAL 0x3
++
++/* Every function's own trampoline slot in g_stubtext (.sceStub.text) sits at
++ * a FIXED address, g_stubtext->iAddr + originalIndex*8 -- every `jal` in the
++ * program that calls that function targets that address directly, baked in
++ * at link time (this is an ET_EXEC binary; there are no relocation entries
++ * left to update it through). Grouping entries by module (below) moves
++ * which logical function occupies which slot index, which means it moves
++ * that function's real, callable address -- so every one of those `jal`s
++ * has to be repointed at the function's new slot to match, or callers
++ * silently invoke whichever *other* function the reordering left sitting at
++ * the address they still target. remap[i] gives the new address for the
++ * function that used to sit at slot i; scanRewriteJal patches every `jal`
++ * in every SHF_EXECINSTR section (.text/.init/.fini -- real code only,
++ * never a data section a stray matching bit pattern could show up in) whose
++ * target matches an entry in remap. Returns how many instructions it
++ * changed, for the caller to sanity-check against how many entries actually
++ * moved. */
++static int scanRewriteJal(const unsigned int *oldAddrs, const unsigned int *newAddrs, int remapCount)
++{
++	int patched = 0;
++	int secIdx;
++
++	for(secIdx = 0; secIdx < (int) g_elfhead.iShnum; secIdx++)
++	{
++		struct ElfSection *sec = &g_elfsections[secIdx];
++		unsigned int *code;
++		unsigned int wordCount;
++		unsigned int w;
++
++		if((sec->iFlags & (SHF_ALLOC | SHF_EXECINSTR)) != (SHF_ALLOC | SHF_EXECINSTR))
++		{
++			continue;
++		}
++
++		code = (unsigned int *) sec->pData;
++		wordCount = sec->iSize / 4;
++
++		for(w = 0; w < wordCount; w++)
++		{
++			unsigned int instr = LW(code[w]);
++			unsigned int op = (instr >> 26) & 0x3F;
++			unsigned int instrAddr;
++			unsigned int target;
++			int i;
++
++			if(op != MIPS_OP_JAL)
++			{
++				continue;
++			}
++
++			instrAddr = sec->iAddr + w * 4;
++			target = ((instrAddr + 4) & 0xF0000000u) | ((instr & 0x03FFFFFFu) << 2);
++
++			for(i = 0; i < remapCount; i++)
++			{
++				if(oldAddrs[i] != target)
++				{
++					continue;
++				}
++				if(oldAddrs[i] == newAddrs[i])
++				{
++					break;
++				}
++
++				SW(&code[w], (instr & 0xFC000000u) | ((newAddrs[i] >> 2) & 0x03FFFFFFu));
++				patched++;
++				if(g_verbose)
++				{
++					fprintf(stderr, "Repointed jal at %08x: %08x -> %08x\n", instrAddr, target, newAddrs[i]);
++				}
++				break;
++			}
++		}
++	}
++
++	return patched;
++}
++
+ int fixup_imports(void)
+ {
+ 	unsigned int *pText;
+@@ -671,6 +770,113 @@
+ 		fprintf(stderr, "Import count %d\n", count);
+ 	}
+
++	/* The loop below sets each module's PspModuleImport::nids/funcs to the
++	 * position of its first entry here, then trusts func_count more
++	 * entries for that module immediately follow -- i.e. it requires
++	 * every entry for a given module to already be contiguous in
++	 * pText/pNid. That's only true if each object file's relocations
++	 * reference imports in module-grouped order. A single translation
++	 * unit that calls into several different PSP modules in ordinary
++	 * control-flow order (this codebase's main.cxx does, driven by its own
++	 * legitimate control flow -- see docs/adr/0047-psp-memory-budget.md)
++	 * breaks that assumption, and no amount of reordering the *linked
++	 * libraries* on the command line can fix it: link order only decides
++	 * which .o files get pulled in, not the relocation order already
++	 * recorded inside any one compiled .o. So stably group the two arrays
++	 * by owning module here first, instead of requiring the input to
++	 * already be grouped -- same relative order within each module's run,
++	 * groups ordered by first appearance. Entries this can't resolve to a
++	 * module (already-processed sentinels, or bad addresses the loop below
++	 * will reject) form their own singleton groups and keep their original
++	 * position, same as before this grouping pass existed.
++	 *
++	 * Grouping alone isn't safe by itself, though: entry i's own trampoline
++	 * -- the address every `jal` calling it targets -- lives at
++	 * g_stubtext->iAddr + i*8, a position derived purely from its INDEX.
++	 * Moving an entry to a new index moves its real, callable address, so
++	 * every existing `jal` to its old address has to be repointed at the
++	 * new one (scanRewriteJal, above) or callers keep hitting whichever
++	 * *other* function the reorder left at the address they still target.
++	 */
++	if(count > 0)
++	{
++		struct PspModuleImport **groups = (struct PspModuleImport **) malloc(sizeof(struct PspModuleImport *) * count);
++		unsigned int *pTextSorted = (unsigned int *) malloc(g_stubtext->iSize);
++		unsigned int *pNidSorted = (unsigned int *) malloc(g_nid->iSize);
++		unsigned int *oldAddrs = (unsigned int *) malloc(sizeof(unsigned int) * count);
++		unsigned int *newAddrs = (unsigned int *) malloc(sizeof(unsigned int) * count);
++		int groupCount = 0;
++		int outPos = 0;
++		int i, j;
++		int jalsPatched;
++		int entriesMoved = 0;
++
++		for(i = 0; i < count; i++)
++		{
++			struct PspModuleImport *key = group_key(LW(pText[i * 2]), LW(pText[i * 2 + 1]));
++
++			for(j = 0; j < groupCount; j++)
++			{
++				if(groups[j] == key)
++				{
++					break;
++				}
++			}
++			if(j == groupCount)
++			{
++				groups[groupCount++] = key;
++			}
++		}
++
++		for(j = 0; j < groupCount; j++)
++		{
++			for(i = 0; i < count; i++)
++			{
++				if(group_key(LW(pText[i * 2]), LW(pText[i * 2 + 1])) != groups[j])
++				{
++					continue;
++				}
++
++				pTextSorted[outPos * 2] = pText[i * 2];
++				pTextSorted[outPos * 2 + 1] = pText[i * 2 + 1];
++				pNidSorted[outPos] = pNid[i];
++				oldAddrs[outPos] = g_stubtext->iAddr + (unsigned int) i * 8;
++				newAddrs[outPos] = g_stubtext->iAddr + (unsigned int) outPos * 8;
++				if(oldAddrs[outPos] != newAddrs[outPos])
++				{
++					entriesMoved++;
++				}
++				outPos++;
++			}
++		}
++
++		if(g_verbose)
++		{
++			fprintf(stderr, "Grouped %d import entries into %d module(s), %d entr%s moved.\n", count, groupCount,
++					entriesMoved, entriesMoved == 1 ? "y" : "ies");
++		}
++
++		jalsPatched = scanRewriteJal(oldAddrs, newAddrs, outPos);
++		if(g_verbose || (entriesMoved > 0))
++		{
++			fprintf(stderr, "Repointed %d jal instruction(s) at %d moved import(s).\n", jalsPatched, entriesMoved);
++		}
++		if((entriesMoved > 0) && (jalsPatched == 0))
++		{
++			fprintf(stderr, "Warning: entries moved but no jal instructions were repointed -- either\n");
++			fprintf(stderr, "the moved imports are unreferenced, or something is calling them in a\n");
++			fprintf(stderr, "way this tool doesn't scan for. Continuing, but verify the result boots.\n");
++		}
++
++		memcpy(pText, pTextSorted, g_stubtext->iSize);
++		memcpy(pNid, pNidSorted, g_nid->iSize);
++		free(pTextSorted);
++		free(pNidSorted);
++		free(oldAddrs);
++		free(newAddrs);
++		free(groups);
++	}
++
+ 	while(count > 0)
+ 	{
+ 		unsigned int stub_addr;

--- a/scripts/build_psp_fixup_imports.bash
+++ b/scripts/build_psp_fixup_imports.bash
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Build a patched replacement for pspdev's psp-fixup-imports (a host tool the
+# PSP CMake toolchain runs automatically after linking rpg2k_psp), and drop it
+# wherever the caller wants it -- normally straight over the pspdev image's
+# own /usr/local/pspdev/bin/psp-fixup-imports, so the rest of the build (an
+# unmodified `psp-cmake` + `cmake --build`) picks it up transparently.
+#
+# Why: the stock tool requires every call site referencing a given PSP module
+# to already be physically contiguous in the linked binary's import metadata,
+# which this project's main.cxx's own (entirely ordinary) control flow does
+# not satisfy -- see patches/psp-fixup-imports-jal-relocation-aware.patch's
+# own preamble and docs/adr/0047-psp-memory-budget.md's P1 for the full
+# story. Without this, the EBOOT links and packs fine but several genuine,
+# correctly-named PSP imports silently resolve to the wrong module at
+# runtime, which is what actually stopped this port's EBOOT from booting to
+# completion under PPSSPP-headless.
+#
+# Usage:
+#   scripts/build_psp_fixup_imports.bash [OUTPUT_PATH]
+#     OUTPUT_PATH defaults to /usr/local/pspdev/bin/psp-fixup-imports, i.e.
+#     "replace the toolchain's own copy in place" -- the right default both
+#     for the psp CI job (see .github/workflows/build.yml) and for local
+#     reproduction inside the same pspdev/pspdev container the CI job uses.
+#
+# Needs: git, a native (host) C compiler (`cc`), and network access to
+# github.com. The pspdev/pspdev image ships neither by default; `apk add
+# --no-cache git build-base` first (build-base is already an existing build
+# dependency for the psp CI job's mruby host cross-build -- see
+# .github/workflows/build.yml -- so this rarely needs installing twice).
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PATCHES_DIR="$REPO_ROOT/patches"
+OUTPUT_PATH="${1:-/usr/local/pspdev/bin/psp-fixup-imports}"
+
+# Pinned in patches/psp-fixup-imports-jal-relocation-aware.patch's own
+# preamble too; keep the two in sync if this ever moves. Confirmed (by
+# disassembling and comparing object files) to match what pspdev/pspdev:latest's
+# own prebuilt psp-fixup-imports binary was built from at the time this was
+# written -- pspdev/pspdev is a moving `:latest` tag, so a future image update
+# could in principle drift from this pin; if the patch stops applying cleanly,
+# that drift is why.
+PSPSDK_COMMIT=314b2083f2e1eaf145fc5de342736336fe1f0148
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+git init -q "$WORK_DIR"
+git -C "$WORK_DIR" remote add origin https://github.com/pspdev/pspsdk.git
+git -C "$WORK_DIR" fetch -q --depth 1 origin "$PSPSDK_COMMIT"
+git -C "$WORK_DIR" checkout -q FETCH_HEAD
+
+patch -p1 -d "$WORK_DIR" < "$PATCHES_DIR/psp-fixup-imports-jal-relocation-aware.patch"
+
+# tools/types.h #includes "config.h" unconditionally (not HAVE_CONFIG_H-
+# guarded), so it has to be named exactly that on the include path -- copy
+# rather than rename the vendored copy in patches/, since "config.h" alone
+# would be a confusing name to find sitting in that directory.
+cp "$PATCHES_DIR/psp-fixup-imports-config.h" "$WORK_DIR/config.h"
+
+cc -O2 -DHAVE_CONFIG_H \
+  -I"$WORK_DIR" \
+  -I"$WORK_DIR/tools" \
+  -o "$WORK_DIR/psp-fixup-imports" \
+  "$WORK_DIR/tools/psp-fixup-imports.c" \
+  "$WORK_DIR/tools/getopt_long.c" \
+  "$WORK_DIR/tools/sha1.c"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+install -m 755 "$WORK_DIR/psp-fixup-imports" "$OUTPUT_PATH"
+echo "Built patched psp-fixup-imports -> $OUTPUT_PATH" >&2


### PR DESCRIPTION
## Summary
These two commits landed on `claude/psp-mfic-mtic-and-link-order-fix` after PR #973 had already auto-merged (right after the first commit) — they never actually made it into `master`. Re-opening them here on a fresh branch off current `master`.

- **The big one**: fixes `psp-fixup-imports` (pspsdk's post-link import-table tool) itself. It requires every call site referencing a given PSP module to already be physically contiguous in the linked binary — a requirement this EBOOT's own `main.cxx` doesn't satisfy (traced to its source: this reflects genuinely necessary separation in the program's own control flow, not an accidental ordering slip a reorder could fix). When out of order, the stock tool silently mis-assigns several genuine, correctly-named imports to the wrong module, and calls into them fail unchecked — this was what actually stopped the EBOOT booting to completion under PPSSPP-headless even after every other known bug on that path (#973) was fixed. A metadata-only regroup patch was tried first and found **unsafe** (confirmed to silently misdirect syscalls to the wrong function — `sceKernelCreateThread` and `sceIoRemove` ended up resolving to the same trampoline address). The real fix additionally scans every executable section for `jal` instructions targeting a moved import slot and repoints them (`patches/psp-fixup-imports-jal-relocation-aware.patch`, `scripts/build_psp_fixup_imports.bash`, wired into the `psp` CI job). Confirmed: 88 imports across 15 modules, 78 moved, ~1620 `jal` instructions repointed, zero "stubs out of order" warnings.
- Updates `docs/adr/0047-psp-memory-budget.md`'s P1 section and `app/psp/README.md` to document the full seven-bug chain found this round, and retracts an earlier JIT-crash theory that turned out to be a diagnostic-instrumentation artifact.

**With the `psp-fixup-imports` fix, this EBOOT now boots dramatically further than at any earlier point in this project's history** — past `RPG2K_PSP_BOOT`, through `_sbrk`'s heap init, through `mrb_open`, into real LVGL widget creation — before hitting a new, separate bug in LVGL's TLSF allocator (a use-after-free/double-free assert, not yet root-caused), documented as the next item on the P1 trail.

## Test plan
- [x] `nix flake check` passes
- [x] Both commits cherry-picked cleanly onto current `master` (one trivial auto-merge in `.github/workflows/build.yml`)
- [x] Previously confirmed (on the original branch, before it merged early) via a full CI run: `psp` and `psp-smoke` both green, including the actual boot test showing markers past `RPG2K_PSP_BOOT`
- [ ] CI on this branch (`psp`, `psp-smoke`, `flake` jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWRDFncfXqFhx7Uw23SJR3