### PR TITLE
map/save: a live Tile Substitution now survives a Save/Continue, matching RPG_RT

### DIFF
--- a/changelog.d/tile-substitution-save-continue.fixed.md
+++ b/changelog.d/tile-substitution-save-continue.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2000/2003 maps:** A live Tile Substitution ("Replace Chipset Tiles")
+  now survives a Save/Continue on the same map, matching real RPG_RT —
+  previously it was silently dropped on Continue exactly as if the player
+  had left and returned to the map, which real RPG_RT only does on an
+  ordinary re-visit, not a resumed save. Round-trips through both the
+  portable save and a real `.lsd` file. Covered by new
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8280,6 +8280,39 @@ not yet verified:
   Encounter Rate, then a Teleport back to the same map id, falls back to
   the map tree node's own `encount_steps`), confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **Tile Substitution never survived a Save/Continue on the same map,
+  unlike real RPG_RT.** The bullet above confirms this codebase correctly
+  *resets* it on an ordinary leaving-and-returning visit (`Game::Map`'s
+  substitution table is never carried by `perform_teleport`'s fresh
+  `load_map`) — but a genuine Save/Continue is a *different* case in real
+  RPG_RT: its `SaveMapInfo.lower_tiles`/`upper_tiles`
+  (`Game_Map::SetupFromSave`, `src/game_map.cpp`, verified against EasyRPG's
+  own fetched source) restore whatever a live Tile Substitution had
+  rewritten, the same way the currently-loaded map's own live event
+  positions round-trip through a save (`#map_event_positions`). This
+  codebase's own `LCF::Schema::SAVE_MAP_EVENT` already parses fields 21/22
+  (`chip_replacement_lower`/`chip_replacement_upper`, `mruby-lcf/mrblib/
+  schema.rb`, confirmed against a real save fixture in `mruby-lcf/test/
+  lcf_test.rb`) — but nothing in `mruby-rpg2k/mrblib` ever wrote or read
+  them, so every Save/Continue silently dropped the table, matching this
+  codebase's own "leaving and returning" reset instead of real RPG_RT's
+  "Continue restores it" behaviour. Fixed by mirroring the exact pattern
+  `#map_event_positions` already uses: `Game::State#tile_substitutions`
+  (`[{old_id => new_id} for the lower layer, same for upper]`), snapshotted
+  every frame from the live `Game::Map` (`Game::Map#substitution_snapshot`,
+  called by the new `Scene::Map#record_tile_substitutions`), round-tripped
+  through both the portable Marshal save (`#to_h`/`.load`) and a real
+  `.lsd` (`#to_lsd`/`.from_lsd`, chunk 111 fields 21/22, converted to/from
+  liblcf's own 144-entry identity-by-default byte array via two new
+  `Game::State.tile_replacement_bytes`/`.tile_replacement_hash` class
+  methods), and reapplied onto the freshly-loaded `Game::Map` by
+  `RPG2k#continue_game` (`main.rb`) via a new `Game::Map#restore_
+  substitutions`. Covered by new `scripts/rpg2k_logic_check.rb` checks (both
+  save formats round-trip the table, an old save missing the field restores
+  the empty default) and a new `scripts/rpg2k_scene_check.rb` check
+  (a substitution snapshotted mid-play restores onto a freshly-built
+  `Game::Map`, contrasted with the existing "leaving and returning drops it"
+  check just above), all confirmed to fail against the pre-fix code.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5224,6 +5224,24 @@ module Game
       !@substitutions[0].empty? || !@substitutions[1].empty?
     end
 
+    # A snapshot ({old_id => new_id} per layer) safe to stash on Game::State
+    # for a Save/Continue -- see Scene::Map#record_tile_substitutions -- dup'd
+    # so later #substitute_tile calls on the live map cannot mutate a saved
+    # copy out from under it.
+    def substitution_snapshot
+      [@substitutions[0].dup, @substitutions[1].dup]
+    end
+
+    # Reapply a snapshot taken by #substitution_snapshot (real RPG_RT's own
+    # SaveMapInfo.lower_tiles/upper_tiles: a Save/Continue on the same map
+    # restores whatever Tile Substitution had rewritten, unlike an ordinary
+    # map re-visit -- see RPG2k#continue_game, main.rb). A no-op for a
+    # fresh/never-substituted state (both hashes empty).
+    def restore_substitutions(lower, upper)
+      @substitutions = [lower || {}, upper || {}]
+      @revision += 1
+    end
+
     private
 
     def tile(layer, index, x, y)
@@ -12320,6 +12338,20 @@ module Game
     # unread and harmless -- and round-trips through both the portable
     # Marshal save and a real `.lsd` the same way #map_event_positions does.
     attr_accessor :map_event_route_index
+    # The current map's own live Tile Substitution table (11750), [{old_id
+    # => new_id} for the lower layer, same for upper] -- see Game::Map
+    # #substitution_snapshot/#restore_substitutions. Real RPG_RT's SaveMapInfo
+    # carries this (`lower_tiles`/`upper_tiles`) alongside the live event
+    # table, so it survives a Save/Continue on the same map exactly like
+    # #map_event_positions, while an ordinary map re-visit (leave and return
+    # with no save involved) still resets it -- already-confirmed, separate
+    # behaviour (docs/TODO.md). Scoped identically to #map_event_positions in
+    # every other way: per-map, reset on #perform_teleport (a fresh
+    # Game::Map's own #initialize starts with no substitutions), snapshotted
+    # every frame by Scene::Map#record_tile_substitutions. Round-trips through
+    # both the portable Marshal save (#to_h/.load) and a real `.lsd` (chunk
+    # 111, LCF::Schema::SAVE_MAP_EVENT fields 21/22 -- see #to_lsd/.from_lsd).
+    attr_accessor :tile_substitutions
 
     def initialize(party, map_id, x, y)
       @party = party
@@ -12359,6 +12391,7 @@ module Game
       @common_event_progress = {}
       @map_event_positions = {}
       @map_event_route_index = {}
+      @tile_substitutions = [{}, {}]
       @system_bgm = {}
       @system_sfx = {}
       # nil = "not configured yet"; #seed_screen_transitions fills each slot in
@@ -12581,6 +12614,7 @@ module Game
         common_event_progress: @common_event_progress,
         map_event_positions: @map_event_positions,
         map_event_route_index: @map_event_route_index,
+        tile_substitutions: @tile_substitutions,
         steps: @steps, last_battle_turns: @last_battle_turns,
         save_count: @save_count, battle_count: @battle_count,
         win_count: @win_count, defeat_count: @defeat_count,
@@ -12828,31 +12862,62 @@ module Game
 
       # Chunk 111 (SAVE_MAP_EVENT/SAVE_MOVABLE) is the currently-loaded map's
       # own live event table, mirrored straight from #map_event_positions/
-      # #map_event_route_index -- both already scoped to the current map
-      # only, see their own doc comments above. Camera scroll (SAVE_MAP_EVENT
-      # fields 1/2) is not modelled by this codebase, so it stays absent,
-      # matching the "view derives from the hero" fallback ADR 0021
-      # documents. Omitted entirely on a State that has not recorded any
-      # positions yet (e.g. a fresh, unplayed save), the same "absent means
-      # nothing to restore" rule the unplaced-vehicle chunks above use.
-      unless @map_event_positions.empty?
+      # #map_event_route_index, plus its Tile Substitution table
+      # (#tile_substitutions, fields 21/22) -- all three already scoped to the
+      # current map only, see their own doc comments above. Camera scroll
+      # (SAVE_MAP_EVENT fields 1/2) is not modelled by this codebase, so it
+      # stays absent, matching the "view derives from the hero" fallback ADR
+      # 0021 documents. Omitted entirely on a State with neither recorded
+      # positions nor a live substitution (e.g. a fresh, unplayed save), the
+      # same "absent means nothing to restore" rule the unplaced-vehicle
+      # chunks above use.
+      lower_subs, upper_subs = @tile_substitutions
+      unless @map_event_positions.empty? && lower_subs.empty? && upper_subs.empty?
         mapev = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MAP_EVENT })
-        events = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
-        @map_event_positions.each do |id, pos|
-          x, y, direction = pos
-          e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
-          e[12] = x
-          e[13] = y
-          e[22] = CharSet::DIR_ROW[direction] || 2
-          idx = @map_event_route_index[id]
-          e[43] = idx if idx
-          events[id] = e
+        unless @map_event_positions.empty?
+          events = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+          @map_event_positions.each do |id, pos|
+            x, y, direction = pos
+            e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+            e[12] = x
+            e[13] = y
+            e[22] = CharSet::DIR_ROW[direction] || 2
+            idx = @map_event_route_index[id]
+            e[43] = idx if idx
+            events[id] = e
+          end
+          mapev[11] = events
         end
-        mapev[11] = events
+        mapev[21] = self.class.tile_replacement_bytes(lower_subs) unless lower_subs.empty?
+        mapev[22] = self.class.tile_replacement_bytes(upper_subs) unless upper_subs.empty?
         save[111] = mapev
       end
 
       save
+    end
+
+    # Build a BGM chunk (an LCF::Array1D over the BGM schema) from our stored
+    # A Tile Substitution layer's {old_id => new_id} table as real RPG_RT's
+    # own SAVE_MAP_EVENT fields 21/22 store it: a 144-entry byte array where
+    # index `i` is "what tile does chip `i` currently display/act as",
+    # identity (`i`) everywhere untouched -- see Game::Map#substitute_tile's
+    # own doc comment for why this port keeps only the diff rather than the
+    # full table live.
+    TILE_REPLACEMENT_SLOTS = 144
+    # Class methods (not instance) so both #to_lsd (an instance method) and
+    # .from_lsd (a class method, see below) can reach them.
+    def self.tile_replacement_bytes(subs)
+      bytes = (0...TILE_REPLACEMENT_SLOTS).to_a
+      subs.each { |old_id, new_id| bytes[old_id] = new_id if old_id >= 0 && old_id < TILE_REPLACEMENT_SLOTS }
+      bytes
+    end
+
+    # The inverse of .tile_replacement_bytes: every index whose stored value
+    # differs from its own identity is a live substitution.
+    def self.tile_replacement_hash(bytes)
+      h = {}
+      bytes.each_with_index { |v, i| h[i] = v if v != i }
+      h
     end
 
     # Build a BGM chunk (an LCF::Array1D over the BGM schema) from our stored
@@ -13142,6 +13207,16 @@ module Game
         state.map_event_positions = positions
         state.map_event_route_index = route_index
       end
+      # The same chunk's Tile Substitution table (fields 21/22): absent on a
+      # save that never rewrote a tile, or one written before this landed.
+      if map_events
+        lower = map_events.chip_replacement_lower
+        upper = map_events.chip_replacement_upper
+        state.tile_substitutions = [
+          lower ? tile_replacement_hash(lower) : {},
+          upper ? tile_replacement_hash(upper) : {},
+        ]
+      end
       state
     end
 
@@ -13271,6 +13346,7 @@ module Game
       state.common_event_progress = h[:common_event_progress] || {}
       state.map_event_positions = h[:map_event_positions] || {}
       state.map_event_route_index = h[:map_event_route_index] || {}
+      state.tile_substitutions = h[:tile_substitutions] || [{}, {}]
       state.escape_target = h[:escape_target]
       state.system_bgm = h[:system_bgm] || {}
       state.system_sfx = h[:system_sfx] || {}

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -830,6 +830,12 @@ class RPG2k
       return
     end
     state.map = load_map state.map_id
+    # Reapply the Tile Substitution table the save carried for this map --
+    # #load_map always builds a fresh, unsubstituted Game::Map (correct for
+    # an ordinary map re-visit), but a genuine Continue on the same map
+    # restores it, matching real RPG_RT's own SaveMapInfo.lower_tiles/
+    # upper_tiles. See Game::State#tile_substitutions.
+    state.map.restore_substitutions(*state.tile_substitutions)
     # apply_access: false -- a resumed save already carries its own
     # save/teleport/escape access (restored by Game::State.load / .from_lsd
     # from whatever a prior Change Save/Teleport/Escape Access command left

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -483,6 +483,7 @@ class RPG2k
           end
         end
         record_map_event_positions
+        record_tile_substitutions
         RGSS::Profiler.section("map.animate_events") { animate_events }
         RGSS::Profiler.section("map.render") { render }
       end
@@ -1267,6 +1268,15 @@ class RPG2k
           # event fallback -- see #build_events' seeding comment.
           @event_last_position[e[:id]] = [ch.x, ch.y, ch.direction]
         end
+      end
+
+      # Snapshot the current map's live Tile Substitution table onto
+      # Game::State every frame, the same "survives a Save/Continue on this
+      # map, resets on an ordinary re-visit" pattern #record_map_event_positions
+      # keeps for event positions -- see Game::State#tile_substitutions and
+      # Game::Map#substitution_snapshot.
+      def record_tile_substitutions
+        @state.tile_substitutions = @map.substitution_snapshot
       end
 
       # Build the Call Event resolver for the current map: common events keyed by

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7854,6 +7854,24 @@ check 'map_event_positions (a wandered NPC\'s live tile + facing) round-trips th
   eq({}, Game::State.load(db, legacy).map_event_positions)
 end
 
+check 'tile_substitutions (a live Tile Substitution table) round-trips through the save' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.tile_substitutions = [{ 4 => 9 }, { 12 => 30 }]
+  loaded = Game::State.load(db, st.to_h)
+  eq [{ 4 => 9 }, { 12 => 30 }], loaded.tile_substitutions
+  # A save written before this field existed restores no substitutions, so
+  # every tile shows its own database graphic -- the same behaviour as
+  # before this change existed at all.
+  legacy = st.to_h
+  legacy.delete(:tile_substitutions)
+  eq [{}, {}], Game::State.load(db, legacy).tile_substitutions
+end
+
 check 'Return to Title Screen raises a :return_title request' do
   st = party_state
   it = Game::Interpreter.new(st)
@@ -9604,6 +9622,29 @@ check 'to_lsd/from_lsd round-trips a map event\'s custom-route index' do
   old = Game::State.from_lsd(db, legacy)
   eq [5, 7, 6], old.map_event_positions[3], 'position still round-trips without a route index'
   eq nil, old.map_event_route_index[3], 'no saved cursor means the route restarts at 0'
+end
+
+check 'to_lsd/from_lsd round-trips a live Tile Substitution table (chunk 111 fields 21/22)' do
+  # Real RPG_RT's SaveMapInfo.lower_tiles/upper_tiles restore a Save/Continue
+  # on the same map to whatever Tile Substitution (11750) had rewritten;
+  # #to_lsd/.from_lsd previously never touched fields 21/22 at all.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.tile_substitutions = [{ 4 => 9 }, { 12 => 30, 40 => 41 }]
+
+  saved = st.to_lsd
+  round = Game::State.from_lsd(db, saved)
+  eq [{ 4 => 9 }, { 12 => 30, 40 => 41 }], round.tile_substitutions
+
+  # A save written before this landed simply omits fields 21/22 (or chunk 111
+  # entirely, if no event ever recorded a position either); from_lsd must
+  # leave a freshly-constructed State's empty default alone rather than crash
+  # reading an absent field.
+  legacy = st.to_lsd
+  legacy[111].delete(21)
+  legacy[111].delete(22)
+  old = Game::State.from_lsd(db, legacy)
+  eq [{}, {}], old.tile_substitutions, 'no saved table means every tile shows its own graphic'
 end
 
 # liblcf's SaveMapEventBase.facing (generator/csv/fields.csv, 0x16 == 22) is

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11666,6 +11666,32 @@ check 'Tile Substitution does not survive leaving and returning to the map' do
      'a fresh map load on Teleport drops the substitution'
 end
 
+check 'Tile Substitution survives a Save/Continue on the same map, unlike an ordinary re-visit' do
+  # Real RPG_RT's own SaveMapInfo.lower_tiles/upper_tiles: a Save/Continue
+  # restores whatever Tile Substitution had rewritten (see
+  # Game::State#tile_substitutions), the opposite of the "leaving and
+  # returning" check just above. #update now snapshots the live map's
+  # substitution table onto Game::State every frame
+  # (Scene::Map#record_tile_substitutions); RPG2k#continue_game (main.rb)
+  # replays it onto the freshly-loaded Game::Map via
+  # Game::Map#restore_substitutions -- reproduced here directly since this
+  # harness has no save-file machinery of its own.
+  cmds = [ECmd.new(IC2::TILE_SUBSTITUTION, [0, 0, 41])]
+  scene = new_scene(parallel_event(cmds), player: [0, 0])
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  eq 41, st.map.lower(3, 3), 'the substitution took on the original map'
+  eq [{ 0 => 41 }, {}], st.tile_substitutions,
+     'the live substitution table was snapshotted onto Game::State'
+
+  # A genuine Continue rebuilds Game::Map from scratch (identical to a
+  # Teleport's own fresh load) and then reapplies the saved table.
+  fresh = Game::Map.new(st.map_id, st.map.unit)
+  eq 0, fresh.lower(3, 3), 'a freshly-built map starts unsubstituted'
+  fresh.restore_substitutions(*st.tile_substitutions)
+  eq 41, fresh.lower(3, 3), 'Continue restores the substitution onto the fresh map'
+end
+
 check 'Enter/Exit Vehicle boards the vehicle the party stands on' do
   cmds = [ECmd.new(IC2::ENTER_EXIT_VEHICLE, [])]
   scene = new_scene(parallel_event(cmds), player: [0, 0])


### PR DESCRIPTION
## Summary

- This codebase already correctly resets a live Tile Substitution ("Replace Chipset Tiles", event code 11750) when the player leaves and returns to a map — real RPG_RT does the same, and this was already fixed/verified in a prior TODO.md bullet.
- What was still missing: real RPG_RT's `SaveMapInfo.lower_tiles`/`upper_tiles` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `Game_Map::SetupFromSave`, `src/game_map.cpp` — `map_info = std::move(save_map);` takes the save's own substitution table verbatim, unlike `Game_Map::Setup`'s fresh `std::iota(...)` identity reset) restore whatever Tile Substitution had rewritten when the player does a plain Save → Continue on the *same* map. This codebase always dropped it on Continue, exactly as if the player had left and returned — real RPG_RT only does that on an ordinary re-visit, not a resumed save.
- This codebase's own `LCF::Schema::SAVE_MAP_EVENT` schema (`mruby-lcf/mrblib/schema.rb`) already parses the relevant liblcf fields (21/22, `chip_replacement_lower`/`chip_replacement_upper`, confirmed against a real save fixture in `mruby-lcf/test/lcf_test.rb`) — they were just never written or read anywhere in `mruby-rpg2k/mrblib`.
- Fixed by mirroring the exact pattern this codebase already uses for `#map_event_positions` (a wandered NPC's live position, which *does* already survive a Save/Continue): a new `Game::State#tile_substitutions` (`[{old_id => new_id} for lower, same for upper]`), snapshotted every frame from the live `Game::Map` (`Game::Map#substitution_snapshot`, called by the new `Scene::Map#record_tile_substitutions`), round-tripped through both the portable Marshal save (`#to_h`/`.load`) and a real `.lsd` (`#to_lsd`/`.from_lsd`, chunk 111 fields 21/22 — converted to/from liblcf's own 144-entry identity-by-default byte array via two new `Game::State.tile_replacement_bytes`/`.tile_replacement_hash` class methods), and reapplied onto the freshly-loaded `Game::Map` by `RPG2k#continue_game` (`main.rb`) via a new `Game::Map#restore_substitutions`.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 726 checks passed (1 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1008 checks passed (2 new)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] All three new checks confirmed to fail against the pre-fix code (`git stash` of the source files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_