### PR TITLE
actor: Change Condition can lift a cursed-armor state outside battle, matching RPG_RT

### DIFF
--- a/changelog.d/change-condition-map-cursed-armor-exemption.fixed.md
+++ b/changelog.d/change-condition-map-cursed-armor-exemption.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 events:** The Change Condition event command can now lift a
+  cursed-equipment-forced status condition when run outside battle,
+  matching RPG_RT's own map-only exemption — but only for a state left at
+  its default "Ends" persistence, never one flagged "Continues after
+  battle". Previously a cursed-armor-forced state could only ever be
+  cured by unequipping the item, even from a map event specifically
+  designed to lift it. Covered by two new `scripts/rpg2k_logic_check.rb`
+  checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8845,6 +8845,48 @@ not yet verified:
   51 at all, so every prior actor fixture started unarmed regardless of
   what a real database's `initial_equipment` might specify), confirmed to
   fail against the pre-fix code before the fix.
+  ✅ **A map-side Change Condition (10480) cannot lift a cursed-armor-forced
+  state even though real RPG_RT specifically carves out an exemption for
+  exactly this case (2026-08-19).** The two fixes above correctly made
+  `#remove_state` refuse a cursed-armor-forced state unconditionally, but
+  RPG_RT's own refusal is not actually unconditional. Confirmed against
+  EasyRPG's actual C++ source, fetched live: `Game_Interpreter::
+  CommandChangeCondition` (`src/game_interpreter.cpp`) calls `actor->
+  RemoveState(state_id, !Game_Battle::IsBattleRunning())`, and
+  `Game_Battler::RemoveState`'s own `always_remove_battle_states`
+  parameter (`src/game_battler.cpp`) is `if (!(always_remove_battle_states
+  && state && state->type == Persistence_ends)) { ps =
+  GetPermanentStates(); }` — the permanent-states lock is skipped entirely
+  when both true: the cure is running outside battle, *and* the state's
+  own database Persistence field is "Ends" (0, the schema default for
+  most non-Poison-style ailments) rather than "Continues after battle"
+  (1). The call site's own comment states the intent outright: "RPG_RT:
+  On the map, will remove battle states even if actor has state inflicted
+  by equipment." Every *other* cure path — an item, a skill, Full
+  Recovery, or Change Condition while a fight is actually running —
+  always passes `false` there, so this exemption is specific to exactly
+  one command run outside battle, not a general softening of the lock.
+  Concretely: an actor whose starting/equipped armor forces Confusion (a
+  state left at its schema-default Persistence) via the Curse flag stays
+  confused forever under the two fixes above — a shrine/blessing map event
+  built around "if cursed, use Change Condition to lift it" (an entirely
+  ordinary editor-authored design, not requiring the player to think to
+  unequip the item) silently failed to do anything. Fixed by giving
+  `Actor#remove_state` a new `always_remove_battle_states:` keyword
+  (mirroring EasyRPG's own parameter name) and a new
+  `#state_persists_type?` helper reading the state's own `situation` row
+  the same way `#can_act?` already does; `Interpreter#do_change_condition`
+  passes `@battle.nil?` — this port's own `!Game_Battle::IsBattleRunning()`
+  — through on every remove. Every other `#remove_state` call site
+  (`#use_medicine`, `#cast_skill`) is untouched, keeping its implicit
+  `false` default. Covered by two new `scripts/rpg2k_logic_check.rb`
+  checks — `#remove_state(state_id, always_remove_battle_states: true)`
+  lifts a battle-only-type cursed-armor-forced state but still refuses a
+  "continues after battle" one even outside battle; a full `Interpreter#
+  do_change_condition` run confirms the same state cannot be lifted with
+  `@battle` set but can once it is nil — both confirmed to fail against
+  the pre-fix code (an `ArgumentError` for the new keyword, and the state
+  surviving a map-side cure) before the fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1699,11 +1699,44 @@ module Game
     # Refuses a state #permanent_states names -- RPG2003 cursed armor
     # currently forcing it -- the same way EasyRPG's `State::Remove`
     # (src/state.cpp) does: `if (ps.Has(state_id)) return false;`.
-    def remove_state(state_id)
-      return nil if permanent_states.include?(state_id)
+    #
+    # `always_remove_battle_states:` mirrors EasyRPG's own
+    # `Game_Battler::RemoveState`'s second parameter of the identical name
+    # (`src/game_battler.cpp`): the Change Condition event command
+    # (`Interpreter#do_change_condition`) passes it true when run outside
+    # battle, and RPG_RT's own `RemoveState` then skips the cursed-armor
+    # lock entirely -- but only for a state whose own database Persistence
+    # field is "Ends" (0, the schema default for most non-Poison-style
+    # ailments), never a "Continues after battle" one (1) -- confirmed
+    # against the actual C++ source, fetched live: `if (!
+    # (always_remove_battle_states && state && state->type ==
+    # Persistence_ends)) { ps = GetPermanentStates(); }`, with the source's
+    # own comment on the call site spelling out why: "RPG_RT: On the map,
+    # will remove battle states even if actor has state inflicted by
+    # equipment." Every other cure path -- an item, a skill, Full Recovery,
+    # or Change Condition while a fight is actually running -- always
+    # passes `false` in real RPG_RT too, so this bypass is exactly as
+    # narrow there as it is here.
+    def remove_state(state_id, always_remove_battle_states: false)
+      bypass = always_remove_battle_states && !state_persists_type?(state_id)
+      return nil if !bypass && permanent_states.include?(state_id)
       removed = @states.delete(state_id)
       @hp = 1 if removed == DEATH_STATE && @hp <= 0
       removed
+    end
+
+    # Whether `state_id`'s own database row is flagged "Continues after
+    # battle" (liblcf's `Persistence_persists`, matching `Battle::
+    # STATE_PERSISTS_ON_MAP`) -- #remove_state's own
+    # `always_remove_battle_states:` bypass only ever applies to the
+    # opposite, schema-default case. A dangling/unknown state id, or a bare
+    # fixture with no `:type` field at all, reads as persisting (never
+    # bypassed) -- the same conservative refusal #remove_state already gave
+    # before this parameter existed.
+    def state_persists_type?(state_id)
+      table = @db.respond_to?(:situation) ? @db.situation : nil
+      row = Game::States.row(state_id, table)
+      !(row && row.respond_to?(:type) && (row.type || 0) != Battle::STATE_PERSISTS_ON_MAP)
     end
 
     # Cure every status condition (RPG2000 Full Recovery clears them). If the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2200,12 +2200,24 @@ module Game
     # the operation (0 add / inflict, non-zero remove / cure) and param3 the state
     # id. Removing the death state (戦闘不能) revives a downed actor; inflicting it
     # knocks the actor out — the HP coupling lives in Game::Actor.
+    #
+    # A cure run outside battle can lift a cursed-equipment-forced state
+    # RPG_RT would otherwise refuse -- confirmed against EasyRPG's actual
+    # C++ source, fetched live: `Game_Interpreter::CommandChangeCondition`
+    # (src/game_interpreter.cpp) calls `actor->RemoveState(state_id,
+    # !Game_Battle::IsBattleRunning())`, and `Game_Battler::RemoveState`'s
+    # own `always_remove_battle_states` bypass (see `Actor#remove_state`'s
+    # doc comment) only ever applies to a state whose own database
+    # Persistence field is "Ends" (not "Continues after battle"). `@battle`
+    # (nil outside a battle-event page, the same flag every other
+    # battle-context check in this file already reads) is this port's own
+    # `!Game_Battle::IsBattleRunning()`.
     def do_change_condition(cmd)
       state_id = cmd.param(3)
       remove = cmd.param(2) != 0
       stat_targets(cmd).each do |a|
         if remove
-          a.remove_state(state_id)
+          a.remove_state(state_id, always_remove_battle_states: @battle.nil?)
         else
           a.add_state(state_id)
           # RPG_RT's crowding-out rule (Game::States::PRUNE_GAP): a state

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4395,6 +4395,72 @@ check "#remove_state refuses a state RPG2003 cursed armor is still forcing" do
   eq [], a.states
 end
 
+# Confirmed against EasyRPG's actual C++ source, fetched live:
+# `Game_Interpreter::CommandChangeCondition` (src/game_interpreter.cpp)
+# calls `actor->RemoveState(state_id, !Game_Battle::IsBattleRunning())`,
+# and `Game_Battler::RemoveState`'s own `always_remove_battle_states`
+# parameter (src/game_battler.cpp) skips the cursed-armor lock entirely --
+# but only for a state whose own database Persistence field is "Ends" (0,
+# the schema default) rather than "Continues after battle" (1) -- with the
+# source's own comment on the call site spelling out why: "RPG_RT: On the
+# map, will remove battle states even if actor has state inflicted by
+# equipment." Every other cure path (an item, a skill, Full Recovery, or
+# Change Condition while a fight is actually running) always passes
+# `false` in real RPG_RT too, matching every *other* #remove_state call in
+# this file.
+check '#remove_state can lift a cursed-armor-forced state outside battle, but ' \
+      'only when the state itself is not flagged to continue after battle' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  situation = { 4 => fake_state(type: 0) } # "Ends" (battle-only), the schema default
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, {}, {}, situation, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  eq [4], a.states
+  eq nil, a.remove_state(4), 'still refused in battle (the default) -- armor is still equipped'
+  eq [4], a.states
+  eq 4, a.remove_state(4, always_remove_battle_states: true),
+     "a map-side cure -- Change Condition run outside battle -- lifts it anyway, RPG_RT's own exemption"
+  eq [], a.states
+
+  # The opposite case: a "Continues after battle" state gets no exemption
+  # even outside battle.
+  situation2 = { 4 => fake_state(type: 1) }
+  db2 = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                        [1], items, {}, {}, situation2, rpg2003: true)
+  a2 = Game::Party.new(db2).leader
+  a2.equip_item(20)
+  eq nil, a2.remove_state(4, always_remove_battle_states: true),
+     'a "continues after battle" state is never map-exempted, cursed armor or not'
+  eq [4], a2.states
+end
+
+check "Interpreter#do_change_condition passes RPG_RT's own map-only cursed-armor " \
+      'exemption through, gated on whether a battle is actually running' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) }
+  situation = { 4 => fake_state(type: 0) }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, {}, {}, situation, rpg2003: true)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  a.equip_item(20)
+  eq [4], a.states
+  ic = Game::Interpreter::Cmd
+
+  # In battle (@battle set): the ordinary refusal still applies.
+  it_battle = Game::Interpreter.new(st)
+  it_battle.battle = Game::Battle.new([], [], Game::Rng.new(1))
+  it_battle.start([FakeCmd.new(ic::CHANGE_CONDITION, [1, 1, 1, 4])])
+  it_battle.update
+  eq [4], a.states, 'in-battle Change Condition cannot lift it either'
+
+  # On the map (@battle nil, the default): RPG_RT's own exemption applies.
+  it_map = Game::Interpreter.new(st)
+  it_map.start([FakeCmd.new(ic::CHANGE_CONDITION, [1, 1, 1, 4])])
+  it_map.update
+  eq [], a.states, 'a map-side Change Condition lifts it'
+end
+
 check "#clear_states (Full Recovery) leaves a cursed-armor-forced state in place" do
   items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) }
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },


### PR DESCRIPTION
## Summary
- Two earlier fixes this session correctly made `Actor#remove_state` refuse a cursed-armor-forced state unconditionally — but RPG_RT's own refusal is not actually unconditional.
- RPG_RT's `Game_Interpreter::CommandChangeCondition` (`src/game_interpreter.cpp`, verified live against EasyRPG Player's C++ source) calls `actor->RemoveState(state_id, !Game_Battle::IsBattleRunning())`, and `Game_Battler::RemoveState`'s own `always_remove_battle_states` parameter (`src/game_battler.cpp`) skips the cursed-armor permanent-states lock entirely when **both** are true: the cure is running outside battle, and the state's own database Persistence field is "Ends" (0, the schema default for most non-Poison-style ailments) rather than "Continues after battle" (1). The call site's own comment states the intent outright: *"RPG_RT: On the map, will remove battle states even if actor has state inflicted by equipment."*
- Every other cure path — an item, a skill, Full Recovery, or Change Condition while a fight is actually running — always passes `false`, so this exemption is specific to exactly one command run outside battle, not a general softening of the lock.
- Concretely: an actor whose equipped armor forces Confusion (left at its schema-default Persistence) via the Curse flag stayed confused forever — a shrine/blessing map event built around "if cursed, use Change Condition to lift it" (an entirely ordinary editor-authored design) silently did nothing.
- Fixed by giving `Actor#remove_state` a new `always_remove_battle_states:` keyword (mirroring EasyRPG's own parameter name) and a new `#state_persists_type?` helper, reading the state's own `situation` row the same way `#can_act?` already does; `Interpreter#do_change_condition` passes `@battle.nil?` — this port's own `!Game_Battle::IsBattleRunning()` — through on every remove. Every other `#remove_state` call site is untouched, keeping its implicit `false` default.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: `#remove_state(state_id, always_remove_battle_states: true)` lifts a battle-only-type cursed-armor-forced state but still refuses a "continues after battle" one even outside battle.
- [x] New check: a full `Interpreter#do_change_condition` run confirms the same state cannot be lifted with `@battle` set but can once it is nil.
- [x] Both confirmed to fail against the pre-fix code (`git stash`) — an `ArgumentError` for the new keyword, and the state surviving a map-side cure.
- [x] Full suite green post-fix: 1032/1032 logic checks, 751 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_