### PR TITLE
psp: define TEST_PLAY; characterize the deeper real-game-data crash

### DIFF
--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -505,6 +505,13 @@ int main(void) {
                   mrb_intern_lit(M, "GAME_DIR"), mrb_str_new_cstr(M, kGameDir));
     mrb_const_set(M, mrb_obj_value(M->object_class),
                   mrb_intern_lit(M, "RTP_DIR"), mrb_str_new_cstr(M, ""));
+    // RPG2k#initialize's native_test_play? (mruby-rpg2k/mrblib/main.rb)
+    // references this constant directly (rescuing NameError if it's
+    // missing) -- every other target's entry point defines it
+    // (src/main.cxx), this build has no command line to carry a real
+    // Test Play flag on, so it is always false.
+    mrb_const_set(M, mrb_obj_value(M->object_class),
+                  mrb_intern_lit(M, "TEST_PLAY"), mrb_false_value());
 
     const char* game_start_result;
     if (game_info) {

--- a/changelog.d/psp-test-play-constant.fixed.md
+++ b/changelog.d/psp-test-play-constant.fixed.md
@@ -1,0 +1,21 @@
+- **The PSP EBOOT now defines the `TEST_PLAY` mruby constant**, matching
+  every other target's own entry point (`src/main.cxx`). RPG2k#initialize
+  (`mruby-rpg2k/mrblib/main.rb`) calls `native_test_play?`, which
+  references `TEST_PLAY` directly (rescuing `NameError` if it's
+  undefined) — the PSP build never defined it, so constructing an RPG2k
+  game with a real project always raised and rescued a `NameError` on
+  its very first line, a code path CI's `psp-smoke` job never exercises
+  (it has no project at `kGameDir`, so it only ever runs the idle HAL
+  loop). `app/psp/main.cxx` now sets `TEST_PLAY` to `false` (this build
+  has no command line to carry a real Test Play flag on), matching
+  `RTP_DIR`/`GAME_DIR`'s existing pattern.
+
+  Found while testing against a real project (Nepheshel, this repo's own
+  `data/Nepheshel206beta` test fixture) — the first time this whole EBOOT
+  has ever been driven with real game data rather than the idle path.
+  This closes one genuine gap, but is not sufficient on its own:
+  constructing `RPG2k` with a real project still crashes shortly after,
+  in a different, not-yet-root-caused way (a low-level mruby VM
+  assertion reached only after several bytecode-level method calls
+  succeed) — see `docs/adr/0047-psp-memory-budget.md` for where this
+  stands.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -630,6 +630,51 @@ the interpreter-linking slice, in this order:
   path — the *real* game-driving depth (P5) remains unmeasured until a
   project is deployed to `kGameDir`, on real hardware or an emulator
   with a Memory Stick image.
+
+  With the nine-bug idle-path trail closed, this EBOOT was tested for
+  the first time against a real project — `data/Nepheshel206beta`, this
+  repo's own test fixture, copied to `kGameDir` — rather than the empty
+  `kGameDir` `psp-smoke` always exercises. This immediately found a
+  **tenth bug, partially fixed**: `RPG2k#initialize`
+  (`mruby-rpg2k/mrblib/main.rb`) calls `native_test_play?`, which
+  references the `TEST_PLAY` mruby constant directly (rescuing
+  `NameError` if undefined) — every other target's entry point defines
+  it (`src/main.cxx`), the PSP build never did. Fixed by setting it to
+  `false` in `app/psp/main.cxx`, matching `GAME_DIR`/`RTP_DIR`'s
+  existing pattern.
+
+  That fix alone is **not sufficient**: constructing `RPG2k` with a real
+  project still crashes shortly after, in a genuinely different way — a
+  `mrb_assert()` inside mruby's bytecode interpreter (`mrb_vm_exec`,
+  `3rd/mruby/src/vm.c`), reached only after several real method calls
+  already execute correctly (including at least one full `OP_ENTER`
+  argument-binding pass). An extensive trace pass (temporary
+  instrumentation across `mrb_funcall_with_block`, `mrb_vm_run`,
+  `mrb_vm_exec`'s entry sequence, and `OP_ENTER`'s own handling, none
+  kept) ruled out, with direct evidence: `CI_PROC_SET`'s
+  `!MRB_PROC_ALIAS_P` assert (the proc is real, non-null, not an alias);
+  `MRB_TRY`'s `setjmp` (succeeds normally — `MRB_USE_CXX_EXCEPTION` is
+  not defined for this build, so this is the plain `setjmp`/`longjmp`
+  path, not C++ exceptions); the computed-goto dispatch table being out
+  of bounds (the decoded opcode, `OP_ENTER` = 57, is well within the
+  119-entry table, and no `__cxa_guard_acquire` call exists anywhere in
+  the compiled `vm.c` object despite it being compiled as C++,
+  confirmed via disassembly); and — tested directly, not just
+  theorized — the `TEST_PLAY` fix above being sufficient on its own (it
+  is not; the crash persists with it applied). The exact failing
+  `mrb_assert()` was not pinned to one of the ~25 candidate call sites
+  within `mrb_vm_exec`'s many opcode handlers before this pass's time
+  budget ran out; a per-opcode trace (needed to see the last few
+  instructions executed before the crash) was attempted but proved too
+  slow to reach the crash point before the test harness's own timeout,
+  since each traced instruction costs a real syscall.
+
+  This is a real, separate, not-yet-fixed bug — the first ever found
+  that specifically requires driving this EBOOT with actual game data
+  rather than the idle path, since nothing before this pass ever tested
+  that. Not part of the original nine-bug boot-blocker count above,
+  which is unaffected and remains fully closed for the idle path
+  `psp-smoke` verifies.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none


### PR DESCRIPTION
## Summary
- Fixes a real gap: `RPG2k#initialize`'s `native_test_play?` (`mruby-rpg2k/mrblib/main.rb`) references the `TEST_PLAY` mruby constant directly (rescuing `NameError` if undefined). Every other target's entry point defines it (`src/main.cxx`); the PSP build never did. `app/psp/main.cxx` now sets it to `false`, matching `GAME_DIR`/`RTP_DIR`'s existing pattern.
- Found testing against a real project (`data/Nepheshel206beta`) for the first time in this whole investigation — CI's `psp-smoke` job only ever exercises the idle path (no project at `kGameDir`).
- **This fix alone is not sufficient.** Constructing `RPG2k` with a real project still crashes shortly after, in a genuinely different way — a `mrb_assert()` inside mruby's bytecode interpreter (`mrb_vm_exec`), reached only after several real method calls (including a full `OP_ENTER` argument-binding pass) already execute correctly. An extensive trace pass ruled out several specific hypotheses with direct evidence (`CI_PROC_SET`'s alias assert, `MRB_TRY`'s `setjmp` succeeding normally, the computed-goto dispatch table being out of bounds, and — tested directly — this `TEST_PLAY` fix alone being sufficient) but did not pin the exact failing assert before running out of budget.
- `docs/adr/0047-psp-memory-budget.md` documents this as a new, tenth, still-open bug — separate from and not affecting the nine-bug idle-path boot trail this file already closes out (verified unaffected: idle-path boot still clean, see test plan).

## Test plan
- [x] Rebuilt the EBOOT; idle path (no project at `kGameDir`, matching CI's `psp-smoke` exactly) still boots cleanly: `RPG2K_PSP_BOOT` → `RPG2K_PSP_MRUBY_OPEN ok` → `RPG2K_PSP_GAME_START none not_found`, zero errors.
- [x] Confirmed with a real project (Nepheshel) that `TEST_PLAY` is now defined and `native_test_play?` no longer raises — but a separate, deeper crash remains, documented in the ADR.
- [ ] CI — pending on this PR.