### PR TITLE
map: a moving vehicle now collides with a different parked one

### DIFF
--- a/changelog.d/moving-vehicle-vs-parked-vehicle-collision.fixed.md
+++ b/changelog.d/moving-vehicle-vs-parked-vehicle-collision.fixed.md
@@ -1,0 +1,6 @@
+- **Vehicles:** A moving Boat/Ship now collides with a different parked
+  Boat/Ship or a grounded Airship, and an Airship can no longer land on a
+  parked Boat/Ship's tile, matching real RPG_RT — vehicle-vs-vehicle
+  collision was never checked before, so a party riding a Boat could sail
+  straight through a parked Ship, and a landing Airship could set down right
+  on top of one. Covered by two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -455,13 +455,43 @@ The work below is roughly ordered by the critical path to a walkable game
   character stepping onto the party's own tile, never the ridden vehicle's
   own movement (driven entirely separately, through `#vehicle_passable?`/
   `VehicleWorld`, which this fix leaves untouched — a moving vehicle's own
-  collision against a *different* parked vehicle remains unmodelled, a
-  narrower, rarer edge case than hero/event collision with a parked one).
+  collision against a *different* parked vehicle remained unmodelled at the
+  time, a narrower, rarer edge case than hero/event collision with a parked
+  one; closed below).
   Covered by two new `scripts/rpg2k_scene_check.rb` checks (a hero on foot
   is blocked by a parked boat but walks straight over a parked airship; a
   map event's own custom-route movement is blocked by both a parked boat
   and a parked airship, unlike the hero's own airship exemption), both
   confirmed to fail against the pre-fix code before the fix.
+  ✅ **The "moving vehicle vs. a different parked vehicle" edge case the
+  paragraph above deliberately left open is now closed too
+  (2026-08-18).** Real RPG_RT lets a moving Boat/Ship collide with a
+  parked Ship/Boat, and refuses an Airship landing on a parked Boat/Ship's
+  tile — confirmed against RPG_RT's actual behavior via EasyRPG Player's
+  own C++ source rather than assumed from the sibling fix above:
+  `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) loops `{ Boat, Ship }`
+  for any non-Airship mover (a moving Boat/Ship is one — it steers as its
+  own `Vehicle`-typed character, not `Player`), then also checks a grounded
+  Airship whenever the mover is not the on-foot Player — true here too, the
+  same `self.GetType() != Game_Character::Player` gate the sibling fix
+  above already traced. `Game_Map::CanLandAirship` separately loops
+  `{ Boat, Ship }` and refuses a landing on either one's tile.
+  `#vehicle_passable?`/`#airship_landable?` (`mruby-rpg2k/mrblib/scene/
+  map.rb`) never consulted another vehicle's own position at all, so a
+  party riding a Boat could sail straight through a parked Ship or a
+  grounded Airship, and a landing Airship could set down right on top of a
+  parked Boat/Ship. Fixed by reusing `#vehicle_blocks?` — already built and
+  tested for the opposite direction above — from both: `block_airship: true`
+  in `#vehicle_passable?`'s boat/ship branch (matching `CheckOrMakeWayEx`'s
+  own Airship-included loop for a non-Airship mover), `block_airship: false`
+  in `#airship_landable?` (matching `CanLandAirship`'s Boat/Ship-only loop).
+  `#vehicle_blocks?`'s own doc comment, which used to claim it was "never"
+  reached for the ridden vehicle's own movement, was corrected to match.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (a boat under
+  way collides with a different parked ship, then with a grounded airship
+  once the ship is moved aside; an airship cannot land on a parked boat's
+  tile but lands normally once it moves away), both confirmed to fail
+  against the pre-fix code before the fix.
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2228,6 +2228,10 @@ class RPG2k
       def airship_landable?(x, y)
         return false unless @map.in_bounds?(x, y)
         return false if blockers_at(x, y).any? { |b| !b[:char].through }
+        # A Boat/Ship parked on the ground blocks a landing too, matching
+        # `Game_Map::CanLandAirship`'s own `for (auto vid: { Boat, Ship })`
+        # loop (`src/game_map.cpp`) -- see `#vehicle_blocks?`.
+        return false if vehicle_blocks?(x, y, block_airship: false)
         row = terrain_row_at(x, y)
         return true if row.nil?
         row.airship_land ? true : false
@@ -2511,6 +2515,15 @@ class RPG2k
           return row.airship_pass ? true : false
         end
         return false if blockers_at(x, y).any? { |b| !b[:char].through }
+        # A moving Boat/Ship also collides with a *different* parked
+        # Boat/Ship, and with a grounded Airship -- `Game_Map::
+        # CheckOrMakeWayEx` (`src/game_map.cpp`) loops `{ Boat, Ship }` for
+        # any non-Airship mover, then also checks the Airship whenever the
+        # mover is not the on-foot player (true for a ridden Boat/Ship,
+        # which moves as its own `Vehicle`-typed character, not `Player`).
+        # See `#vehicle_blocks?`, already used for the opposite direction (a
+        # non-vehicle character walking onto a *parked* vehicle's tile).
+        return false if vehicle_blocks?(x, y, block_airship: true)
         return passable?(x, y, dir) unless row
         type == :boat ? (row.boat_pass ? true : false) : (row.ship_pass ? true : false)
       end
@@ -3910,11 +3923,13 @@ class RPG2k
       # character (a map event's autonomous/custom-route movement, or the
       # player's own forced Set Move Route mirror, `@player_char`). A vehicle
       # currently being ridden still counts here: it tracks the party's own
-      # tile every frame (`#follow_vehicle`), so this only ever blocks a
-      # *different* character trying to step onto the party's own tile, never
-      # the ridden vehicle's own movement (driven through the entirely
-      # separate `#vehicle_passable?`/`VehicleWorld`, never through this
-      # method or `#char_passable?`/`#passable?`).
+      # tile every frame (`#follow_vehicle`), so checking it against a target
+      # tile that is not the party's own current one only ever matches a
+      # *different*, genuinely parked vehicle -- never the mover's own tile.
+      # Called from both directions: `#char_passable?`/`#passable?` for a
+      # non-vehicle character walking onto a parked vehicle's tile, and
+      # `#vehicle_passable?`/`#airship_landable?` for the ridden vehicle's own
+      # steering colliding with a *different* parked one.
       def vehicle_blocks?(x, y, block_airship:)
         types = block_airship ? Game::Vehicle::TYPES : %i[boat ship]
         types.any? do |type|

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7853,6 +7853,85 @@ check 'an unridden boat/ship/airship all block a map event\'s own custom-route m
      'an unridden airship stops the event too, unlike its hero-on-foot exemption above'
 end
 
+# Real RPG_RT lets a moving Boat/Ship collide with a *different*, parked
+# vehicle, and refuses an Airship landing on top of one -- the direction the
+# checks above never exercised (an unridden vehicle blocking a walking hero
+# or a map event), and one this codebase's own #vehicle_passable? /
+# #airship_landable? never checked at all before this fix: neither ever
+# consulted another vehicle's own position, so a party riding a Boat could
+# sail straight through a parked Ship or a grounded Airship, and a landing
+# Airship could set down right on top of a parked Boat/Ship. Verified
+# against RPG_RT's actual behavior via EasyRPG Player's own C++ source
+# (src/game_map.cpp): `Game_Map::CheckOrMakeWayEx` loops `{ Boat, Ship }` for
+# any non-Airship mover, then also checks a grounded Airship whenever the
+# mover is not the on-foot Player -- true for a ridden Boat/Ship, which
+# moves as its own `Vehicle`-typed character, never `Player` -- and
+# `Game_Map::CanLandAirship` separately loops `{ Boat, Ship }` and refuses a
+# landing on either's tile. Fixed by reusing `#vehicle_blocks?` (already
+# used for the opposite direction, tested above) from both
+# `#vehicle_passable?` and `#airship_landable?`.
+check 'a moving boat collides with a different parked ship, and with a ' \
+      'grounded airship' do
+  scene = new_scene({}, player: [0, 0], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 0 # under the party; board in place
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat in place'
+
+  ship = st.vehicle(:ship)
+  ship.map_id = st.map_id
+  ship.x = 1
+  ship.y = 0
+  RGSS::Input.dir_value = 6 # hold right, straight into the parked ship
+  10.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [0, 0], [st.x, st.y], 'a different parked vehicle (the ship) blocks the boat'
+
+  # Move the ship out of the way and put a grounded airship there instead.
+  ship.map_id = 0
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 1
+  air.y = 0
+  RGSS::Input.dir_value = 6
+  10.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [0, 0], [st.x, st.y], 'a grounded airship blocks the boat too'
+end
+
+check 'the airship cannot land on a parked boat/ship\'s tile' do
+  scene = new_scene({}, player: [0, 0], airship_land: true)
+  st = scene.instance_variable_get(:@state)
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 0
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'boarded the airship'
+
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 0 # right where the airship would land in place
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'a parked boat under the airship blocks the landing'
+
+  boat.map_id = 0 # move it away: landing now succeeds
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'landing succeeds once the tile is clear'
+end
+
 check 'Show Battle Animation with the wait flag holds the event then resumes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- Real RPG_RT lets a moving Boat/Ship collide with a different, parked Ship/Boat, and refuses an Airship landing on a parked Boat/Ship's tile. Verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source (fetched live): `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) loops `{ Boat, Ship }` for any non-Airship mover — a moving Boat/Ship is one, since it steers as its own `Vehicle`-typed character, not `Player` — and also checks a grounded Airship whenever the mover isn't the on-foot Player. `Game_Map::CanLandAirship` separately loops `{ Boat, Ship }` and refuses a landing on either one's tile.
- `#vehicle_passable?`/`#airship_landable?` (`mruby-rpg2k/mrblib/scene/map.rb`) never consulted another vehicle's own position at all, so a party riding a Boat could sail straight through a parked Ship or a grounded Airship, and a landing Airship could set down right on top of a parked Boat/Ship. This is the direction an earlier fix (already in `docs/TODO.md`) explicitly left open — that one covered a non-vehicle character walking onto a *parked* vehicle's tile, via `#vehicle_blocks?`, but never wired it into the *ridden* vehicle's own steering.
- Fixed by reusing `#vehicle_blocks?` — already built and regression-tested for the opposite direction — from both: `block_airship: true` in `#vehicle_passable?`'s boat/ship branch (matching `CheckOrMakeWayEx`'s own Airship-included loop for a non-Airship mover), `block_airship: false` in `#airship_landable?` (matching `CanLandAirship`'s Boat/Ship-only loop). Also corrected `#vehicle_blocks?`'s own doc comment, which used to claim it was "never" reached for a ridden vehicle's own movement.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 720 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] Both new checks confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_