### PR TITLE
map: a picture not fixed to the map now shakes with Shake Screen

### DIFF
--- a/changelog.d/picture-shakes-with-screen.fixed.md
+++ b/changelog.d/picture-shakes-with-screen.fixed.md
@@ -1,0 +1,8 @@
+- **Pictures (Show Picture):** A picture not fixed to the map now shakes
+  along with a Shake Screen effect, matching RPG_RT. Previously only a
+  map-fixed picture happened to shake (a side effect of the map-scroll
+  offset already including the shake), while the far more common
+  "not fixed to map" default held rock-steady — a full-screen "impact"
+  graphic, a portrait during dialogue, or a HUD element sat still while
+  everything else on screen visibly jittered. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9993,6 +9993,34 @@ not yet verified:
   28, 14, 0` per-frame sequence for the 100-to-0-over-7-frames example
   above, confirmed to fail against the pre-fix code (it produced `85, 70,
   56, 42, 28, 14, 0` instead) before the fix.
+- ✅ **A Show Picture not fixed to the map held rock-steady through a Shake
+  Screen instead of jittering with the rest of the view, unlike a
+  map-fixed one (2026-08-19).** Confirmed directly against RPG_RT's live
+  source: `ShowParams`'s own default flags (`src/game_pictures.h`) are
+  `int flags = 1 | 32 | 64; // erase_on_map_change | affected_by_flash |
+  affected_by_shake` — every picture is affected by screen shake by
+  default (RPG2000 and pre-1.12 RPG2003 have no per-picture way to turn it
+  off at all), and `Sprite_Picture::Draw` (`src/sprite_picture.cpp`)
+  applies it unconditionally of `fixed_to_map`: `if
+  (data.flags.affected_by_shake) { x -= GetShakeOffsetX(); y -=
+  GetShakeOffsetY(); }`. `Scene::Map#draw_picture`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) only ever subtracted the shake
+  offset for a `fixed_to_map` picture, and only as an accidental side
+  effect of `#camera_position` already folding `screen.shake_offset` into
+  its own `cam_x`/`cam_y` for the *map-scroll* subtraction — a picture
+  shown with the overwhelmingly common "not fixed to map" default got no
+  shake offset applied at all, so a full-screen "impact" graphic, a
+  portrait during dialogue, or a HUD element sat perfectly still while
+  Shake Screen visibly jittered everything else on screen. Fixed by adding
+  an `else` branch that subtracts `@state.screen.shake_offset` directly
+  from a non-map-fixed picture's own draw position, alongside (not instead
+  of) the existing `fixed_to_map` branch — the two are mutually exclusive
+  ways the same offset reaches the screen, so this does not double-apply
+  it to a map-fixed picture. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (a non-map-fixed picture's drawn `dest_rect.x` shifts by exactly
+  the screen's own `shake_offset` once a Shake Screen is under way, the
+  same relationship a map-fixed picture already had via `cam_x`),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A weapon's own genuine 0% hit rate is no longer folded into the
   "nothing equipped" case and silently promoted to the 90% unarmed default
   (2026-08-18).** `Game::Actor#attack_hit_rate` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8249,8 +8249,24 @@ class RPG2k
         dx = pic.x - zw / 2
         dy = pic.y - zh / 2
         if pic.fixed_to_map
+          # `cam_x` (#camera_position) already folds in the screen-shake
+          # offset alongside the map scroll, so a map-fixed picture gets
+          # both from this one subtraction.
           dx -= cam_x
           dy -= cam_y
+        else
+          # A picture that is *not* fixed to the map still shakes with the
+          # screen by default in real RPG_RT: `ShowParams`'s own default
+          # flags (`src/game_pictures.h`) set `affected_by_shake` on for
+          # every picture (RPG2000 and pre-1.12 RPG2003 have no way to turn
+          # it off at all), and `Sprite_Picture::Draw` (src/sprite_
+          # picture.cpp) applies it unconditionally of `fixed_to_map`: `if
+          # (data.flags.affected_by_shake) { x -= GetShakeOffsetX(); ... }`.
+          # Previously a non-map-fixed picture (a full-screen "impact"
+          # graphic, a portrait during dialogue, a HUD) held rock-steady
+          # through a Shake Screen instead of jittering with the rest of
+          # the view.
+          dx -= @state.screen.shake_offset
         end
         @picture_bmp.stretch_blt Rect.new(dx, dy, zw, zh), src,
                                  Rect.new(0, 0, src.width, src.height),

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5636,6 +5636,40 @@ check 'pictures composite in ascending id order, independent of show order' do
      'lower id drawn first, higher id drawn last (on top), regardless of show order'
 end
 
+# RPG_RT's `ShowParams` (src/game_pictures.h) defaults every picture's
+# `affected_by_shake` flag on (RPG2000/pre-1.12 RPG2003 games have no way to
+# turn it off at all), and `Sprite_Picture::Draw` (src/sprite_picture.cpp)
+# applies the shake offset to a picture's screen position unconditionally of
+# `fixed_to_map`: `if (data.flags.affected_by_shake) { x -=
+# GetShakeOffsetX(); ... }`. A picture NOT fixed to the map used to hold
+# rock-steady through a Shake Screen instead of jittering with the rest of
+# the view -- only a map-fixed picture's own scroll subtraction happened to
+# fold the shake in too, as a side effect of #camera_position already
+# including it.
+check 'a picture not fixed to the map still shakes with Shake Screen (RPG_RT)' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
+  bmp = scene.instance_variable_get(:@picture_bmp)
+
+  bmp.clear_stretch_calls
+  scene.update
+  baseline_x = bmp.stretch_calls.first[0].x
+
+  st.screen.shake(6, 5, 30) # power 6, speed 5, 30 frames
+  5.times { scene.update }
+  ok st.screen.shaking?, 'sanity: still shaking'
+
+  bmp.clear_stretch_calls
+  scene.update
+  shaken_x = bmp.stretch_calls.first[0].x
+  offset = st.screen.shake_offset # the offset this same render used
+  ok offset != 0, 'sanity: the shake actually has a nonzero offset by now'
+  eq baseline_x - offset, shaken_x,
+     "the picture's drawn position shifted by the shake offset, matching a " \
+     'map-fixed picture'
+end
+
 check 'a toned picture is tinted before it is composited' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary

- RPG_RT's `ShowParams` (`src/game_pictures.h`) defaults every picture's `affected_by_shake` flag on — `int flags = 1 | 32 | 64; // erase_on_map_change | affected_by_flash | affected_by_shake` — and RPG2000/pre-1.12 RPG2003 have no per-picture way to turn it off at all. `Sprite_Picture::Draw` (`src/sprite_picture.cpp`) applies it unconditionally of `fixed_to_map`: `if (data.flags.affected_by_shake) { x -= GetShakeOffsetX(); y -= GetShakeOffsetY(); }`. Both confirmed by fetching the live source.
- `Scene::Map#draw_picture` (`mruby-rpg2k/mrblib/scene/map.rb`) only ever subtracted the shake offset for a `fixed_to_map` picture, and only as an accidental side effect of `#camera_position` already folding `screen.shake_offset` into its own `cam_x`/`cam_y` for the map-scroll subtraction. A picture shown with the overwhelmingly common "not fixed to map" default got no shake offset applied at all, so a full-screen "impact" graphic, a portrait during dialogue, or a HUD element sat perfectly still while Shake Screen visibly jittered everything else on screen.
- Fixed by adding an `else` branch that subtracts `@state.screen.shake_offset` directly from a non-map-fixed picture's own draw position, alongside (not instead of) the existing `fixed_to_map` branch — the two are mutually exclusive ways the same offset reaches the screen, so this does not double-apply it to a map-fixed picture.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a non-map-fixed picture's drawn `dest_rect.x` shifts by exactly the screen's own `shake_offset` once a Shake Screen is under way, the same relationship a map-fixed picture already had via `cam_x`.
- [x] Confirmed the new check fails against the pre-fix code via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 753 checks passed.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1046 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_