### PR TITLE
title: a disabled Continue now reads the windowskin's own disabled swatch

### DIFF
--- a/changelog.d/title-continue-disabled-swatch.fixed.md
+++ b/changelog.d/title-continue-disabled-swatch.fixed.md
@@ -1,0 +1,8 @@
+- **Title screen:** a disabled Continue label now reads its color from the
+  windowskin's own disabled-colour swatch (system colour index 3), matching
+  every other grayed-out RPG_RT menu command — it used to draw a hardcoded
+  flat gray regardless of the windowskin, so a custom skin with a tinted
+  disabled swatch (rather than neutral gray) rendered Continue wrong, and
+  it never got the shared one-pixel drop-shadow every other label gets. A
+  game with no windowskin loaded still renders the same flat gray as
+  before. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3477,6 +3477,45 @@ The work below is roughly ordered by the critical path to a walkable game
   that they run cleanly); the full `rpg2k_scene_check.rb` (485),
   `rpg2k_logic_check.rb` (773), `rpg2k_save_load_check.rb`, and
   `rpg2k_testbed_logic_check.rb` (125) suites all still pass.
+  ✅ **A disabled Continue's own *rendering* — not just its SE — was also
+  still wrong, found in a separate later pass: it drew a hardcoded flat gray
+  instead of reading the windowskin's own disabled-colour swatch, unlike
+  every other grayed-out RPG_RT menu label (2026-08-18).** `Scene::Title`'s
+  constructor (`mruby-rpg2k/mrblib/scene/title.rb`) already renders the
+  New Game/Continue/Shutdown labels through `#draw_system_text` — the same
+  windowskin-swatch-blend helper `#draw_actor_state` and every field window
+  use for a `\c[n]`-style colour — for every *enabled* label, but the
+  disabled-Continue branch bypassed it entirely for a bare
+  `contents.draw_text` in `Color.new(128, 128, 128, 255)`, a leftover from
+  before this method existed at all; a prior comment on the line rationalised
+  this as deliberate ("the same fallback path `draw_system_text` itself
+  takes when there is no windowskin, reused here on purpose") but that
+  reasoning was never actually checked against the real engine. Confirmed
+  against EasyRPG Player's actual source: `Window_Command::DrawItem`
+  (`src/window_command.cpp`) draws *every* command — enabled or not — through
+  the identical `TextDraw(x, y, color, text)` windowskin-swatch path, the
+  only difference being which `Font::SystemColor` index it passes:
+  `ColorDefault` (0) when enabled, `ColorDisabled` (3, `src/font.h`) when not
+  — set via `Scene_Title::Update`'s own `command_window->SetItemEnabled(1,
+  continue_enabled)` (`src/scene_title.cpp`), which routes through
+  `SetItemEnabled`/`DrawItem` exactly the same as every other `Window_Command`
+  instance in the engine (the field menu, the battle command list, ...).
+  There is no hardcoded gray anywhere in the reference — a windowskin whose
+  own disabled swatch is tinted (blue-ish, brownish, whatever the artist
+  chose) shows that tint on real RPG_RT, complete with the same one-pixel
+  drop-shadow every other label gets, not flat neutral gray. Fixed by
+  passing `#draw_system_text` the disabled swatch's index (3) on that one
+  branch instead of falling straight to `draw_text`; the `font.color` set
+  immediately before it is untouched and still supplies `#draw_system_text`'s
+  own correct fallback (flat, same gray as before) for the no-windowskin
+  case, so a game with no `System/` graphic renders identically to before
+  this fix. Covered by a new `scripts/rpg2k_scene_check.rb` check (a title
+  screen built with a loaded windowskin and no save data blends the disabled
+  Continue label from swatch cell (48, 48) — colour index 3's geometry,
+  pinned the same way the message-text swatch check elsewhere in the same
+  file already does), confirmed to fail against the pre-fix code (zero
+  matching blend calls, since the flat-gray branch never blends at all)
+  before the fix.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -66,16 +66,25 @@ class RPG2k
         @window.open_animation(hide_title? ? 0 : OPEN_ANIM_FRAMES)
 
         # Render the (unchanging) menu labels once, in the windowskin's own
-        # default text colour with RPG_RT's one-pixel shadow. A disabled
-        # Continue is drawn flat gray instead -- the same fallback draw_text
-        # path draw_system_text itself takes when there is no windowskin,
-        # reused here on purpose to read as dimmed rather than styled.
+        # default text colour (system-colour swatch 0) with RPG_RT's
+        # one-pixel shadow. A disabled Continue reads the windowskin's own
+        # *disabled* swatch instead -- EasyRPG's `Window_Command::DrawItem`
+        # (`src/window_command.cpp`), which `Scene_Title` drives via
+        # `command_window->SetItemEnabled(1, continue_enabled)`
+        # (`src/scene_title.cpp`), always looks up `Font::ColorDisabled`
+        # (`src/font.h`, swatch index 3) rather than hardcoding a flat gray --
+        # a custom windowskin whose disabled swatch is tinted (not neutral
+        # gray) shows that tint on real RPG_RT, with the same drop-shadow
+        # every other label gets. `draw_system_text`'s own no-windowskin
+        # fallback (plain `draw_text` in the current font colour) still
+        # supplies the flat gray when there is no skin to sample, so the
+        # `font.color` set below is unchanged, just no longer the only path.
         contents = Bitmap.new content_w, content_h
         @menu_items.each_with_index do |item, index|
           y = index * LINE_HEIGHT + TEXT_PAD_Y
           if index == 1 && !@continue_available
             contents.font.color = Color.new(128, 128, 128, 255)
-            contents.draw_text 0, y, content_w, LINE_HEIGHT, item
+            draw_system_text contents, 0, y, content_w, LINE_HEIGHT, item, skin, 3
           else
             contents.font.color = Color.new(255, 255, 255, 255)
             draw_system_text contents, 0, y, content_w, LINE_HEIGHT, item, skin

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10635,6 +10635,28 @@ check 'no save data: pressing the selection key on Continue plays Buzzer and ope
   eq 1, scene.instance_variable_get(:@selected_index), 'the selection is left untouched'
 end
 
+# EasyRPG's Window_Command::DrawItem (src/window_command.cpp) draws every
+# command through the windowskin's own system-colour palette, chosen by
+# Font::ColorDisabled (index 3, src/font.h) once Scene_Title disables
+# Continue (command_window->SetItemEnabled(1, continue_enabled),
+# src/scene_title.cpp) -- never a hardcoded flat gray. A custom windowskin
+# whose disabled swatch is tinted shows that tint on real RPG_RT, with the
+# same drop-shadow every other label gets.
+check 'no save data, with a windowskin loaded: the disabled Continue label ' \
+      'blends from the windowskin\'s own disabled-colour swatch (index 3), ' \
+      'not a hardcoded flat gray' do
+  db = fake_db
+  db.system.system_graphic = 'Skin1' # non-empty -> load_windowskin returns a real Bitmap
+  parent = TitleParent.new(db, nil, false, false)
+  scene = RPG2k::Scene::Title.new(parent)
+  bc = scene.instance_variable_get(:@window).contents.blend_calls || []
+  # colour 3 -> swatch cell (3%10*16, 3/10*16+48) = (48, 48), the same
+  # geometry the message-text swatch check above pins.
+  ok bc.any? { |call| call[6] == 48 && call[7] == 48 },
+     'the disabled Continue label blends from swatch index 3 (48, 48), ' \
+     'the same convention every other disabled command uses in real RPG_RT'
+end
+
 check 'a save exists: Continue is flagged available and its selection key opens ' \
       'the file-select screen' do
   # Continue used to call parent.continue_game straight from the title screen


### PR DESCRIPTION
## Summary

- `Scene::Title`'s disabled-Continue branch drew a hardcoded flat gray via
  plain `draw_text` instead of going through the same `#draw_system_text`
  windowskin-swatch helper every *enabled* label already uses. A prior
  comment on the line rationalized this as deliberate, but that reasoning
  was never actually checked against the real engine.
- Confirmed against EasyRPG Player's real source: `Window_Command::DrawItem`
  draws every command — enabled or not — through the identical
  windowskin-swatch path, just with `Font::ColorDisabled` (index 3) instead
  of `ColorDefault` (0). There is no hardcoded gray anywhere in the
  reference; a windowskin whose disabled swatch is tinted (not neutral gray)
  shows that tint on real RPG_RT, with the same drop-shadow every other
  label gets.
- Fixed by passing `#draw_system_text` the disabled swatch's index on that
  one branch. The `font.color` set beforehand is unchanged and still
  supplies the correct flat-gray fallback for the no-windowskin case, so a
  game with no `System/` graphic renders identically to before.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 698 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_