### PR TITLE
battle: a lethal hit zeroes the active-time gauge immediately, matching RPG_RT

### DIFF
--- a/changelog.d/gauge-zeroed-on-death-mid-battle.fixed.md
+++ b/changelog.d/gauge-zeroed-on-death-mid-battle.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003 Gauge battle system:** A battler's active-time gauge now
+  zeroes the instant a lethal hit lands, matching RPG_RT, instead of only
+  once the fight itself ends. Previously an ally charged up and then
+  killed mid-fight kept its old charge intact until battle end, so
+  reviving them with an ordinary Full Heal or revival item let them act
+  again almost immediately instead of charging back up from empty like
+  everyone else. Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14203,6 +14203,41 @@ above are repeated here)
   instead of whatever it was charged to), both confirmed to fail against
   the pre-fix code (`NoMethodError`, the accessor did not exist at all)
   before the fix.
+  ✅ **The fix above only zeroed a dead ally's gauge at write-back time
+  (battle end); a lethal hit landing mid-fight left the target's gauge at
+  its stale pre-death charge until then, so an ordinary revival item used
+  within the same fight resurrected the target with its old charge still
+  intact instead of empty (2026-08-19).** The bullet above's own citation
+  already quotes the relevant line — `Game_Battler::AddState`'s Knockout
+  branch (`src/game_battler.cpp`), `if (state_id == kDeathID) {
+  SetAtbGauge(0); SetHp(0); ... }` — and deliberately scoped the fix to
+  cross-*battle* persistence only (`Battle#apply_to_party`'s own
+  `c.hp > 0 ? c.gauge : 0` write-back), reasoning that a `Combatant`'s
+  `#dead?` is purely HP-driven so a single end-of-fight check is
+  sufficient — true for *whether* the gauge ends up zeroed by the time the
+  fight ends, but not for *when*: real RPG_RT's `AddState(kDeathID)` fires
+  the instant death actually lands (`Game_Battler::ChangeHp` calls it
+  itself the moment `new_hp <= 0`), and nothing between that moment and a
+  potential same-fight revival re-charges a dead battler's gauge — so a
+  revived ally in real RPG_RT always resumes from empty, never from
+  whatever it had charged to before dying. Concretely: an ally charged to
+  near-full gauge (e.g. 250,000/300,000) who is killed by an ordinary
+  attack, then revived within the same fight by an ordinary Full Heal/
+  revival item — completely standard RPG2003 Gauge-battle-system content —
+  became immediately eligible to act again at its old near-full charge in
+  this codebase, instead of charging back up from empty like everyone
+  else, a real and exploitable pacing difference. Fixed with a new private
+  `Battle#zero_gauge_on_death(target)` (`target.gauge = 0 if target.dead?`,
+  a harmless no-op if called again on an already-dead target), called from
+  every place a `Combatant`'s HP can newly reach 0: the three raw `hp -=`
+  sites (`#deal_attack_with_current_weapon`, `#apply_skill_hit`,
+  `#enemy_autodestruct`) and `#inflict_state`'s own explicit
+  `target.hp = 0 if sid == DEATH_ID` branch. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a lethal `#deal_attack` zeroes a
+  250,000-charged target's gauge immediately; reviving it by directly
+  raising HP back above 0, as an ordinary revival item would, does not
+  restore the stale charge), confirmed to fail against the pre-fix code
+  (`expected 0, got 250000`) before the fix.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10933,6 +10933,7 @@ module Game
         cap = damage_cap
         dmg = cap if dmg > cap
         t.hp -= dmg
+        zero_gauge_on_death(t)
         # A survivor's physical-release states shake off here too --
         # `SelfDestruct::vExecute` calls the identical `BattlePhysicalStateHeal(100,
         # ...)` a basic attack does (#deal_attack's own #shake_off_states call),
@@ -11547,6 +11548,7 @@ module Game
       cap = damage_cap
       dmg = cap if dmg > cap
       target.hp -= dmg
+      zero_gauge_on_death(target)
       if target.dead?
         woke = []
         inflicted = []
@@ -12026,6 +12028,7 @@ module Game
             absorbed = hp_dmg
           end
           target.hp -= hp_dmg
+          zero_gauge_on_death(target)
         end
         b.hp = [b.hp + absorbed, b.max_hp].min if absorbed > 0
         # The same shared, un-gated `dmg` the HP branch above just used, applied
@@ -12268,10 +12271,35 @@ module Game
     # RPG_RT's crowding-out rule (`Game::States::PRUNE_GAP`): the state that
     # just landed may itself immediately push out one already held, or be
     # pushed out by one already held that outranks it.
+    # The Knockout state landing zeroes the active-time gauge too, not just
+    # HP -- verified against RPG_RT's actual behavior via EasyRPG's own
+    # C++ source, fetched live: `Game_Battler::AddState`'s Knockout branch
+    # (`src/game_battler.cpp`) is `if (state_id == kDeathID) { SetAtbGauge(0);
+    # SetHp(0); ... }`, fired the instant the state lands, from *every*
+    # path that can inflict it -- an ordinary lethal hit (`ChangeHp` calls
+    # `AddState(kDeathID, true)` itself once `new_hp &lt;= 0`), a skill/weapon's
+    # own state-effect list, Change Monster/Actor Condition, all alike.
+    # Distinct from `Actor#atb_gauge`'s own cross-*battle* persistence fix
+    # (`#apply_to_party` writing back 0 for an ally who ended the *fight*
+    # dead): this is the same zeroing but at the moment of death itself,
+    # mid-fight -- without it, an ally charged to near-full gauge who dies
+    # and is then revived by an ordinary Full Heal/revival skill within the
+    # same fight would resume acting from that stale pre-death charge
+    # instead of empty, like anyone else newly readying up. Called from
+    # every place a `Combatant`'s HP can newly reach 0 (this method, and
+    # the three raw `hp -=` sites in #deal_attack_with_current_weapon,
+    # #apply_skill_hit and #enemy_autodestruct) -- calling it again on an
+    # already-dead target is a harmless no-op, matching a corpse's gauge
+    # always reading 0 whether checked once or many times.
+    def zero_gauge_on_death(target)
+      target.gauge = 0 if target.respond_to?(:gauge) && target.dead?
+    end
+
     def inflict_state(target, sid)
       return if target.state?(sid)
       target.states = Game::States.prune((target.states || []) + [sid], @states)
       target.hp = 0 if sid == Game::States::DEATH_ID
+      zero_gauge_on_death(target)
     end
 
     # Cure a state from `target`, reviving it to 1 HP when curing state 1 is

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11796,6 +11796,39 @@ check 'Battle#apply_to_party zeroes the active-time gauge for an ally who ended 
   eq 0, ally.atb_gauge, 'a knocked-out ally does not carry a charge into the next fight'
 end
 
+# Confirmed against EasyRPG's actual C++ source, fetched live:
+# `Game_Battler::AddState`'s Knockout branch (src/game_battler.cpp) is
+# `if (state_id == kDeathID) { SetAtbGauge(0); SetHp(0); ... }`, fired the
+# instant Death lands -- and `Game_Battler::ChangeHp` calls
+# `AddState(kDeathID, true)` itself the moment `new_hp <= 0`, so *every*
+# ordinary lethal hit zeroes the gauge mid-fight, not merely once the
+# fight ends (the already-fixed `Battle#apply_to_party` cross-*battle*
+# persistence checks just above are a separate, later boundary). Without
+# this, an ally charged to near-full gauge who dies and is then revived
+# by an ordinary Full Heal/revival item within the same fight would
+# resume acting from that stale pre-death charge instead of empty, like
+# anyone else newly readying up -- a real, exploitable pacing difference
+# in any RPG2003 project using the Gauge battle system.
+check "a lethal attack zeroes the target's active-time gauge immediately, not " \
+      'merely once the fight ends' do
+  hero = combatant('Hero', 999, 0, 5, 100)
+  foe = combatant('Foe', 0, 0, 5, 1)
+  foe.gauge = 250_000 # charged most of the way up when the killing blow lands
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  bat.send(:deal_attack, hero, foe)
+  ok foe.dead?, 'the hit was lethal'
+  eq 0, foe.gauge, 'the gauge was zeroed the instant Death landed, mid-fight'
+
+  # An ordinary revival effect (a Full Heal/revival item raising HP back
+  # above 0) does not restore the stale pre-death charge -- nothing
+  # recharges a dead battler's gauge in between, matching real RPG_RT,
+  # which never re-zeroes on revival because it was already zeroed the
+  # moment death landed.
+  foe.hp = 10
+  ok !foe.dead?, 'revived'
+  eq 0, foe.gauge, 'revival does not restore the pre-death charge'
+end
+
 check "Battle#apply_to_party clears a battle combo Enable Combo armed, matching RPG_RT (2026-08-19)" do
   # Confirmed against EasyRPG's actual C++ source, fetched live:
   # `Game_Battler::ResetBattle` (src/game_battler.cpp) is `battle_combo_


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Battler::AddState`'s Knockout branch (`src/game_battler.cpp`, verified live against EasyRPG Player's C++ source) is `if (state_id == kDeathID) { SetAtbGauge(0); SetHp(0); ... }`, fired the instant Death lands — and `Game_Battler::ChangeHp` calls `AddState(kDeathID, true)` itself the moment `new_hp <= 0`, so every ordinary lethal hit zeroes the gauge mid-fight, not merely once the fight ends.
- An earlier fix this session (already merged) added persisted cross-battle ATB gauge tracking, but only wrote a dead ally's gauge back to 0 at battle end (`Battle#apply_to_party`'s `c.hp > 0 ? c.gauge : 0`). That's correct for *whether* the gauge ends up zeroed by the time the fight ends, but not for *when* — nothing zeroed it at the actual moment of death.
- Concretely: an ally charged to near-full gauge who dies mid-fight and is then revived within the *same* fight by an ordinary Full Heal/revival item (completely standard RPG2003 Gauge-battle-system content) resumed acting from its stale pre-death charge instead of empty like everyone else — a real, exploitable pacing difference.
- Fixed with a new private `Battle#zero_gauge_on_death(target)` (`target.gauge = 0 if target.dead?`, a harmless no-op on an already-dead target), called from every place a `Combatant`'s HP can newly reach 0: the three raw `hp -=` sites (`#deal_attack_with_current_weapon`, `#apply_skill_hit`, `#enemy_autodestruct`) and `#inflict_state`'s own explicit `DEATH_ID` branch.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a lethal `#deal_attack` zeroes a 250,000-charged target's gauge immediately; reviving it by raising HP back above 0 (as an ordinary revival item would) does not restore the stale charge.
- [x] Confirmed the new check fails against the pre-fix code (`git stash`) — `expected 0, got 250000`.
- [x] Full suite green post-fix: 1033/1033 logic checks, 751 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_