### PR TITLE
battle: a skill's status cure now rolls its own accuracy

### DIFF
--- a/changelog.d/skill-cure-rolls-accuracy.fixed.md
+++ b/changelog.d/skill-cure-rolls-accuracy.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003 battles:** A curative battle skill's status cure (e.g. curing
+  Poison or Silence) now rolls its own accuracy chance, matching RPG_RT.
+  Previously the cure landed unconditionally, so a skill whose configured
+  `hit` rate was below 100% still always cured the status, never missing
+  the way its other effects can. An item's cure is unaffected — RPG_RT
+  genuinely never rolls one, and this codebase still doesn't. Covered by
+  new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14418,6 +14418,39 @@ above are repeated here)
   Monster HP plays the `EnemyKill` SE, matching an ordinary lethal
   Attack/Skill), confirmed to fail against the pre-fix code before the
   fix.
+  ✅ **A curative battle skill's status cure landed unconditionally, with no
+  accuracy roll at all — a Silence/Poison-cure skill whose own `hit` field
+  is below 100 always cured the status, never missing
+  (2026-08-19).** Confirmed directly against RPG_RT's live source: `Game_
+  BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`) gates
+  *every* state a skill's `state_effects` list touches — heal or inflict
+  alike — behind its own `Rand::PercentChance(to_hit_states)` roll before
+  it takes effect (`if (!Rand::PercentChance(to_hit_states)) { continue; }`,
+  checked *before* branching on `heals_states`), the same fresh-per-field
+  idiom this codebase's `#skill_effect_hits?` already gives HP/SP/stat-mod
+  effects. `Game::Battle#apply_skill_hit`'s `cured` selection (both the
+  attack branch's own `cured.each` and the recovery branch's identical
+  line) applied every listed, currently-carried state with no roll of any
+  kind — the recovery branch's own doc comment even said so explicitly,
+  "unconditionally, matching the field item cure", conflating two
+  genuinely different mechanics: `Game_BattleAlgorithm::Item::vExecute`
+  really does cure with no roll at all (`for (...) if (item.state_set[i])
+  if (State::Remove(...)) ...`, no `PercentChance` anywhere in its cure
+  loop), but `Skill::vExecute`'s is roll-gated. Both algorithms share this
+  codebase's `#apply_skill_hit` (`#command_item`/`#command_skill` both
+  feed the same `cmd[:hp]`/`cmd[:cured]` machinery through
+  `#apply_command`), so the fix had to stay correct for both at once —
+  done by reusing `#skill_effect_hits?(cmd)` per cured state exactly the
+  way `stat_mod_keys`/`apply_attr_shift` already do, since an Item command
+  (`#command_item`) never sets `cmd[:chance]` at all, and the helper's own
+  `cmd[:chance] || 100` fallback makes an absent chance an unconditional
+  hit — transparently reproducing Item's roll-free cure while genuinely
+  gating a Skill's. Covered by three new `scripts/rpg2k_logic_check.rb`
+  checks (a Skill's cure rolls its own accuracy and can miss; an Item's
+  cure — no `chance` key — always lands regardless of the roll; an
+  attack-branch Skill's cure rolls independently of its own damage roll),
+  two confirmed to fail against the pre-fix code (`expected [], got [3]`)
+  before the fix.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12061,7 +12061,11 @@ module Game
           stat_changed = {}
         else
           inflicted, already = roll_inflict(target, cmd)
-          cured = (cmd[:cured] || []).select { |s| target.state?(s) }
+          # Each cured state rolls its own independent `to_hit_states`
+          # accuracy check, exactly like a stat mod/attribute shift's own
+          # `skill_effect_hits?` gate just below -- see the comment on the
+          # recovery branch's own `cured` line for the full citation.
+          cured = (cmd[:cured] || []).select { |s| target.state?(s) && skill_effect_hits?(cmd) }
           cured.each { |s| cure_state(target, s) }
           shifted = apply_attr_shift(target, cmd)
           stat_keys = (cmd[:stat_mod_keys] || []).select { skill_effect_hits?(cmd) }
@@ -12140,12 +12144,25 @@ module Game
         was_dead = target.dead?
         target.hp = [target.hp + hp, target.max_hp].min if hp > 0 && !was_dead && skill_effect_hits?(cmd)
         target.mp = [before_mp + mp, target.max_mp].min if mp > 0 && target.max_mp && skill_effect_hits?(cmd)
-        # Cure the item's status conditions from the target (an antidote /
-        # herb), unconditionally, matching the field item cure -- routed
-        # through #cure_state (like the attack branch's own `cured.each`
-        # above) so curing Death also sets HP to 1 the same way every other
-        # cure site in this class does.
-        cured = (cmd[:cured] || []).select { |s| target.state?(s) }
+        # Cure the target's status conditions, routed through #cure_state
+        # (like the attack branch's own `cured.each` above) so curing Death
+        # also sets HP to 1 the same way every other cure site in this class
+        # does. Rolled the same `skill_effect_hits?(cmd)` per-state check the
+        # attack branch's own cure just above uses -- this branch is shared
+        # by both a recovery Skill and an Item (#apply_command's own
+        # `cmd[:hp]`/`cmd[:cured]` machinery, fed by #command_item /
+        # #command_skill alike), and EasyRPG genuinely treats the two
+        # differently here: `Game_BattleAlgorithm::Skill::vExecute`
+        # (src/game_battlealgorithm.cpp) gates every cured state behind its
+        # own `Rand::PercentChance(to_hit_states)`, while `Item::vExecute`'s
+        # cure loop rolls nothing at all (`for (...) if (item.state_set[i])
+        # if (State::Remove(...)) AddAffectedState(...)`) -- reusing
+        # `skill_effect_hits?` here is correct for both, since an Item
+        # command never sets `cmd[:chance]` at all (only a Skill's own
+        # `#battle_skill_command` does), and the helper's own `cmd[:chance]
+        # || 100` fallback makes an absent chance an unconditional hit,
+        # exactly matching Item's own roll-free cure.
+        cured = (cmd[:cured] || []).select { |s| target.state?(s) && skill_effect_hits?(cmd) }
         cured.each { |s| cure_state(target, s) }
         # A revival (this skill's own cure just took Death off the target)
         # layers the skill's heal on top of that HP-to-1 instead of the heal

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -12699,6 +12699,60 @@ check 'battle: a heal skill restoring both HP and SP rolls each independently' d
   eq 10, hero.mp
 end
 
+# RPG_RT's `Game_BattleAlgorithm::Skill::vExecute` (src/game_battlealgorithm.cpp)
+# gates every state a skill would cure behind its own `Rand::PercentChance(
+# to_hit_states)` roll -- the same fresh-per-field idiom `#skill_effect_hits?`
+# already gives HP/SP/stat-mod effects -- while `Item::vExecute`'s own cure
+# loop rolls nothing at all. `#apply_skill_hit`'s `cured` selection used to
+# apply unconditionally in both branches, with no roll of any kind -- correct
+# for an Item, silently wrong for a Skill whose own `hit` (accuracy) is below
+# 100.
+check "battle: a skill's status cure rolls its own accuracy, and can miss" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.states = [3]
+  cmd = { cured: [3], chance: 50 }
+  bat = Game::Battle.new([hero], [foe], FixedRng.new(49), nil, false, false, true)
+  e = bat.send(:apply_skill_hit, hero, foe, 0, 0, cmd)
+  eq [3], e[:cured], 'a roll under the chance cures the state'
+  ok !foe.state?(3)
+
+  miss_foe = combatant('Foe', 0, 0, 5, 100)
+  miss_foe.states = [3]
+  bat2 = Game::Battle.new([hero], [miss_foe], FixedRng.new(50), nil, false, false, true)
+  e2 = bat2.send(:apply_skill_hit, hero, miss_foe, 0, 0, cmd)
+  eq [], e2[:cured], 'a roll at or above the chance misses -- the state stays'
+  ok miss_foe.state?(3)
+end
+
+check "battle: an item's status cure has no chance to roll against, so " \
+      'it always lands' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.states = [3]
+  # No `chance:` key at all -- #command_item never sets one, unlike
+  # #command_skill's own `chance: skill_to_hit(...)`.
+  cmd = { cured: [3] }
+  bat = Game::Battle.new([hero], [foe], FixedRng.new(99), nil, false, false, true)
+  e = bat.send(:apply_skill_hit, hero, foe, 0, 0, cmd)
+  eq [3], e[:cured], "an item's cure lands regardless of the roll, unlike a skill's"
+  ok !foe.state?(3)
+end
+
+check "battle: a skill's status cure on an offensive (attack-branch) hit " \
+      'rolls independently of its damage roll' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.states = [3]
+  cmd = { attack: true, chance: 50, cured: [3] }
+  # First roll (damage) at 10 hits; second roll (the state cure) at 90 misses.
+  bat = Game::Battle.new([hero], [foe], SequenceRng.new([10, 90]), nil, false, false, true)
+  e = bat.send(:apply_skill_hit, hero, foe, -10, 0, cmd)
+  eq 10, e[:damage], 'damage roll (10 < 50) landed'
+  eq [], e[:cured], 'the cure roll (90 >= 50) missed, independently of the damage roll'
+  ok foe.state?(3)
+end
+
 check "battle: a skill's stat-mod effect rolls independently of its HP effect" do
   hero = combatant('Hero', 40, 0, 20, 100)
   foe = combatant('Foe', 0, 0, 5, 100)


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`) gates *every* state a skill's `state_effects` list touches — heal or inflict alike — behind its own `Rand::PercentChance(to_hit_states)` roll before it takes effect, checked before branching on `heals_states`. Confirmed by fetching the live source.
- `Game::Battle#apply_skill_hit`'s `cured` selection (both the attack branch and the recovery branch) applied every listed, currently-carried state unconditionally, with no roll at all. The recovery branch's own doc comment explicitly said "unconditionally, matching the field item cure" — conflating two genuinely different mechanics: `Game_BattleAlgorithm::Item::vExecute` really does cure with no roll at all, but `Skill::vExecute`'s is roll-gated.
- Both algorithms share this codebase's `#apply_skill_hit` (`#command_item`/`#command_skill` both feed the same `cmd[:hp]`/`cmd[:cured]` machinery through `#apply_command`), so the fix has to stay correct for both at once. Fixed by reusing the existing `#skill_effect_hits?(cmd)` idiom per cured state — an Item command never sets `cmd[:chance]` at all, and the helper's own `cmd[:chance] || 100` fallback makes an absent chance an unconditional hit, transparently reproducing Item's roll-free cure while genuinely gating a Skill's.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: a Skill's cure rolls its own accuracy and can miss; an Item's cure (no `chance` key) always lands regardless of the roll; an attack-branch Skill's cure rolls independently of its own damage roll.
- [x] Confirmed two of the new checks fail against the pre-fix code (`expected [], got [3]`) via `git stash`, and pass post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1042 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 752 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_