### PR TITLE
game: tied ATB-ready allies go by readiness order, not seat order

### DIFF
--- a/changelog.d/atb-ready-order-fifo.fixed.md
+++ b/changelog.d/atb-ready-order-fifo.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 gauge battle:** When several party members are simultaneously
+  ready for their active-time turn, the game now offers the command menu to
+  whoever became ready first, matching real RPG_RT — it used to fall back to
+  party seat order instead, since every ready gauge is clamped to the same
+  maximum and there was no other tie-break. Enemy readiness order is
+  unaffected. Covered by a new `scripts/rpg2k3_battle_gauge_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12763,6 +12763,50 @@ above are repeated here)
   line kinds follow the damage line in the same entry, like every other
   landed condition), all confirmed to fail against the pre-fix code (`got
   []`/a missing final line) before the fix.
+  ✅ **A tied active-time (gauge) turn among several ready party members now
+  goes to whoever has been waiting longest, not whoever sits earliest in the
+  party roster (2026-08-18).** RPG_RT's RPG2003 gauge presentation
+  (battle_type 2) always clamps a ready gauge to the exact same maximum —
+  `#advance_gauges` never lets one exceed `GAUGE_MAX` — so several party
+  members becoming ready in the same stretch of frames are always tied on
+  gauge *value* alone; RPG_RT still has to pick one of them first, and it
+  does so by readiness order, not roster position. `Game::Battle
+  #ready_combatants` (`mruby-rpg2k/mrblib/game.rb`) sorted the ready pool by
+  `-gauge` and left ties to fall out however Ruby's `sort_by` happened to
+  place equal keys — in practice, plain array position (`@allies` seat
+  order), since every real tie is a dead heat. So a slow, early-seated ally
+  that only just crossed the threshold could jump the queue in front of a
+  fast ally that had already been sitting ready, full-gauge, for many
+  frames. Confirmed against RPG_RT's own behavior via EasyRPG Player's
+  actual C++ source (fetched live rather than assumed):
+  `Scene_Battle_Rpg2k3::UpdateReadyActors`/`GetNextReadyActor`
+  (`src/scene_battle_rpg2k3.cpp`) maintain a FIFO, `atb_order`, walking only
+  `Main_Data::game_party->GetActors()` (never the enemy troop — an enemy
+  troop's own readiness is handled by an entirely separate, immediate
+  per-frame pass, `CreateEnemyActions`, with no queue involved) — an actor's
+  id is pushed the frame `BattlerReadyToAct()`
+  (`IsAtbGaugeFull() && Exists() && CanAct()`) first turns true and erased
+  the frame it turns false, and `GetNextReadyActor()` always returns
+  `atb_order.front()`: whoever has been in the queue longest. Fixed by
+  adding `#update_ally_ready_order`, a party-only FIFO diffed against the
+  ready set on every `#ready_combatants` call (self-maintaining — no
+  specific frame-loop hook needed, since a call anywhere in the frame sees
+  the same, correctly-ordered queue), and using it as the tie-break for
+  allies specifically once `-gauge` itself ties — enemies keep their
+  existing troop-order tie-break, since RPG_RT's own separation of the two
+  paths means the ally fix has nothing to say about enemy ordering, which
+  this pass did not re-verify. `RPG2k3::Scene::Battle#drive_battle_atb`
+  (`mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb`) and `#interrupting_ready_
+  combatant`, the only two consumers of `#ready_combatants`, both needed no
+  changes — they already just take the front of whatever order it returns.
+  Covered by a new `scripts/rpg2k3_battle_gauge_check.rb` check: two allies
+  with seat order and AGI order deliberately reversed (the faster one seated
+  *later*), ticked to the two already-established crossing frame counts (143
+  then 273, from the existing sibling check just above) so the faster,
+  later-seated ally is ready well before the slower, earlier-seated one
+  catches up — confirmed the faster ally still leads `#ready_combatants`
+  once both are tied at `GAUGE_MAX`, and confirmed to fail against the
+  pre-fix code (`[SeatSlow, SeatFast]`, plain seat order) before the fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9320,11 +9320,56 @@ module Game
       end
     end
 
-    # The combatants whose gauge is full, in descending gauge order (ties broken
-    # by side then by the order they were added), so the active-time turn picker
-    # can pull the next actor off the front. Empty for a turn-based battle.
+    # Party-member FIFO of who became ready (full gauge, alive, actionable)
+    # and is still waiting for a turn -- RPG_RT 2003's own
+    # `Scene_Battle_Rpg2k3::atb_order` (src/scene_battle_rpg2k3.cpp),
+    # confirmed against the real source rather than assumed: `UpdateReadyActors`
+    # walks only `Main_Data::game_party->GetActors()` -- never the enemy troop
+    # -- appending an id the frame `BattlerReadyToAct()` (`IsAtbGaugeFull() &&
+    # Exists() && CanAct()`) first turns true and erasing it the frame it turns
+    # false, and `GetNextReadyActor()` always returns `atb_order.front()`: the
+    # ally who has been waiting *longest*, not whichever has the highest gauge
+    # value. That distinction only ever matters at a tie -- and every ready
+    # gauge is always exactly GAUGE_MAX (#advance_gauges clamps it), so ties
+    # among simultaneously-ready allies are the *only* case that ever reaches
+    # here in real play. Diffed against the ready set on every call rather
+    # than hooked into a specific point in the frame loop, so it stays correct
+    # regardless of how many times (or how sparsely) #ready_combatants itself
+    # is polled.
+    def update_ally_ready_order
+      @ally_ready_order ||= []
+      (@allies || []).each do |a|
+        ready = !a.out_of_play? && a.gauge_full?
+        already = @ally_ready_order.include?(a)
+        if ready && !already
+          @ally_ready_order.push(a)
+        elsif !ready && already
+          @ally_ready_order.delete(a)
+        end
+      end
+    end
+
+    # The combatants whose gauge is full, so the active-time turn picker can
+    # pull the next one off the front. Sorted by descending gauge first (in
+    # real play every ready gauge is clamped to the identical GAUGE_MAX, so
+    # this is always a full tie -- a manually-inflated gauge, past what
+    # #advance_gauges would ever produce, is the only way to actually rank
+    # here); ties are broken by side (allies before enemies, matching
+    # #all_combatants' own ordering) and then, among allies specifically, by
+    # #update_ally_ready_order's FIFO -- whoever has been ready longest, not
+    # whoever sits earlier in the party roster (see there for why: this is
+    # the one part of the tie-break RPG_RT actually specifies). Enemies keep
+    # their existing troop-order tie-break; only the ally half of this was
+    # ever wrong. Empty for a turn-based battle.
     def ready_combatants
-      all_combatants.reject(&:out_of_play?).select(&:gauge_full?).sort_by { |c| -c.gauge }
+      update_ally_ready_order
+      all_combatants.reject(&:out_of_play?).select(&:gauge_full?).sort_by do |c|
+        if side_of(c) == :ally
+          [-c.gauge, 0, @ally_ready_order.index(c) || 0]
+        else
+          [-c.gauge, 1, (@enemies || []).index(c) || 0]
+        end
+      end
     end
 
     # Every combatant in the fight (allies then enemies), for gauge bookkeeping.

--- a/scripts/rpg2k3_battle_gauge_check.rb
+++ b/scripts/rpg2k3_battle_gauge_check.rb
@@ -125,6 +125,31 @@ check 'ready_combatants is ordered by gauge descending' do
   eq [slow, fast], bat.ready_combatants
 end
 
+# RPG_RT 2003's own Scene_Battle_Rpg2k3::atb_order (src/scene_battle_rpg2k3.cpp,
+# confirmed against the real source): among several simultaneously-ready party
+# members -- every ready gauge is clamped to the identical GAUGE_MAX by
+# #advance_gauges, so there is never a real gauge-value difference to sort by
+# -- RPG_RT hands the next turn to whoever has been waiting *longest*, not
+# whoever sits earlier in the party roster. #ready_combatants used to fall
+# back to plain array position once tied, so a slower, earlier-seated ally
+# would jump the queue in front of a faster ally that had already been
+# sitting ready for many frames.
+check 'among tied allies, the one ready longest goes first, not the one ' \
+      'sitting earlier in the party roster' do
+  seat_slow = combatant('SeatSlow', 1, 1, 10, 1) # seat 0, agi 10 (slower)
+  seat_fast = combatant('SeatFast', 1, 1, 20, 1) # seat 1, agi 20 (faster)
+  bat3 = Game::Battle.new([seat_slow, seat_fast], [], Game::Rng.new(1))
+  bat3.battle_type = 2
+  bat3.advance_gauges(143) # 143 ticks: seat 1 (faster) crosses first, same as `fast` above
+  eq [seat_fast], bat3.ready_combatants, 'only seat 1 (faster) is ready so far'
+  bat3.advance_gauges(130) # 273 ticks total: seat 0 catches up, both now tied at max
+  eq Game::Battle::GAUGE_MAX, seat_slow.gauge
+  eq Game::Battle::GAUGE_MAX, seat_fast.gauge
+  eq [seat_fast, seat_slow], bat3.ready_combatants,
+     'seat 1 still goes first -- it became ready first and has been waiting ' \
+     'longer, even though seat 0 sits earlier in the party roster'
+end
+
 check 'a dead battler does not charge or become ready' do
   dead = combatant('Dead', 1, 1, 50, 1)
   dead.hp = 0


### PR DESCRIPTION
## Summary

- RPG_RT's RPG2003 gauge (active-time) battle presentation always clamps a ready gauge to `GAUGE_MAX`, so several party members becoming ready around the same stretch of frames are always tied on gauge *value* alone. RPG_RT still has to pick one to offer the command menu to first, and it does so by who has been waiting longest — not by party seat position.
- `Game::Battle#ready_combatants` (`mruby-rpg2k/mrblib/game.rb`) sorted the ready pool by `-gauge` and left ties to fall out however Ruby's `sort_by` happened to place equal keys — in practice, plain array (seat) order, since every real tie is a dead heat. A slow, early-seated ally that had only just crossed the threshold could jump ahead of a fast ally that had already been sitting ready for many frames.
- Verified against RPG_RT's real behavior via EasyRPG Player's actual C++ source (fetched live): `Scene_Battle_Rpg2k3::UpdateReadyActors`/`GetNextReadyActor` (`src/scene_battle_rpg2k3.cpp`) maintain a FIFO, `atb_order`, scoped to party actors only (`Main_Data::game_party->GetActors()`) — an enemy troop's own readiness runs through a completely separate, immediate per-frame pass (`CreateEnemyActions`) with no queue involved at all. An id is pushed the frame `BattlerReadyToAct()` (`IsAtbGaugeFull() && Exists() && CanAct()`) first turns true, erased the frame it turns false, and `GetNextReadyActor()` always returns `atb_order.front()`.
- Fixed by adding `#update_ally_ready_order`, a party-only FIFO that self-diffs against the ready set on every `#ready_combatants` call (no specific frame-loop hook needed), used as the tie-break for allies specifically once `-gauge` itself ties. Enemy ordering is untouched, since RPG_RT's own separation of the two paths means this fix has nothing to say about it. The two consumers (`RPG2k3::Scene::Battle#drive_battle_atb`/`#interrupting_ready_combatant`) needed no changes — they already just take the front of whatever order `#ready_combatants` returns.

## Test plan

- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures (1 new)
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] `ruby scripts/rpg2k_scene_check.rb` — 718 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] New check confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_