### PR TITLE
Draw A2 table tile "legs" spilling into row below

### DIFF
--- a/changelog.d/vx-a2-table-leg.added.md
+++ b/changelog.d/vx-a2-table-leg.added.md
@@ -1,0 +1,7 @@
+- **VX / VX Ace `Tilemap`** now draws an A2 table (counter) tile's "leg": the
+  8px overhang that spills past the tile's own 32×32 box into the map row
+  below it, matching real RPG Maker VX/VX Ace (and mkxp, the reference used to
+  derive it — MV's corescript inherited the tile geometry but drives this
+  particular effect through a different, JS-only mechanism). Pure arithmetic,
+  exposed as `RGSS::Tilemap.vx_table_leg_quads` and pinned in `mruby-rgss/test`
+  the same way `vx_tile_quads` is.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14634,7 +14634,17 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   a `Scene::Title` (title graphic + New Game / Continue / Shutdown in an
   XP-styled window, title BGM / cursor & decision SE). `src/main.cxx` sizes the
   window to XP's native 640×480.
-- 🚧 **Map scene** — New Game builds the party from `System.party_members`,
+- ~~🚧 **Map scene**~~ — **superseded, not current.** This bullet describes the
+  reimplemented `mruby-rpgxp/mrblib/scene.rb` `Scene::Map` that used to stand in
+  for a game's own scripts; [ADR 0030](adr/0030-rgss-only-the-games-own-engine.md)
+  deleted it (~4,600 lines) once the script host (below) became the only boot
+  path, so nothing here still exists in the repository. Left for history rather
+  than rewritten; the "Remaining" per-row priority note in particular is stale
+  in its own right — that landed, but in the native `RGSS::Tilemap`
+  (`mruby-rgss/src/lib.cxx`) that serves the script host, not in this deleted
+  reimplementation ([ADR 0022](adr/0022-rpgxp-tilemap-priority-layering.md),
+  status: implemented).
+  New Game builds the party from `System.party_members`,
   loads the start map and enters a walkable `Scene::Map`. The three tile layers
   now render through the native `RGSS::Tilemap` — the project's real tileset
   graphic, the seven autotiles assembled from their quads and animated, and

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -110,10 +110,32 @@ MIT-licensed MV corescript, which inherited VX Ace's tile system unchanged, and
 needing a display, both as representative cases and as a checksum over the whole
 sweep.
 
-Remaining polish: `flags` bit 0x10 routes a tile to the existing "above the
-characters" layer, which is the same flat approximation ADR 0022 describes for
-XP, and the A2 table-edge tile drawn *below* its neighbour
-(`Tilemap#_drawTableEdge`) is not done.
+**The A2 table tile's "leg"** — the 8px overhang that spills past a table
+tile's own 32×32 box into the map row below it — is now drawn too. It looked
+like the same gap XP's `priorities` had before [ADR 0022](adr/0022-rpgxp-tilemap-priority-layering.md)
+(there described via MV corescript's `Tilemap#_drawTableEdge`, the JS name),
+but MV's neighbour-examining mechanism is JS-only plumbing, not what real
+VX/VX Ace draws — mkxp's `TileAtlasVX::readAutotileA2` (the actual VX/VX Ace
+tile renderer) does it with no neighbour lookup at all: every table tile
+grows its leg unconditionally, as a pure function of its own id. Cross-checked
+against all 48 A2 shapes: a leg exists on a corner exactly when that corner
+already trips the same-cell "counter row" substitution above (`qsy == 1` or
+`5`), sourced from that corner's own unsubstituted position — so no new
+lookup table was needed, only a second pass so the leg draws after the row
+below's own tile (a plain per-tile pass would let that tile paint back over
+it). Exposed as `Tilemap.vx_table_leg_quads` and pinned in `mruby-rgss/test`
+the same way `vx_tile_quads` is.
+
+**`flags` bit 0x10 ("higher tile") stays a flat "above the characters" layer,
+and that is correct, not a placeholder.** This looked like the same
+approximation ADR 0022 describes for XP's `priorities` — a flat layer instead
+of per-row interleaving with characters — but it is not one: mkxp's
+`TilemapVX` (the reference used above) puts its own "above" layer at a fixed
+`z = 200` (`TilemapVXPrivate::AboveLayer`), never per-row. RMXP's per-row
+`screen_z` is specific to XP's own `Game_Character#screen_z` formula (see the
+ADR); VX/VX Ace's own engine does not do that for `flags` 0x10, so widening
+ADR 0022 to VX would have made this *less* faithful, not more. No follow-up
+wanted here.
 
 ### 2. `Viewport` screen effects — tint, flash and fade all draw ✅
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -4166,6 +4166,58 @@ int vx_tile_quads(int tile_id, int frame, bool table, VXQuad out[8]) {
   return n;
 }
 
+// A table (A2, `flags` bit 0x80) tile grows a short "leg" that spills 8px past
+// its own 32x32 box into the map row below it -- RMXP/VX Ace's authentic
+// table/counter look (a plain flat edge would stop dead at the tile boundary).
+// Ported from mkxp's TileAtlasVX::readAutotileA2 (the real VX/VX Ace tile
+// renderer, GPLv2 -- MV's corescript inherited the tile *geometry* from VX Ace
+// unchanged, per the comment above vx_tile_quads, but drives this particular
+// effect through a different, JS-only mechanism, so mkxp is the reference
+// here instead).
+//
+// A leg exists on the bottom-left / bottom-right corner exactly when that
+// corner would already trigger vx_tile_quads's own same-cell "counter row"
+// substitution above (qsy == 1 or 5) -- confirmed by cross-checking every one
+// of mkxp's 48 shapes' leg source coordinates against VX_FLOOR_QUADS: all 54
+// legs across the 48 shapes matched that corner's own (unsubstituted) quad
+// position exactly. So a leg's source is simply that corner's natural,
+// non-substituted (sx, sy) -- the same value vx_tile_quads's substitution
+// branch already computes and calls sx/sy there -- redrawn 16x16 (not the
+// substitution's 16x8 strip) at dy = TILE_SIZE - half/2, which lands its top
+// 8px over the tile's own bottom edge and its bottom 8px one map row down.
+//
+// Unlike MV's neighbour-examining _drawTableEdge, this needs no lookup of the
+// tile below: mkxp draws every table tile's leg unconditionally (no
+// suppression when the tile below is itself a table), so the leg is a pure
+// function of the owning tile's own id. The caller (tilemap_refresh_vx) must
+// still draw legs in a pass that runs after every plain tile of the same
+// layer, or a tile in the row below would be painted back over the leg.
+int vx_table_leg_quads(int tile_id, VXQuad out[2]) {
+  if (tile_id < VX_TILE_ID_A2 || tile_id >= VX_TILE_ID_A3)
+    return 0;
+  const int half = TILE_SIZE / 2;
+  const int kind = (tile_id - VX_TILE_ID_A1) / 48;
+  const int shape = (tile_id - VX_TILE_ID_A1) % 48;
+  if (shape >= 48)
+    return 0;
+  const int tx = kind % 8, ty = kind / 8;
+  const int bx = tx * 2, by = (ty - 2) * 3;
+  static const int kCorner[2] = {2, 3};  // BL, BR -- VX_FLOOR_QUADS index
+  int n = 0;
+  for (int c = 0; c < 2; ++c) {
+    const int qsx = VX_FLOOR_QUADS[shape][kCorner[c]][0];
+    const int qsy = VX_FLOOR_QUADS[shape][kCorner[c]][1];
+    if (qsy != 1 && qsy != 5)
+      continue;
+    const int sx = (bx * 2 + qsx) * half;
+    const int sy = (by * 2 + qsy) * half;
+    const int dx = c == 0 ? 0 : half;
+    out[n++] = VXQuad{/*sheet=*/1,          sx,   sy,  dx,
+                      TILE_SIZE - half / 2, half, half};
+  }
+  return n;
+}
+
 // z of the priority "above" layer (see the split in tilemap_refresh). INTERIM:
 // a single flat layer above the characters is only an approximation of RMXP's
 // per-row priority interleaving — it puts *every* priority tile above *every*
@@ -4388,6 +4440,41 @@ bool tilemap_refresh_vx(mrb_state* M,
         const int dy0 = ty * TILE_SIZE - static_cast<int>(oy);
         for (int q = 0; q < n; ++q) {
           const VXQuad& v = quads[q];
+          const mrb_value sheet_v = mrb_ary_ref(M, bitmaps, v.sheet);
+          if (!mrb_test(sheet_v) || !DATA_PTR(sheet_v))
+            continue;
+          Bitmap& sheet = DataType<Bitmap>::get(M, sheet_v);
+          blit_blend(target, dx0 + v.dx, dy0 + v.dy, sheet, v.sx, v.sy, v.w,
+                     v.h);
+        }
+      }
+    }
+
+    // Table legs, in a pass of their own after every plain tile of this layer
+    // is down: a leg spills into the row below, so it must draw after that
+    // row's own tile or the leg would be painted straight back over (see
+    // vx_table_leg_quads).
+    VXQuad legs[2];
+    for (int ty = ty0; ty < ty1; ++ty) {
+      for (int tx = tx0; tx < tx1; ++tx) {
+        const int idx = tx + ty * mapw + layer * mapw * maph;
+        if (idx < 0 || idx >= static_cast<int>(md.data.size()))
+          continue;
+        const int id = md.data[idx];
+        if (id < VX_TILE_ID_A2 || id >= VX_TILE_ID_A3 || !flags ||
+            id >= static_cast<int>(flags->data.size()))
+          continue;
+        const int flag = flags->data[id];
+        if ((flag & 0x80) == 0)
+          continue;
+        const int n = vx_table_leg_quads(id, legs);
+        if (n == 0)
+          continue;
+        Bitmap& target = ((flag & 0x10) != 0 && above) ? *above : dst;
+        const int dx0 = tx * TILE_SIZE - static_cast<int>(ox);
+        const int dy0 = ty * TILE_SIZE - static_cast<int>(oy);
+        for (int q = 0; q < n; ++q) {
+          const VXQuad& v = legs[q];
           const mrb_value sheet_v = mrb_ary_ref(M, bitmaps, v.sheet);
           if (!mrb_test(sheet_v) || !DATA_PTR(sheet_v))
             continue;
@@ -4834,6 +4921,33 @@ mrb_value tilemap_vx_tile_quads(mrb_state* M, mrb_value self) {
   mrb_value out = mrb_ary_new_capa(M, n);
   for (int i = 0; i < n; ++i) {
     const VXQuad& q = quads[i];
+    mrb_value row = mrb_ary_new_capa(M, 7);
+    mrb_ary_push(M, row, mrb_fixnum_value(q.sheet));
+    mrb_ary_push(M, row, mrb_fixnum_value(q.sx));
+    mrb_ary_push(M, row, mrb_fixnum_value(q.sy));
+    mrb_ary_push(M, row, mrb_fixnum_value(q.dx));
+    mrb_ary_push(M, row, mrb_fixnum_value(q.dy));
+    mrb_ary_push(M, row, mrb_fixnum_value(q.w));
+    mrb_ary_push(M, row, mrb_fixnum_value(q.h));
+    mrb_ary_push(M, out, row);
+  }
+  return out;
+}
+
+// Tilemap.vx_table_leg_quads(tile_id) -> [[sheet, sx, sy, dx, dy, w, h], ...]
+//
+// The A2 table-tile "leg" that spills into the row below (see
+// vx_table_leg_quads above), exposed the same way vx_tile_quads is: pure
+// arithmetic, pinned without needing the display the headless test binary
+// has not got.
+mrb_value tilemap_vx_table_leg_quads(mrb_state* M, mrb_value self) {
+  mrb_int tile_id = 0;
+  mrb_get_args(M, "i", &tile_id);
+  VXQuad legs[2];
+  const int n = vx_table_leg_quads(static_cast<int>(tile_id), legs);
+  mrb_value out = mrb_ary_new_capa(M, n);
+  for (int i = 0; i < n; ++i) {
+    const VXQuad& q = legs[i];
     mrb_value row = mrb_ary_new_capa(M, 7);
     mrb_ary_push(M, row, mrb_fixnum_value(q.sheet));
     mrb_ary_push(M, row, mrb_fixnum_value(q.sx));
@@ -6344,6 +6458,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, tilemap, "flags=", tilemap_set_flags, MRB_ARGS_REQ(1));
   mrb_define_class_method(M, tilemap, "vx_tile_quads", tilemap_vx_tile_quads,
                           MRB_ARGS_ARG(1, 2));
+  mrb_define_class_method(M, tilemap, "vx_table_leg_quads",
+                          tilemap_vx_table_leg_quads, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "ox=", tilemap_set_ox, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "oy=", tilemap_set_oy, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "update", tilemap_update, MRB_ARGS_NONE());

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1980,6 +1980,50 @@ assert "RGSS::Tilemap.vx_tile_quads splits an A2 table tile" do
   assert_equal [1, 48, 16, 16, 24, 16, 8], table[4]
 end
 
+assert "RGSS::Tilemap.vx_table_leg_quads grows a table tile's leg into the row below" do
+  # A table tile's "leg" is separate from the same-cell counter-row splice
+  # above: it is a full 16x16 quad (not the splice's 16x8 strip), sourced from
+  # that corner's own *unsubstituted* position, and placed at dy = 24 so it
+  # spills 8px past the tile's own 32px box into the map row below. Ported
+  # from mkxp's TileAtlasVX::readAutotileA2 (see the comment on
+  # vx_table_leg_quads in lib.cxx for the derivation).
+  #
+  # Shape 4 (tile id 2820) only trips the "table row" condition (qsy == 1 or
+  # 5) on its bottom-right corner, so it grows one leg, sourced from exactly
+  # the same (sx, sy) as the same-cell strip above (48, 16) — confirming the
+  # leg and the splice draw from the same corner, just to different places.
+  assert_equal [[1, 48, 16, 16, 24, 16, 16]], RGSS::Tilemap.vx_table_leg_quads(2820)
+
+  # Shape 0 (tile id 2816) trips the condition on neither corner: no legs.
+  assert_equal [], RGSS::Tilemap.vx_table_leg_quads(2816)
+
+  # Shape 28 (tile id 2844) trips it on both corners: two legs, one per side
+  # (dx 0 for the left, 16 for the right).
+  assert_equal [[1, 32, 80, 0, 24, 16, 16], [1, 16, 80, 16, 24, 16, 16]],
+               RGSS::Tilemap.vx_table_leg_quads(2844)
+
+  # Only A2 ids can be table tiles; anything else grows no leg.
+  assert_equal [], RGSS::Tilemap.vx_table_leg_quads(2048)
+  assert_equal [], RGSS::Tilemap.vx_table_leg_quads(4352)
+end
+
+assert "RGSS::Tilemap.vx_table_leg_quads matches the reference sweep" do
+  # A checksum over every A2 id (the only range a table tile can come from),
+  # the same rolling-hash shape as vx_tile_quads's own reference-sweep check
+  # above, computed from the same mkxp-derived formula described on
+  # vx_table_leg_quads in lib.cxx.
+  sum = 0
+  id = 2816
+  while id < 4352
+    RGSS::Tilemap.vx_table_leg_quads(id).each do |quad|
+      quad.each { |v| sum = (sum * 31 + v) % 1048573 }
+    end
+    sum = (sum * 31 + id) % 1048573
+    id += 1
+  end
+  assert_equal 359443, sum
+end
+
 assert "RGSS::Tilemap API surface" do
   # Tilemap is now native: Tilemap.new builds an lv_canvas the size of the
   # viewport and blits the visible tiles into it, so construction needs a live

--- a/scripts/rgss_cruby_compat.rb
+++ b/scripts/rgss_cruby_compat.rb
@@ -2068,6 +2068,32 @@ module RGSS
       end
       out
     end
+
+    # Ported from src/lib.cxx's vx_table_leg_quads: the A2 table tile's "leg",
+    # which spills 8px past the tile's own box into the map row below. See
+    # that function's comment for the derivation.
+    def self.vx_table_leg_quads(tile_id)
+      out = []
+      return out if tile_id < VX_TILE_ID_A2 || tile_id >= VX_TILE_ID_A3
+      half = TILE_SIZE / 2
+      kind = (tile_id - VX_TILE_ID_A1) / 48
+      shape = (tile_id - VX_TILE_ID_A1) % 48
+      return out if shape >= 48
+      tx = kind % 8
+      ty = kind / 8
+      bx = tx * 2
+      by = (ty - 2) * 3
+      [[0, 2], [1, 3]].each do |c, corner|
+        qsx = VX_FLOOR_QUADS[shape][corner][0]
+        qsy = VX_FLOOR_QUADS[shape][corner][1]
+        next unless [1, 5].include?(qsy)
+        sx = (bx * 2 + qsx) * half
+        sy = (by * 2 + qsy) * half
+        dx = c.zero? ? 0 : half
+        out << [1, sx, sy, dx, TILE_SIZE - half / 2, half, half]
+      end
+      out
+    end
   end
 
   class Window


### PR DESCRIPTION
Implements rendering of the A2 table (counter) tile "leg" — the 8px overhang that extends past a table tile's 32×32 boundary into the map row below it. This matches authentic RPG Maker VX/VX Ace behavior.

## Summary

Added support for drawing table tile "legs" in VX/VX Ace tilemaps. A table tile's leg is a 16×16 quad sourced from the same corner position that triggers the same-cell "counter row" substitution, but drawn at `dy = 24` so it spills 8px past the tile's own bottom edge into the row below.

## Key Changes

- **`vx_table_leg_quads()` function**: New C++ function that computes leg quads for a given A2 tile ID. A leg exists on a corner exactly when that corner would trigger the counter-row substitution (`qsy == 1` or `5`), sourced from that corner's unsubstituted position. Returns 0, 1, or 2 quads depending on the tile shape.

- **`tilemap_refresh_vx()` leg rendering pass**: Added a second pass after all plain tiles of a layer are drawn. This ensures legs (which spill into the row below) are drawn after that row's own tiles, preventing them from being painted over.

- **`tilemap_vx_table_leg_quads()` Ruby binding**: Exposed the leg quad computation as a class method on `RGSS::Tilemap`, matching the API surface of the existing `vx_tile_quads` method. Pinned with reference sweep tests.

## Implementation Details

- Legs are computed as a pure function of the tile ID alone — no neighbor lookup needed, matching mkxp's `TileAtlasVX::readAutotileA2` (the reference VX/VX Ace tile renderer).
- The leg source coordinates are derived from `VX_FLOOR_QUADS`, the same lookup table used for the counter-row substitution, confirming the geometric relationship.
- Comprehensive test coverage includes specific shape examples (shapes 0, 4, 28) and a reference sweep checksum over all 1,536 A2 tile IDs.
- Documentation updated to clarify that `flags` bit 0x10 ("higher tile") correctly remains a flat layer, not a per-row priority system (which is XP-specific).

https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR