### PR TITLE
party: a use_skill item's own menu usability now checks scope only, matching RPG_RT's IsItemUsable

### DIFF
--- a/changelog.d/use-skill-item-usability-scope-only.fixed.md
+++ b/changelog.d/use-skill-item-usability-scope-only.fixed.md
@@ -1,0 +1,10 @@
+- **RPG2000/2003 items:** An item flagged "use skill" (invokes a skill
+  directly from the Item menu instead of being equipped) is now listed as
+  usable purely by its skill's scope, matching RPG_RT's own quirky
+  shortcut for such items. Previously a stat-buff-only skill (no HP/SP/state
+  effect) behind such an item was silently hidden from both the field and
+  battle Item menus, and an Escape/Teleport-invoking one was wrongly
+  withheld from the menu until escape/teleport access and a destination
+  existed — RPG_RT actually lists it immediately and only fails the cast
+  itself if access/target aren't ready yet. Covered by corrected and new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3272,6 +3272,49 @@ The work below is roughly ordered by the critical path to a walkable game
    only once the action lands, and leaves the caster's own MP untouched),
    confirmed to fail against the pre-fix code (asserting `:target`,
    getting `:ally_target`) before the fix.
+   ✅ **A `use_skill` equipment item's own menu-*usability* check was still
+   routed through the full skill-usability test a type-9 Special item gets,
+   instead of RPG_RT's own separate, much looser `use_skill` shortcut — so
+   a stat-buff-only skill (no HP/SP/state effect) behind such an item was
+   silently hidden from both menus, and an Escape/Teleport-invoking one was
+   wrongly gated on access/target *before* it even appeared in the list
+   (2026-08-18).** The `use_skill` fix above wired `#field_usable?`/
+   `#battle_usable?`'s equipment-type branch to `#field_skill?`/
+   `#battle_skill?` — "the same shape a type-9 special item already gets
+   here" — reusing that precedent without separately checking it against
+   real RPG_RT's own *usability* function. Confirmed against EasyRPG
+   Player's real source, fetched live: `Game_Party::IsItemUsable`
+   (`src/game_party.cpp`) tests `item->use_skill` **before** its own
+   `switch (item->type)` at all — a completely different, self-contained
+   branch from the one a type-9 Special item takes (`Type_special` calls
+   `Algo::IsSkillUsable`, further down in the same switch, which *is* what
+   `#field_skill?`/`#battle_skill?` already correctly mirror) — and its own
+   comment names the difference outright: `// RPG_RT BUG: Does not check if
+   skill is usable`, followed by `return skill && (in_battle ||
+   scope == Scope_self || scope == Scope_ally || scope == Scope_party);`.
+   No `affect_hp`/`affect_sp`/inflicted-state requirement at all (unlike
+   `Algo::IsSkillUsable`), and no Escape/Teleport-specific access-or-target
+   check either (unlike `Game_Party::IsSkillUsable`, the *ordinary* Skill-menu
+   usability test, itself a third, distinct function) — RPG_RT lists a
+   `use_skill` item as soon as its skill's scope is self/ally/party (or
+   unconditionally in battle), full stop; only the actual *cast* — a
+   separate step this codebase's `#cast_escape_skill`/`#cast_teleport_skill`
+   already independently gate on `#escape_skill_available?`/
+   `#teleport_skill_available?`, unchanged by this fix — can still fail if
+   access or a target isn't there yet. Fixed by adding a new
+   `Game::Party#use_skill_item_usable?(it, in_battle)` implementing that
+   literal `skill && (in_battle || scope >= 2)` test, checked first in both
+   `#field_usable?`/`#battle_usable?` (ahead of their `case it.type`, so it
+   applies regardless of type exactly like RPG_RT's own ordering, though in
+   practice the RPG2000/2003 editor only exposes the `use_skill` checkbox
+   for the five equipment types). Covered by rewriting the two existing
+   `scripts/rpg2k_logic_check.rb` Escape/Teleport `use_skill` checks (which
+   had asserted the opposite — that access/target gated *listing*, not just
+   *casting* — reusing `#field_skill?`'s general Escape/Teleport handling
+   without having checked this specific branch of `IsItemUsable` against the
+   real source) and a new check for a pure `affect_attack`-only "Battle
+   Horn" accessory, all three confirmed to fail against the pre-fix code.
+   See `changelog.d/use-skill-item-usability-scope-only.fixed.md`.
 - ✅ Save & Continue — the portable `Marshal` save of the game state
   (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
   menu's Save command; "Continue" reloads it. (One research question remains: a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3778,14 +3778,38 @@ module Game
         return false
       end
       return false unless item_count(id) > 0
+      return use_skill_item_usable?(it, false) if it.use_skill
       case it.type
       when ITEM_MEDICINE, ITEM_SKILL_BOOK, ITEM_SEED then true
       when ITEM_SWITCH then item_field_occasion?(it)
       when ITEM_SPECIAL then field_skill?(db_skill(it.skill_id), state)
-      when Actor::ITEM_WEAPON, ITEM_SHIELD, ITEM_ARMOR, ITEM_HELMET, ITEM_ACCESSORY
-        it.use_skill && field_skill?(db_skill(it.skill_id), state)
       else false
       end
+    end
+
+    # RPG_RT's own extra usability gate an item flagged `use_skill` (field
+    # 71) gets, checked *before* any of the item's own type-specific
+    # occasion rules apply -- and a much looser test than the ordinary
+    # #field_skill?/#battle_skill? usability check a type-9 Special item
+    # goes through: no affect_hp / affect_sp / inflicted-state requirement
+    # at all, just the invoked skill's scope. Confirmed against EasyRPG's
+    # actual C++ source, fetched live: `Game_Party::IsItemUsable`
+    # (`src/game_party.cpp`) tests `item->use_skill` *ahead of* its own
+    # `switch (item->type)` -- its own comment even flags the result as
+    # "RPG_RT BUG: Does not check if skill is usable" -- returning `skill &&
+    # (in_battle || scope == Scope_self || scope == Scope_ally || scope ==
+    # Scope_party)` (liblcf's `Scope_self`/`_ally`/`_party` are `2`/`3`/`4`,
+    # i.e. `scope >= 2`). #field_usable?/#battle_usable? used to instead
+    # route a use_skill equipment item through the same full usability check
+    # a type-9 Special item gets, silently hiding a use_skill item whose
+    # invoked skill only modifies stats (no HP/SP/state effect at all) even
+    # though real RPG_RT offers it. `UseItem`'s own *effect*-dispatch flag
+    # (`do_skill`, this codebase's #skill_invoking_item?/#use_item) is a
+    # separate, correctly-already-five-types-restricted check -- only this
+    # *usability* gate is type-unrestricted in RPG_RT.
+    def use_skill_item_usable?(it, in_battle)
+      sk = db_skill(it.skill_id)
+      sk && (in_battle || sk.scope >= 2)
     end
 
     # An item's occasion flags, read by the **field name the format actually
@@ -5283,12 +5307,11 @@ module Game
         return false
       end
       return false unless item_count(id) > 0
+      return use_skill_item_usable?(it, true) if it.use_skill
       case it.type
       when ITEM_MEDICINE then !item_field_only?(it)
       when ITEM_SWITCH then item_battle_occasion?(it)
       when ITEM_SPECIAL then battle_skill?(db_skill(it.skill_id))
-      when Actor::ITEM_WEAPON, ITEM_SHIELD, ITEM_ARMOR, ITEM_HELMET, ITEM_ACCESSORY
-        it.use_skill && battle_skill?(db_skill(it.skill_id))
       else false
       end
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6363,24 +6363,32 @@ check 'a special item invoking a Teleport skill offers every registered ' \
   eq 1, st.party.item_count(4), 'an unregistered destination consumes nothing'
 end
 
-check 'a use_skill equipment item invoking an Escape skill warps for free like a ' \
-      'special item, and a plain weapon does not' do
-  # #use_special_escape_item used to reject anything whose type was not 9
-  # (ITEM_SPECIAL), so an equipment item flagged `use_skill` (field 71) invoking
-  # an Escape skill could never warp through it -- the identical gap the field
-  # Item menu's #choose_item used to have for such an item. The guard now also
-  # admits a use_skill equipment item (types 1..5), matching #use_equip_skill_item.
+check 'a use_skill equipment item invoking an Escape skill is menu-usable purely by ' \
+      "scope, matching real RPG_RT's own use_skill shortcut -- access/target only " \
+      'gate the cast itself, and a plain weapon is never treated as one' do
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_Party::IsItemUsable` (src/game_party.cpp) checks `item->use_skill`
+  # *before* its own `switch (item->type)`, and its own comment flags the
+  # result as "RPG_RT BUG: Does not check if skill is usable" -- `skill &&
+  # (in_battle || scope == Scope_self/_ally/_party)`, nothing about escape
+  # access or a registered target at all; those only gate the actual warp
+  # (`#cast_escape_skill`'s own `#escape_skill_available?`, unchanged here).
+  # A prior version of this test asserted the opposite -- that #field_usable?
+  # itself withheld the item until access/target existed -- reusing
+  # #field_skill?'s general Escape-type handling without checking this
+  # use_skill-specific branch of IsItemUsable against the real source.
   skills = { 6 => fake_skill(name: 'Blade Escape',
                              type: Game::Party::SKILL_ESCAPE, sp_cost: 4) }
   items = { 3 => fake_item(type: 1, skill_id: 6, use_skill: true, name: 'Escape Blade') }
   st = skill_party(skills, items)
   hero = st.party.actor_by_id(1)
   st.party.gain_item(3, 2)
-  ok !st.party.field_usable?(3, st), 'no access/target yet'
+  ok st.party.field_usable?(3, st), 'listed by scope alone, before access/target exist at all'
+  ok st.party.use_special_escape_item(3, hero, st).nil?, 'the cast itself still needs access'
   st.escape_access = true
-  ok !st.party.field_usable?(3, st), 'access alone is not enough -- no target yet'
-  st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
   ok st.party.field_usable?(3, st)
+  ok st.party.use_special_escape_item(3, hero, st).nil?, 'access alone is not enough -- no target yet'
+  st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
   before = hero.mp
   eq({ map_id: 3, x: 4, y: 5, switch_id: nil }, st.party.use_special_escape_item(3, hero, st))
   eq before, hero.mp, 'free -- the item pays, not the caster'
@@ -6395,23 +6403,46 @@ check 'a use_skill equipment item invoking an Escape skill warps for free like a
      'and is not cast as an escape item'
 end
 
-check 'a use_skill equipment item invoking a Teleport skill warps for free like a ' \
-      'special item' do
+check 'a use_skill equipment item invoking a Teleport skill is menu-usable purely by ' \
+      'scope, matching real RPG_RT -- destinations only gate the cast itself' do
   skills = { 7 => fake_skill(name: 'Blade Teleport',
                              type: Game::Party::SKILL_TELEPORT, sp_cost: 3) }
   items = { 4 => fake_item(type: 1, skill_id: 7, use_skill: true, name: 'Warp Blade') }
   st = skill_party(skills, items)
   hero = st.party.actor_by_id(1)
   st.party.gain_item(4, 1)
-  ok !st.party.field_usable?(4, st), 'no destinations registered yet'
+  ok st.party.field_usable?(4, st), 'listed by scope alone, before any destination is registered'
+  ok st.party.use_special_teleport_item(4, hero, st, 5).nil?, 'the cast itself still needs a destination'
   st.teleport_access = true
   st.teleport_targets[10] = { x: 1, y: 2, switch_id: nil }
   st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
-  ok st.party.field_usable?(4, st), 'access plus any target offers it'
+  ok st.party.field_usable?(4, st)
   before = hero.mp
   eq({ map_id: 5, x: 8, y: 9, switch_id: nil }, st.party.use_special_teleport_item(4, hero, st, 5))
   eq before, hero.mp, 'free -- no SP spent for an item cast'
   eq 1, st.party.item_count(4), 'equipment is not consumed -- a reusable tool'
+end
+
+check 'a use_skill equipment item invoking a pure stat-buff skill (no HP/SP/state ' \
+      'effect at all) is still menu-usable, not silently hidden' do
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_Party::IsItemUsable` (src/game_party.cpp) checks `item->use_skill`
+  # *before* its own `switch (item->type)`, returning `skill && (in_battle
+  # || scope == Scope_self/_ally/_party)` -- nothing about affect_hp /
+  # affect_sp / an inflicted state at all, unlike the full usability check a
+  # type-9 Special item goes through (`Algo::IsSkillUsable`, which does
+  # require one of those). #field_usable?/#battle_usable? used to route a
+  # use_skill equipment item through that same full check (reused from the
+  # Special-item precedent, never verified against IsItemUsable's own
+  # separate use_skill branch), so a "Battle Horn"-style accessory whose
+  # skill only raises ATK (affect_attack, no affect_hp/sp, no state) was
+  # silently excluded from both menus even though real RPG_RT offers it.
+  skills = { 8 => fake_skill(name: 'War Horn', scope: 3, affect_attack: true) }
+  items = { 9 => fake_item(type: 5, skill_id: 8, use_skill: true, name: 'War Horn') }
+  st = skill_party(skills, items)
+  st.party.gain_item(9, 1)
+  ok st.party.field_usable?(9, st), 'a pure stat buff is menu-usable in the field too'
+  ok st.party.battle_usable?(9), 'and from the battle Item menu'
 end
 
 check 'a field heal skill restores HP by the RPG2000 formula and spends SP' do


### PR DESCRIPTION
## Summary
- `Game::Party#field_usable?`/`#battle_usable?`'s `use_skill` equipment-item branch reused the same full skill-usability check (`#field_skill?`/`#battle_skill?`) a type-9 Special item goes through — a precedent borrowed from an earlier fix, never separately verified against RPG_RT's actual *usability* function.
- RPG_RT's `Game_Party::IsItemUsable` (`src/game_party.cpp`, verified live against EasyRPG Player's C++ source) tests `item->use_skill` in its own branch **before** the `switch (item->type)` — a completely separate, much looser test than `Algo::IsSkillUsable` (what a Special item gets): `skill && (in_battle || scope == Scope_self/_ally/_party)`, with the source's own comment calling this out: `// RPG_RT BUG: Does not check if skill is usable`.
- Concretely, this meant: (1) a `use_skill` item invoking a pure stat-buff skill (no HP/SP/state effect) was silently hidden from both menus, though real RPG_RT lists it; (2) a `use_skill` item invoking an Escape/Teleport skill was wrongly withheld from the menu until escape/teleport access and a destination existed — RPG_RT lists it immediately by scope alone and only fails the *cast* if access/target aren't ready.
- Fixed by adding `Game::Party#use_skill_item_usable?(it, in_battle)`, the literal `skill && (in_battle || scope >= 2)` test, checked first in both `#field_usable?`/`#battle_usable?` ahead of the type switch. The actual cast path (`#cast_escape_skill`/`#cast_teleport_skill`'s own access/target gates) is unchanged.

## Test plan
- [x] Rewrote the two existing `scripts/rpg2k_logic_check.rb` Escape/Teleport `use_skill` item checks, which had asserted the opposite (that access/target gated the *listing*, not just the *cast*) — corrected against `IsItemUsable`'s real source.
- [x] Added a new check: a `use_skill` accessory invoking a pure `affect_attack`-only skill is menu-usable in both field and battle.
- [x] All three confirmed to fail against the pre-fix code (`git stash`).
- [x] Full suite green post-fix: 1025/1025 logic checks, 749 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_