### PR TITLE
save/load: holding Down/Up now auto-repeats the file cursor

### DIFF
--- a/changelog.d/save-load-cursor-repeat.fixed.md
+++ b/changelog.d/save-load-cursor-repeat.fixed.md
@@ -1,0 +1,7 @@
+- **Save/load screen:** holding Down/Up now auto-repeats the file cursor
+  after the initial delay, matching real RPG_RT — it used to move exactly
+  one slot per tap no matter how long the key was held. The repeat timing
+  reuses this build's existing, already wine-verified `Input.repeat?`
+  signal (first repeat at 24 held frames, then every 4), the same one the
+  Enter Number widget already relies on. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3543,6 +3543,45 @@ The work below is roughly ordered by the critical path to a walkable game
   cell geometry the same way the title-screen check above does),
   confirmed to fail against the pre-fix code (the occupied-slot assertion
   failed first, since neither slot ever blended anything) before the fix.
+  ✅ **`Scene::SaveLoad`'s own cursor never auto-repeated while Down/Up was
+  held — one slot per tap only, forever, no matter how long the key stayed
+  down (2026-08-18).** Confirmed against EasyRPG Player's actual source:
+  `Window_Selectable::Update` (`src/window_selectable.cpp`) — the base
+  class the real save/load file list is built on — checks `IsTriggered`
+  first and falls through to `IsRepeated(DOWN/UP)` right after, so holding
+  a direction auto-scrolls the list after an initial delay, the same as
+  every other `Window_Selectable`-based list in the real engine (items,
+  skills, ...). `Scene::SaveLoad#update` (`mruby-rpg2k/mrblib/scene/
+  save_load.rb`) only ever checked `Input.trigger?(DOWN/UP)` — a discrete
+  single-frame edge — leaving `Input.repeat?` (this build's own repeat
+  signal, `mruby-rgss/mrblib/lib.rb`) unconsulted. The timing genuinely
+  matches already, not just superficially: EasyRPG's `start_repeat_time =
+  23`/`repeat_time = 4` (`src/input.cpp`) first fires once a button's
+  held-frame count reaches 24 (23 is not a multiple of 4; 24 is) and every
+  4 frames after, exactly the "moves once immediately, then again after 24
+  frames, then every 4 frames" `Input.repeat?` already documents as
+  measured against genuine `RPG_RT.exe` under wine — so this is a pure
+  wiring gap, not a new timing to invent, and matches the identical
+  `#trigger? || #repeat?` gate `Scene::Map#drive_number_input`'s Enter
+  Number digit widget already uses for the same reason. Fixed by ORing
+  `Input.repeat?(DOWN)`/`Input.repeat?(UP)` into the existing trigger
+  checks. **This same gap is systemic across essentially every RPG2000
+  menu/list screen** (`item_menu.rb`, `skill_menu.rb`, `equip_menu.rb`,
+  `status_menu.rb`, `menu.rb`, `order.rb`, `debug_menu.rb`, `title.rb`, and
+  every battle target/command list in `battle.rb`) — each with its own,
+  independently-duplicated cursor code and no shared helper to fix once —
+  deliberately scoped to `Scene::SaveLoad` alone here rather than attempted
+  everywhere in one pass; a future session can lift the same one-line
+  change into each remaining screen. `scripts/rpg2k_scene_check.rb`'s own
+  scriptable `RGSS::Input` stub gained an independent `.repeated` accessor
+  (previously a bare alias of `.triggered`, which made it structurally
+  impossible for a check to hold a key across frames without also reading
+  as a fresh trigger — the exact distinction this fix's own regression
+  check needs to exercise the `#repeat?` half of the gate on its own, not
+  just incidentally pass via `#trigger?`). Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (`Input.repeated` set with
+  `Input.triggered` empty still advances the cursor one slot), confirmed
+  to fail against the pre-fix code before the fix.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -121,9 +121,23 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           @parent.pop
-        elsif Input.trigger?(Input::DOWN)
+        # Holding Down/Up auto-repeats the cursor after the initial delay, not
+        # just a single step per tap -- EasyRPG's `Window_Selectable::Update`
+        # (`src/window_selectable.cpp`), which this screen's file list is a
+        # subclass of, falls through to `Input::IsRepeated` right after its
+        # own `IsTriggered` check. The timing genuinely matches this build's
+        # own `Input.repeat?` already: EasyRPG's `start_repeat_time = 23`/
+        # `repeat_time = 4` (`src/input.cpp`) first fires once `press_time`
+        # reaches 24 (23 is not a multiple of 4, 24 is) and every 4 frames
+        # after, exactly the 24-then-every-4 timing `Input.repeat?`
+        # documents (`mruby-rgss/mrblib/lib.rb`), already measured against
+        # genuine RPG_RT.exe -- so this is a pure wiring gap, not a new
+        # timing to invent, matching the identical `#trigger? ||
+        # #repeat?` gate `Scene::Map#drive_number_input`'s Enter Number
+        # digit widget already uses for the same reason.
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           move_selection 1
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           move_selection(-1)
         elsif Input.trigger?(Input::C)
           confirm_selection

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -181,13 +181,20 @@ module RGSS
     N5 = 25; N6 = 26; N7 = 27; N8 = 28; N9 = 29
     PLUS = 30; MINUS = 31; MULTIPLY = 32; DIVIDE = 33; PERIOD = 34
     class << self
-      attr_accessor :dir_value, :triggered
+      attr_accessor :dir_value, :triggered, :repeated
     end
-    def self.reset; @dir_value = 0; @triggered = []; end
+    def self.reset; @dir_value = 0; @triggered = []; @repeated = []; end
     def self.trigger?(k); Array(@triggered).include?(k); end
-    # The scene treats a held key like a triggered one for widget navigation; the
-    # stub answers both from the same `triggered` set.
-    def self.repeat?(k); Array(@triggered).include?(k); end
+    # A genuinely independent signal from #trigger? -- a check can simulate a
+    # key held across several frames via `Input.repeated = [...]` without it
+    # also reading as a fresh #trigger? on that same frame, mirroring how the
+    # real RGSS::Input (mruby-rgss/mrblib/lib.rb) keeps its own
+    # @pressed/@count-driven @repeated array apart from @triggered. Used to be
+    # a bare alias of #trigger?'s own `@triggered` set, which made it
+    # impossible for a check to exercise the repeat-only branch a widget's own
+    # `Input.trigger?(k) || Input.repeat?(k)` gate takes once a key has been
+    # held long enough to auto-repeat.
+    def self.repeat?(k); Array(@repeated).include?(k); end
     def self.press?(k); Array(@triggered).include?(k); end
     def self.dir4; @dir_value || 0; end
     def self.update; end
@@ -14851,6 +14858,23 @@ check 'Scene::SaveLoad: Down/Up move and wrap across all MAX_SAVE_SLOTS' do
   RGSS::Input.reset
   eq RPG2k::MAX_SAVE_SLOTS - 1, scene.instance_variable_get(:@index),
      'UP from slot 1 wraps to the last slot'
+end
+
+# EasyRPG's Window_Selectable::Update (src/window_selectable.cpp) falls
+# through to Input::IsRepeated(DOWN/UP) right after its own IsTriggered
+# check, so holding a direction auto-scrolls the cursor after the initial
+# delay, not just once per tap. `RGSS::Input.repeated` (distinct from
+# `.triggered`, mirroring the real engine's own separate trigger/repeat
+# signals) lets this check hold a key across frames without it also reading
+# as a fresh trigger, exercising the `#repeat?` half of the gate on its own.
+check 'Scene::SaveLoad: holding Down auto-repeats the cursor, not just a ' \
+      'single step per tap' do
+  scene, = save_load_scene(:load)
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@index),
+     'a held (repeated, not triggered) Down still moves the cursor one slot'
 end
 
 check 'Scene::SaveLoad: cancelling (B) pops back without touching the parent app' do


### PR DESCRIPTION
## Summary

- `Scene::SaveLoad#update` only checked `Input.trigger?(DOWN/UP)` — a
  discrete single-frame edge — so the cursor moved exactly one slot per tap
  no matter how long the key stayed held.
- Confirmed against EasyRPG Player's real source: `Window_Selectable::
  Update` (the base class the real save/load list is built on) falls
  through to `Input::IsRepeated(DOWN/UP)` right after its own `IsTriggered`
  check. The timing genuinely matches this build's own `Input.repeat?`
  already (first repeat at 24 held frames, then every 4 — both independently
  measured/verified against `RPG_RT.exe`'s real constants), so this is a
  pure wiring gap, matching the identical `#trigger? || #repeat?` gate
  `Scene::Map#drive_number_input`'s Enter Number widget already uses.
- Fixed by ORing `Input.repeat?(DOWN)`/`Input.repeat?(UP)` into the existing
  trigger checks. This same gap is systemic across every RPG2000 menu/list
  screen (each with its own duplicated cursor code, no shared helper) —
  deliberately scoped to `Scene::SaveLoad` alone in this PR.
- `scripts/rpg2k_scene_check.rb`'s scriptable `Input` stub gained an
  independent `.repeated` accessor (previously a bare alias of
  `.triggered`), needed for a check to hold a key across frames without it
  also reading as a fresh trigger.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 700 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_