### PR TITLE
battle: a first-strike encounter's opening Escape now always succeeds

### DIFF
--- a/changelog.d/first-strike-escape-guarantee.fixed.md
+++ b/changelog.d/first-strike-escape-guarantee.fixed.md
@@ -1,0 +1,9 @@
+- **Battle scene:** a first-strike (ambush) encounter's opening Escape is now
+  actually guaranteed to succeed, matching real RPG_RT — it used to still
+  roll the ordinary agility-based chance, so a first-strike battle against
+  fast enemies could floor the roll at 0% and trap the party in a fight it
+  should have been able to walk away from unconditionally. `Game::Battle`
+  gained a `#first_strike?` predicate and the battle scene's Escape command
+  now passes it through as the `preemptive` flag the model layer already
+  supported but was never given. Covered by new `scripts/rpg2k_logic_check.rb`
+  and `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1385,7 +1385,40 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_logic_check.rb` checks (a fallen ally still pulling the
   average down; the 143-vs-142 rounding case; a state applied after
   construction not moving an already-read `escape_chance`), confirmed to
-  fail against the pre-fix code before the fix. Basic
+  fail against the pre-fix code before the fix.
+  ✅ **The preemptive first-strike guarantee this same formula summary
+  claims was never actually reachable — `Scene::Battle`'s own Escape
+  command always rolled the ordinary chance, first strike or not
+  (2026-08-18).** `Game::Battle#attempt_escape` correctly implements
+  `preemptive` (see the summary above), and even has its own passing
+  `scripts/rpg2k_logic_check.rb` coverage — but `Scene::Battle
+  #try_battle_escape` (`mruby-rpg2k/mrblib/scene/battle.rb`) called it with
+  **no argument at all**, so `preemptive` defaulted to `false` on every
+  real Escape a player could ever press. `Game::Battle` did not even expose
+  the `@first_strike` flag it was already storing (threaded in from the
+  Enemy Encounter event command's own field, `mruby-rpg2k/mrblib/scene/
+  battle.rb`'s `@req[:first_strike]`) for the scene to read at all. Confirmed
+  against EasyRPG Player's actual source: `Scene_Battle::TryEscape`
+  (`src/scene_battle.cpp`) checks its own `first_strike` member *before* ever
+  touching `escape_chance` — `if (first_strike || ...IsForceFleeEnabled() ||
+  Rand::PercentChance(escape_chance)) return true;` — and that member stays
+  `true` for the whole of the ambush round, cleared only once, right before
+  round 2's own command phase opens (`Scene_Battle_Rpg2k::
+  ProcessSceneActionOption`'s `ePost` substate, `src/scene_battle_rpg2k.cpp`).
+  So a first-strike encounter's opening Escape is unconditionally guaranteed
+  in the real engine — which this codebase's own model layer already knew
+  how to do, it was simply never told to. Fixed with a new `Game::Battle
+  #first_strike?` (`@first_strike && @rounds.zero?` — `@rounds` starts at 0
+  and `#begin_round` only bumps it once every actor already has a command
+  for round 1, including a possible Escape, so it is still 0 for that whole
+  opening command phase and 1-or-higher for every round after, the same
+  window EasyRPG's own flag covers), and `#try_battle_escape` now calls
+  `battle.attempt_escape(battle.first_strike?)`. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (`#first_strike?`'s true/false
+  transitions) and a new `scripts/rpg2k_scene_check.rb` check (a first-strike
+  encounter's Escape succeeds against enemies fast enough to floor the roll
+  at 0%, driven through the real options-window UI), both confirmed to fail
+  against the pre-fix code before the fix. Basic
   attacks can also **miss**: `Battle#to_hit` takes the attacker's base hit rate
   (weapon / unarmed 90, a "miss"-flagged enemy 70) and applies EasyRPG's
   agility-ratio adjustment (`100 - (100 - base)*(srcAgi + tgtAgi)/(2*srcAgi)`),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9193,6 +9193,20 @@ module Game
       Game.clamp(150 - base, 0, 100)
     end
 
+    # Whether the fight is still within its opening first-strike ambush round --
+    # the one window `#attempt_escape`'s own `preemptive` guarantee is meant for.
+    # `@rounds` starts at 0 and is bumped to 1 by `#begin_round` (called once
+    # every actor's command, including a possible Escape, is already chosen for
+    # round 1), so it is still 0 for the whole of that opening command phase and
+    # 1-or-higher for every round after -- the same "still round 1, before it's
+    # actually begun" window EasyRPG's own `first_strike` flag covers
+    # (`Scene_Battle_Rpg2k::ProcessSceneActionOption`'s `ePost` substate clears
+    # it to `false` right before opening round 2's own command phase,
+    # `src/scene_battle_rpg2k.cpp`).
+    def first_strike?
+      @first_strike && @rounds.zero?
+    end
+
     # Attempt to flee the fight. A `preemptive` first strike always succeeds, as
     # does an escape a Force Flee battle page has granted; otherwise a 0..99 roll
     # under #escape_chance wins. Success ends the battle as :escaped (#finished? /

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1353,10 +1353,16 @@ class RPG2k
       # flee once it is dismissed; on a failed roll the party forfeits the
       # round — every member skips and only the enemies act, bannered with
       # `escape_failure` the same way a landed hit is — and the next attempt is
-      # likelier (Game::Battle#attempt_escape).
+      # likelier (Game::Battle#attempt_escape). Still within the opening
+      # first-strike ambush round (`#first_strike?`), the attempt is
+      # unconditionally handed a `preemptive` escape instead of a roll --
+      # EasyRPG's `Scene_Battle::TryEscape` (`src/scene_battle.cpp`) checks its
+      # own `first_strike` flag first, before ever touching `escape_chance`, so
+      # a first-strike encounter's opening Escape always succeeds even against
+      # enemies fast enough to floor the roll at 0%.
       def try_battle_escape
         battle = @ui[:battle]
-        if battle.attempt_escape
+        if battle.attempt_escape(battle.first_strike?)
           # A dedicated Escape SE, not Decision -- confirmed against
           # EasyRPG's own ProcessSceneActionEscape: the success branch plays
           # `GetSystemSE(SFX_Escape)` right before ending the battle. A

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10630,6 +10630,26 @@ check 'a preemptive escape always succeeds regardless of the roll' do
   eq :escaped, b.result
 end
 
+check 'Battle#first_strike? is true only for the opening ambush round, ' \
+      'and only when the encounter is actually a first strike' do
+  # `@rounds` is 0 for the whole of round 1's command phase (before
+  # #begin_round has ever run -- Scene::Battle only calls it once every
+  # actor already has a command, including a possible Escape) and 1 or
+  # higher for every round after, mirroring EasyRPG's own `first_strike`
+  # flag: set for the whole of round 1 and cleared right before round 2's
+  # command phase opens (`Scene_Battle_Rpg2k::ProcessSceneActionOption`'s
+  # `ePost` substate, src/scene_battle_rpg2k.cpp).
+  hero = combatant('Hero', 40, 0, 5, 100)
+  foe = combatant('Slime', 30, 0, 20, 100)
+  fs = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false, false, true)
+  ok fs.first_strike?, 'true before round 1 has begun'
+  fs.begin_round
+  ok !fs.first_strike?, 'false once round 1 has actually begun'
+
+  no_fs = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  ok !no_fs.first_strike?, 'false for an ordinary (non-first-strike) encounter'
+end
+
 check 'attempt_escape is a no-op once the battle is already decided' do
   hero = combatant('Hero', 40, 0, 20, 100)
   downed = combatant('Slime', 0, 0, 5, 0)            # already wiped -> victory

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6416,6 +6416,36 @@ check 'Enemy Encounter scene: selecting Escape from the options window runs Esca
   ok st.switches[2], 'the Escape handler ran'
 end
 
+# EasyRPG's Scene_Battle::TryEscape checks its own `first_strike` flag first,
+# before ever touching `escape_chance` -- so a first-strike encounter's
+# opening Escape always succeeds, even against enemies fast enough to floor
+# the roll at 0%. Scene::Battle#try_battle_escape used to call
+# Game::Battle#attempt_escape with no argument at all (defaulting `preemptive`
+# to false), so it silently fell back to the ordinary roll regardless of
+# first_strike, and a 0%-chance escape here could never succeed.
+check 'Enemy Encounter scene: a first-strike encounter always escapes on the ' \
+      'opening Escape, even against enemies fast enough to floor the roll at 0%' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2, first_strike: true)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  # Both Slimes are agi 5 (fake_db); a far slower hero floors escape_chance
+  # at 0, so only the first-strike guarantee -- never the roll -- can succeed.
+  st.instance_variable_set(:@party, BattleStubParty.new(BattleStubActor.new(agi: 1)))
+  ui = battle_until_phase(scene, :battle_options)
+  ok ui, 'the options window opened'
+
+  2.times { RGSS::Input.triggered = [RGSS::Input::DOWN]; scene.update } # Fight -> Auto Battle -> Escape
+  RGSS::Input.triggered = []
+  eq 2, ui[:opt], 'the cursor landed on Escape'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm Escape
+  scene.update
+  RGSS::Input.triggered = []
+  eq :result, ui[:phase], 'the escape attempt resolved immediately, no failure banner'
+  eq :escape, ui[:result], 'and it succeeded -- the ambush round guarantees it'
+end
+
 check 'Enemy Encounter scene: selecting Auto Battle queues the AI pick for every ' \
       'commandable living ally and starts the round without further input' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

- `Scene::Battle#try_battle_escape` called `Game::Battle#attempt_escape` with
  no argument, so its `preemptive` flag defaulted to `false` on every real
  Escape a player could press — even during a first-strike ambush round,
  where real RPG_RT guarantees the getaway. `Game::Battle` never even
  exposed the `@first_strike` flag it was already storing for the scene to
  read.
- Confirmed against EasyRPG Player's real source: `Scene_Battle::TryEscape`
  checks its own `first_strike` member *before* ever touching
  `escape_chance`, and that member stays `true` for the whole of the ambush
  round, cleared only once round 2's command phase opens.
- Added `Game::Battle#first_strike?` (`@first_strike && @rounds.zero?` — the
  same "round 1 hasn't actually begun yet" window) and threaded it through
  `#try_battle_escape`.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 697 checks passed (new check
      confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_