### PR TITLE
order: holding Down/Up now auto-repeats both of its cursors

### DIFF
--- a/changelog.d/order-menu-cursor-repeat.fixed.md
+++ b/changelog.d/order-menu-cursor-repeat.fixed.md
@@ -1,0 +1,7 @@
+- **Order screen (RPG2003):** holding Down/Up now auto-repeats both the
+  party-reordering pick cursor and the Confirm/Redo prompt cursor, matching
+  real RPG_RT — confirmed against EasyRPG's source that both genuinely
+  auto-repeat here (unlike the equip and status screens' discrete-only
+  actor switches). Continues the same fix already landed for the save/load,
+  field-menu, item, skill, and equip screens. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3666,6 +3666,25 @@ The work below is roughly ordered by the critical path to a walkable game
   already stood (no fix landed, since none was needed). **Still open**:
   `order.rb`, `debug_menu.rb`, `title.rb`, and every battle target/command
   list in `battle.rb`.
+  ✅ **`order.rb` (RPG2003's party-reordering screen) next (2026-08-18) —
+  back to needing the fix, both of its cursors this time.** Confirmed
+  against EasyRPG Player's actual source: `Scene_Order::vUpdate` (`src/
+  scene_order.cpp`) calls `window_left->Update()`/`window_confirm->
+  Update()` **unconditionally, every frame**, before ever checking
+  `GetActive()` — both are genuine `Window_Selectable`s, whose own
+  `Update()` is what actually drives the cursor (the standard
+  trigger-then-repeat), while `GetActive()` only gates which of
+  `UpdateOrder`/`UpdateConfirm` (the Decision/Cancel handling) runs, not
+  the cursor movement itself. So unlike `equip_menu.rb`'s/
+  `status_menu.rb`'s discrete-only actor switches, both of this screen's
+  own cursors — the left-column pick cursor (`#update_left`) and the
+  two-option Confirm/Redo prompt (`#update_confirm`) — genuinely
+  auto-repeat in the real engine, and both gained `|| Input.repeat?(...)`
+  the same way. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+  held, repeat-only Down moves the pick cursor one row; the same, later,
+  flips the Confirm/Redo prompt to Redo), confirmed to fail against the
+  pre-fix code before the fix. **Still open**: `debug_menu.rb`, `title.rb`,
+  and every battle target/command list in `battle.rb`.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/order.rb
+++ b/mruby-rpg2k/mrblib/scene/order.rb
@@ -49,13 +49,23 @@ class RPG2k
 
       private
 
+      # Holding Down/Up auto-repeats both cursors here after the initial
+      # delay, not just a single step per tap -- confirmed against
+      # EasyRPG's actual source: `Scene_Order::vUpdate` (`src/
+      # scene_order.cpp`) calls `window_left->Update()`/`window_confirm->
+      # Update()` unconditionally, every frame, before ever checking which
+      # one is active -- both are genuine `Window_Selectable`s, whose own
+      # `Update()` is what actually drives the cursor (trigger-then-repeat,
+      # see `Scene::ItemMenu#update_items`'s fuller writeup); `GetActive()`
+      # only gates the *Decision/Cancel* handling in `UpdateOrder`/
+      # `UpdateConfirm`, not the cursor movement itself.
       def update_left
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           @counter == 0 ? @parent.pop : undo_last_pick
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           move_cursor(1)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           move_cursor(-1)
         elsif Input.trigger?(Input::C)
           pick_current
@@ -110,7 +120,8 @@ class RPG2k
       def update_confirm
         if Input.trigger?(Input::B)
           redo_picks
-        elsif Input.trigger?(Input::DOWN) || Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::DOWN) || Input.trigger?(Input::UP) ||
+              Input.repeat?(Input::DOWN) || Input.repeat?(Input::UP)
           @confirm_index = @confirm_index == 0 ? 1 : 0
           refresh_confirm_cursor
           play_system_se(SFX_CURSOR)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14683,6 +14683,43 @@ check 'Scene::Order: Redo clears every pick and returns to the left column, ' \
   eq original_order, state.party.actors.map(&:object_id), 'the party is untouched'
 end
 
+# EasyRPG's Scene_Order::vUpdate (src/scene_order.cpp) calls window_left->
+# Update()/window_confirm->Update() unconditionally, every frame -- both
+# genuine Window_Selectables whose own Update() drives the cursor
+# (trigger-then-repeat), before GetActive() ever gates which of
+# UpdateOrder/UpdateConfirm runs. So both cursors here auto-repeat, unlike
+# equip_menu.rb's/status_menu.rb's discrete-only actor switches.
+# `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold
+# a key across frames without it also reading as a fresh trigger.
+check 'Scene::Order: holding Down auto-repeats both the left-column pick ' \
+      'cursor and the Confirm/Redo prompt cursor' do
+  scene, = order_scene
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@cursor_index),
+     'a held (repeated, not triggered) Down still moves the pick cursor one row'
+
+  scene.instance_variable_set(:@cursor_index, 0)
+  RGSS::Input.triggered = [RGSS::Input::C] # pick Hero
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # onto the only unpicked row
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # pick Ally -- both picked, prompt opens
+  scene.update
+  RGSS::Input.reset
+  eq :confirm, scene.instance_variable_get(:@focus)
+  eq 0, scene.instance_variable_get(:@confirm_index), 'defaults to Confirm'
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@confirm_index),
+     'a held (repeated, not triggered) Down still flips the prompt cursor to Redo'
+end
+
 # -- Scene::SaveLoad: the save/load file-select screen -------------------------
 #
 # Scene::Menu's Save command and Scene::Title's Continue entry both used to


### PR DESCRIPTION
## Summary

- `Scene::Order`'s left-column pick cursor and Confirm/Redo prompt cursor
  only ever checked `Input.trigger?(DOWN/UP)`, the same gap already fixed
  on `Scene::SaveLoad` (#990), `Scene::Menu` (#991), `Scene::ItemMenu`
  (#993), `Scene::SkillMenu` (#994), and `Scene::EquipMenu` (#995).
- Confirmed against EasyRPG's actual source: `Scene_Order::vUpdate` calls
  `window_left->Update()`/`window_confirm->Update()` unconditionally, every
  frame, before ever checking `GetActive()` — both are genuine
  `Window_Selectable`s whose own `Update()` drives the cursor via the
  standard trigger-then-repeat, so unlike `equip_menu.rb`'s/
  `status_menu.rb`'s discrete-only actor switches, both cursors here
  genuinely auto-repeat in the real engine.
- Fixed both with `|| Input.repeat?(...)` alongside the existing trigger
  checks.
- The same audit remains open on `debug_menu.rb`, `title.rb`, and every
  battle target/command list in `battle.rb`, tracked in `docs/TODO.md`.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 707 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_