### PR TITLE
battle: a lethal hit also resets stat modifiers and attribute-rank shifts, matching RPG_RT

### DIFF
--- a/changelog.d/knockout-resets-stat-mods-and-attr-ranks.fixed.md
+++ b/changelog.d/knockout-resets-stat-mods-and-attr-ranks.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 battles:** A battler's per-battle ATK/DEF/SPI/AGI stat
+  modifier (from a buff/debuff skill) and any attribute-defence rank
+  shift now reset the instant it dies, matching RPG_RT — the same
+  Knockout reset already applied to the active-time gauge. Previously an
+  ally buffed (or debuffed) mid-fight, then killed and revived within the
+  same fight, kept fighting with the stale pre-death modifier still
+  active instead of a clean slate. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14237,7 +14237,49 @@ above are repeated here)
   250,000-charged target's gauge immediately; reviving it by directly
   raising HP back above 0, as an ordinary revival item would, does not
   restore the stale charge), confirmed to fail against the pre-fix code
-  (`expected 0, got 250000`) before the fix.
+  (`expected 0, got 250000`) before the fix. (This method was renamed to
+  `#apply_knockout_reset` by the very next fix below, which widens it to
+  more of the same Knockout branch's fields — the name and call sites
+  quoted here reflect the state immediately after this specific fix.)
+  ✅ **The fix directly above only ported one field out of the several
+  EasyRPG's own Knockout branch resets — a buff/debuff skill's per-battle
+  ATK/DEF/SPI/AGI modifier and any attribute-defence rank shift survived a
+  mid-fight death and revival exactly as unfixed as the gauge had been
+  (2026-08-19).** The previous fix's own citation already quoted the full
+  branch verbatim without acting on most of it: `Game_Battler::AddState`'s
+  Knockout branch (`src/game_battler.cpp`) is `SetAtbGauge(0); SetHp(0);
+  SetAtkModifier(0); SetDefModifier(0); SetSpiModifier(0);
+  SetAgiModifier(0); SetIsDefending(false); SetCharged(false);
+  attribute_shift.clear();` — all fired unconditionally the instant Death
+  lands. `#atk_mod`/`#def_mod`/`#spi_mod`/`#agi_mod` (a buff/debuff
+  skill's own per-battle stat offset, `#apply_stat_mods`) and `#attr_ranks`
+  (an attribute-defence rank shift, `#apply_attr_shift`) have no other
+  reset path once a fight is under way — unlike the fresh-`Combatant`-
+  per-fight reasoning this class's own doc comment gives for why most of
+  its fields need no explicit reset, which only covers *cross-battle*
+  persistence, not a *mid-battle* death-then-revival. Concretely: an ally
+  buffed by an ordinary ATK-Up-style skill, then killed, then revived
+  within the same fight by an ordinary Full Heal/revival item kept
+  fighting with the stale pre-death buff (or debuff) still active, instead
+  of the clean slate real RPG_RT gives a revived battler — the same
+  "died mid-fight, revived mid-fight" scenario the gauge fix above covers,
+  just for the sibling fields that fix's own citation quoted but didn't
+  act on. `#defending`/`#charged` (`SetIsDefending`/`SetCharged`) are
+  deliberately *not* ported: this codebase already resets both to `false`
+  at the start of every command a battler is given, dead or not, so there
+  is no gap for a Knockout-time reset to close there. Fixed by renaming
+  `#zero_gauge_on_death` to `#apply_knockout_reset` and widening it to
+  also zero the four stat-mod fields and reset `#attr_ranks` to an empty
+  Hash (matching `attribute_shift.clear()` — every reader of `#attr_ranks`
+  already treats a missing key as "no shift, use base" via its own
+  `ranks[aid] || 2`/`base[aid] || 2` fallback, so an empty Hash is exactly
+  equivalent to a cleared shift). Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a foe buffed on all four stats via
+  `#apply_stat_mods` and given an attribute-rank shift via
+  `#apply_attr_shift`, then killed: all four mods and the shift reset to
+  their base values immediately, and stay reset through a same-fight
+  revival), confirmed to fail against the pre-fix code (`expected 0, got
+  4`) before the fix.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10933,7 +10933,7 @@ module Game
         cap = damage_cap
         dmg = cap if dmg > cap
         t.hp -= dmg
-        zero_gauge_on_death(t)
+        apply_knockout_reset(t)
         # A survivor's physical-release states shake off here too --
         # `SelfDestruct::vExecute` calls the identical `BattlePhysicalStateHeal(100,
         # ...)` a basic attack does (#deal_attack's own #shake_off_states call),
@@ -11548,7 +11548,7 @@ module Game
       cap = damage_cap
       dmg = cap if dmg > cap
       target.hp -= dmg
-      zero_gauge_on_death(target)
+      apply_knockout_reset(target)
       if target.dead?
         woke = []
         inflicted = []
@@ -12028,7 +12028,7 @@ module Game
             absorbed = hp_dmg
           end
           target.hp -= hp_dmg
-          zero_gauge_on_death(target)
+          apply_knockout_reset(target)
         end
         b.hp = [b.hp + absorbed, b.max_hp].min if absorbed > 0
         # The same shared, un-gated `dmg` the HP branch above just used, applied
@@ -12271,35 +12271,61 @@ module Game
     # RPG_RT's crowding-out rule (`Game::States::PRUNE_GAP`): the state that
     # just landed may itself immediately push out one already held, or be
     # pushed out by one already held that outranks it.
-    # The Knockout state landing zeroes the active-time gauge too, not just
-    # HP -- verified against RPG_RT's actual behavior via EasyRPG's own
-    # C++ source, fetched live: `Game_Battler::AddState`'s Knockout branch
-    # (`src/game_battler.cpp`) is `if (state_id == kDeathID) { SetAtbGauge(0);
-    # SetHp(0); ... }`, fired the instant the state lands, from *every*
-    # path that can inflict it -- an ordinary lethal hit (`ChangeHp` calls
-    # `AddState(kDeathID, true)` itself once `new_hp &lt;= 0`), a skill/weapon's
-    # own state-effect list, Change Monster/Actor Condition, all alike.
+    # The Knockout state landing resets more than HP -- verified against
+    # RPG_RT's actual behavior via EasyRPG's own C++ source, fetched live:
+    # `Game_Battler::AddState`'s Knockout branch (`src/game_battler.cpp`) is
+    #   if (state_id == kDeathID) {
+    #     SetAtbGauge(0); SetHp(0);
+    #     SetAtkModifier(0); SetDefModifier(0); SetSpiModifier(0); SetAgiModifier(0);
+    #     SetIsDefending(false); SetCharged(false);
+    #     attribute_shift.clear();
+    #   }
+    # fired the instant the state lands, from *every* path that can inflict
+    # it -- an ordinary lethal hit (`ChangeHp` calls `AddState(kDeathID,
+    # true)` itself once `new_hp <= 0`), a skill/weapon's own state-effect
+    # list, Change Monster/Actor Condition, all alike. This method ports
+    # the four fields with no other reset path once a fight is already
+    # under way: the active-time gauge (`#gauge`), the persistent per-battle
+    # ATK/DEF/SPI/AGI modifiers a buff/debuff skill accumulates onto
+    # (`#atk_mod`/`#def_mod`/`#spi_mod`/`#agi_mod`, see #apply_stat_mods --
+    # `SetAtkModifier(0)` and siblings), and any attribute-defence rank
+    # shift a skill has applied (`#attr_ranks`, see #apply_attr_shift --
+    # `attribute_shift.clear()`, matched here by resetting to an empty
+    # Hash, which every reader already treats identically to "no shift"
+    # via its own `ranks[aid] || 2`/`base[aid] || 2` fallback). `#defending`/
+    # `#charged` (`SetIsDefending`/`SetCharged`) are deliberately not
+    # ported: this codebase already resets both to false at the start of
+    # every command a battler is given, dead or not, so there is no gap
+    # for a Knockout-time reset to close there.
+    #
     # Distinct from `Actor#atb_gauge`'s own cross-*battle* persistence fix
     # (`#apply_to_party` writing back 0 for an ally who ended the *fight*
-    # dead): this is the same zeroing but at the moment of death itself,
-    # mid-fight -- without it, an ally charged to near-full gauge who dies
-    # and is then revived by an ordinary Full Heal/revival skill within the
-    # same fight would resume acting from that stale pre-death charge
-    # instead of empty, like anyone else newly readying up. Called from
-    # every place a `Combatant`'s HP can newly reach 0 (this method, and
-    # the three raw `hp -=` sites in #deal_attack_with_current_weapon,
-    # #apply_skill_hit and #enemy_autodestruct) -- calling it again on an
-    # already-dead target is a harmless no-op, matching a corpse's gauge
-    # always reading 0 whether checked once or many times.
-    def zero_gauge_on_death(target)
-      target.gauge = 0 if target.respond_to?(:gauge) && target.dead?
+    # dead): this is the same family of resets but at the moment of death
+    # itself, mid-fight -- without it, an ally buffed (or debuffed) by an
+    # ordinary ATK/DEF/SPI/AGI-affecting skill, or charged to near-full
+    # gauge, who dies and is then revived by an ordinary Full Heal/revival
+    # skill within the same fight would fight on with that stale pre-death
+    # modifier/charge still active instead of the clean slate real RPG_RT
+    # gives a revived battler. Called from every place a `Combatant`'s HP
+    # can newly reach 0 (this method, and the three raw `hp -=` sites in
+    # #deal_attack_with_current_weapon, #apply_skill_hit and
+    # #enemy_autodestruct) -- calling it again on an already-dead target is
+    # a harmless no-op, matching a corpse's own stats always reading the
+    # same reset values whether checked once or many times.
+    def apply_knockout_reset(target)
+      return unless target.dead?
+      target.gauge = 0 if target.respond_to?(:gauge)
+      %i[atk_mod def_mod spi_mod agi_mod].each do |field|
+        target.send("#{field}=", 0) if target.respond_to?(field)
+      end
+      target.attr_ranks = {} if target.respond_to?(:attr_ranks=)
     end
 
     def inflict_state(target, sid)
       return if target.state?(sid)
       target.states = Game::States.prune((target.states || []) + [sid], @states)
       target.hp = 0 if sid == Game::States::DEATH_ID
-      zero_gauge_on_death(target)
+      apply_knockout_reset(target)
     end
 
     # Cure a state from `target`, reviving it to 1 HP when curing state 1 is

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11829,6 +11829,48 @@ check "a lethal attack zeroes the target's active-time gauge immediately, not " 
   eq 0, foe.gauge, 'revival does not restore the pre-death charge'
 end
 
+# Confirmed against EasyRPG's actual C++ source, fetched live:
+# `Game_Battler::AddState`'s Knockout branch (src/game_battler.cpp) also
+# resets `SetAtkModifier(0)`/`SetDefModifier(0)`/`SetSpiModifier(0)`/
+# `SetAgiModifier(0)` and clears `attribute_shift` the instant Death
+# lands -- the exact same branch the gauge check just above already
+# proved this codebase now honours for `#gauge`, but the fix that added
+# it only ever touched `#gauge`. `#atk_mod`/`#def_mod`/`#spi_mod`/
+# `#agi_mod` (a buff/debuff skill's own per-battle stat offset,
+# #apply_stat_mods) and `#attr_ranks` (an attribute-defence rank shift,
+# #apply_attr_shift) have no other reset path once a fight is under way,
+# so an ally buffed (or debuffed) mid-fight, then killed, then revived by
+# an ordinary Full Heal/revival item within the same fight kept fighting
+# with the stale pre-death modifier still active -- real RPG_RT gives a
+# revived battler a clean slate on every one of these fields, not just
+# the gauge.
+check 'a lethal attack also resets stat modifiers and attribute-rank shifts, ' \
+      'the same Knockout branch the gauge fix above already covers' do
+  hero = combatant('Hero', 999, 0, 5, 100)
+  foe = combatant('Foe', 10, 8, 5, 1)
+  foe.spi = 6
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  bat.send(:apply_stat_mods, foe, %i[atk def spi agi], 4) # a buff skill's own effect
+  foe.attr_base_ranks = { 1 => 2 }
+  bat.send(:apply_attr_shift, foe, { attr_shift: 1, attr_ids: [1] }) # a resistance-up skill
+  ok foe.atk_mod > 0 && foe.def_mod > 0 && foe.spi_mod > 0 && foe.agi_mod > 0,
+     'sanity: the buff actually landed on all four stats'
+  eq({ 1 => 3 }, foe.attr_ranks, 'sanity: the attribute shift actually landed')
+
+  bat.send(:deal_attack, hero, foe)
+  ok foe.dead?, 'the hit was lethal'
+  eq 0, foe.atk_mod
+  eq 0, foe.def_mod
+  eq 0, foe.spi_mod
+  eq 0, foe.agi_mod
+  eq({}, foe.attr_ranks, 'the attribute shift was cleared too, not just the raw stat mods')
+
+  # Revival does not restore any of it either, matching the gauge above.
+  foe.hp = 10
+  ok !foe.dead?
+  eq 0, foe.atk_mod, 'a revived ally does not keep its stale pre-death buff'
+end
+
 check "Battle#apply_to_party clears a battle combo Enable Combo armed, matching RPG_RT (2026-08-19)" do
   # Confirmed against EasyRPG's actual C++ source, fetched live:
   # `Game_Battler::ResetBattle` (src/game_battler.cpp) is `battle_combo_


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Battler::AddState`'s Knockout branch (`src/game_battler.cpp`, verified live against EasyRPG Player's C++ source) resets more than HP/gauge the instant Death lands: `SetAtkModifier(0)`/`SetDefModifier(0)`/`SetSpiModifier(0)`/`SetAgiModifier(0)` and `attribute_shift.clear()` all fire unconditionally too.
- An earlier fix this session (already merged) quoted this whole branch verbatim but only ported the gauge line (`Battle#zero_gauge_on_death`) — `#atk_mod`/`#def_mod`/`#spi_mod`/`#agi_mod` (a buff/debuff skill's own per-battle stat offset, `#apply_stat_mods`) and `#attr_ranks` (an attribute-defence rank shift, `#apply_attr_shift`) were left with no reset path once a fight is under way.
- Concretely: an ally buffed by an ordinary ATK-Up-style skill, then killed, then revived within the same fight by an ordinary Full Heal/revival item kept fighting with the stale pre-death buff (or debuff) still active — the same "died mid-fight, revived mid-fight" scenario the gauge fix covers, just for the sibling fields that fix's own citation quoted but didn't act on.
- Fixed by renaming `Battle#zero_gauge_on_death` to `#apply_knockout_reset` and widening it to also zero the four stat-mod fields and reset `#attr_ranks` to an empty Hash (equivalent to `attribute_shift.clear()`, since every reader of `#attr_ranks` already falls back to base on a missing key).
- `#defending`/`#charged` (`SetIsDefending`/`SetCharged`) are deliberately **not** ported: this codebase already resets both to `false` at the start of every command a battler is given, dead or not, so there's no gap for a Knockout-time reset to close there.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a foe buffed on all four stats via `#apply_stat_mods` and given an attribute-rank shift via `#apply_attr_shift`, then killed — all four mods and the shift reset to their base values immediately, and stay reset through a same-fight revival.
- [x] Confirmed the new check fails against the pre-fix code (`git stash`) — `expected 0, got 4`.
- [x] Full suite green post-fix: 1034/1034 logic checks, 751 scene, 41 render, 15 gauge, 13 row — no regressions.
- [x] Documented in `docs/TODO.md` with the EasyRPG citation, and added a `changelog.d/` fragment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_