### PR TITLE
menu: a registered Escape/Teleport target's own switch now flips on warp, matching RPG_RT

### DIFF
--- a/changelog.d/escape-teleport-target-switch.fixed.md
+++ b/changelog.d/escape-teleport-target-switch.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2000/2003 field skills/items:** A registered Set Teleport Target /
+  Set Escape Target's own switch now turns on the instant the party warps
+  there via the corresponding Escape/Teleport field skill or special item,
+  matching real RPG_RT — previously the switch id was stored correctly but
+  silently dropped on the way to the actual warp, so it never flipped.
+  Covered by new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2787,10 +2787,13 @@ The work below is roughly ordered by the critical path to a walkable game
   `Game::State#teleport_targets` entry and named through the map tree's own
   `map_properties` (`Game_Map::GetMapName`), the same source the battle
   backdrop's terrain walk already reads. A registered target's own `switch_id`
-  is round-tripped through the save but — like EasyRPG's `Window_Teleport`,
-  `Game_Targets` and `Scene_Teleport`, none of which read it back — still left
-  unconsumed here too; nothing in the reference implementation gates the list
-  by it, so filtering here would be a guess the real binary does not make.
+  is round-tripped through the save; `Window_Teleport`, `Game_Targets` and
+  `Scene_Teleport` indeed never read it back for the picker list, so
+  filtering the list by it would be a guess the real binary does not make —
+  **but this note previously over-generalised that into "unconsumed here
+  too" full stop, which was wrong: real RPG_RT does consume it, as a switch
+  flip the instant the warp itself lands, not a list filter — now fixed, see
+  the dedicated bullet below.**
   Casting either skill also forces the party off a ridden boat or ship first
   (mirroring `Game_Player::ForceGetOffVehicle`), leaving the vehicle parked
   where it was boarded; the airship is not forced off because it is not
@@ -2801,7 +2804,40 @@ The work below is roughly ordered by the critical path to a walkable game
   legitimately state-gated" from "no menu reaches this skill" on its own, and
   keeps deferring those two types to this note instead of flagging them as
   unreachable.
-  ✅ **The battle-time skill variance is built now, for a recovery skill too —
+- ✅ **A registered Escape/Teleport target's own switch never actually turned
+  on when the party warped there via the corresponding field skill or
+  special item — corrected from this file's own earlier, too-narrow
+  investigation above.** Real RPG_RT's `Game_Player::ReserveTeleport(const
+  lcf::rpg::SaveTarget& target)` (`src/game_player.cpp`, verified against
+  RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched
+  live) — the overload both `Scene_Teleport::vUpdate` (Decision, picking a
+  destination from the list) and `Scene_Skill`'s Escape branch call — does,
+  right after reserving the warp itself: `if (target.switch_on) {
+  Main_Data::game_switches->Set(target.switch_id, true); ...}`. This is a
+  real, reachable side effect of *landing* at the destination, entirely
+  separate from the (correctly unimplemented) picker-list filtering the
+  bullet above already covers — the earlier investigation checked only
+  whether `switch_id` gates the list and, finding it does not, wrongly
+  concluded the field goes unconsumed everywhere; it missed this second,
+  genuine consumer in `game_player.cpp`, a file that pass never checked.
+  `Interpreter#do_set_teleport_target`/`#do_set_escape_target`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) already stored the switch id
+  correctly (nil when the command's own flag is off), and `Game::Party
+  #cast_escape_skill`/`#cast_teleport_skill` (`game.rb`) already resolved
+  the registered target — but both dropped `switch_id` from the
+  `{map_id:, x:, y:}` hash they returned to the scene, so
+  `Scene::SkillMenu#queue_teleport`/`Scene::ItemMenu#queue_teleport` (which
+  only ever set `Game::State#pending_teleport`) had nothing to act on.
+  Fixed by including `switch_id:` in both cast methods' return hashes and
+  having `#queue_teleport` (both scenes) flip `@state.switches[target
+  [:switch_id]] = true` before queuing the warp, mirroring the existing
+  Switch-type field skill/item's own `@state.switches[sid] = true` pattern.
+  Covered by new `scripts/rpg2k_scene_check.rb` checks (an Escape skill's
+  own switch turns on; a Teleport skill's chosen destination's own switch
+  turns on) and corrected pre-existing `scripts/rpg2k_logic_check.rb`
+  exact-hash-equality checks (now including `switch_id:`), all confirmed to
+  fail against the pre-fix code.
+- ✅ **The battle-time skill variance is built now, for a recovery skill too —
   not just an attack one.** This line used to end "Left unbuilt still: the
   battle-time skill variance," describing only the missing half:
   `Game::Party#battle_skill_command`'s attack branch (enemy-scope skills) has

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4381,10 +4381,14 @@ module Game
     end
 
     # Cast an Escape (type 1) skill: spend `caster`'s SP and return the
-    # registered escape destination as `{map_id:, x:, y:}` for the scene to jump
-    # to, or nil when `sid` is not a castable, available Escape skill. Matches
-    # EasyRPG's Scene_Skill, which jumps straight to `Game_Targets`' single
-    # escape target with no picker.
+    # registered escape destination as `{map_id:, x:, y:, switch_id:}` for the
+    # scene to jump to (switch_id nil when the target has none), or nil when
+    # `sid` is not a castable, available Escape skill. Matches EasyRPG's
+    # Scene_Skill, which jumps straight to `Game_Targets`' single escape
+    # target with no picker; `switch_id` mirrors `Game_Player::
+    # ReserveTeleport(const SaveTarget&)`'s own `if (target.switch_on)
+    # Main_Data::game_switches->Set(target.switch_id, true)`, applied by the
+    # scene's own #queue_teleport once the warp itself lands.
     #
     # `free`, like #cast_skill's own flag, casts without the knows-it /
     # can-afford-it gate and without spending SP — used by
@@ -4398,7 +4402,7 @@ module Game
       target = state.escape_target
       return nil unless target
       caster.change_mp(-skill_cost(sk, caster)) unless free
-      { map_id: target[:map_id], x: target[:x], y: target[:y] }
+      { map_id: target[:map_id], x: target[:x], y: target[:y], switch_id: target[:switch_id] }
     end
 
     # Cast a Teleport (type 2) skill to the registered destination named by
@@ -4417,7 +4421,7 @@ module Game
       target = state.teleport_targets[map_id]
       return nil unless target
       caster.change_mp(-skill_cost(sk, caster)) unless free
-      { map_id: map_id, x: target[:x], y: target[:y] }
+      { map_id: map_id, x: target[:x], y: target[:y], switch_id: target[:switch_id] }
     end
 
     # Whether `sk`'s field-menu offer depends on runtime state (`Game::State`)

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -236,9 +236,10 @@ class RPG2k
       end
 
       # Queue the warp for Scene::Map (see Game::State#pending_teleport) and pop
-      # every menu on top of it in one step -- the same shape
-      # Scene::SkillMenu#queue_teleport uses.
+      # every menu on top of it in one step -- the same shape (switch flip
+      # included) Scene::SkillMenu#queue_teleport uses.
       def queue_teleport(target)
+        @state.switches[target[:switch_id]] = true if target[:switch_id]
         @state.pending_teleport = [target[:map_id], target[:x], target[:y], 0]
         @parent.pop_to_map
       end

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -286,8 +286,13 @@ class RPG2k
       end
 
       # Queue the warp for Scene::Map (see Game::State#pending_teleport) and pop
-      # every menu on top of it in one step.
+      # every menu on top of it in one step. A registered target's own switch
+      # (Set Teleport Target / Set Escape Target's optional flag) turns on the
+      # instant the warp is queued, matching real RPG_RT's own
+      # `Game_Player::ReserveTeleport(const SaveTarget&)` -- see
+      # Game::Party#cast_escape_skill/#cast_teleport_skill.
       def queue_teleport(target)
+        @state.switches[target[:switch_id]] = true if target[:switch_id]
         @state.pending_teleport = [target[:map_id], target[:x], target[:y], 0]
         @parent.pop_to_map
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5906,7 +5906,7 @@ check 'an Escape skill is hidden with no runtime state, then gated on access ' \
   st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
   eq [[6, 4]], st.party.field_skills(hero, st)
   before = hero.mp
-  eq({ map_id: 3, x: 4, y: 5 }, st.party.cast_escape_skill(hero, 6, st))
+  eq({ map_id: 3, x: 4, y: 5, switch_id: nil }, st.party.cast_escape_skill(hero, 6, st))
   eq before - 4, hero.mp, "the warp costs the skill's SP like any other cast"
   # Flying (boarded the airship) bars it even with access and a target set --
   # EasyRPG's Algo::IsSkillUsable Type_escape arm reads Game_Player::IsFlying.
@@ -5931,7 +5931,7 @@ check 'a Teleport skill lists every registered destination and warps to the ' \
   st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
   eq [[7, 3]], st.party.field_skills(hero, st), 'access plus any target offers it'
   before = hero.mp
-  eq({ map_id: 5, x: 8, y: 9 }, st.party.cast_teleport_skill(hero, 7, st, 5))
+  eq({ map_id: 5, x: 8, y: 9, switch_id: nil }, st.party.cast_teleport_skill(hero, 7, st, 5))
   eq before - 3, hero.mp
   # An id that was never registered casts nothing and spends nothing.
   before = hero.mp
@@ -6133,7 +6133,7 @@ check 'a special item invoking an Escape skill is hidden with no runtime ' \
   ok st.party.field_usable?(3, st)
   eq [[3, 2]], st.party.field_items(st)
   before = hero.mp
-  eq({ map_id: 3, x: 4, y: 5 }, st.party.use_special_escape_item(3, hero, st))
+  eq({ map_id: 3, x: 4, y: 5, switch_id: nil }, st.party.use_special_escape_item(3, hero, st))
   eq before, hero.mp, 'free -- the item pays, not the caster'
   eq 1, st.party.item_count(3), 'one was consumed'
   # Flying bars it even with access and a target set, same as the skill path.
@@ -6157,7 +6157,7 @@ check 'a special item invoking a Teleport skill offers every registered ' \
   st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
   ok st.party.field_usable?(4, st), 'access plus any target offers it'
   before = hero.mp
-  eq({ map_id: 5, x: 8, y: 9 }, st.party.use_special_teleport_item(4, hero, st, 5))
+  eq({ map_id: 5, x: 8, y: 9, switch_id: nil }, st.party.use_special_teleport_item(4, hero, st, 5))
   eq before, hero.mp, 'free -- no SP spent for an item cast'
   eq 0, st.party.item_count(4), 'consumed'
   # An id that was never registered casts nothing and consumes nothing --
@@ -6186,7 +6186,7 @@ check 'a use_skill equipment item invoking an Escape skill warps for free like a
   st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
   ok st.party.field_usable?(3, st)
   before = hero.mp
-  eq({ map_id: 3, x: 4, y: 5 }, st.party.use_special_escape_item(3, hero, st))
+  eq({ map_id: 3, x: 4, y: 5, switch_id: nil }, st.party.use_special_escape_item(3, hero, st))
   eq before, hero.mp, 'free -- the item pays, not the caster'
   eq 2, st.party.item_count(3), 'equipment is not consumed -- a reusable tool, like #use_equip_skill_item'
   # A plain weapon (no use_skill flag) must never be treated as an escape item.
@@ -6213,7 +6213,7 @@ check 'a use_skill equipment item invoking a Teleport skill warps for free like 
   st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
   ok st.party.field_usable?(4, st), 'access plus any target offers it'
   before = hero.mp
-  eq({ map_id: 5, x: 8, y: 9 }, st.party.use_special_teleport_item(4, hero, st, 5))
+  eq({ map_id: 5, x: 8, y: 9, switch_id: nil }, st.party.use_special_teleport_item(4, hero, st, 5))
   eq before, hero.mp, 'free -- no SP spent for an item cast'
   eq 1, st.party.item_count(4), 'equipment is not consumed -- a reusable tool'
 end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15965,7 +15965,7 @@ class EscapeTeleportItemStubParty < MenuStubParty
     return nil unless id == TELEPORT_ID
     target = state.teleport_targets[map_id]
     return nil unless target
-    { map_id: map_id, x: target[:x], y: target[:y] }
+    { map_id: map_id, x: target[:x], y: target[:y], switch_id: target[:switch_id] }
   end
 end
 
@@ -16148,7 +16148,7 @@ class EscapeTeleportStubParty < MenuStubParty
     return nil unless sid == TELEPORT_SID
     target = state.teleport_targets[map_id]
     return nil unless target
-    { map_id: map_id, x: target[:x], y: target[:y] }
+    { map_id: map_id, x: target[:x], y: target[:y], switch_id: target[:switch_id] }
   end
 end
 
@@ -16172,6 +16172,24 @@ check 'Scene::SkillMenu: an Escape skill queues its target and closes the menu' 
   RGSS::Input.reset
   eq [9, 1, 2, 0], state.pending_teleport, 'queued straight from the one registered escape target'
   ok parent.pop_to_map_called, 'the whole menu stack closes rather than staying open'
+end
+
+check 'Scene::SkillMenu: an Escape skill turns on its registered target\'s switch, matching RPG_RT' do
+  # Real RPG_RT: Game_Player::ReserveTeleport(const SaveTarget&) -- the
+  # overload Scene_Skill's Escape branch calls -- does
+  # `if (target.switch_on) Main_Data::game_switches->Set(target.switch_id, true)`
+  # as a side effect of the warp landing, not a picker-list filter (that
+  # distinction is what this repo's own docs/TODO.md previously missed).
+  parent = fake_parent(fake_db)
+  state = escape_teleport_state
+  state.escape_target = { map_id: 9, x: 1, y: 2, switch_id: 14 }
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  ok !state.switches[14], 'the switch starts off'
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm the first row, Escape
+  scene.update
+  RGSS::Input.reset
+  eq [9, 1, 2, 0], state.pending_teleport
+  ok state.switches[14], 'landing at the registered escape target turned its switch on'
 end
 
 check 'Scene::SkillMenu: a Teleport skill opens a destination list and queues the chosen one' do
@@ -16201,6 +16219,28 @@ check 'Scene::SkillMenu: a Teleport skill opens a destination list and queues th
   RGSS::Input.reset
   eq [20, 21, 22, 0], state.pending_teleport
   ok parent.pop_to_map_called
+end
+
+check 'Scene::SkillMenu: a Teleport skill turns on the chosen destination\'s own switch, ' \
+      'a destination with no switch touches nothing' do
+  parent = fake_parent(fake_db)
+  state = escape_teleport_state
+  state.teleport_targets[20] = { x: 21, y: 22, switch_id: 7 } # only this one carries a switch
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto Teleport
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the second destination (map 20)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm map 20, the one with a switch
+  scene.update
+  RGSS::Input.reset
+  eq [20, 21, 22, 0], state.pending_teleport
+  ok state.switches[7], 'landing at map 20\'s registered target turned its switch on'
 end
 
 check 'Scene::SkillMenu: cancelling the destination list returns to the skill list' do


### PR DESCRIPTION
## Summary

- Real RPG_RT's `Game_Player::ReserveTeleport(const lcf::rpg::SaveTarget& target)` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_player.cpp`) — the overload both `Scene_Teleport::vUpdate` (picking a destination from the Teleport list) and `Scene_Skill`'s Escape branch call — turns the registered target's own switch on as a side effect of the warp landing: `if (target.switch_on) { Main_Data::game_switches->Set(target.switch_id, true); ... }`.
- This is a real, reachable mechanic, and it's distinct from the (correctly unimplemented) picker-list *filtering* that a prior investigation in this repo's `docs/TODO.md` already covered — that pass checked only whether `switch_id` gates which destinations appear in the Teleport list (it does not, in the real binary either) and over-generalized the finding into "unconsumed here too" full stop, missing this second, genuine consumer in `game_player.cpp`, a file that pass never checked. Corrected that note as part of this PR.
- `Interpreter#do_set_teleport_target`/`#do_set_escape_target` (`mruby-rpg2k/mrblib/interpreter.rb`) already stored the switch id correctly, and `Game::Party#cast_escape_skill`/`#cast_teleport_skill` (`game.rb`) already resolved the registered target — but both dropped `switch_id` from the `{map_id:, x:, y:}` hash returned to the scene, so `Scene::SkillMenu#queue_teleport`/`Scene::ItemMenu#queue_teleport` (which only ever set `Game::State#pending_teleport`) had nothing to act on.
- Fixed by including `switch_id:` in both cast methods' return hashes and having `#queue_teleport` (both scenes) flip `@state.switches[target[:switch_id]] = true` before queuing the warp — mirroring the existing Switch-type field skill/item's own `@state.switches[sid] = true` pattern already in this codebase.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 728 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1008 checks passed (6 existing exact-hash checks corrected to include `switch_id:`)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] All new/corrected checks confirmed to fail against the pre-fix code (`git stash` of the source files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_