### PR TITLE
ppsspp: implement four missing SysclibForKernel HLE functions (ADR 0047 bug 8)

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -114,8 +114,8 @@ marker appears, so a regression that links but fails to boot is caught
 automatically; it has no project at `kGameDir`, so it only ever exercises the
 idle path (`RPG2K_PSP_GAME_START none not_found`). The job is
 **non-blocking** — the required build gate is the `psp` job, because the
-EBOOT still does not boot to completion under PPSSPP-headless. Eight
-independent bugs have been found and root-caused chasing that, six of
+EBOOT still does not boot to completion under PPSSPP-headless. Nine
+independent bugs have been found and root-caused chasing that, seven of
 them fixed:
 
 - pspsdk's `sysclib_snprintf`/`sysclib_sprintf` HLE stubs are only partially
@@ -194,37 +194,48 @@ does not share the bug). The resulting null/wild buffer, fed into
 `lv_display_set_buffers`, is what corrupted LVGL's own TLSF pool further
 down the boot path. With that fixed, the EBOOT boots past display
 creation and into `mrb_open`'s GC init before hitting an **eighth bug,
-partially fixed and re-characterized twice**: PPSSPP reports `Bad memory
-access detected! 00000014` (or a nearby address) — a near-null write —
-inside `mrb_gc_init`. First characterized as PPSSPP's x86-64 JIT
-mistranslating the guest code; a follow-up pass found and fixed a real,
-separate bug along the way (`Common/x64Analyzer.cpp` was missing the
-8-bit-register MOV opcodes, `0x88`/`0x8A`, from its crash-recovery
-disassembler, turning what should have been a gracefully-ignored bad
-access into a fatal halt — `nix/patches/ppsspp-x64analyzer-8bit-mov.patch`,
-verified against both of PPSSPP's native JIT backends), but applying it
-does not get this EBOOT booting further. That pass also proposed a
-timing-sensitive guest-side race as the next lead, from comparing four
-PPSSPP CPU-core modes — a third pass overturned that: re-run with a much
-longer timeout (180s, ruling out the interpreter simply being too slow to
-arrive), `-i` reaches the *exact same* point (632 allocations, an
-identical final `strlen(0000011e)` call, byte-for-byte identical teardown)
-as the JIT modes, just without PPSSPP's bad-access logger printing along
-the way — so all four modes agree, ruling out a race. `0x11e` (286) turns
-out to exactly match this build's `mruby/boxing_word.h` word-boxing
-encoding for symbol id 71 (`(71 << 2) | 2`); the earlier "near-null" fault
-addresses (`0x0`/`0x4`/`0xc`/`0x14`) match the same scheme's `Qnil`/
-`Qfalse`/`Qtrue`/`Qundef` constants. Bug 8 is a **deterministic boxed-value/
-raw-pointer type confusion** — a boxed `mrb_value` (holding a `Symbol` in
-the fatal case) passed where a raw `const char*` was expected somewhere in
-`mrb_open`'s core/symbol-table init — not a JIT bug, a race, or heap
-corruption in the TLSF-adjacent sense bugs 6/7 were. Not yet localized to
-a specific call site; the same vendored mruby core runs fine on desktop
-and wasm (different allocator wiring), so the leading suspects are this
-project's own fixed arena allocator or a MIPS o32 ABI edge case specific
-to this toolchain. See
+fixed**: PPSSPP reported `Bad memory access detected! 00000014` (or a
+nearby address) and separately spammed `Unknown syscall ... (module: 255
+func: 4095)` dozens of times during boot. Three earlier passes
+misdiagnosed this (as a PPSSPP JIT bug, then a timing race, then a
+boxed-`mrb_value`/`const char*` type confusion inside mruby); a fourth
+pass, instrumenting `psp-fixup-imports` itself to print its own grouping
+decisions, found the real cause: the grouping is fully correct (the
+earlier `psp-nm`/`psp-objdump` cross-references were reading *stale*
+symbol addresses, from before the tool's own intentional reorder), and
+the actual function at the faulting slot was `strtoul`
+(`SysclibForKernel`, NID `0x6A7900E1`) — one of four `SysclibForKernel`
+imports (`strtoul`, `strncat` `0xD3D1A3B9`, `memchr` `0x68A78817`,
+`tolower` `0x3EC5BBF6`) that PPSSPP's own loader correctly recognizes by
+NID but has no HLE handler for, out of the sixteen this EBOOT pulls in
+(the other twelve, e.g. `strlen`/`memcpy`/`memset`, PPSSPP does
+implement). Every call to one of the four missing functions silently
+did nothing and returned whatever garbage was already in the return
+register — that is what produced this whole bug's symptoms (the
+near-null reads, which happen to match `mruby/boxing_word.h`'s special
+constants coincidentally rather than from any real type confusion, and
+the eventual fatal `strlen` call on garbage). Fixed by adding all four
+to PPSSPP's `SysclibForKernel` HLE table, matching its existing
+entries' style — `nix/patches/ppsspp-sysclibforkernel-missing-functions.patch`.
+Verified: rebuilding PPSSPP with this patch drops the `Unknown syscall`
+count from ~90 to 1 and eliminates the `Bad memory access` flood
+entirely.
+
+With bug 8 fixed, the EBOOT reaches a **ninth bug, found and not yet
+fixed**: `3rd/mruby/src/gc.c:691`'s `mrb_assert(is_gray(obj))` inside
+`gc_mark_children` fires for real — the first genuine mruby-internal
+assertion message this whole trail has reached (`assertion
+"((obj)->gc_color == 0)" failed`, captured via `sceIoWrite` the same
+way every other marker here is). Something re-enters GC marking for an
+object whose color has already moved past `GRAY`; not yet root-caused,
+but worth checking whether the fixed arena's `mrb_arena_realloc`
+(`app/psp/main.cxx`, which can move a live object's backing memory)
+interacts badly with GC state that assumes a marked object's address
+stays put — the one allocator-wiring difference this PSP target has
+that neither desktop's LVGL-pool routing nor wasm's plain-malloc
+routing needs to contend with. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
-P1 for the full eight-bug trail. To reproduce any of this locally, run
+P1 for the full nine-bug trail. To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched
 `ppsspp` package output (see above) rather than nixpkgs' unpatched one —

--- a/changelog.d/ppsspp-sysclibforkernel-missing-functions.fixed.md
+++ b/changelog.d/ppsspp-sysclibforkernel-missing-functions.fixed.md
@@ -1,0 +1,24 @@
+- **PPSSPP's `SysclibForKernel` HLE module now implements `strtoul`,
+  `strncat`, `memchr`, and `tolower`.** This EBOOT's PSP boot pulls in
+  sixteen `SysclibForKernel` imports; PPSSPP's own loader correctly
+  recognized all sixteen by NID, but only had HLE handlers for twelve of
+  them. Calling one of the missing four (routine calls from mruby's
+  vendored core and newlib itself) silently did nothing and returned
+  whatever garbage was already in the return-value register instead of
+  performing the real operation, rather than raising any visible error at
+  the call site — the actual root cause of ADR 0047 P1's bug 8 (three
+  earlier passes misdiagnosed this as a PPSSPP JIT bug, then a timing
+  race, then a boxed-`mrb_value`/`const char*` type confusion inside
+  mruby, before a verbose trace through `psp-fixup-imports`'s own import
+  grouping proved those symbol-address cross-references had been reading
+  *stale* addresses and pointed at the real cause instead).
+  `nix/patches/ppsspp-sysclibforkernel-missing-functions.patch` adds all
+  four, matching the existing entries' style (`Memory::IsValid*`-guarded,
+  `hleLogVerbose`-wrapped calls into the real host libc function). Not
+  yet upstreamed to `hrydgard/ppsspp`. With this fixed, the PSP EBOOT's
+  `Unknown syscall` count during boot drops from ~90 to 1 and the `Bad
+  memory access` flood bug 8 was named for is gone entirely; boot now
+  reaches a new, separate, not-yet-fixed bug (a real mruby GC assertion,
+  `gc.c`'s `gc_mark_children` asserting an object it's marking isn't
+  actually gray) — see `docs/adr/0047-psp-memory-budget.md`'s P1 for the
+  full trail.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -245,9 +245,9 @@ the interpreter-linking slice, in this order:
   emulator with a Memory Stick image. **On the emulator side specifically,
   this heartbeat has never yet produced a captured number**, in CI or
   locally, though the reasons have narrowed a lot:
-  Eight independent bugs have been found and root-caused on this path so
-  far, six of them fixed; boot still does not complete. In the order the
-  EBOOT actually hits them:
+  Nine independent bugs have been found and root-caused on this path so
+  far, seven of them fixed; boot still does not complete. In the order
+  the EBOOT actually hits them:
   1. **Fixed.** pspsdk's `sysclib_snprintf`/`sysclib_sprintf` HLE stubs are
      only partially implemented under PPSSPP-headless and left emulator
      state corrupted enough to crash a few syscalls later — `main.cxx` now
@@ -414,112 +414,103 @@ the interpreter-linking slice, in this order:
   share the bug and to zero-initialize the same way.
 
   With bug 7 fixed, the EBOOT boots past display creation and into
-  `mrb_open`'s GC init before hitting an **eighth bug, partially fixed and
-  re-characterized**: PPSSPP reports `Bad memory access detected!
-  00000014` (or a nearby small address — see below) — a near-null write —
-  inside `mrb_gc_init`. A first pass at this root-caused it to "PPSSPP's
-  x86-64 JIT mistranslating the guest MIPS code", based on: every
-  allocation up to the crash point tracing as valid (a temporary
-  instrumentation pass through the fixed arena and vendored
-  `mrb_gc_init`/`add_heap`/`init_heap_page`/`shape_root`,
-  `3rd/mruby/src/{gc,state,variable}.c`, none kept); the crash log's own
-  disassembly of the faulting *host* instruction, `mov [rbx+r9+0x4],
-  r10b`, inside the JIT block for `mrb_gc_init` (the compiler had inlined
-  `add_heap`'s `init_heap_page` loop into it — `page->objects[i].as.free.tt
-  = MRB_TT_FREE`, a small per-object byte-store loop, is the only matching
-  source shape); and `ppsspp-headless -i` (forces the plain MIPS
-  interpreter, bypassing the JIT entirely) running the identical EBOOT
-  784+ allocations further with zero bad-memory-access errors.
+  `mrb_open`'s GC init before hitting an **eighth bug, fixed**: PPSSPP
+  reported `Bad memory access detected! 00000014` (or a nearby small
+  address) — a near-null read — inside `mrb_gc_init`, and separately
+  spammed `Unknown syscall: Module: '(unknown)' (module: 255 func:
+  4095)` (PPSSPP's own "this NID has no HLE implementation" sentinel)
+  dozens of times during boot. Three earlier passes at this
+  misdiagnosed it — as PPSSPP JIT mistranslation, then as a
+  timing-sensitive guest-side race, then as a boxed-`mrb_value`/
+  `const char*` type confusion inside mruby — each building on a real
+  observation but drawing the wrong conclusion from it (see git history
+  of this file for the full, now-superseded trail; not worth carrying
+  forward here since the actual cause turned out to be much simpler
+  than any of the three).
 
-  A second pass found a real, separate PPSSPP bug along the way — **fixed**:
-  `Common/x64Analyzer.cpp`'s `X86AnalyzeMOV`, which `Core/MemFault.cpp`
-  uses to recover from a bad guest access when `bIgnoreBadMemAccess` is
-  set (headless mode's default), only recognized the 32/64-bit-register
-  MOV opcodes (`0x89`/`0x8B`), not the 8-bit-register forms (`0x88`/`0x8A`)
-  the JIT emits for exactly this kind of byte store — hitting one during
-  recovery hit `X86AnalyzeMOV`'s own `default:` case and got treated as
-  unrecoverable, halting emulation outright instead of being skipped like
-  every other access width already is. `nix/patches/
-  ppsspp-x64analyzer-8bit-mov.patch` adds both missing opcodes; confirmed
-  it eliminates the fatal halt (`Stopping emulation`) under *both* of
-  PPSSPP's native JIT backends (the old per-arch `Core/MIPS/x86/Jit.cpp`
-  and the newer IR-based `Core/MIPS/x86/X64IRJit.cpp`), converting the
-  crash into the same graceful "ignored" recovery every other store width
-  already gets.
+  A fourth pass found the real cause with a verbose trace through this
+  project's own JAL-relocation-aware `psp-fixup-imports`
+  (`patches/psp-fixup-imports-jal-relocation-aware.patch`), temporarily
+  instrumented to print exactly which function landed at which final
+  stub address after its grouping pass. That trace proved the import
+  grouping itself is fully correct (every function lands under its real
+  SCE module name, contiguous, matching the intended reorder one-for-
+  one) — the "sceKernelUnlockLwMutex" label the third pass's
+  `psp-nm`/`psp-objdump` cross-reference had relied on was stale: those
+  tools' symbol tables reflect each stub's *original*, pre-reorder
+  address, not the address the tool's own grouping pass (deliberately)
+  moved its content to, so matching a runtime fault address against
+  that symbol table pointed at the wrong function entirely. The actual
+  function sitting at the faulting slot, per the fresh trace, was
+  `strtoul` (`SysclibForKernel`, NID `0x6A7900E1`) — and cross-checking
+  all sixteen `SysclibForKernel` imports this EBOOT pulls in against
+  PPSSPP's own `Core/HLE/sceKernelInterrupt.cpp` showed PPSSPP
+  implements twelve of them but is missing four: `strtoul`
+  (`0x6A7900E1`), `strncat` (`0xD3D1A3B9`), `memchr` (`0x68A78817`),
+  and `tolower` (`0x3EC5BBF6`) — the exact four functions PPSSPP's
+  loader logs found and cross-checks correctly, but for which the
+  loader's own runtime dispatch has no HLE handler.
 
-  Applying that fix does **not** get this EBOOT booting further, though —
-  and a third pass overturned the "timing-sensitive guest-side race"
-  lead the second pass had proposed (see `-i`'s use above). The `-i`
-  comparison that motivated it was re-run with instrumentation and a
-  much longer timeout (180s instead of the harness's 15s, to rule out
-  the interpreter simply being too slow to arrive) and turns out **not**
-  to be evidence of a race at all: `-i` reaches the *exact same* point —
-  identical allocation count (632), identical final `strlen(0000011e)`
-  call, byte-for-byte identical LwMutex-teardown/`sceKernelExitGame`
-  sequence — as the JIT/`JIT_IR` runs, just without PPSSPP's
-  `bIgnoreBadMemAccess` logger printing anything along the way (its slow,
-  per-instruction memory path evidently doesn't route small guest reads
-  through the same "bad access" check the JIT's fast path does). Since
-  all four CPU-core modes converge on the identical outcome at the
-  identical point regardless of execution strategy, this rules out a
-  JIT-specific or timing-dependent cause entirely: it is a **deterministic
-  guest-side logic bug**, not a race.
+  Every one of those four functions is a call this EBOOT (via mruby's
+  vendored `gc.c`/`class.c`/`string.c`/newlib itself) makes routinely —
+  calling any of them under PPSSPP-headless silently did nothing and
+  returned whatever garbage happened to already be in the return-value
+  register, rather than the guest's intended `memcpy`-adjacent effect.
+  That is what produced this whole bug's signature symptoms: the
+  recurring near-null reads (`0x0`/`0x4`/`0xc`/`0x14`, which do
+  coincidentally match `mruby/boxing_word.h`'s `Qnil`/`Qfalse`/`Qtrue`/
+  `Qundef` constants, as the third pass found — but as a coincidence of
+  what garbage ended up in play, not evidence of an actual boxed-value/
+  pointer type confusion) and the eventual fatal `strlen(0000011e)`
+  call the third pass also found, all downstream fallout from earlier
+  `strtoul`/`strncat`/`memchr`/`tolower` calls silently no-opping rather
+  than doing their real job — not a bug in this EBOOT's own code, in
+  mruby, or in the fixed-arena allocator (ADR 0047's P2) at all.
 
-  That final `strlen(0000011e)` call is the decisive clue. `0x11e` (286)
-  is not a plausible string pointer, but it *exactly* matches this
-  32-bit build's `mruby/boxing_word.h` symbol encoding for symbol id 71:
-  `(71 << WORDBOX_SYMBOL_SHIFT) | WORDBOX_SYMBOL_FLAG` = `(71 << 2) | 2`
-  = `0x11e` (this build defines no `MRB_*_BOXING` macro, so it takes
-  `mrbconf.h`'s default, `MRB_WORD_BOXING`; `MRB_32BIT` then auto-defines
-  `MRB_WORDBOX_NO_INLINE_FLOAT`, which is the specific sub-encoding
-  `WORDBOX_SYMBOL_SHIFT=2`/`WORDBOX_SYMBOL_FLAG=2` matches). Some code on
-  this boot path is passing a **boxed `mrb_value` holding a `Symbol`
-  directly where a raw `const char*` is expected** — `strlen()` on a
-  tagged 32-bit word not a string. The earlier "near-null" fault
-  addresses this whole bug was named for fit the same pattern from the
-  other end: `0x0`/`0x4`/`0xc`/`0x14` are this same boxing scheme's `Qnil`/
-  `Qfalse`/`Qtrue`/`Qundef` constants (`mruby/boxing_word.h`'s
-  `mrb_special_consts`) being dereferenced as pointers, not corrupted
-  heap addresses at all — i.e. bug 8 was never heap corruption in the
-  TLSF-adjacent sense bugs 6/7 were; it is a **boxed-value/raw-pointer
-  type confusion**, recurring at several points through `mrb_open`'s
-  core/symbol-table init, of which the `strlen` call is only the last
-  (fatal) instance before teardown. Not yet localized to a specific
-  call site in `3rd/mruby/src/{gc,state,symbol}.c` (or a caller passing
-  the wrong argument shape into one of them) — every other target this
-  same vendored mruby core serves (desktop, wasm) uses a *different*
-  `mrb_basic_alloc_func` (LVGL's pool desktop-side, plain malloc on
-  wasm) and neither hits this, so the leading suspects are either
-  something specific to routing every allocation through this project's
-  own fixed arena (`app/psp/main.cxx`'s `mrb_arena_alloc`/`_realloc`) or
-  a MIPS o32 ABI/calling-convention edge case in how a `mrb_value`
-  (a 32-bit tagged word on this build) gets passed/returned versus a
-  `const char*` at some call site that only diverges in codegen on this
-  toolchain. With the x64Analyzer fix applied, this EBOOT's own boot
-  still does not complete: execution proceeds through the type-confused
-  reads instead of halting on the first one, but never prints
-  `RPG2K_PSP_MRUBY_OPEN` — consistent with `mrb_open` itself never
-  returning cleanly.
+  Fixed by adding all four missing functions to PPSSPP's own
+  `SysclibForKernel` HLE table, matching the existing entries'
+  established style (`Memory::IsValid*`-guarded, `hleLogVerbose`-wrapped
+  host calls into the real libc function) —
+  `nix/patches/ppsspp-sysclibforkernel-missing-functions.patch`. Not
+  upstreamed to `hrydgard/ppsspp` yet, but a strong upstream candidate:
+  nothing about this gap is specific to this project, and PPSSPP's own
+  choice to implement twelve of the sixteen `SysclibForKernel` NIDs
+  clearly intends to cover this module, just incompletely. Verified:
+  rebuilding PPSSPP with this patch and re-running the identical EBOOT
+  drops the `Unknown syscall` count from ~90 to 1 and eliminates the
+  `Bad memory access` flood entirely; `RPG2K_PSP_MRUBY_OPEN` still isn't
+  reached (see bug 9), but the specific symptoms bug 8 was named for —
+  the near-null reads and the `strlen(0000011e)` fault — are gone.
 
-  Not upstreamed to `hrydgard/ppsspp` yet. The x64Analyzer fix is worth
-  upstreaming on its own regardless of this EBOOT's own outcome — it is a
-  genuine gap relative to PPSSPP's own intended `bIgnoreBadMemAccess`
-  behavior, useful to any guest code that trips a byte-sized bad access
-  under the JIT. `-i` (interpreter mode) is not viable as a shipping
-  workaround (far too slow for real gameplay) but remains useful for
-  diagnosis — though, per above, it no longer looks like a useful
-  differential signal for this specific bug, since it reaches the same
-  broken end state.
+  Whether real hardware shares bug 8 is unknown but plausible in one
+  narrow sense (any *other* SysclibForKernel NID a future change starts
+  calling that PPSSPP still doesn't implement would misbehave the same
+  way there too, per real firmware's own behavior for a genuinely
+  missing kernel export) — moot for the specific four functions this
+  pass fixed, since real firmware does implement them. The P1 device
+  numbers above remain unconfirmed on the emulator and untried on
+  hardware.
 
-  Whether real hardware shares bug 7 is unknown (bugs 3 and 6 are moot on
-  this boot path either way, one because it stopped triggering, the other
-  because it's fixed). Bug 8, now characterized as a deterministic
-  guest-side type confusion rather than anything JIT- or timing-related,
-  is likely **not** emulator-specific — a real MIPS CPU would presumably
-  hit the identical confused read real hardware has no equivalent of
-  PPSSPP's `bIgnoreBadMemAccess` recovery for, making it fatal there too,
-  though this remains untried on hardware. The P1 device numbers above
-  remain unconfirmed on the emulator and untried on hardware.
+  With bug 8 fixed, this EBOOT reaches a **ninth bug, found and not yet
+  fixed**: `3rd/mruby/src/gc.c:691`'s `mrb_assert(is_gray(obj))` inside
+  `gc_mark_children` now fires for real (visible as a genuine
+  `assertion "((obj)->gc_color == 0)" failed` message printed to
+  stderr, captured via the same `sceIoWrite` path every other marker in
+  this trail uses — the first time this whole investigation has reached
+  a *real, unambiguous mruby-internal assertion message* rather than a
+  raw fault address to reverse-engineer). `is_gray`/`GC_GRAY` (`gc.c`
+  around line 188-207) expects every object handed to
+  `gc_mark_children` to still be in the just-pushed-onto-the-mark-stack
+  GRAY state; this one is not, meaning something re-enters the mark
+  routine for an object whose `gc_color` has already moved past GRAY —
+  a double-mark or stale-mark-stack-entry bug. Not yet root-caused:
+  worth checking whether the fixed arena's allocator
+  (`app/psp/main.cxx`'s `mrb_arena_realloc`, which can move a live
+  object's backing memory) interacts badly with GC state that assumes
+  an object's address is stable once marked, since that is the one
+  mechanism this PSP target's allocator wiring introduces that neither
+  desktop's LVGL-pool routing nor wasm's plain-malloc routing has to
+  contend with.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,7 @@
               ./nix/patches/ppsspp-lwmutex-workarea-validate.patch
               ./nix/patches/ppsspp-mfic-mtic-interrupt-mask.patch
               ./nix/patches/ppsspp-x64analyzer-8bit-mov.patch
+              ./nix/patches/ppsspp-sysclibforkernel-missing-functions.patch
             ];
           });
         }

--- a/nix/patches/ppsspp-sysclibforkernel-missing-functions.patch
+++ b/nix/patches/ppsspp-sysclibforkernel-missing-functions.patch
@@ -1,0 +1,72 @@
+--- a/Core/HLE/sceKernelInterrupt.cpp	1970-01-01 09:00:01.000000000 +0900
++++ b/Core/HLE/sceKernelInterrupt.cpp	2026-08-18 16:16:12.877481539 +0900
+@@ -996,6 +996,58 @@
+ 	return hleLogVerbose(Log::sceKernel, toupper(c));
+ }
+
++static u32 sysclib_tolower(u32 c) {
++	return hleLogVerbose(Log::sceKernel, tolower(c));
++}
++
++static u32 sysclib_strtoul(u32 strPtr, u32 endPtrPtr, int base) {
++	if (!Memory::IsValidNullTerminatedString(strPtr)) {
++		return hleLogError(Log::sceKernel, 0, "invalid address");
++	}
++	const char* str = Memory::GetCharPointer(strPtr);
++	char* end = nullptr;
++	u32 result = (u32)strtoul(str, &end, base);
++	if (Memory::IsValidRange(endPtrPtr, 4))
++		Memory::WriteUnchecked_U32(strPtr + (u32)(end - str), endPtrPtr);
++	return hleLogVerbose(Log::sceKernel, result);
++}
++
++static u32 sysclib_memchr(u32 s, int c, u32 size) {
++	if (Memory::IsValidRange(s, size)) {
++		const void *p = memchr(Memory::GetPointerUnchecked(s), c, size);
++		if (p == nullptr)
++			return hleLogVerbose(Log::sceKernel, 0);
++		return hleLogVerbose(Log::sceKernel, s + (u32)((const u8 *)p - Memory::GetPointerUnchecked(s)));
++	}
++	return hleLogError(Log::sceKernel, 0, "invalid address");
++}
++
++static u32 sysclib_strncat(u32 dest, u32 src, u32 size) {
++	if (!Memory::IsValidAddress(dest) || !Memory::IsValidNullTerminatedString(src)) {
++		return hleLogError(Log::sceKernel, 0, "invalid address");
++	}
++
++	u32 destLen = 0;
++	u32 destSize = Memory::ClampValidSizeAt(dest, 0x7FFFFFFF);
++	const u8 *destScan = Memory::GetPointerUnchecked(dest);
++	while (destLen < destSize && destScan[destLen] != 0)
++		destLen++;
++
++	const u8 *srcp = Memory::GetPointerUnchecked(src);
++	u8 *destp = Memory::GetPointerWriteUnchecked(dest) + destLen;
++	u32 srcSize = Memory::ClampValidSizeAt(src, size);
++	u32 i;
++	for (i = 0; i < srcSize && i < size; ++i) {
++		u8 c = srcp[i];
++		if (c == 0)
++			break;
++		*destp++ = c;
++	}
++	*destp = 0;
++
++	return hleLogVerbose(Log::sceKernel, dest);
++}
++
+ const HLEFunction SysclibForKernel[] =
+ {
+ 	{0xAB7592FF, &WrapU_UUU<sysclib_memcpy>,                   "memcpy",                              'x', "xxx",    HLE_KERNEL_SYSCALL },
+@@ -1015,6 +1067,10 @@
+ 	{0x4C0E0274, &WrapU_UI<sysclib_strrchr>,                   "strrchr",                             'x', "xx",    HLE_KERNEL_SYSCALL },
+ 	{0xCE2F7487, &WrapU_U<sysclib_toupper>,                    "toupper",                             'x', "x",     HLE_KERNEL_SYSCALL },
+ 	{0XC2145E80, &WrapI_UIU<sysclib_snprintf>,                 "snprintf",                            'i', "xx",     HLE_KERNEL_SYSCALL },
++	{0x3EC5BBF6, &WrapU_U<sysclib_tolower>,                    "tolower",                             'x', "x",     HLE_KERNEL_SYSCALL },
++	{0x6A7900E1, &WrapU_UUI<sysclib_strtoul>,                  "strtoul",                             'x', "xxi",    HLE_KERNEL_SYSCALL },
++	{0x68A78817, &WrapU_UIU<sysclib_memchr>,                   "memchr",                              'x', "xii",    HLE_KERNEL_SYSCALL },
++	{0xD3D1A3B9, &WrapU_UUU<sysclib_strncat>,                  "strncat",                             'x', "xxi",    HLE_KERNEL_SYSCALL },
+ };
+
+ void Register_Kernel_Library()


### PR DESCRIPTION
## Summary
- **Real, verified fix for ADR 0047 P1's bug 8**, overturning three earlier misdiagnoses (PPSSPP JIT bug — PR #987; timing race — PR #992's follow-up; boxed-`mrb_value`/`const char*` type confusion — PR #999). All three traced back to reading *stale* `psp-nm`/`psp-objdump` symbol addresses that didn't reflect where this project's own JAL-relocation-aware `psp-fixup-imports` tool had (correctly) moved each function — confirmed by instrumenting that tool to print its own grouping decisions directly.
- **Actual root cause**: this EBOOT's boot pulls in 16 `SysclibForKernel` imports; PPSSPP's loader recognizes all 16 by NID but only implements 12 of them. Calling one of the missing four (`strtoul`, `strncat`, `memchr`, `tolower` — routine calls from mruby's vendored core/newlib) silently no-op'd and returned register garbage instead of doing its real job, producing every symptom bug 8 was named for (near-null reads, the eventual fatal `strlen` call).
- `nix/patches/ppsspp-sysclibforkernel-missing-functions.patch` adds all four to `Core/HLE/sceKernelInterrupt.cpp`'s `SysclibForKernel` table, matching the existing entries' style. Not yet upstreamed to `hrydgard/ppsspp`, but a strong candidate — nothing about this gap is project-specific.
- With this fixed, boot reaches a new bug 9: a real mruby GC assertion (`gc.c:691`'s `mrb_assert(is_gray(obj))` inside `gc_mark_children`) — not fixed in this PR, documented in the ADR for the next pass.
- `docs/adr/0047-psp-memory-budget.md` and `app/psp/README.md` updated with the corrected diagnosis and bug 9's discovery.

## Test plan
- [x] Rebuilt PPSSPP with the patch and re-ran the identical EBOOT: `Unknown syscall` count during boot drops from ~90 to 1, and the `Bad memory access` flood bug 8 was named for is gone entirely.
- [x] `nix flake check --no-build` passes.
- [ ] CI — pending on this PR.