### PR TITLE
fix(vxace): real VX Ace projects no longer hit a superclass-mismatch wall

### DIFF
--- a/changelog.d/desktop-lvgl-heap-256mb.changed.md
+++ b/changelog.d/desktop-lvgl-heap-256mb.changed.md
@@ -1,0 +1,11 @@
+- **Desktop build** the LVGL memory pool (which backs *every* allocation on
+  this build — mruby's whole VM heap included, not just graphics — see
+  `src/main.cxx`'s `lvallocf`) grows from 64 MB to 256 MB. A large real game
+  (games maker or not) with a rich enough database — hundreds of maps,
+  enemies, skills, items — could exhaust 64 MB just loading its `Data/`
+  tables, aborting with `NoMemoryError` before a single scene ran. Measured
+  against a real ~60-hour freeware VX Ace release (468 maps, 930 skills, 610
+  enemies, 635 troops): 64 MB and 128 MB both failed during database load,
+  256 MB did not. The PSP and Wio builds keep their own much smaller,
+  already-tuned pools (`app/psp/lv_conf.h`, `app/wio/lv_conf.h`) — this only
+  raises the desktop ceiling, where headroom is cheap.

--- a/changelog.d/rgss-win32api-encode-visibility-methods.added.md
+++ b/changelog.d/rgss-win32api-encode-visibility-methods.added.md
@@ -1,0 +1,16 @@
+- **XP / VX / VX Ace** three more pieces of the "Ruby a real game's scripts
+  assume, that this mruby build does not ship" gap (alongside the existing
+  `Errno` fill-in): `Win32API` (RGSS's Windows-DLL FFI class — construction
+  now always succeeds, and `#call` warns once and answers `0` rather than
+  ending the whole script host over an optional Windows-only feature, e.g.
+  the widely bundled CACAO 画像保存 screenshot-saving utility, which binds
+  several Win32 calls unconditionally at script load time); `String#encode`
+  (a no-op that answers the receiver unchanged and warns once — this build
+  has no real transcoding tables, but nothing in this UTF-8-throughout engine
+  ever depends on the boundary a script transcodes across, typically a
+  Win32API argument); and `Module#private_method_defined?` /
+  `#protected_method_defined?` / `#public_method_defined?` (real answers, not
+  stubs — mruby-metaprog already tracks method visibility for
+  `private_instance_methods` and friends, this just exposes the
+  membership-check form scripts actually call). Found booting a real VX Ace
+  release's bundled community utility scripts.

--- a/changelog.d/vxace-rpg-baseitem-superclass-mismatch.fixed.md
+++ b/changelog.d/vxace-rpg-baseitem-superclass-mismatch.fixed.md
@@ -1,0 +1,15 @@
+- **VX Ace** the RGSS script host now boots real, unmodified VX Ace projects
+  that reopen their own stock `RPG::Actor`/`Class`/`Item`/`Skill`/`Weapon`/
+  `Armor`/`State`/`Enemy` script sections — which is to say, virtually every
+  real VX Ace game, since the editor exposes these as ordinary editable
+  script sections (its "RPG" folder) and every one of them reasserts its
+  superclass on its first line, e.g. `class RPG::Actor < RPG::BaseItem`.
+  Previously this raised `TypeError: superclass mismatch for RPG::Actor` and
+  ended the whole run, because `mruby-rpgxp`'s XP-era schema (loaded first,
+  shared by all three RGSS makers) declared these classes flat, with no
+  superclass, and a class's superclass cannot change once set. The classes
+  now declare the real RGSS3 `BaseItem -> UsableItem/EquipItem -> ...`
+  inheritance chain from their very first (XP-side) declaration, matching
+  what the stock scripts assert. Found booting a real, large freeware VX Ace
+  release (not the synthetic test bed, which never reopens these the way a
+  real project does) — one of the biggest remaining gaps for VX Ace support.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15328,6 +15328,29 @@ screen (544×416). Full rationale:
     display — down to the exact seam values (170/85 either side of a
     white/black edge) and the mirror symmetry of the swept arc, which is what
     actually pins the centre of rotation.
+  - ✅ **The RGSS3 `BaseItem` superclass chain — real VX Ace games boot now.**
+    Found booting a real, large freeware VX Ace release (a ~60-hour RPG, 468
+    maps, 930 skills, 610 enemies) rather than the synthetic test bed, which
+    never reopens a stock `RPG::` class the way a real project does: every VX
+    Ace project exposes `BaseItem`/`UsableItem`/`EquipItem`/`Actor`/`Class`/
+    `Item`/`Skill`/`Weapon`/`Armor`/`State`/`Enemy` as editable script
+    sections, and every one reasserts its stock superclass on its first line
+    (`class RPG::Actor < RPG::BaseItem`), even when only the body below is
+    customised. `mruby-rpgxp` (loaded first, shared by all RGSS makers)
+    declared these classes flat, so reopening with an explicit superclass
+    raised `TypeError: superclass mismatch` and ended the run — likely the
+    single biggest reason a real VX Ace release could not boot at all. Fixed
+    by giving the classes the real chain from their first (XP-side)
+    declaration; see `docs/rpgvx-rgss-api-gap.md` item 7 and the comment on
+    `class BaseItem` in `mruby-rpgxp/mrblib/rgss_data.rb`. The same dig also
+    found the 64 MB desktop LVGL heap (which backs mruby's whole VM heap, not
+    just graphics) too small for this game's database alone — raised to
+    256 MB — and filled in `Win32API`/`String#encode`/
+    `Module#private_method_defined?` (and friends), which the game's bundled
+    community utility scripts assumed. **Still open:** bare (argument-less)
+    `module_function` is a documented no-op in this mruby version (upstream,
+    not project-specific — see the item 7 write-up), which still blocks this
+    same game's error-logging utility script.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -335,6 +335,68 @@ music does not free the stream, and `Mix_GetMusicPosition` kept answering for a
 stopped one; a game saving `bgm_pos` to resume a track later would have recorded
 a position for music that was not playing. Fixed while building the probe.
 
+### 7. The RGSS3 `BaseItem` superclass chain, and what a real game's own community scripts need ✅ (mostly)
+
+Everything above was measured against the synthetic test bed
+(`scripts/rpgvx_testbed_check.rb`) and small hand-authored projects. Neither
+ever *reopens* a stock `RPG::` class the way a real VX Ace project does, so
+this whole class of gap was invisible until a real, large freeware VX Ace
+release (a ~60-hour RPG, 468 maps, 930 skills, 610 enemies) was booted through
+the script host.
+
+**`TypeError: superclass mismatch for RPG::Actor` ended every real VX Ace
+game's boot.** The editor exposes `BaseItem`/`UsableItem`/`EquipItem`/
+`Actor`/`Class`/`Item`/`Skill`/`Weapon`/`Armor`/`State`/`Enemy` as ordinary,
+editable script sections (its "RPG" folder) — unlike XP, which compiles the
+equivalent classes into the DLL. Every one of these sections' first line
+reasserts its stock superclass, e.g. `class RPG::Actor < RPG::BaseItem`, even
+when a game's own customisation only touches the body below it. `mruby-rpgxp`
+(loaded first, shared by all three RGSS makers) declared these classes flat —
+no superclass — because it predates VX Ace and a class's superclass cannot
+change once set. `mruby-rpgvx/mrblib/rgss2_data.rb` worked around that by
+composing the RGSS3 fields through `*Fields` modules instead of real
+inheritance, which was invisible to every check *until a real game's own
+section reasserted the superclass it never got*. Fixed by giving
+`mruby-rpgxp/mrblib/rgss_data.rb` the real chain from each class's first
+declaration (see the comment on `class BaseItem` there) — this is very likely
+the single biggest reason a real VX Ace release could not boot at all.
+
+**The 64 MB LVGL heap** (which backs mruby's whole VM heap on desktop, not
+just graphics) was too small for this game's database alone — `NoMemoryError`
+during `Data/*.rvdata2` loading, before a single scene ran. Raised to 256 MB
+for desktop (PSP/Wio keep their own separate, already-tuned pools).
+
+**Community utility scripts assume more Ruby/Windows surface than this build
+ships**, found by continuing past the superclass fix into the game's own
+bundled scripts: `Win32API` (RGSS's DLL-call class — many optional-feature
+utility scripts, e.g. the widely bundled CACAO 画像保存 screenshot saver,
+bind several calls unconditionally at load time) and `String#encode` (this
+mruby build has no transcoding tables) are now filled in as inert
+warn-once-and-degrade shims — matching the existing `Errno` fill-in's
+philosophy of "must exist, does not have to work" for something outside this
+engine's reach. `Module#private_method_defined?`/`#protected_method_defined?`/
+`#public_method_defined?` are filled in for real (mruby-metaprog already
+tracks the data `private_instance_methods` needs) rather than stubbed.
+
+**Still open: `module_function` with no arguments is a documented no-op in
+this mruby version.** CRuby's "declaration mode" `module_function` — call it
+bare, and every subsequent `def` in that scope becomes both a private
+instance method *and* a public singleton method — needs compiler-level
+"default definee" tracking that upstream mruby's own source marks
+unimplemented (`mrb_mod_module_function` in `3rd/mruby/src/class.c`: `if
+(argc == 0) { /* set MODFUNC SCOPE if implemented */ return mod; }`). The
+explicit-argument form (`module_function :name`, converting an
+already-defined method) works correctly and is what most RGSS scripts use for
+a single utility method, but a module built entirely under a bare
+`module_function` declaration — e.g. the same real game's bundled error-log
+utility, `TKG::ErrorLog`, whose `save` is only ever reachable as
+`TKG::ErrorLog.save(...)` — silently defines no singleton methods at all,
+raising `NoMethodError` the first time the game tries to call one. This is an
+upstream mruby limitation (reproduced and confirmed in isolation, not
+specific to this project's config or build), not something to patch in the
+vendored submodule for one script's sake; real content that needs it working
+would want this revisited.
+
 ## What this means for turning the host on
 
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
@@ -344,6 +406,8 @@ notice is what a project without scripts, or a boot with `RGSS_SCRIPT_HOST=0`,
 gets instead). A bundle now **runs**: it loads its database,
 plays its music, reads input, drives frames, lays out its windows, draws its map,
 tints, flashes and fades the screen, dissolves between scenes, unrolls and tints
-its windows, and — packed or loose — finds its graphics and its music. What is
-left is the two tilemap polish items in item 1 — the flat "above characters"
-layer and the A2 table edge.
+its windows, and — packed or loose — finds its graphics and its music, and
+reopens its own stock `RPG::` script sections without a superclass mismatch.
+Tilemap item 1's remaining polish (the flat "above characters" layer) is the
+only item left in the six sections above; item 7's `module_function` gap is
+the newest and, per a real release, potentially the most consequential.

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -42,7 +42,7 @@
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
     /*Size of the memory available for `lv_malloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (64 * 1024U * 1024U)          /*[bytes]*/
+    #define LV_MEM_SIZE (256 * 1024U * 1024U)          /*[bytes]*/
 
     /*Size of the memory expand for `lv_malloc()` in bytes*/
     #define LV_MEM_POOL_EXPAND_SIZE 0

--- a/mruby-rpgvx/mrblib/rgss2_data.rb
+++ b/mruby-rpgvx/mrblib/rgss2_data.rb
@@ -25,16 +25,23 @@
 # than declaring a competing schema; a record only ever carries the ivars its own
 # stream wrote, so the unused accessors simply read back nil.
 #
-# For the same reason the RGSS3 superclass chain (BaseItem → UsableItem /
-# EquipItem → Skill / Item / Weapon / Armor / …) cannot be expressed with real
-# superclasses: mruby-rpgxp already declares those concrete classes flat, and a
-# class's superclass cannot change when it is reopened. The inherited fields are
-# carried by the `*Fields` modules below instead, which the (otherwise unused)
-# abstract classes include as well — so `RPG::BaseItem` still documents the RGSS3
-# shape while `RPG::Skill` answers `#features`. Everything here is deliberately
-# behaviour-free: these are attribute holders that mirror the editor's data model
-# 1:1, so the runtime and the host-side check (scripts/rpgvx_testbed_check.rb,
-# which loads this exact file under CRuby) read the same fields.
+# The RGSS3 superclass chain (BaseItem → UsableItem / EquipItem → Skill / Item /
+# Weapon / Armor / Actor / Class / Enemy / State) is real inheritance, not just
+# documented in a comment: a genuine VX Ace project exposes these as editable
+# script sections (the editor's "RPG" folder), and every one of them reasserts
+# its superclass on its very first line, e.g. `class RPG::Actor <
+# RPG::BaseItem`. Since a class's superclass cannot change once set, and
+# mruby-rpgxp/mrblib/rgss_data.rb declares these classes first (XP has no
+# BaseItem concept, but the build is shared), the chain has to start there —
+# see the comment above `class BaseItem` in that file. This file only reopens
+# them to add the RGSS2/RGSS3 fields (via the `*Fields` modules, still needed
+# for BaseItem/UsableItem/EquipItem's own fields) rather than declaring a
+# competing schema; a record only ever carries the ivars its own stream wrote,
+# so the unused accessors simply read back nil. Everything here is deliberately
+# behaviour-free: these are attribute holders that mirror the editor's data
+# model 1:1, so the runtime and the host-side check
+# (scripts/rpgvx_testbed_check.rb, which loads this exact file under CRuby)
+# read the same fields.
 #
 # Field names and their nesting follow the RGSS2 / RGSS3 references (the VX and
 # VX Ace help files' "RPG module" chapters); see
@@ -136,9 +143,10 @@ module RPG
 
   # ---- Database records -----------------------------------------------------
 
+  # BaseItem's fields (id/name/icon_index/description/features/note) come from
+  # `< BaseItem`, set by mruby-rpgxp/mrblib/rgss_data.rb's first declaration —
+  # see the comment there.
   class Actor
-    include BaseItemFields
-
     attr_accessor :class_id, :initial_level, :character_name, :character_index,
                   :face_name, :face_index
     # (VX) stats live on the actor, as in XP, and equipment is five id fields.
@@ -152,8 +160,6 @@ module RPG
   end
 
   class Class
-    include BaseItemFields
-
     attr_accessor :learnings
     # (VX)
     attr_accessor :position, :weapon_set, :armor_set, :element_ranks,
@@ -167,8 +173,6 @@ module RPG
   end
 
   class Skill
-    include UsableItemFields
-
     attr_accessor :mp_cost, :message1, :message2
     attr_accessor :hit # (VX)
     # (Ace)
@@ -176,8 +180,6 @@ module RPG
   end
 
   class Item
-    include UsableItemFields
-
     attr_accessor :price, :consumable
     # (VX)
     attr_accessor :hp_recovery_rate, :hp_recovery, :mp_recovery_rate,
@@ -186,8 +188,6 @@ module RPG
   end
 
   class Weapon
-    include EquipItemFields
-
     attr_accessor :animation_id
     # (VX)
     attr_accessor :hit, :atk, :def, :spi, :agi, :two_handed, :fast_attack,
@@ -196,8 +196,6 @@ module RPG
   end
 
   class Armor
-    include EquipItemFields
-
     # (VX) — `kind` is the slot (shield/helmet/body/accessory) VX Ace renamed to
     # `etype_id`, with `atype_id` becoming the armour *type*.
     attr_accessor :kind, :eva, :atk, :def, :spi, :agi, :prevent_critical,
@@ -207,8 +205,6 @@ module RPG
   end
 
   class Enemy
-    include BaseItemFields
-
     attr_accessor :battler_name, :battler_hue, :exp, :gold, :actions
     # (VX)
     attr_accessor :maxhp, :maxmp, :atk, :def, :spi, :agi, :hit, :eva,
@@ -231,8 +227,6 @@ module RPG
   end
 
   class State
-    include BaseItemFields
-
     attr_accessor :restriction, :priority, :message1, :message2, :message3,
                   :message4
     # (VX)

--- a/mruby-rpgvx/test/rpgvx_test.rb
+++ b/mruby-rpgvx/test/rpgvx_test.rb
@@ -258,6 +258,62 @@ assert "VX Ace records carry BaseItem features" do
   assert_equal 0.95, loaded.features[0].value
 end
 
+# Regression test for the real RGSS3 superclass chain: a genuine VX Ace
+# project exposes BaseItem/UsableItem/EquipItem/Actor/Class/Item/Skill/
+# Weapon/Armor/State/Enemy as real, editable script sections (the editor's
+# "RPG" folder), and every one of them reasserts its stock superclass on its
+# very first line -- `class RPG::Actor < RPG::BaseItem`, and so on. Before
+# this was real inheritance (rather than composed `*Fields` modules), that
+# reassertion raised `TypeError: superclass mismatch for RPG::Actor` the
+# moment any unmodified VX Ace game's own "RPG::Actor" section ran --
+# breaking the script host for what is likely *every* real VX Ace game, since
+# script authors routinely customise a section's body without ever touching
+# its class declaration line. Found booting a real, large freeware VX Ace
+# release (not the synthetic test bed, which never reopens these sections the
+# way a real project does). See the comment on `class BaseItem` in
+# mruby-rpgxp/mrblib/rgss_data.rb for the full story.
+assert "VX Ace RPG:: classes reopen with their real stock superclass" do
+  # Mirrors exactly what a stock, unmodified VX Ace project's own script
+  # sections declare -- reopening (not defining for the first time) must not
+  # raise TypeError: superclass mismatch.
+  assert_nothing_raised do
+    eval <<~RUBY
+      class RPG::BaseItem; end
+      class RPG::UsableItem < RPG::BaseItem; end
+      class RPG::EquipItem < RPG::BaseItem; end
+      class RPG::Actor < RPG::BaseItem; end
+      class RPG::Class < RPG::BaseItem; end
+      class RPG::Item < RPG::UsableItem; end
+      class RPG::Skill < RPG::UsableItem; end
+      class RPG::Weapon < RPG::EquipItem; end
+      class RPG::Armor < RPG::EquipItem; end
+      class RPG::State < RPG::BaseItem; end
+      class RPG::Enemy < RPG::BaseItem; end
+    RUBY
+  end
+
+  # mruby's Module has no `<` ancestry operator, so compare via #ancestors.
+  assert_true RPG::Actor.ancestors.include?(RPG::BaseItem)
+  assert_true RPG::Class.ancestors.include?(RPG::BaseItem)
+  assert_true RPG::State.ancestors.include?(RPG::BaseItem)
+  assert_true RPG::Enemy.ancestors.include?(RPG::BaseItem)
+  assert_true RPG::Item.ancestors.include?(RPG::UsableItem)
+  assert_true RPG::Skill.ancestors.include?(RPG::UsableItem)
+  assert_true RPG::Weapon.ancestors.include?(RPG::EquipItem)
+  assert_true RPG::Armor.ancestors.include?(RPG::EquipItem)
+  assert_true RPG::UsableItem.ancestors.include?(RPG::BaseItem)
+  assert_true RPG::EquipItem.ancestors.include?(RPG::BaseItem)
+
+  # Fields inherited via the real superclass, not a redundant `include`.
+  actor = RPG::Actor.new
+  actor.id = 3
+  actor.name = "Inherited"
+  actor.features = []
+  assert_equal 3, actor.id
+  assert_equal "Inherited", actor.name
+  assert_equal [], actor.features
+end
+
 assert "VX Ace RPG::Class holds the exp curve and the stat table" do
   klass = RPG::Class.new
   klass.id = 1

--- a/mruby-rpgxp/mrblib/rgss_data.rb
+++ b/mruby-rpgxp/mrblib/rgss_data.rb
@@ -29,7 +29,25 @@ module RPG
     attr_accessor :name, :volume, :pitch
   end
 
-  class Actor
+  # RGSS3 (VX Ace) introduces a BaseItem -> UsableItem/EquipItem superclass
+  # chain over Actor/Class/Item/Skill/Weapon/Armor/State/Enemy, exposed as
+  # real, editable script sections in the editor's "RPG" folder (XP and plain
+  # VX have no such concept -- these classes are compiled into the DLL, never
+  # user-editable script sections). A genuine VX Ace project ships those
+  # sections unmodified, and each one's very first line reasserts its
+  # superclass, e.g. `class RPG::Actor < RPG::BaseItem`. A class's superclass
+  # cannot change once set, so that only works if it already matches by the
+  # time the game's own section runs -- which means it has to be set here, at
+  # each class's *first* declaration in this shared build, even though XP
+  # itself never uses BaseItem. mruby-rpgvx/mrblib/rgss2_data.rb reopens
+  # BaseItem/UsableItem/EquipItem to add their real (RGSS3) fields; Actor and
+  # friends below just declare the correct ancestor and are reopened the same
+  # way, no superclass clause needed since one is now already set.
+  class BaseItem; end
+  class UsableItem < BaseItem; end
+  class EquipItem < BaseItem; end
+
+  class Actor < BaseItem
     attr_accessor :id, :name, :class_id, :initial_level, :final_level,
                   :exp_basis, :exp_inflation, :character_name, :character_hue,
                   :battler_name, :battler_hue, :parameters,
@@ -37,7 +55,7 @@ module RPG
                   :weapon_fix, :armor1_fix, :armor2_fix, :armor3_fix, :armor4_fix
   end
 
-  class Class
+  class Class < BaseItem
     attr_accessor :id, :name, :position, :weapon_set, :armor_set,
                   :element_ranks, :state_ranks, :learnings
 
@@ -46,7 +64,7 @@ module RPG
     end
   end
 
-  class Item
+  class Item < UsableItem
     attr_accessor :id, :name, :icon_name, :description, :scope, :occasion,
                   :animation1_id, :animation2_id, :menu_se, :common_event_id,
                   :price, :consumable, :parameter_type, :parameter_points,
@@ -55,7 +73,7 @@ module RPG
                   :plus_state_set, :minus_state_set
   end
 
-  class Skill
+  class Skill < UsableItem
     attr_accessor :id, :name, :icon_name, :description, :scope, :occasion,
                   :animation1_id, :animation2_id, :menu_se, :common_event_id,
                   :sp_cost, :power, :atk_f, :eva_f, :str_f, :dex_f, :agi_f,
@@ -63,20 +81,20 @@ module RPG
                   :plus_state_set, :minus_state_set
   end
 
-  class Weapon
+  class Weapon < EquipItem
     attr_accessor :id, :name, :icon_name, :description, :animation1_id,
                   :animation2_id, :price, :atk, :pdef, :mdef, :str_plus,
                   :dex_plus, :agi_plus, :int_plus, :element_set,
                   :plus_state_set, :minus_state_set
   end
 
-  class Armor
+  class Armor < EquipItem
     attr_accessor :id, :name, :icon_name, :description, :kind, :auto_state_id,
                   :price, :pdef, :mdef, :eva, :str_plus, :dex_plus, :agi_plus,
                   :int_plus, :guard_element_set, :guard_state_set
   end
 
-  class State
+  class State < BaseItem
     attr_accessor :id, :name, :animation_id, :restriction, :nonresistance,
                   :zero_hp, :cant_get_exp, :cant_evade, :slip_damage,
                   :rating, :hit_rate, :maxhp_rate, :maxsp_rate, :str_rate,
@@ -163,7 +181,7 @@ module RPG
     attr_accessor :code, :parameters
   end
 
-  class Enemy
+  class Enemy < BaseItem
     attr_accessor :id, :name, :battler_name, :battler_hue, :maxhp, :maxsp,
                   :str, :dex, :agi, :int, :atk, :pdef, :mdef, :eva,
                   :animation1_id, :animation2_id, :element_ranks, :state_ranks,

--- a/mruby-rpgxp/mrblib/rgss_library.rb
+++ b/mruby-rpgxp/mrblib/rgss_library.rb
@@ -94,6 +94,85 @@ module Errno
   class EISDIR < SystemCallError; end unless const_defined?(:EISDIR)
 end
 
+# Ruby's own `Module#private_method_defined?` / `#protected_method_defined?` /
+# `#public_method_defined?`, which this mruby build does not ship as such —
+# unlike `Errno`/`String#encode` above, this one is not a stub: mruby-metaprog
+# already provides `private_instance_methods`/`protected_instance_methods`/
+# `public_instance_methods` (used by `Module#instance_methods` itself), so the
+# visibility-filtered membership check these three ask for is answerable
+# exactly, just not under this name. A real project's scripts reach for these
+# in visibility-aware `method_missing`/introspection helpers — e.g. an error
+# logger's dump of "was this rescue handler overridden privately" — genuinely
+# checking, not merely tolerating being asked.
+unless Module.method_defined?(:private_method_defined?)
+  class Module
+    def private_method_defined?(sym, inherit = true)
+      private_instance_methods(inherit).include?(sym.to_sym)
+    end
+
+    def protected_method_defined?(sym, inherit = true)
+      protected_instance_methods(inherit).include?(sym.to_sym)
+    end
+
+    def public_method_defined?(sym, inherit = true)
+      public_instance_methods(inherit).include?(sym.to_sym)
+    end
+  end
+end
+
+# Ruby's own `String#encode`, which this mruby build does not ship (no
+# mruby-encoding gem is vendored or configured — mruby strings carry no
+# per-instance encoding metadata at all). A Japanese project's scripts
+# routinely transcode a string at a Windows API boundary, e.g. CACAO's widely
+# bundled 画像保存 utility script binds a window title with
+# `load_data(...).game_title.encode('SHIFT_JIS')` before passing it to a (here
+# already-inert, see `Win32API` below) `FindWindow` call. Real transcoding
+# needs conversion tables this build does not have, but nothing in this engine
+# — UTF-8 throughout — ever depends on that boundary being correct, so this
+# degrades the same way `Win32API#call` does: warn once, then answer the
+# receiver unchanged rather than raise. A script that reads the *result* back
+# as authentically Shift_JIS bytes (rather than just handing it to a Win32
+# call this host cannot make anyway) would see the wrong content, but a
+# NoMethodError here fails the whole script host over a boundary the game
+# never gets to observe.
+unless String.method_defined?(:encode)
+  class String
+    def encode(*)
+      RGSS.warn_stub("String#encode")
+      self
+    end
+  end
+end
+
+# RGSS's Win32API: a general FFI mechanism for calling arbitrary Win32 DLL
+# entry points by name, which a project routinely uses for one *optional*
+# Windows-only feature — e.g. CACAO's widely bundled 画像保存
+# (Bitmap#save/Graphics.save_screen) utility script binds
+# MultiByteToWideChar/FindWindow/BitBlt/... at its top level, unconditionally,
+# just by being included in the project.
+#
+# There is no real Win32 to call into here (this engine also targets Linux,
+# the PSP and wasm), and a script that merely *binds* a function is not
+# choosing to use it yet — raising at `Win32API.new` would fail the whole
+# script host over a feature the game may never invoke, exactly the class of
+# unnecessary death this file's `RPG::Cache` fallback avoids for a missing
+# asset. So construction always succeeds, and `#call` — the point an actual
+# Windows API call would happen — warns once per (dllname, funcname) pair and
+# answers 0, `Win32API#call`'s own return type: whatever Windows-only feature
+# it drove (screenshot saving, a custom window border, ...) silently does
+# nothing, same as a project shipping no RTP art.
+class Win32API
+  def initialize(dllname, funcname, import = nil, export = nil)
+    @dllname = dllname
+    @funcname = funcname
+  end
+
+  def call(*args)
+    RGSS.warn_stub("Win32API #{@dllname}.#{@funcname}")
+    0
+  end
+end unless Object.const_defined?(:Win32API)
+
 module RPG
   # The bitmap cache. Every graphic a game loads goes through here — the scripts
   # call `RPG::Cache.character(name, hue)`, `.tile(tileset, id, hue)`,

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -333,6 +333,57 @@ assert "Errno::ENOENT exists so a game's `rescue Errno::ENOENT` resolves" do
   assert_true passed_through, "a foreign exception did not survive the rescue clause"
 end
 
+# Module#private_method_defined? / #protected_method_defined? /
+# #public_method_defined?, filled in from mruby-metaprog's existing
+# private_instance_methods/protected_instance_methods/public_instance_methods
+# (a real answer, not a stub -- see the comment above `class Module` in
+# rgss_library.rb).
+assert "Module visibility-filtered method_defined? variants answer correctly" do
+  m = Module.new
+  m.module_eval do
+    def pub_m; end
+    private def priv_m; end
+    protected def prot_m; end
+  end
+
+  assert_true m.public_method_defined?(:pub_m)
+  assert_false m.public_method_defined?(:priv_m)
+  assert_false m.public_method_defined?(:prot_m)
+
+  assert_true m.private_method_defined?(:priv_m)
+  assert_false m.private_method_defined?(:pub_m)
+  assert_false m.private_method_defined?(:prot_m)
+
+  assert_true m.protected_method_defined?(:prot_m)
+  assert_false m.protected_method_defined?(:pub_m)
+  assert_false m.protected_method_defined?(:priv_m)
+
+  assert_false m.private_method_defined?(:nope)
+end
+
+# Win32API: real games bind Windows-only DLL calls unconditionally at script
+# load time (a very common pattern for an *optional* feature, e.g. CACAO's
+# widely bundled screenshot-saving utility binds MultiByteToWideChar/
+# FindWindow/BitBlt/... just by being included in a project). There is no
+# real Win32 to call into on this engine's targets (also Linux/PSP/wasm), so
+# construction must not raise -- only #call is reached if the game actually
+# tries to use the feature, and even then it degrades to a warning + 0 rather
+# than ending the whole script host over an optional Windows integration.
+assert "Win32API binds without raising and #call degrades to a warning" do
+  api = Win32API.new("user32", "FindWindow", "pp", "l")
+  assert_equal 0, api.call("class", "title")
+end
+
+# String#encode: this mruby build has no real transcoding tables, but a
+# Japanese project's scripts routinely call it at a boundary this engine
+# never observes (e.g. the same screenshot utility encodes a window title
+# before handing it to the now-inert Win32API FindWindow above). Answering
+# the receiver unchanged, rather than raising, is what keeps that boundary
+# from ending the whole script host.
+assert "String#encode is a no-op that does not raise" do
+  assert_equal "hello", "hello".encode("SHIFT_JIS")
+end
+
 assert "RPG::Weather offers the surface Spriteset_Map drives" do
   methods = RPG::Weather.instance_methods
   %i[type= max= ox= oy= update dispose type max ox oy].each do |name|
@@ -463,12 +514,14 @@ assert "eval, Fiber and Kernel#exit / SystemExit are available for the script ho
   # first booted game.
   assert_true Kernel.method_defined?(:eval), "Kernel#eval missing (mruby-eval)"
   assert_true Object.const_defined?(:Fiber), "Fiber missing (mruby-fiber)"
-  # mruby-exit defines Kernel#exit (a private method) alongside SystemExit, so the
-  # constant's presence proves the gem is linked. mruby's Module has no
-  # #private_method_defined? (it is CRuby-only), so we do not reflect on the
-  # private method here.
+  # mruby-exit defines Kernel#exit (a private method) alongside SystemExit;
+  # rgss_library.rb fills in Module#private_method_defined? (this mruby build
+  # has no such gem), so this can check the private method directly, not just
+  # the constant's presence.
   assert_true Object.const_defined?(:SystemExit),
               "SystemExit / Kernel#exit missing (mruby-exit)"
+  assert_true Kernel.private_method_defined?(:exit),
+              "Kernel#exit missing or not private (mruby-exit)"
   # A Fiber round-trips a value through yield/resume, the mechanism the driver
   # relies on to advance one frame per resume.
   f = Fiber.new { Fiber.yield(:frame); :done }

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -204,6 +204,15 @@ ROOT = File.expand_path("..", __dir__)
 load File.join(ROOT, "mruby-rpgxp", "mrblib", "rgssad.rb")
 # The VX shell runs a project's own scripts through the shared RGSS script host.
 load File.join(ROOT, "mruby-rpgxp", "mrblib", "script_host.rb")
+# mruby-rpgxp/mrblib/rgss_data.rb declares the RPG:: schema first (Actor,
+# Class, Item, Skill, Weapon, Armor, State, Enemy, and — since a genuine VX
+# Ace project's own script sections reassert it — the real BaseItem/
+# UsableItem/EquipItem superclass chain over them); mruby-rpgvx/mrbgem.rake
+# depends on mruby-rpgxp for exactly this load-order reason, so this harness
+# has to mirror it or these classes come out flat, missing the fields their
+# real superclass would have carried. See the comment on `class BaseItem` in
+# that file.
+load File.join(ROOT, "mruby-rpgxp", "mrblib", "rgss_data.rb")
 load File.join(ROOT, "mruby-rpgvx", "mrblib", "lib.rb")
 load File.join(ROOT, "mruby-rpgvx", "mrblib", "rgss2_data.rb")
 load File.join(ROOT, "mruby-rpgvx", "mrblib", "rgss2_runtime.rb")


### PR DESCRIPTION
## Summary

- **The headline fix**: a real, unmodified VX Ace project exposes `BaseItem`/`UsableItem`/`EquipItem`/`Actor`/`Class`/`Item`/`Skill`/`Weapon`/`Armor`/`State`/`Enemy` as editable script sections (the editor's "RPG" folder), and every one of them reasserts its stock superclass on its very first line — e.g. `class RPG::Actor < RPG::BaseItem` — even when a game only customises the body below. `mruby-rpgxp`'s XP-era schema (loaded first, shared by all three RGSS makers) declared these classes flat, with no superclass, so reopening with an explicit one raised `TypeError: superclass mismatch for RPG::Actor` and ended the whole run. This was invisible to every existing check, since the synthetic test bed and hand-authored beds never reopen a stock `RPG::` class the way a real project does. **This is very likely the single biggest reason a real VX Ace release could not boot through the script host at all.**
- Fixed by giving `Actor`/`Class`/`Item`/`Skill`/`Weapon`/`Armor`/`State`/`Enemy` (plus new `BaseItem`/`UsableItem`/`EquipItem` scaffolding) the real RGSS3 inheritance chain from their first declaration in `mruby-rpgxp/mrblib/rgss_data.rb`. `mruby-rpgvx/mrblib/rgss2_data.rb`'s `*Fields` module composition becomes redundant for these classes (real inheritance now provides the same fields), so those `include` calls are dropped.
- Found and verified by booting a real, large freeware VX Ace release (downloaded, not vendored — same approach as the existing Lunatic-Core/PrayforYou test beds). Continuing past the superclass fix into that game's own bundled scripts surfaced two more real gaps, both fixed:
  - The 64 MB desktop LVGL heap (which backs mruby's *whole* VM heap, not just graphics — see `lvallocf` in `src/main.cxx`) was too small for the game's database alone, aborting with `NoMemoryError` before any scene ran. Raised to 256 MB for desktop; the PSP and Wio builds keep their own separate, already-tuned pools.
  - `Win32API`, `String#encode` and `Module#private_method_defined?` (and friends) were missing. `Win32API`/`String#encode` are filled in as inert warn-once-and-degrade shims, matching the existing `Errno` fill-in's philosophy — real games commonly bind optional Windows-only utility features (e.g. a widely bundled screenshot-saving script) unconditionally at script load time. `private_method_defined?`/`protected_method_defined?`/`public_method_defined?` are real implementations built on mruby-metaprog's existing `private_instance_methods` and friends, not stubs.
- **Documented but explicitly not fixed**: bare (argument-less) `module_function` is a no-op in this mruby version — a genuine upstream limitation (`3rd/mruby/src/class.c`'s `mrb_mod_module_function` literally comments the scope-affecting form as `/* if implemented */`), reproduced and confirmed in isolation. It still blocks the same real game's bundled error-logging utility script. Patching vendored mruby core for one script's sake is out of scope here; full diagnosis is in `docs/rpgvx-rgss-api-gap.md` item 7.
- `scripts/rpgvx_testbed_check.rb` now also loads `mruby-rpgxp`'s schema file first, matching the real gem dependency order — it previously only loaded `mruby-rpgvx`'s half, which broke once `BaseItem`'s fields started coming from real inheritance instead of module composition.

## Test plan
- [x] `./build/mruby/host/bin/mrbtest` — 1822/1822 OK, 0 failures (includes new regression tests for the superclass chain and the three shims)
- [x] `ruby scripts/rpgxp_testbed_check.rb data/PrayforYou` — OK
- [x] `ruby scripts/rpgvx_testbed_check.rb` — OK
- [x] `ruby scripts/rpgxp_script_host_check.rb` — OK
- [x] `bash scripts/rpgxp_boot_check.bash` against both `data/OpenGame.exe/Testbed/XP` and `data/PrayforYou` — move/menu/battle/save all still pass
- [x] `bash scripts/rgssad_asset_check.bash` — OK
- [x] Manual: a real, large freeware VX Ace release now gets past DB load and all 213 of its own script sections (previously died on section 2), reaching its own `Main`/`rgss_main` boot path
- [x] Changelog fragments added (3, one per distinct fix)
- [x] `docs/TODO.md` and `docs/rpgvx-rgss-api-gap.md` updated with the full diagnosis


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_