### PR TITLE
save/load: slot text now renders through the windowskin's own swatches

### DIFF
--- a/changelog.d/save-load-slot-disabled-swatch.fixed.md
+++ b/changelog.d/save-load-slot-disabled-swatch.fixed.md
@@ -1,0 +1,8 @@
+- **Save/load screen:** every slot's text now renders through the
+  windowskin's own system-colour swatches, matching real RPG_RT — it used
+  to draw flat white regardless of the loaded windowskin, and an empty
+  slot's file label never read as dimmed/disabled the way a genuine save
+  screen's does. An occupied slot's label now uses the windowskin's default
+  swatch (with its usual one-pixel drop-shadow); an empty slot's uses the
+  disabled swatch, the same convention the title screen's Continue command
+  already follows. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3516,6 +3516,33 @@ The work below is roughly ordered by the critical path to a walkable game
   file already does), confirmed to fail against the pre-fix code (zero
   matching blend calls, since the flat-gray branch never blends at all)
   before the fix.
+  ✅ **The same disabled-swatch gap existed on the save/load file-select
+  screen too, and there every line was flat, not just the disabled one
+  (2026-08-18).** `Scene::SaveLoad#draw_slot_box` (`mruby-rpg2k/mrblib/
+  scene/save_load.rb`) never called `#draw_system_text` at all — every
+  line (the file label, and, for an occupied slot, the leader's name and
+  level/HP) drew through a bare `draw_text` in a hardcoded flat white,
+  with no distinction between an empty slot and an occupied one.
+  Confirmed against EasyRPG Player's actual source: `Window_SaveFile::
+  Refresh` (`src/window_savefile.cpp`) draws every text element through
+  `TextDraw(x, y, fc, text)` — the windowskin-swatch path, never a flat
+  colour — where `fc` is `has_save ? Font::ColorDefault :
+  Font::ColorDisabled` (system-colour swatch index 0 or 3, `src/font.h`)
+  for the file label specifically; the name/level/HP lines only ever draw
+  at all once `has_party` is true (an early `return` otherwise, matching
+  this codebase's own "an empty slot shows only the label" comment), so
+  `fc` is always index 0 there regardless — but real RPG_RT still reaches
+  them through the swatch-blend path, windowskin shading and all, not a
+  flat colour. Fixed by converting every `draw_text` call in
+  `#draw_slot_box` to `#draw_system_text`, with the file label's index
+  chosen by `state ? 0 : 3` (`state` being the loaded `Game::State` for an
+  occupied slot, `nil` for an empty one) and the name/level/HP lines left
+  at the default index 0 they were always going to resolve to. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check (an occupied slot's label
+  blends from swatch index 0, an empty slot's from index 3, both pinned by
+  cell geometry the same way the title-screen check above does),
+  confirmed to fail against the pre-fix code (the occupied-slot assertion
+  failed first, since neither slot ever blended anything) before the fix.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -272,21 +272,35 @@ class RPG2k
       # placeholder text at all), and an occupied one shows neither gold nor
       # the current map, and HP with no `/max`, unlike this screen's own
       # previous single-list-window layout.
+      #
+      # Every line renders through `#draw_system_text` (the windowskin
+      # system-colour swatch blend, with RPG_RT's own one-pixel shadow) now,
+      # not a flat `draw_text` -- EasyRPG's `Window_SaveFile::Refresh`
+      # (`src/window_savefile.cpp`) draws every text element in the box
+      # through `TextDraw(x, y, fc, text)`, never a raw colour, with `fc`
+      # itself `has_save ? Font::ColorDefault : Font::ColorDisabled` (system
+      # colour index 0 or 3, `src/font.h`) for the file label specifically --
+      # the same disabled-swatch convention `Scene::Title`'s own Continue
+      # entry already reads (see docs/TODO.md). This screen used to draw
+      # every line flat white regardless of a windowskin's own palette *or*
+      # whether the slot was empty, so an empty slot's "File N" label never
+      # read as dimmed/disabled the way a genuine RPG_RT save screen's does,
+      # and an occupied slot's name/level/HP never took the windowskin's
+      # shading at all.
       def draw_slot_box(win, inner_w, slot_index)
         label = slot_label(slot_index)
         c = Bitmap.new(inner_w, LINE_H * SLOT_LINES)
-        c.font.color = Color.new(255, 255, 255, 255)
-        c.draw_text 0, 0, inner_w, LINE_H, label
         state = @slots[slot_index]
+        draw_system_text c, 0, 0, inner_w, LINE_H, label, @skin, state ? 0 : 3
         if state
           leader = state.party.leader
           name = leader ? leader.name.to_s : ''
           level = leader ? leader.level : 0
           hp = leader ? leader.hp : 0
-          c.draw_text 0, LINE_H, inner_w, LINE_H, name
-          c.draw_text 0, LINE_H * 2, inner_w, LINE_H,
-                      "#{term(:level_short, 'Lv')}#{level}    " \
-                      "#{term(:hp_short, 'HP')}#{hp}"
+          draw_system_text c, 0, LINE_H, inner_w, LINE_H, name, @skin
+          draw_system_text c, 0, LINE_H * 2, inner_w, LINE_H,
+                            "#{term(:level_short, 'Lv')}#{level}    " \
+                            "#{term(:hp_short, 'HP')}#{hp}", @skin
           draw_slot_faces(c, inner_w, state.party.actors)
         end
         win.contents = c

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14711,6 +14711,31 @@ check 'Scene::SaveLoad: an occupied slot shows the leader, level and HP -- no go
                                               'reference capture, unlike this screen\'s old layout'
 end
 
+# EasyRPG's Window_SaveFile::Refresh (src/window_savefile.cpp) draws every
+# text element through TextDraw(x, y, fc, text) -- never a flat colour --
+# with `fc` itself `has_save ? Font::ColorDefault : Font::ColorDisabled`
+# (system-colour swatch index 0 or 3, src/font.h) for the file label. The
+# same disabled-swatch convention Scene::Title's own Continue entry already
+# reads (see the title checks above).
+check 'Scene::SaveLoad: an empty slot\'s file label blends from the windowskin\'s ' \
+      'own disabled-colour swatch (index 3); an occupied slot\'s uses the default ' \
+      '(index 0)' do
+  db = fake_db
+  db.system.system_graphic = 'Skin1' # non-empty -> a real (fixture) windowskin loads
+  st = menu_state
+  st.party.leader = st.party.actors.first
+  parent = fake_parent(db)
+  parent.save_states[1] = st # slot 1 (window index 0) occupied; slot 2 (index 1) stays empty
+  scene, = save_load_scene(:load, nil, nil, parent: parent)
+  occupied_bc = scene.instance_variable_get(:@slot_windows)[0].contents.blend_calls || []
+  empty_bc = scene.instance_variable_get(:@slot_windows)[1].contents.blend_calls || []
+  # colour idx -> swatch cell (idx%10*16, idx/10*16+48): 0 -> (0, 48), 3 -> (48, 48).
+  ok occupied_bc.any? { |call| call[6] == 0 && call[7] == 48 },
+     "the occupied slot's label blends from swatch index 0 (the default)"
+  ok empty_bc.any? { |call| call[6] == 48 && call[7] == 48 },
+     "the empty slot's label blends from swatch index 3 (disabled), not the default"
+end
+
 check 'Scene::SaveLoad: an occupied slot draws each party member\'s own face thumbnail, ' \
       'right-anchored in seat order' do
   # Game::State#to_lsd already exports up to four faceset_name/faceset_index


### PR DESCRIPTION
## Summary

- `Scene::SaveLoad#draw_slot_box` drew every line (the file label, and an
  occupied slot's leader name/level/HP) through a flat, hardcoded white
  `draw_text`, with no distinction between an empty slot and an occupied
  one — the same underlying gap the previous PR (#988) fixed for the title
  screen's disabled Continue.
- Confirmed against EasyRPG Player's real source: `Window_SaveFile::Refresh`
  draws every text element through `TextDraw(x, y, fc, text)` — the
  windowskin-swatch path, never a flat colour — with `fc` itself
  `Font::ColorDefault` (0) or `Font::ColorDisabled` (3) for the file label,
  the same disabled-swatch convention the title screen already follows.
- Converted every `draw_text` call in `#draw_slot_box` to
  `#draw_system_text`, choosing the file label's colour index by whether the
  slot holds a save.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 699 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_