### PR TITLE
battle: a revival item/skill can now actually target a downed ally

### DIFF
--- a/changelog.d/battle-revival-command-targets-downed-ally.fixed.md
+++ b/changelog.d/battle-revival-command-targets-downed-ally.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2003 battles:** A revival item or Death-curing skill queued against
+  an already-downed ally now actually resolves and revives them, matching
+  RPG_RT. Previously every in-battle Skill/Item command fizzled outright
+  on a downed target with no SP or item spent — even a revival one — so a
+  downed ally could be selected as an item/skill's target (already
+  correctly allowed) but the action silently did nothing, leaving them
+  dead. The field-menu equivalents were unaffected; only the in-battle
+  path had this gap. Covered by new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11313,6 +11313,51 @@ not yet verified:
   member and a wounded one confirms the Skill/Item path skips the downed
   member entirely while still healing the wounded member normally (true
   both before and after, since that path was never broken).
+  ✅ **The in-battle Skill/Item command path above was itself checked
+  against the wrong reference — a plain heal genuinely fizzles on a downed
+  target, but so did every revival Skill/Item, which real RPG_RT allows to
+  land: the "explicit state-cure... writing HP directly rather than
+  through any of these three paths" claim was never actually true, and
+  the in-battle path never revived anyone at all until now
+  (2026-08-19).** Confirmed directly against RPG_RT's own per-algorithm
+  `IsTargetValid` override (`src/game_battlealgorithm.cpp`), re-checked at
+  *resolution* time, not just when a target is originally picked
+  (`Scene_Battle_Rpg2k::ProcessBattleActionExecute`: `if (!action->
+  IsCurrentTargetValid()) { ...finish, Execute() never runs... }`,
+  `IsCurrentTargetValid()` → `IsTargetValid(**current_target)`). The
+  generic default (`AlgorithmBase::IsTargetValid`, an ordinary attack) is
+  `target.Exists()` — false the instant HP reaches 0, matching this
+  bullet's own correctly-checked plain-heal case. But
+  `Item::IsTargetValid` ignores the target entirely — `return item.type ==
+  Type_medicine || item.type == Type_switch;` — a medicine/switch item's
+  target is *always* valid, dead or alive. `Skill::IsTargetValid` sits
+  between the two: `if (target.IsDead()) return SkillTargetsAllies(skill)
+  && !skill.state_effects.empty() && skill.state_effects[0];` — a
+  Death-curing, ally-scoped skill may still target a downed ally too.
+  `Game::Battle#apply_command`/`#apply_command_all`
+  (`mruby-rpg2k/mrblib/game.rb`) applied one blanket `target.dead?` gate to
+  every command alike, so a revival item/skill queued against an
+  already-selectable downed ally (`#battle_ally_targets` was already
+  widened, in an earlier fix, specifically so one *could* be picked —
+  making that earlier fix inert in practice, since the queued action just
+  silently fizzled at resolution instead: no SP/item spent, no state
+  cured, no HP restored, the ally staying dead) never actually landed.
+  This codebase's own field-menu equivalents (`Party#use_medicine`,
+  `Party#cast_skill`) were already correctly implemented with no such
+  blanket gate — only the in-battle path had it. Fixed by adding
+  `Game::Battle#command_targets_dead_ok?(cmd)` (`cmd[:kind] == :item`, or a
+  Skill/Item's own `cured` list including `Game::States::DEATH_ID`) and
+  gating both `apply_command`'s single-target check and
+  `apply_command_all`'s per-target `live` filter on it, so a downed target
+  is skipped only when the command genuinely cannot revive it — matching
+  `IsTargetValid` exactly for both algorithms, single- and all-target
+  scopes alike. Covered by two new `scripts/rpg2k_logic_check.rb` checks
+  (a revival item actually resolves and revives a downed ally, tagging the
+  log entry for bag consumption same as any other item hit; a
+  Death-curing skill resolves and revives too, spending its SP, while the
+  existing "fizzles on a fallen target" check just above — a *plain* heal,
+  no `cured` list — is confirmed to still fizzle exactly as before), both
+  new checks confirmed to fail against the pre-fix code before the fix.
   ✅ **A further Change Monster HP hit on an already-downed enemy revived
   it — the bullet above's own guess about this direction was wrong,
   corrected here against RPG_RT's actual behavior (2026-08-18).**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11859,6 +11859,25 @@ module Game
 
     def side_of(b); @allies.any? { |a| a.equal?(b) } ? :ally : :enemy; end
 
+    # Whether a Skill/Item `cmd` may still target an already-downed battler --
+    # EasyRPG's own per-algorithm `IsTargetValid` override
+    # (`src/game_battlealgorithm.cpp`), re-checked at resolution time
+    # (`Scene_Battle_Rpg2k::ProcessBattleActionExecute`'s own `if (!action->
+    # IsCurrentTargetValid()) { ...finish, no Execute()... }`, not just when
+    # the target was originally picked): `Item::IsTargetValid` ignores the
+    # target entirely (`return item.type == Type_medicine || item.type ==
+    # Type_switch;` -- always valid, dead or alive), while the generic
+    # default (`AlgorithmBase::IsTargetValid`, used by an ordinary attack)
+    # is `target.Exists()` -- false the instant HP reaches 0.
+    # `Skill::IsTargetValid` sits between the two: `if (target.IsDead())
+    # return SkillTargetsAllies(skill) && !skill.state_effects.empty() &&
+    # skill.state_effects[0];` -- only a Death-curing, ally-scoped skill may
+    # still target a downed ally.
+    def command_targets_dead_ok?(cmd)
+      return true if cmd[:kind] == :item
+      (cmd[:cured] || []).include?(Game::States::DEATH_ID)
+    end
+
     # Resolve `b`'s queued Skill / Item command and return its log entry, or nil
     # when the chosen target has already fallen this round (the action fizzles —
     # no SP is spent and nothing animates). A skill first spends the caster's SP;
@@ -11866,14 +11885,15 @@ module Game
     # attack (`skill:` names it), while a recovery command (heal skill / medicine)
     # restores HP / SP clamped to the target's maxima and reads as a `recover`.
     #
-    # This `target.dead?` gate is also what keeps a plain heal from reviving a
-    # downed (0 HP) combatant: a fizzled command never reaches #apply_skill_hit
-    # at all, so its HP-raising branch never runs against a dead target in the
-    # first place -- the in-battle mirror of Game::Actor#change_hp's own
-    # `return @hp if dead?` guard on the field. An explicit state-cure (Full
-    # Recovery, a revive item/skill) is the only thing modelled here that can
-    # stand a combatant back up, and it does so by writing HP directly rather
-    # than through this command path.
+    # The `target.dead?` gate is what keeps an ordinary attack or a plain heal
+    # from ever touching a downed (0 HP) combatant -- the in-battle mirror of
+    # Game::Actor#change_hp's own `return @hp if dead?` guard on the field --
+    # but #command_targets_dead_ok? carves out the same two exceptions real
+    # RPG_RT's own `IsTargetValid` does: an Item command's target is always
+    # valid (so a downed ally chosen for a revival medicine, already
+    # selectable per #battle_ally_targets, actually resolves instead of
+    # silently fizzling with the item never consumed), and a Skill command
+    # whose own `cured` list includes Death may still land on one too.
     #
     # A single-target Skill whose target carries Reflect Magic bounces back
     # onto `b` itself (#reflects_skill?) -- checked against the originally
@@ -11889,7 +11909,8 @@ module Game
       cmd = b.command
       return apply_command_all(b, cmd, combo) if cmd[:all]
       target = cmd[:target]
-      return nil if target.nil? || target.dead?
+      return nil if target.nil?
+      return nil if target.dead? && !command_targets_dead_ok?(cmd)
       target = b if reflects_skill?(b, target, cmd)
       b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
       # A combo'd skill repeats its effect `combo` times against the same
@@ -11926,9 +11947,10 @@ module Game
     # then apply the per-target effect to every living target, returning one log
     # entry per hit (which #step_action surfaces one at a time). Fizzles — nil, no
     # SP spent — when every listed target has already fallen this round. Same
-    # per-target `dead?` filter as #apply_command, and for the same reason: a
-    # downed member of an all-ally heal is skipped rather than topped up back to
-    # life (see #apply_command's comment).
+    # per-target `dead?` filter as #apply_command (#command_targets_dead_ok?'s
+    # same two exceptions apply here too -- a party-wide revival item/Full
+    # Recovery-type skill genuinely does stand up every downed member of an
+    # all-ally volley, not just the living ones).
     #
     # If any originally-selected target carries Reflect Magic
     # (#reflecting_target_all), the whole volley redirects onto `b`'s own
@@ -11947,7 +11969,9 @@ module Game
     # own elemental multiplier/variance/absorb fresh against whichever new
     # target it actually lands on.
     def apply_command_all(b, cmd, combo = 1)
-      live = (cmd[:targets] || []).select { |t| t[:target] && !t[:target].dead? }
+      live = (cmd[:targets] || []).select do |t|
+        t[:target] && (!t[:target].dead? || command_targets_dead_ok?(cmd))
+      end
       return nil if live.empty?
       reflected = reflecting_target_all(b, live, cmd)
       if reflected

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13332,6 +13332,57 @@ check 'Battle command_skill fizzles on a fallen target, sparing the SP' do
   eq 0, downed.hp, 'the fallen ally stayed down'
 end
 
+# RPG_RT's own per-algorithm `IsTargetValid` override
+# (`Game_BattleAlgorithm::Item::IsTargetValid`, src/game_battlealgorithm.cpp)
+# ignores the target entirely for a medicine/switch item -- `return
+# item.type == Type_medicine || item.type == Type_switch;` -- always valid,
+# dead or alive -- re-checked at resolution time by
+# `Scene_Battle_Rpg2k::ProcessBattleActionExecute`'s own
+# `IsCurrentTargetValid()` guard, not just when the target was originally
+# picked. `Skill::IsTargetValid` allows a downed target too, but only when
+# the skill is ally-scoped and cures Death (`state_effects[0]`).
+# #apply_command's blanket `target.dead?` gate applied to every command
+# alike, Item and Skill, so a revival item/skill queued against an
+# already-selectable downed ally (see #battle_ally_targets, which already
+# lets one be picked) silently fizzled at resolution: no SP/item spent, no
+# state cured, no HP restored, and the ally stayed dead -- the in-battle
+# path never actually revived anyone, unlike the field-menu
+# #use_medicine/#cast_skill, which were already correct.
+check 'Battle command_item actually revives a downed ally (RPG_RT: an ' \
+      "item's target is always valid)" do
+  user   = combatant('User', 0, 0, 20, 100)
+  downed = combatant('Downed', 0, 0, 5, 100)
+  downed.hp = 0
+  downed.states = [Game::States::DEATH_ID]
+  foe = combatant('Foe', 0, 0, 1, 100)
+  b = Game::Battle.new([user, downed], [foe], Game::Rng.new(1))
+  b.command_item(user, downed, item_id: 4, name: 'Full Recovery', hp: 50,
+                                cured: [Game::States::DEATH_ID])
+  b.begin_round
+  e = b.step_action
+  ok e[:recover], 'the item resolved instead of fizzling on the downed target'
+  eq 4, e[:item_id], 'the item is still consumed'
+  ok !downed.dead?, 'the ally was actually revived'
+  eq 50, downed.hp
+end
+
+check 'Battle command_skill revives a downed ally when the skill cures ' \
+      'Death, but still fizzles a plain heal (RPG_RT: Skill::IsTargetValid)' do
+  mage   = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  downed = combatant('Downed', 0, 0, 5, 100)
+  downed.hp = 0
+  downed.states = [Game::States::DEATH_ID]
+  foe = combatant('Foe', 0, 0, 1, 100)
+  b = Game::Battle.new([mage, downed], [foe], Game::Rng.new(1))
+  b.command_skill(mage, downed, name: 'Life', cost: 5, hp: 40,
+                                 cured: [Game::States::DEATH_ID], chance: 100)
+  b.begin_round
+  e = b.step_action
+  ok e[:recover], 'a Death-curing skill resolves against a downed target'
+  ok !downed.dead?, 'the ally was actually revived'
+  eq 5, mage.mp, 'SP was spent, unlike a fizzled cast'
+end
+
 check 'Battle command_item restores HP and tags the entry for bag consumption' do
   user = combatant('User', 0, 0, 20, 100)
   ally = combatant('Ally', 0, 0, 5, 50)


### PR DESCRIPTION
## Summary

- `Game::Battle#apply_command`/`#apply_command_all` (`mruby-rpg2k/mrblib/game.rb`) gated every Skill/Item command uniformly on `target.dead?`, so a revival item or Death-curing skill queued against an already-downed ally — already selectable as a target, per an earlier fix to `#battle_ally_targets` — silently fizzled at resolution: no SP/item spent, no state cured, no HP restored, and the ally stayed dead. That earlier target-picker fix was consequently inert in practice.
- Confirmed against RPG_RT's own per-algorithm `IsTargetValid` override (`src/game_battlealgorithm.cpp`), re-checked at *resolution* time (`Scene_Battle_Rpg2k::ProcessBattleActionExecute`'s own `IsCurrentTargetValid()` guard), not just when a target is originally picked:
  - The generic default (an ordinary attack) is `target.Exists()` — false the instant HP reaches 0.
  - `Item::IsTargetValid` ignores the target entirely — `return item.type == Type_medicine || item.type == Type_switch;` — always valid, dead or alive.
  - `Skill::IsTargetValid` allows a downed target only when the skill is ally-scoped and cures Death (`state_effects[0]`).
- A prior investigation in this repo's own history (`docs/TODO.md`) checked this exact gate and concluded it was "already correct," citing only the plain-heal case — it never checked EasyRPG's Item-specific `IsTargetValid` override, so it conflated Item/revival-Skill commands with ordinary heals. This codebase's field-menu equivalents (`Party#use_medicine`, `Party#cast_skill`) were already correctly implemented with no such blanket gate.
- Fixed by adding `Game::Battle#command_targets_dead_ok?(cmd)` (`cmd[:kind] == :item`, or a Skill/Item's own `cured` list including `Game::States::DEATH_ID`) and gating both `apply_command`'s single-target check and `apply_command_all`'s per-target `live` filter on it — a downed target is skipped only when the command genuinely cannot revive it, matching `IsTargetValid` for both algorithms and both scopes.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: a revival item actually resolves and revives a downed ally, tagging the entry for bag consumption; a Death-curing skill resolves and revives too, spending its SP. The existing "fizzles on a fallen target" check (a plain heal, no `cured` list) is confirmed to still fizzle exactly as before.
- [x] Confirmed the two new checks fail against the pre-fix code via `git stash`, and pass post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1048 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 753 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_