### PR TITLE
events: Change Actor Name with a blank name genuinely clears it

### DIFF
--- a/changelog.d/change-actor-name-blank-clears.fixed.md
+++ b/changelog.d/change-actor-name-blank-clears.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** A Change Actor Name event command with a blank name now
+  genuinely clears the actor's displayed name, matching RPG_RT. Previously
+  a blank name was silently ignored and the actor kept their old name;
+  the sibling Change Actor Title command already got this right. Covered
+  by a corrected `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5936,6 +5936,34 @@ Everything below is unverified against the codebase.
   #do_change_actor_name` only accepts a literal command string, never
   another actor's own name, so no built-in command can copy one. (Party caps
   at 4, Change Party Member no-ops past that — now fixed, see above.)
+  ✅ **`#do_change_actor_name` itself had its own separate bug, unrelated to
+  the claim just above: a blank Change Actor Name command silently left
+  the actor's old name in place, instead of genuinely blanking it the way
+  real RPG_RT does (2026-08-19).** Confirmed directly against RPG_RT's
+  live source: `Game_Interpreter::CommandChangeHeroName`
+  (`src/game_interpreter.cpp`, code 10610) calls `actor->SetName(...)`
+  completely unconditionally, with no guard against an empty resolved
+  string anywhere in the command. `Game_Actor::SetName`/`GetName`
+  (`src/game_actor.h`) have no blank-string fallback to the database name
+  either -- `SetName`'s only special case is the string exactly matching
+  the actor's own database name (a save-space sentinel,
+  `SaveActor::kEmptyName`, unrelated to blankness), and `GetName()` reads
+  `data.name` straight back once it holds anything else, empty string
+  included. `Interpreter#do_change_actor_name`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) had `return if name.nil? ||
+  name.empty?` -- an early-return with its own doc comment asserting
+  "RPG_RT keeps the previous name", an unverified assumption that turned
+  out backwards, unlike the sibling `#do_change_actor_title` right below
+  it in the same file, which was already correctly unconditional. Fixed
+  by making `#do_change_actor_name` symmetric with
+  `#do_change_actor_title`: `actor.name = cmd.string || '' if actor`, no
+  blank guard. Covered by correcting the existing
+  `scripts/rpg2k_logic_check.rb` check (previously named "...a blank name
+  is ignored", asserting the old actor name survived a blank Change Actor
+  Name -- renamed and reversed to assert the name genuinely blanks,
+  matching the already-correct Title check right beside it), confirmed to
+  fail against the pre-fix code (`expected "", got "Zelda"`) before the
+  fix.
 - ✅ **Processing order** — map/common events process in ascending id order;
   a process that hits Wait/Show-Text yields to the others that tick. **The
   "only one event/parallel-process advances per tick engine-wide (round

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2318,12 +2318,23 @@ module Game
     def identity_target(cmd); party.roster[cmd.param(0)]; end
 
     # Change Actor Name: rename the actor whose id is param0 to the command
-    # string. A blank name is ignored (RPG_RT keeps the previous name).
+    # string, including a blank one -- RPG_RT's own
+    # `Game_Interpreter::CommandChangeHeroName` (src/game_interpreter.cpp,
+    # code 10610) calls `actor->SetName(...)` completely unconditionally,
+    # with no guard against an empty resolved string anywhere in the
+    # command or in `Game_Actor::SetName` itself (src/game_actor.h) --
+    # `SetName`'s only special case is the string exactly matching the
+    # actor's own *database* name (a save-space sentinel, unrelated to
+    # blankness), and `GetName()` reads `data.name` straight back with no
+    # database-name fallback once it's been set to anything else, empty
+    # string included. A blank Change Actor Name genuinely blanks the
+    # actor's displayed name everywhere (menus, battle, the save screen) in
+    # real RPG_RT; it does not leave the previous name intact. Symmetric
+    # with the sibling #do_change_actor_title just below, which already
+    # gets this right.
     def do_change_actor_name(cmd)
-      name = cmd.string
-      return if name.nil? || name.empty?
       actor = identity_target(cmd)
-      actor.name = name if actor
+      actor.name = cmd.string || '' if actor
     end
 
     # Change Actor Title: set the title (class/subtitle shown on the status

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8017,7 +8017,14 @@ end
 
 # -- Change Actor Name / Title / Sprite ---------------------------------------
 
-check 'Change Actor Name renames the actor; a blank name is ignored' do
+# RPG_RT's own `Game_Interpreter::CommandChangeHeroName`
+# (src/game_interpreter.cpp, code 10610) calls `actor->SetName(...)`
+# completely unconditionally, and `Game_Actor::SetName`/`GetName`
+# (src/game_actor.h) have no blank-string fallback to the database name --
+# only a same-as-database-name save-space sentinel, unrelated to blankness.
+# A blank Change Actor Name genuinely blanks the actor's displayed name,
+# symmetric with the Title check just below.
+check 'Change Actor Name renames the actor; a blank name blanks it too' do
   st = party_state
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::CHANGE_ACTOR_NAME, [1], string: 'Zelda')])
@@ -8027,7 +8034,7 @@ check 'Change Actor Name renames the actor; a blank name is ignored' do
   it2 = Game::Interpreter.new(st)
   it2.start([FakeCmd.new(IC::CHANGE_ACTOR_NAME, [1], string: '')])
   it2.update
-  eq 'Zelda', st.party.actor_by_id(1).name # unchanged by the blank name
+  eq '', st.party.actor_by_id(1).name
 end
 
 check 'Change Actor Title sets the title; an empty string clears it' do


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_Interpreter::CommandChangeHeroName` (`src/game_interpreter.cpp`, code 10610) calls `actor->SetName(...)` completely unconditionally, with no guard against an empty resolved string anywhere in the command. `Game_Actor::SetName`/`GetName` (`src/game_actor.h`) have no blank-string fallback to the database name either — `SetName`'s only special case is the string exactly matching the actor's own database name (a save-space sentinel, `SaveActor::kEmptyName`, unrelated to blankness), and `GetName()` reads `data.name` straight back once it holds anything else, empty string included. Both confirmed by fetching the live source.
- `Interpreter#do_change_actor_name` (`mruby-rpg2k/mrblib/interpreter.rb`) had `return if name.nil? || name.empty?` — an early-return whose own doc comment asserted "RPG_RT keeps the previous name," an unverified assumption that turned out backwards. The sibling `#do_change_actor_title` right below it in the same file was already correctly unconditional.
- Fixed by making `#do_change_actor_name` symmetric with `#do_change_actor_title`: `actor.name = cmd.string || '' if actor`, no blank guard.

## Test plan

- [x] Corrected the existing `scripts/rpg2k_logic_check.rb` check (previously named "...a blank name is ignored," asserting the old actor name survived a blank Change Actor Name — renamed and reversed to assert the name genuinely blanks, matching the already-correct Title check right beside it).
- [x] Confirmed the corrected check fails against the pre-fix code (`expected "", got "Zelda"`) via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1049 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 753 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_