### PR TITLE
docs: root-cause ADR 0047 bug 8 to a PPSSPP JIT dynarec bug

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -194,9 +194,18 @@ does not share the bug). The resulting null/wild buffer, fed into
 `lv_display_set_buffers`, is what corrupted LVGL's own TLSF pool further
 down the boot path. With that fixed, the EBOOT boots past display
 creation and into `mrb_open`'s GC init before hitting an **eighth bug,
-found and not yet fixed**: PPSSPP reports `Bad memory access detected!
-00000014` — a near-null pointer write — inside `mrb_gc_init`. Not yet
-root-caused. See
+root-caused but not fixed**: PPSSPP reports `Bad memory access detected!
+00000014` (or a nearby address) — a near-null write — inside
+`mrb_gc_init`. Root-caused to PPSSPP's own x86-64 JIT mistranslating the
+guest code, not this project's: the fault address is layout-sensitive
+(moves between builds that differ only in unrelated diagnostic code),
+PPSSPP's crash log shows the faulting *host* instruction using what looks
+like a null base register despite the *source* pointer being valid the
+whole way through (traced allocation-by-allocation), and forcing PPSSPP's
+interpreter instead of its JIT (`ppsspp-headless -i`) runs hundreds of
+allocations past this point with zero bad-memory-access errors on the
+exact same EBOOT. Not fixed here — patching PPSSPP's dynarec is out of
+scope for this project; worth reporting upstream. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
 P1 for the full eight-bug trail. To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -414,15 +414,71 @@ the interpreter-linking slice, in this order:
   share the bug and to zero-initialize the same way.
 
   With bug 7 fixed, the EBOOT boots past display creation and into
-  `mrb_open`'s GC init before hitting an **eighth bug, found and not yet
-  fixed**: PPSSPP reports `Bad memory access detected! 00000014` — a
-  near-null pointer write — inside `mrb_gc_init`, reproducible identically
-  across repeated runs. Not yet root-caused.
+  `mrb_open`'s GC init before hitting an **eighth bug, root-caused and
+  characterized but not fixed**: PPSSPP reports `Bad memory access
+  detected! 00000014` (or a nearby small address — see below) — a
+  near-null write — inside `mrb_gc_init`. Root-caused to **PPSSPP's x86-64
+  JIT (dynarec) itself mistranslating the guest MIPS code**, not a bug in
+  this EBOOT, mruby, or the fixed-arena allocator (ADR 0047's P2):
+
+  - The custom arena allocator (`app/psp/main.cxx`'s `mrb_arena_alloc`/
+    `mrb_arena_realloc`) was traced allocation-by-allocation with a
+    temporary instrumentation pass (every call's requested size and
+    returned pointer, plus extra trace points added directly to the
+    vendored `mrb_gc_init`/`add_heap`/`init_heap_page`/`shape_root` in
+    `3rd/mruby/src/{gc,state,variable}.c`, none kept). Every allocation up
+    to and past the crash point returns a valid, correctly-sized, 16-byte
+    aligned pointer inside the 8 MB arena; `mrb_calloc`'s `memset` on the
+    freshly allocated `mrb_heap_page` completes cleanly. The corruption is
+    not caused by anything in this trace.
+  - The crash address itself is not a plausible corrupted pointer (which
+    would look like leftover heap garbage) but a small, suspiciously
+    round number matching a struct/loop-offset size (0x14 = 20 =
+    `sizeof(mrb_iv_shape)` in one build; 0x18/0x50 in others) — and it
+    **moves between builds that differ only in added instrumentation
+    elsewhere in the binary**, changing which specific write manifests
+    the fault (sometimes a fatal unhandled access, sometimes one PPSSPP
+    logs as "ignored" and recovers from, in one case letting the process
+    limp forward into an infinite loop until the harness's own timeout
+    force-exits it). That layout-sensitivity is the signature of a
+    miscompiled/mistranslated instruction stream, not a fixed logic bug
+    at a fixed call site.
+  - Direct confirmation: PPSSPP's own crash log, with a JIT block active,
+    includes the disassembled *host* x86-64 instruction at the fault:
+    `mov [rbx+r9+0x4], r10b` inside the JIT block covering
+    `mrb_gc_init` (which the C compiler had inlined `add_heap`'s
+    `init_heap_page` loop into — `page->objects[i].as.free.tt =
+    MRB_TT_FREE`, a small per-object byte-store loop, is the only
+    matching source shape). The computed guest address is consistent
+    with `rbx` (the register holding the `page` base pointer) being
+    zero at that point in the *compiled* code, despite the *source*
+    value being a valid, non-null pointer the whole way through (per the
+    allocator trace above) — i.e. the JIT's register allocation/codegen
+    for this block loses track of the base pointer.
+  - Decisive test: re-running the identical EBOOT under
+    `ppsspp-headless -i` (forces the interpreter, bypassing the JIT
+    entirely) reaches the same code path and executes 784+ further
+    allocations with **zero** bad-memory-access errors (cut off only by
+    the harness's own timeout, since interpreted execution is far
+    slower) — the same guest code that reliably faults under the JIT
+    runs cleanly under the interpreter. This is the strongest evidence
+    the bug is PPSSPP's dynarec, not this project's code.
+
+  Not fixed here: this is a PPSSPP JIT correctness bug, not a one-line
+  semantic fix like bugs 2/4 (both plain HLE no-ops/missing null checks);
+  actually patching it needs someone to dig into PPSSPP's MIPS-to-x86
+  register allocator for whatever code shape this loop produces, out of
+  scope for this pass. `-i` (interpreter mode) is not viable as a
+  shipping workaround (far too slow for real gameplay) but is useful for
+  future diagnosis. Worth reporting upstream to `hrydgard/ppsspp` with
+  this trail as a repro.
 
   Whether real hardware shares bugs 7 or 8 is unknown (bugs 3 and 6 are
   moot on this boot path either way, one because it stopped triggering,
-  the other because it's fixed); the P1 device numbers above remain
-  unconfirmed on the emulator and untried on hardware.
+  the other because it's fixed); bug 8 in particular, being a PPSSPP-only
+  JIT bug, may well be emulator-specific and not present on real hardware
+  at all. The P1 device numbers above remain unconfirmed on the emulator
+  and untried on hardware.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none


### PR DESCRIPTION
## Summary
- Docs-only PR. Root-causes ADR 0047 P1's bug 8 (the `mrb_gc_init` "Bad memory access detected! 00000014" crash that bug 7's fix, PR #984, newly exposed).
- **Not a bug in this project.** Traced allocation-by-allocation through the fixed mruby arena (`app/psp/main.cxx`) and vendored `gc.c`/`state.c`/`variable.c` — every allocation up to and past the crash point is valid. The fault address is layout-sensitive across builds differing only in unrelated diagnostic code (the signature of a miscompiled instruction stream, not a fixed logic bug). PPSSPP's own crash log disassembles the faulting host x86-64 instruction as `mov [rbx+r9+0x4], r10b` inside the JIT block covering `mrb_gc_init`, consistent with the JIT losing track of the `page` base pointer in `rbx` despite the source-level pointer being valid throughout.
- **Decisive test:** `ppsspp-headless -i` (forces the interpreter, bypassing the JIT) runs the identical EBOOT through 784+ further allocations with zero bad-memory-access errors on the same code path that reliably faults under the JIT.
- Characterized, not fixed — this needs digging into PPSSPP's MIPS→x86 register allocator, out of scope for this project. Worth reporting upstream to `hrydgard/ppsspp`. `-i` interpreter mode is not viable as a shipping workaround (far too slow for real gameplay).
- `docs/adr/0047-psp-memory-budget.md` and `app/psp/README.md` updated with the full diagnosis and evidence trail.

## Test plan
- [x] Diagnosis confirmed via allocation-level instrumentation (not kept) and PPSSPP's own crash-log disassembly.
- [x] Decisive interpreter-vs-JIT comparison test, both against the identical EBOOT built from current `master`.
- N/A — no code changes to this project.