### PR TITLE
interpreter: cascaded Auto-Start events share one frame's step budget

### DIFF
--- a/changelog.d/autostart-cascade-shared-step-budget.fixed.md
+++ b/changelog.d/autostart-cascade-shared-step-budget.fixed.md
@@ -1,0 +1,8 @@
+- **Map events:** A cascade of several no-Wait Auto-Start events finishing
+  within the same real frame now shares one combined 10000-command step
+  budget for that frame, matching real RPG_RT — each cascaded event used to
+  get its own fresh 10000-step budget, so a chain of N heavy Auto-Start
+  events could burn up to `N * 10000` steps in a single frame instead of
+  spilling the excess into later frames like a lone heavy event already did.
+  Each Parallel Process keeps its own independent budget, unaffected. Covered
+  by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12817,16 +12817,28 @@ session (reading + documenting only, not fixed — see below):
   re-fires on every subsequent frame once it drains) is now implemented, as
   described in the bullet above. The *within*-frame same-event restart half
   (a no-wait Autorun re-running from the top inside the very same frame, up to
-  the 50000-step-per-frame budget) remains open: doing so faithfully needs
-  `Game::Interpreter`'s `MAX_STEPS` budget threaded *across* repeated
-  `#start`/`#update` calls within one `Scene::Map#update` (today each call
-  gets a fresh budget), and — far more disruptively — would make *every*
-  existing Auto-Start `scripts/rpg2k_scene_check.rb` fixture that does not
-  itself clear its own eligibility (turn off its gating switch, change page,
-  erase itself) before its script naturally ends start looping every frame
-  instead of running once, which is not something a single surgical session
-  can safely audit and re-baseline across ~450 existing checks. Left open, now
-  with a precise citation trail for whoever picks it up next.
+  the 10000-step-per-frame budget) remains open: doing so faithfully needs
+  `#start_autostart`'s own eligibility check to let an id it already started
+  *this same frame* be picked again the instant its script naturally ends
+  with no Wait (today `@started_auto`/`@started_common` block exactly that,
+  unconditionally, deliberately unrelated to the step budget) — and, far more
+  disruptively, would make *every* existing Auto-Start
+  `scripts/rpg2k_scene_check.rb` fixture that does not itself clear its own
+  eligibility (turn off its gating switch, change page, erase itself) before
+  its script naturally ends start looping every frame instead of running
+  once, which is not something a single surgical session can safely audit and
+  re-baseline across ~450 existing checks. Left open, now with a precise
+  citation trail for whoever picks it up next. `Game::Interpreter`'s
+  `MAX_STEPS` budget itself threaded *across* repeated `#start`/`#update`
+  calls within one real frame (previously: every call got its own fresh
+  10000, an independent bug this same restart writeup used to cite as a
+  missing prerequisite) is now fixed on its own, see the "Auto-Start cascade
+  now shares one real frame's step budget" bullet below — a building block
+  for this still-open restart feature, not the feature itself: it only
+  changes how much of a frame's budget a *different*, already-eligible
+  cascaded event gets to spend, and touches no eligibility logic at all, so
+  a same event still cannot restart within its own frame until the
+  paragraph above is separately addressed.
 
 **Untriaged backlog** (raw reference material, not checked against the
 codebase yet):
@@ -12877,6 +12889,52 @@ codebase yet):
   cascades into a distinct auto-start *common* event within the same frame),
   the first and third confirmed to fail against the pre-fix code (the second
   event's switch not yet set) before the fix.
+- ✅ **Auto-Start cascade now shares one real frame's step budget, not a
+  fresh one per event — the cascading fix just above got event *selection*
+  right but left the step-budget half of the same underlying mechanism
+  untouched (2026-08-18).** `Game::Interpreter#update`'s `MAX_STEPS` (10000)
+  budget was a plain local (`steps = 0` at the top of every call), so each
+  `#update` call — including every one `#drive_autostart_cascade`'s own loop
+  makes as it starts a second, third, ... distinct no-Wait Auto-Start event
+  within the same real frame — got its own fresh 10000, rather than the whole
+  frame sharing one. A chain of N heavy, no-Wait Auto-Start events could
+  therefore burn up to `N * 10000` steps in a single real frame instead of a
+  combined 10000 with the rest spilling into later frames, same as a lone
+  heavy event already correctly does. Verified against EasyRPG Player's
+  actual C++ source: `Game_Interpreter::loop_count`/`loop_limit`
+  (`src/game_interpreter.h`) are member variables, not locals reset on every
+  `Update()` call, and `Game_Map::UpdateForegroundEvents`
+  (`src/game_map.cpp`) resets `loop_count` to 0 exactly once per real frame
+  (`interp.Update(!resume_fg)`) then keeps calling `Update(false)` — no
+  reset — for every event it cascades into afterward, so the entire frame's
+  cascade genuinely draws from one shared pool, and `ReachedLoopLimit()`
+  (checked *before* running each command, `for (; loop_count < loop_limit;
+  ++loop_count)`) is what actually stops the whole cascade once it is spent,
+  deferring the rest to the next frame. Fixed by moving the counter onto
+  `Game::Interpreter` as `@frame_steps` (`mruby-rpg2k/mrblib/interpreter.rb`),
+  reset only by a new `#reset_frame_steps`, called exactly once per real
+  frame — from `Scene::Map#update`, right alongside its existing
+  `@started_auto`/`@started_common` per-frame reset, for the shared
+  foreground interpreter, and from `Scene::Map#step_parallel` for each
+  Parallel Process's own, independent interpreter (matching EasyRPG, where
+  each is its own separate `Game_Interpreter` object with its own
+  `loop_count`) — and by moving the budget check in `#update` from *after*
+  each command back to *before* it, so a same-frame call arriving once the
+  budget is already spent (another cascaded event, or one of
+  `Scene::Map#drive_event`'s own "spend this frame's step budget
+  immediately" resumption branches) cannot sneak in one extra command on top
+  of it. This is a narrower building block for the still-open "within-frame
+  same-event restart" question discussed above, not that feature itself —
+  see there for why eligibility (`@started_auto`), not the budget, is what
+  actually gates a same-frame restart, and remains untouched here. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check that stubs `MAX_STEPS` down to 3
+  for the duration of the check (so it does not have to actually run 10000
+  commands): a one-shot Auto-Start event with exactly 3 single-cost commands
+  spends the whole frame's budget, and a second, distinct Auto-Start event
+  cascaded in behind it gets none of its own this same frame (only runs once
+  the next real frame's budget resets), confirmed to fail against the
+  pre-fix code (the second event ran immediately, on its own fresh budget)
+  before the fix.
 - ✅ **A body-less command block still spends a step — already correct, now
   confirmed against this codebase's own code and its own real-game command-
   frequency audit rather than left as a wiki restatement.** The wiki's own

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -221,6 +221,9 @@ module Game
       # exists but is unseeded, and these runs are diffed); seeded like the map
       # scene's own RNG.
       @rng = Game::Rng.new(0x2000)
+      # See MAX_STEPS/#reset_frame_steps: this frame's shared step budget,
+      # not touched by #start (only genuinely reset once per real frame).
+      @frame_steps = 0
       reset_waits
     end
 
@@ -468,28 +471,58 @@ module Game
       name
     end
 
-    # Upper bound on commands run in a single update (one map frame): RPG_RT
-    # processes at most 10000 "steps" of event commands per 1/60s frame, after
-    # which the rest waits for the next frame -- this is what makes a
-    # tight/heavy loop visibly slow down the game instead of freezing it.
+    # Upper bound on commands run in a single real frame (1/60s): RPG_RT
+    # processes at most 10000 "steps" of event commands per frame, after which
+    # the rest waits for the next frame -- this is what makes a tight/heavy
+    # loop visibly slow down the game instead of freezing it. Verified against
+    # EasyRPG Player's actual C++ source: `Game_Interpreter::loop_count`/
+    # `loop_limit` (src/game_interpreter.h) are member variables, not a local
+    # reset on every `Update()` call -- `Game_Map::UpdateForegroundEvents`
+    # (src/game_map.cpp) resets `loop_count` to 0 exactly once per real frame
+    # and then keeps calling `Update(false)` (no reset) as it cascades through
+    # every Auto-Start event that starts and finishes within that same frame,
+    # so the whole cascade shares one 10000-step budget rather than each
+    # event getting its own fresh one. `@frame_steps` (below) is this
+    # codebase's `loop_count`: it is *not* reset here or in #start, only by
+    # #reset_frame_steps, which the owning scene calls exactly once per real
+    # frame (see Scene::Map#update / #step_parallel) -- #start deliberately
+    # leaves it alone so a cascaded Auto-Start started later in the same
+    # frame (Scene::Map#drive_autostart_cascade) keeps spending down the same
+    # frame's budget instead of getting a fresh 10000.
     MAX_STEPS = 10_000
+
+    # Reset this frame's shared step budget. Call exactly once per real frame,
+    # before the first #update call of that frame -- see #update and
+    # MAX_STEPS's own comment above.
+    def reset_frame_steps
+      @frame_steps = 0
+    end
 
     # Advance through commands until the list ends or a command asks to wait.
     # When the current (possibly called) list runs out, control returns to the
     # caller via the call stack; the process ends only once the outermost list is
-    # exhausted.
+    # exhausted. May be called more than once within the same real frame (a
+    # resumed Wait/Battle/Animation that clears mid-frame keeps going rather
+    # than losing a frame -- see Scene::Map#drive_event's own "spend this
+    # frame's step budget immediately" call sites) or after a fresh #start
+    # cascaded in from the same frame's Auto-Start scan -- @frame_steps
+    # persists across all of them, only #reset_frame_steps clears it.
     def update
       return unless @running
-      steps = 0
       until @waiting
         # Unwind any exhausted called lists back to a caller with commands left.
         return_from_call while @index >= @list.size && !@call_stack.empty?
         break if @index >= @list.size # nothing left anywhere
+        # Checked *before* running the next command (matching EasyRPG's own
+        # `for (; loop_count < loop_limit; ++loop_count)`), not after: once a
+        # frame's shared budget is spent, a fresh #update call this same
+        # frame (another cascaded event, or a same-frame resume) must not
+        # sneak in "just one more" command on top of it.
+        break if @frame_steps >= MAX_STEPS
         cmd = @list[@index]
         @index += 1
         execute cmd
-        steps += step_cost(cmd.code)
-        break if steps >= MAX_STEPS
+        @frame_steps += step_cost(cmd.code)
       end
       if finished?
         @running = false

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -434,6 +434,12 @@ class RPG2k
         # visit" bullet in docs/TODO.md.
         @started_auto.clear
         @started_common.clear
+        # This real frame's foreground step budget starts fresh here (see
+        # Game::Interpreter::MAX_STEPS/#reset_frame_steps) -- every
+        # @interpreter.update call below, however many times #drive_event and
+        # #drive_autostart_cascade's own cascading call it this frame, shares
+        # this one reset rather than each getting its own fresh 10000.
+        @interpreter.reset_frame_steps
         if event_busy?
           drive_event
           # Message Options' "move other events during message" toggle: other
@@ -1674,6 +1680,16 @@ class RPG2k
       def step_parallel(p)
         return if p[:gate_switch] && !@state.switches[p[:gate_switch]]
         it = p[:interp]
+        # Each Parallel Process is its own Game_Interpreter in real RPG_RT too,
+        # so it gets its own frame-shared step budget, independent of the
+        # foreground's -- see Game::Interpreter::MAX_STEPS. #step_parallel is
+        # called at most once per real frame per process (#step_parallels'
+        # own once-a-frame loop, or #step_battle_owner_parallel's mutually
+        # exclusive stand-in for the one this fight belongs to), so resetting
+        # here is exactly the once-per-frame reset MAX_STEPS' own comment
+        # requires, however many times `it.update` below ends up called this
+        # same frame (a same-frame Wait/Animation resume can call it twice).
+        it.reset_frame_steps
         if it.waiting?
           wait_kind = it.wait_kind
           drive_parallel_wait(p, it)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2030,6 +2030,53 @@ check 'a distinct auto-start common event cascades in behind a finishing ' \
   ok st.switches[2], 'the auto-start common event cascaded in the same frame'
 end
 
+# The cascade above (and Game::Interpreter#update generally) used to give
+# *every* #update call its own fresh MAX_STEPS budget -- a local `steps = 0`
+# reset at the top of the method -- rather than sharing one budget across a
+# whole real frame's worth of calls. Verified against EasyRPG Player's actual
+# C++ source rather than assumed from the cascading fix's own already-correct
+# writeup above: `Game_Interpreter::loop_count`/`loop_limit`
+# (src/game_interpreter.h) are member variables, not a local, and
+# `Game_Map::UpdateForegroundEvents` (src/game_map.cpp) resets `loop_count`
+# to 0 exactly once per real frame (`interp.Update(!resume_fg)`) and then
+# keeps calling `Update(false)` -- no reset -- as it cascades through every
+# Auto-Start event that starts and finishes within that same frame. So a
+# chain of several heavy, no-Wait Auto-Start events could burn up to
+# `N * 10000` steps in one real frame instead of a combined 10000, spilling
+# the rest into later frames the way a single heavy event already does.
+# Fixed by moving the counter onto `Game::Interpreter` as `@frame_steps`
+# (mruby-rpg2k/mrblib/interpreter.rb), reset only once per real frame
+# (`#reset_frame_steps`, called from `Scene::Map#update` for the foreground
+# interpreter and from `#step_parallel` for each Parallel Process's own,
+# independent budget), and checking it *before* running each command rather
+# than after, matching EasyRPG's `for (; loop_count < loop_limit; ...)`
+# exactly -- otherwise a same-frame call arriving after the budget is already
+# spent would still sneak in one more command apiece.
+check "an Auto-Start cascade shares one real frame's step budget, not a " \
+      "fresh one each (yado.tk's 10000-step budget is per frame, not per event)" do
+  Game::Interpreter.send(:remove_const, :MAX_STEPS)
+  Game::Interpreter.const_set(:MAX_STEPS, 3)
+  begin
+    p1 = page(trigger: 3) # auto-start: 3 single-cost commands, exactly the budget
+    p1.event_commands = [add_var_cmd(1), add_var_cmd(1), add_var_cmd(1)]
+    one_shot_auto(p1, 9001) # fire once: else it would win the race again next frame too
+    p2 = page(trigger: 3) # auto-start: a second, distinct event, cascaded in behind it
+    p2.event_commands = [add_var_cmd(2)]
+    scene = new_scene({ 1 => event(1, 1, p1), 2 => event(2, 2, p2) }, player: [0, 0])
+    st = scene.instance_variable_get(:@state)
+    scene.update
+    eq 3, st.variables[1], 'the first event ran to completion, spending the whole budget'
+    eq 0, st.variables[2],
+       'the cascaded second event must not get a fresh budget of its own -- ' \
+       'nothing was left this frame'
+    scene.update # a fresh real frame resets the shared budget
+    eq 1, st.variables[2], "it runs once the next frame's budget has reset"
+  ensure
+    Game::Interpreter.send(:remove_const, :MAX_STEPS)
+    Game::Interpreter.const_set(:MAX_STEPS, 10_000)
+  end
+end
+
 check 'Wait 0.0 sec doubles a parallel process lap gap to two frames' do
   # A parallel process already gets a free one-frame gap between laps with no
   # explicit wait at all (the check above). Adding a Wait 0.0 stacks one more


### PR DESCRIPTION
## Summary

- `Game::Interpreter#update`'s `MAX_STEPS` (10000) per-frame command budget was a plain local (`steps = 0` reset at the top of every call), so every `#update` call got its own fresh 10000 — including each call `Scene::Map#drive_autostart_cascade`'s own loop makes as it cascades into a second, third, ... distinct no-Wait Auto-Start event within the same real frame (a cascade this codebase already correctly implements for event *selection*, see the earlier "Autorun cascading within one frame" fix). A chain of N heavy, no-Wait Auto-Start events could therefore burn up to `N * 10000` steps in a single real frame instead of a combined 10000, with the excess spilling into later frames the way a lone heavy event already correctly does.
- Verified against EasyRPG Player's actual C++ source: `Game_Interpreter::loop_count`/`loop_limit` (`src/game_interpreter.h`) are member variables, not locals reset on every `Update()` call. `Game_Map::UpdateForegroundEvents` (`src/game_map.cpp`) resets `loop_count` to 0 exactly once per real frame (`interp.Update(!resume_fg)`), then keeps calling `Update(false)` — no reset — as it cascades through every eligible event within that same frame, and `ReachedLoopLimit()` (checked *before* running each command, matching `for (; loop_count < loop_limit; ++loop_count)`) is what actually halts the cascade once the shared budget is spent.
- Fixed by moving the counter onto `Game::Interpreter` as `@frame_steps` (`mruby-rpg2k/mrblib/interpreter.rb`), reset only via a new `#reset_frame_steps`, called exactly once per real frame — from `Scene::Map#update` for the shared foreground interpreter (alongside its existing `@started_auto`/`@started_common` per-frame reset), and from `Scene::Map#step_parallel` for each Parallel Process's own independent interpreter (matching EasyRPG, where each Parallel Process is its own `Game_Interpreter` object with its own budget). Also moved the budget check from *after* each command to *before* it, so a same-frame call arriving once the budget is already spent can't sneak in one extra command.
- This is a narrower building block for the still-open "within-frame same-event restart" question already documented in `docs/TODO.md` — not that feature itself. Eligibility (`@started_auto`/`@started_common`), not the step budget, is what gates a same-frame restart, and is untouched by this change.
- Also corrected a stale claim in the existing "Autorun (auto-start) events run at most once per map visit" `docs/TODO.md` bullet, which had cited this exact per-call-fresh-budget issue as an unaddressed prerequisite.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 715 checks passed (1 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] New check (stubs `MAX_STEPS` down to 3 for the duration of the check) confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_