### PR TITLE
ppsspp: fix 8-bit MOV crash-recovery gap; re-characterize ADR 0047 bug 8

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -194,18 +194,22 @@ does not share the bug). The resulting null/wild buffer, fed into
 `lv_display_set_buffers`, is what corrupted LVGL's own TLSF pool further
 down the boot path. With that fixed, the EBOOT boots past display
 creation and into `mrb_open`'s GC init before hitting an **eighth bug,
-root-caused but not fixed**: PPSSPP reports `Bad memory access detected!
-00000014` (or a nearby address) — a near-null write — inside
-`mrb_gc_init`. Root-caused to PPSSPP's own x86-64 JIT mistranslating the
-guest code, not this project's: the fault address is layout-sensitive
-(moves between builds that differ only in unrelated diagnostic code),
-PPSSPP's crash log shows the faulting *host* instruction using what looks
-like a null base register despite the *source* pointer being valid the
-whole way through (traced allocation-by-allocation), and forcing PPSSPP's
-interpreter instead of its JIT (`ppsspp-headless -i`) runs hundreds of
-allocations past this point with zero bad-memory-access errors on the
-exact same EBOOT. Not fixed here — patching PPSSPP's dynarec is out of
-scope for this project; worth reporting upstream. See
+partially fixed and re-characterized**: PPSSPP reports `Bad memory access
+detected! 00000014` (or a nearby address) — a near-null write — inside
+`mrb_gc_init`. First characterized as PPSSPP's x86-64 JIT mistranslating
+the guest code; a follow-up pass found and fixed a real, separate bug
+along the way (`Common/x64Analyzer.cpp` was missing the 8-bit-register MOV
+opcodes, `0x88`/`0x8A`, from its crash-recovery disassembler, turning what
+should have been a gracefully-ignored bad access into a fatal halt —
+`nix/patches/ppsspp-x64analyzer-8bit-mov.patch`, verified against both of
+PPSSPP's native JIT backends), but applying it does not get this EBOOT
+booting further, and new evidence from comparing all four of PPSSPP's
+CPU-core modes argues *against* the original JIT-mistranslation diagnosis:
+the identical fault reproduces under two independently-implemented native
+backends *and* the IR interpreter (no native codegen at all), while only
+the true single-instruction MIPS interpreter avoids it — pointing toward a
+timing-sensitive guest-side race rather than a JIT bug, though this was
+not chased down further. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
 P1 for the full eight-bug trail. To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`

--- a/changelog.d/ppsspp-x64analyzer-8bit-mov.fixed.md
+++ b/changelog.d/ppsspp-x64analyzer-8bit-mov.fixed.md
@@ -1,0 +1,28 @@
+- **PPSSPP's crash-recovery disassembler (`Common/x64Analyzer.cpp`) no
+  longer hard-stops the emulator on an ordinary 8-bit memory access.** Its
+  `X86AnalyzeMOV`, used by `Core/MemFault.cpp` to recover from a bad guest
+  memory access under the x86-64 JIT/`JIT_IR` backends when
+  `bIgnoreBadMemAccess` is set (headless mode's default), only recognized
+  the 32/64-bit-register MOV opcodes (`0x89`/`0x8B`) and the immediate-store
+  opcodes (`0xC6`/`0xC7`) — not `0x88`/`0x8A`, the 8-bit-register
+  reg&harr;mem forms, which are what the JIT emits for any single-byte
+  guest store/load (e.g. a MIPS `sb`). Hitting one during recovery fell
+  into `X86AnalyzeMOV`'s own `default:` case (logging "Unhandled disasm
+  case in write handler!"), which `MemFault.cpp` then treats as
+  unrecoverable and halts the whole emulated process — even though
+  `bIgnoreBadMemAccess` would otherwise have skipped the instruction and
+  continued exactly as it already does for every other access width.
+  `nix/patches/ppsspp-x64analyzer-8bit-mov.patch` (not yet upstreamed to
+  `hrydgard/ppsspp`) adds both missing opcodes.
+
+  Found chasing [ADR 0047](docs/adr/0047-psp-memory-budget.md)'s P1 bug 8
+  (a `Bad memory access detected!` fatal halt inside mruby's
+  `mrb_gc_init`, previously characterized as a JIT register-allocation
+  bug). That characterization does not hold up: this patch is a real,
+  verified fix (confirmed eliminating the fatal halt under both PPSSPP's
+  x86 JIT and its `JIT_IR` backend, converting it to the same graceful
+  "ignored" recovery every other store width already gets), but applying
+  it does **not** get this EBOOT booting further — the guest-level
+  condition that makes the GC heap-page pointer read as a near-null
+  address at that point is still open, and new evidence (see the ADR)
+  points away from a JIT-specific bug and toward something else entirely.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -414,71 +414,84 @@ the interpreter-linking slice, in this order:
   share the bug and to zero-initialize the same way.
 
   With bug 7 fixed, the EBOOT boots past display creation and into
-  `mrb_open`'s GC init before hitting an **eighth bug, root-caused and
-  characterized but not fixed**: PPSSPP reports `Bad memory access
-  detected! 00000014` (or a nearby small address — see below) — a
-  near-null write — inside `mrb_gc_init`. Root-caused to **PPSSPP's x86-64
-  JIT (dynarec) itself mistranslating the guest MIPS code**, not a bug in
-  this EBOOT, mruby, or the fixed-arena allocator (ADR 0047's P2):
+  `mrb_open`'s GC init before hitting an **eighth bug, partially fixed and
+  re-characterized**: PPSSPP reports `Bad memory access detected!
+  00000014` (or a nearby small address — see below) — a near-null write —
+  inside `mrb_gc_init`. A first pass at this root-caused it to "PPSSPP's
+  x86-64 JIT mistranslating the guest MIPS code", based on: every
+  allocation up to the crash point tracing as valid (a temporary
+  instrumentation pass through the fixed arena and vendored
+  `mrb_gc_init`/`add_heap`/`init_heap_page`/`shape_root`,
+  `3rd/mruby/src/{gc,state,variable}.c`, none kept); the crash log's own
+  disassembly of the faulting *host* instruction, `mov [rbx+r9+0x4],
+  r10b`, inside the JIT block for `mrb_gc_init` (the compiler had inlined
+  `add_heap`'s `init_heap_page` loop into it — `page->objects[i].as.free.tt
+  = MRB_TT_FREE`, a small per-object byte-store loop, is the only matching
+  source shape); and `ppsspp-headless -i` (forces the plain MIPS
+  interpreter, bypassing the JIT entirely) running the identical EBOOT
+  784+ allocations further with zero bad-memory-access errors.
 
-  - The custom arena allocator (`app/psp/main.cxx`'s `mrb_arena_alloc`/
-    `mrb_arena_realloc`) was traced allocation-by-allocation with a
-    temporary instrumentation pass (every call's requested size and
-    returned pointer, plus extra trace points added directly to the
-    vendored `mrb_gc_init`/`add_heap`/`init_heap_page`/`shape_root` in
-    `3rd/mruby/src/{gc,state,variable}.c`, none kept). Every allocation up
-    to and past the crash point returns a valid, correctly-sized, 16-byte
-    aligned pointer inside the 8 MB arena; `mrb_calloc`'s `memset` on the
-    freshly allocated `mrb_heap_page` completes cleanly. The corruption is
-    not caused by anything in this trace.
-  - The crash address itself is not a plausible corrupted pointer (which
-    would look like leftover heap garbage) but a small, suspiciously
-    round number matching a struct/loop-offset size (0x14 = 20 =
-    `sizeof(mrb_iv_shape)` in one build; 0x18/0x50 in others) — and it
-    **moves between builds that differ only in added instrumentation
-    elsewhere in the binary**, changing which specific write manifests
-    the fault (sometimes a fatal unhandled access, sometimes one PPSSPP
-    logs as "ignored" and recovers from, in one case letting the process
-    limp forward into an infinite loop until the harness's own timeout
-    force-exits it). That layout-sensitivity is the signature of a
-    miscompiled/mistranslated instruction stream, not a fixed logic bug
-    at a fixed call site.
-  - Direct confirmation: PPSSPP's own crash log, with a JIT block active,
-    includes the disassembled *host* x86-64 instruction at the fault:
-    `mov [rbx+r9+0x4], r10b` inside the JIT block covering
-    `mrb_gc_init` (which the C compiler had inlined `add_heap`'s
-    `init_heap_page` loop into — `page->objects[i].as.free.tt =
-    MRB_TT_FREE`, a small per-object byte-store loop, is the only
-    matching source shape). The computed guest address is consistent
-    with `rbx` (the register holding the `page` base pointer) being
-    zero at that point in the *compiled* code, despite the *source*
-    value being a valid, non-null pointer the whole way through (per the
-    allocator trace above) — i.e. the JIT's register allocation/codegen
-    for this block loses track of the base pointer.
-  - Decisive test: re-running the identical EBOOT under
-    `ppsspp-headless -i` (forces the interpreter, bypassing the JIT
-    entirely) reaches the same code path and executes 784+ further
-    allocations with **zero** bad-memory-access errors (cut off only by
-    the harness's own timeout, since interpreted execution is far
-    slower) — the same guest code that reliably faults under the JIT
-    runs cleanly under the interpreter. This is the strongest evidence
-    the bug is PPSSPP's dynarec, not this project's code.
+  A second pass found a real, separate PPSSPP bug along the way — **fixed**:
+  `Common/x64Analyzer.cpp`'s `X86AnalyzeMOV`, which `Core/MemFault.cpp`
+  uses to recover from a bad guest access when `bIgnoreBadMemAccess` is
+  set (headless mode's default), only recognized the 32/64-bit-register
+  MOV opcodes (`0x89`/`0x8B`), not the 8-bit-register forms (`0x88`/`0x8A`)
+  the JIT emits for exactly this kind of byte store — hitting one during
+  recovery hit `X86AnalyzeMOV`'s own `default:` case and got treated as
+  unrecoverable, halting emulation outright instead of being skipped like
+  every other access width already is. `nix/patches/
+  ppsspp-x64analyzer-8bit-mov.patch` adds both missing opcodes; confirmed
+  it eliminates the fatal halt (`Stopping emulation`) under *both* of
+  PPSSPP's native JIT backends (the old per-arch `Core/MIPS/x86/Jit.cpp`
+  and the newer IR-based `Core/MIPS/x86/X64IRJit.cpp`), converting the
+  crash into the same graceful "ignored" recovery every other store width
+  already gets.
 
-  Not fixed here: this is a PPSSPP JIT correctness bug, not a one-line
-  semantic fix like bugs 2/4 (both plain HLE no-ops/missing null checks);
-  actually patching it needs someone to dig into PPSSPP's MIPS-to-x86
-  register allocator for whatever code shape this loop produces, out of
-  scope for this pass. `-i` (interpreter mode) is not viable as a
-  shipping workaround (far too slow for real gameplay) but is useful for
-  future diagnosis. Worth reporting upstream to `hrydgard/ppsspp` with
-  this trail as a repro.
+  Applying that fix does **not** get this EBOOT booting further, though —
+  and comparing all four of PPSSPP's CPU-core modes against the identical
+  patched EBOOT turned up evidence against the original "JIT
+  mistranslation" diagnosis: the byte-for-byte *same* fault address
+  sequence (0x18, 0x14, 0x2c, 0x28, ...) reproduces under the old x86 JIT,
+  under `JIT_IR` (an independently-implemented native backend), *and*
+  under `--ir` (`IR_INTERPRETER`, which shares `JIT_IR`'s MIPS-to-IR
+  frontend but does no native code generation at all — it segfaults the
+  *host* process outright at the same point, since the IR interpreter has
+  no `bIgnoreBadMemAccess`-style recovery path). Two independently-coded
+  native backends agreeing byte-for-byte, plus the IR interpreter hitting
+  the identical point despite generating no machine code, is hard to
+  explain as a backend-specific register-allocation bug; it fits a lot
+  better as something shared by every "compile/analyze a block ahead of
+  time" execution mode, and *not* shared by the one mode that's genuinely
+  different — the plain MIPS interpreter, which single-steps each
+  instruction directly against `currentMIPS`'s live state rather than
+  translating a block up front. That points at a timing-sensitive
+  condition (an interrupt or HLE callback racing unprotected/non-reentrant
+  guest state, matching this whole trail's running "memory corruption over
+  logic bugs" theme, and echoing bug 4's own interrupt-masking fix) as the
+  more likely next lead, over a genuine JIT translation bug — but this
+  pass did not chase that down further; it is a real, open question, not
+  a new final diagnosis. With the x64Analyzer fix applied, this EBOOT's
+  own boot still does not complete: execution proceeds past the fault
+  point instead of halting, but the underlying corruption persists, and
+  the guest program calls `sceKernelExitGame()` on its own partway through
+  `mrb_open` without ever printing `RPG2K_PSP_MRUBY_OPEN` — consistent
+  with the corruption leading to wild/divergent control flow rather than
+  a successful `mrb_open()`.
+
+  Not upstreamed to `hrydgard/ppsspp` yet. The x64Analyzer fix is worth
+  upstreaming on its own regardless of this EBOOT's own outcome — it is a
+  genuine gap relative to PPSSPP's own intended `bIgnoreBadMemAccess`
+  behavior, useful to any guest code that trips a byte-sized bad access
+  under the JIT. `-i` (interpreter mode) is not viable as a shipping
+  workaround (far too slow for real gameplay) but remains useful for
+  diagnosis.
 
   Whether real hardware shares bugs 7 or 8 is unknown (bugs 3 and 6 are
   moot on this boot path either way, one because it stopped triggering,
-  the other because it's fixed); bug 8 in particular, being a PPSSPP-only
-  JIT bug, may well be emulator-specific and not present on real hardware
-  at all. The P1 device numbers above remain unconfirmed on the emulator
-  and untried on hardware.
+  the other because it's fixed); bug 8's underlying corruption may or may
+  not be emulator-specific — unresolved by this pass. The P1 device
+  numbers above remain unconfirmed on the emulator and untried on
+  hardware.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/flake.nix
+++ b/flake.nix
@@ -133,11 +133,11 @@
           # Linux-only, matching the package's own meta.platforms: forcing this
           # attribute on darwin (e.g. `nix flake show`) would otherwise throw.
           #
-          # Carries two local patches on top of nixpkgs' build, both found
+          # Carries three local patches on top of nixpkgs' build, all found
           # and root-caused while trying to read the PSP EBOOT's own boot log
           # under PPSSPP-headless (see docs/adr/0047-psp-memory-budget.md and
-          # app/psp/README.md); neither is upstreamed to hrydgard/ppsspp yet,
-          # so both are applied here so this flake's own `ppsspp`/
+          # app/psp/README.md); none are upstreamed to hrydgard/ppsspp yet,
+          # so all three are applied here so this flake's own `ppsspp`/
           # `ppsspp-headless` survive past them. nix/patches/ has the full
           # patches and each one's own note on when it is safe to drop.
           #
@@ -153,10 +153,18 @@
           #     fast interrupt-disable/enable (built directly on those two
           #     instructions, used to guard its non-reentrant C-runtime
           #     state) provides no real protection under PPSSPP.
+          #   - Common/x64Analyzer.cpp's crash-recovery disassembler (used by
+          #     Core/MemFault.cpp when bIgnoreBadMemAccess lets a bad guest
+          #     access be skipped instead of halting) has no case for the
+          #     0x88/0x8A 8-bit-register MOV opcodes, only their 32/64-bit
+          #     counterparts -- so a bad access from an ordinary byte
+          #     store/load hard-stops emulation instead of being skipped like
+          #     every other access width already is.
           ppsspp = pkgs.ppsspp.overrideAttrs (old: {
             patches = (old.patches or [ ]) ++ [
               ./nix/patches/ppsspp-lwmutex-workarea-validate.patch
               ./nix/patches/ppsspp-mfic-mtic-interrupt-mask.patch
+              ./nix/patches/ppsspp-x64analyzer-8bit-mov.patch
             ];
           });
         }

--- a/nix/patches/ppsspp-x64analyzer-8bit-mov.patch
+++ b/nix/patches/ppsspp-x64analyzer-8bit-mov.patch
@@ -1,0 +1,80 @@
+PPSSPP upstream gap: Common/x64Analyzer.cpp's X86AnalyzeMOV -- used by the
+crash handler (Core/MemFault.cpp) to recover from a bad guest memory access
+under the x86-64 JIT/JIT_IR backends when g_Config.bIgnoreBadMemAccess is set
+(headless mode's default; also settable per-game) -- only recognizes MOV
+opcodes 0x89 (32/64-bit reg->mem), 0x8B (32/64-bit mem->reg), 0xC6 and 0xC7
+(immediate stores). It has no case for 0x88 (MOV r/m8, r8, an 8-bit
+reg->mem store) or 0x8A (MOV r8, r/m8, an 8-bit mem->reg load) -- both
+completely ordinary x86-64 instructions the JIT emits for any single-byte
+guest MIPS store/load (e.g. `sb`, or any C struct field write narrower than
+a word). Hitting one during a bad-memory-access recovery falls through to
+the `default:` case, which logs "Unhandled disasm case in write handler!"
+and returns false; MemFault.cpp then treats the access as unrecoverable
+("Bad memory access detected! ... Stopping emulation") and halts the whole
+emulated process, even though bIgnoreBadMemAccess would otherwise have let
+it skip the faulting instruction and continue exactly as it already does
+for 4/8-byte stores through the 0x89 case.
+
+Found while trying to get this project's own PSP EBOOT to boot under
+PPSSPP-headless (see docs/adr/0047-psp-memory-budget.md's P1 and
+app/psp/README.md for the fuller trail -- this was misdiagnosed one layer
+too deep in an earlier pass of that investigation, as a JIT
+register-allocation bug rather than this crash-recovery gap; the crash
+log's own disassembly, `mov [rbx+r9+0x4], r10b`, is exactly an 0x88
+instruction -- an 8-bit byte-store from r10b -- which is what led back
+here). The guest code hitting this is mruby's own GC heap-page
+initialization (3rd/mruby/src/gc.c's init_heap_page loop,
+`p->as.free.tt = MRB_TT_FREE`, a per-object byte-store loop the compiler
+inlined into mrb_gc_init); whatever guest-level condition made that
+specific access land outside mapped memory is a separate question from
+this one, but this patch is what lets PPSSPP's own existing
+bIgnoreBadMemAccess recovery path handle it uniformly with every other
+store width instead of hard-stopping specifically on byte stores.
+
+Adds MOVE_8BIT_REG_TO_MEM (0x88) and MOVE_MEM_TO_8BIT_REG (0x8A) alongside
+the existing MOVE_REG_TO_MEM (0x89) / MOVE_MEM_TO_REG (0x8B) cases,
+following the same pattern already used for MOVZX_BYTE/MOVSX_BYTE
+(info.operandSize = 1) elsewhere in the same function -- both opcodes were
+already routed into X86AnalyzeMOV's accessType==1 (reg/mem) branch by the
+existing `(codeByte & 0xF0) == 0x80` check (0x88 and 0x8A both fall in that
+range), they were just missing from the switch that decides what to do
+once there.
+
+Not yet upstreamed to https://github.com/hrydgard/ppsspp -- applied here
+locally (flake.nix's `ppsspp` package output) alongside the LwMutex
+workarea-validation and mfic/mtic patches in this same directory. Safe to
+drop once upstream adds these two opcodes to X86AnalyzeMOV, or this patch
+fails to apply against a future nixpkgs bump (check Common/x64Analyzer.cpp/
+.h for whether it already stopped being incomplete before just bumping
+context lines).
+
+--- a/Common/x64Analyzer.cpp
++++ b/Common/x64Analyzer.cpp
+@@ -187,6 +187,16 @@
+ 			info.isMemoryWrite = false;
+ 			break;
+
++		case MOVE_8BIT_REG_TO_MEM: //move 8-bit reg to memory
++			info.isMemoryWrite = true;
++			info.operandSize = 1;
++			break;
++
++		case MOVE_MEM_TO_8BIT_REG: //move memory to 8-bit reg
++			info.isMemoryWrite = false;
++			info.operandSize = 1;
++			break;
++
+ 		default:
+ 			ERROR_LOG(Log::CPU, "Unhandled disasm case in write handler!\n\nPlease implement or avoid.");
+ 			return false;
+--- a/Common/x64Analyzer.h
++++ b/Common/x64Analyzer.h
+@@ -54,6 +54,8 @@
+ 	MOVE_16_32BIT   = 0xC7, //move 16 or 32-bit immediate
+ 	MOVE_REG_TO_MEM = 0x89, //move reg to memory
+ 	MOVE_MEM_TO_REG = 0x8B, //move memory to reg
++	MOVE_8BIT_REG_TO_MEM = 0x88, //move 8-bit reg to memory
++	MOVE_MEM_TO_8BIT_REG = 0x8A, //move memory to 8-bit reg
+ };
+
+ enum AccessType {


### PR DESCRIPTION
## Summary
- **Real, verified PPSSPP fix**: `Common/x64Analyzer.cpp`'s `X86AnalyzeMOV` — used by `Core/MemFault.cpp` to recover from a bad guest memory access under the x86-64 JIT/`JIT_IR` backends when `bIgnoreBadMemAccess` is set (headless mode's default) — only recognized the 32/64-bit-register MOV opcodes (`0x89`/`0x8B`), not the 8-bit forms (`0x88`/`0x8A`) the JIT emits for any single-byte guest store/load. Hitting one during recovery fell into the analyzer's `default:` case and got treated as unrecoverable, hard-halting emulation instead of being gracefully skipped like every other access width. `nix/patches/ppsspp-x64analyzer-8bit-mov.patch` adds both opcodes; verified it eliminates the fatal halt under both of PPSSPP's native JIT backends (old per-arch JIT and `JIT_IR`). Not yet upstreamed to `hrydgard/ppsspp`.
- **Corrects PR #987's diagnosis of ADR 0047 bug 8.** That PR characterized bug 8 as a PPSSPP JIT register-allocation/mistranslation bug. Applying this patch does *not* get the PSP EBOOT booting further, and comparing all four of PPSSPP's CPU-core modes against the identical patched EBOOT turned up evidence against that diagnosis: the identical fault reproduces under two independently-implemented native backends *and* the IR interpreter (no native codegen at all), while only the true single-instruction MIPS interpreter avoids it — pointing toward a timing-sensitive guest-side race (echoing bug 4's own interrupt-masking theme) rather than a JIT translation bug. Not chased down further in this pass; documented as an open question.
- `docs/adr/0047-psp-memory-budget.md` and `app/psp/README.md` updated to reflect both the real fix and the corrected diagnosis.

## Test plan
- [x] Confirmed the x64Analyzer fix eliminates the fatal "Stopping emulation" halt under both native JIT backends, converting it into the same graceful ignored-recovery every other store width already gets.
- [x] Compared all four PPSSPP CPU-core modes (old JIT, JIT_IR, IR interpreter, plain MIPS interpreter) against the identical patched EBOOT to gather the re-characterization evidence.
- [x] `nix flake check --no-build` passes.
- [ ] CI — pending on this PR.