### PR TITLE
psp: fill in kKeyNames to fix a reachable null-pointer dereference

### DIFF
--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -282,7 +282,9 @@ void* mrb_arena_realloc(void* p, size_t n) {
 
 // Names for the RGSS key ids, indexed by PspKey, for the on-screen echo.
 const char* const kKeyNames[PSP_INPUT_KEY_COUNT] = {
-    "Up", "Down", "Left", "Right", "A", "B", "C"};
+    "Up", "Down", "Left", "Right", "A",  "B",  "C",  "",  "",  "",   "",   "",
+    "",   "",     "",     "",      "",   "",   "",   "",  "",  "N0", "N1", "N2",
+    "N3", "N4",   "N5",   "N6",    "N7", "N8", "N9", "+", "-", "*",  "/",  "."};
 
 // The Memory Stick install location this build looks for a project at --
 // matching app/psp/README.md's own install instructions (copy EBOOT.PBP to
@@ -413,8 +415,8 @@ void build_ui(void) {
 }
 
 // Rebuild the "Keys:" line from the current pad bitmask.
-void show_keys(uint32_t mask) {
-  static uint32_t last = 0xffffffffu;
+void show_keys(uint64_t mask) {
+  static uint64_t last = 0xffffffffffffffffull;
   if (mask == last)
     return;
   last = mask;
@@ -424,7 +426,9 @@ void show_keys(uint32_t mask) {
   sb.str("Keys:");
   bool any = false;
   for (int k = 0; k < PSP_INPUT_KEY_COUNT; ++k) {
-    if (mask & (1u << k)) {
+    if (mask & (1ull << k)) {
+      if (kKeyNames[k][0] == '\0')
+        continue;
       sb.str(" ");
       sb.str(kKeyNames[k]);
       any = true;

--- a/changelog.d/psp-kkeynames-null-deref.fixed.md
+++ b/changelog.d/psp-kkeynames-null-deref.fixed.md
@@ -1,0 +1,23 @@
+- **The PSP EBOOT's idle "Keys:" status label no longer dereferences a
+  null pointer when Square, L, R, Start, or Select is pressed.**
+  `app/psp/main.cxx`'s `kKeyNames[PSP_INPUT_KEY_COUNT]` (36 entries) was
+  only initialized with 7 strings ("Up"/"Down"/"Left"/"Right"/"A"/"B"/"C");
+  the rest were implicitly null. `mruby-rgss/src/psp.cxx`'s
+  `psp_input_scan()` sets mask bits 21-25 (`PSP_INPUT_N0`..`N4`) when
+  those five buttons are pressed, and `show_keys()` looked up
+  `kKeyNames[k]` for every set bit and passed it straight to
+  `StrBuf::str()`, which dereferences its argument unconditionally —
+  reachable in practice, confirmed interactively under PPSSPP's SDL
+  frontend (`Bad memory access detected and ignored: 00000000` spamming
+  on every affected keypress). Not caught by CI's `psp-smoke` job, which
+  injects no controller input. Fixed by filling in every entry
+  (`N0`-`N9`/`+`/`-`/`*`/`/`/`.` for the reachable ids, empty strings for
+  the currently-unbound gap ids), plus skipping empty names in
+  `show_keys()`'s loop. Also switched `show_keys`'s mask parameter from
+  `uint32_t` to `uint64_t` (matching `psp_input_scan()`'s real return
+  type) and its bit test to `1ull << k`: the old `uint32_t`/`1u << k`
+  combination silently truncated the high bits of the mask on the call
+  site's implicit narrowing conversion, and separately triggered
+  undefined behavior for `k >= 32` regardless (both currently only
+  affecting bit ids the HAL never actually sets, but worth closing while
+  in this code).


### PR DESCRIPTION
## Summary
- Fixes a real, user-reported crash: `app/psp/main.cxx`'s `kKeyNames[PSP_INPUT_KEY_COUNT]` (36 entries) was only initialized with 7 strings; the rest were implicitly null. `psp_input_scan()` sets mask bits 21-25 (`N0`..`N4`) when Square/L/R/Start/Select are pressed, and `show_keys()` passed the corresponding null `kKeyNames[k]` straight into `StrBuf::str()`, which dereferences unconditionally.
- Confirmed reachable interactively: running `./result/bin/ppsspp --graphics=software --windowed --xres=480 --yres=272 build-psp/EBOOT.PBP` and pressing keys produced `Bad memory access detected and ignored: 00000000` spam. Not caught by CI's `psp-smoke` job, which injects no controller input — this predates and is unrelated to ADR 0047's just-closed nine-bug boot trail.
- Also switches `show_keys`'s mask parameter from `uint32_t` to `uint64_t` (matching `psp_input_scan()`'s real return type) and `1u << k` to `1ull << k` — the old combination silently truncated the mask's high bits at the call site and separately triggered undefined behavior for `k >= 32`, both currently affecting only bit ids the HAL never actually sets, but worth closing while in this code.

## Test plan
- [x] Rebuilt the EBOOT; `kKeyNames` now has all 36 entries as valid (possibly empty) non-null strings, eliminating the null dereference by construction.
- [ ] CI — pending on this PR.