### PR TITLE
interpreter: battle Conditional Branch "can act" test drops its fabricated param(2) menu, matching RPG_RT

### DIFF
--- a/changelog.d/battle-conditional-branch-can-act.fixed.md
+++ b/changelog.d/battle-conditional-branch-can-act.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 battle events:** The Conditional Branch "Hero/Monster can act"
+  test now actually checks whether the named battler is asleep, paralysed,
+  or dead, matching RPG_RT. Previously the check invented a menu of
+  sub-tests the real command never has, and its default case ("is in the
+  party"/"is present") ignored the battler's status entirely — so a boss
+  AI page gated on "if Hero can act..." kept treating a slept or
+  paralysed party member as able to act. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12198,6 +12198,52 @@ not yet verified:
   (`command_restricted?` flags a do-nothing, a confused and a berserk ally,
   and clears an unafflicted one), all three confirmed to fail against the
   pre-fix code before the fix.
+  ✅ **The battle-event Conditional Branch's Actor/Enemy "can act" test
+  (13310, RPG2003) had invented an entire menu of `param(2)` sub-tests the
+  real command has no such thing (2026-08-18).** `Interpreter
+  #battle_actor_condition`/`#battle_enemy_condition`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) branched on `cmd.param(2)` as if
+  it selected among "is in the party" / "afflicted by a status" / "can use
+  a battle command" for an actor, or "is present" / "afflicted by a
+  status" for an enemy — and, worse, the `param(2) == 0` case ("is in the
+  party"/"is present") short-circuited straight to `true` without ever
+  consulting the do-nothing restriction. Confirmed against EasyRPG's
+  actual C++ source, fetched live: `Game_Interpreter_Battle::
+  CommandConditionalBranchBattle` (`src/game_interpreter_battle.cpp`)
+  reads only `com.parameters[1]` (the actor/enemy id) for its actor
+  (case 2) and enemy (case 3) branches — `result = actor->CanAct();` /
+  `result = enemy->CanAct();`, `Game_Battler::CanAct` (`src/game_battler.cpp`)
+  — `parameters[2]`/`[3]` are never touched. The real RPG2003 editor's
+  Actor/Enemy tab offers exactly one condition each ("Hero can act" /
+  "Monster can act"), not a menu, and always compiles to the same
+  `param(2)`; this codebase's own adjacent comment already stated the
+  correct behavior ("EasyRPG's actual actor case never sub-dispatches on a
+  second parameter at all") while the code directly below it did something
+  else entirely. Concretely: an ordinary boss-AI page gated on "if Hero
+  [X] can act, taunt them; else target someone else" kept treating a
+  slept/paralysed party member as able to act, since the party's real
+  param(2) value (whatever the editor always writes) almost never equalled
+  the one case (`3` for an actor, previously undocumented as arbitrary)
+  this codebase happened to wire up to the real do-nothing check. Fixed by
+  dropping the fabricated sub-dispatch entirely: both methods now always
+  compute the actor/enemy's own "can act" state regardless of `param(2)`.
+  A second, independent gap surfaced while fixing this: EasyRPG's own
+  `Game_Battler::ChangeHp` folds `AddState(kDeathID)` into every
+  HP-zeroing path, so a dead battler there always already carries the
+  Death state and `CanAct`'s do-nothing scan alone is enough — but this
+  port's own `Game::Battle#deal_attack` mutates a `Combatant`'s `hp`
+  directly (`target.hp -= dmg`) with no matching `#inflict_state(target,
+  DEATH_ID)` call, so `.states` is not a reliable death signal here the
+  way it safely is for `Game::Actor` (whose own `#add_state`/
+  `#remove_state` keep `DEATH_STATE` and `@hp` in sync — see `Actor#dead?`'s
+  identical belt-and-suspenders check). Both fixed methods therefore check
+  `#dead?` explicitly alongside the do-nothing scan rather than assuming a
+  states-only check subsumes it, closing that gap too. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks — a do-nothing-restricted ally/enemy
+  now correctly fails the test under `param(2) == 0` (the value the real
+  editor always emits), and a combatant killed by plain HP loss (no
+  explicit state ever inflicted) still fails it too — both confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ **"Hero X is in the party" always addresses by database ID, not
   current seat/slot order; there is no built-in way to read a member's
   current seat position — confirmed correct.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2619,16 +2619,24 @@ module Game
     # Conditional Branch (battle form, 13310). param0 selects the test:
     #   0 switch param1 is on (param2 == 0) / off
     #   1 variable param1 compared against param2/param3 by param4
-    #   2 actor param1 — sub-test param2: 0 in the party, 1 named param(?),
-    #     2 afflicted by state param3, 3 can use battle command param3
-    #   3 troop member param1 — sub-test param2: 0 present, 1 afflicted by
-    #     state param3
+    #   2 actor param1 can act
+    #   3 troop member param1 can act
     #   4 the currently-targeted troop member is param1
     #   5 actor param1's chosen command is param2
     # Tests 4 and 5 read live battle-UI state the runtime does not model; they
-    # report false rather than guessing, so the else branch runs. Actor
-    # sub-test 3 ("can use battle command") is implemented; sub-test 1
-    # ("named") is not -- see #battle_actor_condition for why.
+    # report false rather than guessing, so the else branch runs. Confirmed
+    # against EasyRPG's actual C++ source, fetched live:
+    # `Game_Interpreter_Battle::CommandConditionalBranchBattle`
+    # (`src/game_interpreter_battle.cpp`) reads only `com.parameters[1]` (the
+    # actor/enemy id) for cases 2 and 3 -- `result = actor->CanAct();` /
+    # `result = enemy->CanAct();` -- `parameters[2]`/`[3]` do not exist as
+    # far as this command is concerned; the editor's own Actor/Enemy tab
+    # offers a single "can act" condition, not a menu of sub-tests. A prior
+    # version of this codebase invented a `param(2)` sub-dispatch ("is in
+    # the party" / "afflicted by state" / "can use battle command" for an
+    # actor; "is present" / "afflicted by state" for an enemy) that has no
+    # counterpart in the real command at all -- see #battle_actor_condition
+    # for why.
     def do_conditional_battle(cmd)
       return if eval_battle_condition(cmd)
       skip_to([Cmd::ELSE_BRANCH_B, Cmd::END_BRANCH_B], cmd.indent)
@@ -2649,45 +2657,51 @@ module Game
       end
     end
 
-    # An actor sub-condition: is the actor in this fight, is it afflicted by
-    # the given status, and can it currently be handed a battle command?
+    # Whether actor `cmd.param(1)` can act right now -- true unless it is
+    # dead or carries a "do nothing" restriction (asleep / paralysed), and
+    # false if it is not even in this fight. Mirrors EasyRPG's
+    # `Game_Battler::CanAct` (via `Game_Interpreter_Battle::
+    # CommandConditionalBranchBattle`'s actor case, `result =
+    # actor->CanAct();`): a Berserk (attack_enemy) or Confusion (attack_ally)
+    # restriction does NOT fail this test -- such an ally still "can act",
+    # it just acts on a forced target instead of the chosen command, which
+    # is why this calls Game::Battle's do_nothing-only check rather than its
+    # broader #command_restricted? (which also flags Berserk/Confusion
+    # because it answers a different question: "does this ally get a normal
+    # command menu"). A prior version of this method branched on
+    # `cmd.param(2)` as if the real command offered a menu of sub-tests ("is
+    # in the party" / "afflicted by a status" / "can use a battle command")
+    # -- the real command has no such thing; RPG_RT's own editor Actor tab
+    # offers only this one condition, and the real C++ source never reads a
+    # second parameter for it at all.
     #
-    # Sub-test 3 mirrors EasyRPG's `Game_Battler::CanAct` (via
-    # `Game_Interpreter_Battle::CommandConditionalBranchBattle`'s actor case):
-    # true unless the ally carries a "do nothing" restriction (asleep /
-    # paralysed). A Berserk (attack_enemy) or Confusion (attack_ally)
-    # restriction does NOT fail this test -- such an ally still "can act", it
-    # just acts on a forced target instead of the chosen command, which is why
-    # this calls Game::Battle's do_nothing-only check rather than its broader
-    # #command_restricted? (which also flags Berserk/Confusion because it
-    # answers a different question: "does this ally get a normal command
-    # menu").
-    #
-    # Sub-test 1 ("named") has no real counterpart to implement: EasyRPG's
-    # actual actor case never sub-dispatches on a second parameter at all --
-    # it unconditionally resolves to CanAct() using only the actor id. There
-    # is no known "named" behavior to match, so it reports false.
+    # The explicit `!ally.dead?` term has no counterpart in EasyRPG's own
+    # `CanAct` -- there, `AddState(kDeathID)` is an inseparable side effect
+    # of every HP-zeroing path (`Game_Battler::ChangeHp`), so a dead battler
+    # always already carries the Death state and the do-nothing scan alone
+    # is enough. This port's own `Game::Battle#deal_attack` instead mutates
+    # a `Combatant`'s `hp` directly (`target.hp -= dmg`) without a matching
+    # `#inflict_state(target, DEATH_ID)` call, so `.states` is not a
+    # reliable death signal here the way it is for `Game::Actor` (whose own
+    # `#add_state`/`#remove_state` do keep `DEATH_STATE` and `@hp` in sync,
+    # see `Actor#dead?`'s identical belt-and-suspenders check) -- checking
+    # `#dead?` explicitly closes that gap rather than assuming it away.
     def battle_actor_condition(cmd)
       ally = @battle && @battle.ally_by_actor_id(cmd.param(1))
-      return false unless ally
-      case cmd.param(2)
-      when 0 then true                                  # is in the party
-      when 2 then ally.state?(cmd.param(3))              # is afflicted by a status
-      when 3 then !@battle.do_nothing_restricted?(ally)  # can use a battle command
-      else false
-      end
+      ally ? !ally.dead? && !@battle.do_nothing_restricted?(ally) : false
     end
 
-    # A troop-member sub-condition: is the member still standing, and is it
-    # afflicted by the given status?
+    # The troop-member analogue of #battle_actor_condition above: whether
+    # enemy `cmd.param(1)` can act right now, matching EasyRPG's
+    # `enemy->CanAct()` (same function, same `com.parameters[1]`-only
+    # signature) -- not, as a prior version of this method modelled it, a
+    # `cmd.param(2)`-selected choice between "is present" and "afflicted by
+    # a status". See #battle_actor_condition just above for why the
+    # `#dead?` term is still spelled out explicitly rather than folded into
+    # a states-only scan.
     def battle_enemy_condition(cmd)
       foe = @battle && @battle.enemy(cmd.param(1))
-      return false unless foe
-      case cmd.param(2)
-      when 0 then !foe.dead?
-      when 1 then foe.state?(cmd.param(3))
-      else false
-      end
+      foe ? !foe.dead? && !@battle.do_nothing_restricted?(foe) : false
     end
 
     # -- conditional branch ---------------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15690,6 +15690,89 @@ check 'battle Conditional Branch actor sub-test 3 (can use battle command) match
   eq 1, st.variables[1], '...yet a confused ally likewise still "can act"'
 end
 
+# Confirmed against EasyRPG's actual C++ source, fetched live:
+# `Game_Interpreter_Battle::CommandConditionalBranchBattle`
+# (src/game_interpreter_battle.cpp) reads only `com.parameters[1]` for its
+# actor (case 2) and enemy (case 3) branches -- `result = actor->CanAct();`
+# / `result = enemy->CanAct();`. `parameters[2]`/`[3]` are never read at
+# all: the real editor's Actor/Enemy tab offers a single "can act"
+# condition, not a menu, and always writes the same param(2). A prior
+# version of this codebase instead branched on param(2) as if it selected
+# among sub-tests ("is in the party" / "afflicted by a status" / "can use a
+# battle command" for an actor; "is present" / "afflicted by a status" for
+# an enemy) -- and its param(2) == 0 case ("is in the party"/"is present")
+# short-circuited straight to `true` without ever consulting the
+# do-nothing restriction, so an ordinary database author's "if Hero can
+# act..." branch (which always compiles to param(2) == 0, the only value
+# the real editor ever emits) would see a slept/paralysed ally reported
+# able to act.
+check 'battle Conditional Branch "can act" test ignores param(2) entirely and ' \
+      'still catches a do-nothing-restricted battler through it' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) } # do-nothing (asleep/paralysed)
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.actor = FakeSourceActor.new(1)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  branch = lambda do |params|
+    [FakeCmd.new(IC::CONDITIONAL_B, params, indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+     FakeCmd.new(IC::ELSE_BRANCH_B, [], indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+     FakeCmd.new(IC::END_BRANCH_B, [], indent: 0)]
+  end
+
+  hero.states = [8]
+  it.start(branch.call([2, 1, 0])) # the editor's only actor condition -- param(2) always 0
+  it.update
+  eq 2, st.variables[1], 'a do-nothing restricted ally fails, matching real CanAct'
+
+  slime.states = [8]
+  it.start(branch.call([3, 0, 0])) # the editor's only enemy condition -- param(2) always 0
+  it.update
+  eq 2, st.variables[1], 'same for a do-nothing restricted enemy'
+end
+
+# `Game::Battle#deal_attack` mutates a Combatant's hp directly (`target.hp
+# -= dmg`) with no matching `#inflict_state(target, DEATH_ID)` call, unlike
+# EasyRPG's own `Game_Battler::ChangeHp` (which folds `AddState(kDeathID)`
+# into every HP-zeroing path) -- so `#dead?`, an explicit HP check, has to
+# be tested alongside the do-nothing-restriction scan in
+# `#battle_actor_condition`/`#battle_enemy_condition` rather than assumed
+# subsumed by it the way it safely is for `Game::Actor` (whose own
+# `#add_state`/`#remove_state` keep `DEATH_STATE` and `@hp` in sync).
+check 'battle Conditional Branch "can act" test also fails a combatant killed by ' \
+      'plain HP loss, not only one carrying an explicit state' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.actor = FakeSourceActor.new(1)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  branch = lambda do |params|
+    [FakeCmd.new(IC::CONDITIONAL_B, params, indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+     FakeCmd.new(IC::ELSE_BRANCH_B, [], indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+     FakeCmd.new(IC::END_BRANCH_B, [], indent: 0)]
+  end
+
+  slime.hp = 0 # plain HP mutation -- no Death state ever lands in .states
+  ok (slime.states || []).empty?, 'sanity: no state was inflicted, just HP zeroed'
+  it.start(branch.call([3, 0, 0]))
+  it.update
+  eq 2, st.variables[1], 'a dead-by-HP enemy still fails the can-act test'
+
+  hero.hp = 0
+  ok (hero.states || []).empty?, 'sanity: same for the ally'
+  it.start(branch.call([2, 1, 0]))
+  it.update
+  eq 2, st.variables[1], 'a dead-by-HP ally still fails the can-act test'
+end
+
 check 'troop-member numbering stays stable when a middle member dies or is hidden' do
   # docs/TODO.md's render-order fix left this "still open": does killing or
   # hiding troop member 1 (the middle of three) shift member 2 down into


### PR DESCRIPTION
## Summary
- `Interpreter#battle_actor_condition`/`#battle_enemy_condition` (`mruby-rpg2k/mrblib/interpreter.rb`) branched on `cmd.param(2)` as if the battle-event Conditional Branch's Actor/Enemy tab (13310, RPG2003) offered a menu of sub-tests — "is in the party" / "afflicted by a status" / "can use a battle command" for an actor, "is present" / "afflicted by a status" for an enemy.
- RPG_RT's `Game_Interpreter_Battle::CommandConditionalBranchBattle` (`src/game_interpreter_battle.cpp`, verified live against EasyRPG Player's C++ source) reads only `com.parameters[1]` (the actor/enemy id) for its actor (case 2) and enemy (case 3) branches: `result = actor->CanAct();` / `result = enemy->CanAct();`. `parameters[2]`/`[3]` are never touched — the real editor's Actor/Enemy tab offers exactly one condition each, not a menu. This codebase's own adjacent comment already stated the correct behavior ("EasyRPG's actual actor case never sub-dispatches on a second parameter at all") while the code directly below it did something else entirely.
- Worse, the `param(2) == 0` case ("is in the party"/"is present") short-circuited straight to `true` without ever consulting the do-nothing restriction. Since the real editor's one condition always compiles to the same `param(2)` value, an ordinary boss-AI page gated on "if Hero can act..." kept treating a slept/paralysed party member as able to act.
- Fixed by dropping the fabricated sub-dispatch entirely: both methods now always compute the actor/enemy's own "can act" state regardless of `param(2)`.
- A second, independent gap surfaced while fixing this: EasyRPG's `Game_Battler::ChangeHp` folds `AddState(kDeathID)` into every HP-zeroing path, so a dead battler there always already carries the Death state and `CanAct`'s do-nothing scan alone is enough — but this port's own `Game::Battle#deal_attack` mutates a `Combatant`'s `hp` directly (`target.hp -= dmg`) with no matching `#inflict_state(target, DEATH_ID)` call, so `.states` is not a reliable death signal here the way it safely is for `Game::Actor`. Both fixed methods now check `#dead?` explicitly alongside the do-nothing scan.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a do-nothing-restricted ally/enemy now correctly fails the "can act" test under `param(2) == 0` (the value the real editor always emits).
- [x] New check: a combatant killed by plain HP loss (no explicit state ever inflicted) still fails the "can act" test.
- [x] Both confirmed to fail against the pre-fix code (`git stash`).
- [x] Full suite green post-fix: 1028/1028 logic checks, 749 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_