### PR TITLE
battle: Enemy Encounter's own backdrop override is now honored

### DIFF
--- a/changelog.d/enemy-encounter-backdrop-override.fixed.md
+++ b/changelog.d/enemy-encounter-backdrop-override.fixed.md
@@ -1,0 +1,6 @@
+- **Battles:** Enemy Encounter's own per-fight battle backdrop override is
+  now honored, matching real RPG_RT — an event author naming an explicit
+  background image, or an explicit terrain to read one from, used to be
+  silently discarded, every scripted encounter falling back to the ordinary
+  map/terrain default regardless of what was actually chosen. Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1666,6 +1666,50 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check that drives a Tint Screen through
   `#update_map_tone` with a fight open and asserts the backdrop tone tracks
   the map layer (and is left alone once the fight is closed).
+  ✅ **Enemy Encounter's own per-fight backdrop override (param2) is now
+  read — it used to be silently discarded, every scripted encounter falling
+  back to the map/terrain default above regardless of what the event author
+  actually chose (2026-08-18).** RPG_RT's own editor gives this command a
+  third choice beyond the map's own automatic backdrop: an explicit
+  background image named directly on the command, or an explicit terrain id
+  to read the backdrop from instead of wherever the party happens to be
+  standing. Confirmed against RPG_RT's actual behavior via EasyRPG Player's
+  own C++ source (fetched live): `Game_Interpreter_Map
+  ::CommandEnemyEncounter` (`src/game_interpreter_map.cpp`) `switch`es on
+  `com.parameters[2]` — 0 (the only case this codebase modelled) calls
+  `Game_Map::SetupBattle`, the map-tree walk already ported as
+  `Game::Backdrop.name_for`; 1 sets `args.background` from the command's own
+  free-text `string` field; 2 sets `args.terrain_id` from `parameters[8]`.
+  `Spriteset_Battle`'s constructor (`src/spriteset_battle.cpp`) proves an
+  explicit background name wins outright (`if (!background_name.empty())
+  ... else Background(terrain_id)`), and `Background(int terrain_id)`
+  (`src/background.cpp`) resolves that terrain's own row directly — no
+  map-tree walk at all, unlike the param2==0 default.
+  `Interpreter#do_enemy_encounter` (`mruby-rpg2k/mrblib/interpreter.rb`)
+  never read `param(2)`, `cmd.string` or `param(8)`, so every fight this
+  command opened used the automatic map/terrain default even when the
+  author had explicitly picked a different one. Fixed by threading
+  `param(2)`'s selection onto `@battle_request` as `:background`
+  (param2==1, `cmd.string`) or `:terrain_id` (param2==2, `param(8)`), and
+  giving `Scene::Battle#encounter_backdrop`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) first refusal on either key before
+  falling back to `Game::Backdrop.name_for` as before. The terrain-id
+  override needed a new `Scene::Map#backdrop_for_terrain_id(tid)`
+  (`mruby-rpg2k/mrblib/scene/map.rb`), factored out of the existing
+  `#terrain_backdrop(x, y)`'s own tile-position lookup so it can read a
+  terrain row directly by id, matching `Background(int terrain_id)`'s own
+  bypass of the map-tree walk. Deliberately scoped to the backdrop alone —
+  RPG2003's own additional `param(6)`/`param(7)` fields this same command
+  carries (battle condition/formation) are a separate, already-documented,
+  deliberately-deferred gap (`game.rb`'s "RPG2003 battle conditions are
+  entirely unmodeled" note), left untouched here. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (param2==1 makes the resulting
+  battle's backdrop the command's own named background; param2==2 makes it
+  the named terrain id's own backdrop, deliberately a different terrain
+  than the one the fixture party is actually standing on, so the check only
+  passes if the override genuinely bypasses positional lookup), both
+  confirmed to fail against the pre-fix code (both returned the empty/flat
+  default) before the fix.
   **Enemies now run their 行動パターン** (action pattern, enemy chunk 42) rather
   than only ever attacking — the single biggest silent gap left in the battle
   system, since **510 of the 959 enemy actions across the two test beds are

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1406,6 +1406,20 @@ module Game
     # resume_battle. The turn-based battle itself is not built yet. A troop id
     # the database no longer has never arms the wait at all -- see
     # #skip_invalid_troop.
+    #
+    # param2 selects the battle backdrop's own source, verified against
+    # EasyRPG Player's actual C++ source rather than assumed:
+    # `Game_Interpreter_Map::CommandEnemyEncounter` (`src/
+    # game_interpreter_map.cpp`) `switch`es on it -- 0 (the ordinary,
+    # previously the only case modelled) leaves no override at all, so
+    # `Scene::Battle#encounter_backdrop` falls back to the map/terrain
+    # default it already computes; 1 names an explicit background image
+    # directly on the command (`cmd.string`, RPG_RT's own free-text field for
+    # this command, ignored entirely by every param0/1/3/4/5 read above); 2
+    # names an explicit terrain id instead (param8), read off that terrain's
+    # own row directly rather than wherever the party happens to be standing.
+    # Threaded onto `@battle_request` as `:background`/`:terrain_id`, read
+    # back by `Scene::Battle#encounter_backdrop`.
     def do_enemy_encounter(cmd)
       escape_mode = cmd.param(3)
       troop_id = cmd.param(0) == 0 ? cmd.param(1) : variables[cmd.param(1)]
@@ -1420,6 +1434,10 @@ module Game
         allow_escape: escape_mode != 0, first_strike: cmd.param(5) != 0,
         defeat_game_over: cmd.param(4) == 0
       }
+      case cmd.param(2)
+      when 1 then @battle_request[:background] = cmd.string.to_s
+      when 2 then @battle_request[:terrain_id] = cmd.param(8)
+      end
       @state.battle_count += 1 # a battle was entered (Control Variables "Other")
       @wait_kind = :battle
       @waiting = true

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -783,10 +783,27 @@ class RPG2k
       # so a page talking mid-round does not fight it for the same row.
       BATTLE_EVENT_MSG_Y = 8
 
-      # The backdrop this encounter fights over: whatever Game::Backdrop resolves
-      # for the current map, given the terrain the party is standing on. '' when
-      # nothing names one, which draws the flat field.
+      # The backdrop this encounter fights over. Enemy Encounter's own param2
+      # selector can override the ordinary map/terrain default per fight,
+      # verified against EasyRPG Player's actual C++ source rather than
+      # assumed: `Game_Interpreter_Map::CommandEnemyEncounter`
+      # (`src/game_interpreter_map.cpp`) sets `args.background` to the
+      # command's own string literal for param2==1, or `args.terrain_id` to an
+      # explicit terrain id (param8) for param2==2 -- `Interpreter
+      # #do_enemy_encounter` threads these onto `@battle_request` as
+      # `:background`/`:terrain_id`. An explicit background name wins outright
+      # (`Spriteset_Battle`'s constructor, `src/spriteset_battle.cpp`: `if
+      # (!background_name.empty()) ... else Background(terrain_id)`); an
+      # explicit terrain id reads straight off that terrain's own row
+      # (`Background(int terrain_id)`, `src/background.cpp`) -- bypassing the
+      # map-tree walk entirely, unlike the ordinary default below. Only when
+      # neither key is present (param2==0, the ordinary case) does this fall
+      # back to whatever `Game::Backdrop` resolves for the current map, given
+      # the terrain the party is standing on. '' when nothing names one, which
+      # draws the flat field.
       def encounter_backdrop
+        return @req[:background].to_s if @req.key?(:background)
+        return @map.backdrop_for_terrain_id(@req[:terrain_id]) if @req.key?(:terrain_id)
         Game::Backdrop.name_for(@state.map_id, @map.map_properties,
                                 @map.terrain_backdrop(@state.x, @state.y))
       end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5076,7 +5076,20 @@ class RPG2k
       # terrain row's `background_name` (field 4). '' when the tile, the terrain
       # table or the field is missing.
       def terrain_backdrop(x, y)
-        tid = terrain_id(x, y)
+        backdrop_for_terrain_id(terrain_id(x, y))
+      end
+
+      # The backdrop named by terrain id `tid` directly, bypassing tile lookup
+      # entirely -- Enemy Encounter's own explicit-terrain override (param2==2,
+      # `Interpreter#do_enemy_encounter`'s `terrain_id:` request field) reads a
+      # terrain the party may not even be standing on, matching EasyRPG's
+      # `Background(int terrain_id)` (`src/background.cpp`), which resolves the
+      # terrain table directly with no map-tree/tile involvement at all --
+      # unlike the ordinary (param2==0) path, which walks the map tree first
+      # and only reads a tile's terrain as one fallback among several (see
+      # `Game::Backdrop.name_for`). '' when the id, the terrain table or the
+      # field is missing.
+      def backdrop_for_terrain_id(tid)
         return '' unless tid && tid > 0 && db.respond_to?(:terrain)
         row = db.terrain[tid]
         return '' unless row && row.respond_to?(:background_name)
@@ -7678,7 +7691,7 @@ class RPG2k
       # Scene::Battle with an explicit `@map.` receiver, which -- like any
       # cross-object call -- only reaches a public method.
       public :play_battle_bgm, :play_victory_bgm, :restore_pre_battle_bgm,
-             :terrain_backdrop, :map_properties, :perform_game_over,
+             :terrain_backdrop, :backdrop_for_terrain_id, :map_properties, :perform_game_over,
               :try_open_debug_menu, :build_animation, :anim_target, :drive_map_animation,
              :fire_animation_flashes, :frames_from_tenths, :load_face_bitmap,
              :step_map_animation, :close_battle, :current_map_tone

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5997,6 +5997,56 @@ def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil, troop_id:
   ]
 end
 
+# Enemy Encounter's own param2 selects the battle backdrop's source, verified
+# against EasyRPG Player's actual C++ source rather than assumed:
+# `Game_Interpreter_Map::CommandEnemyEncounter` (`src/game_interpreter_map.cpp`)
+# `switch`es on it -- 0 (the only case previously modelled) leaves the ordinary
+# map/terrain default in place; 1 names an explicit background image directly
+# on the command (its own free-text `string` field, entirely separate from
+# every numeric param); 2 names an explicit terrain id instead (param8), read
+# off that terrain's own row directly rather than wherever the party happens
+# to be standing (`Background(int terrain_id)`, `src/background.cpp` --
+# confirmed to bypass the map-tree walk `Game_Map::SetupBattle` uses for the
+# param2==0 default entirely). `Interpreter#do_enemy_encounter` used to read
+# neither at all, so a scripted encounter always fell back to the map/terrain
+# default regardless of what the event author actually chose.
+check 'Enemy Encounter (param2=1) names an explicit battle background, ' \
+      'overriding the map/terrain default' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # troop 1, backdrop source 1 (explicit name); the string names it directly.
+  auto.event_commands = [
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 1, 0, 0, 0], indent: 0, string: 'ExplicitBack')
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  5.times { scene.update }
+  battle = scene.instance_variable_get(:@battle)
+  ok battle, 'the battle opened'
+  eq 'ExplicitBack', battle.send(:encounter_backdrop),
+     "param2==1's own string names the backdrop directly"
+end
+
+check 'Enemy Encounter (param2=2) reads an explicit terrain id for the ' \
+      "backdrop, not wherever the party is standing" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # troop 1, backdrop source 2 (explicit terrain); param8 (index 8) names
+  # terrain id 7 -- not 42, the terrain every tile of the fixture map is
+  # tagged with (see fake_db), so this only passes if the override actually
+  # bypasses the party's own standing terrain.
+  auto.event_commands = [
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 2, 0, 0, 0, 0, 0, 7], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  scene.db.terrain[7] = OpenStruct.new(background_name: 'OverrideTerrainBack')
+  5.times { scene.update }
+  battle = scene.instance_variable_get(:@battle)
+  ok battle, 'the battle opened'
+  eq 'OverrideTerrainBack', battle.send(:encounter_backdrop),
+     "param2==2's own terrain id (7) is read directly, not the party's own " \
+     'terrain (42, which names no background at all)'
+end
+
 # Drive a battle by having each living actor Attack the first enemy every round
 # until the result window appears (command / target cursors start on Attack /
 # the first target). The budget is generous: between command phases each round


### PR DESCRIPTION
## Summary

- RPG_RT's own editor gives the Enemy Encounter command a third choice beyond the map's automatic backdrop: an explicit background image named directly on the command, or an explicit terrain id to read the backdrop from instead of wherever the party happens to be standing.
- Verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source (fetched live): `Game_Interpreter_Map::CommandEnemyEncounter` (`src/game_interpreter_map.cpp`) `switch`es on `parameters[2]` — 0 (the only case this codebase modelled) calls `Game_Map::SetupBattle`, the map-tree walk already ported as `Game::Backdrop.name_for`; 1 sets `args.background` from the command's own free-text `string` field; 2 sets `args.terrain_id` from `parameters[8]`. `Spriteset_Battle`'s constructor (`src/spriteset_battle.cpp`) proves an explicit background name wins outright, and `Background(int terrain_id)` (`src/background.cpp`) resolves that terrain's own row directly — no map-tree walk at all, unlike the param2==0 default.
- `Interpreter#do_enemy_encounter` never read `param(2)`, `cmd.string` or `param(8)`, so every fight this command opened used the automatic map/terrain default even when the author had explicitly picked a different one.
- Fixed by threading `param(2)`'s selection onto `@battle_request` as `:background` (param2==1) or `:terrain_id` (param2==2), and giving `Scene::Battle#encounter_backdrop` first refusal on either key before falling back to `Game::Backdrop.name_for` as before. Added `Scene::Map#backdrop_for_terrain_id(tid)`, factored out of the existing `#terrain_backdrop(x, y)`'s tile-position lookup, for the terrain-id override.
- Deliberately scoped to the backdrop alone — this same command's RPG2003-only `param(6)`/`param(7)` fields (battle condition/formation) are a separate, already-documented, deliberately-deferred gap, left untouched here.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 722 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1000 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] Both new checks confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_