### PR TITLE
actor: an Enable Combo no longer carries into the next battle, matching RPG_RT

### DIFF
--- a/changelog.d/battle-combo-reset-on-battle-end.fixed.md
+++ b/changelog.d/battle-combo-reset-on-battle-end.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 battles:** A battle combo armed by the Enable Combo (1007)
+  event command now clears once that fight ends, matching RPG_RT.
+  Previously it stayed armed on the actor forever, multiplying hits in
+  every later battle too — a boss fight scripted with a "double-strike"
+  combo would leak that bonus into every subsequent random encounter.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14073,6 +14073,37 @@ above are repeated here)
   instead of whatever it was charged to), both confirmed to fail against
   the pre-fix code (`NoMethodError`, the accessor did not exist at all)
   before the fix.
+  ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
+  forever, multiplying hits in every later battle too, instead of
+  clearing once that fight ended (2026-08-19).** `Game::Actor
+  #set_battle_combo` (`mruby-rpg2k/mrblib/game.rb`) stores `@battle_combo`
+  directly on the persistent `Actor` object (not a per-fight `Combatant`
+  snapshot, the way `atk_modifier`/`def_modifier`/etc. correctly are), and
+  its own doc comment already claimed the combo "stays armed for the
+  whole fight until another Enable Combo overwrites it" — true, but
+  nothing anywhere ever cleared it at the *end* of that fight either, so
+  it silently persisted into every subsequent one. Confirmed against
+  EasyRPG's actual C++ source, fetched live: `Game_Battler::ResetBattle`
+  (`src/game_battler.cpp`) is `battle_combo_command_id = -1;
+  battle_combo_times = 1;`, and `Game_Actors::ResetBattle`
+  (`src/game_actors.cpp`, looping every actor's own `ResetBattle`) is
+  called at **both** a battle's start and its end — `Game_Battle::Init`
+  and `Game_Battle::Quit` alike (`src/game_battle.cpp`). A boss fight
+  scripted via a battle-event page's Enable Combo (an entirely ordinary,
+  editor-authored way to grant that one fight a scripted "double-strike"
+  mechanic) left every subsequent battle — random encounters, later story
+  fights alike — still multiplying that actor's attack/skill hits by the
+  same `multiple`, since `Game::Battle#combo_hits` reads `Actor
+  #battle_combo` live off the persistent actor, not a snapshot. Fixed
+  with a new `Actor#clear_battle_combo`, called from `Battle
+  #apply_to_party` (the one place a fight's outcome is written back onto
+  the persistent Actor objects, already doing the identical job for HP/
+  MP/states/gauge) for every ally once the fight ends. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a combo armed mid-fight is
+  present on the actor immediately, gone from it right after `#apply_to_
+  party` runs, and a subsequent fight's own `Combatant` reads no combo
+  bonus at all), confirmed to fail against the pre-fix code before the
+  fix.
   ✅ **A living-but-afflicted party member's own alternate-battle-layout
   sprite (RPG2003's per-actor battler graphic, `db.battleranimations`) now
   shows that state's own configured pose, not always plain Idle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3004,6 +3004,21 @@ module Game
       @battle_combo = { command_id: command_id, multiple: multiple }
     end
 
+    # Clear a combo Enable Combo armed, at a fight's end -- matching
+    # EasyRPG's own `Game_Battler::ResetBattle` (`src/game_battler.cpp`):
+    # `battle_combo_command_id = -1; battle_combo_times = 1;`, called for
+    # every actor at both a battle's start and its end
+    # (`Game_Battle::Init`/`Quit`, via `Game_Actors::ResetBattle`,
+    # `src/game_battle.cpp`/`src/game_actors.cpp`) -- so a combo armed for
+    # one fight never carries into the next. #set_battle_combo's own doc
+    # comment already claimed the combo stays armed "until battle end", but
+    # nothing actually enforced that boundary until this existed; see
+    # `Game::Battle#apply_to_party`, the one place a fight's outcome is
+    # written back onto the persistent Actor objects, for the call site.
+    def clear_battle_combo
+      @battle_combo = nil
+    end
+
     # Whether this actor uses the RPG2000 "custom battle command" name
     # (独自戦闘コマンド有効, database field 66) instead of the database's
     # generic Skill term. A class change never touches this — EasyRPG's own
@@ -9393,6 +9408,9 @@ module Game
         # ended this fight dead carries 0 instead, matching AddState's own
         # Knockout-zeroes-the-gauge rule -- see Actor#atb_gauge.
         c.actor.atb_gauge = c.hp > 0 ? c.gauge : 0 if c.actor.respond_to?(:atb_gauge=)
+        # An Enable Combo (1007) armed for this fight never carries into the
+        # next one -- see Actor#clear_battle_combo.
+        c.actor.clear_battle_combo if c.actor.respond_to?(:clear_battle_combo)
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11730,6 +11730,36 @@ check 'Battle#apply_to_party zeroes the active-time gauge for an ally who ended 
   eq 0, ally.atb_gauge, 'a knocked-out ally does not carry a charge into the next fight'
 end
 
+check "Battle#apply_to_party clears a battle combo Enable Combo armed, matching RPG_RT (2026-08-19)" do
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_Battler::ResetBattle` (src/game_battler.cpp) is `battle_combo_
+  # command_id = -1; battle_combo_times = 1;`, called for every actor at
+  # both a battle's start and its end (`Game_Battle::Init`/`Quit`, via
+  # `Game_Actors::ResetBattle`, src/game_battle.cpp / src/game_actors.cpp)
+  # -- so a combo armed by one battle-event page for one specific fight
+  # never carries into the next. #set_battle_combo's own doc comment
+  # already claimed the combo stays armed "until battle end", but nothing
+  # ever actually cleared it: an Enable Combo fired for a scripted boss
+  # fight stayed armed on the actor forever, multiplying hits in every
+  # later random encounter too.
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hero.set_battle_combo(1, 3) # Attack (command 1) hits 3 times, armed this fight
+  eq({ command_id: 1, multiple: 3 }, hero.battle_combo)
+
+  hc = Game::Battle.from_actor(hero)
+  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.apply_to_party
+  eq nil, hero.battle_combo, 'the combo does not survive past this fight'
+
+  # A fresh fight's own Combatant reads no combo bonus either, matching
+  # #combo_hits' own "no combo armed" default of 1.
+  hc2 = Game::Battle.from_actor(hero)
+  bat2 = Game::Battle.new([hc2], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  hc2.last_battle_action = 1
+  eq 1, bat2.send(:combo_hits, hc2, :attack), 'no combo carries into the next fight'
+end
+
 check 'Battle#step_action walks a round one attack at a time for animation' do
   # Two fast heroes vs two slow slimes: agility order is Ace, Bee, then the
   # slimes. #step_action surfaces the round one entry at a time (as the on-screen


### PR DESCRIPTION
## Summary
- `Actor#set_battle_combo` (`mruby-rpg2k/mrblib/game.rb`) stores `@battle_combo` on the persistent `Actor` object, not a per-fight `Combatant` snapshot — unlike `atk_modifier`/`def_modifier`/etc., which correctly live on the fresh-per-fight `Combatant`.
- RPG_RT's `Game_Battler::ResetBattle` (`src/game_battler.cpp`, verified live against EasyRPG Player's C++ source) is `battle_combo_command_id = -1; battle_combo_times = 1;`, and `Game_Actors::ResetBattle` (looping every actor's own `ResetBattle`) is called at **both** a battle's start and its end — `Game_Battle::Init` and `Game_Battle::Quit` alike.
- This codebase's own doc comment on `#set_battle_combo` already claimed the combo "stays armed for the whole fight until another Enable Combo overwrites it" — true, but nothing anywhere ever cleared it once that fight actually ended.
- Concretely: a boss fight scripted via a battle-event page's Enable Combo (an entirely ordinary, editor-authored way to grant that one fight a scripted "double-strike" mechanic) left every subsequent battle — random encounters, later story fights alike — still multiplying that actor's attack/skill hits by the same multiplier, since `Game::Battle#combo_hits` reads `Actor#battle_combo` live off the persistent actor.
- Fixed with a new `Actor#clear_battle_combo`, called from `Battle#apply_to_party` (the one place a fight's outcome is written back onto the persistent Actor objects, already doing the identical job for HP/MP/states/gauge) for every ally once the fight ends.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a combo armed mid-fight is present on the actor immediately, gone right after `#apply_to_party` runs, and a subsequent fight's own `Combatant` reads no combo bonus at all.
- [x] Confirmed the new check fails against the pre-fix code (`git stash`).
- [x] Full suite green post-fix: 1030/1030 logic checks, 749 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_