### PR TITLE
message: an out-of-range \c[n] colour code clamps to 0, matching RPG_RT

### DIFF
--- a/changelog.d/message-color-code-out-of-range.fixed.md
+++ b/changelog.d/message-color-code-out-of-range.fixed.md
@@ -1,0 +1,9 @@
+- **RPG2000/2003 messages:** An out-of-range `\c[n]` colour code (n > 19,
+  the highest real palette slot) now resets to colour 0, matching real
+  RPG_RT — previously it stayed out of range and fell back to a flat,
+  non-blended approximation colour instead of the windowskin's own shaded
+  swatch, a visibly different colour for almost any custom windowskin.
+  A variable-driven `\c[\v[n]]`/`\s[\v[n]]` also now resolves the nested
+  variable correctly, the same way `\n[]`/`\v[]` already did — previously
+  it silently misread the literal escape text as a raw number instead.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2113,9 +2113,43 @@ The work below is roughly ordered by the critical path to a walkable game
   the swatch's shading reads as a top-to-bottom gradient on the text the way
   RPG2000 draws it (`Game::MessagePalette` locates each swatch — a 10×2 grid of
   16×16 cells from y = 48, per EasyRPG's layout), falling back to a flat colour
-  only when no windowskin loaded or for an out-of-range index. When the message
-  is **not pinned** (`position_fixed` off, the RPG2000 default) the window
-  relocates to keep clear of the hero.
+  only when no windowskin is loaded (an out-of-range `\c[n]` index used to
+  reach this same fallback too — see the dedicated ✅ bullet below, which
+  clamps it back into range the same way real RPG_RT does, so a windowskin
+  swatch draws instead). When the message is **not pinned** (`position_fixed`
+  off, the RPG2000 default) the window relocates to keep clear of the hero.
+- ✅ **An out-of-range `\c[n]` colour code (n > 19, past the last real
+  palette slot) stayed out of range instead of resetting to colour 0 —
+  falling back to a flat, non-blended approximation instead of the
+  windowskin's own shaded swatch 0, a visibly different colour for almost
+  any custom windowskin (2026-08-18).** Verified against RPG_RT's actual
+  behavior via EasyRPG Player's own C++ source, fetched live:
+  `Window_Message::UpdateMessage`'s `case 'c': case 'C':` branch
+  (`src/window_message.cpp`) does `text_color = pres.value > 19 ? 0 :
+  pres.value` on the vanilla (non-Maniac-patch) path, i.e. every ordinary
+  RPG2000/2003 game. `Game::Message.scan`'s own `'c', 'C'` case
+  (`mruby-rpg2k/mrblib/game.rb`) stored the raw parsed value unclamped,
+  which later failed `MessagePalette.valid?`'s `0..19` range check at draw
+  time and fell through to `#message_color`'s flat `MSG_COLORS` fallback
+  instead of ever being swatch 0 — reachable with any literal `\c[20]` or
+  higher, and more realistically via a variable-driven `\c[\v[n]]` whose
+  variable's value can exceed 19. Fixed by clamping the same way RPG_RT
+  does at the point the value is parsed, so the renderer never sees an
+  out-of-range value from this code path again. While fixing this, also
+  found and fixed a related gap in the same case: `\c[]`/`\s[]` read their
+  bracket argument with a bare `arg.to_i`, never through the existing
+  `#resolve_arg` helper `\n[]`/`\v[]` already use to unwrap a nested
+  `\v[]` (yado.tk indirect addressing, e.g. `\n[\v[1]]`) — confirmed
+  against EasyRPG's own `Game_Message::ParseColor`/`ParseSpeed`, both of
+  which share the exact same `ParseParam` nested-`\v[]` machinery as
+  `ParseActor`/`ParseVariable`, not special-cased for color/speed at all —
+  so a real `\c[\v[n]]` or `\s[\v[n]]` silently misread the literal text
+  `"\v[n]"` as a raw number (`.to_i` on a non-numeric string is 0) instead
+  of resolving the named variable. Both now route through `#resolve_arg`.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (an out-of-range
+  literal clamps to 0 while 19 itself stays untouched; a nested `\v[]`
+  argument resolves inside both `\c[]` and `\s[]`), confirmed to fail
+  against the pre-fix code.
   ✅ **The exact zone boundary is no longer approximate.** Confirmed against
   EasyRPG's own `Game_Message::GetRealPosition()`, fetched verbatim: the real
   thresholds are `16 * 7` = 112px and `16 * 10` = 160px (7 and 10 map tiles

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -133,11 +133,28 @@ module Game
           when 'c', 'C' # colour change: close the current run, switch colour
             segs << { text: cur, color: color } unless cur.empty?
             cur = ''
-            color = arg ? arg.to_i : 0
+            # An out-of-range index (>19, the highest real palette colour)
+            # resets to colour 0 rather than staying out of range -- EasyRPG's
+            # Window_Message::UpdateMessage (src/window_message.cpp): `text_color
+            # = pres.value > 19 ? 0 : pres.value` (the vanilla, non-Maniac-patch
+            # path, so this applies to every ordinary RPG2000/2003 game). Left
+            # unclamped, an out-of-range colour used to fail the renderer's own
+            # 0..19 validity check and fall back to a flat approximation colour
+            # instead of the windowskin's own (properly shaded) swatch 0 -- see
+            # Scene::Map::MessagePalette.valid?/#message_color. `resolve_arg`
+            # (not a bare `arg.to_i`) so a variable-driven `\C[\V[n]]` resolves
+            # the same way `\N[]`/`\V[]` already do -- EasyRPG's ParseColor is
+            # the exact same ParseParam nested-`\V[]` machinery as ParseActor/
+            # ParseVariable, not special-cased.
+            v = resolve_arg(arg, variables)
+            color = v > 19 ? 0 : v
           when 's', 'S' # speed change: how fast the typewriter reveals from
             # here on, clamped to RPG_RT's 1..20 (EasyRPG Player's
             # window_message.cpp: `speed = Utils::Clamp(pres.value, 1, 20)`).
-            speeds << { at: count, speed: Game.clamp(arg ? arg.to_i : 1, 1, 20) }
+            # `resolve_arg`, not a bare `arg.to_i`, for the same `\S[\V[n]]`
+            # reason as `\C[]` just above (ParseSpeed shares the same
+            # ParseParam nested-variable machinery).
+            speeds << { at: count, speed: Game.clamp(resolve_arg(arg, variables), 1, 20) }
           when '.'      then pauses << { at: count, kind: :quarter }
           when '|'      then pauses << { at: count, kind: :full }
           when '!'      then pauses << { at: count, kind: :key }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -792,6 +792,30 @@ check 'Message.scan threads a starting/ending colour for a caller to chain acros
   eq 0, Game::Message.scan('x', vars, names)[:end_color]
 end
 
+check 'Message.scan clamps an out-of-range \c[n] colour back to 0, matching RPG_RT' do
+  vars = Game::Variables.new
+  names = {}
+  s = Game::Message.scan('a\c[19]b\c[20]c\c[999]d', vars, names)
+  eq [{ text: 'a', color: 0 }, { text: 'b', color: 19 }, { text: 'c', color: 0 },
+      { text: 'd', color: 0 }], s[:segments],
+     '19 is still the highest valid palette index; 20 and anything beyond ' \
+     'resets to colour 0 (EasyRPG\'s window_message.cpp: `text_color = ' \
+     'pres.value > 19 ? 0 : pres.value`), not left out of range'
+end
+
+check 'Message.scan resolves a nested \V[] argument inside \c[]/\s[] too ' \
+      '(yado.tk indirect addressing, the same as \n[]/\v[])' do
+  vars = Game::Variables.new
+  vars[1] = 5   # \c[\V[1]] should pick colour 5
+  vars[2] = 25  # \c[\V[2]] is out of range -> clamps to 0
+  vars[3] = 12  # \s[\V[3]] should set speed 12
+  names = {}
+  s = Game::Message.scan('a\c[\V[1]]b\c[\V[2]]c', vars, names)
+  eq [{ text: 'a', color: 0 }, { text: 'b', color: 5 }, { text: 'c', color: 0 }], s[:segments]
+  s2 = Game::Message.scan('a\s[\V[3]]b', vars, names)
+  eq [{ at: 1, speed: 12 }], s2[:speeds]
+end
+
 check 'Message.scan flags \$ (show gold) and drops it from the text' do
   vars = Object.new
   def vars.[](_i); 0; end


### PR DESCRIPTION
## Summary

- Real RPG_RT's `Window_Message::UpdateMessage` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/window_message.cpp`) does `text_color = pres.value > 19 ? 0 : pres.value` on the vanilla (non-Maniac-patch) path — every ordinary RPG2000/2003 game.
- `Game::Message.scan`'s own `'c', 'C'` case (`mruby-rpg2k/mrblib/game.rb`) stored the raw parsed value unclamped, which later failed `MessagePalette.valid?`'s `0..19` range check at draw time and fell through to `#message_color`'s flat `MSG_COLORS` fallback instead of ever being swatch 0 — a visibly different colour for almost any custom windowskin (most tint their default text color away from plain white). Reachable with any literal `\c[20]` or higher, and more realistically via a variable-driven `\c[\v[n]]` whose variable's value can exceed 19.
- While fixing this, also found and fixed a related gap in the same case: `\c[]`/`\s[]` read their bracket argument with a bare `arg.to_i`, never through the existing `#resolve_arg` helper `\n[]`/`\v[]` already use to unwrap a nested `\v[]` (yado.tk indirect addressing) — confirmed against EasyRPG's own `Game_Message::ParseColor`/`ParseSpeed`, both of which share the exact same `ParseParam` nested-`\v[]` machinery as `ParseActor`/`ParseVariable`, not special-cased for color/speed at all. So a real `\c[\v[n]]` or `\s[\v[n]]` silently misread the literal text `"\v[n]"` as a raw number (`.to_i` on a non-numeric string is 0) instead of resolving the named variable. Both now route through `#resolve_arg`.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1010 checks passed (2 new)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 744 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] Both new checks confirmed to fail against the pre-fix code (`git stash` of the source file)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_