### PR TITLE
battle: an ally's active-time gauge now carries between fights, matching RPG_RT

### DIFF
--- a/changelog.d/battle-gauge-carries-between-fights.fixed.md
+++ b/changelog.d/battle-gauge-carries-between-fights.fixed.md
@@ -1,0 +1,10 @@
+- **RPG2003 gauge battles:** An ally's active-time (ATB) gauge now carries
+  into the next fight instead of always restarting from empty — a survivor
+  keeps the charge it had when the last battle ended, and only a knockout
+  resets it to 0, matching RPG_RT's own `Game_Battler::ResetBattle`, which
+  deliberately does not reset the gauge between fights (only `AddState`'s
+  own Knockout branch zeroes it). Previously every actor's gauge silently
+  reset to 0 at the start of every encounter, since nothing on the party's
+  own actor persisted it between battles the way HP/SP/states/row already
+  do. No effect on RPG2000/alternate-layout battles, where the gauge is
+  never used. Covered by two new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13455,6 +13455,43 @@ above are repeated here)
   catches up — confirmed the faster ally still leads `#ready_combatants`
   once both are tied at `GAUGE_MAX`, and confirmed to fail against the
   pre-fix code (`[SeatSlow, SeatFast]`, plain seat order) before the fix.
+  ✅ **An ally's active-time gauge now carries into the next fight instead of
+  always restarting from empty — a survivor keeps the charge it had when
+  the last battle ended, and only a knockout zeroes it (2026-08-18).**
+  `Game::Battle::Combatant.from_actor` (`mruby-rpg2k/mrblib/game.rb`) builds
+  a brand-new `Combatant` from `Game::Actor` at the start of every
+  `Game::Battle.new`, and `Game::Actor` had no field of its own for the
+  gauge to live in between fights, so every actor's charge silently reset
+  to 0 at the start of every encounter — HP/SP/states/row all round-trip
+  through the actor between battles, but the gauge fell through the gap.
+  Confirmed against RPG_RT's own behavior via EasyRPG's actual C++ source
+  (fetched live): `Game_Battler::ResetBattle` (`src/game_battler.cpp`)
+  explicitly does **not** touch the gauge, with its own comment spelling out
+  why — `"ATB gauge is not reset here. This is on purpose because RPG_RT
+  will freeze the gauge and carry it between battles if
+  !CanActOrRecoverable()"` — and the only place a gauge is ever zeroed is
+  `Game_Battler::AddState`'s own Knockout branch (`if (state_id == kDeathID)
+  { SetAtbGauge(0); SetHp(0); ... }`), fired the instant the Knockout state
+  lands, not merely inspected after the fact. Fixed with a new persisted
+  `Game::Actor#atb_gauge`/`#atb_gauge=` (0..`Battle::GAUGE_MAX`, mirroring
+  the existing `#battle_row` persist-across-fights shape for a different,
+  RPG2003-gauge-presentation-only field): `Combatant.from_actor` now seeds
+  `#gauge` from it the same way `#row` is already seeded, and
+  `Battle#apply_to_party` writes it back at battle end — 0 for an ally who
+  ended the fight dead (`c.hp > 0 ? c.gauge : 0`, evaluated once at
+  write-back time rather than threading a death check through every
+  individual damage-dealing call site, since a `Combatant`'s `#dead?` is
+  purely HP-driven and `c.hp` is already authoritative by then regardless of
+  which of this file's several damage paths caused it) rather than whatever
+  gauge value it happened to be sitting at. Harmless for RPG2000/alternate-
+  layout (`battle_type` 0/1) games: `#advance_gauges` is already a no-op for
+  them, so the gauge never leaves 0 regardless. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a survivor's gauge round-trips
+  through a real `Battle.from_actor` → `#apply_to_party` → `Battle.
+  from_actor` cycle unchanged; a knocked-out ally's gauge comes back 0
+  instead of whatever it was charged to), both confirmed to fail against
+  the pre-fix code (`NoMethodError`, the accessor did not exist at all)
+  before the fix.
   ✅ **A living-but-afflicted party member's own alternate-battle-layout
   sprite (RPG2003's per-actor battler graphic, `db.battleranimations`) now
   shows that state's own configured pose, not always plain Idle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2885,6 +2885,21 @@ module Game
     def battle_row; @row; end
     def battle_row=(row); @row = row == Battle::ROW_BACK ? Battle::ROW_BACK : Battle::ROW_FRONT; end
 
+    # This actor's RPG2003 active-time (gauge) battle charge (0..
+    # Battle::GAUGE_MAX), read by Combatant.from_actor when a fight starts and
+    # written back by Battle#apply_to_party when it ends -- the same
+    # persist-across-fights shape #battle_row already has, for a different,
+    # RPG2003-gauge-presentation-only field. EasyRPG's own
+    # `Game_Battler::ResetBattle` (`src/game_battler.cpp`) explicitly does
+    # *not* reset the gauge: "ATB gauge is not reset here. This is on purpose
+    # because RPG_RT will freeze the gauge and carry it between battles if
+    # !CanActOrRecoverable()" -- only `AddState`'s own Knockout branch zeroes
+    # it (`if (state_id == kDeathID) { SetAtbGauge(0); ... }`), matched here
+    # by #apply_to_party writing back 0 for an ally who ended the fight dead
+    # rather than whatever gauge value it happened to be sitting at.
+    def atb_gauge; @atb_gauge || 0; end
+    def atb_gauge=(v); @atb_gauge = Game.clamp(v || 0, 0, Battle::GAUGE_MAX); end
+
     # Replace the battle-command list (Continue restoring a saved one). nil keeps
     # whatever the database / class defines.
     def battle_commands=(ids)
@@ -8841,6 +8856,11 @@ module Game
       # `row_x_offset` only ever *reads* the already-set row back, for the
       # automatic-placement sprite's own on-screen X (still unmodelled here).
       c.row = a.respond_to?(:battle_row) ? a.battle_row : ROW_FRONT
+      # RPG2003 active-time gauge: seeded from the actor's own persisted
+      # #atb_gauge, the same way #row is -- see Actor#atb_gauge's own
+      # citation for why RPG_RT carries this across fights instead of
+      # starting every battle from empty.
+      c.gauge = a.respond_to?(:atb_gauge) ? a.atb_gauge : 0
       c
     end
 
@@ -9194,6 +9214,10 @@ module Game
         c.actor.states = surviving_states(c.states) if c.states && c.actor.respond_to?(:states=)
         c.actor.set_hp(c.hp)
         c.actor.mp = Game.clamp(c.mp, 0, c.actor.max_mp) if c.mp
+        # A survivor's active-time gauge carries into the next fight; one who
+        # ended this fight dead carries 0 instead, matching AddState's own
+        # Knockout-zeroes-the-gauge rule -- see Actor#atb_gauge.
+        c.actor.atb_gauge = c.hp > 0 ? c.gauge : 0 if c.actor.respond_to?(:atb_gauge=)
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11405,6 +11405,39 @@ check 'Battle#apply_to_party ignores combatants with no source actor' do
   ok true, 'write-back skipped bare combatants without error'
 end
 
+check "Battle#apply_to_party carries a survivor's active-time gauge into the next fight, matching RPG_RT (2026-08-18)" do
+  # EasyRPG's Game_Battler::ResetBattle deliberately does not reset the ATB
+  # gauge -- "ATB gauge is not reset here. This is on purpose because RPG_RT
+  # will freeze the gauge and carry it between battles if
+  # !CanActOrRecoverable()" -- only Knockout (AddState's own kDeathID
+  # branch) zeroes it. Combatant.from_actor previously never seeded #gauge
+  # from anything persistent, so every fight started every actor's gauge at
+  # 0 regardless of how charged they were when the last one ended.
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  eq 0, hero.atb_gauge, 'a fresh actor has never charged'
+
+  hc = Game::Battle.from_actor(hero)
+  hc.gauge = 250_000                 # charged most of the way up mid-fight
+  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.apply_to_party
+  eq 250_000, hero.atb_gauge, "the survivor's charge carries into the next fight"
+
+  hc2 = Game::Battle.from_actor(hero)
+  eq 250_000, hc2.gauge, 'and the next fight starts from that charge, not from empty'
+end
+
+check 'Battle#apply_to_party zeroes the active-time gauge for an ally who ended the fight dead' do
+  st = party_state
+  ally = st.party.actor_by_id(2)
+  ac = Game::Battle.from_actor(ally)
+  ac.gauge = 180_000                 # was charging when the killing blow landed
+  ac.hp = -5                         # knocked out
+  bat = Game::Battle.new([ac], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.apply_to_party
+  eq 0, ally.atb_gauge, 'a knocked-out ally does not carry a charge into the next fight'
+end
+
 check 'Battle#step_action walks a round one attack at a time for animation' do
   # Two fast heroes vs two slow slimes: agility order is Ace, Bee, then the
   # slimes. #step_action surfaces the round one entry at a time (as the on-screen


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Battler::ResetBattle` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_battler.cpp`) deliberately does **not** reset a battler's active-time (ATB) gauge — its own comment explains why: *"ATB gauge is not reset here. This is on purpose because RPG_RT will freeze the gauge and carry it between battles if `!CanActOrRecoverable()`"*. The only place a gauge is ever zeroed is `Game_Battler::AddState`'s own Knockout branch (`if (state_id == kDeathID) { SetAtbGauge(0); SetHp(0); ... }`), fired the instant the Knockout state lands, not merely inspected after the fact.

`Game::Battle::Combatant.from_actor` (`mruby-rpg2k/mrblib/game.rb`) builds a brand-new `Combatant` from `Game::Actor` at the start of every `Game::Battle.new`, and `Game::Actor` had no field of its own for the gauge to live in between fights — HP/SP/states/row all already round-trip through the actor between battles, but the gauge fell through the gap and silently reset to 0 at the start of every encounter, regardless of how charged an ally was when the last fight ended.

Fixed with a new persisted `Game::Actor#atb_gauge`/`#atb_gauge=` (0..`Battle::GAUGE_MAX`), mirroring the existing `#battle_row` persist-across-fights shape for a different, RPG2003-gauge-presentation-only field:

- `Combatant.from_actor` seeds `#gauge` from it the same way `#row` is already seeded.
- `Battle#apply_to_party` writes it back at battle end — 0 for an ally who ended the fight dead (`c.hp > 0 ? c.gauge : 0`, checked once at write-back time rather than threading a death check through every individual damage-dealing call site, since a `Combatant`'s `#dead?` is purely HP-driven and `c.hp` is already authoritative by then regardless of which of this file's several damage paths caused it).

Harmless for RPG2000/alternate-layout (`battle_type` 0/1) games: `#advance_gauges` is already a no-op for them, so the gauge never leaves 0 regardless.

## Test plan

- [x] Two new `scripts/rpg2k_logic_check.rb` checks: a survivor's gauge round-trips through a real `Battle.from_actor` → `#apply_to_party` → `Battle.from_actor` cycle unchanged; a knocked-out ally's gauge comes back 0 instead of whatever it was charged to.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1016 checks passed (2 new)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 744 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] Both new checks confirmed to fail against the pre-fix code (`git stash` of the source file — `NoMethodError`, the accessor did not exist)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_