### PR TITLE
battle: an enemy Transform now flashes near-white, matching RPG_RT

### DIFF
--- a/changelog.d/transform-flash-cue.fixed.md
+++ b/changelog.d/transform-flash-cue.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2000/2003 battles:** An enemy Transformation action now flashes the
+  monster near-white the instant its sprite swaps to the new form,
+  matching RPG_RT's own visual cue. Previously the graphic swap happened
+  as a silent instant cut with no flash at all. Covered by an extended
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7553,6 +7553,32 @@ not yet verified:
   transforming a 950-HP/40-SP monster into a 100-max-HP/10-max-SP form and
   asserting both current values survive exactly, confirmed to fail against
   the pre-fix code (`expected 950, got 100`) before the fix.
+  ✅ **The same Transform action was also missing RPG_RT's own visual cue
+  for it — a near-white flash the instant the sprite swaps to the new form
+  (2026-08-18).** The bullet above already quotes `Game_BattleAlgorithm::
+  Transform::ApplyCustomEffect` (`src/game_battlealgorithm.cpp`) for its
+  HP/SP-clamp behaviour, but that citation stopped one line short: the real
+  function is `enemy->Transform(new_monster_id); enemy->Flash(31,31,31,31,
+  20);` — confirmed against EasyRPG's actual C++ source, fetched live —
+  and `Game_Battler::Flash` (`src/game_battler.cpp`) just stores those five
+  numbers verbatim (`flash.red`/`green`/`blue`/`current_level`/`time_left`)
+  for the renderer to fade out over the next 20 frames. `Scene::Battle
+  #rebuild_battler_sprite` (`mruby-rpg2k/mrblib/scene/battle.rb`) — the only
+  place a transformed combatant's sprite is ever rebuilt, called from
+  `#refresh_battle_sprites` precisely when `battler_name`/`hue` change,
+  which its own comment already documents as "this method's only signal
+  that a Transform ran" — swapped in the new graphic with no flash at all,
+  so every Transform played as a silent instant cut instead of RPG_RT's
+  recognisable flash-of-light. Fixed by calling the native RGSS `Sprite
+  #flash` primitive (already ported and used for Battle Animation target
+  flashes, `#fire_target_flash` a little further down the same file) right
+  after building the new sprite, with `Color.new(31 * 8, 31 * 8, 31 * 8,
+  31 * 8)` for 20 frames — the same 0..31-to-0..255 scale
+  `Interpreter::FLASH_SCALE`/`#fire_target_flash` already apply elsewhere.
+  Covered by extending the existing "a transformed monster is redrawn"
+  `scripts/rpg2k_scene_check.rb` check with an assertion on the rebuilt
+  sprite's own `flash_color`, confirmed to fail against the pre-fix code
+  (no flash armed at all) before the fix.
 - ✅ **A KO'd party member no longer earns EXP from a battle victory.**
   Confirmed against EasyRPG's actual C++ source: `Scene_Battle_Rpg2k
   ::ProcessSceneActionVictory` (`src/scene_battle_rpg2k.cpp`) grants the

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1008,6 +1008,22 @@ class RPG2k
 
       # Redraw troop slot `i` with `foe`'s current battler graphic, keeping its
       # place and depth, and release the sprite and bitmap the old one held.
+      #
+      # This is only ever reached for an actual Transform (see
+      # #refresh_battle_sprites' own comment: a battler_name/hue change is
+      # its one signal that one ran), so the near-white flash RPG_RT itself
+      # plays at the moment of the swap belongs here too. Confirmed against
+      # EasyRPG's actual C++ source, fetched live:
+      # `Game_BattleAlgorithm::Transform::ApplyCustomEffect`
+      # (`src/game_battlealgorithm.cpp`) calls `enemy->Transform(new_id);
+      # enemy->Flash(31,31,31,31,20);` right after the swap, unconditionally
+      # -- this codebase's own prior fix for this same method (see the
+      # `#enemy_transform_action` doc comment) quoted `ApplyCustomEffect`
+      # for its HP/SP-clamp behaviour but stopped short of this second line,
+      # so the swap itself has always been a silent instant cut rather than
+      # RPG_RT's recognisable flash-of-light cue. Scaled by the same 0..31
+      # to 0..255 convention `Interpreter::FLASH_SCALE`/#fire_target_flash
+      # already use for a raw RGSS `Color`.
       def rebuild_battler_sprite(i, foe)
         sprites = @ui[:enemy_sprites]
         member = @ui[:troop].members[i]
@@ -1021,6 +1037,7 @@ class RPG2k
         spr.z = battler_z(i)
         spr.opacity = battler_opacity(member)
         spr.visible = !foe.out_of_play?
+        spr.flash(Color.new(31 * 8, 31 * 8, 31 * 8, 31 * 8), 20)
         sprites[i] = spr
         dispose_battle_sprite(old)
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18299,6 +18299,18 @@ check 'a transformed monster is redrawn with its new battler graphic' do
   ok !ui[:enemy_sprites][0].equal?(before), 'its sprite is rebuilt'
   eq 'Dragon', ui[:sprite_names][0], 'and tracked against the new battler'
   ok ui[:enemy_sprites][0].visible, 'still on the field'
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_BattleAlgorithm::Transform::ApplyCustomEffect`
+  # (src/game_battlealgorithm.cpp) calls `enemy->Flash(31,31,31,31,20)`
+  # unconditionally right after the swap -- the near-white "flash of
+  # light" every RPG_RT transformation shows, on the 0..31 raw scale this
+  # codebase already multiplies by 8 elsewhere (Interpreter::FLASH_SCALE).
+  new_spr = ui[:enemy_sprites][0]
+  ok new_spr.flash_color, 'the transform flashes the new sprite'
+  eq [248, 248, 248, 248],
+     [new_spr.flash_color.red, new_spr.flash_color.green,
+      new_spr.flash_color.blue, new_spr.flash_color.alpha],
+     'near-white, matching Flash(31,31,31,31,...) scaled by 8'
   # A second refresh with nothing changed must not churn the sprite again.
   same = ui[:enemy_sprites][0]
   scene.instance_variable_get(:@battle).send(:refresh_battle_sprites)


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_BattleAlgorithm::Transform::ApplyCustomEffect` (`src/game_battlealgorithm.cpp`, verified live against EasyRPG Player's C++ source) calls `enemy->Transform(new_monster_id); enemy->Flash(31,31,31,31,20);` right after the monster's data row is swapped — a near-white flash for 20 frames, on the same 0..31 raw scale this codebase already applies elsewhere (`Interpreter::FLASH_SCALE`).
- `Scene::Battle#rebuild_battler_sprite` (`mruby-rpg2k/mrblib/scene/battle.rb`) is the only place a transformed combatant's sprite is ever rebuilt (`#refresh_battle_sprites`'s own comment already documents a `battler_name`/`hue` change as "this method's only signal that a Transform ran"), but it never called the native RGSS `Sprite#flash` primitive already ported and used elsewhere for Battle Animation target flashes — so every Transform played as a silent instant graphic swap instead of RPG_RT's recognisable flash-of-light cue.
- This codebase's own earlier fix for this same method (`docs/TODO.md`, the HP/SP-clamp fix) already quoted `ApplyCustomEffect` verbatim but its citation stopped one line short of the `Flash` call — a missed wiring rather than an unported feature.
- Fixed by calling `spr.flash(Color.new(31 * 8, 31 * 8, 31 * 8, 31 * 8), 20)` right after building the new sprite.

## Test plan
- [x] Extended the existing "a transformed monster is redrawn with its new battler graphic" `scripts/rpg2k_scene_check.rb` check with an assertion on the rebuilt sprite's `flash_color`.
- [x] Confirmed the new assertion fails against the pre-fix code (`git stash`) — no flash armed at all.
- [x] Full suite green post-fix: 749/749 scene checks, 1025 logic, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_