### PR TITLE
map: Show Inn issued from a Parallel Process now opens the inn screen

### DIFF
--- a/changelog.d/show-inn-parallel-process.fixed.md
+++ b/changelog.d/show-inn-parallel-process.fixed.md
@@ -1,0 +1,8 @@
+- **Events:** Show Inn issued from a Parallel Process now actually opens the
+  inn screen, matching real RPG_RT — it used to be a silent no-op, the same
+  defect Open Shop and Enter Hero Name had before their own earlier fixes.
+  Also reproduces a documented RPG_RT quirk EasyRPG's own source calls out: a
+  *priced* stay issued from a Parallel Process now barges open over an
+  already-open message window instead of waiting for it to clear, while a
+  *free* stay still waits, matching the asymmetry in real RPG_RT. Covered by
+  two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7060,7 +7060,8 @@ not yet verified:
   `main_flag`/`CanShowMessage` "Emulates RPG_RT behavior (Bug?)" nuance for
   a Parallel-Process caller specifically (it *skips* the message-active
   check rather than honouring it) — both left open for a future, separately
-  well-scoped fix rather than folded into this one.
+  well-scoped fix rather than folded into this one. Both are now fixed, see
+  below.
 - ✅ **Open Shop (10720) issued from a Parallel Process now actually opens the
   shop screen, instead of silently doing nothing.** The exact sibling defect
   to the Enter Hero Name fix just above, now closed the same way. Confirmed
@@ -7091,6 +7092,52 @@ not yet verified:
   Open Shop through open → buy → confirm → leave → resume into its
   [Transaction] branch, confirmed to fail against the pre-fix code (the shop
   screen never opened at all) before the fix.
+- ✅ **Show Inn (10730) issued from a Parallel Process now actually opens the
+  inn screen too, including reproducing EasyRPG's own documented
+  Parallel-Process-specific quirk rather than smoothing it away
+  (2026-08-18).** The last of this family, deliberately left open by the
+  Enter Hero Name/Open Shop bullets above pending its own well-scoped fix,
+  since it is not a plain sibling of those two: EasyRPG's
+  `Game_Interpreter_Map::CommandShowInn` (`src/game_interpreter_map.cpp`,
+  re-fetched and re-read live this session) is still the exact same method
+  for the foreground and every Parallel Process's own interpreter, but a
+  *priced* stay (`inn_price > 0`) is gated `main_flag &&
+  !Game_Message::CanShowMessage(main_flag)` — `main_flag` is false for
+  every non-foreground interpreter, so that whole condition is always false
+  for a Parallel Process, skipping the message-active check entirely.
+  EasyRPG's own comment calls this out explicitly: `// Emulates RPG_RT
+  behavior (Bug?) Inn's called by parallel events overwrite the current
+  message.` `CanShowMessage` itself (`src/game_message.cpp`) is a thin
+  wrapper over `Game_Message::Window::GetAllowNextMessage`, purely a
+  message-window check, unrelated to the shop/name-input widgets. A *free*
+  stay (`inn_price == 0`) keeps the ordinary `IsMessageActive()` gate for
+  every caller alike — `CommandShowInn`'s own separate `if (inn_price == 0)
+  { if (IsMessageActive()) return false; ...` branch never mentions
+  `main_flag` at all. This build's `Interpreter#do_show_inn`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) already recorded the request and
+  suspended on an `:inn` wait regardless of caller, but `Scene::Map
+  #drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) had no `:inn`
+  branch at all, so a Parallel Process's own Show Inn fell into the generic
+  `else` → unconditional `it.resume`, the identical no-op defect Enter Hero
+  Name/Open Shop had. Fixed by threading the owning interpreter through
+  `#drive_inn(it = @interpreter)`, `#start_inn_fade_out(it = @interpreter)`
+  and `#finish_inn(stayed, it = @interpreter)` (mirroring `#drive_shop`'s
+  own `it` idiom), recording it in a new `@inn_interp` ivar (mirroring
+  `@shop[:interp]`, but a standalone ivar rather than a hash field since the
+  inn flow's own state is already spread across several loose ivars, not
+  one shop-style hash) so a second, distinct interpreter's own Show Inn
+  request waits for this one's flow to finish first, and adding the missing
+  `:inn` branch to `#drive_parallel_wait` — but unlike every other branch in
+  this family, it does *not* uniformly block on `@message.nil?`: a priced
+  request (`req[:prompt]`) drives immediately regardless of any open
+  message window, reproducing the emulated bug exactly, while a free stay
+  keeps the ordinary message gate. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (a priced Show Inn from a Parallel
+  Process opens its prompt despite an open, unrelated message window; a
+  free-stay one from a Parallel Process instead waits for that same open
+  message to clear before proceeding), both confirmed to fail against the
+  pre-fix code (neither ever opened/proceeded at all — the plain no-op, not
+  a subtler timing miss) before the fix.
 - ✅ **Return to Title Screen (12510) and Exit Game (5002) now actually fire
   when issued from a Parallel Process, instead of silently doing nothing.**
   The same missing-branch defect as Enter Hero Name / Open Shop above, but
@@ -7101,9 +7148,9 @@ not yet verified:
   (`src/game_interpreter.cpp`) are both plain `Game_Interpreter` methods
   gated only on `Game_Message::IsMessageActive()`, with no `main_flag`
   reference anywhere in either body — same as Open Shop/Enter Hero Name.
-  Show Inn is the one exception in this whole family (its own
-  `main_flag`/`CanShowMessage` nuance is why it stays deliberately
-  unfixed); these two have no such asymmetry to reproduce at all.
+  Show Inn was the one exception in this whole family (its own
+  `main_flag`/`CanShowMessage` nuance, now fixed too, see above); these two
+  have no such asymmetry to reproduce at all.
   `Scene::Map#drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) had
   no `:return_title`/`:exit_game` branches, so both fell into the generic
   `else` → unconditional `it.resume`, silently discarding the request and

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -228,6 +228,7 @@ class RPG2k
         @inn_window = nil
         @inn_bgm_started = false
         @inn_fading_out = false
+        @inn_interp = nil
         @shop = nil
         # The running fight, or nil between encounters -- see Scene::Battle.
         @battle = nil
@@ -1978,6 +1979,38 @@ class RPG2k
           # closes, then drive this one.
           if (@shop.nil? || @shop[:interp].equal?(it)) && @message.nil? && @name_ui.nil?
             drive_shop(it)
+          end
+        elsif it.wait_kind == :inn
+          # Show Inn issued from a Parallel Process: EasyRPG's
+          # `Game_Interpreter_Map::CommandShowInn` (src/game_interpreter_map.cpp)
+          # is the very same method for the foreground and every Parallel
+          # Process's own interpreter -- but unlike Open Shop/Enter Hero
+          # Name just above, it carries one extra, deliberately-preserved
+          # nuance of its own, called out in EasyRPG's own comment
+          # ("Emulates RPG_RT behavior (Bug?)"): a *priced* stay
+          # (`inn_price > 0`, this codebase's `req[:prompt]`) is gated
+          # `main_flag && !Game_Message::CanShowMessage(main_flag)` --
+          # `main_flag` is false for every non-foreground interpreter, so
+          # that whole condition is always false for a Parallel Process,
+          # skipping the message-active check entirely and opening the inn
+          # prompt immediately, barging over whatever message window
+          # happens to be up right now. A *free* stay (`inn_price == 0`)
+          # keeps the ordinary `IsMessageActive()` gate for every caller
+          # alike, foreground or not (`CommandShowInn`'s own separate
+          # `if (inn_price == 0) { if (IsMessageActive()) return false; ...`
+          # branch, with no `main_flag` mentioned at all). Before this
+          # branch existed this fell into the generic #resume below, so a
+          # Parallel Process's own Show Inn silently never opened the inn
+          # screen at all -- the command read as a no-op, and any
+          # [Stay]/[No Stay] handler right after it in `it`'s own list
+          # never ran. The single inn screen is shared the same way the
+          # shop/name-input screens are (`@inn_interp` mirrors
+          # `@shop[:interp]`, see #drive_inn/#finish_inn): a second,
+          # distinct interpreter's own Show Inn waits for this one's flow
+          # to finish before starting its own.
+          if @inn_interp.nil? || @inn_interp.equal?(it)
+            req = it.inn_request
+            drive_inn(it) if (req && req[:prompt]) || @message.nil?
           end
         elsif it.wait_kind == :return_title
           # Return to Title Screen issued from a Parallel Process: EasyRPG's
@@ -4365,20 +4398,29 @@ class RPG2k
       # no-op leave the screen alone, matching real RPG_RT (its inn fade only
       # runs down the accepted-stay `AsyncOp::eCallInn` path -- a cancelled
       # prompt never reaches it).
-      def drive_inn
-        req = @interpreter.inn_request
-        return @interpreter.resume_inn(false) unless req
+      #
+      # `it` defaults to the foreground @interpreter, but #drive_parallel_wait
+      # calls this with a Parallel Process's own instead (mirroring
+      # #drive_shop/#drive_name_input's own `it` idiom) -- @inn_interp records
+      # whichever one currently owns the in-progress inn flow, from here until
+      # #finish_inn, so a second, distinct interpreter's own Show Inn request
+      # waits its turn instead of colliding with this one's window/fade state
+      # (all of it plain scene ivars, not per-interpreter).
+      def drive_inn(it = @interpreter)
+        req = it.inn_request
+        return it.resume_inn(false) unless req
+        @inn_interp = it
         if @inn_fading_out
           return if @state.screen.fading?
           @inn_fading_out = false
-          finish_inn(true)
+          finish_inn(true, it)
           return
         end
         unless @inn_bgm_started
           play_inn_bgm
           @inn_bgm_started = true
         end
-        return start_inn_fade_out unless req[:prompt]
+        return start_inn_fade_out(it) unless req[:prompt]
 
         if @inn_window.nil?
           open_inn_window(req) # opened this frame; take input from the next one
@@ -4397,15 +4439,15 @@ class RPG2k
             # Accept: only honoured when the party can pay; otherwise ignored.
             if req[:can_afford]
               close_inn_window
-              start_inn_fade_out
+              start_inn_fade_out(it)
             end
           else
             close_inn_window
-            finish_inn(false)
+            finish_inn(false, it)
           end
         elsif Input.trigger?(Input::B)
           close_inn_window
-          finish_inn(false)
+          finish_inn(false, it)
         end
       end
 
@@ -4416,12 +4458,12 @@ class RPG2k
       # erased (e.g. an event faded to black right before the Show Inn command)
       # is a no-op transition, per #Game::Screen#erase, so it resolves at once
       # exactly like Erase Screen onto Erase Screen does.
-      def start_inn_fade_out
+      def start_inn_fade_out(it = @interpreter)
         @state.screen.erase(Game::Transition::FADE_OUT)
         if @state.screen.fading?
           @inn_fading_out = true
         else
-          finish_inn(true)
+          finish_inn(true, it)
         end
       end
 
@@ -4432,11 +4474,12 @@ class RPG2k
       # RPG_RT's FinishInn, the fade-in only starts, it does not block: the
       # interpreter resumes immediately below and the screen brightens over the
       # following frames while the game keeps running.
-      def finish_inn(stayed)
+      def finish_inn(stayed, it = @interpreter)
         @inn_bgm_started = false
+        @inn_interp = nil
         restore_pre_inn_bgm
         @state.screen.show(Game::Transition::FADE_IN) if stayed
-        @interpreter.resume_inn(stayed)
+        it.resume_inn(stayed)
       end
 
       # RPG2000 inn term set (A or B) selected by the command's type parameter.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2827,6 +2827,56 @@ check 'Show Inn scene: a free stay (price 0) still plays and restores the inn BG
   ok st.switches[1], 'the Stay branch ran (a free stay always stays)'
 end
 
+# EasyRPG's `Game_Interpreter_Map::CommandShowInn`
+# (src/game_interpreter_map.cpp) is the exact same method for the foreground
+# and every Parallel Process's own interpreter, like Open Shop/Enter Hero
+# Name -- but it carries one extra, deliberately-preserved nuance of its own
+# (EasyRPG's own comment: "Emulates RPG_RT behavior (Bug?) Inn's called by
+# parallel events overwrite the current message"): a *priced* stay is gated
+# `main_flag && !Game_Message::CanShowMessage(main_flag)`, which is always
+# false for a non-foreground interpreter, so the message-active check is
+# skipped entirely -- unlike Open Shop, which keeps the ordinary
+# `IsMessageActive()` gate for every caller alike. Before `Scene::Map
+# #drive_parallel_wait` had an `:inn` branch at all, a Parallel Process's own
+# Show Inn fell into the generic "background: resume" default and read as a
+# complete no-op, the same defect Open Shop/Enter Hero Name had before their
+# own fixes -- so this covers both halves: the missing branch, and the
+# priced-vs-free asymmetry once it exists.
+check 'Show Inn (priced) issued from a Parallel Process barges over an open ' \
+      'message window instead of waiting for it' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4) # Parallel Process
+  par.event_commands = inn_commands(ic, 100)
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, InnStubParty.new(1000))
+  scene.send(:open_message, ['an unrelated message window is up'], false)
+  inn_window = nil
+  6.times { scene.update; inn_window = scene.instance_variable_get(:@inn_window); break if inn_window }
+  ok inn_window, 'the priced inn prompt opened for a Parallel-Process-issued ' \
+                 'command despite an open, unrelated message window -- matches ' \
+                 "EasyRPG's own documented RPG_RT quirk rather than silently " \
+                 'no-opping (the pre-fix behavior) or blocking on the message ' \
+                 '(a plausible-looking but wrong fix)'
+end
+
+check 'Show Inn (free stay) issued from a Parallel Process still waits for an ' \
+      'open message window to clear, unlike the priced case just above' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4) # Parallel Process
+  par.event_commands = inn_commands(ic, 0) # price 0: free stay, no prompt
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, InnStubParty.new(1000))
+  scene.send(:open_message, ['an unrelated message window is up'], false)
+  5.times { scene.update }
+  ok !st.screen.fading?, 'a free stay must not auto-accept while a message window is still open'
+  ok !st.switches[1], 'the Stay branch has not run yet either'
+  scene.send(:close_message)
+  40.times { scene.update } # the free stay proceeds, fades out (35 frames) and resolves
+  ok st.switches[1], 'the free stay ran through to its Stay branch once the message cleared'
+end
+
 check 'Key Input Proc waits for a key, stores its code, then continues' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Interpreter#do_show_inn` (`mruby-rpg2k/mrblib/interpreter.rb`) already recorded the request and suspended on an `:inn` wait regardless of which interpreter ran it, but `Scene::Map#drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) had no `:inn` branch at all, so a Parallel Process's own Show Inn fell into the generic `else` → unconditional `it.resume` default and read as a silent no-op — the same defect Open Shop and Enter Hero Name had before their own earlier fixes (both already documented in `docs/TODO.md`, which explicitly left Show Inn open pending this fix).
- Show Inn carries an extra nuance those two siblings don't. Verified against EasyRPG Player's actual C++ source (fetched live): `Game_Interpreter_Map::CommandShowInn` (`src/game_interpreter_map.cpp`) gates a *priced* stay (`inn_price > 0`) with `main_flag && !Game_Message::CanShowMessage(main_flag)` — `main_flag` is false for every non-foreground interpreter, so that whole condition is always false for a Parallel Process, skipping the message-active check entirely. EasyRPG's own source comment calls this out explicitly: `// Emulates RPG_RT behavior (Bug?) Inn's called by parallel events overwrite the current message.` A *free* stay (`inn_price == 0`) keeps the ordinary `IsMessageActive()` gate for every caller alike — no `main_flag` involved in that branch at all.
- Fixed by threading the owning interpreter through `#drive_inn(it = @interpreter)`, `#start_inn_fade_out(it = @interpreter)` and `#finish_inn(stayed, it = @interpreter)` (mirroring `#drive_shop`'s own `it` idiom), recording it in a new `@inn_interp` ivar so a second, distinct interpreter's own Show Inn request waits for the first one's flow to finish, and adding the missing `:inn` branch to `#drive_parallel_wait` — with the priced-vs-free asymmetry reproduced exactly: a priced request drives immediately regardless of any open message window, a free stay still waits for one to clear.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 717 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] Both new checks confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_