### PR TITLE
title: holding Down/Up now auto-repeats the command cursor

### DIFF
--- a/changelog.d/title-cursor-repeat.fixed.md
+++ b/changelog.d/title-cursor-repeat.fixed.md
@@ -1,0 +1,5 @@
+- **Title screen:** holding Down/Up now auto-repeats the New Game/Continue/
+  Shutdown cursor, matching real RPG_RT — continuing the same fix already
+  landed for the save/load, field-menu, item, skill, equip, and order
+  screens. Reuses this build's existing, wine-verified `Input.repeat?`
+  timing. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3685,6 +3685,28 @@ The work below is roughly ordered by the critical path to a walkable game
   flips the Confirm/Redo prompt to Redo), confirmed to fail against the
   pre-fix code before the fix. **Still open**: `debug_menu.rb`, `title.rb`,
   and every battle target/command list in `battle.rb`.
+  ✅ **`title.rb` next (2026-08-18).** Confirmed against EasyRPG Player's
+  actual source: `Scene_Title::vUpdate` (`src/scene_title.cpp`) calls
+  `command_window->Update()` unconditionally every frame, a genuine
+  `Window_Command` whose own `Update()` drives the cursor via the standard
+  trigger-then-repeat — no custom DOWN/UP handling of its own in
+  `vUpdate()` at all, since the window already does it. Fixed the same
+  `|| Input.repeat?(...)` way as every other plain command list. Covered
+  by a new `scripts/rpg2k_scene_check.rb` check (a held, repeat-only Down
+  moves the title cursor one step), confirmed to fail against the pre-fix
+  code before the fix. **`debug_menu.rb` deliberately skipped, not merely
+  not-yet-reached**: it is real RPG_RT's own F9 test-play menu (see the
+  file's own class comment), but EasyRPG Player's current `Scene_Debug`
+  (`src/scene_debug.cpp`) has since grown into a materially different,
+  modernised debug tool — a range/var/string-view/interpreter-view suite
+  with its own UI vocabulary — not a faithful port of the classic
+  Switch/Variable two-page F9 browser this codebase's own `debug_menu.rb`
+  models, so its current source cannot answer what the *original* engine's
+  F9 menu does here; applying the same fix without a genuine reference
+  would be guessing, not verifying, contrary to this whole series' own
+  method. **Still open**: `debug_menu.rb` (needs a different kind of
+  reference than EasyRPG's current source before it can be checked at
+  all) and every battle target/command list in `battle.rb`.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -99,9 +99,17 @@ class RPG2k
       def update
         @window.update
 
-        if Input.trigger?(Input::DOWN)
+        # Holding Down/Up auto-repeats the cursor after the initial delay,
+        # not just a single step per tap -- confirmed against EasyRPG's
+        # actual source: `Scene_Title::vUpdate` (`src/scene_title.cpp`)
+        # calls `command_window->Update()` unconditionally every frame, a
+        # genuine `Window_Command` (`Window_Selectable` subclass) whose own
+        # `Update()` is what drives the cursor via the standard
+        # trigger-then-repeat (see `Scene::ItemMenu#update_items`'s fuller
+        # writeup and docs/TODO.md).
+        if Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           move_selection 1
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           move_selection(-1)
         end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10630,6 +10630,22 @@ check 'no save data: Continue is flagged unavailable and reachable by the cursor
      'moving down from New Game still lands on Continue'
 end
 
+# See Scene::ItemMenu's identical check for the fuller writeup
+# (Window_Selectable::Update falls through to Input::IsRepeated right after
+# IsTriggered). `RGSS::Input.repeated` (distinct from `.triggered`) lets
+# this check hold a key across frames without it also reading as a fresh
+# trigger.
+check 'holding Down auto-repeats the title command cursor, not just a ' \
+      'single step per tap' do
+  parent = TitleParent.new(fake_db, nil, false, false)
+  scene = RPG2k::Scene::Title.new(parent)
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@selected_index),
+     'a held (repeated, not triggered) Down still moves the cursor one step'
+end
+
 check 'no save data: pressing the selection key on Continue plays Buzzer and opens nothing' do
   parent = TitleParent.new(fake_db, nil, false, false)
   scene = RPG2k::Scene::Title.new(parent)


### PR DESCRIPTION
## Summary

- `Scene::Title`'s New Game/Continue/Shutdown cursor only ever checked
  `Input.trigger?(DOWN/UP)`, the same gap already fixed on `Scene::SaveLoad`
  (#990), `Scene::Menu` (#991), `Scene::ItemMenu` (#993), `Scene::SkillMenu`
  (#994), `Scene::EquipMenu` (#995), and `Scene::Order` (#997).
- Confirmed against EasyRPG's actual source: `Scene_Title::vUpdate` calls
  `command_window->Update()` unconditionally every frame, a genuine
  `Window_Command` whose own `Update()` drives the cursor via the standard
  trigger-then-repeat — no custom DOWN/UP handling in `vUpdate()` itself.
- Fixed the same `|| Input.repeat?(...)` way.
- `debug_menu.rb` deliberately skipped this pass: EasyRPG's current
  `Scene_Debug` has grown into a materially different, modernised debug
  tool (a range/var/string-view/interpreter-view suite), not a faithful
  reference for the classic F9 menu this codebase's `debug_menu.rb` models,
  so it can't be checked the same way without guessing — noted in
  `docs/TODO.md` as needing a different kind of reference before it can be
  picked up.
- The audit remains open on battle's own target/command lists, tracked in
  `docs/TODO.md`.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 708 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_