### PR TITLE
equip menu: slot/candidate cursors auto-repeat, actor switch stays discrete

### DIFF
--- a/changelog.d/equip-menu-cursor-repeat.fixed.md
+++ b/changelog.d/equip-menu-cursor-repeat.fixed.md
@@ -1,0 +1,8 @@
+- **Equip menu:** holding Down/Up now auto-repeats the equip-slot list and
+  the candidate item list, matching real RPG_RT (continuing the same fix
+  already landed for the save/load, field-menu, item, and skill screens).
+  The Right/Left actor switch deliberately stays discrete-only, one tap per
+  press — confirmed against EasyRPG's source that the real engine never
+  auto-repeats it either, since each switch opens a whole new equip screen
+  rather than moving a cursor. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3626,6 +3626,30 @@ The work below is roughly ordered by the critical path to a walkable game
   pre-fix code before the fix. **Still open**: `equip_menu.rb`,
   `status_menu.rb`, `order.rb`, `debug_menu.rb`, `title.rb`, and every
   battle target/command list in `battle.rb`.
+  ✅ **Next: `equip_menu.rb` (2026-08-18) — and the first of this whole
+  series where the fix is *not* uniformly "add `|| #repeat?`
+  everywhere."** The slot list (`#update_slots`'s DOWN/UP) and the
+  equip-candidate item list (`#update_items`'s DOWN/UP) both auto-repeat,
+  living on genuine `Window_Equip`/`Window_EquipItem` — real
+  `Window_Selectable` subclasses — the same as every list fixed so far.
+  But `#update_slots`'s RIGHT/LEFT, which switches which party member is
+  being equipped, does **not**: confirmed against EasyRPG Player's actual
+  source, `Scene_Equip::UpdateEquipSelection` (`src/scene_equip.cpp`)
+  checks `Input::IsTriggered(Input::RIGHT/LEFT)` only, with no
+  `IsRepeated` fallthrough at all, because a switch pushes a **whole new
+  `Scene_Equip` instance** for the new actor rather than moving a cursor
+  within the current one — there is no live scene object left to keep
+  auto-repeating past the first tap. So `#update_slots`'s DOWN/UP gained
+  `|| Input.repeat?(...)` while its RIGHT/LEFT stayed untouched — the
+  first genuinely-checked-and-confirmed exception in this series, not
+  merely an oversight. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (a held, repeat-only Down moves both the slot and candidate
+  cursors one step each; a held, repeat-only Right does *not* switch
+  actors), confirmed to fail against the pre-fix code (the slot-cursor
+  assertion) before the fix. **Still open**: `status_menu.rb`, `order.rb`,
+  `debug_menu.rb`, `title.rb`, and every battle target/command list in
+  `battle.rb` — each worth the same actual-source check `equip_menu.rb`
+  just got, not an assumed blanket `|| #repeat?`.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -92,17 +92,28 @@ class RPG2k
                      "database, showing a placeholder label"
       end
 
+      # The slot cursor (DOWN/UP) auto-repeats while held -- it lives on a
+      # genuine `Window_Equip`, a `Window_Selectable` subclass, whose own
+      # `Update()` falls through to `Input::IsRepeated` the same as every
+      # other list here (see Scene::ItemMenu#update_items's fuller
+      # writeup). The actor switch (RIGHT/LEFT) does **not**: confirmed
+      # against EasyRPG's actual source -- `Scene_Equip::
+      # UpdateEquipSelection` (`src/scene_equip.cpp`) checks
+      # `Input::IsTriggered(Input::RIGHT/LEFT)` only, no `IsRepeated` at
+      # all, since each switch pushes a whole new `Scene_Equip` rather than
+      # moving a cursor within one -- left as a discrete-only, one-tap
+      # action, unlike the DOWN/UP slot cursor right beside it.
       def update_slots
         party = @state.party.actors
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           @parent.pop
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @slot_index += 1
           @slot_index %= @slots.size
           refresh_slot_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @slot_index -= 1
           @slot_index %= @slots.size
           refresh_slot_cursor
@@ -146,12 +157,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_items
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @cand_index += 1
           @cand_index %= candidates.size
           refresh_cand_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @cand_index -= 1
           @cand_index %= candidates.size
           refresh_cand_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15995,6 +15995,39 @@ check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around'
   eq 0, scene.instance_variable_get(:@cand_index), 'Down from the last candidate wraps to the first'
 end
 
+# The slot and candidate cursors live on genuine Window_Selectable
+# subclasses (Window_Equip/Window_EquipItem) whose own Update() auto-repeats
+# DOWN/UP the same as every other list -- see Scene::ItemMenu#update_items's
+# fuller writeup. The actor switch (RIGHT/LEFT) is confirmed NOT to: real
+# EasyRPG's Scene_Equip::UpdateEquipSelection (src/scene_equip.cpp) checks
+# Input::IsTriggered(RIGHT/LEFT) only, no IsRepeated, since each switch
+# pushes a whole new Scene_Equip rather than moving a cursor.
+check 'Scene::EquipMenu: holding Down auto-repeats the slot and candidate ' \
+      'cursors, but holding Right does not switch actors' do
+  scene = menu_scene(RPG2k::Scene::EquipMenu, wrap_menu_state)
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@slot_index),
+     'a held (repeated, not triggered) Down still moves the slot cursor one step'
+
+  RGSS::Input.repeated = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@actor_index),
+     'a held (repeated, not triggered) Right does NOT switch actors -- matches ' \
+     'the real engine\'s own discrete-only IsTriggered gate'
+
+  scene.instance_variable_set(:@mode, :items)
+  scene.instance_variable_set(:@cand_index, 0)
+  scene.send(:build_cand_window)
+  RGSS::Input.repeated = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@cand_index),
+     'a held (repeated, not triggered) Down still moves the candidate cursor one step'
+end
+
 check 'Scene::EquipMenu: 装備固定 refuses to open the item list for that actor' do
   state = wrap_menu_state
   state.party.actors.first.equipment_fixed_flag = true


### PR DESCRIPTION
## Summary

- `Scene::EquipMenu`'s slot list and equip-candidate item list only ever
  checked `Input.trigger?(DOWN/UP)`, the same gap already fixed on
  `Scene::SaveLoad` (#990), `Scene::Menu` (#991), `Scene::ItemMenu` (#993),
  and `Scene::SkillMenu` (#994).
- Unlike those, this screen's RIGHT/LEFT (switching which party member is
  being equipped) is confirmed to **not** auto-repeat in the real engine:
  `Scene_Equip::UpdateEquipSelection` (`src/scene_equip.cpp`) checks
  `Input::IsTriggered(RIGHT/LEFT)` only, no `IsRepeated`, because a switch
  pushes a whole new `Scene_Equip` instance for the new actor rather than
  moving a cursor within the current one.
- Fixed DOWN/UP in both `#update_slots` and `#update_items` with
  `|| Input.repeat?(...)`, left RIGHT/LEFT untouched — the first confirmed
  exception in this series rather than a blanket rule.
- The same gap remains open on the other menu screens (Status/Order/Debug/
  Title, and battle's own target/command lists), tracked in `docs/TODO.md`
  for a future pass, each worth its own real-source check like this one got
  rather than an assumed blanket fix.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 705 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_