### PR TITLE
item menu: holding a direction now auto-repeats the cursor too

### DIFF
--- a/changelog.d/item-menu-cursor-repeat.fixed.md
+++ b/changelog.d/item-menu-cursor-repeat.fixed.md
@@ -1,0 +1,6 @@
+- **Item menu:** holding a direction now auto-repeats the cursor in the
+  item grid (all four directions), the actor-target list, and the
+  registered-teleport-destination list, matching real RPG_RT (continuing
+  the same fix already landed for the save/load and main field-menu
+  screens). Reuses this build's existing, wine-verified `Input.repeat?`
+  timing. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3601,6 +3601,20 @@ The work below is roughly ordered by the critical path to a walkable game
   fix. **Still open, tracked the same way**: `item_menu.rb`, `skill_menu.rb`,
   `equip_menu.rb`, `status_menu.rb`, `order.rb`, `debug_menu.rb`,
   `title.rb`, and every battle target/command list in `battle.rb`.
+  ✅ **Next up the same list: `item_menu.rb` (2026-08-18).** Three cursor
+  spots, all fixed the same way (`|| Input.repeat?(...)` alongside the
+  existing `Input.trigger?` checks): the item grid's own two-column
+  DOWN/UP/RIGHT/LEFT (`#update_items`, `Window_Selectable::Update` handling
+  all four directions identically, not just the two a single-column list
+  needs), the actor-target list's DOWN/UP (`#update_target`), and the
+  registered-teleport-destination list's DOWN/UP (`#update_teleport_
+  target`). Covered by a new `scripts/rpg2k_scene_check.rb` check (a held,
+  repeat-only Right moves the item grid cursor one cell; a held,
+  repeat-only Down moves the actor-target cursor one step), confirmed to
+  fail against the pre-fix code before the fix. **Still open**:
+  `skill_menu.rb`, `equip_menu.rb`, `status_menu.rb`, `order.rb`,
+  `debug_menu.rb`, `title.rb`, and every battle target/command list in
+  `battle.rb`.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -81,17 +81,26 @@ class RPG2k
         @items = nil
       end
 
+      # Holding a direction auto-repeats the cursor after the initial delay,
+      # not just a single step per tap -- `Window_Selectable::Update`
+      # (`src/window_selectable.cpp`), the base every real RPG2000 list is
+      # built on, falls through to `Input::IsRepeated` for all four
+      # directions right after its own `IsTriggered` check. `Input.repeat?`'s
+      # own timing already matches EasyRPG's repeat constants exactly -- see
+      # `Scene::SaveLoad`'s identical fix and its fuller writeup in
+      # docs/TODO.md -- so every check below just gains an `|| #repeat?`
+      # alongside it, the same pure-wiring shape.
       def update_items
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           @parent.pop
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           move_item_cursor(COLUMN_MAX)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           move_item_cursor(-COLUMN_MAX)
-        elsif Input.trigger?(Input::RIGHT)
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
           move_item_cursor(1) if (@item_index + 1) % COLUMN_MAX != 0
-        elsif Input.trigger?(Input::LEFT)
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
           move_item_cursor(-1) if @item_index % COLUMN_MAX != 0
         elsif Input.trigger?(Input::C)
           choose_item
@@ -239,12 +248,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_teleport_target
-        elsif Input.trigger?(Input::DOWN) && !targets.empty?
+        elsif (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !targets.empty?
           @teleport_index += 1
           @teleport_index %= targets.size
           refresh_teleport_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !targets.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !targets.empty?
           @teleport_index -= 1
           @teleport_index %= targets.size
           refresh_teleport_cursor
@@ -315,12 +324,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_target_mode
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @target_index += 1
           @target_index %= party.size
           refresh_target_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @target_index -= 1
           @target_index %= party.size
           refresh_target_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15166,6 +15166,31 @@ check 'Scene::ItemMenu: the item grid cursor does not wrap, the target cursor do
   eq 0, scene.instance_variable_get(:@target_index), 'Down from the last ally wraps to the first'
 end
 
+# EasyRPG's Window_Selectable::Update (the base every real RPG2000 list is
+# built on) falls through to Input::IsRepeated for all four directions
+# right after its own IsTriggered check, so holding a direction
+# auto-repeats the cursor after the initial delay -- see Scene::SaveLoad's
+# identical fix for the fuller writeup. `RGSS::Input.repeated` (distinct
+# from `.triggered`) lets this check hold a key across frames without it
+# also reading as a fresh trigger, exercising the `#repeat?` half of the
+# gate on its own.
+check 'Scene::ItemMenu: holding Right auto-repeats the item grid cursor, and ' \
+      'holding Down auto-repeats the actor-target cursor' do
+  scene = menu_scene(RPG2k::Scene::ItemMenu, wrap_menu_state)
+  RGSS::Input.repeated = [RGSS::Input::RIGHT] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@item_index),
+     'a held (repeated, not triggered) Right still moves the item cursor one cell'
+
+  scene.send(:prompt_item_target, 1)
+  RGSS::Input.repeated = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@target_index),
+     'a held (repeated, not triggered) Down still moves the target cursor one step'
+end
+
 # A party whose only item is a switch (type 10) one -- Game::Party's own
 # decision logic (#use_switch_item) is covered by scripts/rpg2k_logic_check.rb;
 # this stub only has to hand the scene something that behaves the same way, so


### PR DESCRIPTION
## Summary

- `Scene::ItemMenu`'s three cursor spots — the two-column item grid
  (DOWN/UP/RIGHT/LEFT), the actor-target list, and the registered
  teleport-destination list — only ever checked `Input.trigger?`, the same
  gap already fixed on `Scene::SaveLoad` (#990) and `Scene::Menu` (#991).
- `Window_Selectable::Update` falls through to `Input::IsRepeated` for all
  four directions right after its own `IsTriggered` check, not just
  DOWN/UP — the item grid needed RIGHT/LEFT too, unlike the single-column
  lists fixed so far.
- Fixed the same way: every `Input.trigger?(...)` check gained an
  `|| Input.repeat?(...)` alongside it, reusing the existing wine-verified
  repeat timing — no new behavior invented.
- The same gap remains open on the other menu screens (Skill/Equip/Status/
  Order/Debug/Title, and battle's own target/command lists), tracked in
  `docs/TODO.md` for a future pass.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 703 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_