### PR TITLE
battle: an actor's own active state now drives its battle sprite pose

### DIFF
--- a/changelog.d/actor-sprite-active-state-pose.fixed.md
+++ b/changelog.d/actor-sprite-active-state-pose.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 battle:** A living but afflicted party member's own battle
+  sprite (the alternate/gauge layout's per-actor battler graphic) now shows
+  that status's own configured pose, matching real RPG_RT — Poison, Sleep,
+  Confusion and every other active state used to leave the sprite
+  indistinguishable from a perfectly healthy one; only Defend and Dead were
+  ever shown. Falls back to a generic "bad status" pose when the state
+  names none of its own. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13016,6 +13016,51 @@ above are repeated here)
   catches up — confirmed the faster ally still leads `#ready_combatants`
   once both are tied at `GAUGE_MAX`, and confirmed to fail against the
   pre-fix code (`[SeatSlow, SeatFast]`, plain seat order) before the fix.
+  ✅ **A living-but-afflicted party member's own alternate-battle-layout
+  sprite (RPG2003's per-actor battler graphic, `db.battleranimations`) now
+  shows that state's own configured pose, not always plain Idle
+  (2026-08-18).** `Scene::Battle#build_actor_sprite` only ever picked
+  between Idle, Defend and Dead — the code's own comments already flagged
+  this exact gap, citing the same reference this session independently
+  re-fetched and confirmed: `Sprite_Actor::DoIdleAnimation` (`src/
+  sprite_actor.cpp`) checks `IsDefending()` first, unconditionally, but its
+  *remaining* branch for a living party member (one with a real
+  `battler_animation_id`, i.e. not a monster) is `idling_anim = state ?
+  state->battler_animation_id + 1 : AnimationState_Idle` — RPG_RT reads the
+  battler's own *significant active state* (`GetSignificantState`, already
+  the exact function `Game::States.significant` ports) and shows *that
+  state's own configured pose*, falling back to a generic "bad status" pose
+  when the state names none of its own (`if (idling_anim == 101) idling_anim
+  = 7;` — `AnimationState_BadStatus`). Death is not special-cased here at
+  all for an actor: it reaches the identical state-driven branch (a real
+  database's Death row conventionally already points its own
+  `battler_animation_id` at the Dead pose), it is only the *monster* branch
+  (no pose table to consult) that hardcodes Death straight to
+  `AnimationState_Dead`. So Poison, Sleep, Confusion, Blindness or any other
+  active status this codebase's own `dead:`/`defending:` special-casing
+  never covered left a living, afflicted party member's on-screen battler
+  sprite indistinguishable from a perfectly healthy one. Fixed with a new
+  `Game::States.animation_pose(id, table)` (`mruby-rpg2k/mrblib/game.rb`),
+  reading a state row's own `battler_animation_id` field (liblcf schema
+  field 39 on the `situation` chunk, whose own default — `6` — is already
+  this codebase's 0-based pose-array equivalent of the C++ side's raw
+  pre-translation sentinel `100`, so no further `+1`/`101→7` arithmetic is
+  needed on this side), and a new `ACTOR_BAD_STATUS_POSE` (6, the same
+  Null-head-subtracted shift the existing Idle/Dead/Defend constants
+  already use) fallback constant. `#build_actor_sprite` gained a `states:`
+  keyword (the *battle* `Combatant`'s own live states, not the field-side
+  `Actor#states` this class never carries a battle ailment onto) threaded
+  through from all three call sites — `#build_actor_sprites` (initial
+  build), `#add_battle_actor_sprite` (a mid-battle rejoin), and
+  `#reposition_actor_sprite` (a round-end refresh) — consulted only once
+  neither `defending:` nor `dead:` already picked a pose, matching the
+  reference's own check order exactly. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (a party member entering the fight
+  already carrying a state whose own `battler_animation_id` names a real
+  pose draws that pose, not Idle; a state naming none of its own falls back
+  to the generic bad-status pose, still not Idle), both confirmed to fail
+  against the pre-fix code (both drew the Idle pose regardless) before the
+  fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8188,6 +8188,28 @@ module Game
       c.nil? ? DEFAULT_COLOR : c
     end
 
+    # RPG2003's per-state battle-sprite pose: which pose (0-indexed, the same
+    # scheme `Scene::Battle::ACTOR_*_POSE` constants use) a `db.battleranimations`
+    # entry should show while this state is the significant one on a living
+    # party member. Verified against RPG_RT's actual behavior via EasyRPG
+    # Player's own C++ source: `Sprite_Actor::DoIdleAnimation`
+    # (`src/sprite_actor.cpp`) reads `state->battler_animation_id` directly as
+    # the pose to show (its own `+1`/`101->7` dance is that function
+    # translating into the *runtime* `AnimationState` enum, which carries an
+    # extra `Null` head element ahead of `Idle` that this schema's own 0-based
+    # `battler_animation_id` field never had to begin with -- liblcf's own
+    # schema default for this field, field 39 on the `situation` chunk, is
+    # already `6`, this codebase's own `ACTOR_BAD_STATUS_POSE` index, not the
+    # C++ side's raw pre-translation sentinel `100`). DEFAULT_ANIMATION_POSE
+    # is that same fallback for a fixture/older-save row that omits the field
+    # outright.
+    DEFAULT_ANIMATION_POSE = 6
+    def self.animation_pose(id, table)
+      r = row(id, table)
+      p = r && r.respond_to?(:battler_animation_id) ? r.battler_animation_id : nil
+      p.nil? ? DEFAULT_ANIMATION_POSE : p
+    end
+
     # RPG_RT's sentence for a state landing on `battler_name`. The database
     # stores the *predicate* only ("は毒にかかった！"), which RPG2000 prints
     # straight after the battler's name — EasyRPG's GetStateMessage, whose

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -452,10 +452,9 @@ class RPG2k
       # a sprite too (unlike RPG2000's status-window-only layout -- see
       # Game::Party#alternate_battle_layout?), sourced from the database's
       # Battler Animation table (chunk 32, db.battleranimations). Idle,
-      # Defend and Dead are the three poses #build_actor_sprite picks
-      # between (EasyRPG's Sprite_Actor::DoIdleAnimation, src/sprite_actor.cpp
-      # -- its remaining branch, any *other* active state swapping in its own
-      # `situation.battler_animation_id` pose, is still unimplemented here).
+      # Defend, Dead and "some other active state" are the poses
+      # #build_actor_sprite picks between (EasyRPG's Sprite_Actor::
+      # DoIdleAnimation, src/sprite_actor.cpp).
       # A fallen member still gets a sprite (the Dead pose, or Idle when the
       # entry defines no Dead pose of its own) rather than none at all -- the
       # party status window shows everyone regardless either way, so this
@@ -468,7 +467,8 @@ class RPG2k
         return unless @state.party.respond_to?(:alternate_battle_layout?) &&
                       @state.party.alternate_battle_layout?
         @ui[:actor_sprites] = @ui[:allies].each_with_index.map do |ally, i|
-          build_actor_sprite(ally.actor, i, defending: ally.defending, dead: ally.dead?)
+          build_actor_sprite(ally.actor, i, defending: ally.defending, dead: ally.dead?,
+                             states: ally.states)
         end
       end
 
@@ -477,8 +477,16 @@ class RPG2k
       # Pose_Defend -- schema.rb's own comment on chunk 32 lists the full
       # 12-pose order, and matches EasyRPG's own `AnimationState` enum once
       # its one-off `AnimationState_Null` head element is subtracted out).
+      # `ACTOR_BAD_STATUS_POSE` is the same shift applied to
+      # `AnimationState_BadStatus` (7) -- the generic pose an active state
+      # falls back to when its own `battler_animation_id` field (`Game::
+      # States.animation_pose`) names none of its own, matching liblcf's own
+      # schema default for that field (6, not the C++ side's raw
+      # pre-translation sentinel 100 -- see `Game::States.animation_pose`'s
+      # own comment).
       ACTOR_IDLE_POSE = 0
       ACTOR_DEAD_POSE = 4
+      ACTOR_BAD_STATUS_POSE = 6
       ACTOR_DEFEND_POSE = 7
       # `poses[id].animation_type` values: 0 a BattleCharSet sprite sheet
       # (implemented below), 1 a full Battle/<name> (CBA) animation sequence
@@ -497,30 +505,43 @@ class RPG2k
         200 + i
       end
 
-      # A party member's Idle-, Defend- or Dead-pose sprite, or nil when this
-      # step cannot draw one: `actor.battler_animation_id` names no
-      # `db.battleranimations` entry (Game::Actor#battler_animation_id
-      # already logs that diagnostic itself), the resolved entry defines
-      # none of the three poses at all (silent -- an entry legitimately
-      # covering only some of the 12 poses is normal authoring, not a
-      # dangling reference), or the pose uses the `animation_type == 1`
-      # battle/CBA format this step does not implement (logged below,
-      # matching this codebase's "reported gap, not silently invented"
-      # convention for unimplemented behaviour).
+      # A party member's Idle-, Defend-, Dead- or active-state-pose sprite, or
+      # nil when this step cannot draw one: `actor.battler_animation_id`
+      # names no `db.battleranimations` entry (Game::Actor
+      # #battler_animation_id already logs that diagnostic itself), the
+      # resolved entry defines none of the candidate poses at all (silent --
+      # an entry legitimately covering only some of the 12 poses is normal
+      # authoring, not a dangling reference), or the pose uses the
+      # `animation_type == 1` battle/CBA format this step does not implement
+      # (logged below, matching this codebase's "reported gap, not silently
+      # invented" convention for unimplemented behaviour).
       #
       # `defending:`/`dead:` select Pose id 7 (Defend) / 4 (Dead) over Idle
       # -- ported from EasyRPG's `Sprite_Actor::DoIdleAnimation`, whose very
-      # first check is `battler->IsDefending()`, ahead of every state-mapped
-      # pose, and whose monster branch (the one unambiguous case without a
-      # `situation.battler_animation_id` table to consult) resolves the
-      # Knockout state straight to `AnimationState_Dead`; a defeated actor
-      # is treated the same way here rather than through its own state's
-      # configurable pose (the other, still-unimplemented half of that
-      # function's dispatch -- see #build_actor_sprites). Defending wins
-      # over dead, matching the reference's check order, though the two
-      # never actually coincide (a downed actor never has a command to
-      # defend with). Either falls back to Idle when the entry defines no
-      # pose of its own for it, exactly like an entry with no Idle pose
+      # first check is `battler->IsDefending()`, ahead of everything else,
+      # and whose monster branch (the one unambiguous case without a
+      # `situation.battler_animation_id` table to consult at all) resolves
+      # the Knockout state straight to `AnimationState_Dead`; a defeated
+      # actor is treated the same way here rather than through its own
+      # state's configurable pose (a real database's Death row conventionally
+      # already points there anyway). Defending wins over dead, matching the
+      # reference's check order, though the two never actually coincide (a
+      # downed actor never has a command to defend with).
+      #
+      # Neither defending nor dead: RPG_RT's own remaining branch --
+      # `idling_anim = state ? state->battler_animation_id + 1 : Idle` --
+      # reads `states:` (the combatant's own currently-active state ids, not
+      # the field-side `Actor#states` this class never carries battle
+      # ailments onto) for its highest-priority one
+      # (`Game::States.significant`, already the exact port of
+      # `GetSignificantState` this reads) and shows *that* state's own
+      # configured pose (`Game::States.animation_pose`), falling back to the
+      # generic "bad status" pose (`ACTOR_BAD_STATUS_POSE`) when the state
+      # names none of its own, and further to plain Idle if even that pose is
+      # missing from this entry or no state is significant at all.
+      #
+      # Every candidate pose alike falls back to Idle when the entry defines
+      # no pose of its own for it, exactly like an entry with no Idle pose
       # falls back to no sprite at all: a partially-authored table is normal,
       # not an error.
       #
@@ -529,7 +550,7 @@ class RPG2k
       # automatic (1)'s computed grid slot (#automatic_battle_position, the
       # EasyRPG Calculate2k3BattlePosition port) -- confirmed against
       # EasyRPG's actual C++ source, which splits exactly this way.
-      def build_actor_sprite(actor, i, defending: false, dead: false)
+      def build_actor_sprite(actor, i, defending: false, dead: false, states: nil)
         anim_id = actor.respond_to?(:battler_animation_id) ? (actor.battler_animation_id || 0) : 0
         table = db.respond_to?(:battleranimations) ? db.battleranimations : nil
         entry = (table && anim_id > 0) ? table[anim_id] : nil
@@ -541,13 +562,17 @@ class RPG2k
                   elsif dead && poses[ACTOR_DEAD_POSE]
                     ACTOR_DEAD_POSE
                   else
-                    ACTOR_IDLE_POSE
+                    situations = db.respond_to?(:situation) ? db.situation : nil
+                    sig = Game::States.significant(states, situations)
+                    state_pose = sig && Game::States.animation_pose(sig, situations)
+                    (state_pose && poses[state_pose]) ? state_pose : ACTOR_IDLE_POSE
                   end
         pose = poses[pose_id]
         return nil unless pose
 
         if pose.animation_type == ACTOR_POSE_TYPE_BATTLE
-          label = { ACTOR_DEFEND_POSE => 'defend', ACTOR_DEAD_POSE => 'dead' }.fetch(pose_id, 'idle')
+          label = { ACTOR_DEFEND_POSE => 'defend', ACTOR_DEAD_POSE => 'dead',
+                    ACTOR_IDLE_POSE => 'idle' }.fetch(pose_id, 'state')
           $stderr.puts "[RPG2k] actor ##{actor.id}: #{label} pose " \
                        "uses a battle-animation (CBA) sheet, not a BattleCharSet -- not yet " \
                        "implemented, sprite not drawn"
@@ -694,7 +719,7 @@ class RPG2k
         @ui[:allies].push(combatant)
         return unless @ui[:actor_sprites]
         i = @ui[:allies].length - 1
-        @ui[:actor_sprites].push(build_actor_sprite(combatant.actor, i, defending: combatant.defending, dead: combatant.dead?))
+        @ui[:actor_sprites].push(build_actor_sprite(combatant.actor, i, defending: combatant.defending, dead: combatant.dead?, states: combatant.states))
         reset_actor_battler_z
       end
 
@@ -733,7 +758,7 @@ class RPG2k
         i = @ui[:allies].index { |c| c.equal?(combatant) }
         return unless i && sprites[i]
         dispose_battle_sprite(sprites[i])
-        sprites[i] = build_actor_sprite(combatant.actor, i, defending: combatant.defending, dead: combatant.dead?)
+        sprites[i] = build_actor_sprite(combatant.actor, i, defending: combatant.defending, dead: combatant.dead?, states: combatant.states)
       end
 
       # Re-derive every surviving actor sprite's Z from its current index in

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10551,6 +10551,63 @@ check "Enemy Encounter scene: a party member already KO'd going into the fight d
      'the living member still gets the Idle pose'
 end
 
+# Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
+# source: `Sprite_Actor::DoIdleAnimation` (src/sprite_actor.cpp) does not
+# stop at Defend/Dead -- once neither applies, it reads the battler's
+# significant active state (`GetSignificantState`) and shows *that state's
+# own* configured pose (`state->battler_animation_id`), not plain Idle.
+# `#build_actor_sprite` used to have no branch for this at all, so a living
+# but afflicted party member (Poison, Sleep, Confusion, ...) always drew
+# identically to a perfectly healthy one.
+check "Enemy Encounter scene: a living party member carrying a non-death " \
+      "state draws that state's own pose, not Idle" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  anims = { 5 => battle_pose_set(poses: {
+    0 => battle_pose(battler_name: 'Hero', battler_index: 2), # Idle
+    3 => battle_pose(battler_name: 'Hero', battler_index: 9)  # Poison's own pose
+  }) }
+  scene = new_scene({ 1 => event(2, 2, auto) }, battleranimations: anims)
+  scene.db.situation[3].battler_animation_id = 3 # Poison (priority 30) -> pose id 3
+  st = scene.instance_variable_get(:@state)
+  poisoned = BattleStubActor.new(id: 1, battler_animation_id: 5, states: [3])
+  st.instance_variable_set(:@party, BattleStubParty.new(poisoned, alternate_layout: true))
+  ui = battle_to_command(scene)
+
+  sprites = ui[:actor_sprites]
+  ok sprites, 'built when the layout is alternative/gauge'
+  cell = RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+  eq RGSS::Rect.new(0, 9 * cell, cell, cell), sprites[0].src_rect,
+     "the poisoned member's sprite uses Poison's own configured pose " \
+     '(battler_index 9), not the Idle pose'
+end
+
+check 'Enemy Encounter scene: a state naming no pose of its own falls back ' \
+      "to the generic 'bad status' pose, not Idle" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  anims = { 5 => battle_pose_set(poses: {
+    0 => battle_pose(battler_name: 'Hero', battler_index: 2), # Idle
+    6 => battle_pose(battler_name: 'Hero', battler_index: 9)  # generic "bad status" pose
+  }) }
+  scene = new_scene({ 1 => event(2, 2, auto) }, battleranimations: anims)
+  # Poison's own battler_animation_id is left unset in the fixture, matching
+  # a state the author never gave an explicit pose of its own --
+  # Game::States::DEFAULT_ANIMATION_POSE (6) is the fallback.
+  st = scene.instance_variable_get(:@state)
+  poisoned = BattleStubActor.new(id: 1, battler_animation_id: 5, states: [3])
+  st.instance_variable_set(:@party, BattleStubParty.new(poisoned, alternate_layout: true))
+  ui = battle_to_command(scene)
+
+  sprites = ui[:actor_sprites]
+  ok sprites, 'built when the layout is alternative/gauge'
+  cell = RPG2k::Scene::Battle::ACTOR_CHARSET_CELL
+  eq RGSS::Rect.new(0, 9 * cell, cell, cell), sprites[0].src_rect,
+     'falls back to the generic bad-status pose (battler_index 9), not Idle'
+end
+
 check 'Enemy Encounter scene: the traditional (RPG2000) layout draws no actor sprites' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Battle#build_actor_sprite` (RPG2003's alternate/gauge battle layout, per-actor battler graphics) only ever picked between Idle, Defend and Dead — this exact gap was already flagged in the code's own comments, citing the reference this session independently re-fetched and confirmed.
- Verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source (fetched live): `Sprite_Actor::DoIdleAnimation` (`src/sprite_actor.cpp`) checks `IsDefending()` first, unconditionally — but its *remaining* branch for a living party member (a real `battler_animation_id`, not a monster) is `idling_anim = state ? state->battler_animation_id + 1 : AnimationState_Idle`. RPG_RT reads the battler's own *significant active state* (`GetSignificantState`, already the exact function `Game::States.significant` ports) and shows *that state's own configured pose*, falling back to a generic "bad status" pose when the state names none of its own. Death is not special-cased here at all for an actor — it reaches the identical state-driven branch (a real database's Death row conventionally already points its own pose field at the Dead pose); only the *monster* branch (no pose table to consult) hardcodes Death straight to the Dead animation.
- So Poison, Sleep, Confusion, Blindness or any other active status left a living, afflicted party member's on-screen battler sprite indistinguishable from a perfectly healthy one.
- Fixed with a new `Game::States.animation_pose(id, table)` (`mruby-rpg2k/mrblib/game.rb`), reading a state row's own `battler_animation_id` field, and a new `ACTOR_BAD_STATUS_POSE` fallback constant. `#build_actor_sprite` gained a `states:` keyword (the *battle* `Combatant`'s own live states, not the field-side `Actor#states`) threaded through from all three call sites — `#build_actor_sprites`, `#add_battle_actor_sprite`, `#reposition_actor_sprite` — consulted only once neither `defending:` nor `dead:` already picked a pose, matching the reference's own check order exactly.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 724 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1006 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures
- [x] Both new checks confirmed to fail against the pre-fix code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_