### PR TITLE
menu: holding Down/Up now auto-repeats the field menu's cursors too

### DIFF
--- a/changelog.d/menu-cursor-repeat.fixed.md
+++ b/changelog.d/menu-cursor-repeat.fixed.md
@@ -1,0 +1,7 @@
+- **Field menu:** holding Down/Up now auto-repeats the cursor in the main
+  command list, the Skill/Equip/Status party-status panel, and the End Game
+  Yes/No prompt, matching real RPG_RT (the same fix already landed for the
+  save/load screen). Reuses this build's existing, wine-verified
+  `Input.repeat?` timing — no new behavior invented, just wired in. The
+  same gap remains open on the remaining menu screens, tracked in
+  `docs/TODO.md`. Covered by new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3582,6 +3582,25 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check (`Input.repeated` set with
   `Input.triggered` empty still advances the cursor one slot), confirmed
   to fail against the pre-fix code before the fix.
+  ✅ **The same auto-repeat gap, lifted into `Scene::Menu` (the main field
+  menu) next, as flagged above (2026-08-18).** All three of its own cursor
+  spots only ever checked `Input.trigger?`: `#update_command` (the five
+  RPG2000 field commands — Item/Skill/Equip/Save/End Game), `#update_
+  actor_selection` (the party-status panel Skill/Equip/Status hands focus
+  to), and `#update_end_game_confirm` (the Yes/No quit prompt). Confirmed
+  the last of these needed it too, not just the two list cursors: EasyRPG's
+  `Scene_End::vUpdate` (`src/scene_end.cpp`) drives its Yes/No prompt
+  through a genuine `Window_Command`'s own `Update()` — the identical
+  `Window_Selectable` base every other list here already inherits, not a
+  lightweight two-state toggle — so it auto-repeats too. Fixed the same
+  way as `Scene::SaveLoad`: every `Input.trigger?(DOWN/UP)` check gained an
+  `|| Input.repeat?(DOWN/UP)` alongside it, no new timing logic. Covered by
+  two new `scripts/rpg2k_scene_check.rb` checks (the main command cursor
+  and the party-status actor cursor each advance one step on a held,
+  repeat-only Down), confirmed to fail against the pre-fix code before the
+  fix. **Still open, tracked the same way**: `item_menu.rb`, `skill_menu.rb`,
+  `equip_menu.rb`, `status_menu.rb`, `order.rb`, `debug_menu.rb`,
+  `title.rb`, and every battle target/command list in `battle.rb`.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -138,13 +138,24 @@ class RPG2k
 
       private
 
+      # Holding Down/Up auto-repeats the cursor after the initial delay, not
+      # just a single step per tap -- `Window_Selectable::Update`
+      # (`src/window_selectable.cpp`), the base every real RPG2000 command
+      # list is built on, falls through to `Input::IsRepeated` right after
+      # its own `IsTriggered` check. `Input.repeat?`'s own timing (this
+      # build's own `mruby-rgss/mrblib/lib.rb`) already matches EasyRPG's
+      # `start_repeat_time`/`repeat_time` constants (`src/input.cpp`) exactly
+      # -- see `Scene::SaveLoad`'s own identical fix and its fuller writeup
+      # in docs/TODO.md for the frame-by-frame confirmation -- so every
+      # `#trigger?` check below just gains an `|| #repeat?` alongside it,
+      # the same pure-wiring shape.
       def update_command
-        if Input.trigger?(Input::DOWN)
+        if Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @index += 1
           @index %= @commands.size
           refresh_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @index -= 1
           @index %= @commands.size
           refresh_cursor
@@ -166,12 +177,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_actor_selection
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @actor_index += 1
           @actor_index %= party.size
           refresh_status_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @actor_index -= 1
           @actor_index %= party.size
           refresh_status_cursor
@@ -478,7 +489,8 @@ class RPG2k
       # uses. "No" and Cancel are otherwise identical: both just close the
       # prompt back to the command list, no title, no BGM fade.
       def update_end_game_confirm
-        if Input.trigger?(Input::DOWN) || Input.trigger?(Input::UP)
+        if Input.trigger?(Input::DOWN) || Input.trigger?(Input::UP) ||
+           Input.repeat?(Input::DOWN) || Input.repeat?(Input::UP)
           @confirm_index = (@confirm_index == END_GAME_YES) ? END_GAME_NO : END_GAME_YES
           refresh_end_game_cursor
           play_system_se(SFX_CURSOR)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14224,6 +14224,24 @@ check 'Scene::Menu: the main command cursor wraps around' do
   eq 0, scene.instance_variable_get(:@index), 'Down from the last command wraps to the first'
 end
 
+# EasyRPG's Window_Selectable::Update (the base every real RPG2000 command
+# list is built on) falls through to Input::IsRepeated right after its own
+# IsTriggered check, so holding Down/Up auto-scrolls the cursor after the
+# initial delay -- see Scene::SaveLoad's identical fix for the fuller
+# writeup. `RGSS::Input.repeated` (distinct from `.triggered`) lets this
+# check hold a key across frames without it also reading as a fresh
+# trigger, exercising the `#repeat?` half of the gate on its own.
+check 'Scene::Menu: holding Down auto-repeats the main command cursor, not ' \
+      'just a single step per tap' do
+  scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
+  eq 0, scene.instance_variable_get(:@index), 'starts on the first command'
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@index),
+     'a held (repeated, not triggered) Down still moves the cursor one step'
+end
+
 check 'Scene::Menu: choosing Item pushes Scene::ItemMenu directly' do
   # RPG2K_COMMAND_KEYS order is Item, Skill, Equip, Save, End Game -- RPG2000
   # has no Status entry at all (see Scene::Menu's own doc comment, ported from
@@ -14287,6 +14305,21 @@ check 'Scene::Menu: cancelling actor selection returns focus to the command list
   RGSS::Input.reset
   eq :command, scene.instance_variable_get(:@focus)
   ok scene.parent.pushed.empty?, 'nothing was ever pushed'
+end
+
+check 'Scene::Menu: holding Down auto-repeats the party-status actor cursor too' do
+  scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
+  scene.instance_variable_set(:@index, 1) # Skill -> hands focus to the actor list
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :actors, scene.instance_variable_get(:@focus)
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@actor_index),
+     'a held (repeated, not triggered) Down still moves the actor cursor one step'
 end
 
 check 'Scene::Menu: a restricted actor cannot be given the Skill command, ' \


### PR DESCRIPTION
## Summary

- `Scene::Menu`'s three cursor spots — the main command list, the
  party-status actor panel, and the End Game Yes/No prompt — only ever
  checked `Input.trigger?(DOWN/UP)`, so holding the key moved exactly one
  step per initial tap, the same gap `Scene::SaveLoad` had (fixed in #990).
- Confirmed EasyRPG's `Scene_End::vUpdate` drives its Yes/No prompt through
  a genuine `Window_Command`'s own `Update()` — the identical
  `Window_Selectable` base every other list here inherits, not a
  lightweight toggle — so it auto-repeats too, confirming all three spots
  needed the fix.
- Fixed the same way as `Scene::SaveLoad`: every `Input.trigger?(DOWN/UP)`
  check gained an `|| Input.repeat?(DOWN/UP)` alongside it, reusing the
  existing wine-verified repeat timing — no new behavior invented.
- The same gap remains open on the other menu screens (Item/Skill/Equip/
  Status/Order/Debug/Title, and battle's own target/command lists), tracked
  in `docs/TODO.md` for a future pass.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 702 checks passed (both new
      checks confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_