### PR TITLE
docs: confirm RPG2000 move routes discard, never queue

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9290,9 +9290,16 @@ not yet verified:
   is now also implemented (`Scene::Map#debug_through?`).
 
 **Move Route / Character Movement command**
-- Only **one pending move route per character** — issuing a second while
+- ✅ Only **one pending move route per character** — issuing a second while
   the first is still running **discards the first outright** (not queued,
-  not layered).
+  not layered). **Confirmed already correct**, all three targets: a fresh
+  Set Move Route is a plain overwrite with no queueing anywhere in
+  `mruby-rpg2k/mrblib/scene/map.rb` — `force_event_route`'s
+  `ev[:forced_route] = route`, `start_player_route`'s (`Scene::Map`)
+  `@player_route = route`, and `force_vehicle_route`'s
+  `@vehicle_routes[type] = route` all simply replace whatever route (if any)
+  was already running, dropping its remaining queued commands outright. No
+  code carries a second route alongside the first for any of the three.
 - Move-route commands are asynchronous/fire-and-forget by default: the
   interpreter advances immediately while the character keeps sliding in
   the background; only "Proceed With Movement"/"Run All Designated Moves"


### PR DESCRIPTION
## Summary

Resolves one item from the RPG2000 "Full-site sweep" untriaged backlog in `docs/TODO.md`: "Only one pending move route per character — issuing a second while the first is still running discards the first outright (not queued, not layered)."

Verified this against the actual assignment sites in `mruby-rpg2k/mrblib/scene/map.rb`:
- `force_event_route`: `ev[:forced_route] = route`
- `start_player_route`: `@player_route = route`
- `force_vehicle_route`: `@vehicle_routes[type] = route`

All three are plain overwrites — issuing a second Set Move Route on the same target (player, map event, or vehicle) always discards whatever route was still running, matching real RPG_RT. No queueing or layering exists on any of the three paths, so no code change was needed. Marked the item confirmed in `docs/TODO.md` rather than leaving it open for a future pass to re-derive the same fact.

## Test plan
- Documentation-only change (no behavior change); verified by reading the three assignment sites directly.

https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_