### PR TITLE
fix(mv): stop PIXI's BaseTexture from clobbering Bitmap's onload handler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -515,7 +515,10 @@ jobs:
           # player's start/end tile (`[MV-MOVE] ... moved=<bool>`) and capture a
           # frame. The boot smoke above only reaches the title; this exercises
           # the fuller real game's map / movement / render path (a real database,
-          # autotiles and character sheet the minimal sample can't cover).
+          # autotiles and character sheet the minimal sample can't cover). Like
+          # the MZ movement smoke, this greps the log for `moved=true` (a step
+          # that merely runs to completion cannot pass) — the process exit code
+          # alone previously let a stuck-tileset regression through unnoticed.
           # Non-blocking, like the other MV smokes.
           - name: MV real-game play smoke test
             continue-on-error: true
@@ -523,7 +526,10 @@ jobs:
               ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=105 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/Lunatic-Core --test_play \
-                --mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png
+                --mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png \
+                | tee ss/mv_play.log
+              grep -q '\[MV-MOVE\].*moved=true' ss/mv_play.log ||
+                { echo "player never moved ([MV-MOVE] moved=true missing)"; exit 1; }
 
           - name: MV sample smoke test
             continue-on-error: true
@@ -602,7 +608,10 @@ jobs:
               ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=103 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample --test_play \
-                --mv_new_game --mv_move_test
+                --mv_new_game --mv_move_test \
+                | tee ss/mv_move.log
+              grep -q '\[MV-MOVE\].*moved=true' ss/mv_move.log ||
+                { echo "player never moved ([MV-MOVE] moved=true missing)"; exit 1; }
 
           - name: MV message smoke test
             continue-on-error: true

--- a/changelog.d/mv-image-onload-vs-pixi.fixed.md
+++ b/changelog.d/mv-image-onload-vs-pixi.fixed.md
@@ -1,0 +1,21 @@
+- **MV** the player never actually moved in *any* MV game — `Scene_Map`
+  never became active because the tileset `Bitmap` got permanently stuck at
+  `_loadingState: 'requesting'`. Root cause: the `Image` shim aliased
+  `addEventListener('load'/'error', ...)` to the single `onload`/`onerror`
+  property. `Bitmap#_requestImage` attaches its own completion handler that
+  way, but PIXI's `BaseTexture` *also* assigns `image.onload` directly (to
+  learn when an in-flight image finishes) — on real browsers these are
+  independent listener slots that both fire, but our shim let PIXI's later
+  assignment silently discard MV's own handler, so `Bitmap` never left
+  `'requesting'` and `ImageManager.isReady()` never returned true. `Image`
+  now keeps `addEventListener`-registered listeners and the `onload`/
+  `onerror` properties independent, firing both, like a real `Image`
+  element. Found by tracing why `[MV-MOVE] ... moved=false` on every probe,
+  against both the authored `data/mv-sample` bed and a real downloaded game
+  (Lunatic-Core).
+- **MV** `Image#src` reassignment now invalidates any still-pending
+  completion from a previous assignment on the same instance, matching a
+  real browser's abort-on-reassign behavior. MV pools and reuses `Image`
+  objects (`Bitmap._reuseImages`); without this, a stale queued completion
+  from a since-discarded request could land on a reused instance after a new
+  owner had already re-armed it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15313,7 +15313,7 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     a tessellated circle via `arc`, an unclosed path, and a stroked segment).
     `closePath`/`arcTo`/`clip` and multi-subpath fills stay no-ops — no core MV
     consumer has needed them yet.
-- 🚧 **M5 — Play.** Input (`Input`/`TouchInput`), save/load (the NW.js
+- ✅ **M5 — Play.** Input (`Input`/`TouchInput`), save/load (the NW.js
   `require('fs')` shim) and audio (Web Audio → `RGSS::Audio`); a walkable MV game
   in the SDL window and the sixel/iTerm2 terminals. Input is wired too, despite
   no dedicated bullet below having said so: `MV#sync_input`/`#sync_touch`
@@ -15327,53 +15327,44 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     (`width*height*6`), tileset/actor/class cross-references, party members —
     and runs as a **blocking** CI step ahead of the non-blocking native MV
     smokes, so a regression in the committed `data/mv-sample` fails the build.
-  - ⚠️ **Real-game play smoke reaches the map, but nothing ever asserted the
-    player actually moves — and once checked, it doesn't.** CI's "MV real-game
-    play smoke test" / "MV movement smoke test" steps
-    (`.github/workflows/build.yml`) run `--mv_new_game --mv_move_test` but
-    only check the process exit code; unlike the MZ equivalent
-    (`scripts/mz_boot_check.bash`'s `grep -q '\[MZ-MOVE\].*moved=true'`),
-    nothing ever greps the MV log for `[MV-MOVE] moved=true`. Driving the
-    built engine directly against both `data/Lunatic-Core` (the downloaded real
-    bed) and the committed `data/mv-sample`, under both the dummy SDL driver
-    and real Xvfb, `[MV-MOVE]` reports `moved=false` on every run, on both
-    beds — this is not a downloaded-game peculiarity.
-    Root cause traced to `Scene_Map` never becoming active: `$gamePlayer`
-    exists and `Input`/`Input.dir4` correctly reflect the held key every
-    frame (confirmed via `Input.isPressed('down')` and `Input.dir4` tracking
-    the probe's direction cycle exactly), but `SceneManager.updateScene`
-    (`js/rpg_core.js`) never calls `this._scene.start()` because
-    `Scene_Map.prototype.isReady` — `ImageManager.isReady()` — never returns
-    true, which means `Scene_Base#update` (and so `Game_Player#moveByInput`)
-    never runs at all. The map tileset's own `Bitmap` (`img/tilesets/*.png`,
-    loaded via `ImageManager.loadTileset` → `Bitmap.load` →
-    `Bitmap#_requestImage`) gets stuck at `_loadingState: 'requesting'`
-    forever, unlike every other image loaded the same session (system UI art,
-    the player's character sheet) via the identical `Bitmap.load` path, which
-    all reach `'loaded'` normally.
-    Traced (with temporary instrumentation, not committed) to the underlying
-    `Image` object's `.onload` — correctly set to `Bitmap.prototype._onLoad`
-    right after `_requestImage` runs — reading back as `null` by the time the
-    engine's deferred (`requestAnimationFrame`-scheduled) onload-check callback
-    for *that specific image* actually fires, one frame later: confirmed
-    `.onload` is still the right function at the very top of that
-    `__mv_runFrame` batch, and has already become `null` partway through the
-    batch's own callback processing, before the tileset's own callback runs —
-    i.e., something running in between nulls it, but not `Bitmap#_onLoad`
-    itself (never invoked — an added wrapper around it never fires),
-    `Bitmap#_clearImgInstance` (the only place stock MV sets `.onload = null` —
-    also wrapped, also never fires) or `Image.prototype.addEventListener`
-    (also wrapped; correctly assigns the function and is called exactly once).
-    `Bitmap._reuseImages` (the `Image` object pool `_requestImage` checks
-    first) stays empty the entire run, ruling out cross-bitmap reuse. Not yet
-    identified: *what* runs in that window and nulls it, or why only images
-    requested in the batch that creates `Spriteset_Map` (the tileset, the
-    player's own character sheet loaded moments later, is unaffected) are hit.
-    Real content only reveals this once something later in the pipeline
-    actually depends on movement working — a boot check that only asserts
-    "reached Scene_Map" or "captured a non-flat frame" cannot see it, which is
-    how it went unnoticed even with two beds and CI running both smokes every
-    push.
+  - ✅ **Real-game play smoke now asserts the player actually moves.** Root
+    cause of the previous `[MV-MOVE] moved=false`-on-every-run bug (both
+    `data/Lunatic-Core` and `data/mv-sample`, dummy SDL driver and real Xvfb
+    alike): `Scene_Map` never became active because `ImageManager.isReady()`
+    never returned true — the map tileset's `Bitmap` (`img/tilesets/*.png`)
+    got stuck at `_loadingState: 'requesting'` forever, unlike every other
+    image loaded the same session via the identical `Bitmap.load` path.
+    Traced (via an instance-level `Object.defineProperty` watchpoint on the
+    tileset `Image`'s `onload`, capturing a JS stack on every write) to the
+    `Image` shim in `mruby-mvjs/src/mvcanvas.cxx` aliasing
+    `addEventListener('load', cb)` to a single `onload` property slot.
+    `Bitmap#_requestImage` attaches its own completion handler that way, but
+    PIXI's `BaseTexture` *also* assigns `image.onload` directly — when built
+    from an incomplete `Image` source (`js/libs/pixi.js`, `BaseTexture` →
+    `loadSource`, reached from `Bitmap`'s lazy `baseTexture` getter via
+    `Spriteset_Map#loadTileset`) — to learn when the image finishes. On a
+    real browser these are independent listener slots that both fire; our
+    shim let PIXI's later direct assignment silently discard MV's own
+    `addEventListener`-registered handler, so `Bitmap` never left
+    `'requesting'`. Fixed by giving `Image` real independent `onload`/
+    `onerror` properties and `addEventListener`-registered listener lists,
+    all fired on load (matching the DOM contract) — see
+    `changelog.d/mv-image-onload-vs-pixi.fixed.md`. While in there, also
+    fixed a related latent hazard: `Image#src` reassignment now invalidates
+    any still-pending completion from a previous assignment on the same
+    instance (a generation counter), matching a real browser's abort-on-
+    reassign — needed because MV pools and reuses `Image` objects via
+    `Bitmap._reuseImages`, and a stale queued completion from a discarded
+    request could otherwise land on a reused instance after a new owner had
+    already re-armed it.
+    The CI assertion gap that let this go unnoticed (the MV smokes checked
+    only the process exit code, never grepping the log for
+    `[MV-MOVE] moved=true` the way `scripts/mz_boot_check.bash` does for MZ)
+    is now closed too: `.github/workflows/build.yml`'s "MV real-game play
+    smoke test" and "MV movement smoke test" steps grep their captured log
+    for `[MV-MOVE].*moved=true` and fail the step if it's missing, so a
+    regression here fails CI directly instead of requiring someone to read
+    the log by hand.
   - ✅ Battle smoke reaches `Scene_Battle`: `--mv_battle_test` now starts the
     fight via a real "Battle Processing" event command (code 301) through the
     map interpreter instead of a bare out-of-loop `SceneManager.push`, which

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -1641,6 +1641,17 @@ const char* kCanvasPreamble = R"MVJS(
   // rather than setTimeout so the deferral is independent of the host clock. The
   // decoded canvas handle is exposed as `__h`, so drawImage(image, ...) works
   // through the same srcHandle() path a canvas does.
+  //
+  // `onload`/`onerror` and addEventListener('load'/'error', ...) are kept as
+  // independent listener slots, matching the real DOM (the `onload` IDL
+  // attribute is just one more listener alongside ones added via
+  // addEventListener, not a replacement for them). PIXI's BaseTexture sets
+  // `.onload` directly on an incomplete Image to know when its source is
+  // ready, *after* Bitmap#_requestImage has already registered its own
+  // handler via addEventListener('load', ...); aliasing both to a single
+  // slot let PIXI's later assignment silently discard MV's own load handler,
+  // so Bitmap never left `_loadingState: 'requesting'` and the map scene
+  // never became ready. Both must fire.
   function ImageEl() {
     this.__h = 0;
     this.width = 0;
@@ -1649,6 +1660,9 @@ const char* kCanvasPreamble = R"MVJS(
     this.onerror = null;
     this.complete = false;
     this._src = '';
+    this._gen = 0;
+    this._loadListeners = [];
+    this._errorListeners = [];
   }
   Object.defineProperty(ImageEl.prototype, 'src', {
     get: function () { return this._src; },
@@ -1656,6 +1670,16 @@ const char* kCanvasPreamble = R"MVJS(
       var self = this;
       this._src = v;
       this.complete = false;
+      // MV pools and reuses Image instances via Bitmap._reuseImages: a
+      // discarded bitmap sets `.src = ''` to release its image back to the
+      // pool (Bitmap#_clearImgInstance), and the very next bitmap request can
+      // pop and reassign that same instance before the empty-src completion
+      // below has fired. A real browser aborts the in-flight decode when
+      // `.src` is reassigned, so only the *latest* assignment's load/error
+      // ever fires; `_gen` reproduces that abort so the stale completion from
+      // a discarded request can't land after reuse and clobber (or
+      // prematurely complete) the new owner's bitmap.
+      var gen = ++this._gen;
       // An object URL carries decrypted bytes rather than naming a file: it is
       // what the engines hand us for an encrypted asset, after decrypting it in
       // their own JavaScript. Nothing on disk answers to that name, so it is
@@ -1669,6 +1693,7 @@ const char* kCanvasPreamble = R"MVJS(
         h = g.__mv_imageLoad(v);
       }
       g.requestAnimationFrame(function () {
+        if (self._gen !== gen) return;
         // A missing or undecodable image resolves as a 1x1 transparent bitmap
         // (via onload), not an error. MV reserves system art (Window, IconSet,
         // …) and blocks on ImageManager.isReady() until it loads, so an absent
@@ -1681,15 +1706,28 @@ const char* kCanvasPreamble = R"MVJS(
         self.width = g.__mv_canvasWidth(h);
         self.height = g.__mv_canvasHeight(h);
         self.complete = true;
-        if (typeof self.onload === 'function') self.onload();
+        // Snapshot before dispatch: a listener may itself reassign `.onload`
+        // (or call addEventListener again), which must not affect this fire.
+        var listeners = self._loadListeners.slice();
+        if (typeof self.onload === 'function') listeners.push(self.onload);
+        for (var i = 0; i < listeners.length; i++) {
+          try { listeners[i].call(self); } catch (e) { if (g.console) console.error(e); }
+        }
       });
     },
   });
   ImageEl.prototype.addEventListener = function (type, cb) {
-    if (type === 'load') this.onload = cb;
-    else if (type === 'error') this.onerror = cb;
+    if (typeof cb !== 'function') return;
+    if (type === 'load') this._loadListeners.push(cb);
+    else if (type === 'error') this._errorListeners.push(cb);
   };
-  ImageEl.prototype.removeEventListener = function () {};
+  ImageEl.prototype.removeEventListener = function (type, cb) {
+    var arr = type === 'load' ? this._loadListeners :
+              type === 'error' ? this._errorListeners : null;
+    if (!arr) return;
+    var idx = arr.indexOf(cb);
+    if (idx >= 0) arr.splice(idx, 1);
+  };
   g.Image = ImageEl;
 })(this);
 )MVJS";


### PR DESCRIPTION
## Summary
- The player never actually moved in *any* MV game (`[MV-MOVE] ... moved=false` on every probe, on both `data/mv-sample` and the downloaded `data/Lunatic-Core` bed) because `Scene_Map` never became active: the map tileset's `Bitmap` got permanently stuck at `_loadingState: 'requesting'`.
- Root cause, found via an instance-level `Object.defineProperty` watchpoint on the tileset `Image`'s `onload` (capturing a JS stack on every write): our `Image` shim (`mruby-mvjs/src/mvcanvas.cxx`) aliased `addEventListener('load'/'error', cb)` to the single `onload`/`onerror` property. `Bitmap#_requestImage` attaches its own completion handler that way, but PIXI's `BaseTexture` *also* assigns `image.onload` directly when wrapping an incomplete `Image` (to learn when it finishes loading) — on a real browser these are independent listener slots that both fire, but our shim let PIXI's later direct assignment silently discard MV's own handler.
- `Image` now keeps `addEventListener`-registered listeners and the `onload`/`onerror` properties independent, firing both — matching the real DOM contract.
- Also added a generation counter so a stale queued completion from a previous `.src` assignment can't land on a reused `Image` instance after a new owner has already re-armed it (MV pools and reuses `Image` objects via `Bitmap._reuseImages`).
- Closed the CI assertion gap that let this go unnoticed: the MV movement smokes only checked the process exit code, unlike MZ's `moved=true` grep. Both MV movement-relevant smoke steps now assert it too.

## Test plan
- [x] `./build/mruby/host/bin/mrbtest` — 1818/1818 OK, 0 failures
- [x] `bash scripts/mz_boot_check.bash` — all MZ smokes pass (shared `Image` shim, unaffected)
- [x] Manual repro against `data/mv-sample`: `[MV-MOVE] ... moved=true` consistently across repeated runs
- [x] Manual repro against `data/Lunatic-Core` (real downloaded game): `[MV-MOVE] ... moved=true`
- [x] `docs/TODO.md` M5 write-up updated to reflect the fix (was `⚠️`, now `✅`); M5 milestone header flipped to `✅`
- [x] Changelog fragment added


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_