### PR TITLE
status menu: confirm actor cycling already matches RPG_RT, no fix needed

### DIFF
--- a/changelog.d/status-menu-cursor-repeat-confirmed.changed.md
+++ b/changelog.d/status-menu-cursor-repeat-confirmed.changed.md
@@ -1,0 +1,8 @@
+- RPG Maker 2000: confirmed the status screen's Left/Right actor cycling
+  already matches real RPG_RT, no code change needed — unlike the
+  list/grid cursors already fixed to auto-repeat on the save/load, field
+  menu, item, skill, and equip screens, `Scene_Status::vUpdate`
+  (EasyRPG's real source) checks a single-press trigger only, since Left/
+  Right there rebuilds the whole panel for a different party member
+  rather than moving a cursor. Pinned with a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3650,6 +3650,22 @@ The work below is roughly ordered by the critical path to a walkable game
   `debug_menu.rb`, `title.rb`, and every battle target/command list in
   `battle.rb` — each worth the same actual-source check `equip_menu.rb`
   just got, not an assumed blanket `|| #repeat?`.
+  ✅ **`status_menu.rb` checked next (2026-08-18) — confirmed already
+  correct, no code change needed.** Unlike every screen fixed so far, this
+  one has no list/grid cursor at all: it is a read-only single-member
+  detail panel, and LEFT/RIGHT just rebuild the whole thing for a
+  different party member rather than moving a cursor within a
+  `Window_Selectable`. Confirmed against EasyRPG Player's actual source:
+  `Scene_Status::vUpdate` (`src/scene_status.cpp`) checks
+  `Input::IsTriggered(RIGHT/LEFT)` only — no `IsRepeated` fallthrough
+  anywhere in the method — the identical discrete-only shape
+  `equip_menu.rb`'s own actor switch was just confirmed to have. Pinned as
+  a checked invariant rather than left an unverified assumption: a new
+  `scripts/rpg2k_scene_check.rb` check asserts a held, repeat-only Right
+  does *not* cycle the actor, passing against the code exactly as it
+  already stood (no fix landed, since none was needed). **Still open**:
+  `order.rb`, `debug_menu.rb`, `title.rb`, and every battle target/command
+  list in `battle.rb`.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16228,6 +16228,26 @@ check 'Scene::StatusMenu: the actor cursor wraps around' do
   eq 0, scene.instance_variable_get(:@actor_index), 'Right from the last actor wraps to the first'
 end
 
+# Confirmed already correct, no code change needed -- checked while auditing
+# this screen for the same key-repeat gap already fixed on every other menu
+# screen (see docs/TODO.md). Unlike a genuine cursor inside a
+# Window_Selectable list, this screen has no list at all: LEFT/RIGHT just
+# rebuild the whole panel for a different party member, and EasyRPG's real
+# Scene_Status::vUpdate (src/scene_status.cpp) checks
+# Input::IsTriggered(RIGHT/LEFT) only -- no IsRepeated fallthrough anywhere
+# in the method -- so holding the key never auto-cycles members in the real
+# engine either. This check pins that as a checked invariant rather than an
+# unverified assumption.
+check 'Scene::StatusMenu: holding Right does NOT auto-cycle the actor -- ' \
+      'confirmed matching the real engine\'s own discrete-only gate' do
+  scene = menu_scene(RPG2k::Scene::StatusMenu, wrap_menu_state)
+  RGSS::Input.repeated = [RGSS::Input::RIGHT] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@actor_index),
+     'a held (repeated, not triggered) Right does not cycle the actor'
+end
+
 check 'Scene::StatusMenu: a dangling equipped item id logs once, not per rebuild, ' \
       'while the slot still shows the "Item #<id>" placeholder' do
   state = Game::State.new(DanglingItemParty.new, 1, 0, 0)


### PR DESCRIPTION
## Summary

- Checked `Scene::StatusMenu` for the same key-repeat gap already fixed on
  `Scene::SaveLoad` (#990), `Scene::Menu` (#991), `Scene::ItemMenu` (#993),
  `Scene::SkillMenu` (#994), and `Scene::EquipMenu` (#995). This screen has
  no list/grid cursor at all — LEFT/RIGHT just rebuild the whole read-only
  panel for a different party member.
- Confirmed against EasyRPG's actual source: `Scene_Status::vUpdate` checks
  `Input::IsTriggered(RIGHT/LEFT)` only, no `IsRepeated` anywhere in the
  method — the same discrete-only shape `equip_menu.rb`'s own actor switch
  was just confirmed to have.
- No production code change — pinned as a checked invariant with a new
  regression test instead of leaving it an unverified assumption.
- The same audit remains open on `order.rb`, `debug_menu.rb`, `title.rb`,
  and every battle target/command list in `battle.rb`, tracked in
  `docs/TODO.md`.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 706 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_