### PR TITLE
map: random encounters skip a tile with no resolvable terrain row, matching RPG_RT

### DIFF
--- a/changelog.d/encounter-skips-unresolvable-terrain.fixed.md
+++ b/changelog.d/encounter-skips-unresolvable-terrain.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2000/2003 maps:** Stepping on a chipset cell whose terrain id has no
+  matching database row (a dangling reference left behind by a database
+  edit) no longer rolls for a random ("wandering monster") encounter at
+  all, matching RPG_RT's own `Game_Player::UpdateEncounterSteps`, which
+  skips the step entirely rather than substituting a fallback rate.
+  Previously such a tile silently used a fabricated 100% terrain encounter
+  rate and could trigger battles real RPG_RT never would from that spot.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2699,6 +2699,37 @@ The work below is roughly ordered by the critical path to a walkable game
   troop, an empty list never firing, `terrain_set` filtering, the airship
   exemption, a forced route never rolling despite a guaranteed-roll setup, and
   the step-count lookup / override / default / disable cases)
+  ✅ **A chipset cell whose terrain id has no database row now never rolls
+  for a random encounter at all, instead of substituting a fabricated
+  `encounter_rate` of 100 and rolling anyway (2026-08-18).**
+  `Scene::Map#check_random_encounter` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  read the stepped-on tile's terrain row via `#terrain_row_at` (already nil
+  for a chipset cell tagged with an id a database shrink has since removed
+  — see `#warn_stale_terrain`'s "log once, not once per frame" diagnostic,
+  and its own already-correct nil handling in the terrain-damage caller
+  right next to this one), but then substituted `rate = 100` and continued
+  straight through the accumulation and roll for that step regardless.
+  Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
+  source, fetched live: `Game_Player::UpdateEncounterSteps`
+  (`src/game_player.cpp`) does `if (!terrain) { Output::Warning(...);
+  return; }` — no fallback rate, no `total_encounter_rate` increment, no
+  roll for that step, exactly as if it never happened, with no counterpart
+  anywhere in the reference source for a substituted default. A map whose
+  chipset assigns a tile a terrain id the database `terrain` table no
+  longer defines a row for could still trigger — and did trigger —
+  wandering-monster battles from that tile, something real RPG_RT can
+  never do there. Fixed by returning immediately when `#terrain_row_at`
+  comes back nil, before the rate/accumulation/roll logic runs at all — the
+  separate, untouched `terrain.respond_to?(:encounter_rate) ? ... : 100`
+  fallback for a terrain row that *is* found but happens not to define the
+  field stays exactly as it was, since that is this build's own
+  test-fixture tolerance for a bare `OpenStruct` row that omits it, not
+  something a real LCF terrain row (which always carries the field) can
+  actually do. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  (deleting a fixture's terrain row under an otherwise-guaranteed-roll
+  setup — the same dangling-reference simulation the stale-terrain
+  diagnostic check already uses — never starts a battle and never
+  accumulates), confirmed to fail against the pre-fix code before the fix.
 
 #### Menus, save, battle
 - ✅ Menu scene — opens over the map (cancel button); shows party status and a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7679,8 +7679,22 @@ class RPG2k
           @encounter_idx = 0
           return
         end
+        # EasyRPG's Game_Player::UpdateEncounterSteps (src/game_player.cpp)
+        # returns outright when the tile's terrain row can't be resolved at
+        # all (`if (!terrain) { Output::Warning(...); return; }`) -- no
+        # fallback rate, no encounter_total increment, no roll for that step,
+        # exactly as if it never happened. A chipset cell whose terrain id a
+        # database shrink has since removed (#terrain_row_at's own "stale
+        # terrain" diagnostic) used to fall through to a fabricated `rate =
+        # 100` here instead, still rolling for a fight on a tile real RPG_RT
+        # can never trigger one from. `terrain.respond_to?(:encounter_rate)`
+        # below is unrelated and untouched: that's this build's own
+        # test-fixture tolerance for a bare OpenStruct row that omits the
+        # field, not something a real LCF terrain row (which always carries
+        # it) can actually do.
         terrain = terrain_row_at(@state.x, @state.y)
-        rate = terrain && terrain.respond_to?(:encounter_rate) ? terrain.encounter_rate : 100
+        return unless terrain
+        rate = terrain.respond_to?(:encounter_rate) ? terrain.encounter_rate : 100
         @state.encounter_total += rate
         ratio = @state.encounter_total / steps
         @encounter_idx += 1 while ratio >= ENCOUNTER_TABLE[@encounter_idx + 1][0]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18392,6 +18392,28 @@ check 'standing on an Event Touch tile still rolls for a random encounter' do
   eq 1, ui[:troop].id, "the map tree node's own troop"
 end
 
+check "a chipset cell whose terrain id has no database row never rolls for a random " \
+      "encounter, matching RPG_RT (2026-08-18)" do
+  # EasyRPG's Game_Player::UpdateEncounterSteps (src/game_player.cpp) returns
+  # outright when the tile's terrain row can't be resolved at all --
+  # `if (!terrain) { Output::Warning(...); return; }` -- no fallback rate, no
+  # encounter_total increment, no roll, as if the step never happened. This
+  # build's own #check_random_encounter used to fall through to a fabricated
+  # rate of 100 instead, still rolling (and, with this guaranteed-roll setup,
+  # still starting) a fight real RPG_RT can never trigger from that tile.
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
+  scene = new_scene({}, player: [0, 0], map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  # Simulate a database shrink: every tile of the fixture map's chip 0 is
+  # tagged terrain 42 (see fake_chipset), but the row itself is now gone --
+  # the same dangling reference the stale-terrain diagnostic check above uses.
+  scene.db.terrain.delete(42)
+  scene.send(:check_random_encounter)
+  scene.update # give it a frame too, in case a battle wait was queued anyway
+  ok battle_ui(scene).nil?, 'no resolvable terrain row -> no roll, no battle'
+  eq 0, st.encounter_total, 'the step never accumulated either'
+end
+
 check "current_encounter_steps reads the map tree node's own setting, " \
      'overridden by Change Encounter Rate' do
   tree = fake_map_tree(1 => FakeEncounterNode.new({}, 25))


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Player::UpdateEncounterSteps` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_player.cpp`) returns outright when a tile's terrain row can't be resolved at all: `if (!terrain) { Output::Warning(...); return; }` — no fallback rate, no `total_encounter_rate` increment, no roll for that step, as if it never happened.

`Scene::Map#check_random_encounter` (`mruby-rpg2k/mrblib/scene/map.rb`) instead substituted a fabricated rate of 100 when `#terrain_row_at` returned nil (a chipset cell whose terrain id a database shrink has since removed — `#warn_stale_terrain`'s own diagnostic already covers this exact dangling-reference case) and rolled anyway. A tile like that could trigger wandering-monster battles real RPG_RT can never generate there.

Fixed by returning immediately when `#terrain_row_at` comes back nil, before the rate/accumulation/roll logic runs. The separate, untouched `terrain.respond_to?(:encounter_rate) ? ... : 100` fallback for a row that *is* found but happens not to define the field is left alone — that's this build's own test-fixture tolerance for a bare `OpenStruct` row, not something a real LCF terrain row (which always carries the field) can do.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: deleting a fixture's terrain row under an otherwise-guaranteed-roll setup (the same dangling-reference simulation the existing stale-terrain diagnostic check uses) never starts a battle and never accumulates.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 747 checks passed (1 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1019 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] New check confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_