### PR TITLE
docs: MV player movement never actually works, and nothing checks it

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15278,14 +15278,13 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     a tessellated circle via `arc`, an unclosed path, and a stroked segment).
     `closePath`/`arcTo`/`clip` and multi-subpath fills stay no-ops — no core MV
     consumer has needed them yet.
-- ✅ **M5 — Play.** Input (`Input`/`TouchInput`), save/load (the NW.js
+- 🚧 **M5 — Play.** Input (`Input`/`TouchInput`), save/load (the NW.js
   `require('fs')` shim) and audio (Web Audio → `RGSS::Audio`); a walkable MV game
   in the SDL window and the sixel/iTerm2 terminals. Input is wired too, despite
   no dedicated bullet below having said so: `MV#sync_input`/`#sync_touch`
   (`mruby-mvjs/mrblib/mv.rb`, both explicitly commented `# M5:`) push
   `RGSS::Input`/mouse into `Input._currentState`/`TouchInput` every frame
-  before the scene updates, which is what the real-game play smoke's own
-  movement probe exercises. Audible playback itself is the one thing that
+  before the scene updates. Audible playback itself is a separate thing that
   stays unverified here — dispatch and asset resolution are checked, but
   CI has no sound device to actually listen with.
   - ✅ Test-bed data guard: `scripts/mv_testbed_check.rb` validates the MV
@@ -15293,10 +15292,53 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     (`width*height*6`), tileset/actor/class cross-references, party members —
     and runs as a **blocking** CI step ahead of the non-blocking native MV
     smokes, so a regression in the committed `data/mv-sample` fails the build.
-  - ✅ Real-game play smoke: CI drives the downloaded Lunatic-Core bed past the
-    title into New Game → map and a movement probe (`--mv_new_game
-    --mv_move_test`), not just the title boot — so the fuller real game's
-    map/movement/render path is exercised, not only the minimal sample's.
+  - ⚠️ **Real-game play smoke reaches the map, but nothing ever asserted the
+    player actually moves — and once checked, it doesn't.** CI's "MV real-game
+    play smoke test" / "MV movement smoke test" steps
+    (`.github/workflows/build.yml`) run `--mv_new_game --mv_move_test` but
+    only check the process exit code; unlike the MZ equivalent
+    (`scripts/mz_boot_check.bash`'s `grep -q '\[MZ-MOVE\].*moved=true'`),
+    nothing ever greps the MV log for `[MV-MOVE] moved=true`. Driving the
+    built engine directly against both `data/Lunatic-Core` (the downloaded real
+    bed) and the committed `data/mv-sample`, under both the dummy SDL driver
+    and real Xvfb, `[MV-MOVE]` reports `moved=false` on every run, on both
+    beds — this is not a downloaded-game peculiarity.
+    Root cause traced to `Scene_Map` never becoming active: `$gamePlayer`
+    exists and `Input`/`Input.dir4` correctly reflect the held key every
+    frame (confirmed via `Input.isPressed('down')` and `Input.dir4` tracking
+    the probe's direction cycle exactly), but `SceneManager.updateScene`
+    (`js/rpg_core.js`) never calls `this._scene.start()` because
+    `Scene_Map.prototype.isReady` — `ImageManager.isReady()` — never returns
+    true, which means `Scene_Base#update` (and so `Game_Player#moveByInput`)
+    never runs at all. The map tileset's own `Bitmap` (`img/tilesets/*.png`,
+    loaded via `ImageManager.loadTileset` → `Bitmap.load` →
+    `Bitmap#_requestImage`) gets stuck at `_loadingState: 'requesting'`
+    forever, unlike every other image loaded the same session (system UI art,
+    the player's character sheet) via the identical `Bitmap.load` path, which
+    all reach `'loaded'` normally.
+    Traced (with temporary instrumentation, not committed) to the underlying
+    `Image` object's `.onload` — correctly set to `Bitmap.prototype._onLoad`
+    right after `_requestImage` runs — reading back as `null` by the time the
+    engine's deferred (`requestAnimationFrame`-scheduled) onload-check callback
+    for *that specific image* actually fires, one frame later: confirmed
+    `.onload` is still the right function at the very top of that
+    `__mv_runFrame` batch, and has already become `null` partway through the
+    batch's own callback processing, before the tileset's own callback runs —
+    i.e., something running in between nulls it, but not `Bitmap#_onLoad`
+    itself (never invoked — an added wrapper around it never fires),
+    `Bitmap#_clearImgInstance` (the only place stock MV sets `.onload = null` —
+    also wrapped, also never fires) or `Image.prototype.addEventListener`
+    (also wrapped; correctly assigns the function and is called exactly once).
+    `Bitmap._reuseImages` (the `Image` object pool `_requestImage` checks
+    first) stays empty the entire run, ruling out cross-bitmap reuse. Not yet
+    identified: *what* runs in that window and nulls it, or why only images
+    requested in the batch that creates `Spriteset_Map` (the tileset, the
+    player's own character sheet loaded moments later, is unaffected) are hit.
+    Real content only reveals this once something later in the pipeline
+    actually depends on movement working — a boot check that only asserts
+    "reached Scene_Map" or "captured a non-flat frame" cannot see it, which is
+    how it went unnoticed even with two beds and CI running both smokes every
+    push.
   - ✅ Battle smoke reaches `Scene_Battle`: `--mv_battle_test` now starts the
     fight via a real "Battle Processing" event command (code 301) through the
     map interpreter instead of a bare out-of-loop `SceneManager.push`, which


### PR DESCRIPTION
## Summary

Found while investigating a related crash (the `getImageData` fix, #1054): after that fix let a real MV game (Lunatic-Core) boot past the title into `Scene_Map` for the first time, its own movement probe still reported `[MV-MOVE] moved=false`. Re-checked the CI workflow: neither "MV real-game play smoke test" nor "MV movement smoke test" (`.github/workflows/build.yml`) ever greps the log for `moved=true` — unlike the MZ equivalent (`mz_boot_check.bash`'s `grep -q '\[MZ-MOVE\].*moved=true'`), which does, and which does report `moved=true` correctly. So M5 (MV Play) marking movement as verified (my own prior doc pass in #1052, "which is what the real-game play smoke's own movement probe exercises") was wrong: the smoke ran, but nothing was ever actually checking what it found.

Reproduced against both the downloaded Lunatic-Core bed and the committed `mv-sample`, under both `SDL_VIDEODRIVER=dummy` and real Xvfb — `moved=false` on all four combinations, so this is not one game's peculiarity.

Traced the root cause down to `Scene_Map` never becoming active (`Input`/`Input.dir4` track the held key correctly every frame, but `Scene_Base#update` — and so `Game_Player#moveByInput` — never runs, because `Scene_Map#isReady` (`ImageManager.isReady()`) never returns true): the map tileset's own `Bitmap` gets stuck at `_loadingState: 'requesting'` forever, while every other image loaded the same session through the identical `Bitmap.load` path reaches `'loaded'` normally.

Traced further with temporary (uncommitted) instrumentation: the underlying `Image` object's `.onload`, correctly set right after the request, reads back as `null` one frame later, when the engine's own deferred onload-check callback for that image runs — confirmed still correct at the very top of that frame's callback batch, already `null` partway through it, before that image's own callback executes. Ruled out the three places stock MV or our own bridge ever touch `.onload` (`Bitmap#_onLoad`, `Bitmap#_clearImgInstance`, `Image.prototype.addEventListener` — all wrapped, none of them fire) and the `Image` reuse pool (stays empty the whole run). What actually nulls it in that window is not yet identified.

Recorded in `docs/TODO.md` (M5) rather than shipped as a fix: real content only surfaces this once something later in the pipeline depends on movement actually working, which is exactly why two beds and two CI smokes running on every push never caught it — a future pass needs an actual JS debugger on the quickjs side (or the missing `moved=true` assertion added to CI first, so a fix has something to turn green) rather than more log-injection.

## Test plan
- Documentation-only change. The finding itself was reproduced multiple times against two test beds under two SDL video drivers (native build, this session).

https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_