### PR TITLE
battle: Change Monster HP resets stat mods/attr ranks/gauge on kill

### DIFF
--- a/changelog.d/change-monster-hp-knockout-reset.fixed.md
+++ b/changelog.d/change-monster-hp-knockout-reset.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 battles:** Killing a troop member via the Change Monster HP
+  event command now resets its stat modifiers, attribute-defence rank
+  shift and ATB gauge charge immediately, matching RPG_RT — the same
+  Knockout reset every other lethal-HP path in battle already applies.
+  Previously an enemy buffed (or debuffed) mid-fight, then finished off by
+  a scripted Change Monster HP and revived later in the same fight, kept
+  fighting with its stale pre-death modifiers and charge intact. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14320,6 +14320,37 @@ above are repeated here)
   visible in the same C++ block) is a separate, not-yet-investigated
   question — deliberately out of scope here to keep this fix to the single
   confirmed gap.
+  ✅ **A troop member killed by Change Monster HP (13110) kept its stale
+  pre-death stat modifiers, attribute-rank shift and ATB gauge charge
+  through a same-fight revival — a fifth Knockout-reset call site both
+  earlier fix passes above missed (2026-08-19).** Confirmed directly
+  against RPG_RT's actual source, fetched live:
+  `Game_Interpreter_Battle::CommandChangeMonsterHP`
+  (`src/game_interpreter_battle.cpp`) doesn't set HP directly at all — it
+  calls `enemy->ChangeHp(change, lethal)`, and `Game_Battler::ChangeHp`
+  (`src/game_battler.cpp`) itself calls `AddState(kDeathID, true)` the
+  instant the new HP reaches 0, running the exact same Knockout branch
+  quoted twice already in the two fixes just above (gauge, then stat
+  mods/attribute ranks). `Game::Interpreter#do_change_monster_hp`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) never went through that shared
+  path: it ends with a bare `target.hp = hp` Struct write, the same kind
+  of raw assignment the two earlier fixes had already found and patched at
+  every site enumerated *from `game.rb`'s own perspective* (the three raw
+  `hp -=` sites plus `#inflict_state`'s `DEATH_ID` branch) — but
+  `do_change_monster_hp` lives in `interpreter.rb`, so it fell outside
+  that enumeration both times. Fixed by calling the already-existing
+  `Game::Battle#apply_knockout_reset(target)` right after the HP write (a
+  no-op unless `target.dead?`, so it's safe to call unconditionally,
+  matching how `#inflict_state` already calls it); `apply_knockout_reset`
+  was `private` and had to be added to `Game::Battle`'s existing `public
+  :inflict_state, :cure_state` allowlist so `interpreter.rb` could reach
+  it, the same pattern that already exposes `inflict_state`/`cure_state`
+  to this command's sibling, Change Monster Condition. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a troop member given nonzero
+  ATK/DEF/SPI/AGI modifiers, an attribute-rank shift and a charged gauge,
+  then killed via a lethal Change Monster HP: all reset immediately),
+  confirmed to fail against the pre-fix code (`expected 0, got 5`) before
+  the fix.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12353,7 +12353,7 @@ module Game
       target.states = (target.states || []) - [sid]
       target.hp = 1 if sid == Game::States::DEATH_ID
     end
-    public :inflict_state, :cure_state
+    public :inflict_state, :cure_state, :apply_knockout_reset
 
     # Inflict a skill command's `inflict` states on `target`, each landing only if
     # a 0..99 roll comes in under the skill's `chance` (its accuracy) scaled by

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2496,6 +2496,18 @@ module Game
     # 0-HP target used to fall through to `hp = 0 + amount`, then get
     # re-clamped *up* to the lethal-off floor of 1 -- silently reviving a
     # downed enemy back to 1 HP.
+    # RPG_RT routes this through `Game_Battler::ChangeHp`, which itself calls
+    # `AddState(kDeathID, true)` the instant the new HP reaches 0
+    # (src/game_battler.cpp) -- the same Knockout branch that zeroes the ATB
+    # gauge, the four ATK/DEF/SPI/AGI battle modifiers, and any
+    # attribute-defence rank shift (see Game::Battle#apply_knockout_reset,
+    # ported from that exact branch). The three raw `hp -=` sites in
+    # game.rb and Change Monster Condition's own #inflict_state already call
+    # it; this command's `target.hp = hp` was a fifth HP-to-0 path that
+    # missed it -- a troop member zeroed by a scripted Change Monster HP,
+    # then revived later in the same fight, kept its stale pre-death
+    # modifiers/gauge instead of the clean slate every other death path
+    # already gives.
     def do_change_monster_hp(cmd)
       target = @battle && @battle.enemy(cmd.param(0))
       return unless target
@@ -2507,6 +2519,7 @@ module Game
       hp = floor if hp < floor
       hp = target.max_hp if target.max_hp && hp > target.max_hp
       target.hp = hp
+      @battle.apply_knockout_reset(target)
     end
 
     # Change Monster MP (13120): the SP counterpart. Same operand layout minus

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15765,6 +15765,37 @@ check 'Change Monster HP leaves an already-downed target untouched entirely' do
   eq 0, b.enemy(0).hp, 'a heal on a downed target is still a no-op'
 end
 
+# RPG_RT routes this command through Game_Battler::ChangeHp, which itself
+# calls AddState(kDeathID, true) the instant HP reaches 0
+# (src/game_battler.cpp) -- the same Knockout branch that already zeroes
+# the ATB gauge, ATK/DEF/SPI/AGI modifiers and attribute-rank shifts for
+# every other lethal-HP path in this codebase (#deal_attack_with_current_
+# weapon, #apply_skill_hit, #enemy_autodestruct, Change Monster
+# Condition's own #inflict_state). Change Monster HP's own `target.hp =
+# hp` was a fifth such path that missed it.
+check 'Change Monster HP resets stat modifiers, attribute ranks and gauge ' \
+      'the instant it kills a troop member, matching every other lethal path' do
+  b = battle_with(foe_hp: 100)
+  foe = b.enemy(0)
+  foe.atk_mod = 5
+  foe.def_mod = 3
+  foe.spi_mod = 2
+  foe.agi_mod = 4
+  foe.attr_ranks = { 1 => 3 }
+  foe.gauge = 12_345 if foe.respond_to?(:gauge=)
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 999, 1])]) # lethal
+  it.update
+  ok foe.dead?, 'sanity: the hit was lethal'
+  eq 0, foe.atk_mod
+  eq 0, foe.def_mod
+  eq 0, foe.spi_mod
+  eq 0, foe.agi_mod
+  eq({}, foe.attr_ranks, 'the attribute-rank shift was cleared too')
+  eq 0, foe.gauge, 'and the ATB gauge zeroed with it' if foe.respond_to?(:gauge)
+end
+
 check 'Change Monster MP adjusts SP and clamps to its range' do
   b = battle_with(foe_mp: 8)
   it = Game::Interpreter.new(new_state)


### PR DESCRIPTION
## Summary

- `Game_Interpreter_Battle::CommandChangeMonsterHP` (`src/game_interpreter_battle.cpp`) doesn't write HP directly — it calls `enemy->ChangeHp(change, lethal)`, and `Game_Battler::ChangeHp` (`src/game_battler.cpp`) itself calls `AddState(kDeathID, true)` the instant the new HP reaches 0, firing the Knockout branch (zeroes the ATB gauge, ATK/DEF/SPI/AGI battle modifiers, and any attribute-defence rank shift) — both confirmed by fetching the live EasyRPG source.
- `Game::Interpreter#do_change_monster_hp` (`mruby-rpg2k/mrblib/interpreter.rb`) ended with a bare `target.hp = hp` Struct write, bypassing that shared reset. This is a fifth "HP reaches 0" call site that two earlier fix passes for the exact same Knockout-reset gap (gauge, then stat mods/attribute ranks) both missed — they enumerated call sites from `game.rb`'s own perspective and this command lives in `interpreter.rb`.
- Fixed by calling the existing `Game::Battle#apply_knockout_reset(target)` right after the HP write (a no-op unless the target is dead, so safe to call unconditionally — matching how `#inflict_state` already calls it for Change Monster Condition). `apply_knockout_reset` was `private`; exposed it via `Game::Battle`'s existing `public :inflict_state, :cure_state` allowlist, the same pattern that already exposes those two to this command's sibling.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a troop member given nonzero ATK/DEF/SPI/AGI modifiers, an attribute-rank shift and a charged gauge, then killed via a lethal Change Monster HP — all reset immediately.
- [x] Confirmed the new check fails against the pre-fix code (`expected 0, got 5`) via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1036 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 751 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_