### PR TITLE
battle: critical/shake-off rolls now draw at 0% chance, matching RPG_RT

### DIFF
--- a/changelog.d/critical-and-state-shake-zero-chance-rng-draw.fixed.md
+++ b/changelog.d/critical-and-state-shake-zero-chance-rng-draw.fixed.md
@@ -1,0 +1,10 @@
+- **RPG2000/2003 battles:** A critical-hit roll and a physical hit's status
+  shake-off roll now always draw from the RNG, even when the computed chance
+  is exactly 0 — matching RPG_RT's own `Rand::PercentChance`/`Rand::ChanceOf`,
+  which roll unconditionally. Previously both rolls were skipped outright at
+  a 0% chance (the common case for any battler with no crit ability at all),
+  silently desyncing this build's shared RNG stream from a genuine seeded
+  RPG_RT replay by one draw from that point on for the rest of the run. The
+  roll's own outcome (never crit / never shake off at 0%) is unchanged —
+  only whether the draw itself happens. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6432,6 +6432,50 @@ not yet verified:
   5001) and one real-data test-bed check
   (`scripts/rpg2k_testbed_logic_check.rb`), each confirmed to fail against
   the pre-fix code before the fix.
+- ✅ **`#critical?` and `#shake_off_states` now burn an RNG draw even when the
+  computed chance is exactly 0, matching RPG_RT's own unconditional roll —
+  previously both skipped the draw outright, desyncing this build's shared
+  RNG stream from a genuine seeded RPG_RT replay one draw earlier than
+  necessary on almost every fight (2026-08-18).** Found by re-reading
+  `Rand::PercentChance`/`Rand::ChanceOf` (`src/rand.cpp`, fetched live) and
+  their two call sites in `Game_BattleAlgorithm` (`src/game_battlealgorithm.cpp`)
+  character-by-character rather than trusting this file's own doc comments,
+  which (until this fix) incorrectly described the two as rolling
+  unconditionally already. `Rand::PercentChance(int rate)` is
+  `GetRandomNumber(0, 99) < rate` with no gate of any kind — `vExecute`'s two
+  critical-hit call sites (`Normal`/`Skill`, both in `game_battlealgorithm.cpp`)
+  call it as `Rand::PercentChance(crit_chance)` straight off
+  `Algo::CalcCriticalHitChance`'s return value, which is routinely exactly
+  0 (any battler with no crit ability at all — most enemies, and any actor
+  before equipping a crit-capable weapon; also forced to 0 whenever the
+  target `PreventsCritical()` or the two sides share a battler type).
+  `Game::Battle#critical?` (`mruby-rpg2k/mrblib/game.rb`) instead read
+  `chance && chance > 0 && @rng.random(100) < chance` — the `chance > 0 &&`
+  clause skipped the draw entirely at exactly the rate that is the *common*
+  case, not an edge case, so this build's RNG stream fell one draw behind
+  RPG_RT's own on the very first such landed hit and stayed offset for
+  every subsequent roll in the run (that attack's own damage variance, the
+  next actor's to-hit, state infliction, later encounter rolls — one shared
+  stream, so the divergence never resyncs on its own). `#shake_off_states`
+  had the identical bug shape one level down: EasyRPG's
+  `BattlePhysicalStateHeal` (same file) gates its roll only on
+  `state->release_by_damage > 0`, then calls
+  `Rand::ChanceOf(release_chance, 100)` unconditionally even when
+  `release_chance` (`release_by_damage * physical_rate / 100`) itself rounds
+  down to 0 via integer division — this build's own `next unless chance > 0
+  && @rng.random(100) < chance` skipped the draw in that case too, past an
+  already-correct outer `base > 0` gate that already matched
+  `release_by_damage > 0` exactly. Fixed by dropping the `chance > 0 &&`
+  clause from both (`critical?` now `@rng.random(100) < (b.crit_chance ||
+  0)`, keeping only a defensive `|| 0` for a test double whose `crit_chance`
+  can be nil, since a real `Game::Actor`/`Game::Enemy` always returns an
+  Integer) — the roll's own outcome is unchanged (a threshold of 0 can never
+  be beaten by a 0..99 draw either way), only whether the draw itself
+  happens. Covered by two new `scripts/rpg2k_logic_check.rb` checks, each
+  comparing the battle's own `@rng` against a second, independently-seeded
+  reference `Game::Rng` advanced by hand to prove the shared stream's
+  position after the roll, not just the roll's boolean outcome; both
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A Skill/Item's own core effect — HP/SP change and each of the ATK/DEF/
   SPI/AGI stat modifiers — now rolls its own accuracy, instead of applying
   unconditionally on every cast.** Only state infliction ever consulted a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11329,6 +11329,17 @@ module Game
     # matter how hard it was hit: Nepheshel's 睡眠 wakes on 80% of blows and its
     # 混乱 clears on 30%; mtf-meido-action's Sleep is 50% and Provoke / Confuse
     # 25%.
+    #
+    # The roll itself is gated only on `release_by_damage > 0` (the `base > 0`
+    # check below), matching EasyRPG's own `BattlePhysicalStateHeal`
+    # (`src/game_battlealgorithm.cpp`) exactly: once inside that outer gate it
+    # calls `Rand::ChanceOf(release_chance, 100)` unconditionally, with no
+    # further `release_chance > 0` check -- `release_chance` itself (this
+    # method's own `chance`, `release_by_damage * rate / 100`) can still round
+    # down to 0 when `rate` is small, and RPG_RT still burns a roll for it (it
+    # just never passes). A `chance > 0` short-circuit here used to skip that
+    # roll entirely, leaving this build's shared RNG stream one draw ahead of
+    # RPG_RT's own from that point on for the rest of the seeded run.
     def shake_off_states(target, rate)
       woke = []
       return woke if rate <= 0
@@ -11337,7 +11348,7 @@ module Game
         base = d ? state_field(d, :release_by_attack) : 0
         next unless base > 0
         chance = base * rate / 100
-        next unless chance > 0 && @rng.random(100) < chance
+        next unless @rng.random(100) < chance
         target.states.delete(sid)
         (target.state_turns || {}).delete(sid) if target.state_turns
         woke.push(sid)
@@ -11345,12 +11356,22 @@ module Game
       woke
     end
 
-    # Whether `b`'s attack criticals: enabled for the fight, the attacker has a
-    # non-zero `crit_chance`, and a 0..99 roll lands under it -- EasyRPG's
-    # `Rand::PercentChance(int rate)`, `GetRandomNumber(0, 99) < rate`, the
-    # exact overload `Algo::CalcCriticalHitChance`'s already-truncated whole
-    # percent is rolled through. A chance at or above 100 always crits, which
-    # is what a weapon carrying 100% means.
+    # Whether `b`'s attack criticals: enabled for the fight, and a 0..99 roll
+    # lands under `b`'s `crit_chance` -- EasyRPG's `Rand::PercentChance(int
+    # rate)`, `GetRandomNumber(0, 99) < rate`, the exact overload
+    # `Algo::CalcCriticalHitChance`'s already-truncated whole percent is
+    # rolled through. A chance at or above 100 always crits, which is what a
+    # weapon carrying 100% means; a chance of exactly 0 (the common case for
+    # any battler with no crit ability at all) never crits either, but real
+    # RPG_RT still rolls for it -- `Game_BattleAlgorithm`'s `vExecute` calls
+    # `Rand::PercentChance(crit_chance)` with no `crit_chance > 0` guard
+    # (`src/game_battlealgorithm.cpp`, both the basic-attack and skill call
+    # sites). A `chance > 0 &&` short-circuit here used to skip that roll
+    # whenever it computed to exactly 0, leaving this build's shared RNG
+    # stream one draw behind RPG_RT's own for the rest of the seeded run --
+    # every attacker with no crit ability at all (most enemies, and any actor
+    # before equipping a crit-capable weapon) silently desynced it on their
+    # very first landed hit.
     #
     # Drawn with #random, not #scaled: #scaled exists because a modulus of the
     # generator's prime period over-represents the low values a *large*-scale
@@ -11360,8 +11381,7 @@ module Game
     # caller in this file.
     def critical?(b)
       return false unless @criticals
-      chance = b.crit_chance
-      chance && chance > 0 && @rng.random(100) < chance
+      @rng.random(100) < (b.crit_chance || 0)
     end
 
     # Whether `attacker`'s basic attack lands on `target`: a 0..99 roll under the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9918,6 +9918,30 @@ check 'battle: a crit chance is paid out at the rate it states' do
      "a 1-in-20 chance crit #{crits} times in #{trials}, wanted about #{want.round}"
 end
 
+check 'battle: critical? draws from the RNG even at an exact 0% crit chance, matching RPG_RT (2026-08-18)' do
+  # EasyRPG's Rand::PercentChance(crit_chance) rolls unconditionally, even
+  # when crit_chance is exactly 0 -- Game_BattleAlgorithm's vExecute call
+  # sites (src/game_battlealgorithm.cpp, both the basic-attack and skill
+  # ones) carry no `crit_chance > 0` guard around the roll. So a battler with
+  # no crit ability at all (the common case: most enemies, and any actor
+  # before equipping a crit-capable weapon) still burns one draw from the
+  # shared RNG stream on every landed hit. A `chance > 0 &&` short-circuit
+  # here used to skip that draw entirely, leaving this build's own RNG stream
+  # one draw behind RPG_RT's for the rest of a seeded run.
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_chance = 0
+  foe = combatant('Foe', 0, 0, 5, 100)
+  seed = 1
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(seed), nil, false, true)
+  eq false, bat.send(:critical?, hero), 'a 0% chance still never crits'
+
+  reference = Game::Rng.new(seed)
+  reference.random(100) # the one draw a 0-chance PercentChance still consumes
+
+  eq reference.random(100), bat.instance_variable_get(:@rng).random(100),
+     "the battle's own RNG stream did not advance for a 0% crit-chance roll"
+end
+
 check 'battle: a critical hit triples the damage when the fight rolls one' do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.crit_chance = 100                             # certainty -> always crits
@@ -12263,6 +12287,30 @@ check "battle: a purely magical skill's physical_rate of 0 never shakes a status
   bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), states)
   bat.send(:apply_skill_hit, hero, foe, -20, 0, cmd)
   ok foe.state?(8), 'physical_rate 0 never rolls, matching a magical spell'
+end
+
+check 'battle: shake_off_states still draws from the RNG when release_by_attack*rate/100 rounds down to 0, matching RPG_RT (2026-08-18)' do
+  # EasyRPG's BattlePhysicalStateHeal (src/game_battlealgorithm.cpp) only
+  # gates the roll on release_by_damage > 0 (the `base > 0` check below) --
+  # once past that outer gate it calls Rand::ChanceOf(release_chance, 100)
+  # unconditionally, even when release_chance itself (release_by_damage *
+  # physical_rate / 100) rounds down to 0 via integer division. A
+  # `chance > 0 &&` short-circuit here used to skip that draw too, the same
+  # bug as #critical?'s own 0%-chance case just above.
+  states = { 8 => fake_state(release_by_attack: 1) }
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.states = [8]
+  seed = 1
+  bat = Game::Battle.new([combatant('Hero', 40, 0, 20, 100)], [foe], Game::Rng.new(seed), states)
+  woke = bat.send(:shake_off_states, foe, 1) # base 1 * rate 1 / 100 = 0 -- never wakes
+  eq [], woke
+  ok foe.state?(8), 'a chance this low never actually shakes the state off'
+
+  reference = Game::Rng.new(seed)
+  reference.random(100) # the one draw a 0-computed chance still consumes
+
+  eq reference.random(100), bat.instance_variable_get(:@rng).random(100),
+     "the battle's own RNG stream did not advance for a chance that rounded down to 0"
 end
 
 check "battle: a skill's status-shake roll is gated behind the same hit as its damage" do


### PR DESCRIPTION
## Summary

RPG_RT's `Rand::PercentChance`/`Rand::ChanceOf` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/rand.cpp`) roll unconditionally — `GetRandomNumber(0, 99) < rate` / `GetRandomNumber(1, m) <= n`, with no gate on the rate/chance being nonzero. `Game_BattleAlgorithm`'s two call sites for this (`src/game_battlealgorithm.cpp`) never guard the roll either:

- The critical-hit roll (`Normal::vExecute`/`Skill::vExecute`) calls `Rand::PercentChance(crit_chance)` straight off `Algo::CalcCriticalHitChance`'s return value — routinely exactly 0 for any battler with no crit ability at all (most enemies, any actor before equipping a crit-capable weapon; also forced to 0 when the target prevents criticals or both sides share a battler type).
- The physical-hit status shake-off roll (`BattlePhysicalStateHeal`) gates only on `release_by_damage > 0`, then calls `Rand::ChanceOf(release_chance, 100)` unconditionally even when `release_chance` (`release_by_damage * physical_rate / 100`) itself rounds down to 0 via integer division.

`Game::Battle#critical?` and `#shake_off_states` (`mruby-rpg2k/mrblib/game.rb`) instead short-circuited with a `chance > 0 &&` clause before ever touching `@rng` — skipping the RNG draw entirely at exactly the common case above. Since this project shares one RNG stream across an entire seeded run, every attacker with no crit ability landed a hit without burning the draw RPG_RT would have, silently desyncing this build's own stream from a genuine seeded RPG_RT replay by one draw from that point on — every later roll in the run (that attack's own damage variance, the next actor's to-hit, state infliction, later encounter rolls) reads a different value than the real engine would with the same seed.

Fixed by dropping the `chance > 0 &&` clause from both, so the draw always happens once past the existing, already-correct outer gate (`@criticals` for the crit roll, `base > 0` i.e. `release_by_damage > 0` for the shake-off roll) — matching every other probability roll already in this file (`to_hit`, `skill_effect_hits?`, `roll_inflict`, `roll_weapon_states`), none of which carry this guard. The roll's own boolean outcome is unchanged (a 0 threshold can never be beaten by a 0..99 draw) — only whether the draw itself happens.

Also corrects this file's own doc comments above `critical?`, which (before this fix) incorrectly described the roll as already unconditional.

## Test plan

- [x] Two new `scripts/rpg2k_logic_check.rb` checks, each comparing the battle's own `@rng` against a second, independently-seeded reference `Game::Rng` advanced by hand to prove the shared stream's position after the roll, not just the roll's boolean outcome.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1014 checks passed (2 new)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 744 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] Both new checks confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_