### PR TITLE
game: death crowds out a lower-priority state, matching RPG_RT

### DIFF
--- a/changelog.d/death-state-crowds-out-lower-priority-states.fixed.md
+++ b/changelog.d/death-state-crowds-out-lower-priority-states.fixed.md
@@ -1,0 +1,5 @@
+- **Battles:** A lethal Change HP, Simulated Attack, or a battle defeat now
+  clears a lower-priority status ailment (Poison, Blind, ...) the instant the
+  Knockout state lands, matching real RPG_RT — a knocked-out battler used to
+  keep showing the old ailment alongside Knockout instead of just "Dead."
+  Covered by new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10264,19 +10264,62 @@ not yet verified:
   Unlike `#significant`, ties don't matter for pruning — only the *value* of
   the top priority does, so several states sharing it all survive; "ties go
   to the higher state ID" is about which one **displays**, not which ones
-  live. State #1 (Knockout) is exempt on both sides — it is never pruned and
-  its own priority is never consulted as "the current highest" either,
-  matching `#significant`'s existing death special-case; knockout is tracked
-  through HP/`Actor#dead?`, not through this ranking. Wired into every
-  infliction path: `Game::Actor#add_state` callers (`Change Condition`, field
-  `cast_skill`) via a new `Game::Party#state_table` accessor, and
-  `Game::Battle#roll_inflict` via the battle's own state table. One
-  simplification, not confirmed against real RPG_RT: a state's accuracy-roll
-  "landed" report is unconditional even where pruning removes it again the
-  same instant — no test bed exercises two states with a large enough
-  priority gap to say whether the real messaging differs. Covered by new
-  `scripts/rpg2k_logic_check.rb` checks (the pure `States.prune` rule, and
-  one per infliction path), confirmed to fail against the pre-fix code.
+  live. State #1 (Knockout) was originally believed exempt on both sides —
+  never pruned and its own priority never consulted as "the current
+  highest" — matching `#significant`'s own death special-case; **this
+  turned out to be wrong on the second half, corrected below.** Wired into
+  every infliction path: `Game::Actor#add_state` callers (`Change
+  Condition`, field `cast_skill`) via a new `Game::Party#state_table`
+  accessor, and `Game::Battle#roll_inflict` via the battle's own state
+  table. One simplification, not confirmed against real RPG_RT: a state's
+  accuracy-roll "landed" report is unconditional even where pruning removes
+  it again the same instant — no test bed exercises two states with a large
+  enough priority gap to say whether the real messaging differs. Covered by
+  new `scripts/rpg2k_logic_check.rb` checks (the pure `States.prune` rule,
+  and one per infliction path), confirmed to fail against the pre-fix code.
+  ✅ **Death is not actually exempt from the crowding-out rule — it *is*
+  the rule, and the bullet just above had it backwards
+  (2026-08-18).** Re-verified against RPG_RT's actual behavior via EasyRPG
+  Player's own C++ source (fetched live rather than paraphrased):
+  `State::Add` (`src/state.cpp`) computes `sig_state =
+  GetSignificantState(states)` *after* inserting the newly-added id, then
+  clears every state whose own `priority <= sig_state->priority - 10`.
+  `GetSignificantState` returns Death's own row the instant it sees it,
+  before ever comparing priorities — so when Death is carried, `sig_state`
+  in `Add()` is Death, and the threshold becomes *Death's own configured
+  priority* minus 10, applied uniformly to every state including Death
+  itself (which always survives its own threshold trivially, `p <= p - 10`
+  is never true — no special-case needed for that half). A real database
+  conventionally gives Death a high priority (100 by RPG2000's own default)
+  specifically so this wipes a lower-priority ailment (Poison, Blind, ...)
+  the instant a lethal hit lands — real RPG_RT never shows "Dead,
+  Poisoned". `Game::States.prune` (`mruby-rpg2k/mrblib/game.rb`) explicitly
+  excluded `DEATH_ID` from the ranked set before computing `top`, per the
+  bullet above's own (incorrect) reading — the exact opposite of `Add()`'s
+  real behavior. Worse, the one path that actually *adds* Death —
+  `Actor#change_hp`/`#set_hp`, via `#add_state(DEATH_STATE)` — never called
+  `Game::States.prune` at all, unlike every other infliction path already
+  covered by the fix above (`#cast_skill`, `#roll_inflict`,
+  `#roll_weapon_states`), so a lethal Change HP (10630) or Simulated Attack
+  (10500) — or a battle defeat writing HP back onto the party via `#set_hp`
+  — left Death sitting alongside whatever ailment the actor already
+  carried instead of clearing it. Fixed by rewriting `#prune` to reuse
+  `#significant` for `top` (which already returns `DEATH_ID` correctly when
+  present, so Death's own priority participates for free, no id
+  special-cased on either side any more), and adding a new
+  `Actor#knock_out!` — `#add_state(DEATH_STATE)` followed immediately by
+  `Game::States.prune`, the same shape `#cast_skill` already uses for a
+  landed non-death state — called from both `#change_hp` and `#set_hp`
+  wherever they used to call `#add_state(DEATH_STATE)` directly. The
+  existing "death is exempt both ways" `scripts/rpg2k_logic_check.rb` check
+  asserted the old, incorrect claim directly — rewritten to assert the real
+  rule instead (a low-priority state is cleared, a near-Death-priority one
+  survives, Death itself always survives). Covered by three further new
+  checks: a lethal `#change_hp` clears a lower-priority state; a lethal
+  `#set_hp` (the battle write-back path) does too, through the same
+  `#knock_out!`; a state within Death's own priority gap survives
+  alongside it — all three confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ A weapon-type Attribute (as opposed to a magic-type one) gates skill
   usability on having a matching-attribute **weapon** equipped — armor
   with the same attribute does not satisfy it (already flagged as a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2469,7 +2469,7 @@ module Game
       return @hp if dead?
       floor = allow_death ? 0 : 1
       @hp = Game.clamp(@hp + delta, floor, @max_hp)
-      add_state(DEATH_STATE) if @hp <= 0
+      knock_out! if @hp <= 0
       @hp
     end
 
@@ -2545,11 +2545,34 @@ module Game
     def set_hp(value)
       @hp = Game.clamp(value, 0, @max_hp)
       if @hp <= 0
-        add_state(DEATH_STATE)
+        knock_out!
       else
         remove_state(DEATH_STATE)
       end
       @hp
+    end
+
+    # Inflict the death state and immediately apply RPG_RT's own
+    # crowding-out rule to the result (`State::Add`, `src/state.cpp`, runs
+    # this same pass after *every* state it adds, not just Death) -- a
+    # lethal hit does not merely add Death alongside whatever ailments the
+    # actor already carried, it also clears any of them 10+ priority below
+    # Death's own configured priority, the same instant Death lands. Shared
+    # by #change_hp and #set_hp, RPG2000's two HP-changing entry points that
+    # can inflict it (a raw #add_state elsewhere is never followed by this on
+    # its own -- see #cast_skill/#roll_inflict/#roll_weapon_states, which
+    # already call #Game::States.prune themselves right after inflicting a
+    # non-death state, the identical rule from the other direction).
+    def knock_out!
+      add_state(DEATH_STATE)
+      @states = Game::States.prune(@states, state_table)
+    end
+
+    # The database's state (`situation`) table, for Game::States lookups.
+    # nil for a fixture without one, which every Game::States accessor
+    # already tolerates.
+    def state_table
+      @db.respond_to?(:situation) ? @db.situation : nil
     end
 
     # Apply a MP (SP) change, clamped to [0, max_mp]. Returns the new MP.
@@ -8123,22 +8146,31 @@ module Game
     # auto-removed).
     PRUNE_GAP = 10
 
-    # `ids` after RPG_RT's crowding-out rule: any state 10+ priority below the
-    # current highest-priority state it carries is dropped. Only the *value*
-    # of the top priority matters here (unlike #significant, no id is singled
-    # out), so ties do not change what survives -- everything within the gap
-    # of the top, however many states share it, stays. Death (DEATH_ID) is
-    # exempt on both sides: it never gets pruned, and (matching #significant,
-    # which never even reads its priority) it does not count toward "the
-    # current highest" either -- knockout is tracked through HP/#dead?, not
-    # through this ranking. `ids` with one or fewer non-death entries has
-    # nothing to compare, and comes back unchanged.
+    # `ids` after RPG_RT's crowding-out rule: any state 10+ priority below
+    # the *significant* one it carries is dropped. Verified against RPG_RT's
+    # actual behavior via EasyRPG Player's own C++ source rather than
+    # assumed: `State::Add` (`src/state.cpp`) computes `sig_state =
+    # GetSignificantState(states)` *after* inserting the new id, then clears
+    # every state whose own `priority <= sig_state->priority - 10`. Death is
+    # not exempt from this at all -- when carried, it *is* the significant
+    # state (`GetSignificantState` returns Death's own row the instant it
+    # sees it, before ever comparing priorities), so the threshold becomes
+    # *Death's own configured priority* minus 10, which is why a lethal hit
+    # clears a lower-priority ailment (Poison, Blind, ...) immediately: a
+    # real database's Death priority is conventionally set high (RPG2000's
+    # own default is 100) specifically so this rule wipes weaker states the
+    # instant it lands, while Death itself always survives its own threshold
+    # trivially (`p <= p - 10` is never true). #significant already returns
+    # DEATH_ID the moment it is present, so reusing it here for `top` gets
+    # this right for free -- no id needs to be singled out or exempted.
+    # `ids` with one or fewer entries has nothing to compare, and comes back
+    # unchanged.
     def self.prune(ids, table)
       return ids if ids.nil? || ids.size <= 1
-      ranked = ids.reject { |id| id == DEATH_ID }
-      return ids if ranked.size <= 1
-      top = ranked.map { |id| priority_of(id, table) }.max
-      ids.select { |id| id == DEATH_ID || priority_of(id, table) > top - PRUNE_GAP }
+      sig = significant(ids, table)
+      return ids if sig.nil?
+      top = priority_of(sig, table)
+      ids.select { |id| priority_of(id, table) > top - PRUNE_GAP }
     end
 
     # The state's display name, or nil when the table does not name it (a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13176,14 +13176,32 @@ check 'States.prune: states sharing the top priority all survive' do
   eq [2, 3], Game::States.prune([2, 3, 5], table)
 end
 
-check 'States.prune: death is exempt both ways' do
-  table = { 4 => display_state(name: 'Poison', priority: 30) }
-  # Carrying death alongside a low-priority state does not drop the state --
-  # death's priority is never consulted, matching #significant.
-  eq [1, 4], Game::States.prune([1, 4], table)
-  # And death itself is never dropped, however it compares.
-  table[9] = display_state(name: 'Overwhelm', priority: 999)
+# Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
+# source rather than assumed: `State::Add` (src/state.cpp) computes
+# `sig_state = GetSignificantState(states)` *after* inserting the new id,
+# then clears every state whose own priority sits 10+ below
+# `sig_state->priority`. Death is not exempt from this at all -- when
+# carried, `GetSignificantState` returns Death's own row the instant it
+# sees it (before ever comparing priorities), so `sig_state->priority` in
+# `Add()` is *Death's own configured priority*, used as the real threshold
+# for every other state. This is why a lethal hit clears a lower-priority
+# ailment (Poison, Blind, ...) immediately -- a real database's Death
+# priority is conventionally set high (100, RPG2000's own default)
+# specifically so this rule wipes weaker states the instant it lands.
+check 'States.prune: death is not exempt -- its own priority becomes the ' \
+      'pruning threshold' do
+  table = { 1 => display_state(name: 'Dead', priority: 100),
+           4 => display_state(name: 'Poison', priority: 30) }
+  # Poison (30) trails Death's own priority (100) by 70, well past the
+  # 10-point gap, so it is cleared the instant Death lands -- a knocked-out
+  # battler never shows "Dead, Poisoned".
+  eq [1], Game::States.prune([1, 4], table)
+  # A state within 10 of Death's own priority survives alongside it.
+  table[9] = display_state(name: 'NearDeath', priority: 95)
   eq [1, 9], Game::States.prune([1, 4, 9], table)
+  # Death itself is never dropped by its own threshold (p <= p - 10 is
+  # never true).
+  eq [1, 9], Game::States.prune([1, 9], table)
 end
 
 check 'States.prune: a single (or no) non-death state has nothing to compare' do
@@ -13258,6 +13276,46 @@ check "a battle attack skill inflicting a state prunes the target's state set" d
                     hp: c[:hp], mp: c[:mp], inflict: c[:inflict], chance: c[:chance])
   bat.run_round
   eq [3], foe.states, 'the battle-inflicted Petrify displaced the held Poison'
+end
+
+# Change HP / Simulated Attack (via #change_hp) and a battle write-back (via
+# #set_hp) are the two places `Actor#add_state(DEATH_STATE)` can fire outside
+# a skill/weapon infliction -- unlike those (`#cast_skill`/`#roll_inflict`/
+# `#roll_weapon_states`, tested just above), neither used to call
+# `Game::States.prune` at all, so a lethal hit left Death sitting alongside
+# whatever ailment the actor already carried instead of clearing it the way
+# RPG_RT's own `State::Add` does (see `Game::States.prune`'s own comment).
+check 'a lethal Change HP clears a lower-priority state the instant death lands' do
+  states = { 1 => display_state(name: 'Dead', priority: 100),
+            2 => display_state(name: 'Poison', priority: 30) }
+  st = party_state_with_states(states)
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2) # seed with the low-priority state directly
+  hero.change_hp(-9999) # lethal
+  eq true, hero.dead?
+  eq [1], hero.states, 'Death (100) pushed the far-lower-priority Poison (30) out on landing'
+end
+
+check 'a lethal set_hp (a battle write-back) clears a lower-priority state too' do
+  states = { 1 => display_state(name: 'Dead', priority: 100),
+            2 => display_state(name: 'Poison', priority: 30) }
+  st = party_state_with_states(states)
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2)
+  hero.set_hp(0)
+  eq true, hero.dead?
+  eq [1], hero.states, 'set_hp knocks the actor out through the same #knock_out! path'
+end
+
+check "a state within Death's own 10-priority gap survives death alongside it" do
+  states = { 1 => display_state(name: 'Dead', priority: 100),
+            2 => display_state(name: 'NearDeath', priority: 95) }
+  st = party_state_with_states(states)
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2)
+  hero.change_hp(-9999)
+  eq true, hero.dead?
+  eq [2, 1], hero.states, 'a state within the gap of Death\'s own priority is not pruned'
 end
 
 check 'States.name / color fall back when the row does not say' do


### PR DESCRIPTION
## Summary

- Real RPG_RT clears a battler's other status ailments the instant it dies, if those ailments' priority sits 10+ below Death's own configured priority — this is why a poisoned character shows only "Dead," never "Dead, Poisoned."
- Verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source (fetched live): `State::Add` (`src/state.cpp`) computes `sig_state = GetSignificantState(states)` *after* inserting the newly-added id, then clears every state whose own `priority <= sig_state->priority - 10`. `GetSignificantState` returns Death's own row the instant it sees it, before ever comparing priorities — so when Death is carried, the threshold becomes *Death's own configured priority* minus 10, applied to every state including Death itself (which always survives its own threshold trivially).
- `Game::States.prune` (`mruby-rpg2k/mrblib/game.rb`) explicitly excluded `DEATH_ID` from the ranked set before computing the threshold — the exact opposite of `Add()`'s real behavior. Worse, the one path that actually *adds* Death — `Actor#change_hp`/`#set_hp` — never called `Game::States.prune` at all, unlike every other infliction path already covered (`#cast_skill`, `#roll_inflict`, `#roll_weapon_states`), so a lethal Change HP (10630), Simulated Attack (10500), or a battle defeat writing HP back onto the party left Death sitting alongside whatever ailment the actor already carried instead of clearing it.
- Fixed by rewriting `#prune` to reuse `#significant` for the threshold (which already returns `DEATH_ID` correctly when present, so Death's own priority participates for free — no id special-cased on either side), and adding a new `Actor#knock_out!` (`#add_state(DEATH_STATE)` followed immediately by `Game::States.prune`, the same shape `#cast_skill` already uses) called from both `#change_hp` and `#set_hp`.
- An existing test ("death is exempt both ways") asserted the old, incorrect claim directly — rewritten to assert the real rule instead.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 722 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1003 checks passed (3 new, 1 existing check corrected)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] All three new checks confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_