### PR TITLE
ppsspp: fix sysclib_memset/memmove return value — PSP EBOOT boots to completion

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -73,7 +73,7 @@ Requires the [pspdev toolchain](https://github.com/pspdev/pspdev) with `$PSPDEV`
 set (it provides `psp-gcc`, the CMake toolchain file and `create_pbp_file`).
 Run `scripts/build_psp_fixup_imports.bash` first — it replaces the
 toolchain's own `psp-fixup-imports` (normally at `$PSPDEV/bin/`) with a
-patched build; see the seven-bug trail lower in this section for why this
+patched build; see the bug trail lower in this section for why this
 EBOOT needs it to actually boot:
 
 ```sh
@@ -112,11 +112,14 @@ once one is deployed to `kGameDir` instead of just the idle HAL's. CI's
 `psp-smoke` job boots the EBOOT under PPSSPP headless and checks that a
 marker appears, so a regression that links but fails to boot is caught
 automatically; it has no project at `kGameDir`, so it only ever exercises the
-idle path (`RPG2K_PSP_GAME_START none not_found`). The job is
-**non-blocking** — the required build gate is the `psp` job, because the
-EBOOT still does not boot to completion under PPSSPP-headless. Nine
-independent bugs have been found and root-caused chasing that, seven of
-them fixed:
+idle path (`RPG2K_PSP_GAME_START none not_found`). The job is currently
+**non-blocking** (the required build gate is the `psp` job) — a holdover
+from when the EBOOT did not boot to completion under PPSSPP-headless; now
+that it does (see below), promoting `psp-smoke` to a required check is
+worth revisiting. Nine independent bugs were found and root-caused
+chasing that boot-to-completion goal; eight of them fixed, the remaining
+one (pspsdk's own upstream bug) no longer reachable — **boot now
+completes**:
 
 - pspsdk's `sysclib_snprintf`/`sysclib_sprintf` HLE stubs are only partially
   implemented under PPSSPP-headless, and calling into them left the
@@ -221,35 +224,47 @@ Verified: rebuilding PPSSPP with this patch drops the `Unknown syscall`
 count from ~90 to 1 and eliminates the `Bad memory access` flood
 entirely.
 
-With bug 8 fixed, the EBOOT reaches a **ninth bug, extensively
-characterized but not yet fixed**: `3rd/mruby/src/gc.c`'s
-`mrb_assert(is_gray(obj))` inside `gc_mark_children` fires for real —
-the first genuine mruby-internal assertion message this whole trail has
+With bug 8 fixed, the EBOOT reached a **ninth bug — fixed, the last
+blocker on this whole trail**: `3rd/mruby/src/gc.c`'s
+`mrb_assert(is_gray(obj))` inside `gc_mark_children` fired for real —
+the first genuine mruby-internal assertion message this whole trail
 reached (`assertion "((obj)->gc_color == 0)" failed`, captured via
-`sceIoWrite` the same way every other marker here is). A deep trace
-pass ruled out a null `mrb_heap_page` (add_heap's own allocation is
-always a real, valid, non-null pointer) and ruled out
-`MRB_HEAP_PAGE_SIZE=256` (this target's smaller-than-default heap page,
-tested directly against the desktop/wasm-matching default 1024 — bug 9
-reproduces identically either way) — but found a real, different,
-reproducible mechanism instead: under `MRB_GC_STRESS` (forces a full GC
-before every allocation), `add_heap` was observed being called twice in
-immediate succession, both times returning the *identical* page
-address — meaning the very first heap page, created before any object
-is ever allocated from it, gets reclaimed by a full-GC sweep while
-still empty (every slot's `tt == MRB_TT_FREE` from initialization looks
-identical to "genuinely swept dead" to `is_dead()`), and the next
-`add_heap` call gets the same freed memory straight back. That is a
-concrete way a stale reference could end up pointing at reused memory
-with an unrelated color — matching the assertion's shape — but does not
-yet explain the *non*-stress trigger, which remains open. What does
-differ from desktop/wasm, and remains the leading suspect, is this
-target's own fixed-arena allocator (`app/psp/main.cxx`'s
-`mrb_arena_alloc`/`_realloc`/`_free`) — neither desktop's LVGL-pool
-routing nor wasm's plain-malloc routing has been observed to hit this.
-See
+`sceIoWrite` the same way every other marker here is). Several deep
+trace passes ruled out a null `mrb_heap_page`, `MRB_HEAP_PAGE_SIZE=256`
+(tested against the desktop/wasm-matching default 1024 — reproduced
+identically either way), and the fixed arena allocator itself
+(confirmed completely healthy across the whole crash window with
+unconditional tracing) before the real cause turned up: patching
+PPSSPP to log the guest PC/registers on every bad-memory-access event
+showed every fault's `a0` register was exactly zero at
+`init_heap_page`'s object-init loop (inlined into `mrb_gc_init`) — a
+null `page` argument, despite `add_heap`'s `mrb_calloc` call having
+just returned a real, valid, non-null pointer moments earlier in the
+same run. The corruption was inside `mrb_calloc` itself
+(`p = mrb_malloc(...); memset(p, 0, size); return p;`): GCC recognizes
+this "memset then return the same pointer" idiom and, per its builtin
+knowledge that a standard-conforming `memset()` always returns its
+first argument, optimizes it into `return memset(p, 0, size);`. PSP's
+`memset` is a kernel syscall under this toolchain, and PPSSPP's HLE
+implementation of it (`sysclib_memset`,
+`Core/HLE/sceKernelInterrupt.cpp`) returned `0` instead of the
+destination pointer — unlike its sibling `sysclib_memcpy`, which
+correctly returns `dst` — so GCC's optimization silently turned every
+`mrb_calloc` call on this target into one returning PPSSPP's wrong `0`.
+`sysclib_memmove` had the identical bug, fixed alongside it. Fixed by
+adding the destination pointer as both functions' returned value,
+matching their sibling `sysclib_memcpy`/`sysclib_strcat` and the real C
+contract — `nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch`.
+**Verified: this is the fix that gets the EBOOT booting to
+completion** — rebuilding PPSSPP with this patch and re-running the
+identical EBOOT under normal `ppsspp-headless` JIT mode produces
+`RPG2K_PSP_BOOT` → `RPG2K_PSP_MRUBY_OPEN ok` → `RPG2K_PSP_GAME_START
+none not_found` → a continuous `RPG2K_PSP_BRINGUP` heartbeat, running
+cleanly for over 850,000 frames with zero errors, stopped only by the
+test harness's own timeout. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
-P1 for the full nine-bug trail. To reproduce any of this locally, run
+P1 for the full nine-bug trail, including the eliminated theories along
+the way. To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched
 `ppsspp` package output (see above) rather than nixpkgs' unpatched one —

--- a/changelog.d/ppsspp-sysclib-memset-memmove-return-value.fixed.md
+++ b/changelog.d/ppsspp-sysclib-memset-memmove-return-value.fixed.md
@@ -1,0 +1,23 @@
+- **The PSP EBOOT now boots to completion under PPSSPP-headless.** The
+  last of ADR 0047 P1's nine boot blockers traced back to
+  `Core/HLE/sceKernelInterrupt.cpp`'s `sysclib_memset`/`sysclib_memmove`
+  — PPSSPP's HLE implementations of PSP's kernel-syscall-backed
+  `memset`/`memmove` — returning `0` instead of their destination
+  pointer, unlike every sibling pointer-returning function in the same
+  file (`sysclib_memcpy`, `sysclib_strcat`, ...) and unlike real C
+  `memset()`/`memmove()`. mruby's `mrb_calloc` (used for every GC heap
+  page and other core-init structures) does `memset(p, 0, size); return
+  p;` — a pattern GCC recognizes and, per its builtin knowledge that a
+  standard-conforming `memset()` always returns its first argument,
+  optimizes into `return memset(p, 0, size);`. Under PPSSPP's
+  non-compliant HLE `memset`, that silently turned every `mrb_calloc`
+  call into one returning PPSSPP's wrong `0` instead of the real
+  pointer — despite the underlying allocation always succeeding —
+  producing a GC heap corrupted from the very first page it ever
+  created. `nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch`
+  (not yet upstreamed to `hrydgard/ppsspp`) fixes both functions.
+  Verified: the identical EBOOT now boots past `mrb_open` (`RPG2K_PSP_
+  MRUBY_OPEN ok`) and into the idle `RPG2K_PSP_BRINGUP` heartbeat loop,
+  running cleanly for 850,000+ frames with zero errors before the test
+  harness's own timeout — see `docs/adr/0047-psp-memory-budget.md`'s P1
+  for the full nine-bug trail this closes out.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -226,7 +226,11 @@ unaddressed cost:
 Answer these questions, and capture real numbers, as part of — not after —
 the interpreter-linking slice, in this order:
 
-- **P1 — measure before sizing.** Partially done. Finding 1's ~1.2–1.4 MB and
+- **P1 — measure before sizing.** Substantially done — boot now completes
+  under PPSSPP-headless and the idle-path heartbeat captures real device
+  numbers (see below); still partial in that the *mruby* share only
+  reflects the idle path until a real game runs on-device. Finding 1's
+  ~1.2–1.4 MB and
   Finding 5's ~240–350 KB figures are a host x86-64 proxy, not device
   numbers — still worth having over pure guesswork, but not a substitute for
   the device side. That side is now landed too: the bring-up EBOOT's
@@ -242,12 +246,14 @@ the interpreter-linking slice, in this order:
   `psp-smoke` job has no project there, so it only ever exercises the idle
   path — the *mruby* share of the pool remains unmeasured on-device until a
   real game database and map actually runs there, on real hardware or an
-  emulator with a Memory Stick image. **On the emulator side specifically,
-  this heartbeat has never yet produced a captured number**, in CI or
-  locally, though the reasons have narrowed a lot:
-  Nine independent bugs have been found and root-caused on this path so
-  far, seven of them fixed; boot still does not complete. In the order
-  the EBOOT actually hits them:
+  emulator with a Memory Stick image. **The emulator side is now
+  unblocked**: the idle path's own heartbeat numbers are captured below,
+  and CI's `psp-smoke` job (still no project at `kGameDir`) exercises the
+  same idle path automatically on every push.
+  Nine independent bugs were found and root-caused on this path; eight
+  of them fixed, the remaining one (bug 3, pspsdk's own upstream bug) no
+  longer reachable — **boot now completes**. In the order the EBOOT hits
+  them:
   1. **Fixed.** pspsdk's `sysclib_snprintf`/`sysclib_sprintf` HLE stubs are
      only partially implemented under PPSSPP-headless and left emulator
      state corrupted enough to crash a few syscalls later — `main.cxx` now
@@ -491,93 +497,139 @@ the interpreter-linking slice, in this order:
   numbers above remain unconfirmed on the emulator and untried on
   hardware.
 
-  With bug 8 fixed, this EBOOT reaches a **ninth bug, extensively
-  characterized but not yet fixed**: `3rd/mruby/src/gc.c`'s
-  `mrb_assert(is_gray(obj))` inside `gc_mark_children` fires for real
-  (a genuine `assertion "((obj)->gc_color == 0)" failed` message,
-  printed to stderr via the same `sceIoWrite` path every other marker in
-  this trail uses — the first time this whole investigation reached a
-  *real, unambiguous mruby-internal assertion message* rather than a raw
-  fault address to reverse-engineer). `is_gray`/`GC_GRAY` expects every
-  object handed to `gc_mark_children` to still be in the
-  just-pushed-onto-the-mark-stack GRAY state; this one is not — something
-  re-enters the mark routine for an object whose `gc_color` has already
-  moved past GRAY.
+  With bug 8 fixed, this EBOOT reached a **ninth bug — fixed, the last
+  blocker on this whole P1 trail**: `3rd/mruby/src/gc.c`'s
+  `mrb_assert(is_gray(obj))` inside `gc_mark_children` fired for real (a
+  genuine `assertion "((obj)->gc_color == 0)" failed` message, printed
+  to stderr via the same `sceIoWrite` path every other marker in this
+  trail uses — the first time this whole investigation reached a *real,
+  unambiguous mruby-internal assertion message* rather than a raw fault
+  address to reverse-engineer). `is_gray`/`GC_GRAY` expects every object
+  handed to `gc_mark_children` to still be in the
+  just-pushed-onto-the-mark-stack GRAY state; this one was not.
 
-  A deep trace pass (temporary instrumentation in `3rd/mruby/src/gc.c`
-  and `app/psp/main.cxx`, none kept) ruled out several plausible-looking
-  explanations with direct evidence, in order:
+  Several deep trace passes (temporary instrumentation in
+  `3rd/mruby/src/gc.c` and `app/psp/main.cxx`, none kept) ruled out a
+  string of plausible-looking explanations with direct evidence before
+  the real cause turned up — worth recording, since each elimination
+  narrowed the search and the pattern (misdiagnose, get real evidence,
+  correct course) is this whole trail's own method working as intended,
+  same as bug 8's three earlier passes:
 
-  - **Not the fixed arena returning null.** `mrb_arena_alloc` was traced
-    on every call over 4 KB; the large allocations `add_heap` needs
-    (`sizeof(mrb_heap_page)`, ~5–9 KB depending on `MRB_HEAP_PAGE_SIZE`)
-    always succeeded, with megabytes of arena headroom free at the time.
-  - **Not a null `mrb_heap_page`.** `add_heap`'s own `mrb_calloc` result
-    was printed directly on multiple runs; it is a real, valid,
-    non-null pointer inside the arena, not the address-0-based
-    `init_heap_page` walk a null page would produce (an earlier pass's
-    leading theory, since the classic symptom — small, steadily
-    incrementing "bad memory access" addresses at a stride matching
-    `sizeof(RVALUE)` — looks identical to what a null-based array walk
-    would produce).
-  - **A real, reproducible, different mechanism found instead:**
-    `add_heap` was observed being called *twice* in immediate
-    succession, both times returning the *identical* page address.
-    Since a live page is never freed back to the arena while still in
-    use, this can only happen if the *first* page — created directly by
-    `mrb_gc_init()`, before a single object has ever been allocated
-    from it — gets reclaimed by a full-GC sweep before anything
-    populates it: every slot in a freshly-initialized page has
-    `tt == MRB_TT_FREE` (set by `init_heap_page`'s own loop, not because
-    anything died), and `is_dead()` (`(o)->tt == MRB_TT_FREE` is
-    sufficient on its own, no color check) cannot distinguish "freshly
-    carved, never used" from "genuinely swept clean" — so
-    `incremental_sweep_phase`'s dead-page reclamation
-    (`if (dead_slot && !page->region) { ...; mrb_free(mrb, page); }`)
-    can free a brand new, about-to-be-used page out from under its own
-    creator, and the very next `add_heap` call (triggered because
-    `gc->free_heaps` is now null again) gets the identical address back
-    from the arena's free list. This is a strong, concrete lead for how
-    a *stale* reference (a gray-stack entry, or a cached pointer to
-    "the page I was about to allocate from") could end up pointing at
-    memory that has since been reused for something else with an
-    unrelated `gc_color` — exactly the shape of the observed assertion.
-  - **Confirmed reproducible under `MRB_GC_STRESS`** (forces a full GC
-    before every single object allocation — `mrb_obj_alloc`'s own
-    `#ifdef MRB_GC_STRESS mrb_full_gc(mrb); #endif`, no `MRB_DEBUG`
-    needed), which manufactures exactly the "sweep runs before the
-    first page is populated" window on the very first allocation. This
-    is a real, verified mechanism, not speculation — but it does not
-    yet explain the *non*-stress case: with `MRB_GC_STRESS` off (the
-    normal build), reaching a full sweep this early would need an
-    allocation to genuinely fail first (`mrb_realloc_simple`'s
-    fail-then-`mrb_full_gc`-then-retry path), which the arena's ample
-    headroom this early in boot makes implausible. The non-stress
-    trigger for the same underlying vulnerability, if that is indeed
-    what it is, remains open.
-  - **Ruled out: `MRB_HEAP_PAGE_SIZE`.** This target overrides the
-    default 1024-object heap page down to 256 (`build_config.rb`) to
-    save memory; a plausible theory was that the smaller page size
-    (more, smaller pages; add_heap/sweep cycles four times as often)
-    increases exposure to whatever the real race is. Tested directly by
-    rebuilding with the default `MRB_HEAP_PAGE_SIZE=1024` (matching
-    desktop/wasm) — bug 9 reproduced identically (99 bad-memory-access
-    events, `RPG2K_PSP_MRUBY_OPEN` never printed). Page size is not the
-    differentiator.
+  - Not the fixed arena returning null for `add_heap`'s allocation
+    (traced directly; always succeeded, with megabytes of headroom).
+  - Not a null `mrb_heap_page` in the general case (`add_heap`'s own
+    `mrb_calloc` result printed directly on several runs — always a
+    real, valid, non-null pointer).
+  - A real, reproducible premature-heap-page-reclamation mechanism *was*
+    found under `MRB_GC_STRESS` (forces a full GC before every
+    allocation): a freshly-`init_heap_page`'d page, whose every slot
+    starts `tt == MRB_TT_FREE` from initialization rather than genuine
+    death, is indistinguishable from "swept clean" to `is_dead()` and
+    can be reclaimed by a sweep before anything is ever allocated from
+    it. This is a real, latent bug class in `incremental_sweep_phase`'s
+    dead-page detection, worth keeping in mind for the future — but
+    proved not to be bug 9's actual (non-stress) trigger.
+  - `MRB_HEAP_PAGE_SIZE` (this target's memory-saving override, 256
+    instead of the default 1024) was ruled out directly: rebuilding with
+    the desktop/wasm-matching default reproduced bug 9 identically.
+  - `mrb_arena_alloc` itself was confirmed completely healthy across the
+    entire crash window with unconditional (not size-filtered)
+    instrumentation — every allocation, including the specific 16-byte
+    `iv_rehash` call a prior pass had (wrongly) suspected of
+    deterministically returning null, succeeded with a real, valid,
+    sane pointer. Zero `mrb_arena_free` calls happened before the crash
+    either, ruling out a use-after-free via this project's own
+    allocator.
 
-  What *does* differ from desktop/wasm, and remains the leading
-  suspect, is this target's own fixed-arena allocator (`app/psp/main.cxx`'s
-  `mrb_arena_alloc`/`mrb_arena_realloc`/`mrb_arena_free`,
-  ADR 0047's P2) routing every mruby allocation — desktop uses LVGL's
-  pool, wasm uses plain `malloc`, and neither has been observed to hit
-  this. Whether the mechanism is the premature-page-reclamation path
-  above, some other interaction specific to the arena's
-  allocate/split/coalesce bookkeeping, or a MIPS o32/pspdev-toolchain
-  codegen difference for this specific mruby code shape (echoing bug 8's
-  own false leads before its real cause was found) is not yet
-  distinguished. This whole trail's running theme — memory corruption
-  found through patient, evidence-based elimination rather than
-  intuition — held again here; it just did not reach a fix this pass.
+  **The actual cause**, found by patching PPSSPP itself to log the guest
+  program counter and registers on every "bad memory access" event
+  (mirroring how bug 7's TLSF diagnosis and bug 8's crash log were each
+  solved by getting real dynamic data instead of guessing from static
+  code or stale symbol tables): every fault's `a0` register — the first
+  argument to whatever function was executing — was exactly zero, and
+  the guest PC symbolized cleanly (regular compiled code, not an import
+  stub — the stale-symbol trap that misled three passes on bug 8 does
+  not apply here) to `init_heap_page`'s object-initialization loop,
+  inlined into `mrb_gc_init`. That loop's `page` argument was zero —
+  despite `mrb_arena_alloc` printing the *correct*, non-null pointer
+  (`0x08c31d20`) as `add_heap`'s `mrb_calloc` call's own return value,
+  moments earlier, in the very same run.
+
+  The corruption happens inside `mrb_calloc` itself
+  (`3rd/mruby/src/gc.c`):
+
+  ```c
+  p = mrb_malloc(mrb, size);
+  memset(p, 0, size);
+  return p;
+  ```
+
+  GCC recognizes the "call `memset(p, ...)`, then `return p`" idiom and
+  — per its builtin knowledge that a standard-conforming `memset()`
+  always returns its first argument — optimizes this into the
+  equivalent of `return memset(p, 0, size);`. That is a valid,
+  semantics-preserving transformation for any real `memset`. But PSP's
+  `memset` is a *kernel syscall* (`SysclibForKernel`, NID `0x10F3BB61`)
+  under this toolchain, and PPSSPP's HLE implementation of it
+  (`Core/HLE/sceKernelInterrupt.cpp`'s `sysclib_memset`) returned `0`
+  instead of the destination pointer — unlike its own sibling
+  `sysclib_memcpy` a few lines above, which correctly returns `dst`.
+  GCC's optimization silently turned every `mrb_calloc` call on this
+  target into one that returns PPSSPP's wrong `0`, no matter how the
+  underlying allocation actually went. `sysclib_memmove` had the
+  identical bug (also returning `0` instead of `dst`, where real
+  `memmove()` returns its destination too) — not yet observed to be hit
+  on this boot path, but fixed alongside `memset` since it is the exact
+  same class of gap.
+
+  Fixed by adding `destAddr`/`dst` as the returned value in both
+  functions, matching their sibling `sysclib_memcpy`/`sysclib_strcat`
+  and the real C `memset()`/`memmove()` contract —
+  `nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch`. Not
+  upstreamed to `hrydgard/ppsspp` yet, but — like bugs 4 and 8 before it
+  — a strong candidate: nothing about this gap is project-specific, and
+  any guest code compiled with a GCC that performs this same idiom
+  optimization (a common, standard one) would silently get a wrong
+  `memset`/`memmove` return value under PPSSPP.
+
+  **Verified: this is the fix that gets the EBOOT booting to
+  completion.** Rebuilding PPSSPP with this patch and re-running the
+  identical EBOOT under `ppsspp-headless` in normal JIT mode (not `-i`,
+  not `MRB_GC_STRESS`) produces, in order: `RPG2K_PSP_BOOT`,
+  `RPG2K_PSP_MRUBY_OPEN ok`, `RPG2K_PSP_GAME_START none not_found` (no
+  project at `kGameDir` in this smoke-test environment, the expected
+  idle path), then a continuous `RPG2K_PSP_BRINGUP` heartbeat every 200
+  frames — running cleanly for over 850,000 frames with **zero** bad
+  memory accesses, assertions, or errors of any kind, stopped only by
+  the test harness's own 15-second timeout. This is the first time
+  since this whole P1 investigation began that the EBOOT has booted all
+  the way to the idle heartbeat loop under PPSSPP-headless.
+
+  Whether real hardware shares bug 9 is unknown but irrelevant either
+  way: real firmware's own `memset`/`memmove` correctly return their
+  destination pointer (this was purely an emulator-side gap), so real
+  hardware was never going to hit this. With bug 9 fixed, the P1 device
+  numbers this section has been chasing since its very first line are
+  finally reachable on the emulator — first captured
+  `RPG2K_PSP_BRINGUP` line, idle path, `psp-smoke`'s environment (no
+  project at `kGameDir`):
+
+  ```
+  RPG2K_PSP_BRINGUP frame=0 free=782336 maxfree=524288 lvgl_used=2184
+  lvgl_max=2756 stack_free=257872 stack_used_max=4272
+  ```
+
+  `free`/`maxfree` (`sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize`)
+  and `lvgl_used`/`lvgl_max` hold rock-steady across every subsequent
+  heartbeat with no game driving any allocation — expected for the idle
+  path, and itself a useful device-side confirmation that the idle HAL
+  (LVGL + the two status labels, no mruby object churn) has no leak.
+  `stack_used_max` (4272 of the 256 KB `PSP_MAIN_THREAD_STACK_SIZE_KB`
+  budget) reflects only `mrb_open()`'s own init recursion on this idle
+  path — the *real* game-driving depth (P5) remains unmeasured until a
+  project is deployed to `kGameDir`, on real hardware or an emulator
+  with a Memory Stick image.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/flake.nix
+++ b/flake.nix
@@ -133,11 +133,11 @@
           # Linux-only, matching the package's own meta.platforms: forcing this
           # attribute on darwin (e.g. `nix flake show`) would otherwise throw.
           #
-          # Carries three local patches on top of nixpkgs' build, all found
+          # Carries several local patches on top of nixpkgs' build, all found
           # and root-caused while trying to read the PSP EBOOT's own boot log
           # under PPSSPP-headless (see docs/adr/0047-psp-memory-budget.md and
           # app/psp/README.md); none are upstreamed to hrydgard/ppsspp yet,
-          # so all three are applied here so this flake's own `ppsspp`/
+          # so all of them are applied here so this flake's own `ppsspp`/
           # `ppsspp-headless` survive past them. nix/patches/ has the full
           # patches and each one's own note on when it is safe to drop.
           #
@@ -160,12 +160,25 @@
           #     counterparts -- so a bad access from an ordinary byte
           #     store/load hard-stops emulation instead of being skipped like
           #     every other access width already is.
+          #   - Four SysclibForKernel imports (strtoul/strncat/memchr/
+          #     tolower) this EBOOT pulls in have no HLE handler at all,
+          #     silently no-opping and leaving register garbage instead of
+          #     doing the real operation.
+          #   - sysclib_memset/sysclib_memmove (also SysclibForKernel) return
+          #     0 instead of their destination pointer, unlike every sibling
+          #     pointer-returning function in the same file (sysclib_memcpy,
+          #     sysclib_strcat, ...) -- breaking any caller relying on real
+          #     memset()/memmove()'s C-standard return value, including GCC's
+          #     own "memset(p, ...); return p;" idiom optimization, which
+          #     silently becomes "return memset(...)" and returns PPSSPP's
+          #     wrong 0 instead of the real pointer.
           ppsspp = pkgs.ppsspp.overrideAttrs (old: {
             patches = (old.patches or [ ]) ++ [
               ./nix/patches/ppsspp-lwmutex-workarea-validate.patch
               ./nix/patches/ppsspp-mfic-mtic-interrupt-mask.patch
               ./nix/patches/ppsspp-x64analyzer-8bit-mov.patch
               ./nix/patches/ppsspp-sysclibforkernel-missing-functions.patch
+              ./nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch
             ];
           });
         }

--- a/nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch
+++ b/nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch
@@ -1,0 +1,62 @@
+PPSSPP upstream gap: Core/HLE/sceKernelInterrupt.cpp's SysclibForKernel HLE
+implementations of the PSP kernel-syscall-backed memset and memmove --
+sysclib_memset/sysclib_memmove -- return 0 instead of their destination
+pointer. Real libc memset()/memmove() (and every other pointer-returning
+string/mem function in this same file -- sysclib_memcpy, sysclib_strcat,
+sysclib_strncpy, ...) return the destination pointer they were handed, per
+the C standard. sysclib_memset/sysclib_memmove are the only two in this
+whole HLE table that don't -- an inconsistency with their own sibling
+sysclib_memcpy a few lines above, which correctly `return dst;`.
+
+Found while trying to get this project's own PSP EBOOT to boot under
+PPSSPP-headless (see docs/adr/0047-psp-memory-budget.md's P1 and
+app/psp/README.md for the fuller trail -- this is ADR 0047 P1's bug 9).
+mruby's vendored mrb_calloc (3rd/mruby/src/gc.c) is:
+
+    p = mrb_malloc(mrb, size);
+    memset(p, 0, size);
+    return p;
+
+GCC recognizes the "call memset(p, ...), then return p" idiom and (per its
+builtin knowledge that memset()'s return value is always its first
+argument) optimizes this into the equivalent of `return memset(p, 0,
+size);` -- a valid, semantics-preserving transformation for any
+standard-conforming memset. Under PPSSPP's kernel-syscall memset, though,
+the optimized code ends up returning PPSSPP's wrong "0" instead of the
+real pointer `p` -- so every mrb_calloc call (used for every mruby GC heap
+page, and other core-init structures) returns NULL despite the
+allocation actually having succeeded. Confirmed directly: instrumenting
+this project's own fixed-arena allocator showed it always returning a
+valid, non-null pointer for the exact allocation in question, while the
+PPSSPP-side register trace at the point of use (inside mruby's
+init_heap_page, called through this exact mrb_calloc/memset path) showed
+the argument register holding zero instead of that same pointer.
+
+Adds destAddr/dst as the returned value in both functions, matching their
+sibling sysclib_memcpy/sysclib_strcat and the real C memset()/memmove()
+contract.
+
+Not yet upstreamed to https://github.com/hrydgard/ppsspp -- applied here
+locally (flake.nix's `ppsspp` package output) alongside this repo's other
+local PPSSPP patches in this same directory.
+
+--- a/Core/HLE/sceKernelInterrupt.cpp
++++ b/Core/HLE/sceKernelInterrupt.cpp
+@@ -895,7 +895,7 @@
+ 		memset(Memory::GetPointerWriteUnchecked(destAddr), data, size);
+ 	}
+ 	NotifyMemInfo(MemBlockFlags::WRITE, destAddr, size, "KernelMemset");
+-	return hleLogVerbose(Log::sceKernel, 0);
++	return hleLogVerbose(Log::sceKernel, destAddr);
+ }
+
+ static int sysclib_strstr(u32 s1, u32 s2) {
+@@ -928,7 +928,7 @@
+ 	if (MemBlockInfoDetailed(size)) {
+ 		NotifyMemInfoCopy(dst, src, size, "KernelMemmove/");
+ 	}
+-	return hleLogVerbose(Log::sceKernel, 0);
++	return hleLogVerbose(Log::sceKernel, dst);
+ }
+
+ static u32 sysclib_strncpy(u32 dest, u32 src, u32 size) {


### PR DESCRIPTION
## Summary
**This is the last of ADR 0047 P1's nine boot blockers. The PSP EBOOT now boots to completion under PPSSPP-headless — independently re-verified by me before opening this PR.**

- Several deep trace passes this session ruled out, with direct evidence: a null `mrb_heap_page`, `MRB_HEAP_PAGE_SIZE`'s value (256 vs. desktop/wasm's default 1024), and the fixed arena allocator (confirmed completely healthy — every allocation across the crash window succeeds with a real, valid pointer, and zero frees happen before the crash).
- **Real cause**, found by patching PPSSPP to log guest PC/registers on every "bad memory access" event: every fault's `a0` register was exactly zero at `init_heap_page`'s object-init loop — a null `page` argument, despite `add_heap`'s `mrb_calloc` call having returned a real, valid pointer moments earlier in the same run.
- The corruption happens inside `mrb_calloc` (`3rd/mruby/src/gc.c`): `p = mrb_malloc(...); memset(p, 0, size); return p;`. GCC recognizes this idiom and — per its builtin knowledge that a standard-conforming `memset()` always returns its first argument — optimizes it into `return memset(p, 0, size);`. PSP's `memset` is a kernel syscall under this toolchain, and PPSSPP's HLE implementation (`sysclib_memset`, `Core/HLE/sceKernelInterrupt.cpp`) returned `0` instead of the destination pointer, unlike its sibling `sysclib_memcpy`. GCC's optimization silently turned every `mrb_calloc` call on this target into one returning PPSSPP's wrong `0`. `sysclib_memmove` had the identical bug, fixed alongside it.
- `nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch` fixes both, matching their sibling functions and the real C contract. Not yet upstreamed to `hrydgard/ppsspp`, but a strong candidate — this affects any guest code compiled with the same common GCC optimization.
- `docs/adr/0047-psp-memory-budget.md` and `app/psp/README.md` updated with the full nine-bug trail's conclusion.

## Test plan
- [x] Rebuilt PPSSPP with the patch and re-ran the identical EBOOT under normal `ppsspp-headless` JIT mode (not `-i`, not `MRB_GC_STRESS`): `RPG2K_PSP_BOOT` → `RPG2K_PSP_MRUBY_OPEN ok` → `RPG2K_PSP_GAME_START none not_found` → a continuous `RPG2K_PSP_BRINGUP` heartbeat, running cleanly for 850,000+ frames with zero errors before the harness's own timeout.
- [x] **Independently re-verified by me** (a separate, fresh docker build + `nix build '.#ppsspp'` + `ppsspp-headless` run): 0 bad-memory-access events, `RPG2K_PSP_MRUBY_OPEN ok`, 9,262 heartbeat cycles reaching frame 926000 with sane, stable memory numbers.
- [x] `nix flake check --no-build` passes.
- [ ] CI — pending on this PR.