### PR TITLE
map: Open Shop and Show Inn now play system SE, matching RPG_RT

### DIFF
--- a/changelog.d/shop-inn-sound-effects.fixed.md
+++ b/changelog.d/shop-inn-sound-effects.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2000/2003 maps:** Open Shop and Show Inn now play RPG_RT's system SE
+  on every interaction — Cursor on list/counter movement, Decision on a
+  successful command/purchase/sale/stay, Buzzer when a selection is
+  refused (an unaffordable good, an unaffordable inn stay), and Cancel on
+  backing out — previously both played no sound effects at all. Covered by
+  five new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3730,6 +3730,53 @@ The work below is roughly ordered by the critical path to a walkable game
   move, character confirm, Cancel-with-a-character, Cancel-with-none, and
   an overflowing character's Decision-then-Buzzer pair all get their
   correct SE), confirmed to fail against the pre-fix code.
+- ✅ **The same "silent embedded widget" family, found once more: Open Shop
+  and Show Inn played zero sound effects at all (2026-08-18).** Verified
+  against RPG_RT's actual behavior via EasyRPG Player's own C++ source,
+  fetched live. `Window_Shop::Update` (`src/window_shop.cpp`) plays Cursor
+  on every Buy/Sell/Leave move and Decision unconditionally on any confirm
+  (all three commands always succeed, so there is no Buzzer case for the
+  command list). `Scene_Shop::UpdateBuySelection`/`UpdateSellSelection`
+  (`src/scene_shop.cpp`) play Decision when an item can actually be
+  bought/sold right now and Buzzer instead the moment that check fails —
+  this codebase's own `#open_shop_quantity`'s `max < 1` guard is that same
+  check, just never wired to a sound. `Window_ShopNumber::Update`
+  (`src/window_shopnumber.cpp`) plays Cursor **only when the quantity
+  counter's value actually changed** (`if (last_number != number)`) — RIGHT
+  past the affordable/held max, or LEFT below one, are silent since the
+  clamp leaves the count unchanged. `Scene_Shop::UpdateNumberInput` plays
+  Decision on committing the stack and Cancel on backing out; every Cancel
+  key elsewhere in the shop (`UpdateCommandSelection`/`UpdateBuySelection`/
+  `UpdateSellSelection`) plays Cancel too. Show Inn (`CommandShowInn`,
+  `src/game_interpreter_map.cpp`) is implemented in real RPG_RT on top of
+  the ordinary Show Message + Show Choices machinery
+  (`pm.PushChoice(accept, can_afford); pm.PushChoice(cancel);`) — the same
+  generic choice window every other yes/no prompt already gets Cursor/
+  Decision/Cancel from — with the Accept choice explicitly **disabled**
+  when the party can't afford it, so confirming it plays Buzzer rather than
+  Decision, the same "confirming a disabled choice" rule established
+  elsewhere in this codebase's own field-menu SFX work. This codebase's own
+  Inn/Shop are custom `Scene::Map`-embedded widgets, not routed through the
+  generic Show Choices code at all, so none of the above carried over
+  automatically. Fixed by adding the same `play_system_se`/`SFX_*` calls
+  already used throughout this file's other embedded widgets:
+  `#shop_move_cursor` (shared by the command list and the buy/sell list —
+  both a `Window_Selectable` subclass in real RPG_RT) plays `SFX_CURSOR` on
+  every successful move; `#drive_shop_command` plays `SFX_DECISION`
+  unconditionally on confirm and `SFX_CANCEL` on B; `#drive_shop_list`
+  plays `SFX_DECISION` when `#open_shop_quantity` (now returning a proper
+  boolean) actually opens the counter, `SFX_BUZZER` when it does not, and
+  `SFX_CANCEL` on B; `#drive_shop_quantity` plays `SFX_CURSOR` only when
+  `#shop_quantity_move` reports the count changed, `SFX_DECISION` on
+  commit, `SFX_CANCEL` on B; `#drive_inn` plays `SFX_CURSOR` on UP/DOWN,
+  `SFX_DECISION` on confirming Accept-when-affordable or Cancel,
+  `SFX_BUZZER` on confirming Accept-when-unaffordable (previously a silent
+  no-op, matching the ignored-but-inert behaviour already there — now heard
+  as well as ignored), and `SFX_CANCEL` on B. Both are common RPG2000/2003
+  event commands, reachable in essentially any game that uses them, not a
+  hypothetical edge case. Covered by five new `scripts/rpg2k_scene_check.rb`
+  checks across Inn and Shop's command list/buy list/quantity counter, all
+  confirmed to fail against the pre-fix code.
   ✅ **A disabled Continue's own *rendering* — not just its SE — was also
   still wrong, found in a separate later pass: it drew a hardcoded flat gray
   instead of reading the windowskin's own disabled-colour swatch, unlike

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4469,22 +4469,32 @@ class RPG2k
           @inn_choice += 1
           @inn_choice %= 2
           set_inn_cursor
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::UP)
           @inn_choice -= 1
           @inn_choice %= 2
           set_inn_cursor
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
           if @inn_choice.zero?
-            # Accept: only honoured when the party can pay; otherwise ignored.
+            # Accept: only honoured when the party can pay -- otherwise the
+            # choice is disabled, matching EasyRPG's own `pm.PushChoice(accept,
+            # can_afford)` (src/game_interpreter_map.cpp), and confirming a
+            # disabled choice plays Buzzer rather than Decision.
             if req[:can_afford]
+              play_system_se(SFX_DECISION)
               close_inn_window
               start_inn_fade_out(it)
+            else
+              play_system_se(SFX_BUZZER)
             end
           else
+            play_system_se(SFX_DECISION)
             close_inn_window
             finish_inn(false, it)
           end
         elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
           close_inn_window
           finish_inn(false, it)
         end
@@ -4817,28 +4827,48 @@ class RPG2k
         win.contents = c
       end
 
+      # Confirmed against EasyRPG's Window_Shop::Update (src/window_shop.cpp):
+      # the Buy/Sell/Leave list plays Decision unconditionally on any
+      # confirm (all three commands always succeed, so there is no Buzzer
+      # case here) and Cancel on B (Scene_Shop::UpdateCommandSelection),
+      # matching every other RPG2000 command list.
       def drive_shop_command
         lines = shop_lines
         if shop_move_cursor(lines)
           # cursor moved
         elsif Input.trigger?(Input::C)
+          play_system_se(SFX_DECISION)
           case lines[@shop[:index]][1]
           when :buy  then shop_switch(:buy)
           when :sell then shop_switch(:sell)
           when :leave then leave_shop
           end
         elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
           leave_shop
         end
       end
 
+      # Confirmed against EasyRPG's Scene_Shop::UpdateBuySelection/
+      # UpdateSellSelection (src/scene_shop.cpp): Decision opens the
+      # quantity counter for an item the party can actually buy/sell right
+      # now, Buzzer instead the instant that check fails (`buy_window->
+      # CheckEnable`/`item->price > 0`) -- #open_shop_quantity's own `max <
+      # 1` guard is that same check -- and Cancel on B either way
+      # (Scene_Shop::UpdateBuySelection/UpdateSellSelection's own Cancel
+      # branch).
       def drive_shop_list
         lines = shop_lines
         if shop_move_cursor(lines)
           # cursor moved
         elsif Input.trigger?(Input::C) && !lines.empty?
-          open_shop_quantity(lines[@shop[:index]][1])
+          if open_shop_quantity(lines[@shop[:index]][1])
+            play_system_se(SFX_DECISION)
+          else
+            play_system_se(SFX_BUZZER)
+          end
         elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
           @shop[:has_menu] ? shop_switch(:command) : leave_shop
         end
       end
@@ -4869,10 +4899,11 @@ class RPG2k
       def open_shop_quantity(id)
         model = @shop[:model]
         max = @shop[:screen] == :buy ? model.max_buy(id) : model.max_sell(id)
-        return if max < 1
+        return false if max < 1
         @shop[:quantity] = { id: id, count: 1, max: max, mode: @shop[:screen] }
         @shop[:screen] = :quantity
         draw_shop
+        true
       end
 
       # Drive the quantity counter: RIGHT / LEFT by one, UP / DOWN by ten (both
@@ -4882,6 +4913,7 @@ class RPG2k
         q = @shop[:quantity]
         if shop_quantity_move(q)
           draw_shop
+          play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
           model = @shop[:model]
           mode = q[:mode]
@@ -4889,7 +4921,9 @@ class RPG2k
           @shop[:quantity] = nil
           @shop[:screen] = mode == :buy ? :purchased : :sold
           draw_shop
+          play_system_se(SFX_DECISION)
         elsif Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
           close_shop_quantity
         end
       end
@@ -4920,17 +4954,25 @@ class RPG2k
         draw_shop
       end
 
-      # Move the shop cursor with Up / Down; returns true if it moved.
+      # Move the shop cursor with Up / Down; returns true if it moved. Plays
+      # Cursor SE on every successful move, the same base `Window_Selectable
+      # ::Update` behaviour every other RPG2000 list window gets (see the
+      # field-menu SFX audit elsewhere in this file/docs/TODO.md) -- shared
+      # by the command list and the buy/sell list alike, both backed by a
+      # `Window_Selectable` subclass in real RPG_RT (`Window_Shop`/
+      # `Window_ShopBuy`/`Window_ShopSell`).
       def shop_move_cursor(lines)
         if Input.trigger?(Input::DOWN) && !lines.empty?
           @shop[:index] += 1
           @shop[:index] %= lines.length
           draw_shop
+          play_system_se(SFX_CURSOR)
           true
         elsif Input.trigger?(Input::UP) && !lines.empty?
           @shop[:index] -= 1
           @shop[:index] %= lines.length
           draw_shop
+          play_system_se(SFX_CURSOR)
           true
         else
           false

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2765,6 +2765,43 @@ check 'Show Inn scene: an unaffordable Accept is ignored' do
   ok st.switches[2], 'the No Stay branch ran on cancel'
 end
 
+check 'Show Inn scene: plays the RPG_RT system SE on every interaction' do
+  # Confirmed against EasyRPG's Window_Selectable-style Cursor plays and
+  # Scene::Map's own Show Choices, plus CommandShowInn's own
+  # `pm.PushChoice(accept, can_afford)` (src/game_interpreter_map.cpp): a
+  # disabled Accept plays Buzzer rather than Decision.
+  scene, = inn_scene(50, inn_commands(Game::Interpreter::Cmd, 100)) # 50g < 100g
+  5.times { scene.update } # cursor starts on Cancel (unaffordable)
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::UP] # move to Accept
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'moving the cursor plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm Accept -- unaffordable, disabled
+  scene.update
+  eq 'Buzzer1', RGSS::Audio.se_calls.last&.first, 'confirming a disabled Accept plays buzzer'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move to Cancel
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm Cancel
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'Decision1', RGSS::Audio.se_calls.last&.first, 'confirming Cancel (a valid choice) plays decision'
+end
+
+check 'Show Inn scene: the physical Cancel key plays the RPG_RT cancel SE' do
+  scene, = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  5.times { scene.update }
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'Cancel1', RGSS::Audio.se_calls.last&.first
+end
+
 check 'Show Inn scene: the Accept / Cancel cursor wraps around' do
   scene, _st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
   5.times { scene.update } # inn command runs; the greeting prompt opens
@@ -5948,6 +5985,102 @@ check 'Open Shop scene: an unaffordable good never opens the counter' do
   eq :buy, shop[:screen], 'still on the list'
   ok shop[:quantity].nil?, 'no counter for something out of reach'
   eq 50, st.party.gold
+end
+
+check 'Open Shop scene: the command list plays the RPG_RT system SE' do
+  # Confirmed against EasyRPG's Window_Shop::Update (src/window_shop.cpp):
+  # Cursor on every move, Decision on any of Buy/Sell/Leave (all three
+  # always succeed, so there is no Buzzer case here); Cancel on B
+  # (Scene_Shop::UpdateCommandSelection, src/scene_shop.cpp).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0), # buy+sell
+                         ECmd.new(ic::SHOP_END, [], indent: 0)]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # opens on the Buy/Sell/Leave command list
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'moving the cursor plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm Sell
+  scene.update
+  eq 'Decision1', RGSS::Audio.se_calls.last&.first, 'confirming a command plays decision'
+
+  eq :sell, scene.instance_variable_get(:@shop)[:screen]
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::B] # leave the sell list, back to the command list
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'Cancel1', RGSS::Audio.se_calls.last&.first, 'B plays the cancel SE'
+end
+
+check 'Open Shop scene: the buy list plays cursor/decision SE, buzzer for an unaffordable good' do
+  # Confirmed against EasyRPG's Scene_Shop::UpdateBuySelection
+  # (src/scene_shop.cpp): Decision opens the quantity counter for an
+  # affordable good, Buzzer instead the moment `buy_window->CheckEnable`
+  # fails -- #open_shop_quantity's own `max < 1` guard is that same check.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3, 5], indent: 0), # buy-only
+                         ECmd.new(ic::SHOP_END, [], indent: 0)]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(50)) # good 3 costs 100, good 5 does not
+  3.times { scene.update } # opens straight onto the buy list (buy-only)
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'moving the cursor plays the cursor SE'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::UP] # back to good 3 (100g, unaffordable at 50g)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  eq 'Buzzer1', RGSS::Audio.se_calls.last&.first, 'an unaffordable good plays buzzer, not decision'
+  eq :buy, scene.instance_variable_get(:@shop)[:screen], 'the counter never opened'
+end
+
+check 'Open Shop scene: the quantity counter plays cursor/decision/cancel SE' do
+  # Confirmed against EasyRPG's Window_ShopNumber::Update
+  # (src/window_shopnumber.cpp, cursor only when the count actually
+  # changed) and Scene_Shop::UpdateNumberInput (src/scene_shop.cpp,
+  # decision on commit, cancel on B).
+  scene, = shop_quantity_scene(500)
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'a changed count plays the cursor SE'
+
+  RGSS::Input.triggered = [RGSS::Input::LEFT] # back to 1, the floor -- changes count 2 -> 1
+  scene.update
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::LEFT] # already at the floor -- no change this time
+  scene.update
+  RGSS::Input.triggered = []
+  eq [], RGSS::Audio.se_calls, 'an unchanged count plays nothing'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the purchase
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'Decision1', RGSS::Audio.se_calls.last&.first, 'confirming the counter plays decision'
+
+  scene2, = shop_quantity_scene(500)
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::B] # cancel out
+  scene2.update
+  RGSS::Input.triggered = []
+  eq 'Cancel1', RGSS::Audio.se_calls.last&.first, 'cancelling the counter plays cancel'
 end
 
 check 'Open Shop scene: leaving without buying runs the No Transaction branch' do


### PR DESCRIPTION
## Summary

Continuing this session's "silent embedded widget" series (Input Number, Enter Hero Name) — this time Open Shop and Show Inn.

- Real RPG_RT's `Window_Shop::Update` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/window_shop.cpp`) plays Cursor on every Buy/Sell/Leave move and Decision unconditionally on confirm (all three commands always succeed, so there's no Buzzer case for the command list).
- `Scene_Shop::UpdateBuySelection`/`UpdateSellSelection` (`src/scene_shop.cpp`) play Decision when an item can actually be bought/sold right now and Buzzer instead the moment that check fails — this codebase's own `#open_shop_quantity`'s `max < 1` guard is that same check, just never wired to a sound.
- `Window_ShopNumber::Update` (`src/window_shopnumber.cpp`) plays Cursor **only when the quantity counter's value actually changed** — pressing RIGHT past the affordable/held max, or LEFT below one, is silent since the clamp leaves the count unchanged.
- `Scene_Shop::UpdateNumberInput` plays Decision on committing the stack and Cancel on backing out; every Cancel key elsewhere in the shop plays Cancel too.
- Show Inn (`CommandShowInn`, `src/game_interpreter_map.cpp`) is implemented in real RPG_RT on top of the ordinary Show Message + Show Choices machinery (`pm.PushChoice(accept, can_afford); pm.PushChoice(cancel);`), with the Accept choice explicitly **disabled** when the party can't afford it — so confirming it plays Buzzer rather than Decision, the same "confirming a disabled choice" rule.
- This codebase's own Inn/Shop are custom `Scene::Map`-embedded widgets, not routed through the generic Show Choices code at all, so none of the above carried over automatically — zero `play_system_se` calls anywhere across either implementation.
- Fixed by adding the same `play_system_se`/`SFX_*` calls already used throughout this file's other embedded widgets: `#shop_move_cursor` (shared by the command list and the buy/sell list, both a `Window_Selectable` subclass in real RPG_RT) plays `SFX_CURSOR` on every successful move; `#drive_shop_command` plays `SFX_DECISION` unconditionally on confirm and `SFX_CANCEL` on B; `#drive_shop_list` plays `SFX_DECISION` when `#open_shop_quantity` (now returning a proper boolean) actually opens the counter, `SFX_BUZZER` when it does not, `SFX_CANCEL` on B; `#drive_shop_quantity` plays `SFX_CURSOR` only when `#shop_quantity_move` reports the count changed, `SFX_DECISION` on commit, `SFX_CANCEL` on B; `#drive_inn` plays `SFX_CURSOR` on UP/DOWN, `SFX_DECISION` on confirming Accept-when-affordable or Cancel, `SFX_BUZZER` on confirming Accept-when-unaffordable (previously a silent no-op — now heard as well as ignored), `SFX_CANCEL` on B.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 744 checks passed (5 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1008 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] All five new checks confirmed to fail against the pre-fix code (`git stash` of the source file)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_