### PR TITLE
map: Show Battle Animation's Whole Screen option now tiles across the screen, matching RPG_RT

### DIFF
--- a/changelog.d/show-battle-animation-whole-screen.fixed.md
+++ b/changelog.d/show-battle-animation-whole-screen.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2000/2003 maps:** Show Battle Animation's "Whole screen" target
+  option now actually tiles the animation across the entire visible
+  screen, matching RPG_RT. Previously this parameter was silently
+  ignored and every such animation rendered as a small effect anchored to
+  the target character instead of a screen-wide wash. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4686,6 +4686,50 @@ The work below is roughly ordered by the critical path to a walkable game
   staying put for center; a map-triggered animation carrying RPG_RT's own
   24px map-target height, not the CharSet frame's 32px), confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Show Battle Animation's own "Whole screen" target option (param3) was
+  silently dropped, so it always rendered anchored to the target character
+  instead of tiled across the visible screen (2026-08-19).**
+  `Interpreter#do_show_battle_animation` (`mruby-rpg2k/mrblib/
+  interpreter.rb`) recorded `animation`/`target`/`wait` off `cmd.param(0..2)`
+  but never read `cmd.param(3)` at all. Confirmed against EasyRPG's actual
+  C++ source, fetched live: `Game_Interpreter_Map::
+  CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) is `bool
+  global = com.parameters[3] > 0;`, threaded straight through `Game_Screen::
+  ShowBattleAnimation` into `BattleAnimationMap`'s own `global` flag — and
+  this command's own `CmdSetup<..., 4>` requires all four parameters, so
+  this is not a 2003-only extension nor an optional trailing field, unlike
+  some other commands in this file. `BattleAnimationMap::Draw`
+  (`src/battle_animation.cpp`) branches on it: `DrawSingle` (the only path
+  this codebase ever took) anchors the animation to the target character;
+  `DrawGlobal` instead tiles it nine times in a 3x3 grid, each copy offset
+  by a full screen width/height (`GetScreenEffectsRect()`), so a single
+  animation cell — smaller than the screen — ends up covering the entire
+  visible area regardless of where the camera sits. Choosing "Whole screen"
+  in the editor's own Show Battle Animation target dropdown (a standard,
+  commonly-authored way to do a screen-wide explosion/flash cutscene
+  effect, not an obscure option) writes this exact parameter — so every
+  such animation played as a small effect stuck to the hero (or whatever
+  `target` resolved to) instead of the intended full-screen wash. Fixed by
+  reading `cmd.param(3)` into a new `global:` key on the `@battle_animation`
+  request, and a new `Scene::Map#global_animation_targets`, called from
+  `#start_map_animation` when it is set: nine `#anim_target` descriptors
+  built directly in this scene's own map-pixel/camera-offset space (so the
+  ordinary per-target `tx - cam_x + TILE / 2` conversion every other draw
+  already applies places each tile at exactly `i * SCREEN_W + SCREEN_W / 2`
+  on screen with no special-casing at draw time), each with `height: nil`
+  since a full-screen tile has no sprite bounding box for
+  `#animation_position_offset` to split against — matching `DrawGlobal`,
+  which never goes through `DrawSingle`'s position/character-height offset
+  logic at all. Every tile shares the same `flash_target` (the original
+  single character `BattleAnimationMap::FlashTargets` itself always
+  flashes, `global` or not, per its own unconditional `target->Flash(...)`
+  call); `ShakeTargets` needed no equivalent change, already a
+  confirmed-empty no-op for this map form regardless of `global`. Covered
+  by two new `scripts/rpg2k_scene_check.rb` checks (a "Whole screen"
+  animation builds a 3x3 grid of `height: nil` targets spaced exactly one
+  screen width/height apart, confirmed to fail against the pre-fix code —
+  `expected 9, got 1` — before the fix; an ordinary single-target animation
+  with no fourth parameter at all is completely unaffected).
   ✅ **Per-cell transparency is no longer approximated away either.** Each
   cell of an animation frame carries its own `transparency` (`battle_anime`
   chunk 19's per-cell field 10 — liblcf's

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3374,11 +3374,13 @@ module Game
 
     # Show Battle Animation (11210): play battle animation param0 over a target
     # character on the map. param1 is the target id (the player, an event, or
-    # this event — the Move Event target scheme) and param2 the "wait until it
-    # finishes" flag. EasyRPG's own `Game_Interpreter_Map::
-    # CommandShowBattleAnimation` (src/game_interpreter_map.cpp) always starts the
-    # animation through `Game_Screen::ShowBattleAnimation` regardless of the wait
-    # flag — only whether `_state.wait_time` is then set (pausing the interpreter)
+    # this event — the Move Event target scheme), param2 the "wait until it
+    # finishes" flag, and param3 whether the editor's "Whole screen" target
+    # option was chosen instead of a single character. EasyRPG's own
+    # `Game_Interpreter_Map::CommandShowBattleAnimation`
+    # (src/game_interpreter_map.cpp) always starts the animation through
+    # `Game_Screen::ShowBattleAnimation` regardless of the wait flag — only
+    # whether `_state.wait_time` is then set (pausing the interpreter)
     # depends on it — so a fire-and-forget play is not merely non-blocking, it is
     # still expected to render. With the wait flag set, this suspends on an
     # :animation wait so the owning scene can hold the event for the animation's
@@ -3386,9 +3388,20 @@ module Game
     # wait); with it unset, `@battle_animation_pending` flags this request for
     # #take_battle_animation_request instead, since nothing will ever visit an
     # :animation wait for it otherwise.
+    #
+    # `param3` (`global`) is confirmed against EasyRPG's actual C++ source,
+    # fetched live: `bool global = com.parameters[3] > 0;`, threaded through
+    # `Game_Screen::ShowBattleAnimation`/`BattleAnimationMap` unchanged, and
+    # this command's own `CmdSetup<..., 4>` requires all four parameters —
+    # it is not a 2003-only extension. A prior version of this method never
+    # read it at all, so every "Whole screen" animation (the standard,
+    # editor-authored way to do a screen-wide explosion/flash cutscene
+    # effect) rendered anchored to the target character instead of tiled
+    # across the visible screen (`Scene::Map#global_animation_targets`,
+    # matching `BattleAnimationMap::DrawGlobal`).
     def do_show_battle_animation(cmd)
       @battle_animation = { animation: cmd.param(0), target: cmd.param(1),
-                            wait: cmd.param(2) != 0 }
+                            wait: cmd.param(2) != 0, global: cmd.param(3) != 0 }
       if cmd.param(2) != 0
         @wait_kind = :animation
         @waiting = true

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5993,15 +5993,58 @@ class RPG2k
       def start_map_animation(req)
         return nil unless req
         return @battle.start_battle_page_animation(req) if req[:battle]
-        tx, ty = animation_target_pixel(req[:target])
-        # Every map target -- the player, a map event, a vehicle -- gets the
-        # same fixed height for #animation_position_offset's Head/Feet split
-        # (see ANIM_MAP_TARGET_HEIGHT's own comment for why this is 24, not
-        # the CharSet frame's actual 32px), so the sprite bounding box is
-        # known without asking what kind of character this actually is.
-        target = anim_target(tx, ty, height: ANIM_MAP_TARGET_HEIGHT, index: nil,
-                             flash_target: map_animation_flash_target(req[:target]))
-        build_animation(req[:animation], [target], false)
+        flash_target = map_animation_flash_target(req[:target])
+        targets =
+          if req[:global]
+            global_animation_targets(flash_target)
+          else
+            tx, ty = animation_target_pixel(req[:target])
+            # Every map target -- the player, a map event, a vehicle -- gets
+            # the same fixed height for #animation_position_offset's
+            # Head/Feet split (see ANIM_MAP_TARGET_HEIGHT's own comment for
+            # why this is 24, not the CharSet frame's actual 32px), so the
+            # sprite bounding box is known without asking what kind of
+            # character this actually is.
+            [anim_target(tx, ty, height: ANIM_MAP_TARGET_HEIGHT, index: nil, flash_target: flash_target)]
+          end
+        build_animation(req[:animation], targets, false)
+      end
+
+      # The 3x3 grid of map-pixel target descriptors a **whole-screen** Show
+      # Battle Animation (11210 param3, the editor's "Whole screen" target
+      # option) tiles itself across, matching EasyRPG's actual C++ source,
+      # fetched live: `BattleAnimationMap::DrawGlobal`
+      # (src/battle_animation.cpp) draws the animation nine times, offset by
+      # a full screen width/height in each direction (`for y in -1..1: for x
+      # in -1..1: DrawAt(dst, rect.width*x+rect.x, rect.height*y+rect.y)`,
+      # `rect` the current visible screen area) -- since a single animation
+      # cell is smaller than the screen, this is what makes it cover the
+      # whole visible area regardless of where the camera happens to sit,
+      # rather than appearing only once at a single point on it.
+      #
+      # Built directly in this scene's own map-pixel/camera-offset space
+      # (`#camera_position`, the same one every other draw here already
+      # subtracts) rather than screen space, so the ordinary per-target `tx -
+      # cam_x + TILE / 2` conversion in #render_map_animation places each
+      # tile at exactly `i * SCREEN_W + SCREEN_W / 2` on screen with no
+      # special-casing there. `height: nil` -- like the ally-side "middle of
+      # the screen" fallback -- since a full-screen tile has no sprite
+      # bounding box for #animation_position_offset to split; EasyRPG's own
+      # `DrawGlobal` never goes through `DrawSingle`'s position/character-
+      # height logic at all. Every tile shares the same `flash_target`
+      # (the original single character `BattleAnimationMap::FlashTargets`
+      # itself always flashes, `global` or not) so a flash_scope-1 timing
+      # still pulses the right character; `ShakeTargets` is already a
+      # confirmed-empty no-op for this map form regardless.
+      def global_animation_targets(flash_target)
+        cam_x, cam_y = camera_position
+        (-1..1).flat_map do |gy|
+          (-1..1).map do |gx|
+            tx = cam_x - TILE / 2 + gx * SCREEN_W + SCREEN_W / 2
+            ty = cam_y - TILE / 2 + gy * SCREEN_H + SCREEN_H / 2
+            anim_target(tx, ty, height: nil, index: nil, flash_target: flash_target)
+          end
+        end
       end
 
       # The character a map-triggered flash_scope-1 timing (see

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8527,6 +8527,65 @@ check "a map-triggered Show Battle Animation carries RPG_RT's own 24px map-targe
       'or the battle-only nil fallback'
 end
 
+check "Show Battle Animation's Whole Screen option (param3) tiles the animation " \
+      'across the screen, not just over the target character' do
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_Interpreter_Map::CommandShowBattleAnimation`
+  # (src/game_interpreter_map.cpp) reads `bool global = com.parameters[3] >
+  # 0;` and threads it through to `BattleAnimationMap::DrawGlobal`
+  # (src/battle_animation.cpp), which draws the animation nine times in a
+  # 3x3 grid offset by a full screen width/height in each direction --
+  # covering the whole visible screen regardless of where the camera
+  # happens to sit. A prior version of this codebase never read param3 at
+  # all, so a "Whole screen" animation always rendered as a single copy
+  # anchored to the target character instead.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1, 1], indent: 0), # animation, player, wait, global=1
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  anim = nil
+  40.times do
+    scene.update
+    anim = scene.instance_variable_get(:@map_animation)
+    break if anim
+  end
+  ok anim, 'the animation actually started'
+  eq 9, anim[:targets].size, 'a 3x3 tiled grid of targets, not just the one character'
+  ok anim[:targets].all? { |t| t[:height].nil? },
+     'no sprite bounding box to split -- matching DrawGlobal, which never goes ' \
+     "through DrawSingle's position/character-height offset logic at all"
+  xs = anim[:targets].map { |t| t[:tx] }.uniq.sort
+  ys = anim[:targets].map { |t| t[:ty] }.uniq.sort
+  eq 3, xs.size
+  eq 3, ys.size
+  eq RPG2k::Scene::Map::SCREEN_W, xs[1] - xs[0], 'adjacent tiles are exactly one screen width apart'
+  eq RPG2k::Scene::Map::SCREEN_W, xs[2] - xs[1]
+  eq RPG2k::Scene::Map::SCREEN_H, ys[1] - ys[0], 'and one screen height apart vertically'
+  eq RPG2k::Scene::Map::SCREEN_H, ys[2] - ys[1]
+end
+
+check 'Show Battle Animation with no Whole Screen flag still draws a single ' \
+      'target, unaffected by the param3 fix' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0), # animation, player, wait -- no 4th param
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  anim = nil
+  40.times do
+    scene.update
+    anim = scene.instance_variable_get(:@map_animation)
+    break if anim
+  end
+  ok anim, 'the animation actually started'
+  eq 1, anim[:targets].size, 'an ordinary target-character animation, exactly as before'
+end
+
 # A map-triggered Show Battle Animation's flash_scope-1 timing used to be
 # silently dropped: #fire_animation_flashes only ever reached
 # #fire_target_flash's battle-only enemy-sprite mechanism, which a map scene


### PR DESCRIPTION
## Summary
- `Interpreter#do_show_battle_animation` (`mruby-rpg2k/mrblib/interpreter.rb`) recorded `animation`/`target`/`wait` off `cmd.param(0..2)` but never read `cmd.param(3)` — the editor's "Whole screen" target option for Show Battle Animation (11210).
- RPG_RT's `Game_Interpreter_Map::CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`, verified live against EasyRPG Player's C++ source) is `bool global = com.parameters[3] > 0;`, threaded through `Game_Screen::ShowBattleAnimation` into `BattleAnimationMap`'s own `global` flag — the command's own `CmdSetup<..., 4>` requires all four parameters, so this isn't an optional/2003-only field.
- `BattleAnimationMap::Draw` (`src/battle_animation.cpp`) branches on it: `DrawSingle` (the only path this codebase ever took) anchors the animation to the target character; `DrawGlobal` instead tiles it nine times in a 3x3 grid, each copy offset by a full screen width/height, so a single animation cell ends up covering the entire visible screen regardless of camera position.
- Choosing "Whole screen" in the editor's own Show Battle Animation target dropdown is a standard, commonly-authored way to do a screen-wide explosion/flash cutscene effect — so every such animation played as a small effect stuck to the hero instead of the intended full-screen wash.
- Fixed by reading `cmd.param(3)` into a new `global:` key, and a new `Scene::Map#global_animation_targets` building nine `#anim_target` descriptors directly in this scene's own map-pixel/camera-offset space (so the ordinary per-target draw-time conversion places each tile correctly with no special-casing), each with `height: nil` matching `DrawGlobal` never going through `DrawSingle`'s position/character-height offset logic at all.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a "Whole screen" animation builds a 3x3 grid of `height: nil` targets spaced exactly one screen width/height apart.
- [x] New check: an ordinary single-target animation with no fourth parameter at all is completely unaffected (still exactly 1 target).
- [x] Confirmed the new checks fail against the pre-fix code (`git stash`) — `expected 9, got 1`.
- [x] Full suite green post-fix: 751/751 scene checks, 1030 logic, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_