### PR TITLE
interpreter: Flash Screen scales its 0..31 params to 0..255, matching RPG_RT

### DIFF
--- a/changelog.d/flash-screen-scale.fixed.md
+++ b/changelog.d/flash-screen-scale.fixed.md
@@ -1,0 +1,9 @@
+- **RPG2000/2003 maps:** The Flash Screen event command now scales its
+  colour/strength parameters (raw database 0..31) to the 0..255 range used
+  everywhere else in the engine, matching RPG_RT's own `Flash::MakeColor`
+  (`r*8, g*8, b*8, level*8`). Previously the command fed its raw values
+  straight through unscaled, so an ordinary Flash Screen — damage flashes,
+  warning strobes, RPG2003 Begin-mode strobes — rendered roughly 8x too dark
+  and too transparent, nearly invisible instead of the intended color pulse.
+  Two existing `scripts/rpg2k_logic_check.rb` checks were using out-of-range
+  input values and needed correcting alongside the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2428,7 +2428,10 @@ The work below is roughly ordered by the critical path to a walkable game
   with the current renderer. **Flash Screen** (11040) drives `Game::Screen` too:
   a colour + strength that fades to zero over the duration, and it **is** drawn:
   a screen-sized colour sprite above everything, shown at the flash's strength
-  through `Sprite#opacity`. **Pan Screen** (11060) drives
+  through `Sprite#opacity`. **The command's own raw 0..31 parameters used to
+  reach that sprite unscaled instead of the 0..255 range every other flash
+  caller uses — see the dedicated ✅ bullet under the RPG2003 Flash Screen
+  cluster further down this document.** **Pan Screen** (11060) drives
   `Game::Screen` as well: lock / unlock freeze or resume the camera's hero
   follow, and pan / reset scroll a pixel offset toward a target that `Scene::Map`
   adds to the camera (so — like the shake — the pan **is** visible; while locked
@@ -7367,6 +7370,44 @@ not yet verified:
   proving a non-RPG2003 party ignores a stray 7th parameter and always
   settles — the `Game::Screen` test and the two interpreter dispatch tests
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **`Interpreter#do_flash_screen` now scales Flash Screen's own raw 0..31
+  colour/strength parameters to the 0..255 range every other flash caller in
+  this codebase already uses, instead of feeding them through unscaled
+  (2026-08-18).** `Game::Screen#flash`/`#flash_begin`
+  (`mruby-rpg2k/mrblib/game.rb`) store whatever `r`/`g`/`b`/`power` they are
+  given verbatim, with no internal scaling, and `Scene::Map#update_screen_
+  overlay`'s own comment is explicit that both halves of the screen-overlay
+  pipeline are "0..255 already" — every *other* caller already honours that:
+  `Scene::Map::STEP_DAMAGE_FLASH = [31 * 8, 10 * 8, 10 * 8, 20 * 8, 6]` and
+  both `#fire_animation_flashes`/`#fire_map_target_flash` scale a troop's raw
+  `flash_red`/`flash_green`/`flash_blue`/`flash_power` fields by 8 before
+  ever calling `#flash`. `Interpreter#do_flash_screen` — the handler for the
+  **Flash Screen** (11040) event command itself, the one path a real project
+  actually authors directly — was simply missed when that convention was
+  established: it passed `cmd.param(0..3)` straight through unscaled in both
+  its mode-0 (one-shot) and mode-1 (Begin) branches. Verified against RPG_RT's
+  actual behavior via EasyRPG Player's own C++ source, fetched live:
+  `Game_Screen::FlashMapStepDamage` (`src/game_screen.cpp`) itself calls
+  `FlashOnce(31, 10, 10, 20, 6)` — confirming the command's own parameters
+  are genuinely stored on the raw 0..31 scale internally, exactly matching
+  this codebase's pre-`* 8` convention — and `Flash::MakeColor`
+  (`src/flash.h`) is where the multiply happens, at render time only:
+  `Color(r * 8, g * 8, b * 8, current_level * 8)`. A Flash Screen command
+  using RPG_RT's own classic "damage flash" values (R=31, G=0, B=0, Power=20
+  — identical to `FlashMapStepDamage`'s own call) should show a strong red
+  overlay at peak opacity 160/255; unscaled, this codebase showed an
+  essentially-black (31,0,0) overlay at 20/255 (≈8%) opacity — nearly
+  invisible instead of a strong red pulse, for every ordinary use of the
+  command (damage flashes, warning strobes, RPG2003 Begin-mode strobes).
+  Fixed by multiplying `cmd.param(0..3)` by a new `FLASH_SCALE = 8` constant
+  in both branches. Two existing `scripts/rpg2k_logic_check.rb` checks
+  ("Flash Screen without a wait starts a flash and does not pause", "RPG2003
+  Flash Screen mode 1 (Begin) strobes indefinitely and never pauses") had
+  been passing raw command parameters already at the 0..255 scale (255 for
+  "white", far past the command's own 0..31 range) and asserting them
+  unscaled — corrected to realistic 0..31 inputs and their now-correctly-
+  scaled 0..255 expectations, both confirmed to fail against the pre-fix
+  code before the fix.
 - ✅ **An ally's equipped shield/armor/helmet/accessory can now resist a
   status effect from landing at all, instead of only its A-E susceptibility
   rank ever mattering.** Confirmed against EasyRPG's actual C++ source:

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3211,19 +3211,29 @@ module Game
     # RPG2000 project, or an RPG2003 one never given the extended layout) always
     # falls back to a plain one-shot flash, mode 0. Only mode 0 ever waits — Begin
     # and End never suspend the interpreter, since the strobe runs indefinitely.
+    #
+    # param0..3 store the raw RPG2000/2003 0..31 flash scale (confirmed against
+    # EasyRPG's own `Game_Screen::FlashMapStepDamage`, `FlashOnce(31, 10, 10, 20,
+    # 6)`), which real RPG_RT only ever multiplies by 8 at render time
+    # (`Flash::MakeColor`, `src/flash.h`: `Color(r*8, g*8, b*8, level*8)`) --
+    # `Game::Screen#flash`/`#flash_begin` instead expect the already-scaled 0..255
+    # values every other caller in this codebase already passes (`Scene::Map::
+    # STEP_DAMAGE_FLASH`, `#fire_animation_flashes`/`#fire_map_target_flash`, all
+    # `* 8`), so the raw command params are scaled here to match.
+    FLASH_SCALE = 8
     def do_flash_screen(cmd)
       mode = @state.party.rpg2003? && cmd.parameters.size > 6 ? cmd.param(6) : 0
       case mode
       when 1
         frames = cmd.param(4) * FRAMES_PER_TENTH
-        @state.screen.flash_begin(cmd.param(0), cmd.param(1), cmd.param(2),
-                                  cmd.param(3), frames)
+        @state.screen.flash_begin(cmd.param(0) * FLASH_SCALE, cmd.param(1) * FLASH_SCALE,
+                                  cmd.param(2) * FLASH_SCALE, cmd.param(3) * FLASH_SCALE, frames)
       when 2
         @state.screen.flash_end
       else
         frames = cmd.param(4) * FRAMES_PER_TENTH
-        @state.screen.flash(cmd.param(0), cmd.param(1), cmd.param(2),
-                            cmd.param(3), frames)
+        @state.screen.flash(cmd.param(0) * FLASH_SCALE, cmd.param(1) * FLASH_SCALE,
+                            cmd.param(2) * FLASH_SCALE, cmd.param(3) * FLASH_SCALE, frames)
         return unless cmd.param(5) != 0 && @state.screen.flashing?
         @wait_kind = :screen
         @waiting = true

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2195,14 +2195,16 @@ end
 check 'Flash Screen without a wait starts a flash and does not pause' do
   st = new_state
   it = Game::Interpreter.new(st)
-  # white flash, strength 31, 5 tenths (30 frames), wait 0.
-  it.start([FakeCmd.new(IC::FLASH_SCREEN, [255, 255, 255, 31, 5, 0]),
+  # white flash, strength 31 (the command's own raw 0..31 scale), 5 tenths
+  # (30 frames), wait 0.
+  it.start([FakeCmd.new(IC::FLASH_SCREEN, [31, 31, 31, 31, 5, 0]),
             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
   it.update
   ok !it.waiting?, 'a no-wait flash keeps running'
   eq true, st.switches[1], 'the command after the flash still ran'
   ok st.screen.flashing?, 'a flash is in progress'
-  eq [255, 255, 255, 31], st.screen.flash_color
+  eq [248, 248, 248, 248], st.screen.flash_color,
+     "scaled to the 0..255 range every #flash caller uses (EasyRPG's Flash::MakeColor: r*8, g*8, b*8, level*8)"
 end
 
 check 'Flash Screen with a wait pauses until the flash fades out' do
@@ -2224,18 +2226,20 @@ end
 check 'RPG2003 Flash Screen mode 1 (Begin) strobes indefinitely and never pauses' do
   st = new_state(rpg2003: true)
   it = Game::Interpreter.new(st)
-  # red, peak strength 20, 2 tenths (12 frames), wait 0, mode 1 (Begin).
-  it.start([FakeCmd.new(IC::FLASH_SCREEN, [255, 0, 0, 20, 2, 0, 1]),
+  # red, peak strength 20 (the command's own raw 0..31 scale, scaled to 160
+  # of 255 -- EasyRPG's Flash::MakeColor: r*8, g*8, b*8, level*8), 2 tenths
+  # (12 frames), wait 0, mode 1 (Begin).
+  it.start([FakeCmd.new(IC::FLASH_SCREEN, [31, 0, 0, 20, 2, 0, 1]),
             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
   it.update
   ok !it.waiting?, 'Begin never pauses the interpreter'
   eq true, st.switches[1], 'the command after Begin still ran'
   ok st.screen.flashing?
-  eq 20, st.screen.flash_color[3]
+  eq 160, st.screen.flash_color[3]
   11.times { st.screen.update }
-  ok st.screen.flash_color[3] < 20, 'decaying before the period ends'
+  ok st.screen.flash_color[3] < 160, 'decaying before the period ends'
   st.screen.update # the 12th update: the period lapses
-  eq 20, st.screen.flash_color[3], 're-armed to peak instead of settling at 0'
+  eq 160, st.screen.flash_color[3], 're-armed to peak instead of settling at 0'
   ok st.screen.flashing?, 'still strobing after one full period'
 end
 


### PR DESCRIPTION
## Summary

`Game::Screen#flash`/`#flash_begin` (`mruby-rpg2k/mrblib/game.rb`) store whatever `r`/`g`/`b`/`power` they are given verbatim, with no internal scaling — `Scene::Map#update_screen_overlay`'s own comment already documents that both halves of the screen-overlay pipeline expect "0..255 already". Every other caller already honours that: `Scene::Map::STEP_DAMAGE_FLASH = [31 * 8, 10 * 8, 10 * 8, 20 * 8, 6]` and both `#fire_animation_flashes`/`#fire_map_target_flash` scale a troop's raw flash fields by 8 before calling `#flash`.

`Interpreter#do_flash_screen` — the handler for the **Flash Screen** (11040) event command itself — was missed when that convention was established: it passed `cmd.param(0..3)` straight through unscaled in both its mode-0 (one-shot) and mode-1 (Begin) branches.

Verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `Game_Screen::FlashMapStepDamage` (`src/game_screen.cpp`) itself calls `FlashOnce(31, 10, 10, 20, 6)`, confirming the command's own parameters are genuinely stored on the raw 0..31 scale internally, and `Flash::MakeColor` (`src/flash.h`) is where the multiply happens, at render time only: `Color(r*8, g*8, b*8, current_level*8)`.

A Flash Screen using RPG_RT's own classic "damage flash" values (R=31, G=0, B=0, Power=20, identical to `FlashMapStepDamage`'s own call) should show a strong red overlay at peak opacity 160/255; unscaled, this codebase showed an essentially-black overlay at 20/255 (~8%) opacity — nearly invisible instead of a strong red pulse, for every ordinary use of the command (damage flashes, warning strobes, RPG2003 Begin-mode strobes).

Fixed by multiplying `cmd.param(0..3)` by a new `FLASH_SCALE = 8` constant in both branches.

## Test plan

- [x] Two existing `scripts/rpg2k_logic_check.rb` checks had been passing raw parameters already at the 0..255 scale (255, far past the command's own 0..31 range) and asserting them unscaled — corrected to realistic 0..31 inputs and their now-correctly-scaled expectations.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1022 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 747 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] Both corrected checks confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_