### PR TITLE
battle: an item-invoked skill now opens with the item's own line by default, matching RPG_RT

### DIFF
--- a/changelog.d/item-invoked-skill-battle-message.fixed.md
+++ b/changelog.d/item-invoked-skill-battle-message.fixed.md
@@ -1,0 +1,9 @@
+- **RPG2000/2003 battle log:** A skill invoked by a battle item (a special
+  item, or a weapon/shield/armour/helmet/accessory flagged to invoke a
+  skill) now opens with the *item's own* "used it!" line when the item
+  leaves its `using_message` field at the database default, matching real
+  RPG_RT — previously such an item always displayed the skill's own borrowed
+  sentence instead, regardless of the item's own flag. An item that
+  explicitly sets `using_message` still shows the skill's own sentence, and
+  a skill cast from the Skill menu is unaffected either way. Covered by four
+  new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4634,6 +4634,56 @@ The work below is roughly ordered by the critical path to a walkable game
   the first skill's text, follows the cursor onto the second, and keeps
   showing it once a target is being picked), confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **A special/`use_skill` battle item invoking a skill now opens the
+  battle log with the *item's own* line when the item leaves its
+  `using_message` field at the database default, instead of always taking
+  the skill's own sentence (2026-08-18).** Item schema field 51
+  `using_message` (`mruby-lcf/mrblib/schema.rb`) is an **int**, distinct
+  from the skill-only `using_message1`/`using_message2` **string** fields of
+  the same near-name, and until now was never once read —
+  `Scene::Battle#battle_action_body` (`mruby-rpg2k/mrblib/scene/battle.rb`)
+  dispatched on `e[:skill_id]` before ever checking `e[:item_id]`, so a
+  skill cast through a battle item (a type-9 special item, or a weapon/
+  shield/armour/helmet/accessory flagged `use_skill`) always took
+  `#battle_skill_body`'s own `using_message1`/`using_message2` sentence,
+  the same as a skill picked from the Skill menu. Verified against EasyRPG
+  Player's actual C++ source: `Game_BattleAlgorithm::Skill::GetStartMessage`
+  (`src/game_battlealgorithm.cpp`) checks `item && item->using_message == 0`
+  **first**, unconditionally, before ever reading the skill's own message
+  fields — `if (item && item->using_message == 0) { ... return
+  BattleMessage::GetItemStartMessage2k(*GetSource(), *item); ... }` — and
+  falls through to the skill's own sentence only once that guard fails,
+  i.e. only when the item's own `using_message` is nonzero. Since the
+  schema default for an item's `using_message` field is 0, an ordinary
+  skill-casting item left at its editor default (the common case) is
+  supposed to open with its own name ("リトはやくそうを使った！"), never the
+  skill's borrowed sentence — this build showed the skill's sentence for
+  *every* such item regardless of the flag. `EasyRPG`'s own
+  `GetFailureMessage` reads only the skill, never the item
+  (`BattleMessage::GetSkillFailureMessage(*GetSource(), *GetTarget(),
+  skill)`), so the fix is scoped to the opening line(s) only — the damage /
+  recovery / absorb / failure lines that follow are untouched. Fixed with a
+  new `Scene::Battle#skill_start_lines(e, row, caster)`, called from
+  `#battle_skill_body` in place of the previous bare `bt.skill_start(row,
+  caster)`: when `e[:item_id]` resolves to a real database row (through
+  `@state.party.db_item`) whose `using_message` is 0/unset, it builds the
+  item's own generic line (`Game::States::BattleText.item_start`, the same
+  helper `#battle_item_body` already uses for a plain, non-skill item)
+  instead; a skill cast with no `item_id` at all (the Skill menu) or an
+  item that explicitly sets `using_message` nonzero both fall through to
+  the skill's own `#skill_start` sentence unchanged. A dangling `item_id`
+  (a database row `db_item` can no longer resolve) degrades to the skill's
+  own sentence too, rather than a blank item name — there is no real item
+  struct to read a `using_message` flag off, and this codebase's usual
+  dangling-id rule is to degrade gracefully rather than print something
+  the game itself never could. Covered by four new
+  `scripts/rpg2k_scene_check.rb` checks (an item-invoked skill at the
+  `using_message` 0 default opens with the item's own line; the same skill
+  keeps its own two sentences once the item sets `using_message` nonzero; a
+  dangling `item_id` degrades to the skill's sentence rather than a blank
+  item name; a Skill-menu cast with no `item_id` is untouched), the first
+  confirmed to fail against the pre-fix code (`expected` the item's own
+  line, `got` the skill's two sentences instead) before the fix.
 
 ### yado.tk quirks backlog
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8374,9 +8374,11 @@ module Game
 
       # An item has no sentence of its own — it borrows the `use_item` term, and
       # is the one line RPG2000 builds from *two* names: 「リトはポーションを使っ
-      # た！」 is the caster, は, the item, and the term. (`item.using_message` is
-      # an int selecting a battle animation layout, not a string; no RPG2000 item
-      # carries a sentence.)
+      # た！」 is the caster, は, the item, and the term. `item.using_message`
+      # (schema field 51) is an int, not a string — but it is not dead data: a
+      # skill-casting item (special/use_skill) reads as 0 or nonzero, gating
+      # whether *this* generic line or the invoked skill's own sentence(s)
+      # opens the log entry — see Scene::Battle#skill_start_lines.
       def self.item_start(terms, caster_name, item_name)
         t = term(terms, :use_item)
         t && "#{caster_name}#{ALLY_PARTICLE.strip}#{item_name}#{t}"

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2574,7 +2574,7 @@ class RPG2k
         bt = Game::States::BattleText
         row = db.respond_to?(:skill) && db.skill ? db.skill[e[:skill_id]] : nil
         caster = (e[:recover] ? e[:actor] : e[:attacker]).to_s
-        lines = bt.skill_start(row, caster)
+        lines = skill_start_lines(e, row, caster)
         return [battle_action_line(e)] if lines.empty?
         t = db.respond_to?(:term) ? db.term : nil
         rest = battle_skill_result(t, row, e)
@@ -2583,6 +2583,56 @@ class RPG2k
       rescue StandardError => ex
         $stderr.puts "[RPG2k] skill message lookup failed: #{ex.message}"
         [battle_action_line(e)]
+      end
+
+      # The opening line(s) of a skill's log entry: the *casting item's own*
+      # generic "used it!" line when a special/use_skill battle item invoked
+      # this skill and left its own `using_message` field (item schema field
+      # 51 -- distinct from the skill-only `using_message1`/`using_message2`
+      # string fields) at the database default 0, else the skill's own
+      # sentence(s) (`#skill_start`).
+      #
+      # Confirmed against EasyRPG Player's actual C++ source:
+      # `Game_BattleAlgorithm::Skill::GetStartMessage`
+      # (`src/game_battlealgorithm.cpp`) checks `item && item->using_message
+      # == 0` **before** ever looking at the skill's own `using_message1`/
+      # `using_message2`:
+      #   if (item && item->using_message == 0) {
+      #     ...
+      #     return BattleMessage::GetItemStartMessage2k(*GetSource(), *item);
+      #     ...
+      #   }
+      # falling through to the skill's own sentence only once that guard
+      # fails -- i.e. only when the item sets `using_message` nonzero. Since
+      # `mruby-lcf/mrblib/schema.rb`'s item `using_message` field defaults to
+      # 0, an ordinary skill-casting item left at its editor default (the
+      # common case) opens with its own name ("リトはやくそうを使った！"), not
+      # the skill's borrowed sentence. This used to unconditionally take the
+      # skill's own two sentences for *every* item-invoked skill regardless
+      # of the item's `using_message` flag -- the item's own message was
+      # database data this build read (`Game::Party#skill_hit`'s `sk.hit ==
+      # -1` fallback already proves the pattern of respecting such sentinels)
+      # but never actually consulted here.
+      #
+      # A skill cast from the Skill menu itself carries no `item_id` at all,
+      # so it is untouched: it always takes its own sentence, matching
+      # `GetStartMessage`'s `item` being null in that case. An `item_id` the
+      # database no longer has a row for (a dangling id) falls back the same
+      # way -- there is no real `item` to read `using_message` off, so this
+      # degrades to the skill's own sentence rather than a blank item name,
+      # matching this codebase's usual dangling-id-degrades-gracefully rule.
+      def skill_start_lines(e, row, caster)
+        bt = Game::States::BattleText
+        it = e[:item_id] && @state.party.db_item(e[:item_id])
+        if it
+          uses_skill_message = it.respond_to?(:using_message) && (it.using_message || 0) != 0
+          unless uses_skill_message
+            t = db.respond_to?(:term) ? db.term : nil
+            line = bt.item_start(t, caster, it.name.to_s)
+            return line ? [line] : []
+          end
+        end
+        bt.skill_start(row, caster)
       end
 
       # What the skill did: the damage / dodge line for an attack, nothing extra
@@ -2672,9 +2722,9 @@ class RPG2k
       end
 
       # Which term words this entry's "so-and-so did a thing" line, or nil when
-      # RPG2000 has none for it — a skill or an item names itself instead (its
-      # own `using_message` is a separate field, still unread), and "does
-      # nothing" is a state's own sentence rather than a term.
+      # RPG2000 has none for it — a skill or an item names itself instead
+      # (`#battle_skill_body`/`#skill_start_lines`, `#battle_item_body`), and
+      # "does nothing" is a state's own sentence rather than a term.
       def battle_start_field(e)
         return nil if e[:recover] || e[:skill] || e[:nothing]
         return :enemy_transform if e[:transform]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14472,6 +14472,55 @@ check 'an item that did nothing keeps the composed line' do
      .first.include?('no effect')
 end
 
+# A special/use_skill battle item invoking a skill: verified against EasyRPG
+# Player's actual C++ source, `Game_BattleAlgorithm::Skill::GetStartMessage`
+# (`src/game_battlealgorithm.cpp`) -- `if (item && item->using_message == 0)
+# ... return BattleMessage::GetItemStartMessage2k(...)`, checked *before* ever
+# reading the skill's own `using_message1`/`using_message2`. The item
+# schema's own `using_message` field (`mruby-lcf/mrblib/schema.rb`, distinct
+# from the skill-only string fields of the same near-name) defaults to 0, so
+# an item left at that default opens with its own name, not the skill's
+# sentence -- previously this build always took the skill's two sentences
+# for *every* item-invoked skill, the item's own `using_message` flag never
+# once read.
+check 'an item-invoking skill left at using_message\'s 0 default opens with ' \
+      'the item\'s own line, not the skill\'s' do
+  party = BattleStubParty.new(item_db: { 20 => OpenStruct.new(name: 'Fire Bomb', using_message: 0) })
+  scene, = battle_at_command(nil, party: party)
+  eq ['HeroはFire Bombを使った！', 'Slimeに 42 のダメージを与えた！'],
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 42, skill: 'Fire',
+                  skill_id: 8, item_id: 20, target_ally: false })
+end
+
+check 'the same item-invoked skill keeps its own two sentences once the ' \
+      'item sets using_message nonzero' do
+  party = BattleStubParty.new(item_db: { 21 => OpenStruct.new(name: 'Fire Scroll', using_message: 1) })
+  scene, = battle_at_command(nil, party: party)
+  eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！', 'Slimeに 42 のダメージを与えた！'],
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 42, skill: 'Fire',
+                  skill_id: 8, item_id: 21, target_ally: false })
+end
+
+check 'a skill invoked by an item id the database no longer has a row for ' \
+      'degrades to the skill\'s own sentence, not a blank item name' do
+  party = BattleStubParty.new(item_db: {})
+  scene, = battle_at_command(nil, party: party)
+  eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！', 'Slimeに 42 のダメージを与えた！'],
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 42, skill: 'Fire',
+                  skill_id: 8, item_id: 999, target_ally: false })
+end
+
+check 'a skill cast from the Skill menu (no item_id at all) is untouched' do
+  scene, = battle_at_command
+  eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！', 'Slimeに 42 のダメージを与えた！'],
+     scene.instance_variable_get(:@battle).send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 42, skill: 'Fire',
+                  skill_id: 8, target_ally: false })
+end
+
 check 'a drain adds its own line after the damage' do
   scene, = battle_at_command
   eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',


### PR DESCRIPTION
## Summary

- Real RPG_RT's `Game_BattleAlgorithm::Skill::GetStartMessage` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_battlealgorithm.cpp`) checks `item && item->using_message == 0` **before** ever reading the skill's own `using_message1`/`using_message2` fields: `if (item && item->using_message == 0) { ... return BattleMessage::GetItemStartMessage2k(*GetSource(), *item); ... }`.
- A skill invoked by a battle item (a type-9 special item, or a weapon/shield/armour/helmet/accessory flagged `use_skill`) is supposed to open the battle log with the *item's own* generic "used it!" line whenever the item leaves its `using_message` field (item schema field 51, an int — distinct from the skill-only `using_message1`/`using_message2` string fields) at the database default of 0, which is the common case. Only once that field is explicitly set nonzero does the skill's own borrowed sentence show instead.
- `Scene::Battle#battle_action_body` (`mruby-rpg2k/mrblib/scene/battle.rb`) dispatched on `e[:skill_id]` alone, so an item-invoked skill always took `#battle_skill_body`'s bare `using_message1`/`using_message2` sentence — the item's own `using_message` flag was never once read, regardless of what it was set to.
- Fixed with a new `Scene::Battle#skill_start_lines(e, row, caster)`, consulted from `#battle_skill_body` in place of the previous bare call: when `e[:item_id]` resolves to a real database row (via `@state.party.db_item`) whose `using_message` is 0/unset, it builds the item's own generic line (`Game::States::BattleText.item_start`, the same helper a plain non-skill item already uses); a Skill-menu cast (no `item_id` at all), an item that explicitly sets `using_message` nonzero, and a dangling `item_id` (no real database row to read a flag off) all fall through to the skill's own sentence unchanged — the last one matching this codebase's usual "degrade gracefully, don't print something the game itself never could" rule for dangling ids.
- Also corrected a stale doc comment on `BattleText.item_start` that had claimed `using_message` was pure battle-animation data never consulted anywhere in this codebase — it now is, right here.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 732 checks passed (4 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1008 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] The primary new check confirmed to fail against the pre-fix code (`git stash` of the source files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_