### PR TITLE
picture: Move Picture eases in float precision, matching RPG_RT

### DIFF
--- a/changelog.d/picture-move-float-interpolation.fixed.md
+++ b/changelog.d/picture-move-float-interpolation.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2000/2003 pictures:** Move Picture's per-frame easing now keeps full
+  precision between frames instead of feeding the previous frame's
+  already-rounded position back into the next frame's own calculation,
+  matching RPG_RT's own float-precision interpolation (truncated only at
+  display time). Previously the rounding error compounded frame over frame,
+  producing a visibly different, slightly laggier motion path for nearly
+  any Move Picture whose distance isn't an exact multiple of its duration —
+  the common case. Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -843,7 +843,10 @@ The work below is roughly ordered by the critical path to a walkable game
   `Game::State`, decoded with EasyRPG's parameter layout (literal or
   variable-sourced coordinates, transparency → opacity); Move eases every
   parameter to its target over the duration and its wait flag suspends the
-  interpreter (`:picture`) until the move settles; `Scene::Map` composites the
+  interpreter (`:picture`) until the move settles — **the easing itself used
+  to compound its own rounding error frame over frame instead of resetting
+  each time, now fixed; see the dedicated ✅ bullet under "Pictures" further
+  down this document.** `Scene::Map` composites the
   pictures (id-ordered, zoomed via `stretch_blt`, at their opacity) into a layer
   above the map and below the message window. Picture **tone** is **drawn** now:
   the source is toned through the native `Bitmap#tone_blt` before compositing,
@@ -9575,6 +9578,44 @@ not yet verified:
   fail against the pre-fix code.
 
 **Pictures**
+- ✅ **Move Picture's own per-frame easing now keeps full float precision
+  between frames instead of feeding the previous frame's already-truncated
+  Integer position back into the next frame's own division — RPG_RT's real
+  rounding never compounds this way (2026-08-18).** `Game::Picture#step`
+  (`mruby-rpg2k/mrblib/game.rb`) computed `cur + (target - cur) / @frames`
+  with plain Ruby integer division and wrote the truncated result straight
+  back into `@x`/`@y`/`@zoom`/`@opacity`/`@red`/`@green`/`@blue`/
+  `@saturation`, which the *next* frame's own `step` call then read as
+  `cur` — so each frame's truncation error carried into the next frame's
+  arithmetic and kept accumulating, rather than resetting. Verified against
+  RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched
+  live: `Game_Pictures::Picture::Update` (`src/game_pictures.cpp`) keeps the
+  running interpolated value in a `double` (`data.current_x` et al.,
+  `interpolate`'s `(finish - current) / dt + current`, `dt` the frames
+  remaining) across every frame, and only ever truncates to a whole pixel at
+  *display* time (`sprite_picture.cpp`'s `int x = data.current_x`) — that
+  truncated value is never written back into `data.current_x` itself, so
+  the real rounding error never compounds: each frame's fraction is (up to
+  float precision) exactly `1/remaining` of the *true* remaining distance,
+  not of the previously-truncated one. A move from x=0 to x=10 over 7 frames
+  is the smallest clean repro: this build's old per-frame sequence was `1,
+  2, 3, 4, 6, 8, 10`; RPG_RT's real one (float state, truncate only for
+  display) is `1, 2, 4, 5, 7, 8, 10` — both agree on the first two frames
+  and the final landing frame, but diverge by a full pixel on frames 3
+  through 6, a visibly different (and slightly laggier) motion path for
+  nearly every real Move Picture call, since an exactly-divisible distance
+  is the unusual case. Fixed by keeping `@x`/`@y`/etc as the full-precision
+  (now `Float`) running state internally, dividing by `@frames.to_f` instead
+  of the bare Integer, and exposing every one of the eight parameters
+  through a new explicit reader (`def x; @x.to_i; end`, etc., replacing the
+  old direct `attr_reader`) that truncates toward zero right at the point of
+  read — matching `int x = data.current_x`'s own truncation exactly (`Float
+  #to_i` in Ruby also truncates toward zero, not floors) — so every other
+  caller (rendering, the LSD writer) still only ever sees a plain `Integer`,
+  unchanged. Covered by a new `scripts/rpg2k_logic_check.rb` check asserting
+  the exact `1, 2, 4, 5, 7, 8, 10` per-frame sequence for the 0-to-10-over-
+  7-frames example above, confirmed to fail against the pre-fix code (it
+  produced `1, 2, 3, 4, 6, 8, 10` instead) before the fix.
 - ✅ **50 concurrent picture slots; higher id always draws on top,
   independent of show order — confirmed already correct.**
   `Scene::Map#draw_pictures` composites `@state.pictures.keys.sort`, so the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7507,7 +7507,19 @@ module Game
   # but not yet drawn.
   class Picture
     attr_reader :id, :name, :fixed_to_map, :use_transparent_color
-    attr_reader :x, :y, :zoom, :opacity, :red, :green, :blue, :saturation
+
+    # Every interpolated field is truncated to a whole number here (matching
+    # EasyRPG's own `int x = data.current_x;`, `sprite_picture.cpp`) but held
+    # at full float precision internally between frames -- see #step's own
+    # comment for why the two must not be the same value.
+    def x; @x.to_i; end
+    def y; @y.to_i; end
+    def zoom; @zoom.to_i; end
+    def opacity; @opacity.to_i; end
+    def red; @red.to_i; end
+    def green; @green.to_i; end
+    def blue; @blue.to_i; end
+    def saturation; @saturation.to_i; end
 
     def initialize(id, opts = {})
       @id = id
@@ -7537,8 +7549,24 @@ module Game
     def moving?; @frames > 0; end
 
     # Advance one frame of the in-flight move (a no-op when at rest). Every
-    # parameter eases a `1/remaining` fraction toward its target, so integer
-    # division still lands exactly on the target on the final frame.
+    # parameter eases a `1/remaining` fraction toward its target, in float
+    # precision, so it still lands exactly on the target on the final frame
+    # (`(target - cur) / 1.0` is exactly `target - cur`).
+    #
+    # EasyRPG's own `Game_Pictures::Picture::Update` (`src/game_pictures.cpp`)
+    # keeps this same running fraction in a double (`data.current_x` et al.,
+    # `interpolate`'s `(finish - current) / dt + current`) across every frame
+    # and truncates only for display (`sprite_picture.cpp`'s `int x =
+    # data.current_x`) -- the truncation never feeds back into the next
+    # frame's own calculation. A prior version of this method instead fed the
+    # *already-truncated* `@x` (an Integer, via plain `/` integer division)
+    # back into the next call, so the rounding error compounded frame over
+    # frame instead of resetting each time: a 0->10 move over 7 frames here
+    # produced 1, 2, 3, 4, 6, 8, 10 where real RPG_RT's own (float-precision,
+    # truncate-for-display-only) sequence is 1, 2, 4, 5, 7, 8, 10 -- a
+    # visibly different, laggier path any time the move distance is not an
+    # exact multiple of the frame count, which is nearly every real Move
+    # Picture call.
     def update
       return unless moving?
       @x = step(@x, @tx); @y = step(@y, @ty)
@@ -7550,7 +7578,7 @@ module Game
 
     private
 
-    def step(cur, target); cur + (target - cur) / @frames; end
+    def step(cur, target); cur + (target - cur) / @frames.to_f; end
 
     def finish_move
       @x = @tx; @y = @ty; @zoom = @tzoom; @opacity = @topacity

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7826,6 +7826,26 @@ check 'Game::Picture with non-divisible steps still lands exactly' do
   ok !p.moving?
 end
 
+check "Game::Picture interpolates in float precision, not by feeding the previous " \
+      "frame's truncated integer back in, matching RPG_RT (2026-08-18)" do
+  # EasyRPG's Game_Pictures::Picture::Update (src/game_pictures.cpp) keeps
+  # the running interpolated position in a double (`data.current_x`,
+  # `interpolate`'s `(finish - current) / dt + current`) across every frame
+  # and truncates only for display (sprite_picture.cpp's `int x =
+  # data.current_x`) -- the truncation never feeds back into the next
+  # frame's own calculation. #step used to feed the *already-truncated*
+  # Integer @x back into the next call's `(target - cur) / @frames` (plain
+  # integer division), compounding the rounding error frame over frame
+  # instead of resetting each time.
+  p = Game::Picture.new(1, x: 0, y: 0)
+  p.move_to(10, 0, 100, 255, 100, 100, 100, 100, 7) # 0 -> 10 over 7 frames
+  seen = []
+  7.times { p.update; seen.push(p.x) }
+  eq [1, 2, 4, 5, 7, 8, 10], seen,
+     'RPG_RT\'s real per-frame sequence -- the pre-fix code produced [1, 2, 3, 4, 6, 8, 10] instead'
+  ok !p.moving?
+end
+
 check 'Game::Picture with zero duration applies immediately' do
   p = Game::Picture.new(1, x: 5, y: 5, opacity: 0)
   p.move_to(99, 88, 150, 128, 100, 100, 100, 100, 0)


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Pictures::Picture::Update` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_pictures.cpp`) keeps the running interpolated value in a `double` (`data.current_x` et al., `interpolate`'s `(finish - current) / dt + current`) across every frame, truncating to a whole pixel only at display time (`sprite_picture.cpp`'s `int x = data.current_x`). The truncated value is never written back into `data.current_x`, so the real rounding error never compounds.

`Game::Picture#step` (`mruby-rpg2k/mrblib/game.rb`) instead computed `cur + (target - cur) / @frames` with plain Integer division and wrote the truncated result straight back into `@x`/`@y`/`@zoom`/`@opacity`/etc, which the next frame's own `step` call then read as `cur` — so each frame's truncation error carried into the next frame's arithmetic and kept accumulating instead of resetting.

A move from x=0 to x=10 over 7 frames is the smallest clean repro: the old per-frame sequence was `1, 2, 3, 4, 6, 8, 10`; RPG_RT's real one is `1, 2, 4, 5, 7, 8, 10` — both agree on the first two frames and the landing frame, but diverge by a full pixel on frames 3–6, a visibly different, laggier motion path for nearly any real Move Picture call, since an exactly-divisible distance is the unusual case.

Fixed by keeping `@x`/`@y`/etc as the full-precision (now `Float`) running state internally, dividing by `@frames.to_f` instead of the bare Integer, and exposing every parameter through a new explicit reader (`def x; @x.to_i; end`, etc, replacing the old direct `attr_reader`) that truncates toward zero at the point of read — matching `int x = data.current_x`'s own truncation exactly (`Float#to_i` in Ruby also truncates toward zero) — so every other caller still only ever sees a plain `Integer`, unchanged.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check asserting the exact `1, 2, 4, 5, 7, 8, 10` per-frame sequence for the 0-to-10-over-7-frames example above.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1022 checks passed (1 new)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 747 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] New check confirmed to fail against the pre-fix code (`git stash` of the source file — produced `1, 2, 3, 4, 6, 8, 10`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_