### PR TITLE
battle: revival heal now layers on the state-cure's HP-to-1 floor

### DIFF
--- a/changelog.d/revival-heal-lands-on-cure-hp-floor.fixed.md
+++ b/changelog.d/revival-heal-lands-on-cure-hp-floor.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 battles:** A revival skill or item now correctly revives an
+  ally who took heavy overkill damage, matching RPG_RT. Previously the
+  skill's heal was added directly onto the target's stale (possibly
+  deeply negative) HP before the status cure ran, so a revival item could
+  fail to actually bring HP above zero even though it was consumed and
+  reported the target's Knockout cured. The heal now lands on top of the
+  cure's own HP-to-1 floor instead, the same order RPG_RT applies them
+  in. Covered by new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11456,6 +11456,40 @@ not yet verified:
   Monster Condition inflicting state 1 does too, and curing it while
   downed revives to 1), both confirmed to fail against the pre-fix code
   before the fix.
+  ✅ **The recovery branch's revival interaction deferred just above is now
+  fixed: a revival skill/item could silently fail to revive an ally who'd
+  taken heavy overkill damage, even though the item was consumed and the
+  log reported the state cured (2026-08-19).** Re-verified directly against
+  RPG_RT's live source: `AlgorithmBase::ApplyHpEffect`
+  (`src/game_battlealgorithm.cpp`) is a hard no-op on an already-dead
+  target (`if (target->IsDead()) return 0;`) — the heal never touches a
+  corpse's raw HP at all — and reviving is handled entirely by
+  `ApplyStateEffect`'s own two-step mechanism quoted above: the state cure
+  sets HP to 1 first, then (only if that cure actually revived the target)
+  `ChangeHp(GetAffectedHp() - 1, false)` layers the skill's heal on top,
+  floored at 1 by `ChangeHp`'s own non-lethal clamp. `Game::Battle
+  #apply_skill_hit`'s recovery branch (`mruby-rpg2k/mrblib/game.rb`) did
+  the opposite: it added the heal directly onto the target's stale HP
+  first (nothing floors HP at 0 mid-fight, so an overkill hit can leave it
+  deeply negative, e.g. -200), *then* cured the state as a bare
+  `states -= cured` array edit with no HP-to-1 side effect at all — so a
+  50-HP revival item on a target sitting at -200 HP wrote `-200 + 50 =
+  -150` and left them just as dead as before, silently. Fixed by: skipping
+  the initial heal write entirely while the target is still dead (matching
+  `ApplyHpEffect`'s no-op); routing the cure through `#cure_state` (as the
+  attack branch already does) so curing Death sets HP to 1 the same way
+  every other cure site in this class does; and, only when that cure just
+  revived the target, adding the skill's heal on top of that 1 with the
+  same `[.., 1].max` floor `ChangeHp`'s own non-lethal clamp gives. A
+  revival item configured with no heal at all (`hp: 0`) now correctly
+  lands on exactly 1, matching `#cure_state`'s own bare-revival fallback
+  used everywhere else, instead of adding 0 to a still-negative total.
+  Covered by three new `scripts/rpg2k_logic_check.rb` checks (a revival
+  skill on a target at -200 HP revives to the heal amount, not the heal
+  added to -200; a revival item with no heal configured lands on exactly
+  1 from a target at -50 HP; an ordinary heal on a still-standing target
+  is unaffected), the first two confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ A weapon-type Attribute (as opposed to a magic-type one) gates skill
   usability on having a matching-attribute **weapon** equipped — armor
   with the same attribute does not satisfy it (already flagged as a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12130,28 +12130,38 @@ module Game
         # EasyRPG calls `Rand::PercentChance(to_hit)` fresh inside each of
         # `affect_hp`/`affect_sp`'s own `if`, not once for the whole skill
         # (#skill_effect_hits?). A skill that restores HP and SP alike can
-        # therefore land one and miss the other.
-        target.hp = [target.hp + hp, target.max_hp].min if hp > 0 && skill_effect_hits?(cmd)
+        # therefore land one and miss the other. The HP write itself is
+        # skipped entirely on an already-dead target -- EasyRPG's own
+        # `ApplyHpEffect` (src/game_battlealgorithm.cpp) is a hard no-op
+        # (`if (target->IsDead()) return 0;`) before it ever reaches its own
+        # accuracy roll, never adding the skill's heal onto a corpse's raw
+        # (possibly deeply negative, nothing floors HP at 0 mid-fight)
+        # HP total -- reviving is handled entirely by the cure step below.
+        was_dead = target.dead?
+        target.hp = [target.hp + hp, target.max_hp].min if hp > 0 && !was_dead && skill_effect_hits?(cmd)
         target.mp = [before_mp + mp, target.max_mp].min if mp > 0 && target.max_mp && skill_effect_hits?(cmd)
-        # Cure the item's status conditions from the target (an antidote / herb),
-        # unconditionally, matching the field item cure. Deliberately not
-        # routed through #cure_state: unlike every other cure site in this
-        # class, this branch's own `hp` (the skill's raw HP effect, already
-        # variance/attribute-adjusted above) already reaches a downed target
-        # directly -- the `target.hp = ...` line just above carries no
-        # `!target.dead?` guard -- so a revival skill's own configured heal
-        # amount already lands here without #cure_state's own hp-to-1
-        # fallback, and adding it on top risks *overwriting* a larger heal
-        # down to 1 rather than complementing it. RPG_RT's own two-step
-        # mechanism for this exact interaction (`AlgorithmBase::
-        # ApplyStateEffect`, src/game_battlealgorithm.cpp: cure first sets
-        # HP to 1, then a second, additive `ChangeHp(GetAffectedHp() - 1,
-        # false)` layers the skill's own heal on top) is closely related but
-        # not equivalent to this branch's current heal-then-cure ordering,
-        # and deserves its own dedicated, separately-verified fix rather
-        # than folding an approximation into this session's narrower one.
+        # Cure the item's status conditions from the target (an antidote /
+        # herb), unconditionally, matching the field item cure -- routed
+        # through #cure_state (like the attack branch's own `cured.each`
+        # above) so curing Death also sets HP to 1 the same way every other
+        # cure site in this class does.
         cured = (cmd[:cured] || []).select { |s| target.state?(s) }
-        target.states = (target.states || []) - cured unless cured.empty?
+        cured.each { |s| cure_state(target, s) }
+        # A revival (this skill's own cure just took Death off the target)
+        # layers the skill's heal on top of that HP-to-1 instead of the heal
+        # being skipped above, matching EasyRPG's own two-step mechanism
+        # exactly: `AlgorithmBase::ApplyStateEffect`'s `if (was_dead &&
+        # !target->IsDead()) target->ChangeHp(GetAffectedHp() - 1, false)`
+        # -- `ChangeHp`'s own non-lethal floor (`req_new_hp = std::max(1,
+        # req_new_hp)`) is why this reads `[.., 1].max` below rather than
+        # simply adding `hp - 1`. A revival item with no heal configured
+        # (`hp` 0) lands on exactly 1, matching #cure_state's own bare
+        # revival fallback used everywhere else.
+        if was_dead && !target.dead?
+          revived = target.hp + (hp - 1)
+          revived = 1 if revived < 1
+          target.hp = target.max_hp ? [revived, target.max_hp].min : revived
+        end
         # An RPG2003 reverse_state_effect ally/self-scoped skill flips
         # #battle_skill_command's own `cmd[:inflict]` on instead of `cmd[:cured]`
         # (see its comment) -- roll it here the same way an attack skill does,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -12739,6 +12739,61 @@ check "battle: an attribute-defence shift rolls its own hit chance per " \
   eq 2, foe.attr_ranks[2], 'attribute 2 kept its rank -- its own roll missed'
 end
 
+# RPG_RT's own two-step mechanism for a revival skill/item (`AlgorithmBase::
+# ApplyHpEffect`/`ApplyStateEffect`, src/game_battlealgorithm.cpp):
+# ApplyHpEffect is a hard no-op on an already-dead target
+# (`if (target->IsDead()) return 0;`), so the heal never lands against the
+# target's raw HP total (nothing floors HP at 0 mid-fight -- an overkill hit
+# can leave it deeply negative). Reviving instead happens entirely through
+# the state cure: removing Death sets HP to 1
+# (`Game_Battler::RemoveStates`), and only then does
+# `if (was_dead && !target->IsDead()) target->ChangeHp(GetAffectedHp() - 1,
+# false)` layer the skill's own heal on top of that 1, floored at 1 by
+# ChangeHp's own non-lethal clamp. #apply_skill_hit's recovery branch used
+# to add the heal directly onto the target's stale (possibly very negative)
+# HP first, then cure the state as a bare array edit with no HP-to-1 side
+# effect at all -- so a revival item could fail to actually revive an ally
+# who'd taken heavy overkill damage, even though the item was consumed and
+# the log reported the state cured.
+check 'battle: a revival skill heals from the cure\'s HP-to-1 floor, not ' \
+      "the target's stale negative HP" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.hp = -200 # overkill damage -- nothing floors HP at 0 mid-fight
+  foe.states = [1]
+  ok foe.dead?, 'sanity: -200 HP is dead'
+  cmd = { cured: [1], chance: 100 }
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  e = bat.send(:apply_skill_hit, hero, foe, 50, 0, cmd)
+  eq [1], e[:cured]
+  ok !foe.dead?, 'revived'
+  eq 50, foe.hp, 'revived to 1, then +49 on top -- not 50 added to -200'
+end
+
+check 'battle: a revival skill with no heal configured still lands the ' \
+      "cure's own HP-to-1, not a stale negative total" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.hp = -50
+  foe.states = [1]
+  cmd = { cured: [1], chance: 100 }
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  bat.send(:apply_skill_hit, hero, foe, 0, 0, cmd)
+  ok !foe.dead?, 'revived even with hp: 0'
+  eq 1, foe.hp
+end
+
+check "battle: a heal on a still-standing target is unaffected by the " \
+      "revival fix" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.hp = 40
+  cmd = { chance: 100 }
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  bat.send(:apply_skill_hit, hero, foe, 20, 0, cmd)
+  eq 60, foe.hp, 'an ordinary heal on a live target adds normally'
+end
+
 check "battle: a skill/spell attack now rolls its own critical hit too" do
   # EasyRPG's Game_BattleAlgorithm::Skill::vExecute rolls
   # Algo::CalcCriticalHitChance(source, target, WeaponAll, ...) -- the exact


### PR DESCRIPTION
## Summary

- RPG_RT's `AlgorithmBase::ApplyHpEffect` (`src/game_battlealgorithm.cpp`) is a hard no-op on an already-dead target (`if (target->IsDead()) return 0;`) — the heal never touches a corpse's raw HP. Reviving is handled entirely by `ApplyStateEffect`'s own two-step mechanism: the state cure sets HP to 1 first (`Game_Battler::RemoveStates`), then, only if that cure actually revived the target, `ChangeHp(GetAffectedHp() - 1, false)` layers the skill's heal on top, floored at 1 by `ChangeHp`'s own non-lethal clamp. Both confirmed by fetching the live EasyRPG source.
- `Game::Battle#apply_skill_hit`'s recovery branch (`mruby-rpg2k/mrblib/game.rb`) did the opposite: it added the heal directly onto the target's stale HP first — nothing floors HP at 0 mid-fight, so an overkill hit can leave it deeply negative (e.g. -200) — then cured the state as a bare `states -= cured` array edit with no HP-to-1 side effect at all. A 50-HP revival item on a target at -200 HP wrote `-200 + 50 = -150` and left them just as dead as before, even though the item was consumed and the log reported the state cured.
- This exact gap was already correctly diagnosed in the code's own comment and in `docs/TODO.md`, both explicitly deferring it for "its own dedicated, separately-verified fix" — this PR provides that fix.
- Fixed by: skipping the initial heal write while the target is still dead; routing the cure through `#cure_state` (matching the attack branch, which already does this) so curing Death sets HP to 1; and, only when that cure just revived the target, adding the skill's heal on top of that 1 with the same non-lethal floor `ChangeHp` gives.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: a revival skill on a target at -200 HP revives to the heal amount (not the heal added to -200); a revival item with no heal configured lands on exactly 1 from a target at -50 HP; an ordinary heal on a still-standing target is unaffected.
- [x] Confirmed the first two new checks fail against the pre-fix code via `git stash`, and pass post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1039 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 751 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_