### PR TITLE
states: a cursed-armor-forced state survives the crowding-out pass

### DIFF
--- a/changelog.d/permanent-state-survives-crowding-out.fixed.md
+++ b/changelog.d/permanent-state-survives-crowding-out.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003 states:** A state RPG2003 cursed armor is actively forcing on
+  an actor now survives a lethal hit (or any other state landing alongside
+  it), matching RPG_RT. Previously a low-priority cursed state was wiped
+  outright the instant a higher-priority state landed — most commonly
+  Death itself — and stayed gone permanently, not even restorable by Full
+  Recovery, until the armor was physically unequipped and re-equipped.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8887,6 +8887,40 @@ not yet verified:
   `@battle` set but can once it is nil — both confirmed to fail against
   the pre-fix code (an `ArgumentError` for the new keyword, and the state
   surviving a map-side cure) before the fix.
+  ✅ **A lethal hit stripped a cursed-armor-forced state outright instead
+  of leaving it in place, the sibling exemption every fix above this one
+  quoted the surrounding `State::Add` crowding-out loop for but never
+  actually ported (2026-08-19).** Confirmed directly against RPG_RT's live
+  source, the very same function this cluster's fixes already cite:
+  `State::Add` (`src/state.cpp`)'s crowding-out pass is `if
+  (priority <= sig_state->priority - 10 && !ps.Has(i + 1)) { states[i] =
+  0; }` — `ps` being the caller's `PermanentStates`
+  (`Game_Actor::GetPermanentStates`), already ported as `Actor
+  #permanent_states` for `#remove_state`/`#clear_states` above. The
+  `!ps.Has(i + 1)` clause exempts a cursed-item-forced state from this
+  same wipe, so it survives even when it sits well below whatever just
+  landed — most commonly Death itself, conventionally the highest-priority
+  state in a real database. `Game::States.prune`
+  (`mruby-rpg2k/mrblib/game.rb`) had no such exemption at all: a lethal
+  hit (`Actor#knock_out!`, `Party#cast_skill`'s own prune call, and
+  `Interpreter#do_change_condition`'s own inflict-side prune, all three
+  calling `#prune` right after landing a state) stripped a low-priority
+  cursed state from `@states` the instant a higher-priority one (usually
+  Death) landed alongside it — and since every cure path can only ever
+  *keep* an id already present in `@states`, never re-add a missing one,
+  the state stayed gone permanently, not even restorable by Full Recovery,
+  until the player physically unequipped and re-equipped the cursed item.
+  Real RPG_RT never loses it in the first place. Fixed by giving
+  `Game::States.prune` a new `keep:` parameter (default `[]`) and passing
+  `permanent_states` through at all three Actor-side call sites (a fourth,
+  `Game::Battle`'s own in-battle `#inflict_state` prune call on a
+  `Combatant`, has no `permanent_states` concept modelled at all and is
+  deliberately left out of scope here — a separate question for its own
+  investigation). Covered by a new `scripts/rpg2k_logic_check.rb` check (a
+  cursed-armor-forced low-priority state survives a lethal hit that also
+  inflicts a higher-priority Death, and still resists a subsequent Full
+  Recovery — only unequipping the armor clears it), confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2739,7 +2739,7 @@ module Game
     # non-death state, the identical rule from the other direction).
     def knock_out!
       add_state(DEATH_STATE)
-      @states = Game::States.prune(@states, state_table)
+      @states = Game::States.prune(@states, state_table, keep: permanent_states)
     end
 
     # The database's state (`situation`) table, for Game::States lookups.
@@ -4998,7 +4998,7 @@ module Game
         # RPG_RT's crowding-out rule (see Game::States::PRUNE_GAP): a state
         # just landed may itself immediately push out one already held, or
         # be pushed out by one already held that outranks it.
-        t.states = Game::States.prune(t.states, state_table) if landed
+        t.states = Game::States.prune(t.states, state_table, keep: t.permanent_states) if landed
         before_hp = t.hp
         before_mp = t.mp
         if sk.affect_hp && amount > 0
@@ -8524,12 +8524,26 @@ module Game
     # this right for free -- no id needs to be singled out or exempted.
     # `ids` with one or fewer entries has nothing to compare, and comes back
     # unchanged.
-    def self.prune(ids, table)
+    #
+    # `keep:` is RPG2003 cursed armor's own exemption from this same pass --
+    # `State::Add`'s loop reads `if (priority <= sig->priority - 10 &&
+    # !ps.Has(i + 1)) { states[i] = 0; }`, `ps` being the caller's
+    # `PermanentStates` (`Game_Actor::GetPermanentStates`,
+    # src/game_actor.cpp): a state a worn cursed item is actively forcing on
+    # survives the crowding-out pass even when it sits well below the
+    # landing state's priority. Without it, a lethal hit (Death landing at
+    # its own conventionally-high priority) stripped a low-priority cursed
+    # state from `@states` outright -- and since every cure path can only
+    # ever *keep* an id already present, never re-add a missing one, the
+    # state stayed gone until the player physically unequipped and
+    # re-equipped the cursed item, instead of the state persisting (as worn)
+    # the whole time the way real RPG_RT's own exemption guarantees.
+    def self.prune(ids, table, keep: [])
       return ids if ids.nil? || ids.size <= 1
       sig = significant(ids, table)
       return ids if sig.nil?
       top = priority_of(sig, table)
-      ids.select { |id| priority_of(id, table) > top - PRUNE_GAP }
+      ids.select { |id| keep.include?(id) || priority_of(id, table) > top - PRUNE_GAP }
     end
 
     # The state's display name, or nil when the table does not name it (a

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2247,8 +2247,10 @@ module Game
           a.add_state(state_id)
           # RPG_RT's crowding-out rule (Game::States::PRUNE_GAP): a state
           # just inflicted may push out (or itself be pushed out by) one
-          # already held that outranks it by 10+ priority.
-          a.states = Game::States.prune(a.states, party.state_table)
+          # already held that outranks it by 10+ priority -- except a state
+          # a's own worn cursed armor is forcing on (`keep:`, see #prune's
+          # own citation), which the same C++ pass exempts from the wipe.
+          a.states = Game::States.prune(a.states, party.state_table, keep: a.permanent_states)
         end
       end
       check_game_over

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4395,6 +4395,38 @@ check "#remove_state refuses a state RPG2003 cursed armor is still forcing" do
   eq [], a.states
 end
 
+# RPG_RT's own crowding-out pass (`State::Add`, src/state.cpp) exempts a
+# cursed-armor-forced state from being wiped by a bigger, later-landing one:
+# `if (priority <= sig->priority - 10 && !ps.Has(i + 1)) { states[i] = 0; }`
+# -- `Game::States.prune` (game.rb) had no such exemption at all, so a
+# lethal hit (Death landing at a conventionally high priority) stripped a
+# low-priority cursed state outright. Since #remove_state/#clear_states can
+# only ever *keep* an id already present, never re-add a missing one, the
+# state stayed gone -- even through Full Recovery -- until the player
+# physically unequipped and re-equipped the cursed item, instead of
+# persisting the whole time real RPG_RT guarantees it does.
+check "a lethal hit does not strip a state RPG2003 cursed armor is still " \
+      'forcing, even though the hit also inflicts a higher-priority Death' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  situation = { 1 => fake_state(priority: 100), 4 => fake_state(priority: 50) }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, {}, {}, situation, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  eq [4], a.states, 'cursed armor state landed'
+  a.change_hp(-9999)
+  ok a.dead?, 'sanity: the hit was lethal'
+  ok a.states.include?(1), 'sanity: Death landed too'
+  ok a.states.include?(4),
+     "the cursed state survived Death's own crowding-out pass, matching " \
+     "the armor's own PermanentStates exemption"
+  # Full Recovery still cannot cure it -- the armor is still equipped.
+  a.full_heal
+  ok a.states.include?(4), 'Full Recovery does not touch it either'
+  a.unequip(2) # armor slot
+  eq [], a.states, 'only taking the armor off actually clears it'
+end
+
 # Confirmed against EasyRPG's actual C++ source, fetched live:
 # `Game_Interpreter::CommandChangeCondition` (src/game_interpreter.cpp)
 # calls `actor->RemoveState(state_id, !Game_Battle::IsBattleRunning())`,


### PR DESCRIPTION
## Summary

- RPG_RT's `State::Add` crowding-out pass (`src/state.cpp`) — the same function this repo's own `Game::States.prune` already ports and cites — is `if (priority <= sig_state->priority - 10 && !ps.Has(i + 1)) { states[i] = 0; }`, `ps` being the caller's `PermanentStates` (`Game_Actor::GetPermanentStates`). The `!ps.Has(i + 1)` clause exempts a cursed-item-forced state from being wiped by a bigger, later-landing state — most commonly Death itself, conventionally the highest-priority state in a real database.
- `Game::States.prune` had no such exemption at all, so a lethal hit stripped a low-priority cursed state outright the instant Death landed alongside it. Since every cure path can only ever *keep* an id already present in `@states`, never re-add a missing one, the state stayed gone permanently — not even restorable by Full Recovery — until the player physically unequipped and re-equipped the cursed item.
- This is the same "quoted the C++ branch but only ported part of it" gap this repo has fixed before elsewhere: the surrounding `PermanentStates` mechanism (`Actor#permanent_states`) is already correctly wired into `#remove_state`/`#clear_states`, but never into `#prune`'s own crowding-out pass.
- Fixed by giving `Game::States.prune` a new `keep:` parameter (default `[]`) and passing `permanent_states` through at all three Actor-side call sites (`Actor#knock_out!`, `Party#cast_skill`'s prune call, `Interpreter#do_change_condition`'s inflict-side prune call). A fourth call site — `Game::Battle`'s own in-battle `#inflict_state` prune on a `Combatant` — has no `permanent_states` concept modelled at all and is deliberately left out of scope, a separate question for its own investigation.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a cursed-armor-forced low-priority state survives a lethal hit that also inflicts a higher-priority Death, and still resists a subsequent Full Recovery — only unequipping the armor clears it.
- [x] Confirmed the new check fails against the pre-fix code via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1049 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 753 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_