### PR TITLE
actor: a weapon's own 0% hit rate is no longer treated as unequipped, matching RPG_RT

### DIFF
--- a/changelog.d/attack-hit-rate-zero-hit-weapon.fixed.md
+++ b/changelog.d/attack-hit-rate-zero-hit-weapon.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2000/2003 battles:** A weapon whose own hit rate is a deliberate 0%
+  now actually gives its wielder a 0% basic-attack hit rate, matching
+  RPG_RT's own `INT_MIN` "nothing equipped" sentinel. Previously a
+  "cursed" weapon like this was silently treated as if no weapon were
+  equipped at all, handing its wielder the 90% unarmed default instead of
+  the intended chance to always miss. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9725,6 +9725,29 @@ not yet verified:
   28, 14, 0` per-frame sequence for the 100-to-0-over-7-frames example
   above, confirmed to fail against the pre-fix code (it produced `85, 70,
   56, 42, 28, 14, 0` instead) before the fix.
+- ✅ **A weapon's own genuine 0% hit rate is no longer folded into the
+  "nothing equipped" case and silently promoted to the 90% unarmed default
+  (2026-08-18).** `Game::Actor#attack_hit_rate` (`mruby-rpg2k/mrblib/
+  game.rb`) took the highest `hit` field among the actor's equipped weapons
+  and then wrote `best && best > 0 ? best : 90` — so a "cursed" weapon
+  whose own `hit` field is a deliberate, database-authored 0 (a real item a
+  project can build: a weapon that atk-boosts but genuinely never lands a
+  hit) got treated exactly like an *empty* weapon slot, silently handed the
+  90% unarmed default instead of its own intended 0%. Verified against
+  RPG_RT's actual behavior via EasyRPG Player's own C++ source, fetched
+  live: `Game_Actor::GetHitChance` (`src/game_actor.cpp`) folds every
+  equipped weapon's `hit` field through `hit = std::max(hit, item.hit)`
+  starting from `hit = INT_MIN`, then `if (hit != INT_MIN) return hit;` —
+  RPG_RT uses `INT_MIN` itself as the "nothing equipped" sentinel, not `<=
+  0`, so a real weapon whose `hit` happens to be exactly 0 is returned
+  as-is; only a truly empty weapon slot (no weapon ever raised `hit` above
+  `INT_MIN`) falls through to the unarmed default. Fixed by tracking `best`
+  as `nil` when unset instead of comparing it against 0, and returning `90`
+  only when `best.nil?` — a found weapon's own hit rate, zero included, now
+  passes straight through. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (a single weapon with `hit: 0` equipped, asserting `attack_hit_rate
+  == 0`), confirmed to fail against the pre-fix code (it returned `90`
+  instead) before the fix.
 - ✅ **50 concurrent picture slots; higher id always draws on top,
   independent of show order — confirmed already correct.**
   `Scene::Map#draw_pictures` composites `@state.pictures.keys.sort`, so the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2133,7 +2133,15 @@ module Game
     # The actor's basic-attack base hit rate (percent): the highest `hit` among
     # the equipped weapons (item field 17), or the RPG2000 unarmed default of 90
     # when nothing is equipped or the row omits it. Feeds the battle's to-hit
-    # roll (EasyRPG's Game_Actor::GetHitChance).
+    # roll. Confirmed against EasyRPG Player's actual C++ source rather than
+    # assumed: `Game_Actor::GetHitChance` (`src/game_actor.cpp`) uses `INT_MIN`
+    # as its own "nothing equipped" sentinel (`hit = std::max(hit, item.hit)`,
+    # `if (hit != INT_MIN) return hit;`), so an equipped weapon whose own `hit`
+    # field is a genuine 0 -- a real, intentional "never lands a hit" item, not
+    # a missing field -- is returned as-is; only a truly empty weapon slot falls
+    # back to 90. A prior version of this method instead folded that
+    # found-but-zero case into the nothing-found one (`best && best > 0 ? best
+    # : 90`), silently treating a 0%-hit weapon as if it were unequipped.
     def attack_hit_rate
       best = nil
       if @db.respond_to?(:item)
@@ -2145,7 +2153,7 @@ module Game
           best = h if h && (best.nil? || h > best)
         end
       end
-      best && best > 0 ? best : 90
+      best.nil? ? 90 : best
     end
 
     # The battle animation a basic Attack plays with this actor's current gear:

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -17542,6 +17542,26 @@ check 'equipping a second weapon from the bag lands it in the shield slot' do
   eq 2, hero.strike_count, 'two ordinary weapons still add up to two swings'
 end
 
+check 'a weapon with its own genuine 0% hit rate is used as-is, not treated ' \
+      'as unequipped' do
+  # Confirmed against EasyRPG's actual C++ source: Game_Actor::GetHitChance
+  # (src/game_actor.cpp) uses INT_MIN as its own "nothing equipped" sentinel
+  # (`hit = std::max(hit, item.hit)`, `if (hit != INT_MIN) return hit;`), so
+  # a "cursed" weapon whose own `hit` field is a genuine 0 -- intentionally
+  # unable to land a hit, not a missing field -- is returned as 0, not
+  # folded into the "nothing found" case and defaulted back up to 90.
+  items = { 1 => fake_item(type: 1, atk: 5, hit: 0) } # a cursed blade
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 8 })
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  ok st.party.equip_from_bag(hero, 1, Game::Actor::WEAPON_SLOT)
+  eq 0, hero.attack_hit_rate, 'the weapon\'s own 0% hit rate, not the 90% ' \
+     'unarmed default'
+end
+
 check 'a single weapon (no second hand filled) still swings once unless it is ' \
       'itself 二刀流' do
   st = double_hand_party


### PR DESCRIPTION
## Summary
- `Game::Actor#attack_hit_rate` took the best `hit` field among equipped weapons and wrote `best && best > 0 ? best : 90`, so a weapon with a deliberate, database-authored `hit: 0` was folded into the "nothing equipped" case and silently promoted to the 90% unarmed default.
- RPG_RT's `Game_Actor::GetHitChance` (`src/game_actor.cpp`, verified live against EasyRPG Player's C++ source) uses `INT_MIN` as its own "nothing equipped" sentinel (`hit = std::max(hit, item.hit)`, `if (hit != INT_MIN) return hit;`) — a real weapon whose `hit` field happens to be exactly 0 is returned as-is; only a truly empty weapon slot falls back to 90.
- Fixed by tracking `best` as `nil` when unset and returning 90 only when `best.nil?`, so a found weapon's own hit rate — zero included — now passes straight through.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a single weapon equipped with `hit: 0` asserts `attack_hit_rate == 0`.
- [x] Confirmed the new check fails against pre-fix code (`git stash`) — it returned 90 instead of 0.
- [x] Full suite green post-fix: `ruby scripts/rpg2k_logic_check.rb` — 1024/1024 checks passed, no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_