### PR TITLE
map: vehicle BGM boarding/disembarking now silences instead of leaking, matching RPG_RT

### DIFF
--- a/changelog.d/vehicle-bgm-silences-instead-of-leaking.fixed.md
+++ b/changelog.d/vehicle-bgm-silences-instead-of-leaking.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2000/2003 maps:** Boarding a vehicle whose BGM is left unconfigured
+  (blank database field, no Change System BGM override) now silences
+  whatever field music was playing, and disembarking onto a map with no BGM
+  of its own now silences the vehicle's music the same way — matching
+  RPG_RT's own `Game_System::BgmPlay`, where a blank track means "play
+  nothing" and stops the current track rather than leaving the previous one
+  running. Previously both cases left the wrong track playing right through
+  the transition. Covered by two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1999,6 +1999,34 @@ The work below is roughly ordered by the critical path to a walkable game
   confirmed to fail against the pre-fix code (`8` instead of `16`) before
   the fix. Boarding **plays the vehicle's own BGM** (the database System
   boat / ship / airship music) and disembarking restores the map BGM.
+  ✅ **A vehicle (or map) with no configured BGM at all now silences
+  whatever was playing instead of leaving it running — the claim just above
+  ("boarding plays the vehicle's own BGM... disembarking restores the map
+  BGM") only ever covered the case where there is a track to switch to
+  (2026-08-18).** `Scene::Map#play_vehicle_bgm`/`#restore_pre_vehicle_bgm`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) both used to `return` outright when
+  the target BGM (`#vehicle_bgm(type)` / the remembered pre-boarding track)
+  was nil or blank, leaving the audio backend untouched — boarding a
+  vehicle whose database field is blank (and no Change System BGM override
+  is set) left the field's own track playing right through the ride, and
+  disembarking onto a map with no field BGM at all left the vehicle's own
+  track playing instead of falling silent. Verified against RPG_RT's actual
+  behavior via EasyRPG Player's own C++ source, fetched live:
+  `Game_Player::GetOnVehicle`/`GetOffVehicle` (`src/game_player.cpp`) both
+  call `Game_System::BgmPlay` **unconditionally** (`BgmPlay(vehicle->
+  GetBGM())` boarding, `BgmPlay(GetBeforeVehicleMusic())` disembarking), and
+  `BgmPlay` (`src/game_system.cpp`) itself branches on the track's own name
+  — `"(OFF) means play nothing"` — calling `BgmStop()` for a blank/`"(OFF)"`
+  track rather than treating the call as a no-op. Fixed with a new shared
+  `#play_bgm_or_stop(music)`, a direct port of that same branch (`#play_bgm`
+  when `music` names a real file, else `RGSS::Audio.bgm_stop` +
+  `@state.current_bgm = nil`), that both `#play_vehicle_bgm` and
+  `#restore_pre_vehicle_bgm` now route every call through instead of
+  early-returning past the equivalent of `BgmPlay` entirely. Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks (boarding a vehicle with a blank
+  database BGM field stops the field's own currently-playing track;
+  disembarking onto a field with no BGM stops the vehicle's own track the
+  same way), both confirmed to fail against the pre-fix code before the fix.
   ✅ **A Change System BGM override for a vehicle's slot is now honoured
   too**, ahead of the database default. `Scene::Map#vehicle_bgm` used to read
   `db.system.send("#{type}_music")` unconditionally, so an event that ran

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2293,28 +2293,44 @@ class RPG2k
         @state.current_bgm = music
       end
 
+      # EasyRPG's Game_System::BgmPlay (src/game_system.cpp) is unconditional
+      # wherever RPG_RT calls it -- a blank/"(OFF)" track still hits its own
+      # `else { BgmStop(); }` branch ("(OFF) means play nothing"), silencing
+      # whatever was already playing, rather than leaving the call a no-op.
+      # #play_vehicle_bgm and #restore_pre_vehicle_bgm both port one such
+      # unconditional call (boarding's `BgmPlay(vehicle->GetBGM())`,
+      # disembarking's `BgmPlay(GetBeforeVehicleMusic())`, both
+      # `src/game_player.cpp`), so both route through this shared stop-or-play
+      # helper instead of silently no-op'ing when the target track is
+      # nil/blank -- a vehicle with no configured BGM used to leave whatever
+      # was already playing running right through the ride, and disembarking
+      # back into a map that itself had no BGM used to leave the vehicle's own
+      # track still playing, neither of which real RPG_RT does.
+      def play_bgm_or_stop(music)
+        if music && music[:name] && !music[:name].to_s.empty?
+          play_bgm(music)
+        else
+          RGSS::Audio.bgm_stop
+          @state.current_bgm = nil
+        end
+      end
+
       # Play the vehicle's own BGM — a Change System BGM (10660) override for
       # its slot when one is set, else the database System boat / ship /
       # airship music — remembering the BGM that was playing so
-      # #restore_pre_vehicle_bgm can bring it back on disembark. A vehicle
-      # with no configured BGM (override or database) leaves the current
-      # music playing.
+      # #restore_pre_vehicle_bgm can bring it back on disembark.
       def play_vehicle_bgm(type)
-        music = vehicle_bgm(type)
-        return unless music
         @pre_vehicle_bgm = @state.current_bgm
-        play_bgm(music)
+        play_bgm_or_stop(vehicle_bgm(type))
       rescue StandardError => e
         $stderr.puts "[RPG2k] vehicle BGM failed: #{e.message}"
       end
 
       # Restore the BGM that was playing before the party boarded (the map BGM).
-      # A no-op when boarding did not switch the music.
       def restore_pre_vehicle_bgm
         bgm = @pre_vehicle_bgm
         @pre_vehicle_bgm = nil
-        return unless bgm && bgm[:name] && !bgm[:name].empty?
-        play_bgm(bgm)
+        play_bgm_or_stop(bgm)
       rescue StandardError => e
         $stderr.puts "[RPG2k] restoring BGM failed: #{e.message}"
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -222,6 +222,7 @@ module RGSS
       @bgm_fade_calls = []
       @me_calls = []
       @me_stop_calls = 0
+      @bgm_stop_calls = 0
     end
     # Recorded separately from bgm_calls: a same-file Play BGM re-trigger
     # calls this instead of bgm_play (see Game::Interpreter#play_audio /
@@ -237,7 +238,12 @@ module RGSS
     # fired -- e.g. the End Game confirmation's Game_System::BgmFade(400).
     class << self; attr_accessor :bgm_fade_calls; end
     def self.bgm_fade(*a); (@bgm_fade_calls ||= []) << a; end
-    def self.bgm_stop(*); end
+    # Record bgm_stop calls too (a blank vehicle/restore BGM's own "play
+    # nothing" branch -- see Scene::Map#play_bgm_or_stop) so a check can
+    # assert the native backend actually got told to stop, not just that
+    # bgm_play was skipped.
+    class << self; attr_accessor :bgm_stop_calls; end
+    def self.bgm_stop(*); @bgm_stop_calls = (@bgm_stop_calls || 0) + 1; end
     # Scriptable playback position, so the "BGM played once" watcher can be
     # driven: a value that jumps backwards is how SDL_mixer reports a loop.
     class << self; attr_accessor :pos; end
@@ -9707,6 +9713,68 @@ check 'boarding a vehicle plays a Change System BGM override instead of the data
   eq 'CustomBoat', st.current_bgm[:name], 'the override plays instead of the database BoatBGM'
   eq 55, st.current_bgm[:volume]
   eq 90, st.current_bgm[:tempo]
+end
+
+check 'boarding a vehicle with no configured BGM stops the field music instead of leaving it ' \
+      'playing, matching RPG_RT (2026-08-18)' do
+  # EasyRPG's Game_System::BgmPlay (src/game_system.cpp) is unconditional --
+  # a blank/"(OFF)" track still hits its own `else { BgmStop(); }` branch
+  # ("(OFF) means play nothing"), silencing whatever was already playing.
+  # Boarding a vehicle whose database BGM field is blank (and no Change
+  # System BGM override is set) used to leave the field's own currently-
+  # playing track running right through the ride, since #play_vehicle_bgm
+  # simply returned without touching the audio backend at all.
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  db = scene.instance_variable_get(:@db)
+  db.system.boat_music.file = '' # no boat BGM configured, database or override
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  st.direction = 2
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded
+  eq [], RGSS::Audio.bgm_calls, 'no new track started'
+  eq 1, RGSS::Audio.bgm_stop_calls, 'but the field music was stopped'
+  eq nil, st.current_bgm, 'silence, not the map track still nominally "current"'
+end
+
+check 'disembarking back onto a map with no field BGM stops the vehicle music the same way ' \
+      '(2026-08-18)' do
+  # The mirror image of the check just above: #restore_pre_vehicle_bgm ports
+  # the identical unconditional `BgmPlay(GetBeforeVehicleMusic())` call
+  # (`src/game_player.cpp`), so a pre-boarding field with no BGM playing at
+  # all must silence the vehicle's own track on disembark, not leave it
+  # running now that the party is back on foot.
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.current_bgm = nil # the field had no BGM playing when the party boarded
+  st.direction = 2
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded
+  eq 'BoatBGM', st.current_bgm[:name], 'boarded normally, the database boat music started'
+  st.direction = 8 # face back toward the shore
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # disembark
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'disembarked back onto foot'
+  eq [], RGSS::Audio.bgm_calls, 'no track restored'
+  eq 1, RGSS::Audio.bgm_stop_calls, 'the vehicle music stopped instead of continuing'
+  eq nil, st.current_bgm
 end
 
 check 'Enemy Encounter scene: the round animates action by action, not at once' do


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Player::GetOnVehicle`/`GetOffVehicle` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_player.cpp`) both call `Game_System::BgmPlay` **unconditionally** — `BgmPlay(vehicle->GetBGM())` boarding, `BgmPlay(GetBeforeVehicleMusic())` disembarking. `Game_System::BgmPlay` itself (`src/game_system.cpp`) branches on the track's own name — *"(OFF) means play nothing"* — calling `BgmStop()` for a blank/`"(OFF)"` track rather than treating the call as a no-op.

`Scene::Map#play_vehicle_bgm`/`#restore_pre_vehicle_bgm` (`mruby-rpg2k/mrblib/scene/map.rb`) instead returned outright when the target BGM was nil/blank, leaving the audio backend untouched:

- Boarding a vehicle with a blank database BGM field (and no Change System BGM override) left the field's own track playing right through the ride.
- Disembarking onto a map with no field BGM at all left the vehicle's own track playing instead of falling silent.

Fixed with a new shared `#play_bgm_or_stop(music)`, a direct port of `BgmPlay`'s own branch: `#play_bgm` when `music` names a real file, else `RGSS::Audio.bgm_stop` + `@state.current_bgm = nil`. Both `#play_vehicle_bgm` and `#restore_pre_vehicle_bgm` now route every call through it instead of early-returning past the equivalent of `BgmPlay` entirely.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks: boarding a vehicle with a blank database BGM field stops the field's own currently-playing track; disembarking onto a field with no BGM stops the vehicle's own track the same way.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 746 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1019 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] Both new checks confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_