### PR TITLE
game: a transformation reseeds attr_base_ranks too

### DIFF
--- a/changelog.d/transform-attr-base-ranks.fixed.md
+++ b/changelog.d/transform-attr-base-ranks.fixed.md
@@ -1,0 +1,5 @@
+- **A transformed monster's later attribute-defence shifts now cap against
+  its new form's own resistance, not the pre-transform monster's.**
+  `#enemy_transform_action` updated the monster's current attribute ranks on
+  Transform but left the snapshotted "base" a later shift is capped +-1
+  around still pointing at the original form.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1641,6 +1641,23 @@ The work below is roughly ordered by the critical path to a walkable game
   position, `levitate` and `hidden` are untouched, since a Transform keeps
   its place and never revives a hidden member. One new
   `rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix code.
+  ✅ **A transformation also reseeds `attr_base_ranks` now, so a later
+  attribute-defence shift caps against the new form's own rank, not the
+  original monster's (2026-08-18).** EasyRPG's real mechanism is a
+  persistent shift *delta* (`Game_Battler::attribute_shift`, clamped to
+  +-1 total) added onto a *live* base (`Game_Enemy::GetBaseAttributeRate`,
+  `src/game_enemy.cpp`, reads straight off the currently-transformed
+  `enemy` pointer) -- there being only the one pointer, a Transform can
+  never make it stale there. This port instead represents the shift as an
+  absolute rank, capped against a base *snapshotted once at spawn*
+  (`Combatant#attr_base_ranks`), so any event that changes what "the
+  current form" is has to explicitly re-seed that snapshot -- exactly the
+  event `#enemy_transform_action` already updates `attr_ranks`'s own
+  sibling field for and forgot to update `attr_base_ranks` alongside, the
+  identical shape as the reward-sync bug fixed just above. One new
+  `rpg2k_logic_check.rb` check (transforms into a monster with a different
+  attribute rank, then applies a shift and confirms the cap follows the
+  new form), confirmed to fail against the pre-fix code.
   ✅ **Charge was only ever spent by the enemy's own next Attack, not by
   anything else it might do first (2026-08-18).** `Game_BattleAlgorithm::
   AlgorithmBase::Start()` (`src/game_battlealgorithm.cpp`, confirmed against

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10537,6 +10537,17 @@ module Game
       b.max_hp = into.max_hp; b.max_mp = into.max_sp
       b.crit_chance = Battle.crit_chance_of(into)
       b.attr_ranks = Battle.attr_ranks_of(into)
+      # #apply_attr_shift caps a later attribute-defence shift to +-1 of
+      # `attr_base_ranks`, snapshotted once at spawn (Combatant.from_actor/
+      # from_enemy) since this port represents the shift as an absolute rank
+      # rather than EasyRPG's own persistent delta (`Game_Battler::
+      # attribute_shift`, added onto a *live* `GetBaseAttributeRate` that
+      # reads straight off the currently-transformed `enemy` row -- see
+      # `Game_Enemy::GetBaseAttributeRate`, `src/game_enemy.cpp`). A
+      # transform changes what "the base" is, exactly the event a snapshot
+      # needs to be told about; left stale, a later shift is capped against
+      # the pre-transform monster's own resistance instead of this one's.
+      b.attr_base_ranks = b.attr_ranks.dup
       b.state_ranks = Battle.state_ranks_of(into)
       b.hit_rate = Battle.hit_rate_of(into)
       b.actions = into.actions

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -16224,6 +16224,37 @@ check 'a transformation carries current HP/SP over unchanged, not reclamped to t
   eq 40, foe.mp, 'current SP carries over unchanged too'
 end
 
+# EasyRPG's own attribute-rank shift is a persistent delta (Game_Battler::
+# attribute_shift, clamped to +-1 total) added onto a *live* base
+# (Game_Enemy::GetBaseAttributeRate reads straight off the currently-
+# transformed `enemy` row, src/game_enemy.cpp) -- a Transform can never make
+# it stale, there being only the one pointer. This port instead snapshots the
+# base once (Combatant#attr_base_ranks, set at spawn) to cap an absolute
+# rank value, so a Transform has to explicitly re-seed it -- exactly the
+# `attr_ranks`/`attr_base_ranks` pair #enemy_transform_action already
+# updates the sibling of, just as the reward-sync fix's `exp`/`gold` pair was.
+check "a transformation reseeds attr_base_ranks, so a later shift caps against the new form's rank" do
+  row = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                   :agility, :exp, :gold, :attribute_ranks).new(
+    'Dragon', 900, 50, 90, 40, 30, 25, 0, 0, [4]) # attribute 1 at rank E (4)
+  db = Struct.new(:enemy).new({ 1 => row })
+  ai = Game::EnemyAi.new(db, new_state)
+  foe = combatant('Slime', 40, 0, 5, 500)
+  foe.attr_ranks = { 1 => 0 }
+  foe.attr_base_ranks = { 1 => 0 } # attribute 1 at rank A (0), pre-transform
+  b = ai_battle([enemy_action(kind: 2, enemy_id: 1)], ai, foe: foe)
+  b.begin_round
+  b.step_action # the hero
+  e = b.step_action
+  eq true, e[:transform]
+  eq({ 1 => 4 }, foe.attr_base_ranks, "the new form's own rank, not the stale pre-transform one")
+  # A -1 shift caps against the *new* base (4, window 3..4) -- 4 - 1 = 3.
+  # Against the stale pre-transform base (0, window 0..1) it would clamp to 1.
+  moved = b.send(:apply_attr_shift, foe, { attr_shift: -1, attr_ids: [1] })
+  eq [1], moved
+  eq 3, foe.attr_ranks[1], "capped against the new form's own rank, not the stale pre-transform one"
+end
+
 # -- the database path ---------------------------------------------------------
 
 check 'Game::Enemy decodes its action pattern off the database row' do


### PR DESCRIPTION
## Summary

- Same shape as #979 (just-merged): `enemy_transform_action` updates a sibling pair of fields for the new monster, but only one half of the pair. This time it's `attr_ranks`/`attr_base_ranks` — the transform already repoints `attr_ranks` to the new form, but leaves `attr_base_ranks` (the snapshot `#apply_attr_shift` caps a later attribute-defence shift to +-1 of) pointing at the pre-transform monster.
- Checked against EasyRPG's actual mechanism (`src/game_battler.cpp`/`src/game_enemy.cpp`): it represents an attribute shift as a *persistent delta* (`Game_Battler::attribute_shift`, clamped to ±1 total, cleared only at `ResetBattle`) added onto a **live** base — `Game_Enemy::GetBaseAttributeRate` reads straight off the currently-transformed `enemy` pointer, so a Transform can never make it stale there (there's only the one pointer). This port instead represents the shift as an absolute rank, capped against a base *snapshotted once at spawn* — a legitimate alternate design, but one that means any event changing what "the current form" is has to explicitly re-seed that snapshot. Transform is exactly such an event, and it was only updating `attr_ranks`, not its sibling.
- Net effect: a monster transforming from a form with a low resistance rank into one with a high resistance rank (or vice versa) would have any subsequent attribute-defence shift forcibly clamped back toward the *old* form's rank instead of the new one's.
- Fix: one line, `b.attr_base_ranks = b.attr_ranks.dup`, mirroring the exact pattern `Combatant.from_actor`/`Combatant.from_enemy` already use to seed it at spawn.
- `docs/TODO.md` gets a dated follow-up note; changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 999 checks passed (1 new: transforms a combatant into a monster with a different attribute rank, then applies a shift and confirms the cap follows the new form's rank rather than the stale pre-transform one — confirmed to fail against the pre-fix code before landing the fix)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 694 checks passed (unchanged)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_