### PR TITLE
actor: learn_skill keeps the skill list sorted by id, matching RPG_RT

### DIFF
--- a/changelog.d/learn-skill-sort-order.fixed.md
+++ b/changelog.d/learn-skill-sort-order.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2000/2003 actors:** A newly learned skill now sorts into the
+  actor's skill list by id, matching RPG_RT, instead of simply being
+  appended in learn order. This was invisible in the Skill menu (already
+  sorted for display) but changed the RNG-jitter draw order for Auto
+  Battle's own skill-vs-attack ranking, which could pick a different
+  skill on a near-tie. Covered by a strengthened
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2115,6 +2115,42 @@ The work below is roughly ordered by the critical path to a walkable game
   still announces each skill on its own level's page; a skill taught early
   via Change Skills still stays quiet once the level that would have taught
   it is reached.)
+  ✅ **A learned skill's own position in the actor's skill list is now
+  kept in ascending id order, not learn order (2026-08-18).**
+  `Actor#learn_skill` (`mruby-rpg2k/mrblib/game.rb`) simply `push`ed the new
+  id onto `@skills`, leaving the array in whatever order the skills were
+  actually taught — levelling through a growth table not itself
+  monotonic in skill id, or an ordinary Change Skills (10440) event
+  teaching a low-numbered spell after a high-numbered one, both entirely
+  normal authoring. Confirmed against EasyRPG's actual C++ source, fetched
+  live: `Game_Actor::LearnSkill` (`src/game_actor.cpp`) is `data.skills.
+  push_back(skill_id); std::sort(data.skills.begin(), data.skills.end());`
+  — called identically from levelling (`LearnLevelSkills`), Change Class,
+  and the Change Skills event command alike — so RPG_RT's own skill list
+  is *always* ascending-id-sorted, never in learn order. This stayed
+  invisible in every skill *menu*: `Game::Party#field_skills`/
+  `#battle_skills` (`game.rb`) already call `.sort` before listing, so the
+  Skill command always looked right. It was not invisible to
+  `Game::Battle#choose_auto_battle_command`, which iterates an actor's own
+  raw, unsorted `#skills` and calls `#auto_battle_skill_rank` per
+  candidate — a function that draws one `@rng.random(100)` jitter roll per
+  skill with a positive rank. Consuming that shared RNG stream in a
+  different order than real RPG_RT drifts every subsequent roll for the
+  rest of a seeded fight (hit/miss, damage variance, enemy AI alike), and
+  can pick a different skill outright on a near-tie — an externally
+  observable AI decision difference for any Forced-AI actor or any
+  RPG2003 player using the in-battle Auto Battle command, the moment that
+  actor knows two or more skills learned out of numeric order. Fixed by
+  adding `@skills.sort!` after the push in `#learn_skill`. Covered by
+  strengthening the existing "Actor learns skills from the growth table up
+  to its level" `scripts/rpg2k_logic_check.rb` check, whose own learn
+  table (25@L1, 32@L1, 27@L5) already exercises the out-of-order case —
+  its assertions used to defensively call `.sort` on the result, masking
+  exactly this bug, and now assert the raw `#skills` order directly (plus
+  two new assertions covering a subsequent high-id and low-id
+  `#learn_skill` call each sorting into place), confirmed to fail against
+  the pre-fix code (`expected [25, 27, 32], got [25, 32, 27]`) before the
+  fix.
 - ✅ **Message window** — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`,
   `\_` space). `\n[n]` names the **live** actor out of the roster rather than the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1619,9 +1619,27 @@ module Game
     end
 
     # Learn / forget a skill (the Change Skill operations and levelling).
+    #
+    # Confirmed against EasyRPG's actual C++ source, fetched live:
+    # `Game_Actor::LearnSkill` (`src/game_actor.cpp`) is `data.skills.
+    # push_back(skill_id); std::sort(data.skills.begin(), data.skills.end());`
+    # -- every learn, from levelling (`LearnLevelSkills`), Change Class, or
+    # the Change Skills event command alike, re-sorts the actor's skill
+    # list into ascending id order immediately, so it is never in "learn
+    # order". This matters beyond display (`#field_skills`/`#battle_skills`
+    # already `.sort` before listing, so the menus never looked wrong):
+    # `#choose_auto_battle_command` iterates the actor's own raw `#skills`
+    # unsorted, and `#auto_battle_skill_rank` draws one `@rng.random(100)`
+    # jitter roll per candidate skill -- so learning a low-id skill after a
+    # higher-id one (an entirely ordinary Change Skills event, or a growth
+    # table not monotonic in skill id) consumed the shared RNG stream in a
+    # different order than real RPG_RT, drifting every roll for the rest of
+    # a seeded fight, and could pick a different skill outright on a
+    # near-tie.
     def learn_skill(skill_id)
       return if skill_id.nil? || skill_id == 0 || @skills.include?(skill_id)
       @skills.push(skill_id)
+      @skills.sort!
     end
 
     def forget_skill(skill_id)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4610,19 +4610,28 @@ end
 
 check 'Actor learns skills from the growth table up to its level' do
   # 25@L1, 32@L1, 27@L5 -- mirrors a real actor whose L5 skill set is 25/27/32.
+  # Deliberately learned out of numeric order (27 joins last, place-wise, yet
+  # sorts before 32): confirmed against EasyRPG's actual C++ source, fetched
+  # live -- `Game_Actor::LearnSkill` (src/game_actor.cpp) is `data.skills.
+  # push_back(skill_id); std::sort(data.skills.begin(), data.skills.end());`,
+  # so RPG_RT's own skill list is always ascending-id-sorted, never in learn
+  # order. Asserted directly against `#skills` (not `#skills.sort`, which
+  # would hide the exact ordering bug this pins) for that reason.
   learns = [[25, 1], [32, 1], [27, 5]]
   db = FakeActorDB.new(
     { 1 => SkillRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4], learns) }, [1])
   a = Game::Party.new(db).leader
-  eq [25, 32], a.skills.sort            # only the L1 skills at level 1
+  eq [25, 32], a.skills                 # only the L1 skills at level 1
   a.set_level(5)
-  eq [25, 27, 32], a.skills.sort        # 27 joins at level 5
+  eq [25, 27, 32], a.skills             # 27 joins at level 5, sorted in, not appended
   a.set_level(1)
-  eq [25, 27, 32], a.skills.sort        # levelling down keeps learnt skills
+  eq [25, 27, 32], a.skills             # levelling down keeps learnt skills
   ok a.knows_skill?(27)
   ok !a.knows_skill?(99)
-  # learn / forget mutate the set.
+  # learn / forget mutate the set, #learn_skill keeping it sorted throughout.
   a.learn_skill(99); ok a.knows_skill?(99)
+  eq [25, 27, 32, 99], a.skills, 'learning a high id keeps the low ids in front'
+  a.learn_skill(1); eq [1, 25, 27, 32, 99], a.skills, 'and a low id sorts to the very front'
   a.forget_skill(27); ok !a.knows_skill?(27)
   # restoring a saved set replaces it.
   a.skills = [1, 2, 2, 0]


### PR DESCRIPTION
## Summary
- `Actor#learn_skill` (`mruby-rpg2k/mrblib/game.rb`) simply `push`ed the new id onto `@skills`, leaving the array in learn order rather than sorted order.
- RPG_RT's `Game_Actor::LearnSkill` (`src/game_actor.cpp`, verified live against EasyRPG Player's C++ source) is `data.skills.push_back(skill_id); std::sort(data.skills.begin(), data.skills.end());` — called identically from levelling (`LearnLevelSkills`), Change Class, and the Change Skills event command alike, so RPG_RT's own skill list is always ascending-id-sorted, never learn order.
- This stayed invisible in every skill menu — `Game::Party#field_skills`/`#battle_skills` already call `.sort` before listing — but not to `Game::Battle#choose_auto_battle_command`, which iterates an actor's raw, unsorted `#skills` and draws one `@rng.random(100)` jitter roll per candidate skill. Consuming that shared RNG stream in a different order than real RPG_RT drifts every subsequent roll for the rest of a seeded fight, and can flip a near-tied skill choice — an observable AI difference for any Forced-AI actor or RPG2003 Auto Battle command, the moment an actor knows two or more skills learned out of numeric order (an ordinary growth table not monotonic in skill id, or a story event teaching a low-id skill after a high-id one).
- Fixed by adding `@skills.sort!` after the push in `#learn_skill`.

## Test plan
- [x] Strengthened the existing "Actor learns skills from the growth table up to its level" `scripts/rpg2k_logic_check.rb` check — its own learn table (25@L1, 32@L1, 27@L5) already exercises the out-of-order case, but its assertions defensively called `.sort` on the result, masking the bug. Now asserts the raw `#skills` order directly, plus two new assertions for a subsequent high-id and low-id `#learn_skill` call each sorting into place.
- [x] Confirmed the tightened check fails against the pre-fix code (`git stash`) — `expected [25, 27, 32], got [25, 32, 27]`.
- [x] Full suite green post-fix: 1028/1028 logic checks, 749 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_