### PR TITLE
battle: an item invoking an attack skill actually casts it now

### DIFF
--- a/changelog.d/battle-item-invoked-skill.fixed.md
+++ b/changelog.d/battle-item-invoked-skill.fixed.md
@@ -1,0 +1,10 @@
+- **Battle scene:** a special/`use_skill` item invoking an enemy- or
+  all-enemy-scope attack skill (Nepheshel's thrown-bomb line among them) is
+  now actually usable from the in-fight Item menu — it used to be offered
+  there, prompt for an *ally*, and silently do nothing, since the confirm
+  handler always ran the plain medicine math instead of casting the item's
+  invoked skill. `#drive_battle_item` now dispatches on the skill's own
+  scope the same way the Skill menu already does, the item pays instead of
+  the caster's own SP, and the cast is correctly exempt from Reflect Magic,
+  matching a caster's own item-backed cast in the real engine. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2848,6 +2848,70 @@ The work below is roughly ordered by the critical path to a walkable game
    invoking an Escape/Teleport skill warps for free and a plain weapon is
    never treated as one), confirmed to fail against the pre-fix code. See
    `changelog.d/menu-use-skill-equipment-item.fixed.md`.
+   ✅ **The battle-scene half of this same fix was still missing its own
+   dispatch, so an enemy-scope item skill (Nepheshel's whole thrown-bomb
+   line — 火炎玉, 爆裂玉, 氷結玉, 雷撃玉 and the rest — is exactly this
+   shape) was selectable from the in-fight Item menu but did nothing at
+   all (2026-08-18).** The fix above landed `#battle_usable?`/
+   `#battle_skill?` (the model layer both scenes share, which is why such
+   an item correctly appeared in the battle Item list to begin with) and
+   `Scene::ItemMenu#choose_item`'s own scope dispatch, but that dispatch
+   lives on the **field** menu class; the in-fight Item menu is a
+   different scene entirely (`RPG2k::Scene::Battle`, split out from
+   `Scene::Map` by ADR 0052, `mruby-rpg2k/mrblib/scene/battle.rb`), and
+   its own `#drive_battle_item` confirm branch was never given the
+   equivalent special-case. It always fell into the generic
+   ally-target/`#battle_item_command` path — pure medicine arithmetic
+   (`#item_recovery` reading `recover_hp`/`recover_sp` and friends, fields
+   a skill-invoking item's row never sets) — so confirming such an item
+   prompted for an *ally* and then computed a 0 HP/0 SP, no-cure "use"
+   that consumed nothing and changed nothing, regardless of what its
+   invoked skill actually did. Confirmed against EasyRPG Player's real
+   source: `Scene_Battle::ItemSelected` (`src/scene_battle.cpp`) resolves
+   the item's `skill_id` and calls `AssignSkill(skill, item)` — the
+   identical dispatch an ordinary Skill-menu pick goes through
+   (`SkillSelected` calls `AssignSkill(skill, nullptr)`), which switches on
+   the skill's own `scope` to pick enemy/ally/self/all-enemy/all-ally
+   target selection; `Game_BattleAlgorithm::Skill::vStart`
+   (`src/game_battlealgorithm.cpp`) is what actually charges for it —
+   `if (item) ConsumeItemUse(item->ID); else source->ChangeSp(-cost)` — so
+   the item pays and no SP moves, never both. Fixed by giving
+   `#drive_battle_item`'s confirm branch the same scope-based dispatch
+   `#confirm_battle_skill` already uses for an ordinary skill pick
+   (`Game::Party#battle_skill_target`), reached via a new
+   `Game::Party#skill_invoking_item?` (the exact `it.type == ITEM_SPECIAL
+   || (it.use_skill && (1..5).cover?(it.type))` test `Scene::ItemMenu
+   #choose_item` already inlines, shared here rather than duplicated a
+   third time). `Game::Party#battle_skill_command` gained a `free:`
+   keyword (mirroring `vStart`'s own item-vs-SP branch: `cost` is 0 when
+   set, matching `#use_special_item`/`#use_equip_skill_item`'s identical
+   "the item is the cost" rule on the field side) and `Game::Party
+   #command_skill`/`#command_skill_all` gained an `item_id:` field
+   alongside their existing `skill_id:`, threaded onto the produced log
+   entry as `Game::Battle#apply_skill_hit`'s already-existing recovery
+   branch does for `command_item` (its attack branch was missing the
+   identical field entirely — a latent asymmetry never exercised until
+   this fix needed it on an *attack*-shaped item cast — added to match).
+   That `item_id:` is what makes the item consume from the bag when the
+   action lands (`#drive_battle_animate`'s existing `entry[:item_id]`
+   check, shared with an ordinary medicine) and, matching
+   `Skill::IsReflected`'s own `if (item) return false;`, is what
+   `Game::Battle#reflects_skill?`'s pre-existing `cmd[:skill_id] &&
+   !cmd[:item_id]` guard already relies on to keep an item-cast skill from
+   ever bouncing off a Reflect-warded target the way a caster's own cast
+   would. `Scene::Battle#apply_pending_skill`/`#apply_pending_skill_all`
+   (already shared by the Skill menu's own single- and all-target casts)
+   now read an optional `item_id` off the pending action and pass it
+   through unchanged rather than needing a parallel copy of either method.
+   Escape/Teleport-type item skills need no new handling here — they were
+   already excluded from the battle item list entirely by `#battle_skill?`
+   before this fix, unchanged. Covered by a new `scripts/rpg2k_scene_check.rb`
+   check (a special item invoking a single-enemy attack skill routes to
+   enemy target selection rather than an ally prompt, deals the skill's
+   real damage rather than a 0-effect medicine cast, consumes the item
+   only once the action lands, and leaves the caster's own MP untouched),
+   confirmed to fail against the pre-fix code (asserting `:target`,
+   getting `:ally_target`) before the fix.
 - ✅ Save & Continue — the portable `Marshal` save of the game state
   (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
   menu's Save command; "Continue" reloads it. (One research question remains: a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4967,8 +4967,15 @@ module Game
     # Both branches carry the skill's own `variance` now — `Game::Battle#apply_
     # skill_hit` is what actually spreads either sign of effect by it, this
     # method just reports the number the skill row names.
-    def battle_skill_command(sk, caster, target)
-      cost = skill_cost(sk, caster)
+    #
+    # `free:` is for a skill invoked by a special/use_skill item rather than
+    # chosen from the caster's own skill list — EasyRPG's own
+    # `Game_BattleAlgorithm::Skill::vStart` (`src/game_battlealgorithm.cpp`)
+    # branches on whether an item backs the cast: `if (item)
+    # ConsumeItemUse(item->ID); else source->ChangeSp(-cost)` — the item pays
+    # instead of the caster's own SP, never both.
+    def battle_skill_command(sk, caster, target, free: false)
+      cost = free ? 0 : skill_cost(sk, caster)
       base = skill_effect(sk, caster)
       # Attribute-defence shifting isn't scoped to attack skills -- a "raise
       # my own resistance" buff and a "lower the enemy's" debuff are both this
@@ -5064,6 +5071,16 @@ module Game
           # RPG2003 reverse case above turns this into an inflict instead.
           cured: cure_ids, inflict: inflict_ids, chance: skill_to_hit(sk, caster, target) }
       end
+    end
+
+    # Whether item `it` invokes a skill directly (a type-9 Special item, or an
+    # equipment item flagged `use_skill`, field 71) rather than being a plain
+    # medicine/switch item — the same test `Scene::ItemMenu#choose_item`
+    # inlines for the field menu's own dispatch, shared here for the battle
+    # menu's identical one (see #battle_usable? just below, which already
+    # gates such an item on its invoked skill being battle-usable at all).
+    def skill_invoking_item?(it)
+      it && (it.type == ITEM_SPECIAL || (it.use_skill && (1..5).cover?(it.type)))
     end
 
     # Whether item `id` can be used in battle: a medicine flagged occasion_battle
@@ -9610,13 +9627,20 @@ module Game
     # (rather than defaulted `false`) when the caller does not pass it, so
     # #apply_skill_hit still falls back to the sign of `hp` for a command built
     # by hand with a negative `hp` and no explicit `attack:`.
+    #
+    # `item_id:` is for a skill invoked by a special/use_skill battle item
+    # rather than chosen from the caster's own list (see #battle_skill_command's
+    # `free:`, which such a caller pairs this with) -- carried through to the
+    # produced log entry exactly like #command_item's own field, for
+    # #drive_battle_animate's bag consumption and #reflects_skill?'s
+    # item-casts-are-never-reflected exclusion.
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
                       chance: 100, variance: 0, attributes: nil, skill_id: nil,
                       absorb: false, attr_shift: nil, attr_ids: nil,
                       stat_mod_keys: nil, stat_effect: 0, cured: nil, attack: nil,
-                      physical_rate: 0)
+                      physical_rate: 0, item_id: nil)
       ally.command = { kind: :skill, target: target, name: name,
-                       skill_id: skill_id, absorb: absorb, attack: attack,
+                       skill_id: skill_id, item_id: item_id, absorb: absorb, attack: attack,
                        cost: cost, hp: hp, mp: mp,
                        inflict: inflict || [], chance: chance, variance: variance,
                        attributes: attributes || [],
@@ -9644,13 +9668,18 @@ module Game
     # property of the skill itself, not of who it lands on. #apply_command
     # produces one log entry per living target, drained one at a time by
     # #step_action.
+    #
+    # `item_id:` mirrors #command_skill's own identical field, for the same
+    # item-invoked-skill case's bag consumption -- #apply_command_all already
+    # keeps it on the volley's first produced entry only, the same
+    # single-consumption rule #command_item_all's own `item_id:` follows.
     def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
                           variance: 0, attributes: nil, skill_id: nil,
                           absorb: false, attr_shift: nil, attr_ids: nil,
                           stat_mod_keys: nil, stat_effect: 0, cured: nil, attack: nil,
-                          physical_rate: 0)
+                          physical_rate: 0, item_id: nil)
       ally.command = { kind: :skill, all: true, targets: targets, name: name,
-                       skill_id: skill_id, absorb: absorb, attack: attack, cost: cost,
+                       skill_id: skill_id, item_id: item_id, absorb: absorb, attack: attack, cost: cost,
                        inflict: inflict || [], chance: chance,
                        variance: variance, attributes: attributes || [],
                        attr_shift: attr_shift, attr_ids: attr_ids || [],
@@ -11539,7 +11568,13 @@ module Game
           attr_shifted: shifted, attr_shift_dir: cmd[:attr_shift],
           stat_changed: stat_changed,
           target_ally: ally?(target), skill: cmd[:name],
-          skill_id: cmd[:skill_id], target_index: @enemies.index(target),
+          # `cmd[:item_id]` mirrors the recovery branch's own identical field
+          # just below -- an attack-flavoured skill invoked by a battle item
+          # (a thrown bomb) needs it on the log entry exactly as much as a
+          # medicine's own recovery does, for the same bag-consumption
+          # (#drive_battle_animate) and reflect-exclusion (#reflects_skill?)
+          # reasons.
+          item_id: cmd[:item_id], skill_id: cmd[:skill_id], target_index: @enemies.index(target),
           absorbed_hp: absorbed, sp_damage: sp_dmg,
           target_mp: target.mp }
       else

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1480,7 +1480,7 @@ class RPG2k
           play_system_se(SFX_DECISION)
           target = foes[@ui[:target_i]]
           close_battle_target
-          if pending_kind == :skill
+          if pending_skill?
             apply_pending_skill(target)
           else
             @ui[:battle].command_attack(current_actor, target)
@@ -1494,6 +1494,9 @@ class RPG2k
           if pending_kind == :skill
             @ui[:phase] = :skill
             draw_battle_skill
+          elsif pending_skill? # an item-invoked skill: back out to the item list
+            @ui[:phase] = :item
+            draw_battle_item
           else
             @ui[:pending] = nil
             @ui[:phase] = :command
@@ -1503,6 +1506,16 @@ class RPG2k
       end
 
       def pending_kind; @ui[:pending] && @ui[:pending][:kind]; end
+
+      # Whether the pending action casts a skill -- either chosen from the
+      # Skill menu (`kind: :skill`) or invoked by a special/use_skill battle
+      # item (`kind: :item` with a resolved `sk`, see #drive_battle_item's
+      # confirm branch) -- as opposed to a plain medicine/switch item or a
+      # basic Attack, both of which leave `sk` unset. #apply_pending_skill/
+      # #apply_pending_skill_all read `@ui[:pending][:item_id]` themselves to
+      # tell the two skill sources apart where that still matters (the SP
+      # cost and the log entry's bag-consumption id).
+      def pending_skill?; @ui[:pending] && @ui[:pending][:sk]; end
 
       # -- Skill sub-menu ------------------------------------------------------
 
@@ -1597,13 +1610,21 @@ class RPG2k
       end
 
       # Commit the pending skill on `target` (SP cost / effect from the model),
-      # then move to the next actor.
+      # then move to the next actor. `item_id` set (a special/use_skill battle
+      # item invoking this skill, see #drive_battle_item's confirm branch)
+      # makes the item pay instead of the caster's own SP -- EasyRPG's
+      # `Game_BattleAlgorithm::Skill::vStart` (`src/game_battlealgorithm.cpp`)
+      # consumes the item rather than calling `ChangeSp` whenever one backs
+      # the cast -- and rides onto the built command for
+      # #drive_battle_animate's bag consumption and #reflects_skill?'s own
+      # item-casts-are-never-reflected exclusion.
       def apply_pending_skill(target)
         sk = @ui[:pending][:sk]
         sid = @ui[:pending][:sid]
-        c = @state.party.battle_skill_command(sk, current_actor, target)
+        item_id = @ui[:pending][:item_id]
+        c = @state.party.battle_skill_command(sk, current_actor, target, free: !item_id.nil?)
         @ui[:battle].command_skill(current_actor, target,
-                                          name: sk.name, skill_id: sid,
+                                          name: sk.name, skill_id: sid, item_id: item_id,
                                           absorb: c[:absorb] ? true : false,
                                           # Left as `c[:attack]` verbatim (not coerced to a
                                           # boolean): a stub `battle_skill_command` in the test
@@ -1633,17 +1654,20 @@ class RPG2k
       # living enemies for an attack skill, all living allies for a heal): build
       # one per-target effect from the model (attack damage varies with each
       # target's defence) and queue them as a single volley. The shared SP cost /
-      # infliction ride along once.
+      # infliction ride along once. `item_id`: see #apply_pending_skill's
+      # identical comment -- the item pays instead of SP, and rides the
+      # command for bag consumption / reflect exclusion.
       def apply_pending_skill_all(targets)
         sk = @ui[:pending][:sk]
         sid = @ui[:pending][:sid]
-        meta = @state.party.battle_skill_command(sk, current_actor, targets.first)
+        item_id = @ui[:pending][:item_id]
+        meta = @state.party.battle_skill_command(sk, current_actor, targets.first, free: !item_id.nil?)
         effects = targets.map do |t|
-          c = @state.party.battle_skill_command(sk, current_actor, t)
+          c = @state.party.battle_skill_command(sk, current_actor, t, free: !item_id.nil?)
           { target: t, hp: c[:hp], mp: c[:mp] }
         end
         @ui[:battle].command_skill_all(current_actor, effects,
-                                              name: sk.name, skill_id: sid,
+                                              name: sk.name, skill_id: sid, item_id: item_id,
                                               absorb: meta[:absorb] ? true : false,
                                               attack: meta[:attack], # see #apply_pending_skill's comment
                                               cost: meta[:cost],
@@ -1697,7 +1721,37 @@ class RPG2k
           it = @state.party.db_item(item_id)
           @ui[:pending] = { kind: :item, item_id: item_id, it: it }
           close_battle_item
-          if @state.party.switch_item?(item_id)
+          # A type-9 special item, or an equipment item flagged `use_skill`,
+          # invokes the skill named in its `skill_id` instead of being plain
+          # medicine -- the invoked skill's own scope decides where this goes
+          # next, exactly like #confirm_battle_skill dispatches an ordinary
+          # skill chosen from the Skill menu (`Scene_Battle::AssignSkill`,
+          # `src/scene_battle.cpp`, dispatches an item-backed skill through
+          # the identical scope switch). `#battle_usable?` already excluded
+          # this item from the list entirely unless its skill is battle-usable
+          # in the first place (never Escape/Teleport, see #battle_skill?), so
+          # every skill reached here is one #battle_skill_target can resolve.
+          sk = @state.party.skill_invoking_item?(it) ? @state.party.db_skill(it.skill_id) : nil
+          if sk
+            @ui[:pending][:sk] = sk
+            @ui[:pending][:sid] = it.skill_id
+            case @state.party.battle_skill_target(sk)
+            when :self
+              apply_pending_skill(current_actor)
+            when :enemy
+              @ui[:target_i] = 0
+              @ui[:phase] = :target
+              draw_battle_target
+            when :all_enemy
+              apply_pending_skill_all(living_foes)
+            when :all_ally
+              apply_pending_skill_all(living_allies)
+            else # :ally
+              @ui[:ally_i] = 0
+              @ui[:phase] = :ally_target
+              draw_battle_ally_target
+            end
+          elsif @state.party.switch_item?(item_id)
             apply_pending_switch_item
           elsif @state.party.item_all_allies?(it)
             # The whole roster, dead included -- EasyRPG's own entire_party
@@ -1741,7 +1795,7 @@ class RPG2k
           play_system_se(SFX_DECISION)
           target = allies[@ui[:ally_i]]
           close_battle_ally_target
-          if pending_kind == :skill
+          if pending_skill?
             apply_pending_skill(target)
           else
             apply_pending_item(target)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9132,7 +9132,7 @@ class BattleMagicParty
   def battle_skills(actor, _caster); actor.skills.include?(1) ? [[1, 3]] : []; end
   def db_skill(id); id == 1 ? OpenStruct.new(name: 'Fire', scope: 0) : nil; end
   def battle_skill_target(sk); sk.scope == 0 ? :enemy : :ally; end
-  def battle_skill_command(_sk, _caster, _target); { cost: 3, hp: -15, mp: 0 }; end
+  def battle_skill_command(_sk, _caster, _target, free: false); { cost: free ? 0 : 3, hp: -15, mp: 0 }; end
   # A skill's weapon-type Attribute requirement -- true (unrestricted) by
   # default, so every check predating the equip-gate stays on its own path;
   # see BattleWeaponGateParty below for a check that flips this.
@@ -9144,6 +9144,9 @@ class BattleMagicParty
   def battle_item_command(_it, _target); { hp: 20, mp: 0 }; end
   def item_all_allies?(it); it.respond_to?(:scope) && it.scope == 1; end
   def switch_item?(_id); false; end
+  # This stub's one item (Potion) is a plain medicine, never skill-invoking;
+  # see BattleSkillItemParty below for a stub covering the opposite case.
+  def skill_invoking_item?(_it); false; end
   # These checks drive an already-opening or already-open battle, not the
   # missing-troop-id diagnostic path -- every id reads as present.
   def db_enemy_group(_id); true; end
@@ -9405,6 +9408,81 @@ check 'Enemy Encounter scene: an item-triggered heal bypasses the weapon-Attribu
   eq :ally_target, ui[:phase]
   press_key(scene, RGSS::Input::C)    # heal the Hero -> round animates
   eq :animate, ui[:phase], 'the item cast went through with the weapon requirement still unmet'
+end
+
+# A party whose bag also holds a type-9 special item invoking an enemy-scope
+# attack skill (Nepheshel's own thrown-bomb line, per docs/TODO.md) --
+# Game::Party's own decision logic (#skill_invoking_item?/
+# #battle_skill_command's `free:`) is covered by rpg2k_logic_check.rb; this
+# stub only has to hand the scene something that behaves the same way, so
+# this check stays about the RGSS wiring: does confirming the item in the
+# battle Item menu route to *enemy* target selection and deal real skill
+# damage, instead of the pre-fix behaviour of prompting for an *ally* and
+# running the plain #battle_item_command medicine math (which this item's
+# database row carries none of, so it silently did nothing at all).
+class BattleSkillItemParty < BattleMagicParty
+  BOMB_ID = 7
+
+  def initialize(hurt: false)
+    super
+    @items[BOMB_ID] = 2
+  end
+
+  def db_item(id)
+    return OpenStruct.new(name: 'Fire Bomb', type: Game::Party::ITEM_SPECIAL, skill_id: 2) if id == BOMB_ID
+
+    super
+  end
+
+  def skill_invoking_item?(it)
+    it.respond_to?(:type) && it.type == Game::Party::ITEM_SPECIAL
+  end
+
+  def db_skill(id)
+    return OpenStruct.new(name: 'Firebolt', scope: 0) if id == 2
+
+    super
+  end
+
+  def battle_skill_command(sk, caster, target, free: false)
+    return { cost: free ? 0 : 5, hp: -25, mp: 0, attack: true } if sk.respond_to?(:name) && sk.name == 'Firebolt'
+
+    super(sk, caster, target, free: free)
+  end
+end
+
+check 'Enemy Encounter scene: a special item invoking an enemy-scope skill ' \
+      'routes to enemy target selection and deals real damage, not an inert ' \
+      'ally-targeted medicine cast' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleSkillItemParty.new)
+  ui = battle_to_command(scene)
+
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  eq :item, ui[:phase]
+  press_key(scene, RGSS::Input::DOWN) # Potion (id 5) -> Fire Bomb (id 7, sorted second)
+  press_key(scene, RGSS::Input::C)    # choose the Fire Bomb
+  eq :target, ui[:phase], 'an enemy-scope item skill prompts for an enemy, not an ally'
+
+  foe_hp = ui[:foes].first.hp
+  press_key(scene, RGSS::Input::C)    # confirm the first foe -> round animates
+  eq :animate, ui[:phase]
+  eq 2, st.party.item_count(BattleSkillItemParty::BOMB_ID),
+     'not spent yet -- an item action is only consumed once it lands'
+
+  scene.update                        # the Hero's action lands
+  entry = ui[:battle].log.first
+  eq 25, foe_hp - ui[:foes].first.hp, 'the skill\'s real damage landed, not a 0-effect medicine cast'
+  eq 1, st.party.item_count(BattleSkillItemParty::BOMB_ID), 'one Fire Bomb consumed'
+  eq 10, ui[:allies].first.mp, 'the caster\'s own MP is untouched -- the item paid, not the caster'
+  ok entry[:item_id] == BattleSkillItemParty::BOMB_ID, "the log entry carries the item's id"
 end
 
 # A party whose Hero knows no battle skill at all, so Skill's own list opens


### PR DESCRIPTION
## Summary

- `Scene::Battle#drive_battle_item` always fell into the ally-target /
  `battle_item_command` path (pure medicine arithmetic), so a special or
  `use_skill` equipment item invoking an enemy-scope attack skill
  (Nepheshel's thrown-bomb line among them) prompted for an *ally* and
  computed a 0-effect "use" that consumed nothing, regardless of what the
  invoked skill actually did — even though such an item correctly appeared
  in the battle Item menu to begin with.
- Confirmed against EasyRPG Player's real source: `Scene_Battle::
  ItemSelected` resolves the item's skill and calls `AssignSkill(skill,
  item)` — the identical scope-based dispatch an ordinary Skill-menu pick
  goes through — and `Game_BattleAlgorithm::Skill::vStart` consumes the
  item instead of charging the caster's SP.
- `#drive_battle_item` now dispatches on the invoked skill's own scope via
  `#battle_skill_target`, `Game::Party#battle_skill_command` gained a
  `free:` flag so the item pays instead of SP, and `#command_skill`/
  `#command_skill_all` gained an `item_id:` field so the cast is correctly
  exempt from Reflect Magic and consumes the item once the action lands,
  matching an ordinary medicine.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 695 checks passed (new
      regression check confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 999 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_