### PR TITLE
game_over: only Decision dismisses the screen, not Cancel too

### DIFF
--- a/changelog.d/game-over-decision-only.fixed.md
+++ b/changelog.d/game-over-decision-only.fixed.md
@@ -1,0 +1,5 @@
+- **Game Over screen:** Only the Decision key now dismisses the Game Over
+  screen and returns to the title, matching real RPG_RT — Cancel used to work
+  too, but EasyRPG's own `Scene_Gameover::vUpdate` checks only
+  `Input::IsTriggered(Input::DECISION)`, with no reference to Cancel
+  anywhere. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1561,6 +1561,29 @@ The work below is roughly ordered by the critical path to a walkable game
   confirmed to fail against the pre-fix code before the fix. The other
   System BGM slots (battle / victory / inn / boat / ship / airship) are
   still save-fidelity-only, per the note above.
+  ✅ **The Game Over screen dismissed on Cancel as well as Decision — real
+  RPG_RT only accepts Decision (2026-08-18).**
+  `Scene::GameOver#update` (`mruby-rpg2k/mrblib/scene/game_over.rb`)
+  returned to the title on `Input.trigger?(Input::C) ||
+  Input.trigger?(Input::B)`, the same "either button" idiom this codebase's
+  message/choice/menu windows correctly use — but the Game Over screen is
+  not one of those. Verified against EasyRPG Player's actual C++ source
+  (fetched live rather than paraphrased): `Scene_Gameover::vUpdate`
+  (`src/scene_gameover.cpp`) is `if (Input::IsTriggered(Input::DECISION))
+  { Scene::ReturnToTitleScene(); }` — the entire file contains no reference
+  to `Input::CANCEL` anywhere. Pressing Cancel on the real screen does
+  nothing at all; only Decision returns to the title. Fixed by dropping the
+  `Input::B` half of the dismiss check (the pre-arming debounce, which
+  watches both keys purely to swallow whatever key was still held from the
+  battle result that led here, was left alone — delaying arming by a frame
+  is harmless, unlike actually dismissing on the wrong key). An existing
+  check ("a game with no game-over picture still reaches the screen") had
+  been asserting the buggy behavior itself, dismissing with `Input::B` —
+  switched to `Input::C` to keep testing what it was meant to test (a
+  missing picture does not block dismissal) rather than the bug. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check confirming Cancel is inert and
+  Decision still works right after, confirmed to fail against the pre-fix
+  code before the fix.
   **The battle backdrop is chosen from the game's own data now** rather than
   always being the flat void. RPG2000 keeps it on the map-tree node, not the map:
   `Game::Backdrop.name_for` reads the node's `backdrop_type`, a tri-state the

--- a/mruby-rpg2k/mrblib/scene/game_over.rb
+++ b/mruby-rpg2k/mrblib/scene/game_over.rb
@@ -1,8 +1,8 @@
 class RPG2k
   module Scene
     # The RPG2000 Game Over screen: the database's `GameOver/<name>` picture
-    # filling the screen with its game-over music playing, dismissed by a button
-    # press, which returns to a fresh title.
+    # filling the screen with its game-over music playing, dismissed by the
+    # Decision key, which returns to a fresh title.
     #
     # RPG_RT reaches this the same two ways this build does — the Game Over event
     # command (12420) and a battle defeat whose encounter says "game over" rather
@@ -42,7 +42,11 @@ class RPG2k
           @armed = true unless Input.press?(Input::C) || Input.press?(Input::B)
           return
         end
-        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        # EasyRPG's `Scene_Gameover::vUpdate` (src/scene_gameover.cpp) checks
+        # only `Input::IsTriggered(Input::DECISION)` -- no Cancel anywhere in
+        # the file. Unlike the message/choice/menu windows this screen
+        # otherwise resembles, Cancel does not also dismiss it.
+        return unless Input.trigger?(Input::C)
         parent.return_to_title
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6879,6 +6879,28 @@ check 'a button still held from the battle does not skip the Game Over screen' d
   Input.reset
 end
 
+# Verified against EasyRPG Player's actual C++ source rather than assumed
+# from this screen's own resemblance to a message/choice/menu window (every
+# one of which does accept Cancel): `Scene_Gameover::vUpdate`
+# (src/scene_gameover.cpp) checks only `Input::IsTriggered(Input::DECISION)`
+# -- there is no reference to `Input::CANCEL` anywhere in the file. Pressing
+# Cancel on the real Game Over screen does nothing at all.
+check 'the Cancel button does not dismiss the Game Over screen -- only Decision does' do
+  parent = fake_parent(fake_db)
+  Input.reset
+  scene = RPG2k::Scene::GameOver.new(parent)
+  scene.update # arm: no key held yet
+  Input.triggered = [Input::B]
+  scene.update
+  ok !parent.returned_to_title, 'Cancel is not a dismiss trigger for this screen'
+  Input.reset
+  scene.update
+  Input.triggered = [Input::C]
+  scene.update
+  ok parent.returned_to_title, 'Decision still dismisses it, right after'
+  Input.reset
+end
+
 check 'a game with no game-over picture still reaches the screen' do
   db = fake_db
   db.system.gameover_name = ''
@@ -6887,7 +6909,7 @@ check 'a game with no game-over picture still reaches the screen' do
   scene = RPG2k::Scene::GameOver.new(parent)
   eq nil, scene.instance_variable_get(:@picture).bitmap, 'nothing to show'
   scene.update
-  Input.triggered = [Input::B]
+  Input.triggered = [Input::C]
   scene.update
   ok parent.returned_to_title, 'and it still dismisses to the title'
   Input.reset


### PR DESCRIPTION
## Summary

- `Scene::GameOver#update` (`mruby-rpg2k/mrblib/scene/game_over.rb`) returned to the title on `Input.trigger?(Input::C) || Input.trigger?(Input::B)` — the same "either button dismisses" idiom this codebase's message/choice/menu windows correctly use. But the Game Over screen isn't one of those.
- Verified against EasyRPG Player's actual C++ source (fetched live): `Scene_Gameover::vUpdate` (`src/scene_gameover.cpp`) is `if (Input::IsTriggered(Input::DECISION)) { Scene::ReturnToTitleScene(); }` — the entire file contains no reference to `Input::CANCEL` anywhere. Pressing Cancel on the real screen does nothing; only Decision returns to the title.
- Fixed by dropping the `Input::B` half of the dismiss check. The pre-arming debounce (which watches both keys purely to swallow whatever key was still held from the preceding battle-result screen) was left alone — it can only delay arming by a frame, never dismiss on the wrong key, so it's harmless and out of scope for this fix.
- An existing check ("a game with no game-over picture still reaches the screen") had itself been asserting the buggy behavior — dismissing with `Input::B`. Switched to `Input::C` so it keeps testing what it was meant to (a missing picture doesn't block dismissal) rather than the bug.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 718 checks passed (1 new, 1 existing check corrected)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] New check confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_