### PR TITLE
map: riding the airship skips terrain damage and the footstep SE

### DIFF
--- a/changelog.d/airship-skips-terrain-damage.fixed.md
+++ b/changelog.d/airship-skips-terrain-damage.fixed.md
@@ -1,0 +1,5 @@
+- **Riding the airship now skips terrain damage and the RPG2003 footstep SE
+  entirely**, matching EasyRPG's `Game_Player::Move`, which returns before
+  ever looking up the stepped-on tile's terrain while airborne. A boat or
+  ship still takes terrain damage as usual, since they sail the water
+  layer's own terrain rather than flying over it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11193,6 +11193,19 @@ now passed to both rather than queried twice. Covered by three new
 firing once per tile walked; an RPG2000 fixture never playing one even when
 the field is set; and an RPG2003 fixture with `on_damage_se` set staying
 silent on a harmless tile while playing on every tile of a damaging one.
+✅ **Riding the airship now skips terrain damage and the footstep SE
+entirely (2026-08-18).** `#note_party_step` looked up and applied the
+stepped-on tile's terrain regardless of what the party was riding.
+EasyRPG's real `Game_Player::Move` returns via its own `InAirship()` check
+*before* it ever looks up the terrain row at all -- neither the HP damage
+nor the RPG2003 footstep SE fire while airborne, and the exemption is
+airship-specific (`InAirship()`, not a general `boarded?` test): a
+boat/ship still sails the water layer's own terrain and takes it exactly
+like walking does. The status-condition map-step slip
+(`Party#apply_map_step_damage`) has no such gate in the reference
+(`UpdateNextMovementAction`'s own `ApplyStateDamage` call is
+unconditional) and is untouched. One new `rpg2k_scene_check.rb` check,
+confirmed to fail against the pre-fix code.
 ✅ **A dangling chipset id no longer renders a map blank and fully passable
 with no trace** — the "chipset" case from the "invalid hero, skill, item,
 enemy, enemy group, battle animation, terrain, chipset, common event" list

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7230,11 +7230,25 @@ class RPG2k
         # to say so" moment -- except a heal never flashes red or counts as
         # "damaged" for the footstep SE below, matching EasyRPG's own
         # `Game_Player::Move`, which only sets `red_flash` for positive damage.
-        row = terrain_row_at(@state.x, @state.y)
-        terrain_hit = terrain_step_damage(row)
-        terrain_damaged = !terrain_hit.empty? && row && row.respond_to?(:damage) &&
-                          row.damage && row.damage > 0
-        play_terrain_footstep_se(row, terrain_damaged)
+        #
+        # Skipped entirely while riding the airship: `Game_Player::Move`
+        # returns via `InAirship()`'s own early check *before* it ever looks
+        # up the stepped-on tile's terrain row, so an airborne party takes
+        # neither the HP damage nor (RPG2003) the footstep SE for whatever is
+        # below it -- unlike a boat/ship, which still sails the water layer's
+        # own terrain and is not exempted (`InAirship()` alone, not a general
+        # `boarded?` check). The status-condition slip above has no such
+        # gate in the reference (`UpdateNextMovementAction`'s own
+        # `ApplyStateDamage` call runs unconditionally), so it stays outside
+        # this guard.
+        terrain_damaged = false
+        unless @state.boarded == :airship
+          row = terrain_row_at(@state.x, @state.y)
+          terrain_hit = terrain_step_damage(row)
+          terrain_damaged = !terrain_hit.empty? && row && row.respond_to?(:damage) &&
+                            row.damage && row.damage > 0
+          play_terrain_footstep_se(row, terrain_damaged)
+        end
         return if hit.empty? && !terrain_damaged
         @state.screen.flash(*STEP_DAMAGE_FLASH) if state_damaged || terrain_damaged
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16136,6 +16136,35 @@ check 'on_damage_se withholds the footstep on a harmless step, and plays it on a
   eq 2, RGSS::Audio.se_calls.count { |c| c[0] == 'Hurt1' }, 'and plays it on every step that does'
 end
 
+# Riding the airship skips terrain damage and the footstep SE entirely --
+# EasyRPG's `Game_Player::Move` returns via `InAirship()`'s own early check
+# *before* it ever looks up the stepped-on tile's terrain row, so neither
+# fires while airborne. `InAirship()` alone, not a general `boarded?`
+# check: a boat/ship still sails the water layer's own terrain and is not
+# exempted (`check_random_encounter`'s own "riding the airship skips the
+# roll entirely" check above is the same exemption for a different step
+# effect). #note_party_step's status-condition slip damage has no such
+# gate in the reference (`UpdateNextMovementAction`'s `ApplyStateDamage`
+# call is unconditional), so it is untouched by this and not exercised here.
+check 'riding the airship skips terrain damage and the RPG2003 footstep SE' do
+  RGSS::Audio.reset_se
+  grounded = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [grounded], rpg2003: true,
+                     terrain_damage: 3, footstep: 'Step1')
+  walk(scene, 2)
+  ok grounded.hp < 100, 'on foot, the damaging terrain hurts as usual'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Step1' }, 'and the footstep plays'
+
+  RGSS::Audio.reset_se
+  airborne = SlipActor.new([])
+  scene2 = new_scene({}, player: [0, 0], members: [airborne], rpg2003: true,
+                      terrain_damage: 3, footstep: 'Step1')
+  scene2.instance_variable_get(:@state).boarded = :airship
+  walk(scene2, 2)
+  eq 100, airborne.hp, 'riding the airship, the same terrain does nothing'
+  ok RGSS::Audio.se_calls.none? { |c| c[0] == 'Step1' }, 'and no footstep plays either'
+end
+
 # -- bush depth (下半身消去) ---------------------------------------------------
 
 # Every tile of the synthetic map is terrain 42, so `bush_depth:` sets what the


### PR DESCRIPTION
## Summary

- `Scene::Map#note_party_step` looked up and applied the stepped-on tile's terrain damage (and, on RPG2003, its footstep SE) on every step, regardless of what the party was riding.
- Confirmed against EasyRPG's actual `Game_Player::Move` (`src/game_player.cpp`): it returns via its own `InAirship()` early check **before** ever looking up the tile's terrain row — so an airborne party takes neither the HP damage nor the footstep SE for whatever is below it.
- The exemption is airship-specific (`InAirship()`, not a general `boarded?` test) — a boat or ship still sails the water layer's own terrain and is not exempted, matching the same shape as the already-landed "riding the airship skips the random-encounter roll entirely" check (`Scene::Map#check_random_encounter`).
- The status-condition map-step slip damage (`Party#apply_map_step_damage`, e.g. a poison state's periodic drain) has no such gate in the reference (`Game_Player::UpdateNextMovementAction`'s own `ApplyStateDamage` call runs unconditionally right after `IncSteps`), so it's untouched by this fix.
- `docs/TODO.md`'s footstep-SE entry gets a dated follow-up note; changelog fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 695 checks passed (1 new: on foot, damaging terrain hurts and the footstep plays as usual; riding the airship over the identical terrain does neither — confirmed to fail against the pre-fix code before landing the fix)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 999 checks passed (unchanged)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 14 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzxXVyc558bNmiFHcAfvA)_