### PR TITLE
map: event_position now resolves a hidden/erased event, not nil

### DIFF
--- a/changelog.d/event-position-hidden-erased-fallback.fixed.md
+++ b/changelog.d/event-position-hidden-erased-fallback.fixed.md
@@ -1,0 +1,8 @@
+- **Map events:** Control Variables' "Characters" X/Y/Direction operand and
+  Conditional Branch's "Character Direction is" test now resolve an erased
+  or currently-inactive-page map event at its last known position and
+  facing, matching real RPG_RT — they used to read 0/false (with a "map
+  event not found" warning) for any event outside its own live page, the
+  same gap Store Event ID already had fixed for it. Reuses the existing
+  `@event_last_position` fallback table. Covered by new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11742,6 +11742,36 @@ animation still plays nothing through `#start_battle_animation`.
   at that last-known tile, not its original spawn tile; a hidden event still
   outranks a lower-id live event sharing its old tile), all three of the new
   ones confirmed to fail against the pre-fix code before the fix.
+  ✅ **`#event_position` — the sibling query behind Control Variables'
+  "Characters" X/Y/Direction operand and Conditional Branch's "Character
+  Direction is" test — had the identical gap `#event_id_at` just above was
+  fixed for, and was simply never given the same treatment
+  (2026-08-18).** It searched only `@events` (the live/active-page list)
+  and returned `nil` for anything else, so a Control Variables read of an
+  erased or currently-inactive-page event's position/facing logged a "map
+  event not found" warning and read 0 instead of a real number, and a
+  Conditional Branch testing such an event's direction always took the
+  else branch regardless of what its frozen facing actually was. Confirmed
+  against EasyRPG Player's actual C++ source rather than left a guess —
+  the same call chain `#event_id_at`'s own writeup already traced for
+  Store Event ID applies here unchanged: `Game_Interpreter::GetCharacter`
+  (`src/game_interpreter.cpp`) → `Game_Character::GetCharacter`
+  (`src/game_character.cpp`) → `Game_Map::GetEvent` (`src/game_map.cpp`)
+  is an unconditional lookup by id with no active-state filter at all, and
+  `CommandEraseEvent` (`src/game_interpreter.cpp`) only flips the event's
+  own active flag — it never removes the `Game_Event` from the map's own
+  event list — so `ControlVariables::Event`'s X/Y/Direction cases
+  (`src/game_interpreter_control_variables.cpp`) and Conditional Branch's
+  own "Orientation of char" case keep reading a real, frozen last
+  position/facing off it. Fixed by giving `#event_position` the exact same
+  fallback to `@event_last_position` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  `#event_id_at` already has — no new state needed, since that table
+  already exists and is already kept current for this purpose. Covered by
+  two new `scripts/rpg2k_scene_check.rb` checks, mirroring `#event_id_at`'s
+  own sibling checks (a hidden event whose page stopped matching after
+  walking two tiles answers at that last-known tile and facing, not `nil`;
+  a temporarily-erased event answers at the tile it was erased on, not
+  `nil`), both confirmed to fail against the pre-fix code before the fix.
 
 **Database field semantics** (from the `11_db/` sweep, 48 findings — the
 single densest source in this pass; only the ones not already listed

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3987,13 +3987,36 @@ class RPG2k
       public :event_id_at
 
       # Position of the map event with the given id (its tile x/y and facing), for
-      # the Control Variables "character" operand, or nil when there is no such
-      # event. Queried by the interpreter via map_info.
+      # the Control Variables "character" operand and the Conditional Branch
+      # "Character Direction is" test, or nil when the id names no event at all.
+      # Queried by the interpreter via map_info.
+      #
+      # Falls back to @event_last_position -- the same frozen-position table
+      # #event_id_at already falls back to, for the identical reason -- for an
+      # event whose current page doesn't match any condition, or one Erase
+      # Event has removed for the rest of this visit: verified against
+      # EasyRPG Player's actual C++ source rather than left a guess.
+      # `Game_Interpreter::GetCharacter` (src/game_interpreter.cpp) ->
+      # `Game_Character::GetCharacter` (src/game_character.cpp) ->
+      # `Game_Map::GetEvent` (src/game_map.cpp) is an unconditional lookup by
+      # id with no active-state filter at all, and `CommandEraseEvent`
+      # (src/game_interpreter.cpp) only flips the event's own active flag --
+      # it never removes the `Game_Event` from the map's own event list -- so
+      # both `ControlVariables::Event`'s X/Y/Direction cases
+      # (src/game_interpreter_control_variables.cpp) and Conditional Branch's
+      # own "Orientation of char" case (src/game_interpreter.cpp) keep reading
+      # a real, frozen last position/facing off it, not nothing. `@events`
+      # (the live/active-page list this method used to search exclusively) is
+      # exactly what #event_id_at's own identical fallback already had to
+      # solve this same gap for.
       def event_position(id)
         ev = @events.find { |e| e[:id] == id }
-        return nil unless ev
-        c = ev[:char]
-        { x: c.x, y: c.y, direction: c.direction }
+        if ev
+          c = ev[:char]
+          return { x: c.x, y: c.y, direction: c.direction }
+        end
+        pos = @event_last_position[id]
+        pos && { x: pos[0], y: pos[1], direction: pos[2] }
       end
       public :event_position
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4451,6 +4451,53 @@ check 'a hidden event still outranks a lower-id live event sharing its old tile'
      'the higher-id hidden event still wins over the live lower-id event'
 end
 
+# #event_position (Control Variables' "Characters" X/Y/Direction operand and
+# Conditional Branch's "Character Direction is" test) used to search only
+# @events -- the live/active-page list -- and answer nil for anything else,
+# unlike its sibling #event_id_at just above, which already falls back to
+# @event_last_position for the identical reason. Verified against EasyRPG
+# Player's actual C++ source: Game_Interpreter::GetCharacter ->
+# Game_Character::GetCharacter -> Game_Map::GetEvent (src/game_map.cpp) is an
+# unconditional lookup by id with no active-state filter, and
+# CommandEraseEvent (src/game_interpreter.cpp) only flips the event's own
+# active flag -- it never removes the Game_Event from the map's own event
+# list -- so ControlVariables::Event's X/Y/Direction cases
+# (src/game_interpreter_control_variables.cpp) and Conditional Branch's own
+# "Orientation of char" case keep reading a real, frozen last position/facing
+# off it rather than nothing.
+check '#event_position resolves a hidden event at wherever it stood before ' \
+      'its page stopped matching, not nil' do
+  gated = page(trigger: 0, x_move_type: Game::MoveType::CUSTOM,
+               route: move_route([R::MOVE_RIGHT, R::MOVE_RIGHT], repeat: false))
+  gated.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 5)
+  scene = new_scene({ 2 => event(2, 2, gated) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.switches[5] = true
+  40.times { scene.update } # walks right twice and settles at (4, 2), facing right
+  eq [4, 2], [chars(scene)[2].x, chars(scene)[2].y], 'the route finished'
+
+  st.switches[5] = false
+  5.times { scene.update }
+  ok event_hashes(scene)[2].nil?, 'the condition no longer holds, so it drops off the map'
+  pos = scene.event_position(2)
+  ok pos, 'still answers instead of nil'
+  eq [4, 2], [pos[:x], pos[:y]], 'at its last-known tile, not its spawn tile'
+  eq 6, pos[:direction], 'and its last-known facing (right, from the MOVE_RIGHT route)'
+end
+
+check '#event_position resolves a temporarily-erased event at its frozen ' \
+      'position for the rest of the visit' do
+  ic = Game::Interpreter::Cmd
+  erasing = page(trigger: 3)
+  erasing.event_commands = [ECmd.new(ic::ERASE_EVENT, [])]
+  scene = new_scene({ 3 => event(2, 1, erasing) }, player: [5, 5])
+  10.times { scene.update }
+  ok event_hashes(scene)[3].nil?, 'the event is erased'
+  pos = scene.event_position(3)
+  ok pos, 'still answers instead of nil'
+  eq [2, 1], [pos[:x], pos[:y]], 'at the tile it was erased on'
+end
+
 check 'Proceed With Movement holds the interpreter until a forced route finishes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Map#event_position` (Control Variables' "Characters" X/Y/Direction
  operand, and Conditional Branch's "Character Direction is" test) searched
  only `@events` — the live/active-page list — and returned `nil` for
  anything else, unlike its sibling `#event_id_at`, which already falls
  back to `@event_last_position` for the identical reason.
- Confirmed against EasyRPG's actual source: `Game_Interpreter::
  GetCharacter` → `Game_Character::GetCharacter` → `Game_Map::GetEvent` is
  an unconditional lookup by id with no active-state filter, and
  `CommandEraseEvent` only flips the event's own active flag — it never
  removes the `Game_Event` from the map's own event list — so both real
  consumers keep reading a real, frozen last position/facing off it.
- Fixed by giving `#event_position` the same `@event_last_position`
  fallback `#event_id_at` already has — no new state needed.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 711 checks passed (both new
      checks confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_