### PR TITLE
battle: a charged enemy is now forced to attack, not its AI pattern

### DIFF
--- a/changelog.d/enemy-charge-forces-attack.fixed.md
+++ b/changelog.d/enemy-charge-forces-attack.fixed.md
@@ -1,0 +1,7 @@
+- **Battle:** a charged enemy is now guaranteed a single doubled Attack, the
+  same way real RPG_RT forces it — it used to still run its ordinary AI
+  pattern and could end up Defending, casting a Skill, or otherwise never
+  attacking at all, silently wasting the charge for nothing. `Game::Battle
+  #strike` now skips pattern selection outright while charged, falling
+  through to the same forced-Attack path an empty pattern already used.
+  Covered by corrected/new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1680,6 +1680,39 @@ The work below is roughly ordered by the critical path to a walkable game
   two independent `#deal_attack` calls each re-read (and the first one
   cleared) `b.charged`, so only the first swing of a charged dual attack
   ever doubled.
+  ✅ **A charged enemy could still run its ordinary AI pattern and end up
+  Defending, casting a Skill or otherwise not attacking at all — real
+  RPG_RT forces a plain single Attack instead, bypassing pattern selection
+  entirely (2026-08-18).** The two fixes just above corrected what happens
+  once *some* action runs while charged; this is the earlier step neither
+  addressed: whether the pattern gets consulted at all. Confirmed against
+  EasyRPG Player's actual source: `EnemyAi::SetStateRestrictedAction`
+  (`src/enemyai.cpp`) checks `source.IsCharged()` right after its
+  attack_ally/attack_enemy forced-restriction branches (both already
+  correctly ported in `#strike`, see the "forced action" comment there)
+  and, if set, calls `MakeAttack(source, 1)` and returns — `Scene_Battle::
+  UpdateBattleAlgorithm`'s own `if (!SetStateRestrictedAction(*enemy)) ...
+  SetEnemyAiAction(...)` (`scene_battle_rpg2k.cpp`) only ever consults
+  `GetEnemyAi()`'s rating-weighted pattern picker when that returns false —
+  so a charged enemy is *guaranteed* exactly one doubled Attack, never a
+  Defend, Skill, Observe, another Charge, Self-Destruct, Transform or even
+  a pattern-chosen Attack Twice. `Game::Battle#strike`'s enemy branch used
+  to call `#choose_enemy_action` unconditionally and only fell back to a
+  plain Attack when the pattern yielded nothing at all — so a
+  single-entry Defend (or any other non-Attack) pattern could win the draw
+  while charged and simply waste it for nothing, contradicting the
+  regression check this very investigation had itself added for the two
+  fixes above (which asserted a Defend running while charged, the wrong
+  behaviour, as if it were the fix). Fixed by skipping
+  `#choose_enemy_action` outright when `b.charged`, falling straight
+  through to the same forced-Attack fallback path an *empty* pattern
+  already used — which already reads and spends `b.charged` itself via
+  `#deal_attack_with_current_weapon`'s own `charged.nil?` branch, so no
+  further threading was needed. The mis-asserting regression check was
+  corrected to assert the opposite (a Defend pattern never runs while
+  charged; a plain doubled Attack does instead), and a second new check
+  confirms the same for an Attack Twice pattern specifically (only one
+  swing runs, not two), both confirmed to fail against the pre-fix code.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10122,12 +10122,27 @@ module Game
       # reads 1.
       return apply_command(b, combo_hits(b, :skill)) if b.command
       return nil if side_of(b) == :ally && b.defending # defending = no attack
-      # An enemy with a 行動パターン chooses from it rather than always swinging.
+      # An enemy with a 行動パターン chooses from it rather than always swinging
+      # -- except while charged, which forces a plain single Attack instead,
+      # bypassing the pattern draw entirely. EasyRPG's own
+      # `EnemyAi::SetStateRestrictedAction` (src/enemyai.cpp) checks
+      # `source.IsCharged()` right after its attack_ally/attack_enemy
+      # restriction branches (both already handled above) and, if set, calls
+      # `MakeAttack(source, 1)` and returns *before* `SetEnemyAiAction` (the
+      # rating-weighted pattern picker) is ever consulted
+      # (`scene_battle_rpg2k.cpp`'s `if (!SetStateRestrictedAction(*enemy))
+      # ... SetEnemyAiAction(...)`) -- so a charged enemy can never end up
+      # Defending, casting a Skill, self-destructing, or gathering another
+      # Charge; it is guaranteed exactly one doubled swing. `choose_enemy_action`
+      # is skipped outright rather than filtered afterward, falling through to
+      # the same forced-attack path below an empty pattern already uses --
+      # which already reads and spends `b.charged` itself
+      # (#deal_attack_with_current_weapon's own `charged.nil?` fallback).
       if side_of(b) == :enemy
         # A guard raised last turn expires as this one begins (the allies' is
         # cleared by #end_round; an enemy acts on its own schedule).
         b.defending = false
-        act = choose_enemy_action(b)
+        act = b.charged ? nil : choose_enemy_action(b)
         return perform_enemy_action(b, act) if act
       end
       target = attack_target(b)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15601,38 +15601,49 @@ check 'a charge doubles the enemy next attack, then is spent' do
   ok !foe.charged, 'and the charge is spent'
 end
 
-check 'a charge is wasted by an intervening non-attack action, not just an attack' do
-  # EasyRPG's Game_BattleAlgorithm::AlgorithmBase::Start() calls
-  # source->SetCharged(false) unconditionally, for every algorithm kind, not
-  # only inside Normal (the plain-attack algorithm) -- confirmed against
-  # game_battlealgorithm.cpp. #perform_enemy_action ports that: it
-  # snapshots-and-clears `b.charged` before dispatching, so an intervening
-  # Defend spends the charge exactly as an intervening Attack would, and it
-  # never survives to a later turn.
+check 'a charged enemy is forced to attack, never running a pattern action ' \
+      'like Defend even when the pattern would otherwise choose it' do
+  # EasyRPG's EnemyAi::SetStateRestrictedAction (src/enemyai.cpp) checks
+  # source.IsCharged() right after its attack_ally/attack_enemy restriction
+  # branches and, if set, calls MakeAttack(source, 1) and returns *before*
+  # SetEnemyAiAction (the rating-weighted pattern picker) is ever consulted
+  # (scene_battle_rpg2k.cpp's `if (!SetStateRestrictedAction(*enemy)) ...
+  # SetEnemyAiAction(...)`) -- so a charged enemy can never end up Defending
+  # (or casting a Skill, self-destructing, ...); it is guaranteed exactly one
+  # doubled Attack. #strike now skips #choose_enemy_action outright while
+  # charged, matching that gate -- it used to run the pattern normally, so a
+  # single-entry Defend pattern would win the draw and spend the charge for
+  # nothing (Game_BattleAlgorithm::AlgorithmBase::Start()'s own unconditional
+  # SetCharged(false) still fires for *any* algorithm once one actually runs,
+  # confirmed against game_battlealgorithm.cpp and ported by
+  # #perform_enemy_action -- that part was already correct, it just used to
+  # be reachable by the wrong action kind).
   foe = combatant('Slime', 40, 0, 5, 500)
   charge = enemy_action(kind: 0, basic: 4)
   defend = enemy_action(kind: 0, basic: 2)
-  attack = enemy_action(kind: 0, basic: 0)
   b = ai_battle([charge], nil, foe: foe)
   b.begin_round; b.step_action
   eq true, b.step_action[:charge], 'the monster gathers strength'
   ok foe.charged, 'the charge is held'
+  # A pattern of nothing but Defend would win the draw outright if consulted.
   foe.actions = [defend]
   b.end_round; b.begin_round; b.step_action
-  eq true, b.step_action[:defend], 'a Defend runs instead of an Attack'
-  ok !foe.charged, 'and the charge is already gone, spent by the Defend'
-  foe.actions = [attack]
-  b.end_round; b.begin_round; b.step_action
   e = b.step_action
-  eq 20, e[:damage], 'the later attack lands at base damage -- no stale charge left to double it'
-  ok !e[:charged]
+  ok !e[:defend], 'the Defend pattern never runs while charged'
+  eq 40, e[:damage], 'a plain Attack runs instead, doubled by the charge'
+  ok !foe.charged, 'and the charge is spent by it'
 end
 
-check 'a charged dual attack doubles both swings, not only the first' do
-  # EasyRPG's own dual attack is one Normal algorithm with a repeat count of
-  # 2 (enemyai.cpp's MakeAttack(enemy, 2)), not two separate algorithm
-  # instances -- Init() (and so the captured charged_attack flag) runs once
-  # for the whole action, so a charge doubles every swing it covers.
+check 'a charged enemy is forced to a single Attack even when its pattern ' \
+      'would otherwise choose Attack Twice' do
+  # EasyRPG's EnemyAi::SetStateRestrictedAction forces a hardcoded
+  # MakeAttack(source, 1) while charged -- a fixed one-hit repeat count, not
+  # whatever #enemy.GetEnemyAi() would have picked -- so a charged enemy
+  # can never reach a genuine "Attack Twice" pattern action either, the same
+  # way it can never reach Defend (see the check above). A dual attack
+  # *pattern action* stays otherwise correct and reachable while not
+  # charged -- see "a dual attack strikes twice in one turn" below -- this
+  # is specifically about the two never coinciding.
   foe = combatant('Slime', 40, 0, 5, 500)
   charge = enemy_action(kind: 0, basic: 4)
   dual = enemy_action(kind: 0, basic: 1)
@@ -15643,10 +15654,9 @@ check 'a charged dual attack doubles both swings, not only the first' do
   foe.actions = [dual]
   b.end_round; b.begin_round; b.step_action
   first = b.step_action
-  second = b.step_action
-  eq 40, first[:damage], 'first swing doubled'
-  eq 40, second[:damage], 'second swing doubled too'
-  ok !foe.charged, 'spent by the action as a whole, not per swing'
+  eq 40, first[:damage], 'a single doubled swing runs'
+  ok !foe.charged, 'and the charge is spent by it'
+  ok b.step_action.nil?, 'no second swing from the bypassed dual-attack pattern -- the round is over'
 end
 
 check 'a dual attack strikes twice in one turn' do


### PR DESCRIPTION
## Summary

- `Game::Battle#strike` ran an enemy's ordinary rating-weighted AI pattern
  even while charged, so it could end up Defending, casting a Skill, or
  otherwise not attacking at all — silently wasting the charge for nothing.
- Confirmed against EasyRPG Player's real source: `EnemyAi::
  SetStateRestrictedAction` checks `IsCharged()` right after its
  attack_ally/attack_enemy restriction branches and forces `MakeAttack(source,
  1)`, returning *before* the rating-weighted pattern picker is ever
  consulted — a charged enemy is guaranteed exactly one doubled Attack.
- `#strike` now skips `#choose_enemy_action` outright while charged, falling
  through to the same forced-Attack fallback path an empty pattern already
  used, which already reads and spends `b.charged` itself.
- The regression check this fix's own prior investigation had added actually
  asserted the wrong behavior (a Defend running while charged, as if that
  were correct) — corrected it, and added a second check for the Attack
  Twice pattern case.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 999 checks passed (both new/
      corrected checks confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 696 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_