### PR TITLE
skill: a revival with Affect HP off heals a percentage, not a flat 1

### DIFF
--- a/changelog.d/revival-affect-hp-off-percentage-heal.fixed.md
+++ b/changelog.d/revival-affect-hp-off-percentage-heal.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003 skills:** A revival skill whose own "Affect HP" flag is off —
+  a common "cure Death, heal a % of max HP" design, distinct from a
+  flat-amount reviver — now heals the correct percentage of max HP,
+  matching RPG_RT, in both battle and from the field menu. Previously such
+  a skill always revived the target to a flat 1 HP, the same as a skill
+  with no heal configured at all, ignoring its own Power/rate entirely.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14451,6 +14451,52 @@ above are repeated here)
   attack-branch Skill's cure rolls independently of its own damage roll),
   two confirmed to fail against the pre-fix code (`expected [], got [3]`)
   before the fix.
+  ✅ **A revival skill/item whose own "Affect HP" flag is off — a common
+  "cure Death, heal a % of max HP" design, distinct from a flat-amount
+  reviver — always revived to a flat 1 HP instead of a percentage of max
+  HP, both in battle and from the field menu (2026-08-19).** Confirmed
+  directly against RPG_RT's live source, in two independent functions:
+  `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`,
+  the in-battle path) is `if (IsRevived() && effect > 0) { if
+  (skill.affect_hp) { SetAffectedHp(std::max(0, effect)); } else {
+  SetAffectedHp(target->GetMaxHp() * effect / 100); } }` — reading a
+  *percentage* of max HP instead of the flat-1 the earlier revival fix
+  (just above, `apply_skill_hit`'s cure-then-additive-heal) otherwise
+  falls through to whenever Affect HP is off. `Game_Battler::UseSkill`
+  (`src/game_battler.cpp`, the out-of-battle/field-menu path) implements
+  the identical rule independently via its own `cure_hp_percentage` bool
+  ("If Death is cured and HP is not selected, we set a bool so it later
+  heals HP percentage"), confirming this is a general RPG_RT mechanic, not
+  a battle-only quirk. `Game::Battle#battle_skill_command`
+  (`mruby-rpg2k/mrblib/game.rb`) forces `hp: 0` in its recovery-branch hash
+  whenever a skill's own `affect_hp` is off, regardless of its configured
+  Power/rate — so `#apply_skill_hit`'s revival block (added by the earlier
+  fix above) always saw `hp == 0` for such a skill and floored to 1,
+  identical to a skill/item with no heal configured at all. `Game::Party
+  #cast_skill` (the field-menu path) had the matching gap: `t.change_hp
+  (amount) if sk.affect_hp && amount > 0` never ran at all when `affect_hp`
+  was off, leaving the target on `#remove_state`'s own bare revival floor
+  of 1 with no percentage heal on top. Fixed in both places: `apply_skill_
+  hit`'s revival block now computes `affected_hp = hp`, falling back to
+  `target.max_hp * cmd[:stat_effect] / 100` (`cmd[:stat_effect]` already
+  the skill's raw, un-gated magnitude — `#battle_skill_command`'s own
+  `base`, the same figure the ATK/DEF/SPI/AGI stat-mod effect already
+  reuses) whenever `hp` is 0 but that raw magnitude is positive — which can
+  only happen when Affect HP was off, since an on-flag skill's own `hp`
+  already equals that scaled figure whenever it's nonzero, so no extra
+  flag has to ride along in `cmd` to tell the two cases apart; `cast_skill`
+  gained a parallel `elsif revived && amount > 0 && t.max_hp` branch
+  mirroring `UseSkill`'s own `ChangeHp(GetMaxHp() * effect / 100 -
+  revived, false)`. An Item is unaffected either way — `#command_item`
+  never sets `cmd[:stat_effect]` at all, so the percentage branch can never
+  trigger for one, matching how `Item::vExecute` has no such override to
+  begin with (it reads `item.recover_hp_rate` directly, a separate,
+  already-correct mechanism). Covered by four new
+  `scripts/rpg2k_logic_check.rb` checks (a battle-path and a field-menu-path
+  check each for the percentage landing correctly, and for it capping at
+  max HP rather than overshooting), all four confirmed to fail against the
+  pre-fix code (`expected 25, got 1` / `expected 50, got 1` / `expected
+  50, got 1` / `expected 100, got 1`) before the fix.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4976,12 +4976,17 @@ module Game
       affected = []
       skill_targets(sk, caster, target).each do |t|
         changed = false
+        was_dead = t.dead?
         cured.each do |s|
           if t.state?(s)
             t.remove_state(s)
             changed = true
           end
         end
+        # Whether curing Death just revived `t` -- #remove_state's own
+        # bare-revival fallback already floors it to 1 HP the instant Death
+        # comes off, matching EasyRPG's `RemoveState`.
+        revived = was_dead && !t.dead?
         landed = false
         inflicted.each do |s|
           unless t.state?(s)
@@ -4996,7 +5001,21 @@ module Game
         t.states = Game::States.prune(t.states, state_table) if landed
         before_hp = t.hp
         before_mp = t.mp
-        t.change_hp(amount) if sk.affect_hp && amount > 0
+        if sk.affect_hp && amount > 0
+          t.change_hp(amount)
+        elsif revived && amount > 0 && t.max_hp
+          # A revival skill with Affect HP off heals a percentage of max HP
+          # instead of leaving `t` on the bare revival floor of 1 --
+          # `Game_Battler::UseSkill` (src/game_battler.cpp), the out-of-
+          # battle counterpart to `Skill::vExecute`'s identical in-battle
+          # rule (see Game::Battle#apply_skill_hit's own citation): "If
+          # Death is cured and HP is not selected, we set a bool so it later
+          # heals HP percentage" -- `ChangeHp(GetMaxHp() * effect / 100 -
+          # revived, false)`, additive on top of the cure's own HP-to-1
+          # (`revived` there is the literal int 1, the same role `- 1`
+          # plays here).
+          t.change_hp(t.max_hp * amount / 100 - 1)
+        end
         t.change_mp(amount) if sk.affect_sp && amount > 0
         changed ||= t.hp != before_hp || t.mp != before_mp
         affected.push(t) if changed
@@ -12165,17 +12184,46 @@ module Game
         cured = (cmd[:cured] || []).select { |s| target.state?(s) && skill_effect_hits?(cmd) }
         cured.each { |s| cure_state(target, s) }
         # A revival (this skill's own cure just took Death off the target)
-        # layers the skill's heal on top of that HP-to-1 instead of the heal
-        # being skipped above, matching EasyRPG's own two-step mechanism
-        # exactly: `AlgorithmBase::ApplyStateEffect`'s `if (was_dead &&
+        # layers a heal on top of that HP-to-1 instead of the heal being
+        # skipped above, matching EasyRPG's own two-step mechanism exactly:
+        # `AlgorithmBase::ApplyStateEffect`'s `if (was_dead &&
         # !target->IsDead()) target->ChangeHp(GetAffectedHp() - 1, false)`
         # -- `ChangeHp`'s own non-lethal floor (`req_new_hp = std::max(1,
         # req_new_hp)`) is why this reads `[.., 1].max` below rather than
-        # simply adding `hp - 1`. A revival item with no heal configured
-        # (`hp` 0) lands on exactly 1, matching #cure_state's own bare
+        # simply adding `affected_hp - 1`. A revival item with no heal
+        # configured (`hp` 0, and no `cmd[:stat_effect]` at all -- items
+        # never set it) lands on exactly 1, matching #cure_state's own bare
         # revival fallback used everywhere else.
+        #
+        # `affected_hp` is `hp` itself when the skill's own Affect HP flag
+        # was on (`hp` already the correct, gated magnitude) -- but a
+        # revival *skill* with Affect HP off (a common "cure Death, heal a
+        # % of max HP" design, distinct from a flat-amount reviver, which
+        # would check Affect HP) forces `hp` to 0 in #battle_skill_command
+        # regardless of the skill's own Power/rate, and EasyRPG's own
+        # `Skill::vExecute` reads a *percentage* in that exact case instead
+        # of the flat-1 floor: `if (IsRevived() && effect > 0) { if
+        # (skill.affect_hp) { SetAffectedHp(std::max(0, effect)); } else {
+        # SetAffectedHp(target->GetMaxHp() * effect / 100); } }` --
+        # `effect` there is the skill's own raw, un-gated magnitude
+        # (`Algo::CalcSkillEffect`, before any affect_hp gating), matching
+        # this codebase's `cmd[:stat_effect]` (`#battle_skill_command`'s own
+        # `base`, already the ATK/DEF/SPI/AGI stat-mod's identical raw
+        # figure). `hp` being 0 with `cmd[:stat_effect]` positive can only
+        # happen when Affect HP was off (an on-flag skill's own `hp` already
+        # equals `stat_effect`'s scaled figure whenever it's nonzero), so no
+        # separate flag has to ride along in `cmd` to tell the two apart.
+        # `Game_Battler::UseSkill`'s own `cure_hp_percentage` bool
+        # (src/game_battler.cpp) implements the identical rule for the
+        # out-of-battle/menu skill-cast path independently, confirming this
+        # is a general RPG_RT mechanic and not a battle-only quirk -- though
+        # only the battle path is fixed here.
         if was_dead && !target.dead?
-          revived = target.hp + (hp - 1)
+          affected_hp = hp
+          if affected_hp.zero? && (cmd[:stat_effect] || 0) > 0 && target.max_hp
+            affected_hp = target.max_hp * cmd[:stat_effect] / 100
+          end
+          revived = target.hp + (affected_hp - 1)
           revived = 1 if revived < 1
           target.hp = target.max_hp ? [revived, target.max_hp].min : revived
         end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6864,6 +6864,39 @@ check 'a revive skill cures the death state, then its HP recovery lands' do
   eq 33, ally.hp                               # revived to 1, then +32
 end
 
+check 'a revival skill with Affect HP off heals a percentage of max HP, ' \
+      'not a flat 1' do
+  # RPG_RT's Game_Battler::UseSkill (src/game_battler.cpp) sets a
+  # `cure_hp_percentage` bool the instant a Death cure revives the target
+  # while the skill's own Affect HP flag is off, then heals
+  # `GetMaxHp() * effect / 100` instead of leaving the target on the bare
+  # revival floor of 1 -- the field-menu counterpart to
+  # Game::Battle#apply_skill_hit's identical in-battle fix.
+  skills = { 8 => fake_skill(name: 'Half Life', scope: 3, sp_cost: 6,
+                              power: 50, hp: false, state_effects: [1]) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.learn_skill(8)
+  ally.change_hp(-9999)
+  eq true, ally.dead?
+  eq [ally], st.party.cast_skill(hero, 8, ally)
+  eq false, ally.dead?
+  eq 25, ally.hp, "50% of Ally's 50 max HP, not the flat-1 floor a flat-amount reviver gets"
+end
+
+check 'a percentage revival from the field menu still caps at max HP' do
+  skills = { 9 => fake_skill(name: 'Full Life', scope: 3, sp_cost: 8,
+                              power: 200, hp: false, state_effects: [1]) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.learn_skill(9)
+  ally.change_hp(-9999)
+  st.party.cast_skill(hero, 9, ally)
+  eq 50, ally.hp, "capped at Ally's 50 max HP, not 100"
+end
+
 check 'a plain heal skill cannot revive a downed ally' do
   skills = { 7 => fake_skill(name: 'Heal', scope: 3, sp_cost: 5,
                              power: 20, mrate: 40, hp: true) }
@@ -12835,6 +12868,45 @@ check 'battle: a revival skill with no heal configured still lands the ' \
   bat.send(:apply_skill_hit, hero, foe, 0, 0, cmd)
   ok !foe.dead?, 'revived even with hp: 0'
   eq 1, foe.hp
+end
+
+# RPG_RT's `Skill::vExecute` (src/game_battlealgorithm.cpp) reads a
+# *percentage* of max HP for a revival whose Affect HP flag is off, instead
+# of the flat-1 floor a flat-amount reviver (Affect HP on) lands on: `if
+# (IsRevived() && effect > 0) { if (skill.affect_hp) {
+# SetAffectedHp(std::max(0, effect)); } else { SetAffectedHp(
+# target->GetMaxHp() * effect / 100); } }` -- a common "cure Death, heal a
+# % of max HP" skill design. #battle_skill_command forces `hp` to 0 whenever
+# Affect HP is off regardless of the skill's own Power, so the revival block
+# used to always floor such a skill to 1 HP, identical to a skill/item with
+# no heal configured at all.
+check 'battle: a revival skill with Affect HP off heals a percentage of ' \
+      'max HP, not a flat 1 (RPG_RT)' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.max_hp = 100
+  foe.hp = -30
+  foe.states = [1]
+  # hp: 0 (Affect HP off) but stat_effect: 50 -- the skill's own raw
+  # magnitude, still present the same way a buff-only skill's stat-mod
+  # effect is (see #battle_skill_command's own `stat_effect: base` comment).
+  cmd = { cured: [1], chance: 100, stat_effect: 50 }
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  bat.send(:apply_skill_hit, hero, foe, 0, 0, cmd)
+  ok !foe.dead?, 'revived'
+  eq 50, foe.hp, "50% of a 100 max HP, not the flat-1 floor a flat-amount reviver gets"
+end
+
+check "battle: a percentage revival still caps at the target's max HP" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.max_hp = 100
+  foe.hp = -10
+  foe.states = [1]
+  cmd = { cured: [1], chance: 100, stat_effect: 300 } # 300% would overshoot
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  bat.send(:apply_skill_hit, hero, foe, 0, 0, cmd)
+  eq 100, foe.hp, 'capped at max HP, not 300'
 end
 
 check "battle: a heal on a still-standing target is unaffected by the " \


### PR DESCRIPTION
## Summary

- RPG_RT reads a *percentage* of max HP for a revival whose "Affect HP" flag is off — a common "cure Death, heal a % of max HP" design, distinct from a flat-amount reviver (which would check Affect HP). Confirmed in two independent, freshly-fetched functions:
  - `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`, in-battle): `if (IsRevived() && effect > 0) { if (skill.affect_hp) { SetAffectedHp(std::max(0, effect)); } else { SetAffectedHp(target->GetMaxHp() * effect / 100); } }`.
  - `Game_Battler::UseSkill` (`src/game_battler.cpp`, field-menu): the identical rule via its own `cure_hp_percentage` bool — "If Death is cured and HP is not selected, we set a bool so it later heals HP percentage".
- `Game::Battle#battle_skill_command` forces `hp: 0` whenever a skill's `affect_hp` is off, regardless of its configured Power/rate, so `#apply_skill_hit`'s revival block (from a recent prior fix) always floored such a skill to 1 HP — identical to a skill with no heal configured at all. `Game::Party#cast_skill` (field-menu path) had the matching gap.
- Fixed in both places: `apply_skill_hit`'s revival block now falls back to `target.max_hp * cmd[:stat_effect] / 100` (the skill's already-available raw magnitude) whenever `hp` is 0 but that raw magnitude is positive — which can only happen when Affect HP was off. `cast_skill` gained a parallel branch mirroring `UseSkill`'s own formula.
- An Item is unaffected either way — `#command_item` never sets `cmd[:stat_effect]`, matching how `Item::vExecute` has no such override (it reads `item.recover_hp_rate` directly, a separate, already-correct mechanism).

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: a battle-path and a field-menu-path check each for the percentage landing correctly, and for it capping at max HP rather than overshooting.
- [x] Confirmed all four new checks fail against the pre-fix code via `git stash`, and pass post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1046 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 752 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_