### PR TITLE
battle: attribute-defence shift rolls its own hit chance per attribute id

### DIFF
--- a/changelog.d/attribute-shift-rolls-per-attribute-id.fixed.md
+++ b/changelog.d/attribute-shift-rolls-per-attribute-id.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 battles:** A skill that shifts attribute-defence ranks (e.g. a
+  "Ward Fire"-style buff, or a curse that weakens resistance) now rolls its
+  own independent hit chance for each targeted attribute, matching RPG_RT.
+  Previously the shift landed on every listed attribute unconditionally,
+  with no accuracy roll at all, so a skill tagged to affect several
+  attributes at once always shifted all of them together instead of
+  potentially hitting some and missing others like its other effects
+  already do. Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14280,6 +14280,46 @@ above are repeated here)
   their base values immediately, and stay reset through a same-fight
   revival), confirmed to fail against the pre-fix code (`expected 0, got
   4`) before the fix.
+  ✅ **An attribute-defence rank shift landed on every targeted attribute
+  every single cast, with no accuracy roll at all — RPG_RT rolls one
+  independently per attribute id (2026-08-19).** Confirmed directly against
+  `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`,
+  fetched live): the `affect_attr_defence` block loops
+  `for (int i = 0; i < skill.attribute_effects.size(); i++)` and only calls
+  `AddAffectedAttribute`/`SetIsSuccess` when
+  `Rand::PercentChance(to_hit_attribute_shift)` succeeds *for that specific
+  id* — a skill tagged to shift several attributes at once (e.g. a "Ward"
+  skill raising resistance to both Fire and Ice) can land on one and miss
+  the other in the same cast, exactly like this codebase's own
+  `stat_mod_keys`/HP/SP effects already roll independently of each other
+  via `#skill_effect_hits?`. `Game::Battle#apply_attr_shift`
+  (`mruby-rpg2k/mrblib/game.rb`) applied the shift to every id in
+  `cmd[:attr_ids]` unconditionally instead, the same "quoted the C++ branch
+  but only ported part of it" gap as the Knockout-reset fixes just above —
+  here the missing part was the roll immediately guarding
+  `AddAffectedAttribute` itself, not a field further down the same
+  function. (Separately checked while re-reading the surrounding source:
+  `affect_attack`/`affect_defense`/`affect_spirit`/`affect_agility` each
+  roll their own independent `Rand::PercentChance(to_hit)` too, but this
+  codebase's existing `stat_keys = (cmd[:stat_mod_keys] ||
+  []).select { skill_effect_hits?(cmd) }` already re-invokes
+  `#skill_effect_hits?` — a fresh, independent roll — once per key via
+  `Array#select`'s block, so that side was already correct and needed no
+  change.) Fixed by rolling `#skill_effect_hits?(cmd)` inside
+  `#apply_attr_shift`'s own `ids.each` loop, once per attribute id, reusing
+  the same `cmd[:chance]` (already `skill_to_hit(sk, caster, target)`,
+  threaded through unchanged) the skill's other effects already roll
+  against — an id whose own roll misses is skipped entirely, same as a
+  missed stat-mod or heal effect already is. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a two-attribute shift with a
+  seeded `SequenceRng` landing exactly one of two 50%-chance rolls: only
+  the attribute whose own roll hit actually moves, the other keeps its
+  starting rank), confirmed to fail against the pre-fix code
+  (`expected [1], got [1, 2]`) before the fix. `#skill_attr_shift`'s own
+  `IsImmuneToAttributeDownshifts()` gate on a *negative* shift (also
+  visible in the same C++ block) is a separate, not-yet-investigated
+  question — deliberately out of scope here to keep this fix to the single
+  confirmed gap.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12180,6 +12180,16 @@ module Game
     # (A..E) range. Returns the attribute ids actually moved -- an attribute
     # already at its cap, or a skill that doesn't touch attribute defence at
     # all, moves nothing.
+    #
+    # RPG_RT rolls its own independent hit chance per targeted attribute id
+    # here (`Game_BattleAlgorithm::Skill::vExecute`, src/game_battlealgorithm.cpp:
+    # `Rand::PercentChance(to_hit_attribute_shift)` inside the `for` loop over
+    # `skill.attribute_effects`, evaluated separately for every `id` even
+    # though every id shares the same skill-wide `to_hit`) -- the same
+    # "rolled fresh per affected field" idiom `#skill_effect_hits?` already
+    # gives `stat_mod_keys` above (see its doc comment), reused verbatim here
+    # rather than applying the shift unconditionally to every id the skill
+    # lists.
     def apply_attr_shift(target, cmd)
       shift = cmd[:attr_shift]
       ids = cmd[:attr_ids]
@@ -12188,6 +12198,7 @@ module Game
       base = target.attr_base_ranks || {}
       moved = []
       ids.each do |aid|
+        next unless skill_effect_hits?(cmd)
         b = Game.clamp(base[aid] || 2, 0, 4)
         cur = target.attr_ranks[aid] || b
         nxt = Game.clamp(cur + shift, Game.clamp(b - 1, 0, 4), Game.clamp(b + 1, 0, 4))

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -12715,6 +12715,30 @@ check "battle: a skill's stat-mod effect rolls independently of its HP effect" d
      '(-20 clamped to the asymmetric -base/2..+base band, base def 20)')
 end
 
+check "battle: an attribute-defence shift rolls its own hit chance per " \
+      "attribute id, not once for the whole skill" do
+  # RPG_RT (Game_BattleAlgorithm::Skill::vExecute,
+  # src/game_battlealgorithm.cpp) rolls an independent
+  # `Rand::PercentChance(to_hit_attribute_shift)` inside the `for` loop over
+  # every targeted attribute id, even though they all share the same
+  # skill-wide to-hit -- so a multi-attribute shift skill can land on some
+  # ids and miss on others in a single cast. #apply_attr_shift previously
+  # applied the shift to every listed id unconditionally, with no roll at
+  # all.
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.attr_ranks = { 1 => 2, 2 => 2 }
+  foe.attr_base_ranks = { 1 => 2, 2 => 2 }
+  bat = Game::Battle.new([combatant('Hero', 40, 0, 20, 100)], [foe],
+                         SequenceRng.new([49, 60]), nil, false, false, true)
+  # First roll (attribute 1) at 49 hits; second roll (attribute 2) at 60
+  # misses -- same 50% chance for both, one independent roll each.
+  moved = bat.send(:apply_attr_shift, foe, { attr_shift: -1, attr_ids: [1, 2],
+                                              chance: 50 })
+  eq [1], moved, 'only the id whose own roll hit actually shifted'
+  eq 1, foe.attr_ranks[1], 'attribute 1 shifted down (C -> B)'
+  eq 2, foe.attr_ranks[2], 'attribute 2 kept its rank -- its own roll missed'
+end
+
 check "battle: a skill/spell attack now rolls its own critical hit too" do
   # EasyRPG's Game_BattleAlgorithm::Skill::vExecute rolls
   # Algo::CalcCriticalHitChance(source, target, WeaponAll, ...) -- the exact


### PR DESCRIPTION
## Summary

- `Game::Battle#apply_attr_shift` (an RPG2003 skill's attribute-defence rank shift, e.g. a "Ward Fire"-style resistance buff or a curse that weakens a resistance) applied the shift to every targeted attribute id unconditionally, with no accuracy roll at all.
- RPG_RT rolls an independent `Rand::PercentChance(to_hit_attribute_shift)` per targeted attribute id inside `Game_BattleAlgorithm::Skill::vExecute`'s `affect_attr_defence` loop (`src/game_battlealgorithm.cpp`, confirmed by fetching the live source), so a skill tagged to shift several attributes at once can land on some and miss others in the same cast — the same "rolled fresh per affected field" behavior this codebase's `stat_mod_keys`/HP/SP skill effects already have via `#skill_effect_hits?`.
- Fixed by rolling `#skill_effect_hits?(cmd)` once per attribute id inside `#apply_attr_shift`'s loop, reusing the same `cmd[:chance]` the skill's other effects already roll against.
- While re-reading the surrounding C++ for context, separately verified that `affect_attack`/`affect_defense`/`affect_spirit`/`affect_agility`'s own independent per-stat rolls are *already* correctly implemented by this codebase's existing `stat_keys = (cmd[:stat_mod_keys] || []).select { skill_effect_hits?(cmd) }` (each `.select` iteration re-invokes `#skill_effect_hits?` for a fresh, independent roll) — no change needed there.
- `Game_BattleAlgorithm::Skill::vExecute`'s separate `IsImmuneToAttributeDownshifts()` gate on negative shifts is a related, not-yet-investigated gap, deliberately left out of scope here.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a two-attribute shift with a seeded RNG landing exactly one of two 50%-chance rolls — only the attribute whose own roll hit actually moves.
- [x] Confirmed the new check fails against the pre-fix code (`expected [1], got [1, 2]`) via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1035 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 751 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_