### PR TITLE
party: gain_item erases a bag entry at count 0, matching RPG_RT

### DIFF
--- a/changelog.d/gain-item-erases-zero-count-entry.fixed.md
+++ b/changelog.d/gain-item-erases-zero-count-entry.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2000/2003 save files:** Losing the last copy of an item (selling it,
+  a Take Item event draining the last one) no longer leaves a phantom
+  zero-count entry behind in the party's bag — it's erased outright, matching
+  RPG_RT's own `Game_Party::AddItem`. Previously invisible in ordinary play,
+  but the leaked zero-count id was written into the save file's inventory
+  chunk and read back on every subsequent Continue, accumulating one row per
+  item ever fully depleted for the life of a save. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5420,6 +5420,37 @@ Everything below is unverified against the codebase.
   item the party never held at all still equips it (conjured, not drawn
   from a bag that had none), and unequipping does not add a copy back
   either. **Every sub-claim in this bullet is now confirmed correct.**
+- ✅ **`#gain_item` now erases a bag entry outright once its count reaches 0,
+  instead of leaving a phantom zero-count key behind forever (2026-08-18).**
+  `Game::Party#gain_item`/`#lose_item` (`mruby-rpg2k/mrblib/game.rb`)
+  unconditionally did `@items[id] = c` even when `c` (the new count) landed
+  on exactly 0 — losing the last copy of an item (selling it, a Take Item
+  event draining the last one, a shop purchase's own change-making) or
+  losing a copy of an item never held at all (`item_count` reads 0, `n < 0`,
+  the clamp floors the sum back to 0) both left `@items[id] == 0` sitting in
+  the bag hash rather than removing the id from it entirely. Every in-session
+  reader already guards on `count > 0` (`#has_item?`, `#field_items`,
+  `#battle_items`, the shop screens), so this was invisible in ordinary
+  play — but not invisible in the save file: `Game::State#to_h`'s inventory
+  writer builds chunk 109's `item_ids`/`item_counts` (`LCF::Schema::
+  SAVE_INVENTORY`) straight off `@party.items.keys.sort`, with no filtering,
+  so a phantom 0-count id was written into a real SAVE_INVENTORY chunk and
+  read straight back in by `.from_lsd` — something an authentic RPG_RT save
+  never contains, and a leak that accumulates one row per item ever fully
+  depleted for the life of a save file. Verified against RPG_RT's actual
+  behavior via EasyRPG Player's own C++ source, fetched live:
+  `Game_Party::AddItem` (`src/game_party.cpp`) erases the id/count/usage
+  triple from its arrays outright the instant `total_items <= 0`
+  (`data.item_ids.erase(...)` etc.), and its own `!has` early branch only
+  ever *inserts* a fresh entry when `amount > 0` — losing a copy of an item
+  never held at all reaches neither branch and creates nothing. Fixed by
+  branching `#gain_item` on `c == 0`: `@items.delete(id)` (only when the id
+  was actually present, so a never-held item losing a copy stays a true
+  no-op rather than bumping `@revision` for nothing) instead of storing a
+  zero. Covered by a new `scripts/rpg2k_logic_check.rb` check (losing the
+  last copy of a held item erases its bag key entirely, not just zeroes it;
+  losing a copy of an item never held creates no phantom entry either),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **Call Event** — every checkable engine-behavior sub-claim is confirmed
   correct: it doesn't move the target event, ignores its appearance
   conditions, can't cross maps, continues the *caller* right after itself

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3515,8 +3515,27 @@ module Game
           @item_usage[id] = 0
         end
       end
-      return c if @items[id] == c
-      @items[id] = c
+      # Losing the last copy erases the bag entry outright, the same way
+      # EasyRPG's `Game_Party::AddItem` (`src/game_party.cpp`) does when
+      # `total_items <= 0` -- it removes the id/count/usage triple from its
+      # arrays rather than storing a 0 count, and never inserts one at all
+      # for an item that was never held in the first place (its own early
+      # `!has` branch only inserts when `amount > 0`). Storing `@items[id] =
+      # 0` here instead used to leave a phantom zero-count key sitting in
+      # the bag hash forever -- invisible in ordinary play, since every
+      # reader already guards on `count > 0`, but not invisible in the save
+      # file: `#to_h`'s inventory writer builds chunk 109's `item_ids`/
+      # `item_counts` straight off `@party.items.keys`, so the junk id got
+      # written into SAVE_INVENTORY and read straight back by `.from_lsd`,
+      # accumulating one row per item ever fully depleted for the life of
+      # the save.
+      if c == 0
+        return c unless @items.key?(id)
+        @items.delete(id)
+      else
+        return c if @items[id] == c
+        @items[id] = c
+      end
       @revision += 1
       c
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5480,6 +5480,29 @@ check 'gain_item clamps at 99, silently, past a single gain or several ' \
   eq 49, st.party.item_count(5), 'losing still works normally once below the cap again'
 end
 
+check "gain_item erases the bag entry outright at count 0, matching RPG_RT's " \
+      "own array-backed inventory (2026-08-18)" do
+  # EasyRPG's Game_Party::AddItem (src/game_party.cpp) erases the id/count/
+  # usage triple from its arrays the instant `total_items <= 0`, and its own
+  # `!has` branch only ever inserts a fresh entry when `amount > 0` -- an
+  # item never held at all, losing a copy of, gets no entry created either.
+  # This codebase's own #gain_item instead used to store `@items[id] = 0`
+  # unconditionally, leaving a phantom zero-count key in the bag hash
+  # forever -- invisible to every reader (all guard on count > 0), but not
+  # invisible in the save file: #to_h's own inventory writer builds chunk
+  # 109's item_ids/item_counts straight off `@party.items.keys`, so the
+  # junk id would have been written into a real save.
+  st = item_party({ 5 => fake_item(type: 6, rhp: 50) })
+  st.party.gain_item(5, 3)
+  st.party.lose_item(5, 3)
+  eq 0, st.party.item_count(5)
+  ok !st.party.items.key?(5), 'losing the last copy erases the bag entry, not just zeroes it'
+
+  st.party.lose_item(9, 1) # item 9 was never held at all
+  eq 0, st.party.item_count(9)
+  ok !st.party.items.key?(9), 'losing an item never held creates no phantom entry either'
+end
+
 # -- 使用回数 (item uses count, item field 6) ---------------------------------
 
 check 'an item with 使用回数 N is only consumed once a copy has been used N times' do


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Party::AddItem` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_party.cpp`) erases the id/count/usage triple from its arrays outright the instant `total_items <= 0`, and its own `!has` early branch only ever inserts a fresh entry when `amount > 0` — losing a copy of an item never held at all reaches neither branch and creates nothing.

`Game::Party#gain_item` (`mruby-rpg2k/mrblib/game.rb`) instead did `@items[id] = c` unconditionally, even when `c` landed on exactly 0 — losing the last copy of a held item (selling it, a Take Item event draining the last one), or losing a copy of an item never held at all, both left a phantom `@items[id] == 0` entry sitting in the bag hash forever instead of removing the id. Every in-session reader already guards on `count > 0` (`#has_item?`, `#field_items`, `#battle_items`, the shop screens), so this was invisible in ordinary play — but not in the save file: `Game::State#to_h`'s inventory writer builds chunk 109's `item_ids`/`item_counts` (`LCF::Schema::SAVE_INVENTORY`) straight off `@party.items.keys.sort` with no filtering, so the phantom id got written into a real SAVE_INVENTORY chunk and read straight back in by `.from_lsd` — something an authentic RPG_RT save never contains, accumulating one row per item ever fully depleted for the life of a save file.

Fixed by branching `#gain_item` on `c == 0`: `@items.delete(id)` (only when the id was actually present, so a never-held item losing a copy stays a true no-op rather than bumping `@revision` for nothing) instead of storing a zero.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: losing the last copy of a held item erases its bag key entirely, not just zeroes it; losing a copy of an item never held creates no phantom entry either.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1019 checks passed (1 new)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 744 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] New check confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_