### PR TITLE
map: Input Number now plays cursor/decision system SE, matching RPG_RT

### DIFF
--- a/changelog.d/input-number-sound-effects.fixed.md
+++ b/changelog.d/input-number-sound-effects.fixed.md
@@ -1,0 +1,4 @@
+- **RPG2000/2003 maps:** The Input Number event-command widget now plays
+  the Cursor system SE on every digit adjustment and the Decision SE on
+  confirm, matching real RPG_RT — previously it played no sound effects at
+  all. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3666,6 +3666,35 @@ The work below is roughly ordered by the critical path to a walkable game
   that they run cleanly); the full `rpg2k_scene_check.rb` (485),
   `rpg2k_logic_check.rb` (773), `rpg2k_save_load_check.rb`, and
   `rpg2k_testbed_logic_check.rb` (125) suites all still pass.
+- ✅ **That same SFX audit scoped itself to the separate `Scene::*` menu
+  screens and missed `Scene::Map`'s own embedded Input Number widget, which
+  played no sound effects at all (2026-08-18).** Verified against RPG_RT's
+  actual behavior via EasyRPG Player's own C++ source, fetched live:
+  `Window_NumberInput::Update` (`src/window_numberinput.cpp`) plays the
+  Cursor system SE on every UP/DOWN/LEFT/RIGHT digit adjustment (and numpad
+  digit entry, which this codebase's widget does not support a way to
+  reach at all — a distinct, smaller gap not addressed here), and
+  `Window_Message::InputNumber` (`src/window_message.cpp`) plays Decision
+  right before committing the entered value on confirm. `Scene::Map
+  #drive_number_input` (`mruby-rpg2k/mrblib/scene/map.rb`) had zero
+  `play_system_se` calls anywhere in its body — silent on every
+  interaction — unlike the structurally identical Show Choices handler a
+  few lines up in the very same file (`#drive_message`'s choice-list
+  branch), which already plays `SFX_CURSOR`/`SFX_DECISION` correctly.
+  Fixed by adding the same two calls `#drive_message` already uses, in the
+  same places. Input Number is a common RPG2000/2003 event command
+  (variable-entry shops, quiz puzzles, code locks), so this was reachable
+  in essentially any game that uses it, not a hypothetical edge case.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (each of UP/DOWN/
+  LEFT/RIGHT plays the Cursor SE, confirming plays Decision), confirmed to
+  fail against the pre-fix code. The Enter Hero Name widget
+  (`#handle_name_input`/`#handle_kana_name_input`/`#name_input_confirm`/
+  `#name_input_backspace`, same file) has an identical gap — verified
+  against `src/scene_name.cpp`/`src/window_name.cpp`, also fetched this
+  pass — left as a follow-up rather than bundled in here, since it touches
+  several more input branches (Decision on confirm/append, Cancel-then-
+  backspace vs. Cancel-with-empty-text Buzzer, an overflowing name) and
+  deserves its own dedicated, focused fix.
   ✅ **A disabled Continue's own *rendering* — not just its SE — was also
   still wrong, found in a separate later pass: it drew a hardcoded flat gray
   instead of reading the windowskin's own disabled-colour swatch, unlike

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7258,22 +7258,34 @@ class RPG2k
         end
       end
 
+      # Confirmed against EasyRPG's Window_NumberInput::Update (src/
+      # window_numberinput.cpp): every digit adjustment/cursor move plays the
+      # Cursor system SE, and Window_Message::InputNumber (src/
+      # window_message.cpp) plays Decision on confirm -- the same shape
+      # Show Choices already gets a few lines up in this same method's
+      # sibling handler (#drive_message's choice-list branch), just missed
+      # here.
       def drive_number_input
         ni = @number_input
         model = ni[:model]
         if Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           model.inc
           draw_number_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           model.dec
           draw_number_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
           model.left
           draw_number_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
           model.right
           draw_number_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
+          play_system_se(SFX_DECISION)
           value = model.value
           embedded = ni[:embedded]
           interp = ni[:interp] || @interpreter

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3585,6 +3585,46 @@ check 'Input Number opens a widget; confirming stores the entered value' do
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
+check 'Input Number plays the Cursor SE on every digit move and Decision on confirm' do
+  # Confirmed against EasyRPG's Window_NumberInput::Update (src/
+  # window_numberinput.cpp, every UP/DOWN/LEFT/RIGHT plays SFX_Cursor) and
+  # Window_Message::InputNumber (src/window_message.cpp, Decision on
+  # confirm) -- the same SE Show Choices already plays, just missing here.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::INPUT_NUMBER, [2, 5])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+
+  ni = nil
+  12.times { scene.update; ni = scene.instance_variable_get(:@number_input); break if ni }
+  ok ni, 'the number-entry widget opened'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::UP]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'UP plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'DOWN plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'RIGHT plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::LEFT]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'LEFT plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  eq 'Decision1', RGSS::Audio.se_calls.last&.first, 'confirming plays the decision SE'
+end
+
 check 'a message types out gradually, then a button completes and dismisses it' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- Real RPG_RT's `Window_NumberInput::Update` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/window_numberinput.cpp`) plays the Cursor system SE on every UP/DOWN/LEFT/RIGHT digit adjustment, and `Window_Message::InputNumber` (`src/window_message.cpp`) plays Decision right before committing the entered value on confirm.
- `Scene::Map#drive_number_input` (`mruby-rpg2k/mrblib/scene/map.rb`) had zero `play_system_se` calls anywhere in its body — silent on every interaction — unlike the structurally identical Show Choices handler a few lines up in the very same file (`#drive_message`'s choice-list branch), which already plays `SFX_CURSOR`/`SFX_DECISION` correctly.
- This is a gap a prior SFX audit in this codebase (see `docs/TODO.md`) missed: that pass scoped itself to the separate `Scene::*` menu screens (Menu/Item/Skill/Equip/Status/SaveLoad) and Title, never reaching `Scene::Map`'s own embedded widgets (Show Choices got fixed there separately; Input Number did not). Input Number is a common RPG2000/2003 event command (variable-entry shops, quiz puzzles, code locks), so this was reachable in essentially any game that uses it.
- Fixed by adding the same two calls the Show Choices handler already uses, in the same places: `play_system_se(SFX_CURSOR)` in each of the UP/DOWN/LEFT/RIGHT branches, `play_system_se(SFX_DECISION)` in the confirm branch.
- The Enter Hero Name widget has an identical gap (verified against `src/scene_name.cpp`/`src/window_name.cpp` too), documented in `docs/TODO.md` as a follow-up rather than bundled in here — it touches several more input branches (Decision, Cancel-then-backspace vs. an empty-text Buzzer, an overflowing-name Buzzer) and deserves its own focused fix.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 738 checks passed (1 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1008 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] The new check confirmed to fail against the pre-fix code (`git stash` of the source file)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_