### PR TITLE
actor: an RPG2003 class is inert until Change Class actually runs, matching RPG_RT

### DIFF
--- a/changelog.d/class-inert-until-change-class.fixed.md
+++ b/changelog.d/class-inert-until-change-class.fixed.md
@@ -1,0 +1,11 @@
+- **RPG2003 actors:** An actor's database-declared *starting* class (chunk
+  11 field 57) no longer takes effect on its own — matching RPG_RT, which
+  keeps reading the actor's own row for its growth curve, EXP curve, learn
+  table, battle-command list, 強力防御, 強制AI, 二刀流 and 装備固定 until an
+  actual Change Class event runs. Previously all of these silently drew
+  from the class the moment the actor was built, well before any Change
+  Class command fired — a common RPG2003 authoring pattern (skipping an
+  explicit Change Class at party-join time) meant every affected actor's
+  stats, EXP thresholds, skills and traits were wrong from the very first
+  frame. Covered by four new/corrected `scripts/rpg2k_logic_check.rb`
+  checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1886,8 +1886,10 @@ The work below is roughly ordered by the critical path to a walkable game
   `LearnLevelSkills` / `CalculateExp` branch on `class_id > 0`), EXP resets to
   the new level's threshold, and the command's skill mode (keep / reset / add)
   and parameter mode (keep / halve / the class's level-1 or current-level values)
-  both apply; an actor whose row names a class reads its curves from startup, and
-  the change survives Save / Continue. **Change Battle Commands** (1009) edits
+  both apply; the change survives Save / Continue. **An actor whose row merely
+  *names* a starting class does *not* read its curves from startup — see the
+  dedicated ✅ bullet below correcting this claim, further down this document.**
+  **Change Battle Commands** (1009) edits
   the actor's 戦闘コマンド list with RPG_RT's six-plus-Row capacity rule.
   **Force Flee** (1006), **Enable Combo** (1007) and **Call Common Event** (1005)
   run inside a battle-event page — Force Flee either grants the party a
@@ -13452,6 +13454,66 @@ above are repeated here)
   already queued), all confirmed to fail against the pre-fix code (a bare
   `NoMethodError: undefined method 'force_ai?'`/`'choose_auto_battle_command'`)
   before the fix.
+- ✅ **The RPG2003 class-row-then-actor-row lookup this bullet, `#strong_defence?`
+  and the Change Class writeup near the top of this document all describe as
+  the correct precedence was itself missing a gate — an actor's database-
+  declared *starting* class (chunk 11 field 57) never actually took effect
+  for any of these traits, or for the growth curve / learn table / EXP curve
+  / battle-command list, until a real Change Class event ran; this build
+  applied the class row the instant `class_id` was merely nonzero
+  (2026-08-18).** `Game::Actor#curve_row`/`#strong_defence?`/`#force_ai?`/
+  `#double_hand?`/`#equipment_fixed?`/`#class_battle_commands`
+  (`mruby-rpg2k/mrblib/game.rb`) all read `class_row_for(@class_id) if
+  @class_id && @class_id > 0` (or the equivalent `@class_row || @db_row`) —
+  live from `@class_id`, which `#initialize`/`set_class_id` seeds straight
+  from the actor's own database row the instant the actor is built, whether
+  or not any Change Class command has ever run. Only `#battler_animation_id`
+  got this right, gated on a separate `@class_changed` flag instead — its own
+  comment already carries the full citation this fix now applies everywhere
+  else too: EasyRPG's `Game_Actor::ChangeClass` (`src/game_actor.cpp`) has an
+  explicit code comment, *"The class settings are not applied when the actor
+  has a class on startup but only when the 'Change Class' event command is
+  used"* — confirmed directly against the C++ source rather than trusted on
+  the comment's word alone: the constructor (`Game_Actor::Game_Actor`) seeds
+  `data.super_guard`/`lock_equipment`/`two_weapon`/`auto_battle` from
+  `dbActor->...` alone and never touches `data.class_id` at all (it stays
+  liblcf's own "-1, never changed" sentinel until `ChangeClass` explicitly
+  writes it), and `ChangeClass` is the *only* place any of those four fields,
+  `battler_animation`, or `battle_commands` are ever copied in from a class
+  row (`cls->...`) instead of the actor's own (`dbActor->...`) — matching,
+  fully independently, `GetBaseMaxHp`/`GetBaseMaxSp`/`GetBaseAtk`/
+  `GetBaseDef`/`GetBaseSpi`/`GetBaseAgi`/the skill list/`CalculateExp`, which
+  all gate on the identical runtime `data.class_id > 0` (not
+  `GetClass()`'s own separate `dbActor->class_id` fallback, which exists only
+  for *identity* purposes — an actor's name/skill-list source — not curve
+  purposes). A database that gives an actor a starting class (a common
+  RPG2003 authoring pattern, letting a game skip an explicit Change Class at
+  party-join time) had every one of these traits, and the actor's HP/SP/ATK/
+  DEF/SPI/AGI growth, EXP thresholds, learnable skills and battle-command
+  list, silently drawn from the class from the very first frame — RPG_RT
+  instead keeps reading the actor's own row for all of it until a real
+  Change Class fires, exactly as `#battler_animation_id` already modelled.
+  Fixed by gating every one of these six accessors on `@class_changed &&
+  @class_id > 0 && @class_row`, the identical condition
+  `#battler_animation_id` already used, instead of `@class_id > 0` alone —
+  `#restore_class` (Continue's own "a saved class was already live" path)
+  needed its own internal reordering to match, setting `@class_changed =
+  true` *before* the `#set_level` call that rescales stats through
+  `#curve_row`, not after, so a restored live class change still computes
+  the restored level's stats off the right curve. Two existing
+  `scripts/rpg2k_logic_check.rb` checks encoded the old (incorrect) behaviour
+  as intentional and needed correcting rather than just adding new coverage
+  alongside them: "an actor with a startup class reads its curve, learn
+  table and EXP from it" (now split into asserting the actor's own row wins
+  immediately, then the class's own after an explicit `#change_class` call)
+  and "Change Class to level 1 rewinds the level; an unknown class is a
+  no-op" (whose second half's expected max HP after a *failed* class change
+  dropped from the class's 220 to the actor's own 120, since the startup
+  class was never actually activated either). Covered by two further new
+  `scripts/rpg2k_logic_check.rb` checks (all four boolean traits read the
+  actor's own row immediately and the class's only after `#change_class`;
+  `#battle_commands`' own lazy materialisation does the same), all four
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An enemy's battle-graphic hue shift (field 3, `battler_hue`) is now
   implemented — the same "parsed by the schema but read nowhere in
   `mruby-rpg2k`" shape as `levitate`/`avoid_attacks`/`reflect_magic`/

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2321,9 +2321,15 @@ module Game
     # 強力防御 — an actor whose Defend halves damage a *second* time (a quarter
     # rather than a half, per EasyRPG's `AdjustDamageForDefend`). This one is a
     # property of the actor row (field 24), not of gear, and an RPG2003 class can
-    # override it the way it overrides the growth curves.
+    # override it the way it overrides the growth curves -- but, like the growth
+    # curves themselves (#curve_row), only once an actual Change Class event has
+    # run: `Game_Actor::ChangeClass` (`src/game_actor.cpp`) is where
+    # `data.super_guard` (this trait) is copied in from `cls->super_guard`; the
+    # constructor seeds it from `dbActor->super_guard` and never consults a
+    # class row at all, so a class merely named on the actor's own row is inert
+    # for this trait too until Change Class actually fires.
     def strong_defence?
-      row = class_row_for(@class_id) if @class_id && @class_id > 0
+      row = @class_row if @class_changed && @class_id && @class_id > 0
       row ||= @db_row
       row.respond_to?(:strong_defence) ? (row.strong_defence ? true : false) : false
     end
@@ -2341,7 +2347,12 @@ module Game
     # `data.auto_battle` passthrough, seeded from `dbActor->auto_battle` (or
     # `cls->auto_battle` once a class overrides it, `src/game_actor.cpp`) —
     # the identical row-then-class precedence this reader already follows for
-    # every other actor/class-overridable trait. `Scene_Battle_Rpg2k::
+    # every other actor/class-overridable trait, and, like every one of them
+    # (#strong_defence?/#curve_row), only "once a class overrides it" via an
+    # actual Change Class event -- `data.auto_battle` is seeded from
+    # `dbActor->auto_battle` at construction and only overwritten with
+    # `cls->auto_battle` inside `ChangeClass` itself, never merely because the
+    # actor's own row names a starting class. `Scene_Battle_Rpg2k::
     # SelectNextActor` (`src/scene_battle_rpg2k.cpp`) checks it right after
     # the CanAct()/forced-restriction gates and, if set, calls the default
     # AutoBattle algorithm's `SetAutoBattleAction` instead of ever opening
@@ -2349,7 +2360,7 @@ module Game
     # this codebase's own port of that same algorithm (`AutoBattle::
     # RpgRtCompat`, the one real, un-patched RPG_RT always runs).
     def force_ai?
-      row = class_row_for(@class_id) if @class_id && @class_id > 0
+      row = @class_row if @class_changed && @class_id && @class_id > 0
       row ||= @db_row
       row.respond_to?(:force_ai) ? (row.force_ai ? true : false) : false
     end
@@ -2367,8 +2378,12 @@ module Game
     # scan every equipped slot for an item whose own *type* is a weapon rather
     # than hard-coding slot 0, so once a second weapon sits in the shield slot
     # they pick it up (and the better of the two) with no change of their own.
+    # Like every other class-overridable trait here, inert until an actual
+    # Change Class event runs (`data.two_weapon` is copied in from `cls->
+    # two_weapon` only inside `ChangeClass`, never merely because the actor's
+    # own row names a starting class) -- see #curve_row.
     def double_hand?
-      row = class_row_for(@class_id) if @class_id && @class_id > 0
+      row = @class_row if @class_changed && @class_id && @class_id > 0
       row ||= @db_row
       row.respond_to?(:double_hand) ? (row.double_hand ? true : false) : false
     end
@@ -2394,9 +2409,14 @@ module Game
     # still forces past both halves either way (`Game_Actor::ChangeEquipment`
     # never consults this method at all), so nothing in `Game::Party` reads
     # this -- the bag-swapping methods stay usable for a caller that already
-    # knows better, the same way they do not re-check `menu_access`.
+    # knows better, the same way they do not re-check `menu_access`. The
+    # class half is, like every other class-overridable trait here, inert
+    # until an actual Change Class event runs (`data.lock_equipment` is
+    # copied in from `cls->lock_equipment` only inside `ChangeClass`, never
+    # merely because the actor's own row names a starting class) -- see
+    # #curve_row.
     def equipment_fixed?
-      row = class_row_for(@class_id) if @class_id && @class_id > 0
+      row = @class_row if @class_changed && @class_id && @class_id > 0
       row ||= @db_row
       return true if row.respond_to?(:equipment_fixed) && row.equipment_fixed
       state_cursed?
@@ -2865,9 +2885,14 @@ module Game
     # intermediate value for a caller that has none to restore.
     def restore_class(id)
       set_class_id(id)
+      # Must be set before #set_level runs: #curve_row now reads it to decide
+      # whether the class row is live at all, and #set_level's own
+      # #base_stats call goes through #curve_row to rescale at the restored
+      # level -- setting this after would compute the restored level's stats
+      # off the actor's own row instead of the just-restored class's.
+      @class_changed = true
       set_level(@level, preserve_mod: false)
       @battle_commands = nil
-      @class_changed = true
     end
 
     # Whether a Change Class (or a restored one, see #restore_class) has ever
@@ -3006,9 +3031,17 @@ module Game
 
     # The battle-command list the actor's current class (or, class-less, its
     # database row) defines. An edition / fixture row without the field yields
-    # the RPG2003 default of Row alone.
+    # the RPG2003 default of Row alone. Only ever called once an actual
+    # Change Class has happened (from #change_class itself, after
+    # `@class_changed` is already set) or from #battle_commands' own lazy
+    # materialisation on first read -- gated on `@class_changed` the same way
+    # #curve_row is, since an actor's database-declared starting class does
+    # not make its command list live either: EasyRPG's `data.battle_commands`
+    # is copied in from `cls->battle_commands` only inside `ChangeClass`,
+    # from `dbActor->battle_commands` at plain construction and every other
+    # time.
     def class_battle_commands
-      row = @class_row || @db_row
+      row = @class_changed && @class_id > 0 && @class_row ? @class_row : @db_row
       list = row.respond_to?(:battle_commands) ? row.battle_commands : nil
       list.is_a?(Array) && !list.empty? ? list.dup : [0]
     end
@@ -3067,11 +3100,17 @@ module Game
     end
 
     # The database row the level-scaled tables are read from: the class row (職業)
-    # when the actor has a class, the actor row otherwise. Only the growth curve,
-    # the learn table and the EXP curve follow the class -- the attribute / state
-    # ranks stay on the actor row, which is where RPG_RT keeps reading them.
+    # once an actual Change Class event has run, the actor row otherwise --
+    # RPG_RT ignores a class merely *named* on the actor's own database row
+    # (chunk 11 field 57, a game's "starting class") until Change Class (1008)
+    # actually fires; see #battler_animation_id's own citation of EasyRPG's
+    # `Game_Actor::ChangeClass` comment, which this mirrors via the identical
+    # `@class_changed` gate rather than `@class_id > 0` alone. Only the growth
+    # curve, the learn table and the EXP curve follow the class -- the
+    # attribute / state ranks stay on the actor row, which is where RPG_RT
+    # keeps reading them.
     def curve_row
-      @class_row || @db_row
+      @class_changed && @class_id > 0 && @class_row ? @class_row : @db_row
     end
 
     # Point the actor at class `id` (0 = none), resolving its database row. A

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3422,10 +3422,16 @@ class JobRow
               # 62, into db.battleranimations) -- Actor#battler_animation_id's
               # "Change Class actually ran" branch. Defaults to 1, the schema
               # default for this field.
-              :battler_animation
+              :battler_animation,
+              # The class's own overrides for the same four actor/class-
+              # overridable booleans FakePlayerRow already carries --
+              # #strong_defence?/#force_ai?/#double_hand?/#equipment_fixed?'s
+              # own "only once Change Class has actually run" gate.
+              :strong_defence, :force_ai, :double_hand, :equipment_fixed
   def initialize(name, curve, learns = [], battle_commands = nil,
                  exp_basic: 30, exp_increase: 30, exp_correction: 0,
-                 battler_animation: 1)
+                 battler_animation: 1, strong_defence: nil, force_ai: nil,
+                 double_hand: nil, equipment_fixed: nil)
     @name = name
     @curve = curve
     @skills = FakeLearnTable.new(learns)
@@ -3434,6 +3440,10 @@ class JobRow
     @exp_increase = exp_increase
     @exp_correction = exp_correction
     @battler_animation = battler_animation
+    @strong_defence = strong_defence
+    @force_ai = force_ai
+    @double_hand = double_hand
+    @equipment_fixed = equipment_fixed
   end
 
   def int16_values(idx); idx == 31 ? @curve : nil; end
@@ -4585,11 +4595,31 @@ def class_state(class_id = 0, actor_learns = [[10, 1]])
   Game::State.new(Game::Party.new(class_db(class_id, actor_learns)), 1, 0, 0)
 end
 
-check 'an actor with a startup class reads its curve, learn table and EXP from it' do
+check "an actor with a startup class reads class_id immediately, but its curve, " \
+      "learn table and EXP stay on the actor's own row until an actual Change Class " \
+      "runs (2026-08-18)" do
+  # RPG2003 lets an actor start in a class (chunk 11 field 57) with no Change
+  # Class event ever firing -- EasyRPG's own comment on this is explicit
+  # ("The class settings are not applied when the actor has a class on
+  # startup but only when the 'Change Class' event command is used",
+  # Game_Actor::ChangeClass, src/game_actor.cpp), and confirmed directly
+  # against the C++ source for the growth-curve accessors too
+  # (Game_Actor::GetBaseMaxHp et al., all gated on the *runtime*
+  # `data.class_id > 0`, which the constructor never seeds from the
+  # database's own `dbActor->class_id` -- only ChangeClass itself ever
+  # writes it). #battler_animation_id already got this rule right (see its
+  # own near-identical check); #curve_row/#learn_table/#calc_exp did not,
+  # until now.
   a = class_state(1).party.actor_by_id(1)
-  eq 1, a.class_id
-  eq 220, a.max_hp, "class 1's level-3 max HP, not the actor row's 120"
-  eq [21, 22], a.skills.sort, "the class's learn table, not the actor's skill 10"
+  eq 1, a.class_id, "the starting class is live (Actor#class_id reads it back)"
+  eq 120, a.max_hp, "yet the actor's own row wins -- the class's level-3 max HP " \
+                     "(220) is never consulted without a real Change Class event"
+  eq [10], a.skills, "the actor's own known skill, not the class's learn table"
+
+  a.change_class(1, 3, Game::Actor::CLASS_SKILL_RESET, Game::Actor::CLASS_PARAM_RESET_LEVEL)
+  eq 220, a.max_hp, "a real Change Class now activates the class's own curve"
+  eq [21, 22], a.skills.sort, "...and its learn table"
+
   # A database with no class table (every RPG2000 game) leaves the actor
   # class-less, so nothing changes for 2000 data.
   b = party_state.party.actor_by_id(1)
@@ -4682,7 +4712,8 @@ check 'Change Class to level 1 rewinds the level; an unknown class is a no-op' d
   b = class_state(1).party.actor_by_id(1)
   eq false, b.change_class(99, 3, 0, 0), 'an undefined class changes nothing'
   eq 1, b.class_id
-  eq 220, b.max_hp, 'and leaves the stats it had'
+  eq 120, b.max_hp, 'and leaves the stats it had -- the startup class (id 1) was ' \
+                    'never actually activated by a real Change Class either'
 end
 
 check 'Change Class shows one level-up line when it taught skills' do
@@ -4820,6 +4851,22 @@ check 'a class change takes the class battle commands' do
   a = class_state.party.actor_by_id(1)
   a.change_class(1, 3, 0, 0)
   eq [3, 0, -1, -1, -1, -1, -1], a.battle_commands
+end
+
+check "battle_commands ignores a database-default starting class too, until a real Change " \
+      "Class runs (2026-08-18)" do
+  # The same #curve_row bug shape: EasyRPG's data.battle_commands is copied
+  # in from cls->battle_commands only inside ChangeClass itself, from
+  # dbActor->battle_commands at plain construction and every other time --
+  # #battle_commands' own lazy #class_battle_commands materialisation used
+  # to consult the class row the instant @class_id was nonzero, regardless
+  # of whether a real Change Class had ever run.
+  a = class_state(1).party.actor_by_id(1)
+  eq 1, a.class_id, 'the starting class is live'
+  eq [1, 2, 0, -1, -1, -1, -1], a.battle_commands, "the actor's own row wins, not class 1's " \
+                                                    '[3, 0, -1, -1, -1, -1, -1]'
+  a.change_class(1, 3, Game::Actor::CLASS_SKILL_NO_CHANGE, Game::Actor::CLASS_PARAM_NO_CHANGE)
+  eq [3, 0, -1, -1, -1, -1, -1], a.battle_commands, 'a real Change Class now activates it'
 end
 
 check 'a class change and its battle commands survive Save / Continue' do
@@ -5006,6 +5053,41 @@ check "Game::Actor#battler_animation_id ignores a database-default starting clas
   eq 1, a.class_id, "the starting class is live (Actor#class_id reads it back)"
   eq 3, a.battler_animation_id, "yet the actor's own database default wins -- the class's " \
                                 '(4) is never consulted without a real Change Class event'
+end
+
+check "Game::Actor#strong_defence?/#force_ai?/#double_hand?/#equipment_fixed? all ignore a " \
+      "database-default starting class the same way, until a real Change Class event " \
+      "runs (2026-08-18)" do
+  # The identical bug shape as #curve_row/#battler_animation_id, confirmed
+  # against RPG_RT's actual behavior via EasyRPG Player's own C++ source,
+  # fetched live: Game_Actor::ChangeClass (src/game_actor.cpp) is the *only*
+  # place data.super_guard/lock_equipment/two_weapon/auto_battle are ever
+  # copied in from a class row (cls->...) -- the constructor seeds all four
+  # from dbActor->... alone and never looks at a class at all, matching the
+  # method's own explicit comment: "The class settings are not applied when
+  # the actor has a class on startup but only when the 'Change Class' event
+  # command is used."
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 1) }
+  players[1].strong_defence = false
+  players[1].force_ai = false
+  players[1].double_hand = false
+  players[1].equipment_fixed = false
+  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [],
+                           strong_defence: true, force_ai: true,
+                           double_hand: true, equipment_fixed: true) }
+  db = FakeActorDB.new(players, [1], {}, {}, jobs)
+  a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
+  eq 1, a.class_id, 'the starting class is live'
+  ok !a.strong_defence?, "the actor's own row (false) wins over the class's (true)"
+  ok !a.force_ai?, "the actor's own row (false) wins over the class's (true)"
+  ok !a.double_hand?, "the actor's own row (false) wins over the class's (true)"
+  ok !a.equipment_fixed?, "the actor's own row (false) wins over the class's (true)"
+
+  a.change_class(1, 5, Game::Actor::CLASS_SKILL_NO_CHANGE, Game::Actor::CLASS_PARAM_NO_CHANGE)
+  ok a.strong_defence?, 'a real Change Class now activates the class row'
+  ok a.force_ai?
+  ok a.double_hand?
+  ok a.equipment_fixed?
 end
 
 check "Game::Actor#battler_animation_id falls back to 1 when Change Class leaves the actor " \


### PR DESCRIPTION
## Summary

EasyRPG's `Game_Actor::ChangeClass` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_actor.cpp`) carries an explicit code comment: *"The class settings are not applied when the actor has a class on startup but only when the 'Change Class' event command is used."* Confirmed directly against the C++ source rather than trusted on the comment's word alone: the constructor seeds `data.super_guard`/`lock_equipment`/`two_weapon`/`auto_battle` from `dbActor->...` alone and never touches `data.class_id` at all (it stays liblcf's own "-1, never changed" sentinel until `ChangeClass` explicitly writes it). `ChangeClass` is the *only* place any of those four fields, `battler_animation`, or `battle_commands` are ever copied in from a class row (`cls->...`) instead of the actor's own — matching, independently, `GetBaseMaxHp`/`GetBaseMaxSp`/`GetBaseAtk`/`GetBaseDef`/`GetBaseSpi`/`GetBaseAgi`/the skill list/`CalculateExp`, which all gate on the identical runtime `data.class_id > 0`.

`Game::Actor#curve_row`/`#strong_defence?`/`#force_ai?`/`#double_hand?`/`#equipment_fixed?`/`#class_battle_commands` (`mruby-rpg2k/mrblib/game.rb`) instead read the class row the instant `@class_id` was merely nonzero — live from `set_class_id`, seeded straight from the actor's own database row at construction, whether or not any Change Class command had ever run. Only `#battler_animation_id` got this right already, gated on a separate `@class_changed` flag — its own comment already carried the correct citation this fix now applies everywhere else too.

A database that gives an actor a starting class (a common RPG2003 authoring pattern, skipping an explicit Change Class at party-join time) had every one of these traits, and the actor's stat growth, EXP thresholds, learnable skills and battle-command list, silently drawn from the class from the very first frame instead of RPG_RT's own actor-row-until-Change-Class behavior.

Fixed by gating all six accessors on `@class_changed && @class_id > 0 && @class_row`, matching `#battler_animation_id` exactly. `#restore_class` (Continue's "a saved class was already live" path) needed its own internal reordering to match: `@class_changed` must be set *before* the `#set_level` call that rescales stats through `#curve_row`, not after, so a restored live class change still computes the restored level's stats off the right curve.

Two existing `scripts/rpg2k_logic_check.rb` checks encoded the old (incorrect) behaviour as intentional and needed correcting rather than just adding coverage alongside them:
- "an actor with a startup class reads its curve, learn table and EXP from it" — now split into asserting the actor's own row wins immediately, then the class's own after an explicit `#change_class` call.
- "Change Class to level 1 rewinds the level; an unknown class is a no-op" — the second half's expected max HP after a *failed* class change dropped from the class's 220 to the actor's own 120, since the startup class was never actually activated either.

## Test plan

- [x] Two existing checks corrected (see above) to reflect the real RPG_RT behavior instead of the previous (incorrect) one.
- [x] Two further new `scripts/rpg2k_logic_check.rb` checks: all four boolean traits read the actor's own row immediately and the class's only after `#change_class`; `#battle_commands`' own lazy materialisation does the same.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1021 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 747 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] All four new/corrected checks confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_