### PR TITLE
psp: fix LVGL TLSF corruption (ADR 0047 bug 7)

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -114,8 +114,8 @@ marker appears, so a regression that links but fails to boot is caught
 automatically; it has no project at `kGameDir`, so it only ever exercises the
 idle path (`RPG2K_PSP_GAME_START none not_found`). The job is
 **non-blocking** — the required build gate is the `psp` job, because the
-EBOOT still does not boot to completion under PPSSPP-headless. Seven
-independent bugs have been found and root-caused chasing that, five of
+EBOOT still does not boot to completion under PPSSPP-headless. Eight
+independent bugs have been found and root-caused chasing that, six of
 them fixed:
 
 - pspsdk's `sysclib_snprintf`/`sysclib_sprintf` HLE stubs are only partially
@@ -179,19 +179,26 @@ upstream, not worth working around here.
   wired into the `psp` CI job ahead of `psp-cmake`/`cmake --build`. Not yet
   upstreamed to `pspdev/pspsdk`.
 
-With that fixed, this EBOOT now boots dramatically further than at any
-earlier point on this whole trail — past `RPG2K_PSP_BOOT`, through
-`_sbrk`'s heap init, through `mrb_open`, into real LVGL widget creation —
-and hits a **seventh bug, found and not yet fixed**: LVGL's builtin TLSF
-allocator asserts `block already marked as free` inside `lv_tlsf_realloc`,
-most plausibly reached from `build_ui()`'s per-frame
-`lv_label_set_text(g_status_label, ...)` update. Confirmed not a sizing
-issue (bumping `LV_MEM_SIZE` 8x made no difference), so more likely
-something elsewhere corrupting a TLSF block's free/used bit than a bug in
-the allocator itself — matching this whole trail's running theme of memory
-corruption over logic bugs. See
+With that fixed, this EBOOT boots dramatically further than at any earlier
+point on this whole trail — past `RPG2K_PSP_BOOT`, through `_sbrk`'s heap
+init, through `mrb_open`, into real LVGL widget creation — and hit a
+**seventh bug, also fixed**: LVGL's builtin TLSF allocator asserted `block
+already marked as free` inside `lv_tlsf_realloc`. Confirmed not a sizing
+issue (bumping `LV_MEM_SIZE` 8x made no difference); root-caused with a
+print-capable `LV_ASSERT_HANDLER` to `psp_display_create`
+(`mruby-rgss/src/psp.cxx`), where `std::vector<uint8_t>::assign(n, 0)` —
+used to size and zero the two LVGL draw buffers — is broken on this pspdev
+g++/libstdc++ build specifically when growing an empty vector: it
+allocates correctly but leaves the vector's `data()` null (`resize(n)`
+does not share the bug). The resulting null/wild buffer, fed into
+`lv_display_set_buffers`, is what corrupted LVGL's own TLSF pool further
+down the boot path. With that fixed, the EBOOT boots past display
+creation and into `mrb_open`'s GC init before hitting an **eighth bug,
+found and not yet fixed**: PPSSPP reports `Bad memory access detected!
+00000014` — a near-null pointer write — inside `mrb_gc_init`. Not yet
+root-caused. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
-P1 for the full seven-bug trail. To reproduce any of this locally, run
+P1 for the full eight-bug trail. To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched
 `ppsspp` package output (see above) rather than nixpkgs' unpatched one —

--- a/changelog.d/psp-lvgl-draw-buf-vector-assign.fixed.md
+++ b/changelog.d/psp-lvgl-draw-buf-vector-assign.fixed.md
@@ -1,0 +1,22 @@
+- **The PSP EBOOT no longer crashes inside `psp_display_create` on a null
+  LVGL draw buffer.** `std::vector<uint8_t>::assign(n, 0)`, called there to
+  size-and-zero the two LVGL partial-render draw buffers on first use, is
+  broken on this pspdev g++/libstdc++ build specifically when growing an
+  empty (0-capacity) vector: it allocates the buffer correctly but leaves the
+  vector's own begin pointer null while its end pointer holds the real
+  allocated address, so `.data()` comes back null and `.size()` comes back as
+  that allocated pointer's raw integer value reinterpreted as a count.
+  Confirmed in isolation against the same toolchain: `vector(n, 0)`'s
+  constructor and `vector::resize(n)` do not share the bug, only `assign()`
+  does. `lv_display_set_buffers` then either tripped its own `buf1 != NULL`
+  assert on the null pointer, or -- on binary layouts where the timing
+  differs enough that the bad pointer isn't exactly null -- handed LVGL and
+  later `flush_cb` calls a wild pointer to write display pixels through,
+  corrupting unrelated memory including LVGL's own TLSF allocator pool. That
+  corruption is what the "block already marked as free" assert deeper in
+  `docs/adr/0047-psp-memory-budget.md`'s P1 trail (bug 7) traced back to.
+  Fixed by switching both buffers to `.resize(n)`, which zero-initializes the
+  same way and does not hit the bug. With this fixed, the EBOOT now boots
+  past display creation and into `mrb_open`'s GC init before hitting a new,
+  separate, not-yet-diagnosed crash (a near-null write inside `mrb_gc_init`);
+  see the ADR for the full trail.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -245,9 +245,9 @@ the interpreter-linking slice, in this order:
   emulator with a Memory Stick image. **On the emulator side specifically,
   this heartbeat has never yet produced a captured number**, in CI or
   locally, though the reasons have narrowed a lot:
-  Five independent bugs have been found and root-caused on this path so far,
-  three of them fixed; boot still does not complete. In the order the EBOOT
-  actually hits them:
+  Eight independent bugs have been found and root-caused on this path so
+  far, six of them fixed; boot still does not complete. In the order the
+  EBOOT actually hits them:
   1. **Fixed.** pspsdk's `sysclib_snprintf`/`sysclib_sprintf` HLE stubs are
      only partially implemented under PPSSPP-headless and left emulator
      state corrupted enough to crash a few syscalls later — `main.cxx` now
@@ -384,27 +384,45 @@ the interpreter-linking slice, in this order:
   earlier point on this whole P1 trail: past `RPG2K_PSP_BOOT`, through
   `_sbrk`'s heap init (correctly allocating the full requested size this
   time, confirmed via PPSSPP's own memory-partition log line), through
-  `mrb_open`, into real LVGL widget creation in `build_ui()`. It then hits
-  a **seventh bug, found and not yet fixed**: LVGL's builtin TLSF
-  allocator's `lv_tlsf_realloc` (`3rd/lvgl/src/stdlib/builtin/lv_tlsf.c`)
-  asserts `block already marked as free` — a use-after-free/double-free
-  detector, not a sizing issue (confirmed: bumping `LV_MEM_SIZE` 8x, from
-  256 KB to 2 MB, made no difference at all to whether or where the assert
-  fired, which a genuine capacity problem would not do). Traced to its
-  caller via a temporary `__builtin_return_address(0)` capture in
-  `psp_lvgl_assert_halt` (not kept — diagnostic only): `lv_tlsf_realloc`
-  itself, most plausibly reached from `build_ui()`'s second
-  `lv_label_set_text(g_status_label, ...)` call (the per-frame pressed-keys
-  status update; LVGL labels reallocate their internal text buffer on
-  change) reallocating a block some other write already corrupted the
-  free/used bit of, rather than a bug in LVGL's own allocator itself
-  (matching this whole trail's running theme of memory corruption over
-  logic bugs). Not yet root-caused further.
+  `mrb_open`, into real LVGL widget creation in `build_ui()`. It then hit
+  a **seventh bug — fixed**: LVGL's builtin TLSF allocator's
+  `lv_tlsf_realloc` (`3rd/lvgl/src/stdlib/builtin/lv_tlsf.c`) asserted
+  `block already marked as free` — a use-after-free/double-free detector,
+  not a sizing issue (confirmed: bumping `LV_MEM_SIZE` 8x, from 256 KB to
+  2 MB, made no difference at all to whether or where the assert fired,
+  which a genuine capacity problem would not do). Root-caused with a
+  print-capable `LV_ASSERT_HANDLER` (routed through
+  `lv_log_register_print_cb`, printing LVGL's own formatted file+line
+  assert message instead of guessing from a return address) to
+  `psp_display_create` (`mruby-rgss/src/psp.cxx`): the two LVGL
+  partial-render draw buffers were sized with
+  `std::vector<uint8_t>::assign(n, 0)`, which is broken on this pspdev
+  g++/libstdc++ build specifically when growing an empty (0-capacity)
+  vector — it allocates the buffer correctly but leaves the vector's own
+  begin pointer null while its end pointer holds the real allocated
+  address, so `.data()` comes back null and `.size()` comes back as that
+  allocated pointer's raw integer value reinterpreted as a count
+  (confirmed in isolation against the same toolchain: `vector(n, 0)`'s
+  constructor and `vector::resize(n)` do not share the bug, only
+  `assign()` does). The null/wild pointer fed straight into
+  `lv_display_set_buffers` either tripped its own `buf1 != NULL` assert
+  directly, or — on binary layouts where the corrupted pointer wasn't
+  exactly null — let LVGL and `flush_cb` write display pixels through it
+  into unrelated memory, corrupting LVGL's own TLSF pool; that corruption
+  is what the `block already marked as free` assert actually traced back
+  to. Fixed by switching both buffers to `.resize(n)`, confirmed not to
+  share the bug and to zero-initialize the same way.
 
-  Whether real hardware shares bug 7 is unknown (bugs 3 and 6 are moot on
-  this boot path either way, one because it stopped triggering, the other
-  because it's fixed); the P1 device numbers above remain unconfirmed on
-  the emulator and untried on hardware.
+  With bug 7 fixed, the EBOOT boots past display creation and into
+  `mrb_open`'s GC init before hitting an **eighth bug, found and not yet
+  fixed**: PPSSPP reports `Bad memory access detected! 00000014` — a
+  near-null pointer write — inside `mrb_gc_init`, reproducible identically
+  across repeated runs. Not yet root-caused.
+
+  Whether real hardware shares bugs 7 or 8 is unknown (bugs 3 and 6 are
+  moot on this boot path either way, one because it stopped triggering,
+  the other because it's fixed); the P1 device numbers above remain
+  unconfirmed on the emulator and untried on hardware.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/mruby-rgss/src/psp.cxx
+++ b/mruby-rgss/src/psp.cxx
@@ -159,8 +159,28 @@ lv_display_t* psp_display_create(int32_t hor_res, int32_t ver_res) {
   if (rows == 0)
     rows = 1;
   const size_t buf_bytes = rows * static_cast<size_t>(hor_res) * kBpp;
-  g_buf1.assign(buf_bytes, 0);
-  g_buf2.assign(buf_bytes, 0);
+  // std::vector<uint8_t>::assign(n, 0) on this pspdev g++/libstdc++ build is
+  // broken specifically when growing an empty (0-capacity) vector: it
+  // allocates the buffer correctly but leaves the vector's own begin pointer
+  // null while its end pointer is set to the real allocated address, so
+  // data() comes back null and size() comes back as the raw allocated
+  // pointer's integer value reinterpreted as a count (confirmed by isolated
+  // testing -- vector(n, 0)'s constructor and vector::resize(n) both do not
+  // have this bug on the same toolchain, only assign() does). g_buf1/g_buf2
+  // are always empty here (this runs once, at display creation), so resize()
+  // -- which zero-initializes new elements the same as assign(n, 0) would --
+  // is a correct, working substitute rather than a real behavior change.
+  // This was P1's bug 7: passing the resulting null buf1 straight through to
+  // lv_display_set_buffers tripped its own `buf1 != NULL` assert once traced
+  // with a print-capable LV_ASSERT_HANDLER; on binary layouts where the same
+  // vector bug instead leaves a wild, non-null-but-wrong pointer in play
+  // (confirmed layout-dependent -- the exact corruption point moved when
+  // unrelated diagnostic code shifted the binary), LVGL and later flush_cb
+  // calls write through it into unrelated memory instead, corrupting LVGL's
+  // own TLSF pool -- which is what the original "block already marked as
+  // free" assert deeper in this ADR's P1 trail actually traced back to.
+  g_buf1.resize(buf_bytes);
+  g_buf2.resize(buf_bytes);
 
   lv_display_set_buffers(disp, g_buf1.data(), g_buf2.data(),
                          static_cast<uint32_t>(buf_bytes),


### PR DESCRIPTION
## Summary
- ADR 0047's P1 bug 7 (LVGL's builtin TLSF allocator asserting `block already marked as free` during PSP boot under PPSSPP-headless) is fixed. Root cause: `psp_display_create` (`mruby-rgss/src/psp.cxx`) sized its two LVGL partial-render draw buffers with `std::vector<uint8_t>::assign(n, 0)`, which is broken on this pspdev g++/libstdc++ build specifically when growing an empty (0-capacity) vector — it allocates correctly but leaves the vector's own `data()` null. The resulting null/wild buffer fed into `lv_display_set_buffers` is what corrupted LVGL's own TLSF pool further down the boot path. Fixed by switching both to `.resize(n)`, confirmed not to share the bug.
- With bug 7 fixed, the EBOOT now boots past display creation and into `mrb_open`'s GC init before hitting a new, separate, not-yet-fixed crash (`Bad memory access detected! 00000014`, a near-null write inside `mrb_gc_init`) — documented as bug 8 in the ADR, not addressed by this PR.
- `docs/adr/0047-psp-memory-budget.md` and `app/psp/README.md` updated to record bug 7's resolution and bug 8's discovery.

## Test plan
- [x] Rebuilt the EBOOT via the full docker/pspdev pipeline (`scripts/build_psp_fixup_imports.bash` + `psp-cmake`/`cmake --build`).
- [x] Re-ran under `ppsspp-headless` twice for reproducibility: no more null-buffer assert, no more TLSF corruption; boots through to the new `mrb_gc_init` crash both times.
- [x] Diagnosis confirmed directly (not inferred) via a temporary print-capable `LV_ASSERT_HANDLER` showing LVGL's own file+line assert message, plus isolated in-binary tests of `malloc`/`operator new`/`vector(n,0)`/`vector::resize(n)` at the same allocation size, all working correctly — only `vector::assign(n, 0)` on an empty vector exhibited the bug.
- [ ] CI (`psp` + `psp-smoke` jobs) — pending on this PR.