### PR TITLE
skill menu: holding a direction now auto-repeats the cursor too

### DIFF
--- a/changelog.d/skill-menu-cursor-repeat.fixed.md
+++ b/changelog.d/skill-menu-cursor-repeat.fixed.md
@@ -1,0 +1,7 @@
+- **Skill menu:** holding a direction now auto-repeats the cursor in the
+  skill grid (all four directions), the actor-target list, and the
+  registered-teleport-destination list, matching real RPG_RT (continuing
+  the same fix already landed for the save/load, main field-menu, and item
+  menu screens). Reuses this build's existing, wine-verified
+  `Input.repeat?` timing. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3615,6 +3615,17 @@ The work below is roughly ordered by the critical path to a walkable game
   `skill_menu.rb`, `equip_menu.rb`, `status_menu.rb`, `order.rb`,
   `debug_menu.rb`, `title.rb`, and every battle target/command list in
   `battle.rb`.
+  ✅ **Next: `skill_menu.rb` (2026-08-18).** The identical three cursor
+  spots as `item_menu.rb` — the skill grid's own two-column DOWN/UP/RIGHT/
+  LEFT (`#update_skills`), the actor-target list's DOWN/UP (`#update_
+  target`), and the registered-teleport-destination list's DOWN/UP
+  (`#update_teleport_target`) — fixed the same `|| Input.repeat?(...)` way.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a held, repeat-only
+  Right moves the skill grid cursor one cell; a held, repeat-only Down
+  moves the actor-target cursor one step), confirmed to fail against the
+  pre-fix code before the fix. **Still open**: `equip_menu.rb`,
+  `status_menu.rb`, `order.rb`, `debug_menu.rb`, `title.rb`, and every
+  battle target/command list in `battle.rb`.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -90,17 +90,22 @@ class RPG2k
         n.nil? || n.empty? ? "Skill #{sid}" : n
       end
 
+      # Holding a direction auto-repeats the cursor after the initial delay,
+      # not just a single step per tap -- see Scene::ItemMenu#update_items's
+      # identical comment (`Window_Selectable::Update`, `src/
+      # window_selectable.cpp`, and docs/TODO.md for the fuller writeup);
+      # every check below just gains an `|| #repeat?` alongside it.
       def update_skills
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           @parent.pop
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           move_skill_cursor(COLUMN_MAX)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           move_skill_cursor(-COLUMN_MAX)
-        elsif Input.trigger?(Input::RIGHT)
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
           move_skill_cursor(1) if (@skill_index + 1) % COLUMN_MAX != 0
-        elsif Input.trigger?(Input::LEFT)
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
           move_skill_cursor(-1) if @skill_index % COLUMN_MAX != 0
         elsif Input.trigger?(Input::C)
           choose_skill
@@ -157,12 +162,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_target
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @target_index += 1
           @target_index %= party.size
           refresh_target_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @target_index -= 1
           @target_index %= party.size
           refresh_target_cursor
@@ -235,12 +240,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_teleport_target
-        elsif Input.trigger?(Input::DOWN) && !targets.empty?
+        elsif (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !targets.empty?
           @teleport_index += 1
           @teleport_index %= targets.size
           refresh_teleport_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !targets.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !targets.empty?
           @teleport_index -= 1
           @teleport_index %= targets.size
           refresh_teleport_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15511,6 +15511,30 @@ check 'Scene::SkillMenu: the skill grid cursor does not wrap, caster is fixed, '
   eq 0, scene.instance_variable_get(:@target_index), 'Down from the last ally wraps to the first'
 end
 
+# See Scene::ItemMenu's identical check for the fuller writeup
+# (Window_Selectable::Update falls through to Input::IsRepeated for all
+# four directions right after IsTriggered). `RGSS::Input.repeated`
+# (distinct from `.triggered`) lets this check hold a key across frames
+# without it also reading as a fresh trigger.
+check 'Scene::SkillMenu: holding Right auto-repeats the skill grid cursor, and ' \
+      'holding Down auto-repeats the actor-target cursor' do
+  scene = menu_scene(RPG2k::Scene::SkillMenu, wrap_menu_state)
+  RGSS::Input.repeated = [RGSS::Input::RIGHT] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@skill_index),
+     'a held (repeated, not triggered) Right still moves the skill cursor one cell'
+
+  scene.instance_variable_set(:@mode, :target)
+  scene.instance_variable_set(:@target_index, 0)
+  scene.send(:build_target_window)
+  RGSS::Input.repeated = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@target_index),
+     'a held (repeated, not triggered) Down still moves the target cursor one step'
+end
+
 # A party whose only two skills are Escape (30) and Teleport (31), each
 # offered once #escape_access / #teleport_access and a target are set on the
 # real Game::State that holds it -- Game::Party's own decision logic


### PR DESCRIPTION
## Summary

- `Scene::SkillMenu`'s three cursor spots — the two-column skill grid
  (DOWN/UP/RIGHT/LEFT), the actor-target list, and the registered
  teleport-destination list — only ever checked `Input.trigger?`, the same
  gap already fixed on `Scene::SaveLoad` (#990), `Scene::Menu` (#991), and
  `Scene::ItemMenu` (#993).
- Fixed the same way: every `Input.trigger?(...)` check gained an
  `|| Input.repeat?(...)` alongside it, reusing the existing wine-verified
  repeat timing — no new behavior invented.
- The same gap remains open on the other menu screens (Equip/Status/Order/
  Debug/Title, and battle's own target/command lists), tracked in
  `docs/TODO.md` for a future pass.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 704 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_