### PR TITLE
battle: holding Down/Up now auto-repeats every cursor in the UI

### DIFF
--- a/changelog.d/battle-cursor-repeat.fixed.md
+++ b/changelog.d/battle-cursor-repeat.fixed.md
@@ -1,0 +1,8 @@
+- **Battle:** holding Down/Up now auto-repeats every cursor in the battle
+  UI — the options window (Fight/Auto Battle/Escape), the per-actor command
+  list, and the Skill/Item/enemy-target/ally-target lists — matching real
+  RPG_RT. This closes out the key-repeat fix already landed for the
+  save/load, field-menu, item, skill, equip, order, and title screens; only
+  the classic F9 debug menu remains open, pending a genuine reference for
+  its original behavior. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3707,6 +3707,37 @@ The work below is roughly ordered by the critical path to a walkable game
   method. **Still open**: `debug_menu.rb` (needs a different kind of
   reference than EasyRPG's current source before it can be checked at
   all) and every battle target/command list in `battle.rb`.
+  ✅ **`battle.rb` last (2026-08-18) — closes out this whole series.** All
+  six of its own cursor spots (`#drive_battle_options`, `#drive_battle_
+  command`, `#drive_battle_target` (enemy), `#drive_battle_skill`, `#drive_
+  battle_item`, `#drive_battle_ally_target`) only ever checked
+  `Input.trigger?(DOWN/UP)`. Confirmed against EasyRPG Player's actual
+  source: `Scene_Battle::UpdateUi` (`src/scene_battle.cpp`, the *shared*
+  base class, not the RPG2000-specific subclass), called unconditionally
+  every frame from `Scene_Battle_Rpg2k::vUpdate` (`grep`-confirmed: no
+  `IsTriggered(Input::DOWN/UP)` anywhere in `scene_battle_rpg2k.cpp`
+  itself at all — the base class's `UpdateUi` is the only place any of it
+  happens), calls `.Update()` on every one of `command_window`/
+  `status_window`/`item_window`/`skill_window`/`target_window`/
+  `options_window` — all genuine `Window_Selectable`s, whose own
+  `Update()` drives the cursor via the standard trigger-then-repeat, the
+  same as every menu screen in this series, before `SetActive`/
+  `GetActive` (confirmed via `status_window->SetActive(true)` right where
+  ally-target selection begins) ever gates which window's own Decision/
+  Cancel handling actually runs — the identical "cursor movement isn't
+  gated by which window is active" shape `Scene_Order` already established.
+  No exception this time, unlike `equip_menu.rb`/`status_menu.rb`'s
+  discrete-only actor switches: every one of the six spots gained
+  `|| Input.repeat?(...)` alongside its existing trigger checks. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check (a held, repeat-only Down
+  moves the options cursor, the per-actor command cursor, and the
+  enemy-target cursor each one step, driven through a real encounter from
+  the options window onward), confirmed to fail against the pre-fix code
+  before the fix. **This closes the whole key-repeat series** — every
+  RPG2000/2003 menu and battle list screen has now either been fixed the
+  same `|| Input.repeat?(...)` way or explicitly confirmed (with a citation
+  and a regression test) to be correctly discrete-only, except
+  `debug_menu.rb`, left open pending a genuine classic-F9-menu reference.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1182,14 +1182,25 @@ class RPG2k
         end
       end
 
-      # Per-actor command menu: Attack, Skill, Defend or Item.
+      # Per-actor command menu: Attack, Skill, Defend or Item. Holding Down/Up
+      # auto-repeats the cursor after the initial delay -- confirmed against
+      # EasyRPG's actual source: `Scene_Battle::UpdateUi` (`src/
+      # scene_battle.cpp`), called unconditionally every frame from
+      # `Scene_Battle_Rpg2k::vUpdate`, calls `.Update()` on every one of
+      # `command_window`/`status_window`/`item_window`/`skill_window`/
+      # `target_window`/`options_window` -- all genuine `Window_Selectable`s,
+      # whose own `Update()` is what drives the cursor via the standard
+      # trigger-then-repeat (see `Scene::ItemMenu#update_items`'s fuller
+      # writeup and docs/TODO.md), before `SetActive`/`GetActive` ever gates
+      # which one's Decision/Cancel handling actually runs. So every cursor
+      # spot in this scene gains `|| #repeat?` the same way.
       def drive_battle_command
-        if Input.trigger?(Input::DOWN)
+        if Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @ui[:cmd] += 1
           @ui[:cmd] %= battle_commands.length
           draw_battle_command
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @ui[:cmd] -= 1
           @ui[:cmd] %= battle_commands.length
           draw_battle_command
@@ -1281,12 +1292,12 @@ class RPG2k
       # back to).
       def drive_battle_options
         rows = battle_option_rows
-        if Input.trigger?(Input::DOWN)
+        if Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @ui[:opt] += 1
           @ui[:opt] %= rows.length
           draw_battle_options
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @ui[:opt] -= 1
           @ui[:opt] %= rows.length
           draw_battle_options
@@ -1472,12 +1483,12 @@ class RPG2k
       # enemy-scope Skill) hits.
       def drive_battle_target
         foes = living_foes
-        if Input.trigger?(Input::DOWN) && !foes.empty?
+        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !foes.empty?
           @ui[:target_i] += 1
           @ui[:target_i] %= foes.length
           draw_battle_target
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !foes.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !foes.empty?
           @ui[:target_i] -= 1
           @ui[:target_i] %= foes.length
           draw_battle_target
@@ -1558,12 +1569,12 @@ class RPG2k
 
       def drive_battle_skill
         skills = @ui[:skills]
-        if Input.trigger?(Input::DOWN) && !skills.empty?
+        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !skills.empty?
           @ui[:skill_i] += 1
           @ui[:skill_i] %= skills.length
           draw_battle_skill
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !skills.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !skills.empty?
           @ui[:skill_i] -= 1
           @ui[:skill_i] %= skills.length
           draw_battle_skill
@@ -1711,12 +1722,12 @@ class RPG2k
 
       def drive_battle_item
         items = @ui[:items]
-        if Input.trigger?(Input::DOWN) && !items.empty?
+        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !items.empty?
           @ui[:item_i] += 1
           @ui[:item_i] %= items.length
           draw_battle_item
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !items.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !items.empty?
           @ui[:item_i] -= 1
           @ui[:item_i] %= items.length
           draw_battle_item
@@ -1783,12 +1794,12 @@ class RPG2k
 
       def drive_battle_ally_target
         allies = battle_ally_targets
-        if Input.trigger?(Input::DOWN) && !allies.empty?
+        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !allies.empty?
           @ui[:ally_i] += 1
           @ui[:ally_i] %= allies.length
           draw_battle_ally_target
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) && !allies.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !allies.empty?
           @ui[:ally_i] -= 1
           @ui[:ally_i] %= allies.length
           draw_battle_ally_target

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9249,6 +9249,58 @@ check 'Enemy Encounter scene: casting an attack Skill damages a foe and spends S
   eq 7, ui[:allies].first.mp, 'the caster spent 3 SP (10 -> 7)'
 end
 
+# EasyRPG's Scene_Battle::UpdateUi (src/scene_battle.cpp), called
+# unconditionally every frame from Scene_Battle_Rpg2k::vUpdate, calls
+# .Update() on every one of command_window/status_window/item_window/
+# skill_window/target_window/options_window -- all genuine
+# Window_Selectables, whose own Update() drives the cursor via the
+# standard trigger-then-repeat, before SetActive/GetActive ever gates which
+# one's Decision/Cancel handling runs (see Scene::Order's identical shape).
+# `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold
+# a key across frames without it also reading as a fresh trigger.
+check 'Enemy Encounter scene: holding Down auto-repeats the battle options, ' \
+      'command and enemy-target cursors alike' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleMagicParty.new)
+  ui = battle_until_phase(scene, :battle_options)
+  ok ui, 'the options window opened'
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, ui[:opt], 'a held (repeated, not triggered) Down still moves the options cursor'
+
+  RGSS::Input.triggered = [RGSS::Input::UP] # back onto Fight
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss with Fight -> command phase
+  scene.update
+  RGSS::Input.reset
+  eq :command, ui[:phase]
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 1, ui[:cmd], 'a held (repeated, not triggered) Down still moves the command cursor'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # Skill -> Fire (enemy-scope) -> target
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :target, ui[:phase]
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 1, ui[:target_i], 'a held (repeated, not triggered) Down still moves the enemy-target cursor'
+end
+
 check 'Enemy Encounter scene: using an Item heals and consumes one from the bag' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Battle`'s six cursor spots — the options window (Fight/Auto
  Battle/Escape), the per-actor command list, and the Skill/Item/
  enemy-target/ally-target lists — only ever checked
  `Input.trigger?(DOWN/UP)`, the same gap already fixed across every other
  menu screen in this series (`Scene::SaveLoad` #990, `Scene::Menu` #991,
  `Scene::ItemMenu` #993, `Scene::SkillMenu` #994, `Scene::EquipMenu` #995,
  `Scene::Order` #997, `Scene::Title` #998).
- Confirmed against EasyRPG's actual source: `Scene_Battle::UpdateUi` (the
  shared base class, not the RPG2000-specific subclass), called
  unconditionally every frame from `Scene_Battle_Rpg2k::vUpdate` (no
  `IsTriggered(DOWN/UP)` anywhere in `scene_battle_rpg2k.cpp` itself), calls
  `.Update()` on every one of `command_window`/`status_window`/
  `item_window`/`skill_window`/`target_window`/`options_window` — all
  genuine `Window_Selectable`s whose own `Update()` drives the cursor via
  the standard trigger-then-repeat, before `SetActive`/`GetActive` ever
  gates which window's Decision/Cancel handling runs.
- No exception this time, unlike `equip_menu.rb`'s/`status_menu.rb`'s
  discrete-only actor switches: all six spots gained
  `|| Input.repeat?(...)`.
- **This closes the whole key-repeat series** — every RPG2000/2003 menu and
  battle list screen is now either fixed the same way or explicitly
  confirmed (with citation + regression test) to be correctly
  discrete-only, except `debug_menu.rb`, left open in `docs/TODO.md`
  pending a genuine classic-F9-menu reference (EasyRPG's current debug
  scene has evolved into a materially different tool, not a faithful
  comparison target).

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 709 checks passed (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_