### PR TITLE
screen: Tint Screen eases in float precision, matching RPG_RT

### DIFF
--- a/changelog.d/tint-screen-float-interpolation.fixed.md
+++ b/changelog.d/tint-screen-float-interpolation.fixed.md
@@ -1,0 +1,10 @@
+- **RPG2000/2003 maps:** Tint Screen's per-frame interpolation now keeps
+  full precision between frames instead of feeding the previous frame's
+  already-rounded channel value back into the next frame's own
+  calculation, matching RPG_RT's own float-precision interpolation
+  (truncated only where the tint is actually drawn) — the same bug already
+  fixed for Move Picture, now applied here too. Previously the rounding
+  error compounded frame over frame, producing a slightly different
+  darkening-overlay opacity during any Tint Screen transition whose
+  duration doesn't evenly divide the distance — the common case. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2416,7 +2416,11 @@ The work below is roughly ordered by the critical path to a walkable game
   RPG2000 channels (red/green/blue/saturation, 0..200) toward their target over
   the command's duration (advanced each frame by `Scene::Map`), and the wait
   flag pauses the interpreter until the effect settles (a `:screen` wait,
-  resumed by the scene once `Game::Screen#busy?` clears). The **darkening** half
+  resumed by the scene once `Game::Screen#busy?` clears). **That
+  interpolation used to compound its own rounding error frame over frame
+  instead of resetting each time, now fixed; see the dedicated ✅ bullet
+  further down this document, right where the identical `Game::Picture` bug
+  was fixed.** The **darkening** half
   of the tint now draws: `Scene::Map` overlays a black screen sprite (below the
   flash / fade overlays) whose opacity approximates how far the tone averages
   below neutral, so a night / cave tint dims the map. A full tone — the colour
@@ -9685,6 +9689,42 @@ not yet verified:
   the exact `1, 2, 4, 5, 7, 8, 10` per-frame sequence for the 0-to-10-over-
   7-frames example above, confirmed to fail against the pre-fix code (it
   produced `1, 2, 3, 4, 6, 8, 10` instead) before the fix.
+- ✅ **Tint Screen's own per-frame interpolation had the identical
+  compounding-rounding-error bug as Move Picture just above — never applied
+  the same fix when that one landed (2026-08-18).** `Game::Screen
+  #update_tint` (`mruby-rpg2k/mrblib/game.rb`) computed `@r += (@tr - @r) /
+  @frames` with plain Ruby integer division and wrote the truncated result
+  straight back into `@r`/`@g`/`@b`/`@sat`, which the *next* frame's own
+  call then read back as its own starting point — the same "feed the
+  previous frame's already-truncated value back into the next frame's own
+  division" shape `Game::Picture#step` had, just never noticed here.
+  Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
+  source, fetched live: `Game_Screen::UpdateScreenEffects`
+  (`src/game_screen.cpp`) interpolates via a free `interpolate(d, x0, x1) =
+  (x0*(d-1) + x1) / d` — algebraically identical to `x0 + (x1-x0)/d` — and
+  confirmed directly against liblcf's own generated `SaveScreen` struct
+  (`src/generated/lcf/rpg/savescreen.h`) rather than assumed from the
+  formula alone: `tint_current_red`/`green`/`blue`/`sat` are `double`, while
+  `tint_finish_red`/`green`/`blue`/`sat` (the targets) stay `int32_t` — the
+  running value is genuinely float-precision internally and only ever
+  truncated where the tint is actually consumed (building the render
+  `Tone`), the same split `Game::Picture`'s own fix already ported. A tint
+  from red 100 to 0 over 7 frames is the smallest clean repro, the exact
+  same shape as Move Picture's own 0-to-10-over-7 example: this build's old
+  per-frame sequence was `85, 70, 56, 42, 28, 14, 0`; RPG_RT's real one
+  (float state, truncate only for display) is `85, 71, 57, 42, 28, 14, 0` —
+  frames 2 and 3 land one channel unit higher, a small but real, directly
+  observable divergence in the value driving `Scene::Map`'s own darkening-
+  overlay opacity during any non-power-of-two-length Tint Screen. Fixed by
+  dividing by `@frames.to_f` instead of the bare Integer (keeping `@r`/`@g`/
+  `@b`/`@sat` as the full-precision running state, now `Float` mid-
+  transition) and truncating only in `#tint`'s own reader (`@r.to_i`, etc.,
+  replacing the old bare `[@r, @g, @b, @sat]`) — every other caller still
+  only ever sees a plain `Integer`, unchanged. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check asserting the exact `85, 71, 57, 42,
+  28, 14, 0` per-frame sequence for the 100-to-0-over-7-frames example
+  above, confirmed to fail against the pre-fix code (it produced `85, 70,
+  56, 42, 28, 14, 0` instead) before the fix.
 - ✅ **50 concurrent picture slots; higher id always draws on top,
   independent of show order — confirmed already correct.**
   `Scene::Map#draw_pictures` composites `@state.pictures.keys.sort`, so the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7129,8 +7129,14 @@ module Game
       @fade_transition = 0 # RPG2000 transition style (see Erase/Show Screen)
     end
 
-    # Current tint as [red, green, blue, saturation] (each 0..200, 100 neutral).
-    def tint; [@r, @g, @b, @sat]; end
+    # Current tint as [red, green, blue, saturation] (each 0..200, 100
+    # neutral), truncated to a whole number here -- matching EasyRPG's own
+    # `tint_current_red` et al. (`double` fields, truncated only where they
+    # are actually consumed, e.g. building the render `Tone`) -- while
+    # #update_tint keeps the full float precision internally between frames.
+    # See #update_tint's own comment for why the two must not be the same
+    # value.
+    def tint; [@r.to_i, @g.to_i, @b.to_i, @sat.to_i]; end
 
     # True while a tint transition is still in progress.
     def tinting?; @frames > 0; end
@@ -7407,12 +7413,27 @@ module Game
       @transition = nil
     end
 
+    # EasyRPG's `Game_Screen::UpdateScreenEffects` (`src/game_screen.cpp`)
+    # interpolates the tint in a `double` (`tint_current_red` et al. --
+    # confirmed against liblcf's own generated `SaveScreen` struct, where
+    # those four fields are `double` while the `tint_finish_*` targets stay
+    # `int32_t`) across every frame of the transition, via `interpolate(d,
+    # x0, x1) = (x0*(d-1) + x1) / d` -- algebraically `x0 + (x1-x0)/d` -- and
+    # only ever truncates to a whole number where the tint is actually read
+    # (#tint, mirroring EasyRPG's own render-time cast). A prior version of
+    # this method instead used plain Ruby integer division and wrote the
+    # truncated result straight back into `@r`/`@g`/`@b`/`@sat`, which the
+    # *next* frame's own step then read back as its own starting point --
+    # the same "feed the previous frame's truncated value back into the next
+    # frame's own division" bug already fixed for `Game::Picture#step`
+    # (rounding error compounding across the whole transition instead of
+    # resetting each frame), just never applied here.
     def update_tint
       return if @frames <= 0
-      @r += (@tr - @r) / @frames
-      @g += (@tg - @g) / @frames
-      @b += (@tb - @b) / @frames
-      @sat += (@tsat - @sat) / @frames
+      @r += (@tr - @r) / @frames.to_f
+      @g += (@tg - @g) / @frames.to_f
+      @b += (@tb - @b) / @frames.to_f
+      @sat += (@tsat - @sat) / @frames.to_f
       @frames -= 1
       return unless @frames.zero?
       @r = @tr; @g = @tg; @b = @tb; @sat = @tsat # land exactly on the target

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -951,6 +951,27 @@ check 'Screen tint with non-divisible steps still lands exactly' do
   ok !s.tinting?
 end
 
+check "Screen tint interpolates in float precision, not by feeding the previous " \
+      "frame's truncated integer back in, matching RPG_RT (2026-08-18)" do
+  # EasyRPG's Game_Screen::UpdateScreenEffects (src/game_screen.cpp)
+  # interpolates the tint in a double (tint_current_red et al. -- confirmed
+  # against liblcf's own generated SaveScreen struct, where those four
+  # fields are double while tint_finish_* stays int32_t) across every frame,
+  # via interpolate(d, x0, x1) = (x0*(d-1) + x1) / d, and only ever
+  # truncates to a whole number where the tint is actually consumed. #update
+  # used to feed the *already-truncated* Integer @r back into the next
+  # call's `(target - cur) / @frames` (plain integer division), compounding
+  # the rounding error frame over frame instead of resetting each time --
+  # the same bug already fixed for Game::Picture#step.
+  s = Game::Screen.new
+  s.tint_to(0, 100, 100, 100, 7) # red 100 -> 0 over 7 frames
+  seen = []
+  7.times { s.update; seen.push(s.tint[0]) }
+  eq [85, 71, 57, 42, 28, 14, 0], seen,
+     "RPG_RT's real per-frame sequence -- the pre-fix code produced [85, 70, 56, 42, 28, 14, 0] instead"
+  ok !s.tinting?
+end
+
 check 'Screen tint with zero duration applies immediately' do
   s = Game::Screen.new
   s.tint_to(0, 50, 200, 100, 0)


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Screen::UpdateScreenEffects` (verified against RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched live: `src/game_screen.cpp`) interpolates the tint via `interpolate(d, x0, x1) = (x0*(d-1) + x1) / d` — algebraically `x0 + (x1-x0)/d` — and confirmed against liblcf's own generated `SaveScreen` struct rather than assumed from the formula alone: `tint_current_red`/`green`/`blue`/`sat` are `double`, while `tint_finish_red`/`green`/`blue`/`sat` (the targets) stay `int32_t`. The running value is genuinely float-precision internally and only ever truncated where the tint is actually consumed (building the render `Tone`).

`Game::Screen#update_tint` (`mruby-rpg2k/mrblib/game.rb`) instead computed `@r += (@tr - @r) / @frames` with plain Integer division and wrote the truncated result straight back into `@r`/`@g`/`@b`/`@sat`, which the next frame's own call then read back as its own starting point — the same "feed the previous frame's already-truncated value back into the next frame's own division" bug already fixed for `Game::Picture#step`, just never applied here.

A tint from red 100 to 0 over 7 frames is the smallest clean repro: the old per-frame sequence was `85, 70, 56, 42, 28, 14, 0`; RPG_RT's real one is `85, 71, 57, 42, 28, 14, 0` — frames 2 and 3 land one channel unit higher, a real divergence in the value driving `Scene::Map`'s own darkening-overlay opacity during any non-power-of-two-length Tint Screen transition.

Fixed by dividing by `@frames.to_f` instead of the bare Integer (keeping `@r`/`@g`/`@b`/`@sat` as the full-precision running state, now `Float` mid-transition) and truncating only in `#tint`'s own reader (`@r.to_i`, etc.) — every other caller still only ever sees a plain `Integer`, unchanged.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check asserting the exact `85, 71, 57, 42, 28, 14, 0` per-frame sequence for the 100-to-0-over-7-frames example above.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1023 checks passed (1 new)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 749 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` / `rpg2k3_battle_row_check.rb` — unaffected, both green
- [x] New check confirmed to fail against the pre-fix code (`git stash` of the source file — produced `85, 70, 56, 42, 28, 14, 0`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_