### PR TITLE
interpreter: Change Equipment's remove mode reads the slot from param3, not param4, matching RPG_RT

### DIFF
--- a/changelog.d/change-equipment-remove-slot-param.fixed.md
+++ b/changelog.d/change-equipment-remove-slot-param.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2000/2003 events:** The Change Equipment event command's "Remove
+  Equipment" mode now removes the slot the designer actually picked,
+  matching RPG_RT. It previously read the slot from the wrong command
+  parameter (the one that only means anything in the sibling "Equip"
+  mode), so it usually unequipped the weapon slot regardless of which
+  slot was chosen. Covered by strengthened and new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5570,6 +5570,11 @@ Everything below is unverified against the codebase.
   item the party never held at all still equips it (conjured, not drawn
   from a bag that had none), and unequipping does not add a copy back
   either. **Every sub-claim in this bullet is now confirmed correct.**
+  (Superseded by a later fix, per the community デフォ戦bot trivia cited in
+  `do_change_equipment`'s own doc comment: the command was found to swap
+  through the party's bag after all, the same way the Equip menu does —
+  see `#equip_item_from_bag`/`#unequip_to_bag` in the current source. The
+  "bypasses the bag entirely" claim above no longer describes the code.)
 - ✅ **`#gain_item` now erases a bag entry outright once its count reaches 0,
   instead of leaving a phantom zero-count key behind forever (2026-08-18).**
   `Game::Party#gain_item`/`#lose_item` (`mruby-rpg2k/mrblib/game.rb`)
@@ -5601,6 +5606,36 @@ Everything below is unverified against the codebase.
   last copy of a held item erases its bag key entirely, not just zeroes it;
   losing a copy of an item never held creates no phantom entry either),
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **Change Equipment's remove mode read the slot from the wrong command
+  parameter — param4 instead of param3 — so an ordinary "Remove Equipment"
+  event could unequip the wrong slot, or none at all (2026-08-19).**
+  `Interpreter#do_change_equipment` (`mruby-rpg2k/mrblib/interpreter.rb`)
+  called `party.unequip_to_bag(a, cmd.param(4))` for the remove branch
+  (`cmd.param(2) != 0`). Every other command in this file maps `cmd.param(n)`
+  1:1 onto EasyRPG's own `com.parameters[n]` — confirmed directly against
+  `CommandChangeSkills`, the very next command up in the same C++ file,
+  which `#do_change_skills` already mirrors exactly — but this one command's
+  remove branch broke that mapping. Verified against EasyRPG's actual C++
+  source, fetched live: `Game_Interpreter::CommandChangeEquipment`
+  (`src/game_interpreter.cpp`) is `switch (com.parameters[2]) { case 1:
+  item_id = 0; slot = com.parameters[3] + 1; break; }` — the slot comes from
+  `parameters[3]`; `parameters[4]` is read only in the sibling equip branch
+  (`case 0`), as the item id's own `ValueOrVariable` operand, and has no
+  meaning at all in remove mode. An ordinary editor-authored "Change
+  Equipment → Remove Equipment → [Armor]" command therefore removed
+  whatever slot `param4` happened to hold instead — usually 0 (the item-id
+  operand's own default), silently always unequipping the weapon slot
+  regardless of which slot the designer actually picked, or "remove every
+  slot" (param3 5) doing nothing observable at all if param4 landed outside
+  0..5. Fixed by reading `cmd.param(3)` instead. Two of the three existing
+  `scripts/rpg2k_logic_check.rb` Change Equipment removal checks happened to
+  set param3 and param4 to the same value and so never caught this;
+  tightened to set param4 to a mismatched decoy value (proving it is
+  ignored) and a new check exercises the concrete failure mode directly — a
+  command naming the armour slot (param3 2) with the weapon slot as a decoy
+  in param4 (0) must remove the armour and leave the weapon on, the
+  opposite of what the pre-fix code did — all three confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **Call Event** — every checkable engine-behavior sub-claim is confirmed
   correct: it doesn't move the target event, ignores its appearance
   conditions, can't cross maps, continues the *caller* right after itself

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2401,9 +2401,23 @@ module Game
 
     # Change Equipment (10450). param2 selects the operation: 0 equips an item
     # (param3 0 = the item id in param4, 1 = the id held in variable param4) into
-    # the slot matching its type; 1 removes equipment, param4 selecting the slot
-    # (0..4, or 5 for every slot). Confirmed against real events, e.g.
+    # the slot matching its type; 1 removes equipment, **param3** selecting the
+    # slot (0..4, or 5 for every slot). Confirmed against real events, e.g.
     # `[1, 3, 0, 0, 127]` equips armour 127 onto actor 3.
+    #
+    # The remove branch's slot index is confirmed against EasyRPG's actual C++
+    # source, fetched live: `Game_Interpreter::CommandChangeEquipment`
+    # (`src/game_interpreter.cpp`) is `switch (com.parameters[2]) { case 1:
+    # item_id = 0; slot = com.parameters[3] + 1; break; }` -- `parameters[3]`,
+    # not `[4]` (which is only ever read in the sibling `case 0` equip branch,
+    # as the item id's own ValueOrVariable operand). A prior version of this
+    # method read `cmd.param(4)` for the remove slot instead, unlike every
+    # other command in this file's own `cmd.param(n)` <-> `com.parameters[n]`
+    # 1:1 mapping (confirmed against `CommandChangeSkills`, the immediately
+    # preceding command in the same C++ file, which #do_change_skills already
+    # mirrors exactly) -- an ordinary editor-authored "Change Equipment >
+    # Remove Equipment > [some slot]" command would unequip whatever slot
+    # `param(4)` happened to hold instead of the one actually chosen.
     #
     # Both operations swap through the party's bag, same as the equip menu
     # (`Game::Party#equip_item_from_bag` / `#unequip_to_bag`) -- confirmed
@@ -2421,7 +2435,7 @@ module Game
         # command might be allowed the item and another not.
         targets.each { |a| party.equip_item_from_bag(a, item) if party.item_usable_by?(it, a.id) }
       else
-        targets.each { |a| party.unequip_to_bag(a, cmd.param(4)) }
+        targets.each { |a| party.unequip_to_bag(a, cmd.param(3)) }
       end
       check_game_over # losing an item's max-HP bonus can knock the party out
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5501,8 +5501,14 @@ check 'Change Equipment command equips into the type slot and removes' do
   Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 1, 5])]); it.update }
   eq 11, a.def         # base 2 + 9
   eq 8, a.equipment[2]
-  # Remove the weapon slot (op 1, slot 0).
-  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, 0])]); it.update }
+  # Remove the weapon slot (op 1, slot param3 0). param4 (99, garbage here) is
+  # confirmed against EasyRPG's actual C++ source, fetched live --
+  # `Game_Interpreter::CommandChangeEquipment` (src/game_interpreter.cpp)
+  # reads the remove-mode slot from `com.parameters[3]` (`slot =
+  # com.parameters[3] + 1`), never `[4]`, which is only ever read in the
+  # sibling equip-mode branch as the item id's own ValueOrVariable operand --
+  # to have no bearing on which slot comes off.
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, 99])]); it.update }
   eq 3, a.atk
   eq 0, a.equipment[0]
   eq 8, a.equipment[2] # armour still on
@@ -5565,14 +5571,20 @@ check 'Change Equipment command returns the previously-equipped item to ' \
   eq 9, a.equipment[0], 'now wearing the replacement'
   eq 1, st.party.item_count(7), 'the displaced weapon landed back in the bag'
   eq 0, st.party.item_count(9), 'the replacement itself is worn, not sitting in the bag too'
-  # Remove it outright (op 1): 9 comes back to the bag too.
+  # Remove it outright (op 1, slot param3 0; param4 0 here is coincidentally
+  # the same value, unlike the garbage-param4 case above, but still the one
+  # EasyRPG's real C++ source never reads for this branch).
   Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, 0])]); it.update }
   eq 0, a.equipment[0], 'unequipped'
   eq 1, st.party.item_count(9), 'and it returned to the bag on removal too'
 end
 
-check 'Change Equipment command "remove every slot" (param4 5) returns each ' \
+check 'Change Equipment command "remove every slot" (param3 5) returns each ' \
       'slot to the bag in turn' do
+  # The slot lives in param3, not param4 -- confirmed against EasyRPG's
+  # actual C++ source, fetched live: `Game_Interpreter::
+  # CommandChangeEquipment`'s remove branch is `slot = com.parameters[3] +
+  # 1`. param4 (99, garbage here) proves it is never consulted.
   items = { 7 => fake_item(atk: 15, type: 1),   # weapon -> slot 0
             8 => fake_item(dfn: 9, type: 3) }   # armour -> slot 2
   db = FakeActorDB.new(
@@ -5582,10 +5594,42 @@ check 'Change Equipment command "remove every slot" (param4 5) returns each ' \
   Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
   Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 8])]); it.update }
   eq [7, 0, 8, 0, 0], a.equipment
-  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, Game::Actor::EQUIP_ORDER.size])]); it.update }
+  Game::Interpreter.new(st).tap do |it|
+    it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, Game::Actor::EQUIP_ORDER.size, 99])])
+    it.update
+  end
   eq [0, 0, 0, 0, 0], a.equipment, 'every slot cleared'
   eq 1, st.party.item_count(7), 'the weapon came back to the bag'
   eq 1, st.party.item_count(8), 'the armour came back to the bag too'
+end
+
+check 'Change Equipment command removes exactly the slot named in param3, ' \
+      'not param4' do
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_Interpreter::CommandChangeEquipment` (src/game_interpreter.cpp)
+  # reads the remove-mode slot from `com.parameters[3]` (`slot =
+  # com.parameters[3] + 1`) -- the same 1:1 `cmd.param(n)` <-> `com.
+  # parameters[n]` mapping every other command in this file uses (e.g.
+  # `CommandChangeSkills`, the immediately preceding command in the same
+  # C++ file, which #do_change_skills already mirrors exactly). An armour
+  # slot (2) named in param3, with param4 set to the weapon slot (0) --
+  # what a prior, wrong version of this method would have removed instead
+  # -- must remove the armour and leave the weapon alone.
+  items = { 7 => fake_item(atk: 15, type: 1),   # weapon -> slot 0
+            8 => fake_item(dfn: 9, type: 3) }   # armour -> slot 2
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 8])]); it.update }
+  eq [7, 0, 8, 0, 0], a.equipment
+  # Remove op, param3 = 2 (armour slot), param4 = 0 (the weapon slot, a
+  # decoy a param4-reading implementation would remove instead).
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 2, 0])]); it.update }
+  eq [7, 0, 0, 0, 0], a.equipment, 'the armour (param3) came off, the weapon (param4) stayed on'
+  eq 1, st.party.item_count(8), 'the removed armour landed back in the bag'
+  eq 0, st.party.item_count(7), 'the weapon is still worn, not in the bag'
 end
 
 check 'Change Equipment command respects an actor_set restriction, per actor' do


### PR DESCRIPTION
## Summary
- `Interpreter#do_change_equipment`'s remove branch (`mruby-rpg2k/mrblib/interpreter.rb`) called `party.unequip_to_bag(a, cmd.param(4))` — reading the slot to unequip from `param(4)`.
- RPG_RT's `Game_Interpreter::CommandChangeEquipment` (`src/game_interpreter.cpp`, verified live against EasyRPG Player's C++ source) is `switch (com.parameters[2]) { case 1: item_id = 0; slot = com.parameters[3] + 1; break; }` — the remove-mode slot comes from `parameters[3]`; `parameters[4]` is only ever read in the sibling equip branch (`case 0`), as the item id's own `ValueOrVariable` operand, and has no meaning in remove mode.
- Every other command in this file maps `cmd.param(n)` 1:1 onto `com.parameters[n]` — confirmed directly against `CommandChangeSkills`, the immediately preceding command in the same C++ file, which `#do_change_skills` already mirrors exactly. This one command's remove branch broke that mapping.
- Concretely: an ordinary editor-authored "Change Equipment → Remove Equipment → [Armor]" command removed whatever slot `param4` happened to hold instead — usually 0 (the item-id operand's own leftover default), silently always unequipping the weapon slot regardless of which slot the designer actually picked.
- Fixed by reading `cmd.param(3)` instead.

## Test plan
- [x] Two of the three existing `scripts/rpg2k_logic_check.rb` Change Equipment removal checks happened to set param3 and param4 to the same value and so never caught this — tightened to set param4 to a mismatched decoy value, proving it's ignored.
- [x] Added a new check exercising the concrete failure mode directly: a command naming the armour slot (param3 2) with the weapon slot as a decoy in param4 (0) must remove the armour and leave the weapon on — the opposite of what the pre-fix code did.
- [x] All three confirmed to fail against the pre-fix code (`git stash`).
- [x] Full suite green post-fix: 1029/1029 logic checks, 749 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation (and flagged a stale adjacent claim that the command "bypasses the bag entirely" — superseded by a later fix, current code does swap through the bag), and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_