### PR TITLE
mv: getImageData returns a real Uint8ClampedArray, not a plain Array

### DIFF
--- a/changelog.d/mv-canvas-imagedata-typed-array.fixed.md
+++ b/changelog.d/mv-canvas-imagedata-typed-array.fixed.md
@@ -1,0 +1,8 @@
+- **MV** `CanvasRenderingContext2D.getImageData` now returns a real
+  `Uint8ClampedArray` (matching the Canvas2D spec) instead of a plain Array.
+  Third-party code that calls typed-array-only methods on `ImageData.data` —
+  notably PIXI's own `extract.canvas`, which `Bitmap.snap`/`snapToBitmap`
+  routes scene-transition snapshots through — threw `TypeError: not a
+  function` on `data.set(...)`, crashing the game the first time it tried to
+  transition scenes. Found booting a real downloaded MV game (Lunatic-Core)
+  into New Game, where it broke every probe past the title screen.

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -981,14 +981,17 @@ JSValue js_get_pixel(JSContext* ctx,
 }
 
 // __mv_canvasPutData(handle, dx, dy, w, h, data)
-// Write a w*h block of RGBA bytes (a flat [r,g,b,a,...] array as produced by
-// getImageData) into the canvas at (dx, dy). Per the canvas spec putImageData
-// *replaces* pixels (no source-over blend) and ignores the current transform,
-// so this is a straight copy, clipped to the canvas bounds. Values are clamped
-// to 0-255 to mimic the Uint8ClampedArray a real ImageData exposes (our
-// getImageData hands back a plain array, so MV's `pixels[i] += tone` can run
-// out of range). MV drives this from Bitmap.adjustTone / rotateHue, which read
-// the pixels back, recolour them and write them out.
+// Write a w*h block of RGBA bytes (a flat [r,g,b,a,...] array-like, as
+// produced by getImageData or handed in raw) into the canvas at (dx, dy). Per
+// the canvas spec putImageData *replaces* pixels (no source-over blend) and
+// ignores the current transform, so this is a straight copy, clipped to the
+// canvas bounds. Values are clamped to 0-255 defensively -- getImageData's own
+// Uint8ClampedArray already clamps `pixels[i] += tone` writes at assignment
+// (MV drives this from Bitmap.adjustTone / rotateHue, which read the pixels
+// back, recolour them and write them out), but `data` is read generically
+// (js_num_array, by .length and index) so a caller handing in a plain array
+// or object literal directly -- as a synthetic ImageData, or a value read
+// back out of range some other way -- still gets a spec-correct result.
 JSValue js_put_data(JSContext* ctx,
                     JSValueConst,
                     int argc,
@@ -1301,11 +1304,17 @@ const char* kCanvasPreamble = R"MVJS(
   };
   Ctx.prototype.getImageData = function (x, y, w, h) {
     w = w | 0; h = h | 0;
-    var data = [];
+    // A real Uint8ClampedArray, not a plain Array: third-party code (PIXI's
+    // extract.canvas, which Bitmap.snap/snapToBitmap goes through) calls
+    // typed-array-only methods like .set() on it, which a plain Array does
+    // not have -- see the TypeError this used to throw, caught booting a real
+    // MV game (Lunatic-Core) into its title-screen snapshot transition.
+    var data = new Uint8ClampedArray(w * h * 4);
+    var idx = 0;
     for (var j = 0; j < h; j++) {
       for (var i = 0; i < w; i++) {
         var p = g.__mv_canvasGetPixel(this.__h, (x | 0) + i, (y | 0) + j);
-        data.push(p[0], p[1], p[2], p[3]);
+        data[idx++] = p[0]; data[idx++] = p[1]; data[idx++] = p[2]; data[idx++] = p[3];
       }
     }
     return { width: w, height: h, data: data };


### PR DESCRIPTION
## Summary

Found booting a real downloaded MV game (Lunatic-Core) past the title: New Game crashed with

```
TypeError: not a function
    at canvas (.../pixi.js:28175:33)
    at ... (.../rpg_core.js:934:56)
    ...
```

PIXI's own screen-capture path (`Graphics._renderer.extract.canvas`, which `Bitmap.snap`/`snapToBitmap` use for scene-transition snapshots) reads the pixels back via `readPixels` into an `ImageData` and then calls `canvasData.data.set(webglPixels)` — a typed-array-only method our `getImageData`'s plain `Array` (built with `push()`) does not have.

The plain array was a deliberate simplification (see the comment it replaced on `js_put_data`): MV's own `Bitmap.adjustTone`/`rotateHue` do `pixels[i] += tone`, which needed no typed-array semantics since the native put side already clamped on write. That covered every *MV core* caller, but not third-party code — PIXI's internals here — that assumes a spec-compliant `ImageData` and calls real typed-array methods on its data.

`getImageData` now builds a real `Uint8ClampedArray`. This does not change observed behavior for MV's own `pixels[i] += tone` pattern — a `Uint8ClampedArray` clamps at the point of assignment, same end result the native clamp in `js_put_data` already produced — so all four existing `getImageData`/`putImageData` tests pass unchanged; `js_put_data`'s own native clamp stays as a defensive backstop for a caller handing in a raw array literal directly (see the "ignores the current transform" test, which does exactly that).

## Test plan
- `./build/mruby/host/bin/mrbtest` — full suite green (1818 assertions), including all 4 `getImageData`/`putImageData` cases in `mruby-mvjs/test/canvas_test.rb`.
- Built the engine from scratch and drove the real downloaded MV test bed (`data/Lunatic-Core`, `scripts/download-lunatic-core.bash`) through `--mv_new_game`: before the fix it crashed with the `TypeError` above on the first scene transition; after the fix it boots through New Game into `Scene_Map` cleanly.

https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_