### PR TITLE
battle: Change Monster HP now plays the enemy-kill SE on a scripted kill

### DIFF
--- a/changelog.d/change-monster-hp-kill-se.fixed.md
+++ b/changelog.d/change-monster-hp-kill-se.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 battles:** A troop member killed by a scripted Change Monster HP
+  event command now plays the enemy-kill sound effect, matching RPG_RT.
+  Previously a scripted kill (a battle-event page's damage-over-time tick,
+  a scripted boss-phase kill) finished the monster off in total silence,
+  unlike an ordinary lethal Attack or Skill. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14385,6 +14385,39 @@ above are repeated here)
   then killed via a lethal Change Monster HP: all reset immediately),
   confirmed to fail against the pre-fix code (`expected 0, got 5`) before
   the fix.
+  ✅ **A troop member killed by a scripted Change Monster HP died in total
+  silence — no enemy-kill sound at all, unlike an ordinary lethal Attack
+  or Skill (2026-08-19).** Confirmed directly against RPG_RT's live
+  source, immediately below the `ChangeHp` call the fix just above already
+  cites: `Game_Interpreter_Battle::CommandChangeMonsterHP`
+  (`src/game_interpreter_battle.cpp`) is `enemy->ChangeHp(change, lethal);
+  ... if (enemy->IsDead()) { Main_Data::game_system->SePlay(Main_Data::
+  game_system->GetSystemSE(Main_Data::game_system->SFX_EnemyKill));
+  enemy->SetDeathTimer(); }` — the command plays the enemy-kill system SE
+  itself, directly, the instant its own kill lands. This codebase's own
+  death cue for an ordinary lethal Attack/Skill already exists —
+  `Scene::Battle#play_battle_action_se` plays `SFX_ENEMY_DEATH` off
+  `entry[:defeated]`, the hash a combat action returns
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) — but `Game::Interpreter
+  #do_change_monster_hp` produces no such `entry` for the scene to read,
+  so a scripted kill (a battle-event page's damage-over-time tick, a
+  scripted boss-phase kill) silently finished the monster off with no
+  sound and no death cue at all. Fixed the same way this codebase already
+  bridges other event-command-to-scene notifications that have no `entry`
+  to ride on (Show Hidden Monster's `@revealed_monsters`, Force Flee's
+  `@fled_monsters`): a new `@monster_kills` queue, pushed with the troop
+  index whenever `do_change_monster_hp`'s own write makes `target.dead?`
+  newly true, drained every frame by `Scene::Battle
+  #apply_battle_event_requests` (already the poll point for those sibling
+  queues) into a new `#play_monster_kill_se` (`play_system_se
+  (SFX_ENEMY_DEATH)`). `SetDeathTimer`'s own fade/blink animation has no
+  equivalent anywhere in this codebase's sprite system (a dead enemy's
+  sprite already simply stops drawing) and is deliberately left out of
+  scope — this fix restores only the missing sound. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a troop page's lethal Change
+  Monster HP plays the `EnemyKill` SE, matching an ordinary lethal
+  Attack/Skill), confirmed to fail against the pre-fix code before the
+  fix.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -208,6 +208,7 @@ module Game
       @triggered_by_decision_key = false
       @revealed_monsters = []
       @fled_monsters = []
+      @monster_kills = []
       @battle_background = nil
       @input_variable = nil
       @input_digits = 1
@@ -290,6 +291,7 @@ module Game
       @movie_request = nil
       @revealed_monsters = []
       @fled_monsters = []
+      @monster_kills = []
       @battle_background = nil
       # Cleared per run so a reused interpreter (the shared foreground one, or a
       # looping parallel process) never inherits the previous event's trigger;
@@ -460,6 +462,21 @@ module Game
     def take_fled_monsters
       ids = @fled_monsters
       @fled_monsters = []
+      ids
+    end
+
+    # Drain the troop-member indices Change Monster HP (13110) has just killed
+    # since the last call. RPG_RT's own `CommandChangeMonsterHP`
+    # (src/game_interpreter_battle.cpp) plays the enemy-kill system SE
+    # (`SePlay(GetSystemSE(SFX_EnemyKill))`) the instant the command's own
+    # `enemy->IsDead()` check goes true, same as any other in-combat kill --
+    # #do_change_monster_hp writes straight to the live combatant with no
+    # `entry` hash for the scene's own #play_battle_action_se to read, so
+    # this queue is this command's only way to tell the scene a kill just
+    # happened. Non-blocking.
+    def take_monster_kills
+      ids = @monster_kills
+      @monster_kills = []
       ids
     end
 
@@ -2508,6 +2525,24 @@ module Game
     # then revived later in the same fight, kept its stale pre-death
     # modifiers/gauge instead of the clean slate every other death path
     # already gives.
+    #
+    # RPG_RT's own `CommandChangeMonsterHP` (src/game_interpreter_battle.cpp)
+    # also plays the enemy-kill system SE the instant its own `IsDead()`
+    # check goes true: `if (enemy->IsDead()) { SePlay(GetSystemSE(
+    # SFX_EnemyKill)); enemy->SetDeathTimer(); }`, right after the
+    # `ChangeHp` call above -- the same death cue an ordinary lethal Attack/
+    # Skill already plays via the scene's own `#play_battle_action_se`
+    # (`entry[:defeated]` -> `SFX_ENEMY_DEATH`). This command produces no
+    # such `entry` for the scene to read, so a scripted kill (a battle
+    # event's damage-over-time page, a scripted boss-phase transition)
+    # silently killed the monster with no sound at all. `#SetDeathTimer`'s
+    # own fade/blink animation has no equivalent in this codebase's sprite
+    # system at all (a dead enemy's sprite already just stops drawing, see
+    # `Scene::Battle`'s `dead?`-gated visibility) and is deliberately not
+    # chased here -- out of scope for this fix, which only restores the
+    # missing sound. Queued the same way Show Hidden Monster/Force Flee
+    # already tell the scene about a mid-battle change it has no other way
+    # to see (see #take_monster_kills).
     def do_change_monster_hp(cmd)
       target = @battle && @battle.enemy(cmd.param(0))
       return unless target
@@ -2520,6 +2555,7 @@ module Game
       hp = target.max_hp if target.max_hp && hp > target.max_hp
       target.hp = hp
       @battle.apply_knockout_reset(target)
+      @monster_kills.push(cmd.param(0)) if target.dead?
     end
 
     # Change Monster MP (13120): the SP counterpart. Same operand layout minus

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2390,6 +2390,8 @@ class RPG2k
         fled = it.take_fled_monsters
         fled.each { |i| remove_fled_monster(i) }
         play_escape_se unless fled.empty?
+        kills = it.take_monster_kills
+        kills.each { play_monster_kill_se }
         name = it.take_battle_background
         rebuild_battle_back(name) unless name.nil?
         refresh_battle_status
@@ -2433,6 +2435,17 @@ class RPG2k
       # The escape sound RPG_RT plays when a Force Flee sends enemies running.
       def play_escape_se
         play_system_se(SFX_ESCAPE)
+      end
+
+      # The kill sound RPG_RT's own `CommandChangeMonsterHP`
+      # (src/game_interpreter_battle.cpp) plays directly the instant a
+      # scripted Change Monster HP finishes a troop member off
+      # (`SePlay(GetSystemSE(SFX_EnemyKill))`) -- the same cue an ordinary
+      # lethal Attack/Skill already gets via #play_battle_action_se's own
+      # `entry[:defeated]` check, which this event-command path never
+      # produces an `entry` for.
+      def play_monster_kill_se
+        play_system_se(SFX_ENEMY_DEATH)
       end
 
       # Terminate Battle: leave the fight with no victory / defeat processing.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12913,6 +12913,34 @@ check 'a page can wound a monster through Change Monster HP' do
   eq foe.max_hp - 7, foe.hp, 'the page took 7 HP off the first troop member'
 end
 
+# RPG_RT's own `CommandChangeMonsterHP` (src/game_interpreter_battle.cpp)
+# plays the enemy-kill system SE directly the instant its own `IsDead()`
+# check goes true, the same cue an ordinary lethal Attack/Skill already gets
+# via `#play_battle_action_se`'s `entry[:defeated]` check -- a check this
+# event-command path never produces, so a scripted kill (a damage-over-time
+# battle-event page, say) used to fell a monster in total silence.
+check 'a page killing a monster through Change Monster HP plays the ' \
+      'enemy-kill SE (RPG_RT)' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::CHANGE_MONSTER_HP, [0, 1, 0, 9999, 1])]) }
+  scene, _st = battle_scene_with_pages(pages)
+  RGSS::Audio.reset_se
+  90.times do
+    ui = battle_ui(scene)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
+    scene.update
+    RGSS::Input.triggered = []
+    ui = battle_ui(scene)
+    break if ui && ui[:phase] == :command
+  end
+  ui = battle_ui(scene)
+  foe = ui[:battle].enemy(0)
+  ok foe.dead?, 'the scripted hit killed troop member 0'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'EnemyKill' },
+     "the scripted kill played the enemy-kill SE, same as an ordinary " \
+     'lethal Attack/Skill'
+end
+
 check 'Change Battle Background from a page rebuilds the backdrop sprite' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::CHANGE_BATTLE_BG, [], string: 'Cave')]) }


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_Interpreter_Battle::CommandChangeMonsterHP` (`src/game_interpreter_battle.cpp`) plays the enemy-kill system SE directly, the instant its own `IsDead()` check goes true, right after the `ChangeHp` call: `if (enemy->IsDead()) { SePlay(GetSystemSE(SFX_EnemyKill)); enemy->SetDeathTimer(); }` — confirmed by fetching the live source.
- This codebase's death cue for an ordinary lethal Attack/Skill already exists (`Scene::Battle#play_battle_action_se` plays `SFX_ENEMY_DEATH` off `entry[:defeated]`), but `Game::Interpreter#do_change_monster_hp` produces no such `entry` for the scene to read — so a scripted kill (a battle-event page's damage-over-time tick, a scripted boss-phase kill) silently finished the monster off with no sound at all.
- Fixed the same way this codebase already bridges other event-command-to-scene notifications with no `entry` to ride on (Show Hidden Monster's `@revealed_monsters`, Force Flee's `@fled_monsters`): a new `@monster_kills` queue, pushed whenever `do_change_monster_hp`'s own HP write newly kills the target, drained every frame by `Scene::Battle#apply_battle_event_requests` (already the poll point for those sibling queues) into a new `#play_monster_kill_se`.
- `SetDeathTimer`'s own fade/blink animation has no equivalent anywhere in this codebase's sprite system (a dead enemy's sprite already simply stops drawing) and is deliberately left out of scope — this fix restores only the missing sound.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a troop page's lethal Change Monster HP plays the `EnemyKill` SE, matching an ordinary lethal Attack/Skill.
- [x] Confirmed the new check fails against the pre-fix code via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 752 checks passed.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1039 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_