### PR TITLE
map: Change/Trade Event Location now reach hidden and erased events

### DIFF
--- a/changelog.d/change-event-location-hidden-erased-fallback.fixed.md
+++ b/changelog.d/change-event-location-hidden-erased-fallback.fixed.md
@@ -1,0 +1,7 @@
+- **Map events:** Change Event Location and Trade Event Locations now
+  reposition a hidden (page condition currently unmet) or temporarily-erased
+  map event, matching real RPG_RT — they used to silently do nothing against
+  such a target, and for Trade Event Locations that aborted the *whole* swap,
+  so even the other, perfectly live, participant failed to move. Reuses the
+  existing `@event_last_position`/`@erased_event_positions` fallback tables.
+  Covered by new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11772,6 +11772,51 @@ animation still plays nothing through `#start_battle_animation`.
   walking two tiles answers at that last-known tile and facing, not `nil`;
   a temporarily-erased event answers at the tile it was erased on, not
   `nil`), both confirmed to fail against the pre-fix code before the fix.
+  ✅ **Change Event Location / Trade Event Locations silently no-op'd on a
+  hidden or temporarily-erased map event — the write-side sibling of
+  `#event_id_at`/`#event_position`'s own fix just above, left with the
+  identical gap (2026-08-18).** Both commands are routed through
+  `#char_location`/`#set_char_location` (`mruby-rpg2k/mrblib/scene/map.rb`),
+  and both helpers searched only `@events` (the live/active-page list),
+  answering/accepting `nil` for anything else. For Change Event Location
+  this meant the command was a complete no-op against such a target. For
+  Trade Event Locations it was worse: `#apply_location_request`'s swap
+  branch resolves both sides' tiles before moving either
+  (`a = char_location(...); b = char_location(...); return unless a && b`),
+  so one hidden/erased participant aborted the *entire* swap — the other,
+  perfectly live, event failed to move too. Confirmed against EasyRPG
+  Player's actual C++ source — the same call chain traced for Store Event
+  ID/`#event_position` applies unchanged here:
+  `Game_Interpreter::CommandChangeEventLocation` and
+  `CommandTradeEventLocations` (`src/game_interpreter.cpp`) both resolve
+  their target(s) through `Game_Interpreter::GetCharacter` →
+  `Game_Character::GetCharacter` (`src/game_character.cpp`) →
+  `Game_Map::GetEvent` (`src/game_map.cpp`), the identical unconditional
+  by-id lookup with no active-state filter — RPG_RT genuinely repositions
+  such an event's single, persistent backing object, live, hidden or
+  erased alike. Fixed by giving `#char_location`/`#set_char_location` the
+  same `@event_last_position` fallback `#event_id_at`/`#event_position`
+  already use for reading, extended to the write side: repositioning a
+  hidden target updates its `@event_last_position` entry (picked up again
+  the moment its page reactivates and something re-reads its position, the
+  same way ordinary movement already keeps that table current), and
+  repositioning an erased target also updates its frozen
+  `@erased_event_positions` entry, so `#event_id_at` stops answering for it
+  at the old tile and starts at the new one — keeping the two tables
+  consistent with each other exactly as `#erase_event`'s own seeding of
+  `@erased_event_positions` already relies on. `#erase_event`'s comment
+  claiming an erased event "cannot move any further" was corrected
+  alongside the fix, since it no longer held. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (Change Event Location repositions
+  a hidden event, confirmed via `#event_id_at`/`#event_position` at both
+  the old and new tile; Trade Event Locations swaps a live event with a
+  hidden one, confirmed the live event actually moves — the case that used
+  to silently abort entirely; Change Event Location repositions an
+  already-erased event, with a `Wait 0.0` between Erase Event and the move
+  so the erasure is genuinely applied — `@events.delete` happens in a
+  separate post-step pass, not inline with the command — before the move
+  command runs), all three confirmed to fail against the pre-fix code
+  before the fix.
 
 **Database field semantics** (from the `11_db/` sweep, 48 findings — the
 single densest source in this pass; only the ones not already listed

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2799,9 +2799,13 @@ class RPG2k
         @erased_events[ev[:id]] = true
         tile = [ev[:char].x, ev[:char].y]
         deindex_event_tile(ev, tile[0], tile[1])
-        # Frozen at the tile it occupied right before erasure -- an erased
-        # event cannot move any further, and #event_id_at still needs it (see
-        # there) even though it no longer blocks or draws.
+        # Starts frozen at the tile it occupied right before erasure --
+        # #event_id_at still needs it (see there) even though the event no
+        # longer blocks or draws. Not immutable, though: Change Event
+        # Location / Trade Event Locations can still reposition an erased
+        # event's single backing object (see #set_char_location), and keep
+        # this table in sync when they do, the same way ordinary movement
+        # keeps @event_last_position current for a merely-hidden one.
         @erased_event_positions[ev[:id]] = tile
         @parallels.reject! { |p| p[:event].equal?(ev) } if @parallels
       end
@@ -3494,7 +3498,17 @@ class RPG2k
       end
 
       # The current tile of a target character (the same target ids as Move
-      # Event), or nil for the player-less vehicle slots / a missing event.
+      # Event), or nil for the player-less vehicle slots / a wholly unknown
+      # event id. A hidden (page condition unmet) or temporarily-erased map
+      # event still answers here, from @event_last_position -- the same
+      # fallback #event_position already uses, for the identical reason (see
+      # its own comment): `Game_Interpreter::GetCharacter` ->
+      # `Game_Character::GetCharacter` -> `Game_Map::GetEvent`
+      # (src/game_character.cpp / src/game_map.cpp) is an unconditional
+      # lookup by id with no active-state filter, so Change Event Location /
+      # Trade Event Locations (both routed through here) genuinely read and
+      # reposition such an event's real, single backing object in RPG_RT --
+      # they are not restricted to only ever touching a currently-visible one.
       def char_location(target, this_event)
         case target
         when MOVE_TARGET_PLAYER
@@ -3506,7 +3520,12 @@ class RPG2k
           [v.x, v.y]
         else
           ev = @events.find { |e| e[:id] == target }
-          ev ? [ev[:char].x, ev[:char].y] : nil
+          if ev
+            [ev[:char].x, ev[:char].y]
+          else
+            pos = @event_last_position[target]
+            pos && [pos[0], pos[1]]
+          end
         end
       end
 
@@ -3516,6 +3535,17 @@ class RPG2k
       # alone, matching Teleport's own "0 means keep it" convention. Trade
       # Event Locations carries no facing at all, so it always calls this
       # with `dir` left at its default).
+      #
+      # A hidden or temporarily-erased map event target (no live
+      # Game::Character to move) is repositioned in @event_last_position
+      # instead -- the same table #char_location's own identical fallback
+      # reads -- so a later page refresh that reactivates it, or a Show
+      # Hidden Monster-style un-erase this codebase might add, resumes at
+      # wherever the command actually sent it rather than a stale pre-move
+      # tile. An erased target's frozen @erased_event_positions entry (what
+      # #event_id_at reads for it -- see #erase_event) is updated the same
+      # way, so a tile-occupancy query at the *old* location stops answering
+      # for it and the *new* one starts.
       def set_char_location(target, this_event, x, y, dir = nil)
         case target
         when MOVE_TARGET_PLAYER
@@ -3535,6 +3565,10 @@ class RPG2k
           if ev
             move_event_to(ev, x, y)
             ev[:char].face!(dir) if dir && dir > 0
+          elsif @event_last_position[target]
+            prior_dir = @event_last_position[target][2]
+            @event_last_position[target] = [x, y, (dir && dir > 0) ? dir : prior_dir]
+            @erased_event_positions[target] = [x, y] if @erased_events[target]
           end
         end
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3363,6 +3363,73 @@ check 'Trade Event Locations swaps two events' do
   eq [2, 2], [b.x, b.y], 'event 2 took event 1 old tile'
 end
 
+# Change Event Location / Trade Event Locations are #event_position's write-
+# side siblings, both routed through #char_location/#set_char_location, and
+# had the identical gap: only @events (the live/active-page list) was
+# searched, so targeting a hidden (page condition unmet) or temporarily-
+# erased event silently did nothing at all -- worse for Trade Event
+# Locations, whose #apply_location_request aborts the *entire* swap
+# (`return unless a && b`) the moment either side resolves to nil, so even
+# the live participant failed to move. Verified against EasyRPG Player's
+# actual C++ source: CommandChangeEventLocation and
+# CommandTradeEventLocations (src/game_interpreter.cpp) both resolve their
+# target(s) through the same unconditional-by-id Game_Interpreter::
+# GetCharacter -> Game_Character::GetCharacter -> Game_Map::GetEvent chain
+# #event_position's own fix already relies on, so RPG_RT genuinely
+# repositions such an event's single, persistent backing object. Fixed by
+# giving #char_location/#set_char_location the same @event_last_position
+# fallback #event_id_at/#event_position already use, keeping
+# @erased_event_positions in sync too for an erased target so #event_id_at
+# answers correctly at the new tile afterward.
+check 'Change Event Location repositions a hidden event, not just a live one' do
+  ic = Game::Interpreter::Cmd
+  hidden = page(trigger: 0)
+  hidden.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 5)
+  auto = page(trigger: 3) # auto-start: move hidden event 2 to (6, 6)
+  auto.event_commands = [ECmd.new(ic::CHANGE_EVENT_LOCATION, [2, 0, 6, 6])]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(2, 2, hidden) },
+                    player: [5, 5])
+  5.times { scene.update }
+  ok event_hashes(scene)[2].nil?, 'event 2 has no active page, so it is not on the map'
+  eq 2, scene.event_id_at(6, 6), 'it was still repositioned, to its new tile'
+  eq 0, scene.event_id_at(2, 2), 'and no longer answers at its old tile'
+  pos = scene.event_position(2)
+  eq [6, 6], [pos[:x], pos[:y]], 'and #event_position agrees'
+end
+
+check 'Trade Event Locations swaps a live event with a hidden one' do
+  ic = Game::Interpreter::Cmd
+  hidden = page(trigger: 0)
+  hidden.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 5)
+  auto = page(trigger: 3) # auto-start: swap this event (1) with hidden event 2
+  auto.event_commands = [ECmd.new(ic::TRADE_EVENT_LOCATIONS, [10005, 2])]
+  scene = new_scene({ 1 => event(2, 2, auto), 2 => event(6, 6, hidden) },
+                    player: [5, 5])
+  5.times { scene.update }
+  a = chars(scene)[1]
+  eq [6, 6], [a.x, a.y], "the live event took the hidden event's old tile " \
+                         '(pre-fix, the whole swap silently aborted)'
+  ok event_hashes(scene)[2].nil?, 'event 2 is still hidden'
+  eq 2, scene.event_id_at(2, 2), "and now answers at event 1's old tile instead"
+  eq 1, scene.event_id_at(6, 6),
+     "its own old tile now answers for the live event that moved onto it"
+end
+
+check 'Change Event Location repositions an already-erased event too' do
+  ic = Game::Interpreter::Cmd
+  erasing = page(trigger: 3)
+  erasing.event_commands = [
+    ECmd.new(ic::ERASE_EVENT, []),
+    ECmd.new(ic::WAIT, [0]), # let Erase Event actually apply before moving on
+    ECmd.new(ic::CHANGE_EVENT_LOCATION, [1, 0, 7, 7]),
+  ]
+  scene = new_scene({ 1 => event(2, 1, erasing) }, player: [5, 5])
+  10.times { scene.update }
+  ok event_hashes(scene)[1].nil?, 'the event is erased'
+  eq 1, scene.event_id_at(7, 7), 'it was still repositioned after erasure, to its new tile'
+  eq 0, scene.event_id_at(2, 1), 'and no longer answers at the tile it was erased on'
+end
+
 check 'Change Map Tileset rebuilds the map chipset from the new id' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- Change Event Location and Trade Event Locations were routed through `#char_location`/`#set_char_location` (`mruby-rpg2k/mrblib/scene/map.rb`), which only ever searched `@events` (the live/active-page list) — the same gap the previous PR (#1001) fixed for `#event_id_at`/`#event_position` on the read side.
- For Change Event Location this meant the command silently no-op'd against a hidden (page condition currently unmet) or temporarily-erased target. For Trade Event Locations it was worse: `#apply_location_request`'s swap branch resolves both sides' tiles before moving either (`return unless a && b`), so a hidden/erased participant aborted the *entire* swap — the other, perfectly live, event failed to move too.
- Verified against EasyRPG Player's actual C++ source: `CommandChangeEventLocation`/`CommandTradeEventLocations` (`src/game_interpreter.cpp`) resolve targets through the same unconditional-by-id `GetCharacter` chain already traced for the read-side fix, so RPG_RT genuinely repositions such an event's single, persistent backing object regardless of its current active state.
- Fixed by giving `#char_location`/`#set_char_location` the same `@event_last_position` fallback the read side already uses, extended to the write side: a hidden target's `@event_last_position` entry is updated (picked up again once its page reactivates), and an erased target's frozen `@erased_event_positions` entry is kept in sync too, so `#event_id_at` answers at the new tile afterward.
- Corrected `#erase_event`'s comment, which claimed an erased event "cannot move any further" — no longer true.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 714 checks passed (3 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] All 3 new checks confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_