### PR TITLE
interpreter: Change Monster HP no-ops entirely on a dead enemy

### DIFF
--- a/changelog.d/change-monster-hp-dead-enemy-noop.fixed.md
+++ b/changelog.d/change-monster-hp-dead-enemy-noop.fixed.md
@@ -1,0 +1,6 @@
+- **Battles:** Change Monster HP is now a complete no-op against an
+  already-downed enemy, matching real RPG_RT — a further damaging hit used to
+  silently revive it to 1 HP instead of leaving it dead. Also fixed the
+  command's percentage-amount mode to scale off the target's current HP, not
+  its maximum, matching RPG_RT. Covered by new `scripts/rpg2k_logic_check.rb`
+  checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10224,9 +10224,11 @@ not yet verified:
   positive amount on a 0 HP enemy (`dead?` is `hp <= 0` for a Combatant)
   unconditionally raised it back above 0, silently reviving it — fixed by
   making a positive amount a no-op once the target is already dead,
-  mirroring `Actor#change_hp`; a further (negative) hit on an already-dead
-  enemy is untouched by the guard and simply re-clamps to the command's
-  existing lethal-flag floor as before. The **in-battle Skill/Item
+  mirroring `Actor#change_hp`. **A further (negative) hit on an
+  already-dead enemy was believed untouched by this guard, simply
+  re-clamping to the command's existing lethal-flag floor — this turned out
+  to be wrong, see below: it silently revived the enemy too, the opposite
+  direction from this bullet's own fix.** The **in-battle Skill/Item
   command** path (a heal spell/item cast mid-fight) was checked too and
   found already correct: `Game::Battle#apply_command` / `#apply_command_all`
   gate every Skill/Item command — single- and all-target alike — on
@@ -10241,6 +10243,36 @@ not yet verified:
   member and a wounded one confirms the Skill/Item path skips the downed
   member entirely while still healing the wounded member normally (true
   both before and after, since that path was never broken).
+  ✅ **A further Change Monster HP hit on an already-downed enemy revived
+  it — the bullet above's own guess about this direction was wrong,
+  corrected here against RPG_RT's actual behavior (2026-08-18).**
+  EasyRPG's `Game_Interpreter_Battle::CommandChangeMonsterHP` (`src/
+  game_interpreter_battle.cpp`, re-fetched and read live this session
+  rather than left as the earlier bullet's unverified guess) checks `if
+  (enemy->IsDead()) return true;` as the very first thing — *before*
+  reading the direction, amount source or lethal flag at all, so nothing
+  past that point ever runs against a dead enemy, whichever direction. This
+  codebase's `Interpreter#do_change_monster_hp`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) only guarded the healing direction
+  (`return if target.dead? && amount > 0`); a further *hit* on a 0-HP
+  target fell through to `hp = 0 + amount` (negative), which then got
+  re-clamped *up* to the lethal-off floor of 1 — the exact silent revival
+  the healing-direction guard was written to prevent, just reached from the
+  other side. Fixed by moving the dead check to the top, unconditional,
+  before `amount` is even computed, matching RPG_RT's own early return
+  exactly. A second, related inaccuracy in the same command was fixed
+  alongside it: `#monster_change_amount`'s percentage mode (param2==2)
+  read `battler.max_hp`, but `CommandChangeMonsterHP`'s own `case 2:
+  change = com.parameters[3] * hp / 100;` computes it from `hp =
+  enemy->GetHp()` — the target's *current* HP, captured once at the top —
+  not its maximum (`CommandChangeMonsterMP` has no percentage case at all,
+  so this only ever mattered for HP). An existing
+  `scripts/rpg2k_logic_check.rb` check had encoded the old, incorrect
+  max_hp-based percentage directly in its own expected value — corrected
+  to the current-HP-based one. Covered by a new check confirming a downed
+  enemy stays at 0 HP (not revived to the lethal-off floor) after a
+  further hit, and a heal on it remains a no-op too, both confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ Damage Processing (the raw event command, Simulated Attack 10500) uses a
   **different formula** from the built-in normal attack: normal attack =
   `(ATK÷2) − (DEF÷4)`, but this command computes `AttackPower − (DEF÷4)`

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2434,12 +2434,17 @@ module Game
 
     # The amount a Change Monster HP / MP command applies. param2 selects how
     # param3 is read: 0 a constant, 1 the value of that variable, 2 (HP only) a
-    # percentage of the target's maximum. Mirrors EasyRPG's
-    # CommandChangeMonsterHP / CommandChangeMonsterMP.
+    # percentage of the target's *current* HP, not its maximum -- EasyRPG's
+    # `Game_Interpreter_Battle::CommandChangeMonsterHP` (`src/
+    # game_interpreter_battle.cpp`) reads `hp = enemy->GetHp()` once up top
+    # and computes `change = com.parameters[3] * hp / 100` from that captured
+    # value for case 2; `CommandChangeMonsterMP` has no percentage case at
+    # all (param2 is only ever 0/1 there -- the editor offers no % option for
+    # Change Monster MP), so this only ever matters for the HP path.
     def monster_change_amount(cmd, battler)
       case cmd.param(2)
       when 1 then variables[cmd.param(3)]
-      when 2 then cmd.param(3) * (battler.max_hp || 0) / 100
+      when 2 then cmd.param(3) * (battler.hp || 0) / 100
       else cmd.param(3)
       end
     end
@@ -2447,18 +2452,22 @@ module Game
     # Change Monster HP (13110): heal or hurt troop member param0. param1 is the
     # direction (non-zero = lose HP), param2/param3 the amount (see above) and
     # param4 whether the damage may be lethal — when it may not, the monster is
-    # left on 1 HP instead of going down.
+    # left on 1 HP instead of going down. An already-downed target is left
+    # untouched entirely, whichever direction: EasyRPG's own
+    # `CommandChangeMonsterHP` (`src/game_interpreter_battle.cpp`) checks
+    # `if (enemy->IsDead()) return true;` *before* reading param2/param3 or
+    # the direction/lethal flags at all, so nothing past that point ever
+    # runs against a dead enemy -- not just a further heal (this codebase's
+    # own prior guard only covered that half), a further *hit* on a
+    # 0-HP target used to fall through to `hp = 0 + amount`, then get
+    # re-clamped *up* to the lethal-off floor of 1 -- silently reviving a
+    # downed enemy back to 1 HP.
     def do_change_monster_hp(cmd)
       target = @battle && @battle.enemy(cmd.param(0))
       return unless target
+      return if target.dead?
       amount = monster_change_amount(cmd, target)
       amount = -amount if cmd.param(1) != 0
-      # yado.tk quirk: a downed (0 HP) enemy stays down. A positive amount
-      # here is a no-op on an already-dead target -- like Game::Actor#change_hp,
-      # clearing the KO needs Change State / Full Recovery even after this
-      # would otherwise put it back above 0. A further (negative) hit on a
-      # dead target is left alone: it just re-clamps to the same floor below.
-      return if target.dead? && amount > 0
       hp = target.hp + amount
       floor = cmd.param(4) != 0 ? 0 : 1
       hp = floor if hp < floor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14996,15 +14996,43 @@ check 'Change Monster HP heals, reads a variable and a percentage' do
   it.update
   eq 45, b.enemy(0).hp
 
-  # percentage operand (2): 10% of max_hp (100) = 10
+  # percentage operand (2): 10% of the target's *current* hp (45, not max_hp
+  # 100) = 4, per EasyRPG's CommandChangeMonsterHP (src/
+  # game_interpreter_battle.cpp), which reads `hp = enemy->GetHp()` and
+  # computes the percentage from that captured value, not GetMaxHp().
   it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 2, 10, 1])])
   it.update
-  eq 55, b.enemy(0).hp
+  eq 49, b.enemy(0).hp
 
   # Healing never exceeds the maximum.
   it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 0, 999, 1])])
   it.update
   eq 100, b.enemy(0).hp
+end
+
+# Verified against EasyRPG's own CommandChangeMonsterHP
+# (src/game_interpreter_battle.cpp): `if (enemy->IsDead()) return true;` runs
+# before anything else -- direction, amount source (param2/param3) and the
+# lethal flag (param4) are never even read once the target is already dead.
+# A further *hit* on a 0-HP target used to fall through to `hp = 0 + amount`,
+# then get re-clamped *up* to the lethal-off floor of 1 -- silently reviving
+# a downed enemy. Only the healing direction was previously guarded.
+check 'Change Monster HP leaves an already-downed target untouched entirely' do
+  b = battle_with(foe_hp: 100)
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  b.enemy(0).hp = 0
+  ok b.enemy(0).dead?, 'the target starts downed'
+  # lose direction (1), lethal off (param4 == 0): used to re-clamp to the
+  # lethal-off floor of 1.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 30, 0])])
+  it.update
+  eq 0, b.enemy(0).hp, 'a downed target stays at 0, not revived to the lethal-off floor'
+  ok b.enemy(0).dead?, 'and stays downed'
+  # A heal is untouched too (already correctly guarded before this fix).
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 0, 30, 1])])
+  it.update
+  eq 0, b.enemy(0).hp, 'a heal on a downed target is still a no-op'
 end
 
 check 'Change Monster MP adjusts SP and clamps to its range' do


### PR DESCRIPTION
## Summary

- Real RPG_RT's Change Monster HP command is a complete no-op the instant its target is already dead, in either direction. Verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source (fetched live): `Game_Interpreter_Battle::CommandChangeMonsterHP` (`src/game_interpreter_battle.cpp`) checks `if (enemy->IsDead()) return true;` as the very first thing — before reading the direction, amount source, or lethal flag at all.
- `Interpreter#do_change_monster_hp` (`mruby-rpg2k/mrblib/interpreter.rb`) only guarded the healing direction (`return if target.dead? && amount > 0`). A further *hit* on a 0-HP target fell through to `hp = 0 + amount` (negative), which then got re-clamped *up* to the lethal-off floor of 1 — silently reviving a downed enemy back to 1 HP, the exact bug the healing-direction guard was written to prevent, just reached from the other side.
- Fixed by moving the dead check to the top, unconditional, before `amount` is even computed — matching RPG_RT's own early return exactly.
- A second, related inaccuracy in the same command is fixed alongside it: `#monster_change_amount`'s percentage mode (param2==2) read `battler.max_hp`, but `CommandChangeMonsterHP`'s own `case 2: change = com.parameters[3] * hp / 100;` computes it from the target's *current* HP (`hp = enemy->GetHp()`, captured once at the top), not its maximum. (`CommandChangeMonsterMP` has no percentage case at all, so this only ever mattered for HP.)
- An existing check had encoded both the old, incorrect "further hit is untouched" claim and the max_hp-based percentage directly — corrected to the real behavior.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 722 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1004 checks passed (1 new, 1 existing check corrected)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] New check confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_