### PR TITLE
actor: RPG2003 cursed starting equipment now inflicts its state at spawn, matching RPG_RT

### DIFF
--- a/changelog.d/cursed-starting-equipment.fixed.md
+++ b/changelog.d/cursed-starting-equipment.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003 actors:** An actor whose *starting* shield/armor/helmet/
+  accessory is flagged "cursed" (forces a status condition while worn) now
+  begins the game already afflicted, matching RPG_RT. Previously the
+  forced state only applied once the item was equipped through the equip
+  menu or a Change Equipment command — starting gear carrying the flag had
+  no effect until manually unequipped and re-equipped. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8695,6 +8695,41 @@ not yet verified:
   `#clear_states`/Full Recovery leaves the forced state in place, and a
   curative medicine item can't touch it either — all three confirmed to
   fail against the pre-fix code before the fix.
+  ✅ **RPG2003 cursed armor set as an actor's own *starting* equipment
+  never inflicted its forced state at all — only equipping the exact same
+  item later, through the equip menu or a Change Equipment command,
+  reached `#adjust_equipment_states` (2026-08-18).** Both fixes above
+  correctly wired `#equip_item`/`#unequip`/`#equip`, but `Actor#initialize`
+  (`mruby-rpg2k/mrblib/game.rb`) sets `@equipment`/`@states` directly from
+  the database row and never calls any of them, so a hero whose starting
+  shield/armor/helmet/accessory in Database > Actors already carries the
+  Curse flag booted up with the item worn but the state simply absent —
+  `#permanent_states` would correctly refuse to let it be cured, but there
+  was nothing to cure in the first place. Confirmed against EasyRPG's
+  actual C++ source, fetched live: `Game_Actor::Game_Actor(int actor_id)`
+  (`src/game_actor.cpp`) calls `SetEquipment(i + 1, ids[i])` for every one
+  of the five initial-equipment slots at construction — the exact same
+  function, and so the exact same `AdjustEquipmentStates` call, an ordinary
+  mid-game equip change goes through; RPG_RT does not special-case the
+  starting loadout at all. A "cursed berserker" or "anti-hero with a
+  drawback" starting-gear design — an intentional, editor-supported
+  RPG2003 pattern — silently lost its entire hook under this gap, and it
+  only self-healed the moment the item was manually taken off and put back
+  on (which does go through `#unequip`/`#equip` correctly). Fixed by
+  calling `@equipment.each { |id| adjust_equipment_states(id, true) }` at
+  the end of `#initialize`, placed after HP/MP are already set to their
+  max — matching `Game_Actor::Game_Actor`'s own ordering (`SetHp`/`SetSp`
+  precede the equip loop there), so a maximally cursed starting item whose
+  `state_set` includes the Death state itself still leaves the actor at 0
+  HP rather than having that overwritten back to full by a later
+  full-heal-on-spawn step. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (a fresh actor constructed with cursed armor already in its
+  `initial_equipment` starts with the forced state already present, and
+  can still be cured normally by taking the armor back off after), using a
+  new `InitialEquipmentRow` fixture (no existing fixture row exposed field
+  51 at all, so every prior actor fixture started unarmed regardless of
+  what a real database's `initial_equipment` might specify), confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1511,6 +1511,25 @@ module Game
       @exp = exp_for_level(@level) # EXP consistent with the starting level
       @hp = @max_hp
       @mp = @max_mp
+      # RPG2003 "cursed" starting gear (an item flagged Curse/
+      # reverse_state_effect with its own state_set) inflicts its forced
+      # states from the very first frame, not only once equipped through a
+      # later Equip command. Confirmed against EasyRPG's actual C++ source,
+      # fetched live: `Game_Actor::Game_Actor(int actor_id)`
+      # (src/game_actor.cpp) calls `SetEquipment(i + 1, ids[i])` for every
+      # one of the five initial-equipment slots -- the exact same function
+      # (and therefore the exact same `AdjustEquipmentStates` call) an
+      # ordinary mid-game equip change goes through -- so an actor whose
+      # starting shield/armor/helmet/accessory is cursed begins the game
+      # already afflicted, visible in the status window from turn one.
+      # #equip_item/#unequip/#equip below already call
+      # #adjust_equipment_states for every later change; only the
+      # constructor's own starting loadout skipped it. Placed after HP/MP
+      # are set to their max above, matching EasyRPG's own ordering
+      # (`SetHp`/`SetSp` precede the equip loop there), so a (deliberately
+      # extreme) cursed item whose state_set includes the Death state still
+      # leaves the actor at 0 HP rather than being overwritten back to full.
+      @equipment.each { |id| adjust_equipment_states(id, true) }
     end
 
     attr_writer :exp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3223,6 +3223,19 @@ class SkillRow < CurveRow
 
   def skills; FakeLearnTable.new(@learns); end
 end
+# Like FakePlayerRow but exposing the database's own starting loadout (field
+# 51, `initial_equipment`, an EQUIP_ORDER-shaped array of up to five item
+# ids) -- an ordinary FakePlayerRow has no such field at all, so
+# Actor#initialize's `a.respond_to?(:initial_equipment)` guard always reads
+# false for one and every existing fixture actor starts unarmed and unworn.
+class InitialEquipmentRow < FakePlayerRow
+  def initialize(name, cs, ci, level, status, equip)
+    super(name, cs, ci, level, status)
+    @equip = equip
+  end
+
+  def initial_equipment; @equip; end
+end
 # `equipment_setting` mirrors System field 97 (Game::Party#equip_by_class?'s
 # own source) -- nil, the default, reads as "by Actor" the same way a
 # genuine database's own field default (0) does.
@@ -4303,6 +4316,29 @@ check 'equipping RPG2003 cursed armor inflicts its own states; unequipping cures
   eq [4], a.states, 'the state came on the instant it was worn'
   a.unequip(2) # armor slot
   eq [], a.states, 'and left the instant it came off'
+end
+
+check 'RPG2003 cursed armor set as *starting* gear inflicts its state from the ' \
+      'very first frame, not only once equipped through a later Equip command' do
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_Actor::Game_Actor(int actor_id)` (src/game_actor.cpp) calls
+  # `SetEquipment(i + 1, ids[i])` for every one of the five
+  # initial-equipment slots -- the exact same function (and so the exact
+  # same `AdjustEquipmentStates` call) an ordinary mid-game Equip command
+  # goes through -- so a hero whose *starting* armor/shield/helmet/
+  # accessory is cursed begins the game already afflicted, visible in the
+  # status window from turn one. #equip_item/#unequip/#equip already
+  # called #adjust_equipment_states for every later change; only
+  # Actor#initialize's own starting loadout skipped it.
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  row = InitialEquipmentRow.new('Hero', '', 0, 5, { max_hp: 100 },
+                                [0, 0, 20, 0, 0]) # weapon/shield/ARMOR/helmet/accessory
+  db = FakeActorDB.new({ 1 => row }, [1], items, rpg2003: true)
+  a = Game::Party.new(db).leader
+  eq 20, a.equipment[2], 'wearing the cursed armor from construction, not equipped after'
+  eq [4], a.states, 'already afflicted before any Equip command ever ran'
+  a.unequip(2) # armor slot
+  eq [], a.states, 'and can still be cured normally by taking the armor back off'
 end
 
 check 'cursed armor state infliction is RPG2003-only' do


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Actor::Game_Actor(int actor_id)` (`src/game_actor.cpp`, verified live against EasyRPG Player's C++ source) calls `SetEquipment(i + 1, ids[i])` for every one of the five initial-equipment slots at construction — the exact same function (and therefore the exact same `AdjustEquipmentStates` call) an ordinary mid-game equip change goes through. RPG_RT does not special-case the starting loadout.
- `Actor#initialize` (`mruby-rpg2k/mrblib/game.rb`) instead set `@equipment`/`@states` directly from the database row and never called `#adjust_equipment_states` — a gap distinct from the two already-fixed equip-mutation paths (`docs/TODO.md`'s earlier cursed-armor fixes), which correctly wired `#equip_item`/`#unequip`/`#equip` but never touched the constructor.
- Concretely: an actor whose starting shield/armor/helmet/accessory carries RPG2003's Curse flag (an intentional "cursed berserker"/"anti-hero with a drawback" design the editor fully supports) booted up wearing the item but not afflicted by its forced state — the bug only self-healed once the item was manually unequipped and re-equipped.
- Fixed by calling `@equipment.each { |id| adjust_equipment_states(id, true) }` at the end of `#initialize`, placed after HP/MP are set to their max — matching the real constructor's own ordering, so a (deliberately extreme) starting curse whose `state_set` includes the Death state still leaves the actor at 0 HP rather than being overwritten back to full by the later full-heal-on-spawn step.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a fresh actor constructed with cursed armor already in `initial_equipment` starts with the forced state already present, and can still be cured normally by taking the armor back off.
- [x] Added a new `InitialEquipmentRow` fixture — no existing fixture row exposed the database's `initial_equipment` field at all, so every prior actor fixture started unarmed regardless of what a real database might specify.
- [x] Confirmed the new check fails against the pre-fix code (`git stash`).
- [x] Full suite green post-fix: 1026/1026 logic checks, 749 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_