### PR TITLE
map: boarding/landing the airship now snaps the hero to face left, matching RPG_RT

### DIFF
--- a/changelog.d/airship-board-land-face-left.fixed.md
+++ b/changelog.d/airship-board-land-face-left.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2000/2003 maps:** Boarding or landing the airship now snaps the hero
+  to face left, matching RPG_RT's own `SetFacing(Left)` at both transitions
+  (which bypasses Direction Fix entirely). Previously the hero kept
+  whatever direction they were last facing through the whole flight and
+  after landing. Boat and ship boarding are unaffected — RPG_RT has no
+  equivalent facing change for them. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6077,6 +6077,34 @@ Everything below is unverified against the codebase.
   tile would; one parked on a different map reads nil again; a boarded one
   reports the identical screen position the hero riding it does), confirmed
   to fail against the pre-fix code before the fix.
+  ✅ **Boarding or landing the airship now snaps the hero to face left, the
+  same way it already forces the party off the manual command menu — this
+  build never touched the hero's facing at either transition (2026-08-18).**
+  Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
+  source, fetched live: `Game_Player::GetOnVehicle`'s airship branch
+  (`src/game_player.cpp`) calls `SetFacing(Left)` unconditionally the
+  instant boarding begins — its own comment is explicit that this bypasses
+  Direction Fix entirely (`"Note: RPG_RT ignores the lock_facing flag
+  here!"`) — and `GetOffVehicle`'s `InAirship()` branch does the identical
+  `SetFacing(Left)` right before `StartDescent()`. Neither the boat nor the
+  ship branch of either function has any equivalent call at all (boat/ship
+  disembarking instead calls `vehicle->SetDefaultDirection()` on the
+  *vehicle*, not the player), so this is airship-specific. `Scene::Map
+  #board_as`/`#disembark_vehicle` (`mruby-rpg2k/mrblib/scene/map.rb`) never
+  touched `@state.direction` at all: a party walking downward that boarded
+  a placed airship kept facing down through the whole flight and after
+  landing, instead of RPG_RT's real behaviour of snapping to face left the
+  instant boarding starts (and again the instant landing does) regardless
+  of whatever direction the hero was last actually facing or moving.
+  Fixed by setting `@state.direction = 4` (numpad left) in `#board_as` when
+  `type == :airship`, and again in `#disembark_vehicle`'s airship branch once
+  `#airship_landable?` passes — matching `SetFacing(Left)`'s own placement
+  in both EasyRPG functions exactly, and leaving the boat/ship paths
+  completely untouched. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (boarding and then landing the airship both snap a differently-
+  facing hero to face left; the control case confirms boarding a boat never
+  touches facing at all), the airship one confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **Battle Event** — separate command set from Map/Common events
   entirely (`Game::Interpreter`'s battle-only opcodes — `CHANGE_MONSTER_HP`/
   `MP`/`CONDITION`, `SHOW_HIDDEN_MONSTER`, `FORCE_FLEE`, `TERMINATE_BATTLE`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2207,9 +2207,17 @@ class RPG2k
         false
       end
 
-      # Mark the party aboard `type` and switch to the vehicle's BGM.
+      # Mark the party aboard `type` and switch to the vehicle's BGM. Boarding
+      # the airship also snaps the hero to face left -- verified against
+      # RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched
+      # live: `Game_Player::GetOnVehicle`'s airship branch (`src/
+      # game_player.cpp`) calls `SetFacing(Left)` unconditionally the instant
+      # boarding begins, with its own comment noting this bypasses Direction
+      # Fix ("RPG_RT ignores the lock_facing flag here!") -- the boat/ship
+      # branch has no equivalent call at all, so this is airship-specific.
       def board_as(type)
         @state.boarded = type
+        @state.direction = 4 if type == :airship
         play_vehicle_bgm(type)
       end
 
@@ -2218,10 +2226,13 @@ class RPG2k
       # party vacates; the airship instead lands in place — RPG_RT tests the
       # terrain directly under it, not the tile ahead, since it has no "shore"
       # to step onto. Either way a no-op when the landing spot is blocked (the
-      # party stays aboard).
+      # party stays aboard). Disembarking the airship also snaps the hero to
+      # face left, mirroring `Game_Player::GetOffVehicle`'s own unconditional
+      # `SetFacing(Left)` right before `StartDescent()` -- see #board_as.
       def disembark_vehicle
         if @state.boarded == :airship
           return unless airship_landable?(@state.x, @state.y)
+          @state.direction = 4
           follow_vehicle # the airship is left where it touched down
           @state.boarded = nil
           restore_pre_vehicle_bgm # the map BGM resumes

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7964,6 +7964,53 @@ check 'the airship lands in place where the terrain allows it' do
   eq [0, 0], [air.x, air.y], 'the airship stayed where it landed'
 end
 
+check 'boarding and landing the airship snaps the hero to face left, matching RPG_RT ' \
+      '(2026-08-18)' do
+  # Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
+  # source, fetched live: Game_Player::GetOnVehicle's airship branch (src/
+  # game_player.cpp) calls SetFacing(Left) unconditionally the instant
+  # boarding begins ("RPG_RT ignores the lock_facing flag here!"), and
+  # GetOffVehicle's own InAirship branch does the identical SetFacing(Left)
+  # right before StartDescent() -- the boat/ship branches have no equivalent
+  # call at all, so this is airship-specific.
+  scene = new_scene({}, player: [0, 0], airship_land: true)
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # facing down beforehand
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 0
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'boarded the airship'
+  eq 4, st.direction, 'boarding snapped the hero to face left'
+
+  st.direction = 8 # face a different direction mid-flight
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'landed'
+  eq 4, st.direction, 'landing snapped the hero to face left too'
+end
+
+check 'boarding a boat/ship does not force any particular facing' do
+  # Control for the airship-specific check above: EasyRPG's boat/ship
+  # boarding branch never calls SetFacing on the player at all.
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face down, toward the boat
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat ahead'
+  eq 2, st.direction, 'still facing down -- boarding a boat does not touch facing'
+end
+
 check 'boarding the airship doubles the party\'s per-frame slide speed; boat/ship do not' do
   # Confirmed against EasyRPG's actual C++ source: Game_Vehicle's constructor
   # (src/game_vehicle.cpp) gives Boat/Ship `MoveSpeed_normal` -- identical to


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Player::GetOnVehicle` airship branch (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_player.cpp`) calls `SetFacing(Left)` unconditionally the instant boarding begins — its own comment: *"Note: RPG_RT ignores the lock_facing flag here!"* — and `GetOffVehicle`'s `InAirship()` branch does the identical `SetFacing(Left)` right before `StartDescent()`. Neither the boat nor the ship branch of either function has any equivalent call (boat/ship disembarking instead calls `vehicle->SetDefaultDirection()` on the *vehicle*, not the player), so this is airship-specific.

`Scene::Map#board_as`/`#disembark_vehicle` (`mruby-rpg2k/mrblib/scene/map.rb`) never touched `@state.direction` at all: a party walking downward that boarded a placed airship kept facing down through the whole flight and after landing, instead of snapping to face left the instant boarding starts (and again the instant landing does), regardless of whatever direction the hero was last actually facing or moving.

Fixed by setting `@state.direction = 4` (numpad left) in `#board_as` when `type == :airship`, and again in `#disembark_vehicle`'s airship branch once `#airship_landable?` passes — matching `SetFacing(Left)`'s own placement in both EasyRPG functions exactly, leaving the boat/ship paths completely untouched.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks: boarding and then landing the airship both snap a differently-facing hero to face left; the control case confirms boarding a boat never touches facing at all.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 749 checks passed (2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1022 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] The airship check confirmed to fail against the pre-fix code (`git stash` of the source file)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_