### PR TITLE
map: a map event's database Move Speed now converts to the internal scale, matching RPG_RT

### DIFF
--- a/changelog.d/event-move-speed-database-conversion.fixed.md
+++ b/changelog.d/event-move-speed-database-conversion.fixed.md
@@ -1,0 +1,10 @@
+- **RPG2000/2003 maps:** A map event's own database Move Speed is now
+  converted into this engine's internal scale before use, matching real
+  RPG_RT — previously the raw database value was fed straight through
+  unconverted, so an ordinary, unconfigured NPC (database default "Normal")
+  walked at exactly the hero's own pace instead of real RPG_RT's slower
+  default, and every other explicit event Move Speed was off by one full
+  notch (2x too fast). The slowest Move Speed setting is also now reachable
+  instead of silently clamping up to the next notch. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks and a corrected
+  `scripts/rpg2k_logic_check.rb` clamp-bounds check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5260,6 +5260,41 @@ Everything below is unverified against the codebase.
   readers of `Character#move_speed`, and the subpixel requirement were the
   three reasons this was deferred before the subpixel accumulator made a
   single-pass, non-re-baselining fix possible.
+- ✅ **A map event's own database Move Speed was never converted into this
+  engine's internal scale, so every ordinary NPC paced the hero exactly —
+  real RPG_RT's own well-known "NPCs default to walking slower than the
+  hero" trait was invisible.** The bullet above fixed the per-frame slide
+  *formula* to be `move_speed`-driven and established the port's internal
+  convention (stored `move_speed` = real RPG_RT's own 1-indexed Move Speed
+  **minus 1**, so `1 << s` reproduces EasyRPG's `1 << (1 + GetMoveSpeed())`
+  exactly, `src/game_character.cpp`) — but the one place that loads an
+  ordinary map event's *own* database Move Speed, `Scene::Map#page_move_speed`
+  (`mruby-rpg2k/mrblib/scene/map.rb`), still handed the raw liblcf field
+  straight through unconverted: `page.move_speed || 3`. Real RPG_RT's player
+  defaults to Move Speed **4** (`Game_Player`'s constructor: `SetMoveSpeed(4)`)
+  while liblcf's own `EventPage.move_speed` field defaults to **3**
+  ("Normal") — so a real, unconfigured NPC walks at half the hero's default
+  rate (16 vs. 8 frames/tile). Feeding the raw `3` straight into this
+  engine's internal (real-minus-1) scale made that default NPC resolve to
+  internal `3` too — the *hero's own* rate — pacing the player exactly,
+  every explicit non-default Move Speed off by the same one full notch (an
+  exact 2× pixel-rate error at every level, since the formula is a power of
+  two), and skewing that event's walk-animation cadence and jump distance
+  identically since they key off the same unconverted `move_speed`. Fixed by
+  converting at the one load site (`page_move_speed`: `(page.move_speed ||
+  3) - 1`); `clamp_speed`'s floor widened from 1 to 0 (and the `SPEED_UP`/
+  `SPEED_DOWN` move-route commands' clamp bounds shifted from 1..6 to 0..5
+  to match, mirroring EasyRPG's own `SetMoveSpeed(min(GetMoveSpeed() + 1,
+  6))`/`max(GetMoveSpeed() - 1, 1)`) so real Move Speed 1 (the slowest, LCF's
+  own floor) is reachable instead of silently clamping up to real Move Speed
+  2; `JUMP_SLIDE_STEP`/`ANIM_STATIONARY_FRAMES` gained the matching internal-0
+  entries (`2` and `12`, from the same `jump_speed[]`/`GetStationaryAnimFrames`
+  arrays cited above, at their own index 0). Covered by new
+  `scripts/rpg2k_scene_check.rb` checks (a default-page event resolves to
+  internal `2`, the slowest real setting to internal `0` rather than
+  clamping up) and a corrected existing `scripts/rpg2k_logic_check.rb`
+  clamp-bounds check; the full scene suite (725 checks) and logic suite
+  (1006 checks) still pass.
 - ✅ **Repeat/Loop** — loops forever without an explicit Break Loop.
   `Interpreter#do_end_loop` unconditionally scans back to the matching
   `Loop` marker and jumps `@index` there every single time it is reached —

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5686,8 +5686,12 @@ module Game
       when END_JUMP   then [:effect, true] # an End Jump with no Begin: skipped
       when LOCK_FACING   then character.facing_locked = true;  [:effect, true]
       when UNLOCK_FACING then character.facing_locked = false; [:effect, true]
-      when SPEED_UP   then character.move_speed = [character.move_speed + 1, 6].min; [:effect, true]
-      when SPEED_DOWN then character.move_speed = [character.move_speed - 1, 1].max; [:effect, true]
+      # Bounds are the internal 0..5 scale (real Move Speed 1..6 minus 1; see
+      # Scene::Map::SLIDE_UNITS/#page_move_speed), matching EasyRPG's own
+      # `SetMoveSpeed(min(GetMoveSpeed() + 1, 6))` / `max(GetMoveSpeed() - 1, 1)`
+      # (src/game_character.cpp) shifted down by that same offset.
+      when SPEED_UP   then character.move_speed = [character.move_speed + 1, 5].min; [:effect, true]
+      when SPEED_DOWN then character.move_speed = [character.move_speed - 1, 0].max; [:effect, true]
       when FREQ_UP    then character.move_frequency = [character.move_frequency + 1, 8].min; [:effect, true]
       when FREQ_DOWN  then character.move_frequency = [character.move_frequency - 1, 1].max; [:effect, true]
       when SWITCH_ON  then world.set_switch(cmd.parameter_a, true);  [:effect, true]

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -18,30 +18,37 @@ class RPG2k
       COLS = SCREEN_W / TILE + 1
       ROWS = SCREEN_H / TILE + 1
       # Sub-pixel movement model. RPG2000's Move Speed (1..6) is no longer dead:
-      # the per-frame slide advance for a character of move_speed `s` is
-      # `1 << s` quarter-tile units (a full tile is SLIDE_UNITS), so
-      # frames-per-tile is 64 / (1 << s) = 32, 16, 8, 4, 2, 1 for s = 1..6. The
-      # default (s = 3) yields 8 frames/tile, identical to the old hardcoded
-      # 2px/frame, so the baseline is untouched -- only the previously-ignored
-      # non-default speeds (and the SPEED_UP / SPEED_DOWN move-route commands)
-      # now take effect. The port's move_speed is +1 from EasyRPG's 1-indexed
-      # convention, which is why the formula is `1 << s` rather than EasyRPG's
-      # `1 << (1 + s)`; see docs/TODO.md "Move Speed is dead code".
+      # the per-frame slide advance for a character of internal move_speed `s`
+      # is `1 << s` quarter-tile units (a full tile is SLIDE_UNITS), so
+      # frames-per-tile is 64 / (1 << s) = 32, 16, 8, 4, 2, 1 for s = 0..5. The
+      # default (s = 2, i.e. real Move Speed 3, "Normal") yields 8 frames/tile,
+      # identical to the old hardcoded 2px/frame, so the baseline is untouched
+      # -- only the previously-ignored non-default speeds (and the SPEED_UP /
+      # SPEED_DOWN move-route commands) now take effect. The port's internal
+      # move_speed is real RPG_RT's own 1-indexed Move Speed minus 1 (matching
+      # EasyRPG's `1 << (1 + GetMoveSpeed())`, `src/game_character.cpp`), which
+      # is why the formula here is plain `1 << s`; see #page_move_speed for
+      # where that conversion happens and docs/TODO.md "Move Speed is dead
+      # code".
       SLIDE_UNITS = TILE * 4   # quarter-tile units per tile (64)
 
-      # Jump slide advance (quarter-tile units/frame) by move_speed, port 1..6.
-      # From EasyRPG's jump_speed[] = {8,12,16,24,32,64} (over a 256-unit tile),
-      # ÷4 into quarter-tile units and shifted by the port's +1 offset so it
-      # lines up with the walk `1 << s` above; the top speed clamps to the last.
-      JUMP_SLIDE_STEP = { 1 => 3, 2 => 4, 3 => 6, 4 => 8, 5 => 16, 6 => 16 }.freeze
+      # Jump slide advance (quarter-tile units/frame) by move_speed, port 0..5.
+      # From EasyRPG's jump_speed[] = {8,12,16,24,32,64} (over a 256-unit tile,
+      # 0-indexed by the port's own real-minus-1 offset), ÷4 into quarter-tile
+      # units; the top speed clamps to the last.
+      JUMP_SLIDE_STEP = { 0 => 2, 1 => 3, 2 => 4, 3 => 6, 4 => 8, 5 => 16 }.freeze
 
-      # Walk-animation frame cadence by move_speed, port 1..6, matching EasyRPG's
-      # GetStationaryAnimFrames shifted by the same +1 offset; the default (3)
-      # keeps the prior 6-frame period, so existing animation pacing is unchanged.
-      ANIM_STATIONARY_FRAMES = { 1 => 10, 2 => 8, 3 => 6, 4 => 5, 5 => 4, 6 => 4 }.freeze
+      # Walk-animation frame cadence by move_speed, port 0..5, matching EasyRPG's
+      # GetStationaryAnimFrames (limits[] = {12,10,8,6,5,4}, 0-indexed by the
+      # same real-minus-1 offset); the default (2) keeps the prior 6-frame
+      # period, so existing animation pacing is unchanged.
+      ANIM_STATIONARY_FRAMES = { 0 => 12, 1 => 10, 2 => 8, 3 => 6, 4 => 5, 5 => 4 }.freeze
 
-      # Clamp a (possibly out-of-range) move_speed to the valid RPG2000 1..6.
-      def clamp_speed(s); v = s.to_i; v < 1 ? 1 : v > 6 ? 6 : v; end
+      # Clamp a (possibly out-of-range) internal move_speed to the port's own
+      # 0..5 scale -- the real RPG2000 Move Speed field is 1..6 (see
+      # #page_move_speed), one notch above this internal scale, matching
+      # EasyRPG's own Utils::Clamp(GetMoveSpeed(), 1, 6).
+      def clamp_speed(s); v = s.to_i; v < 0 ? 0 : v > 5 ? 5 : v; end
 
       # Quarter-tile units advanced per frame while walking at `s`.
       def walk_slide_step(s); 1 << clamp_speed(s); end
@@ -1336,7 +1343,14 @@ class RPG2k
       # Converted to the runtime numpad convention by build_event.
       def page_direction(page); page_field(:direction, 2) { d = page.direction; (0..3).include?(d) ? d : 2 }; end
       def page_move_type(page); page_field(:move_type, 0) { page.move_type || 0 }; end
-      def page_move_speed(page); page_field(:move_speed, 3) { page.move_speed || 3 }; end
+      # The page's stored Move Speed is real RPG_RT's own 1..6 scale (liblcf
+      # default 3, "Normal"); converted to this engine's internal 0..5 scale
+      # (real minus 1, see the SLIDE_UNITS comment above) so it lines up with
+      # #walk_slide_step/#jump_slide_step/#anim_frame_period, which otherwise
+      # treated a raw event's Move Speed as one full notch faster than real
+      # RPG_RT -- e.g. the default "Normal" (3) walked at the player's own
+      # default rate (real 4) instead of the correct half-speed.
+      def page_move_speed(page); page_field(:move_speed, 2) { (page.move_speed || 3) - 1 }; end
       def page_move_frequency(page); page_field(:move_frequency, 3) { page.move_frequency || 3 }; end
       def page_move_route(page); page_field(:move_route, nil) { page.move_route }; end
       def page_charset_name(page); page_field(:charset_name, nil) { page.charset_name }; end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -632,14 +632,16 @@ end
 
 check 'speed/frequency/through/transparency flags clamp at their bounds' do
   c = Game::Character.new(0, 0)
-  c.move_speed = 6
+  # 5 is the internal scale's own max (real RPG_RT Move Speed 6, its own
+  # max, minus this engine's -1 offset -- see Scene::Map::SLIDE_UNITS).
+  c.move_speed = 5
   c.move_frequency = 1
   cmds = [mc(R::SPEED_UP), mc(R::FREQ_DOWN), mc(R::THROUGH_ON),
           mc(R::LOCK_FACING), mc(R::TRANSP_UP)]
   route = R.new(cmds, repeat: false)
   w = FakeWorld.new
   cmds.size.times { route.step(c, w) }
-  eq 6, c.move_speed          # clamped at the max
+  eq 5, c.move_speed          # clamped at the max
   eq 1, c.move_frequency      # clamped at the min
   eq true, c.through
   eq true, c.facing_locked

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -625,9 +625,9 @@ end
 def page(x_move_type: Game::MoveType::STATIONARY, route: nil, trigger: 0,
          frequency: 6, direction: 2, charset_name: '', charset_index: 0,
          layer: 0, pattern: 1, animation_type: 0, translucent: false,
-         overlap_forbidden: false)
+         overlap_forbidden: false, move_speed: 3)
   OpenStruct.new(
-    condition: nil, direction: direction, move_type: x_move_type, move_speed: 3,
+    condition: nil, direction: direction, move_type: x_move_type, move_speed: move_speed,
     move_frequency: frequency, charset_name: charset_name,
     charset_index: charset_index, trigger: trigger, event_commands: nil,
     move_route: route, layer: layer, pattern: pattern,
@@ -5401,7 +5401,10 @@ check 'a wandering event cycles its walk phase; a stationary one rests' do
   scene = new_scene({ 1 => mover, 2 => still }, player: [5, 4])
   eh = event_hashes(scene)
   slid = false
-  200.times { scene.update; slid ||= eh[1][:moving] }
+  # 400, not 200: a default-speed event now correctly takes 16 frames to
+  # cross a tile (internal move_speed 2, i.e. real RPG_RT's own default
+  # event speed 3) instead of the old, unconverted 8 -- see #page_move_speed.
+  400.times { scene.update; slid ||= eh[1][:moving] }
   ok slid, 'a random mover slides between tiles at some point'
   ok [eh[1][:char].x, eh[1][:char].y] != [3, 2], 'the mover changed tiles'
   ok eh[1][:anim_phase] != 0, 'the mover advanced its walk animation while sliding'
@@ -7754,19 +7757,41 @@ end
 
 check 'Move Speed is no longer dead: it drives the per-frame slide, jump and anim' do
   scene = new_scene({}, player: [0, 0])
-  # walk_slide_step returns quarter-tile units/frame. Default (3) -> 8 -> 8
-  # frames/tile (unchanged baseline); fastest (6) -> 64 -> 1 frame/tile;
-  # slowest (1) -> 2 -> 32 frames/tile. Before this fix every speed ignored
-  # move_speed and advanced a hardcoded 2 TILE-units (= 8 quarter-units)/frame.
+  # walk_slide_step/jump_slide_step/anim_frame_period take the *internal*
+  # (real RPG_RT Move Speed - 1) scale -- see #page_move_speed. Internal 0..5
+  # maps to real Move Speed 1..6, giving frames/tile 64,32,16,8,4,2 (matching
+  # EasyRPG's `1 << (1 + GetMoveSpeed())`, src/game_character.cpp, exactly).
+  # Internal 3 (real 4, the player's own default) keeps the prior hardcoded
+  # 8-frames/tile baseline unchanged; internal 0 (real 1, the slowest) used
+  # to be unreachable (clamp_speed floored at 1, i.e. real 2).
+  eq 1,  scene.send(:walk_slide_step, 0)
   eq 2,  scene.send(:walk_slide_step, 1)
   eq 8,  scene.send(:walk_slide_step, 3)
-  eq 64, scene.send(:walk_slide_step, 6)
-  # Jump uses its own table (default 3 -> 6 quarter-units/frame, ~11 frames),
+  eq 32, scene.send(:walk_slide_step, 5)
+  # Jump uses its own table (internal 3 -> 6 quarter-units/frame, ~11 frames),
   # not the walk rate.
   eq 6,  scene.send(:jump_slide_step, 3)
-  # Animation cadence is move_speed-dependent; default (3) keeps the prior 6.
+  # Animation cadence is move_speed-dependent; internal 3 keeps the prior 6.
   eq 6,  scene.send(:anim_frame_period, 3)
   eq 4,  scene.send(:anim_frame_period, 5)
+end
+
+check "an event's database Move Speed converts from RPG_RT's real 1..6 scale, not fed through raw" do
+  # Real RPG_RT's Game_Player ctor defaults the *hero* to Move Speed 4, but
+  # liblcf's EventPage.move_speed field defaults to 3 ("Normal") -- so an
+  # ordinary, unconfigured NPC event walks at half the hero's default rate in
+  # a real game (16 frames/tile vs. the hero's 8). Before this fix
+  # #page_move_speed fed the raw 1..6 LCF value straight into
+  # Character#move_speed, so a default event paced the hero exactly instead.
+  ev = event(0, 0, page) # page's default move_speed: 3, i.e. real "Normal"
+  scene = new_scene({ 1 => ev })
+  eq 2, chars(scene)[1].move_speed, 'real Move Speed 3 becomes internal 2 (real - 1)'
+  eq 4, scene.send(:walk_slide_step, chars(scene)[1].move_speed),
+     "half the hero's own default 8 quarter-units/frame walk rate"
+
+  slow = event(0, 0, page(move_speed: 1)) # the slowest real setting
+  scene2 = new_scene({ 1 => slow })
+  eq 0, chars(scene2)[1].move_speed, 'real Move Speed 1 becomes internal 0, not clamped up to 1'
 end
 
 check 'the airship crosses a tile in half the frames walking on foot takes' do


### PR DESCRIPTION
## Summary

- Real RPG_RT's player defaults to Move Speed **4** (`Game_Player`'s constructor: `SetMoveSpeed(4)`), while liblcf's own `EventPage.move_speed` field defaults to **3** ("Normal") — so a real, unconfigured NPC walks at half the hero's default rate (16 vs. 8 frames/tile). Verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source (fetched live): `src/game_character.cpp`'s `1 << (1 + GetMoveSpeed())` slide formula and `GetStationaryAnimFrames`'s `limits[] = {12,10,8,6,5,4}` table, both indexed by the real 1..6 Move Speed.
- A prior fix in this codebase (see the "Move Speed is no longer dead code" entry in `docs/TODO.md`) made the per-frame slide formula move_speed-driven and established this engine's own internal convention: stored `move_speed` = real RPG_RT's Move Speed **minus 1**, so `1 << s` reproduces EasyRPG's formula exactly. The player's own default (`Character#initialize`'s `@move_speed = 3`) already applies this shift correctly (representing real 4).
- The one place that was missed: `Scene::Map#page_move_speed` (`mruby-rpg2k/mrblib/scene/map.rb`), which loads an ordinary map *event's* own database Move Speed, still handed the raw liblcf field straight through unconverted (`page.move_speed || 3`). That made a default NPC resolve to internal `3` — the *hero's own* rate — pacing the player exactly instead of walking at half speed, and skewed every explicit event Move Speed by the same one full notch (an exact 2× pixel-rate error at each level, since the formula is a power of two), plus that event's walk-animation cadence and jump distance identically (they key off the same unconverted `move_speed`).
- Fixed by converting at the one load site (`page_move_speed`: `(page.move_speed || 3) - 1`). `clamp_speed`'s floor widened from 1 to 0 (and the `SPEED_UP`/`SPEED_DOWN` move-route commands' clamp bounds shifted from 1..6 to 0..5 to match, mirroring EasyRPG's own `SetMoveSpeed(min(GetMoveSpeed() + 1, 6))`/`max(GetMoveSpeed() - 1, 1)`) so real Move Speed 1 (the slowest, LCF's own floor) is reachable instead of silently clamping up to real Move Speed 2. `JUMP_SLIDE_STEP`/`ANIM_STATIONARY_FRAMES` gained the matching internal-0 entries (`2` and `12`), from the same `jump_speed[]`/`GetStationaryAnimFrames` arrays at their own index 0.
- An existing scene check ("a wandering event cycles its walk phase") needed its iteration budget doubled (200 → 400), since a default-speed event now correctly takes twice as many frames to cross a tile. An existing logic check ("speed/frequency/... flags clamp at their bounds") had its expected clamp value corrected from 6 to 5 to match the internal scale's new ceiling.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 725 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1006 checks passed (1 existing check corrected)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] New/corrected checks confirmed to fail against the pre-fix code (`git stash` of the two source files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_