### PR TITLE
battle: defend-halving no longer floors damage at 1, matching RPG_RT

### DIFF
--- a/changelog.d/defend-halving-no-floor.fixed.md
+++ b/changelog.d/defend-halving-no-floor.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2000/2003 battles:** A defending (or 強力防御/strong-defence) target
+  can now take genuine 0 damage from a weak enough hit, matching RPG_RT's
+  `AdjustDamageForDefend`, which is a bare halving with no floor. Previously
+  the halving was floored at a minimum of 1 — a low-ATK attacker's hit
+  against a high-DEF guarding target chipped through for 1 HP where real
+  RPG_RT deals none — for both a basic attack and an enemy's self-destruct.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6738,7 +6738,42 @@ not yet verified:
   real builders instead of a hand-built `cmd` hash: `#command_skill` and
   `#command_skill_all` each queuing a real cast whose shake-off now actually
   fires, and `#skill_command_hash` carrying every field through from a raw
-  AI-cast result.
+  AI-cast result. **The `dmg = [dmg/2,1].max if t.defending` shape quoted
+  above as already correct turned out to itself carry a bug — a floor
+  `AdjustDamageForDefend` does not have — fixed separately, see the
+  dedicated ✅ bullet below.**
+- ✅ **Defend-halving (`AdjustDamageForDefend`) carried a floor of its own
+  that real RPG_RT does not — a defending, let alone a strong-defence,
+  target could never actually take 0 damage from a weak hit, only ever a
+  minimum of 1 (2026-08-18).** `Game::Battle#deal_attack_with_current_weapon`
+  and `#enemy_autodestruct` (`mruby-rpg2k/mrblib/game.rb`) both applied
+  Defend's halving as `dmg = [dmg / 2, 1].max` (twice, for 強力防御) — the
+  same shape the self-destruct double-halving fix just above quotes and
+  treats as the correct baseline it was only missing a second application
+  of. Verified against RPG_RT's actual behavior via EasyRPG Player's own
+  C++ source, fetched live: `Algo::AdjustDamageForDefend` (`src/algo.cpp`)
+  is a bare `dmg /= 2` (twice for `HasStrongDefense()`), with no
+  `std::max` of any kind — unlike the *base* damage formula's own
+  `std::max(0, atk/2 - def/4)` floor (`CalcNormalAttackEffect`, already
+  correctly ported as `Battle.attack_damage`'s `d < 0 ? 0 : d`), which is
+  presumably where the `,1` here was copied from without re-deriving it
+  against `AdjustDamageForDefend` specifically, which both
+  `Normal::vExecute` and `SelfDestruct::vExecute`
+  (`src/game_battlealgorithm.cpp`) call verbatim with no floor added back
+  afterward. A defending target facing a hit whose base damage (post
+  variance, pre-defend) is exactly 1 — a real, reachable value for a
+  low-ATK attacker against a high-DEF guard — took a guaranteed 1 "chip"
+  through a full guard here instead of RPG_RT's genuine 0; the gap widens
+  for a 強力防御 target, where a base of 2 or 3 also floors to a nonzero
+  hit here (`[[2/2,1].max=1]`/`[[3/2,1].max=1]→[1/2,1].max=1`) against
+  RPG_RT's real 0/0. Fixed by dropping the `, 1` from both call sites —
+  plain `dmg /= 2`, twice for strong defence, matching the C++ exactly (Ruby
+  integer division floors the same way C++'s truncation does for the
+  non-negative `dmg` both callers already guarantee at this point). Covered
+  by two new `scripts/rpg2k_logic_check.rb` checks (a defending target's
+  base-damage-1 hit lands for 0, both with and without 強力防御's second
+  halving; the identical pair for `#enemy_autodestruct`), all confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ **Simulated Attack's damage spread now uses RPG_RT's real variance
   formula, not a coarser stand-in this method's own comment misattributed to
   EasyRPG's source.** `Interpreter#do_simulated_attack` modelled its damage

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10697,9 +10697,12 @@ module Game
         dmg = effective_atk(b) - effective_def(t) / 2
         dmg = 0 if dmg < 0
         dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
+        # No floor on either halving -- see #deal_attack_with_current_weapon's
+        # own citation of `AdjustDamageForDefend` (`src/algo.cpp`): a bare
+        # `dmg /= 2`, twice for strong defence, with no `std::max` at all.
         if t.defending && dmg > 0
-          dmg = [dmg / 2, 1].max
-          dmg = [dmg / 2, 1].max if t.strong_defence
+          dmg /= 2
+          dmg /= 2 if t.strong_defence
         end
         cap = damage_cap
         dmg = cap if dmg > cap
@@ -11302,10 +11305,16 @@ module Game
       # Defending halves the blow, and 強力防御 halves it again — a quarter, not a
       # half (EasyRPG's `AdjustDamageForDefend` applies the second `dmg /= 2`
       # for a battler with strong defence). Seven of Nepheshel's 50 actors have
-      # it, including its hero.
+      # it, including its hero. Neither halving carries a floor of its own --
+      # `AdjustDamageForDefend` (`src/algo.cpp`) is a bare `dmg /= 2` (twice,
+      # for strong defence) with no `std::max` of any kind, unlike the base
+      # formula's own `std::max(0, atk/2 - def/4)` floor (already correctly
+      # ported as `Battle.attack_damage`'s `d < 0 ? 0 : d`) -- a defending,
+      # let alone a strong-defending, target can and does take a genuine 0
+      # from a weak hit that would otherwise have landed for 1.
       if target.defending && dmg > 0
-        dmg = [dmg / 2, 1].max
-        dmg = [dmg / 2, 1].max if target.strong_defence
+        dmg /= 2
+        dmg /= 2 if target.strong_defence
       end
       # RPG_RT's damage popup tops out at a fixed width -- a crit/charge blow
       # that would compute past it still only ever takes #damage_cap.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11364,6 +11364,28 @@ check 'Battle: a defending ally takes half damage and does not attack' do
   eq 90, hero.hp, 'took half of 20 = 10'
 end
 
+check "battle: defend-halving carries no floor of its own, matching RPG_RT's AdjustDamageForDefend (2026-08-18)" do
+  # EasyRPG's AdjustDamageForDefend (src/algo.cpp) is a bare `dmg /= 2` (twice
+  # for strong defence), with no std::max of any kind -- unlike the base
+  # damage formula's own std::max(0, atk/2 - def/4) floor (already correctly
+  # ported as Battle.attack_damage's own 0 floor). A defending target facing
+  # a weak enough hit can and does take a genuine 0, not a guaranteed minimum
+  # of 1 chipping through a full guard.
+  hero = combatant('Hero', 6, 0, 5, 100)
+  foe = combatant('Foe', 0, 8, 5, 100)     # base: 6/2 - 8/4 = 1
+  foe.defending = true
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1)) # 3-arg: variance off
+  eq 0, bat.send(:deal_attack, hero, foe)[:damage],
+     'base damage 1, halved by Defend -> 0, not floored to 1'
+
+  guarded = combatant('Guarded', 0, 8, 5, 100)
+  guarded.defending = true
+  guarded.strong_defence = true
+  bat2 = Game::Battle.new([hero], [guarded], Game::Rng.new(1))
+  eq 0, bat2.send(:deal_attack, hero, guarded)[:damage],
+     'base damage 1, halved twice (Defend + 強力防御) -> still 0, not floored to 1'
+end
+
 check 'Battle#apply_to_party writes post-battle HP back, KOing at 0' do
   st = party_state
   hero = st.party.actor_by_id(1)   # hp 100
@@ -13282,6 +13304,25 @@ check "battle: a self-destruct's 強力防御 halves a defending target's blow t
   bat2 = Game::Battle.new([guarded], [bomber], Game::Rng.new(1))
   eq 12, bat2.send(:enemy_autodestruct, bomber).first[:damage],
      'base 50, halved twice: once for Defend, again for 強力防御 (25 -> 12)'
+end
+
+check "battle: a self-destruct's defend-halving carries no floor either, matching RPG_RT (2026-08-18)" do
+  # Same AdjustDamageForDefend bare `dmg /= 2` this method shares verbatim
+  # with #deal_attack -- no std::max floor of any kind.
+  weak_bomber = combatant('Bomber', 1, 0, 5, 1) # base: atk 1 - def 0 / 2 = 1
+  plain = combatant('Plain', 0, 0, 5, 100)
+  plain.defending = true
+  bat1 = Game::Battle.new([plain], [weak_bomber], Game::Rng.new(1))
+  eq 0, bat1.send(:enemy_autodestruct, weak_bomber).first[:damage],
+     'base 1, halved by Defend -> 0, not floored to 1'
+
+  bomber = combatant('Bomber', 3, 0, 5, 1) # base: atk 3 - def 0 / 2 = 3
+  guarded = combatant('Guarded', 0, 0, 5, 100)
+  guarded.defending = true
+  guarded.strong_defence = true
+  bat2 = Game::Battle.new([guarded], [bomber], Game::Rng.new(1))
+  eq 0, bat2.send(:enemy_autodestruct, bomber).first[:damage],
+     'base 3, halved twice (3 -> 1 -> 0), not floored to 1 at either step'
 end
 
 check 'battle: a self-destruct shakes loose a survivor\'s status the same as a basic attack' do


### PR DESCRIPTION
## Summary

RPG_RT's `Algo::AdjustDamageForDefend` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/algo.cpp`) is a bare `dmg /= 2` (twice, for strong defence / 強力防御), with no `std::max` floor of any kind — unlike the *base* damage formula's own `std::max(0, atk/2 - def/4)` floor (`CalcNormalAttackEffect`, already correctly ported as `Battle.attack_damage`'s `d < 0 ? 0 : d`). Both `Normal::vExecute` and `SelfDestruct::vExecute` (`src/game_battlealgorithm.cpp`) call it verbatim with no floor added back afterward, so a defending target can and does take a genuine 0 from a weak enough hit.

`Game::Battle#deal_attack_with_current_weapon` and `#enemy_autodestruct` (`mruby-rpg2k/mrblib/game.rb`) instead applied the halving as `dmg = [dmg / 2, 1].max` (twice, for strong defence) — presumably copied from the base formula's own floor shape without re-deriving it against `AdjustDamageForDefend` specifically. A base-damage-1 hit against a defending target chipped through for 1 HP instead of RPG_RT's real 0; the gap widens for a 強力防御 target (a base of 2 or 3 also floors nonzero here against RPG_RT's real 0/0).

Fixed by dropping the `, 1` from both call sites — plain `dmg /= 2`, twice for strong defence, matching the C++ exactly (Ruby integer division floors the same way C++'s truncation does for the non-negative `dmg` both callers already guarantee at this point).

Also corrects `docs/TODO.md`'s own prior writeup of the self-destruct double-halving fix, which quoted this exact `[dmg/2,1].max` shape as the already-correct baseline it was only missing a second application of.

## Test plan

- [x] Two new `scripts/rpg2k_logic_check.rb` checks: a defending target's base-damage-1 hit lands for 0, with and without 強力防御's second halving; the identical pair for `#enemy_autodestruct`.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1018 checks passed (2 new)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 744 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] Both new checks confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_