### PR TITLE
map: Enter Hero Name now plays cursor/decision/cancel/buzzer system SE, matching RPG_RT

### DIFF
--- a/changelog.d/enter-hero-name-sound-effects.fixed.md
+++ b/changelog.d/enter-hero-name-sound-effects.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2000/2003 maps:** The Enter Hero Name widget now plays RPG_RT's
+  system SE on every interaction — Cursor on each grid move, Decision on
+  every confirm (before dispatching on the highlighted cell), Buzzer when a
+  character would overflow the field, and Cancel (or Buzzer with nothing
+  left to erase) on backspace — previously it played no sound effects at
+  all. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3695,6 +3695,41 @@ The work below is roughly ordered by the critical path to a walkable game
   several more input branches (Decision on confirm/append, Cancel-then-
   backspace vs. Cancel-with-empty-text Buzzer, an overflowing name) and
   deserves its own dedicated, focused fix.
+- ✅ **That follow-up: the Enter Hero Name widget now plays RPG_RT's system
+  SE on every interaction too (2026-08-18).** Re-verified against EasyRPG
+  Player's own C++ source, fetched live, rather than trusting the note
+  above at face value: `Scene_Name::vUpdate` (`src/scene_name.cpp`) plays
+  Decision **unconditionally the instant Decision is pressed**, before ever
+  dispatching on which cell is highlighted — the same for OK/DONE, a
+  hiragana/katakana page toggle, or an ordinary character — and its Cancel
+  branch is a genuinely separate input path: `if
+  (name_window->Get().size() > 0) { ...Cancel...; Erase(); } else {
+  ...Buzzer...; }` (`Erase()` removes exactly one trailing character, a
+  backspace, confirmed by reading `Window_Name::Erase`,
+  `src/window_name.cpp`, not "clear the whole field"). `Window_Keyboard
+  ::Update`'s own `play_cursor` flag (`src/window_keyboard.cpp`) plays
+  Cursor SE on every grid move. `Window_Name::Append` plays Buzzer and
+  silently drops the character the instant appending it would overflow the
+  field — layered *after* the unconditional Decision already played for
+  that same keypress, not instead of it. This codebase's own grid adds an
+  on-screen "BS" cell real RPG_RT's keyboard has no equivalent of; treated
+  as an ordinary Decision-dispatched cell (Decision SE only, no extra SE of
+  its own), distinct from the *physical* Cancel key,
+  which now gets the real Cancel/Buzzer branch. Fixed by adding
+  `play_system_se(SFX_CURSOR)` to every grid-move branch in both
+  `#handle_name_input`/`#handle_kana_name_input`, `play_system_se
+  (SFX_DECISION)` unconditionally in each Decision branch before
+  dispatching to `#name_input_confirm`/`#kana_name_input_confirm`,
+  `play_system_se(SFX_BUZZER)` in each of their character-cell branches
+  when the field is already full, and a new `#name_input_cancel` (Cancel
+  SE + backspace when non-empty, Buzzer-only when empty) replacing the
+  bare, silent `#name_input_backspace` call on the physical Cancel key —
+  the on-screen "BS" cell now calls the renamed `#backspace_name_input`
+  directly, since the Decision that dispatched to it already played its
+  own SE. Covered by a new `scripts/rpg2k_scene_check.rb` check (cursor
+  move, character confirm, Cancel-with-a-character, Cancel-with-none, and
+  an overflowing character's Decision-then-Buzzer pair all get their
+  correct SE), confirmed to fail against the pre-fix code.
   ✅ **A disabled Continue's own *rendering* — not just its SE — was also
   still wrong, found in a separate later pass: it drew a hardcoded flat gray
   instead of reading the windowskin's own disabled-colour swatch, unlike

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5285,6 +5285,16 @@ class RPG2k
         [NAME_COLS, NAME_CELLS.length - row * NAME_COLS].min
       end
 
+      # Confirmed against EasyRPG's Scene_Name::vUpdate (src/scene_name.cpp):
+      # every cursor move plays Cursor SE (Window_Keyboard::Update's own
+      # `play_cursor`, src/window_keyboard.cpp), and Decision plays
+      # unconditionally the instant C is pressed, before dispatching on
+      # which cell is highlighted -- the same for OK/DONE, a page toggle or
+      # an ordinary character. Cancel is a genuinely separate branch from
+      # Decision in real RPG_RT, not this codebase's on-screen "BS" cell
+      # (which real RPG_RT's own keyboard grid has no equivalent of): it
+      # erases one character with its own Cancel SE, or Buzzer with nothing
+      # to erase -- see #name_input_cancel.
       def handle_name_input
         ui = @name_ui
         row = ui[:sel] / NAME_COLS
@@ -5293,38 +5303,66 @@ class RPG2k
         if Input.trigger?(Input::RIGHT)
           ui[:sel] = row * NAME_COLS + (col + 1) % name_row_len(row)
           draw_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::LEFT)
           ui[:sel] = row * NAME_COLS + (col - 1) % name_row_len(row)
           draw_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::DOWN)
           new_row = (row + 1) % rows
           ui[:sel] = new_row * NAME_COLS + col % name_row_len(new_row)
           draw_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::UP)
           new_row = (row - 1) % rows
           ui[:sel] = new_row * NAME_COLS + col % name_row_len(new_row)
           draw_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
+          play_system_se(SFX_DECISION)
           name_input_confirm
         elsif Input.trigger?(Input::B)
-          name_input_backspace
+          name_input_cancel
         end
       end
 
-      # Act on the highlighted cell: OK commits, BS backspaces, any other cell
-      # types its character (up to NAME_MAX).
+      # Act on the highlighted cell: OK commits, BS backspaces (no SE of its
+      # own -- the Decision that dispatched here, #handle_name_input, already
+      # played one), any other cell types its character (up to NAME_MAX) or,
+      # once full, rejects it with Buzzer -- matching EasyRPG's
+      # Window_Name::Append (src/window_name.cpp), which plays Buzzer and
+      # drops the appended text the instant it would overflow the field.
       def name_input_confirm
         cell = NAME_CELLS[@name_ui[:sel]]
         case cell
         when 'OK' then commit_name_input
-        when 'BS' then name_input_backspace
+        when 'BS' then backspace_name_input
         else
-          @name_ui[:name] += cell if @name_ui[:name].length < NAME_MAX
+          if @name_ui[:name].length < NAME_MAX
+            @name_ui[:name] += cell
+          else
+            play_system_se(SFX_BUZZER)
+          end
           draw_name_input
         end
       end
 
-      def name_input_backspace
+      # The physical Cancel key (not the on-screen "BS" cell, see
+      # #handle_name_input's own doc comment): erase one character with its
+      # own Cancel SE, or Buzzer when the name is already empty -- matching
+      # EasyRPG's Scene_Name::vUpdate Cancel branch exactly (`if
+      # (name_window->Get().size() > 0) { ...Cancel...; Erase(); } else {
+      # ...Buzzer...; }`).
+      def name_input_cancel
+        if @name_ui[:name].empty?
+          play_system_se(SFX_BUZZER)
+        else
+          play_system_se(SFX_CANCEL)
+          backspace_name_input
+        end
+      end
+
+      def backspace_name_input
         @name_ui[:name] = @name_ui[:name].chop
         @name_ui[:kana] ? draw_kana_name_input : draw_name_input
       end
@@ -5377,27 +5415,35 @@ class RPG2k
         if Input.trigger?(Input::RIGHT)
           ui[:sel] = row * NAME_KANA_COLS + (col + 1) % rows[row].length
           draw_kana_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::LEFT)
           ui[:sel] = row * NAME_KANA_COLS + (col - 1) % rows[row].length
           draw_kana_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::DOWN)
           new_row = (row + 1) % rows.length
           ui[:sel] = new_row * NAME_KANA_COLS + col % rows[new_row].length
           draw_kana_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::UP)
           new_row = (row - 1) % rows.length
           ui[:sel] = new_row * NAME_KANA_COLS + col % rows[new_row].length
           draw_kana_name_input
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
+          play_system_se(SFX_DECISION)
           kana_name_input_confirm
         elsif Input.trigger?(Input::B)
-          name_input_backspace
+          name_input_cancel
         end
       end
 
       # Act on the highlighted cell: :confirm commits, :toggle swaps the
       # hiragana/katakana page, any kana cell types its character (up to
-      # NAME_KANA_MAX).
+      # NAME_KANA_MAX) or, once full, rejects it with Buzzer -- see
+      # #name_input_confirm's identical doc comment, which this mirrors (the
+      # kana grid has no on-screen backspace cell of its own, only the
+      # physical Cancel key, #name_input_cancel).
       def kana_name_input_confirm
         ui = @name_ui
         rows = name_kana_rows(ui[:page])
@@ -5408,7 +5454,11 @@ class RPG2k
           ui[:page] = ui[:page] == :hiragana ? :katakana : :hiragana
           draw_kana_name_input
         else
-          ui[:name] += cell if ui[:name].length < NAME_KANA_MAX
+          if ui[:name].length < NAME_KANA_MAX
+            ui[:name] += cell
+          else
+            play_system_se(SFX_BUZZER)
+          end
           draw_kana_name_input
         end
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7141,6 +7141,54 @@ check 'Enter Hero Name: typing on the grid and confirming renames the actor' do
   ok st.switches[5], 'the event resumed after entry'
 end
 
+check 'Enter Hero Name plays the RPG_RT system SE on every interaction' do
+  # Confirmed against EasyRPG's Scene_Name::vUpdate (src/scene_name.cpp,
+  # Cursor on every grid move, Decision unconditionally on every C press
+  # before dispatching on the highlighted cell), Window_Name::Append (src/
+  # window_name.cpp, Buzzer when a character would overflow the field) and
+  # the same vUpdate's Cancel branch (Cancel with a character to erase,
+  # Buzzer with none) -- this widget used to play nothing at all.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::NAME_INPUT, [1, 2, 0], indent: 0)] # actor 1, letters, no seed
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  ui = nil
+  6.times { scene.update; ui = scene.instance_variable_get(:@name_ui); break if ui }
+  ok ui, 'the name-entry widget opened'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'moving the cursor plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # types a character
+  scene.update
+  eq 'Decision1', RGSS::Audio.se_calls.last&.first, 'confirming a character cell plays decision'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::B] # backspace it -- name is non-empty
+  scene.update
+  eq 'Cancel1', RGSS::Audio.se_calls.last&.first, 'Cancel with a character to erase plays cancel'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::B] # backspace again -- now empty
+  scene.update
+  eq 'Buzzer1', RGSS::Audio.se_calls.last&.first, 'Cancel with nothing to erase plays buzzer instead'
+
+  ui[:name] = 'A' * RPG2k::Scene::Map::NAME_MAX # fill the field
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # try to type one more -- rejected
+  scene.update
+  RGSS::Input.triggered = []
+  eq ['Decision1', 'Buzzer1'], RGSS::Audio.se_calls.map(&:first),
+     'an overflowing character still plays decision first (RPG_RT plays it ' \
+     'unconditionally before dispatch), then buzzer for the rejected append'
+  eq RPG2k::Scene::Map::NAME_MAX, ui[:name].length, 'the character was not appended'
+end
+
 # EasyRPG's `Game_Interpreter_Map::CommandEnterHeroName`
 # (src/game_interpreter_map.cpp) is the exact same method for the foreground
 # and every Parallel Process's own interpreter -- gated only on


### PR DESCRIPTION
## Summary

This is the follow-up flagged (but deliberately deferred) in the previous PR's `docs/TODO.md` entry for the Input Number SE fix.

- Real RPG_RT's `Scene_Name::vUpdate` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/scene_name.cpp`) plays Decision **unconditionally the instant Decision is pressed**, before ever dispatching on which cell is highlighted — the same for OK/DONE, a hiragana/katakana page toggle, or an ordinary character. Its Cancel branch is a genuinely separate input path: `if (name_window->Get().size() > 0) { ...Cancel...; Erase(); } else { ...Buzzer...; }` — `Window_Name::Erase` (`src/window_name.cpp`) removes exactly one trailing character (a backspace), not the whole field.
- `Window_Keyboard::Update`'s own `play_cursor` flag (`src/window_keyboard.cpp`) plays Cursor SE on every grid move. `Window_Name::Append` plays Buzzer and silently drops the character the instant appending it would overflow the field — layered *after* the unconditional Decision already played for that same keypress, not instead of it.
- `Scene::Map#handle_name_input`/`#handle_kana_name_input`/`#name_input_confirm`/`#name_input_backspace` (`mruby-rpg2k/mrblib/scene/map.rb`) had zero `play_system_se` calls anywhere in their bodies — silent on every interaction.
- This codebase's own grid adds an on-screen "BS" cell that real RPG_RT's keyboard has no equivalent of. Treated as an ordinary Decision-dispatched cell (gets the Decision SE already played at dispatch, nothing extra), distinct from the *physical* Cancel key, which now gets the real Cancel/Buzzer branch via a new `#name_input_cancel`.
- Fixed by adding `play_system_se(SFX_CURSOR)` to every grid-move branch, `play_system_se(SFX_DECISION)` unconditionally before dispatching to the confirm handlers, `play_system_se(SFX_BUZZER)` in each character-cell branch when the field is already full, and the new `#name_input_cancel` replacing the bare, silent backspace call on the physical Cancel key (the on-screen "BS" cell now calls the renamed `#backspace_name_input` directly).

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 739 checks passed (1 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1008 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] The new check confirmed to fail against the pre-fix code (`git stash` of the source file)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_