### PR TITLE
message: bracket arguments now parse character-by-character, matching RPG_RT

### DIFF
--- a/changelog.d/message-bracket-argument-parsing.fixed.md
+++ b/changelog.d/message-bracket-argument-parsing.fixed.md
@@ -1,0 +1,12 @@
+- **RPG2000/2003 messages:** `\N[]`/`\V[]`/`\C[]`/`\S[]` bracket arguments now
+  parse character-by-character like RPG_RT's own `Game_Message::ParseParam`,
+  instead of extracting the raw substring up to the first `]` and re-parsing
+  it. A literal digit run and a nested `\V[]` reference in the same bracket
+  now concatenate (`\N[1\V[2]]` with variable 2 = 45 names actor 145, not
+  actor 1), nested `\V[]` resolution is capped at one level deep as in real
+  RPG_RT (a second nesting level, e.g. `\V[\V[\V[1]]]`, is left unevaluated
+  and its own closing bracket is dropped into the message as stray text
+  rather than being consumed), and an unrecognised character inside a
+  bracket now stops further digit accumulation while keeping the value
+  already read, rather than being silently absorbed. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9361,7 +9361,47 @@ not yet verified:
   case this fix covers). An out-of-range `\N[]` argument crashing real
   RPG_RT is a genuine engine crash, not reproduced here. Covered by a new
   `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the
-  pre-fix code.
+  pre-fix code. **`#read_bracket`/`#resolve_arg` were later replaced
+  entirely by a proper character-scanning port, `#parse_bracket_value` —
+  see the dedicated ✅ bullet below — which the "balance nested `[`/`]`
+  pairs, then regex-match the extracted substring" approach described
+  above turned out not to actually match RPG_RT's own algorithm.**
+- ✅ **The nested-`\V[]` fix just above got the *shape* right (a bracket
+  argument can contain a `\V[]` reference) but not RPG_RT's actual
+  character-scanning algorithm underneath it, in three separate ways
+  (2026-08-18).** Verified against RPG_RT's actual behavior via EasyRPG
+  Player's own C++ source, fetched live: `Game_Message::ParseParam`
+  (`src/game_message.cpp`, the single function backing `\N[]`/`\V[]`/
+  `\C[]`/`\S[]` alike — `ParseColor`/`ParseSpeed`/`ParseActor`/
+  `ParseVariable` are thin wrappers over it) does not treat a bracket
+  argument as "one literal number OR one whole nested `\V[]`" the way
+  `#read_bracket`+`#resolve_arg` did — it scans character by character:
+  (1) a literal digit run and a `\V[]` reference in the *same* bracket
+  **concatenate** (`\N[1\V[2]]` with variable 2 = 45 becomes 145, not "1" —
+  the old code fell through to `String#to_i` on the raw extracted
+  substring, silently dropping the `\V[]` reference entirely, matching
+  only the leading digit run), via RPG_RT's own `m = 10; m *= 10 while m <
+  var_val; value = value * m + var_val` arithmetic; (2) the recursion
+  depth is capped at exactly **one** level (EasyRPG's own
+  `rpg_rt_default_max_recursion = 1`, distinct from its own looser
+  8-level `easyrpg_default_max_recursion` extension this port does not
+  take) — `\N[\V[\V[1]]]`'s inner `\V[1]` is never evaluated, unlike the
+  old `#resolve_arg`, which recursed without any limit; (3) the first
+  character that is neither a digit nor a recognised nested reference
+  stops further accumulation but **keeps** whatever was already read
+  (RPG_RT: "stop parsing until the next closing bracket"), which
+  `#read_bracket`'s own generic `[`/`]`-balancing (treating *every*
+  bracket pair as nesting, not just ones following a recognised `\v`/`\V`)
+  could not express at all. Fixed by replacing `#read_bracket`/
+  `#resolve_arg` with a single `Game::Message.parse_bracket_value`, a
+  direct port of `ParseParam`'s scanning loop operating on the shared
+  scan index directly rather than a two-phase extract-then-reparse.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (a literal
+  digit run concatenates with a `\V[]` reference's value; a
+  doubly-nested `\V[\V[1]]]` inside `\N[]`/`\V[]` only recurses one level,
+  reproducing RPG_RT's own quirk of leaving a stray `]` behind when
+  nested past that limit rather than resolving cleanly), confirmed to
+  fail against the pre-fix code.
 
 **Pictures**
 - ✅ **50 concurrent picture slots; higher id always draws on top,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -124,10 +124,21 @@ module Game
         if ch == "\\" && i + 1 < n
           code = text[i + 1]
           i += 2
-          arg, i = read_bracket(text, i)
           case code
-          when 'v', 'V' then (s = variables[resolve_arg(arg, variables)].to_s; cur << s; count += s.length) if arg
-          when 'n', 'N' then (s = (names[resolve_arg(arg, variables)] || '').to_s; cur << s; count += s.length) if arg
+          when 'v', 'V'
+            if text[i] == '['
+              val, i = parse_bracket_value(text, i, variables)
+              s = variables[val].to_s
+              cur << s
+              count += s.length
+            end
+          when 'n', 'N'
+            if text[i] == '['
+              val, i = parse_bracket_value(text, i, variables)
+              s = (names[val] || '').to_s
+              cur << s
+              count += s.length
+            end
           when "\\"     then cur << "\\"; count += 1
           when '_'      then cur << ' '; count += 1 # half-width space
           when 'c', 'C' # colour change: close the current run, switch colour
@@ -141,20 +152,31 @@ module Game
             # unclamped, an out-of-range colour used to fail the renderer's own
             # 0..19 validity check and fall back to a flat approximation colour
             # instead of the windowskin's own (properly shaded) swatch 0 -- see
-            # Scene::Map::MessagePalette.valid?/#message_color. `resolve_arg`
+            # Scene::Map::MessagePalette.valid?/#message_color. `#parse_bracket_value`
             # (not a bare `arg.to_i`) so a variable-driven `\C[\V[n]]` resolves
             # the same way `\N[]`/`\V[]` already do -- EasyRPG's ParseColor is
             # the exact same ParseParam nested-`\V[]` machinery as ParseActor/
-            # ParseVariable, not special-cased.
-            v = resolve_arg(arg, variables)
-            color = v > 19 ? 0 : v
+            # ParseVariable, not special-cased. No bracket at all resets to 0
+            # too (`\C` alone), matching the pre-existing default.
+            if text[i] == '['
+              v, i = parse_bracket_value(text, i, variables)
+              color = v > 19 ? 0 : v
+            else
+              color = 0
+            end
           when 's', 'S' # speed change: how fast the typewriter reveals from
             # here on, clamped to RPG_RT's 1..20 (EasyRPG Player's
             # window_message.cpp: `speed = Utils::Clamp(pres.value, 1, 20)`).
-            # `resolve_arg`, not a bare `arg.to_i`, for the same `\S[\V[n]]`
-            # reason as `\C[]` just above (ParseSpeed shares the same
-            # ParseParam nested-variable machinery).
-            speeds << { at: count, speed: Game.clamp(resolve_arg(arg, variables), 1, 20) }
+            # `#parse_bracket_value`, not a bare `arg.to_i`, for the same
+            # `\S[\V[n]]` reason as `\C[]` just above (ParseSpeed shares the
+            # same ParseParam nested-variable machinery). No bracket at all
+            # defaults to full speed (1), matching the pre-existing default.
+            if text[i] == '['
+              v, i = parse_bracket_value(text, i, variables)
+              speeds << { at: count, speed: Game.clamp(v, 1, 20) }
+            else
+              speeds << { at: count, speed: 1 }
+            end
           when '.'      then pauses << { at: count, kind: :quarter }
           when '|'      then pauses << { at: count, kind: :full }
           when '!'      then pauses << { at: count, kind: :key }
@@ -209,35 +231,72 @@ module Game
       end
     end
 
-    # Read an optional "[digits]" argument at position i; returns [value, new_i].
-    # Brackets nest (yado.tk: `\N[]`/`\V[]` accept a `\V[n]` argument in place
-    # of a literal number, e.g. `\N[\V[1]]`), so an inner `[`/`]` pair widens
-    # the scan rather than closing it early -- otherwise `\N[\V[1]]` would read
-    # its argument as only `\V[1` (stopping at the *inner* `]`) and leave the
-    # outer `]` behind as stray literal text.
-    def self.read_bracket(text, i)
-      return [nil, i] unless i < text.length && text[i] == '['
-      j = i + 1
-      depth = 1
-      while j < text.length && depth > 0
-        depth += 1 if text[j] == '['
-        depth -= 1 if text[j] == ']'
-        j += 1 if depth > 0
+    # Parse a `\N[]`/`\V[]`/`\C[]`/`\S[]` bracket argument to the integer it
+    # names, starting at `text[i]` (which must be the opening `[` -- callers
+    # check that themselves, since "no bracket at all" has a different
+    # default per code and is not this method's concern). Returns
+    # `[value, new_i]`, `new_i` positioned just past the matching `]`.
+    #
+    # Confirmed against EasyRPG's `Game_Message::ParseParam`
+    # (`src/game_message.cpp`), which backs all four codes identically
+    # (`ParseColor`/`ParseSpeed`/`ParseActor`/`ParseVariable` are thin
+    # wrappers over the same function) -- this is a straight port of its
+    # character-scanning loop, not the "extract a balanced-bracket substring,
+    # then regex it" approach this used to take:
+    #
+    # - Digits accumulate positionally (`value = value * 10 + digit`).
+    # - A nested `\v[]`/`\V[]` reference (yado.tk: `\N[\V[1]]` substitutes
+    #   variable 1's own *value* in place of a literal number) recurses one
+    #   level deep at most -- RPG_RT's own limit (EasyRPG's
+    #   `rpg_rt_default_max_recursion = 1`, vs. its own looser 8-level
+    #   `easyrpg_default_max_recursion` extension this port does not take);
+    #   `\N[\V[\V[1]]]`'s inner `\V[1]` is simply never reached, same as
+    #   real RPG_RT. The recursion resolves the *inner* bracket to a variable
+    #   *index*, then reads that variable's own value and concatenates its
+    #   decimal digits onto whatever was already accumulated -- `\N[1\V[2]]`
+    #   with variable 2 = 45 becomes 145, not "1" or "45" -- via RPG_RT's own
+    #   `m = 10; m *= 10 while m < var_val; value = value * m + var_val`
+    #   arithmetic, ported verbatim (including its own quirk of only ever
+    #   widening `m` in powers of 10 relative to the newly-read value, not
+    #   the exact combined digit width -- this is RPG_RT's real arithmetic,
+    #   not an approximation to smooth over).
+    # - The first character that is neither a digit nor a recognised nested
+    #   reference stops further accumulation but *keeps* whatever was
+    #   already read (RPG_RT: "stop parsing until the next closing bracket"),
+    #   rather than resetting to 0 -- unlike this method's own predecessor,
+    #   which fell through to `String#to_i` and silently dropped everything
+    #   from the first non-leading-digit character on.
+    def self.parse_bracket_value(text, i, variables, depth = 1)
+      n = text.length
+      # No bracket at all (reachable recursively too -- a malformed nested
+      # reference like `\N[\V]`, `\v` with no `[` following): RPG_RT's own
+      # ParseParam returns 0 without consuming anything, matching `if (iter
+      # == end || *iter != '[') { return { iter, 0 }; }`.
+      return [0, i] unless i < n && text[i] == '['
+      i += 1
+      value = 0
+      stop_parsing = false
+      while i < n && text[i] != ']'
+        if stop_parsing
+          i += 1
+          next
+        end
+        ch = text[i]
+        if ch >= '0' && ch <= '9'
+          value = value * 10 + ch.to_i
+          i += 1
+        elsif depth > 0 && ch == '\\' && i + 1 < n && (text[i + 1] == 'V' || text[i + 1] == 'v')
+          var_id, i = parse_bracket_value(text, i + 2, variables, depth - 1)
+          var_val = variables[var_id].to_i
+          m = 10
+          m *= 10 while value != 0 && m < var_val
+          value = value * m + var_val
+        else
+          stop_parsing = true
+        end
       end
-      val = text[(i + 1)...j]
-      j += 1 if j < text.length # consume the matching ']'
-      [val, j]
-    end
-
-    # Resolve a control code's bracket argument to the integer it names,
-    # recursively unwrapping a nested `\v[]`/`\V[]` (yado.tk: `\N[\V[1]]`
-    # substitutes variable 1's *value* as the actor id, not the literal text
-    # "\V[1]"; `\V[\V[1]]` reads the same way for indirect variable display).
-    # A plain numeric argument resolves the same as before (`"3".to_i`).
-    def self.resolve_arg(arg, variables)
-      return 0 if arg.nil?
-      m = /\A\\[vV]\[(.*)\]\z/m.match(arg)
-      m ? variables[resolve_arg(m[1], variables)].to_i : arg.to_i
+      i += 1 if i < n # consume the matching ']'
+      [value, i]
     end
   end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1170,6 +1170,48 @@ check 'Message.expand resolves a nested \V[] argument inside \N[]/\V[] (yado.tk 
   eq 'Aria!', Game::Message.expand('\N[\V[1]]!', vars, names)
 end
 
+check 'Message.expand concatenates a \V[] reference\'s decimal digits onto a ' \
+      'literal prefix, matching RPG_RT\'s own arithmetic' do
+  # Confirmed against EasyRPG's Game_Message::ParseParam (src/
+  # game_message.cpp): a bracket argument is not "a literal number OR one
+  # whole nested \V[]" -- RPG_RT scans it character by character, so a
+  # literal digit run and a \V[] reference in the same bracket combine:
+  # `\N[1\V[2]]` with variable 2 = 45 becomes 145 (`value = value * m +
+  # var_val`, m the smallest power of ten >= var_val), not "1" (the old
+  # behaviour, which fell through to String#to_i on the raw substring and
+  # silently dropped the \V[] reference entirely) and not "45".
+  vars = Game::Variables.new
+  vars[2] = 45
+  vars[145] = 7 # \V[1\V[2]] should display variable #145's value
+  names = { 145 => 'Aria' } # \N[1\V[2]] should name actor #145
+  eq 'Aria', Game::Message.expand('\N[1\V[2]]', vars, names)
+  eq '7', Game::Message.expand('\V[1\V[2]]', vars, names)
+end
+
+check 'Message.expand only recurses one \V[] level deep inside \N[]/\V[], matching RPG_RT' do
+  # RPG_RT's own recursion limit is exactly 1 level (EasyRPG's own
+  # `rpg_rt_default_max_recursion = 1`, vs. its looser 8-level extension
+  # this port intentionally does not take): `\N[\V[\V[1]]]`'s *inner*
+  # `\V[1]` is never evaluated at all -- parsing it stops immediately
+  # (nothing recognised past the second `\V[`), leaving that whole nested
+  # argument at index 0, so the *outer* reference reads variable 0's value,
+  # not variable 1's (7) and not variable 7's (99, what a naive unlimited-
+  # recursion implementation would wrongly reach through \V[1] -> 7 -> var 7).
+  #
+  # RPG_RT's own char-by-char scan has no real bracket-depth matching of its
+  # own -- once recursion is exhausted it just fast-forwards to the very
+  # next literal `]` it meets (the *inner* \V[1]'s own bracket, one level
+  # too deep to belong to the frame that hits it), so the outer bracket's
+  # true closing `]` is left behind unconsumed -- a real RPG_RT quirk this
+  # port reproduces faithfully, not a defect to paper over here.
+  vars = Game::Variables.new
+  vars[0] = 3
+  vars[1] = 7
+  vars[7] = 99
+  names = { 3 => 'Aria' }
+  eq 'Aria]', Game::Message.expand('\N[\V[\V[1]]]', vars, names)
+end
+
 check 'Message.parse splits colour runs and expands codes within them' do
   vars = Game::Variables.new
   vars[3] = 7


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Message::ParseParam` (the shared function backing `\N[]`/`\V[]`/`\C[]`/`\S[]`, with `ParseColor`/`ParseSpeed`/`ParseActor`/`ParseVariable` as thin wrappers over it — `src/game_message.cpp` in EasyRPG Player, which reimplements RPG_RT's real behavior) scans a bracket argument character by character. This build's previous `Game::Message.read_bracket`/`resolve_arg` instead extracted the raw substring up to the first `]` and re-parsed it as a two-phase step, which diverges from RPG_RT in three separate ways:

1. **Digit/`\V[]` concatenation.** A literal digit run and a nested `\V[]`/`\v[]` reference in the *same* bracket concatenate via RPG_RT's own digit-shift arithmetic (`m = 10; m *= 10 while m < var_val; value = value * m + var_val`) — `\N[1\V[2]]` with variable 2 = 45 should name actor **145**, not actor 1. The old code's `String#to_i` on the raw extracted substring silently dropped the trailing `\V[]` reference, matching only the leading digit run.
2. **One-level recursion cap.** Nested `\V[]` resolution is capped at exactly one level deep, matching EasyRPG's own `rpg_rt_default_max_recursion = 1` (distinct from its own looser 8-level `easyrpg_default_max_recursion` extension, which this port does not take) — `\N[\V[\V[1]]]`'s inner `\V[1]` is never evaluated. The old `resolve_arg` recursed with no limit at all.
3. **Stop-but-keep semantics.** The first character that is neither a digit nor a recognised nested reference stops further digit accumulation but *keeps* whatever was already read, matching RPG_RT's "stop parsing until the next closing bracket." The old `read_bracket`'s generic `[`/`]`-balancing couldn't express this — it treated every bracket pair as nesting, not just ones following a recognised `\v`/`\V`.

Fixed by replacing `read_bracket`/`resolve_arg` with a single `Game::Message.parse_bracket_value`, a direct port of `ParseParam`'s scanning loop operating on the shared scan index in one pass, used by all four control codes (`\N[]`/`\V[]`/`\C[]`/`\S[]`) and both message entry points (`Message.expand`/`Message.parse`).

Also documents (in `docs/TODO.md`) that a prior nested-`\V[]` fix on this same code path had the right *shape* (a bracket argument can contain a `\V[]` reference) but not RPG_RT's actual scanning algorithm underneath it — corrected in place rather than silently superseded.

## Test plan

- Two new `scripts/rpg2k_logic_check.rb` checks:
  - a literal digit run concatenates with a `\V[]` reference's value (`\N[1\V[2]]`, `\V[1\V[2]]`)
  - a doubly-nested `\V[\V[1]]` inside `\N[]`/`\V[]` only recurses one level, reproducing RPG_RT's own quirk of leaving a stray `]` behind rather than resolving cleanly
- Both confirmed to fail against the pre-fix code via `git stash`, and pass after the fix.
- Full suite green: `rpg2k_logic_check.rb` (1012 checks), `rpg2k_scene_check.rb` (744), `rpg2k_render_check.rb` (41), `rpg2k3_battle_gauge_check.rb` (15), `rpg2k3_battle_row_check.rb` (13).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_