### PR TITLE
Add Select mode and debug teleport to the F9 Map viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@
   whole-map viewer: every tile of the current map at one pixel per tile
   (green passable, dark red blocked), with a marker for the player and every
   active map event, panned with the arrow keys and recentred on the player
-  with C
+  with C. **R** enters Select mode, a single-tile cursor (arrow keys move it,
+  the viewport auto-scrolling to keep it in view) that reports the tile
+  underneath — coordinates, passable/blocked, and any map event standing
+  there — and warps the player onto it with C, through the same queued-warp
+  mechanism a Teleport field skill uses rather than editing position by hand
 - `--rpg2k_preview_map=<id>` starts New Game on a chosen map, centred on its
   middle tile, instead of the database's configured start position — a quick
   way to inspect one map's rendering without a save file positioned there.

--- a/changelog.d/rpg2k-map-viewer-select-teleport.added.md
+++ b/changelog.d/rpg2k-map-viewer-select-teleport.added.md
@@ -1,0 +1,12 @@
+- **The F9 debug menu's Map viewer gained a Select mode and a debug teleport.**
+  Press **R** inside the whole-map viewer to drop a single-tile cursor on the
+  player's own position; arrow keys move it one tile at a time (the viewport
+  auto-scrolling to keep it in view), and the header reports the tile
+  underneath — coordinates, whether the chipset marks it passable or blocked,
+  and the name of any map event standing there. **C** warps the player onto
+  the selected tile and returns to the map; **B** backs out of Select mode
+  without moving anyone, or closes the viewer entirely from pan mode. The warp
+  goes through `Game::State#pending_teleport`, the same queued-warp mechanism
+  a Teleport field skill uses, so `Scene::Map` runs the real teleport
+  machinery (map reload, access/BGM setup) on its next update rather than the
+  viewer editing the player's position by hand.

--- a/mruby-rpg2k/mrblib/scene/map_viewer.rb
+++ b/mruby-rpg2k/mrblib/scene/map_viewer.rb
@@ -17,19 +17,33 @@ class RPG2k
     # would.
     #
     # Arrow keys pan the viewport when the map doesn't fit on screen at once;
-    # C recentres on the player; B closes back to the debug menu.
+    # C recentres on the player; R enters Select mode, a single-tile cursor
+    # (arrow keys move it, viewport auto-scrolling to follow) that reports the
+    # tile under it -- coordinates, passable/blocked, and the map event there,
+    # if any -- and can teleport the player onto it with C. B backs out of
+    # Select mode, or closes the viewer back to the debug menu if it is
+    # already in pan mode.
+    #
+    # The teleport goes through Game::State#pending_teleport, the same queued-
+    # warp mechanism a Teleport field skill uses (see Scene::ItemMenu/
+    # SkillMenu#queue_teleport) -- Scene::Map picks it up and runs the real
+    # Teleport-command machinery (reloading the map, replaying its access/BGM
+    # setup) on its very next #update, rather than this scene hand-mutating
+    # `@state.x`/`@state.y` and leaving that machinery unrun.
     class MapViewer < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
       HEADER_H = 16
       FOOTER_H = 16
       PAN_STEP = 8
+      CURSOR_MARGIN = 2
 
       PASSABLE_COLOR = Color.new(64, 160, 64, 255)
       BLOCKED_COLOR = Color.new(160, 48, 48, 255)
       UNKNOWN_COLOR = Color.new(96, 96, 96, 255)
       PLAYER_COLOR = Color.new(255, 255, 0, 255)
       EVENT_COLOR = Color.new(80, 200, 255, 255)
+      CURSOR_COLOR = Color.new(255, 255, 255, 255)
       TEXT_COLOR = Color.new(255, 255, 255, 255)
       HINT_COLOR = Color.new(200, 200, 200, 255)
 
@@ -48,6 +62,7 @@ class RPG2k
         @view_w = @contents.width
         @view_h = @contents.height - HEADER_H - FOOTER_H
         @pannable = @map && (@map.width > @view_w || @map.height > @view_h)
+        @select = false
         @ox = 0
         @oy = 0
         center_on_player
@@ -60,17 +75,87 @@ class RPG2k
       end
 
       def update
+        @select ? update_select : update_pan
+      end
+
+      private
+
+      def update_pan
         if Input.trigger?(Input::B)
           @parent.pop
         elsif Input.trigger?(Input::C)
           center_on_player
           refresh
+        elsif Input.trigger?(Input::R)
+          enter_select_mode
         elsif @pannable
           refresh if pan
         end
       end
 
-      private
+      def update_select
+        if Input.trigger?(Input::B) || Input.trigger?(Input::R)
+          @select = false
+          refresh
+        elsif Input.trigger?(Input::C)
+          teleport_to_cursor
+        elsif move_cursor
+          refresh
+        end
+      end
+
+      def enter_select_mode
+        return unless @map
+        @select = true
+        @cx = @state.x
+        @cy = @state.y
+        ensure_cursor_visible
+        refresh
+      end
+
+      # One tile per press/repeat, unlike #pan's fixed pixel step -- the
+      # cursor is choosing a tile to inspect or warp to, not scrolling.
+      def move_cursor
+        moved = false
+        max_cx = @map.width - 1
+        max_cy = @map.height - 1
+        if (Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)) && @cx.positive?
+          @cx -= 1
+          moved = true
+        elsif (Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)) && @cx < max_cx
+          @cx += 1
+          moved = true
+        end
+        if (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && @cy.positive?
+          @cy -= 1
+          moved = true
+        elsif (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && @cy < max_cy
+          @cy += 1
+          moved = true
+        end
+        ensure_cursor_visible if moved
+        moved
+      end
+
+      def ensure_cursor_visible
+        @ox = clamp(scroll_to_fit(@cx, @ox, @view_w), 0, max_ox)
+        @oy = clamp(scroll_to_fit(@cy, @oy, @view_h), 0, max_oy)
+      end
+
+      # The smallest scroll offset change that brings `pos` back inside
+      # [offset, offset + extent) -- unchanged if it's in view already.
+      def scroll_to_fit(pos, offset, extent)
+        return pos if pos < offset
+        return pos - extent + 1 if pos >= offset + extent
+        offset
+      end
+
+      # Direction 0 leaves the player's facing as it was, the same convention
+      # Scene::ItemMenu/SkillMenu#queue_teleport use for their own warps.
+      def teleport_to_cursor
+        @state.pending_teleport = [@map.id, @cx, @cy, 0]
+        @parent.pop_to_map
+      end
 
       def build_chipset
         return nil unless @map
@@ -131,19 +216,51 @@ class RPG2k
         draw_tiles
         draw_events
         draw_player
+        draw_cursor
         draw_footer
       end
 
       def draw_header
         @contents.font.color = TEXT_COLOR
-        text = @map ? "Map #{@map.id}  #{@map.width}x#{@map.height}  " \
-                      "x:#{@state.x} y:#{@state.y}" : 'No map loaded'
+        text = @select ? select_header_text : player_header_text
         @contents.draw_text 0, 0, @contents.width, HEADER_H, text
+      end
+
+      def player_header_text
+        return 'No map loaded' unless @map
+        "Map #{@map.id}  #{@map.width}x#{@map.height}  x:#{@state.x} y:#{@state.y}"
+      end
+
+      def select_header_text
+        color = tile_color(@cx, @cy)
+        word = if color.equal?(BLOCKED_COLOR) then 'blocked'
+               elsif color.equal?(PASSABLE_COLOR) then 'passable'
+               else 'unknown'
+               end
+        ev = event_at(@cx, @cy)
+        ev_text = ev ? "  Event ##{ev[0]} #{ev[1]}" : ''
+        "Cursor x:#{@cx} y:#{@cy}  #{word}#{ev_text}"
+      end
+
+      # The id and name of the map event standing at (x, y), or nil -- shares
+      # #each_event_position's live-position-over-spawn-point rule with
+      # #draw_events, so the cursor reports the same place the marker is
+      # actually drawn.
+      def event_at(x, y)
+        found = nil
+        each_event_position { |id, name, ex, ey| found = [id, name] if ex == x && ey == y }
+        found
       end
 
       def draw_footer
         @contents.font.color = HINT_COLOR
-        hint = @pannable ? 'Arrows:Pan  C:Center  B:Close' : 'B:Close'
+        hint = if @select
+                 'Arrows:Move  C:Teleport  B:Cancel'
+               elsif @pannable
+                 'Arrows:Pan  C:Center  R:Select  B:Close'
+               else
+                 'R:Select  B:Close'
+               end
         @contents.draw_text 0, HEADER_H + @view_h, @contents.width, FOOTER_H, hint
       end
 
@@ -188,13 +305,19 @@ class RPG2k
         passable ? PASSABLE_COLOR : BLOCKED_COLOR
       end
 
-      # Every event the map unit names, at its live wandered position when one
-      # has been recorded (Scene::Map#record_map_event_positions) or its
-      # authored spawn point otherwise. This state has no record of which
-      # events an Erase Event command removed this visit (that flag lives on
-      # the running Scene::Map, not Game::State), so a freshly-erased event
-      # can still show a marker here until the map is re-entered.
       def draw_events
+        each_event_position { |_id, _name, x, y| mark(x, y, EVENT_COLOR) }
+      end
+
+      # Yields [id, name, x, y] for every event the map unit names, at its
+      # live wandered position when one has been recorded
+      # (Scene::Map#record_map_event_positions) or its authored spawn point
+      # otherwise. Shared by #draw_events and #event_at so both agree on
+      # where an event actually is. Neither knows which events an Erase Event
+      # command removed this visit (that flag lives on the running Scene::Map,
+      # not Game::State), so a freshly-erased event can still show up here
+      # until the map is re-entered.
+      def each_event_position
         return unless @map
         events = @map.unit.events
         return unless events
@@ -203,7 +326,7 @@ class RPG2k
           pos = positions[id]
           x = pos ? pos[0] : ev.x
           y = pos ? pos[1] : ev.y
-          mark(x, y, EVENT_COLOR)
+          yield id, ev.name, x, y
         end
       end
 
@@ -216,6 +339,24 @@ class RPG2k
         vy = y - @oy
         return if vx.negative? || vy.negative? || vx >= @view_w || vy >= @view_h
         @contents.fill_rect vx - 1, HEADER_H + vy - 1, 3, 3, color
+      end
+
+      # A hollow box around the cursor tile, not a filled block like #mark --
+      # it needs to stay legible sitting on top of the player or an event
+      # marker, which it starts right on top of (Select mode opens on the
+      # player's own tile).
+      def draw_cursor
+        return unless @select
+        vx = @cx - @ox
+        vy = @cy - @oy
+        return if vx.negative? || vy.negative? || vx >= @view_w || vy >= @view_h
+        x = vx - CURSOR_MARGIN
+        y = HEADER_H + vy - CURSOR_MARGIN
+        size = CURSOR_MARGIN * 2 + 1
+        @contents.fill_rect x, y, size, 1, CURSOR_COLOR
+        @contents.fill_rect x, y + size - 1, size, 1, CURSOR_COLOR
+        @contents.fill_rect x, y, 1, size, CURSOR_COLOR
+        @contents.fill_rect x + size - 1, y, 1, size, CURSOR_COLOR
       end
     end
   end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18980,6 +18980,100 @@ check 'MapViewer pans a map bigger than the viewport, clamped to its edges, and 
   eq 200 - view_w / 2, scene.instance_variable_get(:@ox), 'C recentres back on the player'
 end
 
+check 'R enters MapViewer Select mode on the player tile; B backs out to pan mode ' \
+     'without closing the viewer' do
+  st = menu_state
+  st.map = fake_map(1, {})
+  st.x = 2; st.y = 3
+  scene = RPG2k::Scene::MapViewer.new(fake_parent(fake_db), st)
+
+  RGSS::Input.triggered = [RGSS::Input::R]
+  scene.update
+  ok scene.instance_variable_get(:@select), 'R enters Select mode'
+  eq 2, scene.instance_variable_get(:@cx), 'the cursor opens on the player tile, x'
+  eq 3, scene.instance_variable_get(:@cy), 'the cursor opens on the player tile, y'
+
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  ok !scene.instance_variable_get(:@select), 'B backs out of Select mode'
+  ok !scene.parent.pop_called, 'B in Select mode does not close the whole viewer'
+
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  eq 1, scene.parent.pop_called, 'a second B, now back in pan mode, closes it'
+end
+
+check 'MapViewer Select mode reports the tile under the cursor: coordinates, ' \
+     'passability, and any event standing there' do
+  ev = event(4, 1, page)
+  st = menu_state
+  st.map = fake_map(1, { 1 => ev })
+  st.x = 0; st.y = 1
+  scene = RPG2k::Scene::MapViewer.new(fake_parent(fake_db), st)
+
+  RGSS::Input.triggered = [RGSS::Input::R]
+  scene.update # enter Select mode, cursor opens at the player's (0, 1)
+  4.times do
+    RGSS::Input.triggered = [RGSS::Input::RIGHT]
+    scene.update
+  end
+  eq 4, scene.instance_variable_get(:@cx), 'four RIGHT presses moved the cursor one tile each'
+  eq 1, scene.instance_variable_get(:@cy)
+
+  text = scene.send(:select_header_text)
+  ok text.include?('x:4 y:1'), "header names the cursor's tile: #{text.inspect}"
+  ok text.include?('passable'), 'fake_chipset has no passability table: reads passable'
+  ok text.include?('Event #1'), 'the event standing on this tile is named in the header'
+end
+
+check 'C in MapViewer Select mode queues a teleport to the cursor tile and returns ' \
+     'to the map' do
+  st = menu_state
+  st.map = fake_map(1, {})
+  st.x = 1; st.y = 1
+  scene = RPG2k::Scene::MapViewer.new(fake_parent(fake_db), st)
+
+  RGSS::Input.triggered = [RGSS::Input::R]
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  eq 2, scene.instance_variable_get(:@cx)
+  eq 2, scene.instance_variable_get(:@cy)
+
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  eq [1, 2, 2, 0], st.pending_teleport,
+     'queues the same [map_id, x, y, dir] shape Scene::ItemMenu/SkillMenu#queue_teleport use'
+  ok scene.parent.pop_to_map_called,
+     'C pops the whole scene stack back to the map, not just this viewer, so Scene::Map ' \
+     'picks the teleport up on its next #update'
+end
+
+check 'the cursor auto-scrolls the MapViewer viewport to stay in view while moving ' \
+     'in Select mode' do
+  st = menu_state
+  st.map = big_map(1, 400, 300)
+  st.x = 200; st.y = 150
+  scene = RPG2k::Scene::MapViewer.new(fake_parent(fake_db), st)
+  view_w = scene.instance_variable_get(:@view_w)
+
+  RGSS::Input.triggered = [RGSS::Input::R]
+  scene.update # cursor opens on the player tile, already in view
+  ox_before = scene.instance_variable_get(:@ox)
+
+  # Walk the cursor past the current viewport's right edge.
+  ((view_w / 2) + 1).times do
+    RGSS::Input.triggered = [RGSS::Input::RIGHT]
+    scene.update
+  end
+  cx = scene.instance_variable_get(:@cx)
+  ox = scene.instance_variable_get(:@ox)
+  ok ox > ox_before, 'the viewport scrolled right to keep up with the cursor'
+  ok cx >= ox && cx < ox + view_w, 'the cursor stays inside the (now-scrolled) viewport'
+end
+
 check "a troop's terrain_set excludes it from a tile it does not cover" do
   scene = new_scene({})
   scene.db.enemy_group[9] = OpenStruct.new(name: 'Wolves', members: {}, terrain_set: [0])


### PR DESCRIPTION
## Summary

Follow-up to the whole-map viewer added in #1049 (already merged). Adds a
Select mode and a debug teleport, so the viewer can also be used to jump
around a map while testing, not just look at it.

## Key Changes

- **Select mode (`R`)**: drops a single-tile cursor on the player's own
  position inside the map viewer. Arrow keys move it one tile at a time,
  with the viewport auto-scrolling to keep it in view.
- **Tile inspection**: the header reports the tile under the cursor —
  coordinates, whether the chipset marks it passable or blocked, and the
  name of any map event standing there.
- **Debug teleport (`C`)**: warps the player onto the selected tile and
  returns to the map. `B` backs out of Select mode without moving anyone, or
  closes the viewer entirely from pan mode.

## Implementation Details

- The teleport goes through `Game::State#pending_teleport`, the same
  queued-warp mechanism a Teleport field skill uses
  (`Scene::ItemMenu`/`SkillMenu#queue_teleport`) — `Scene::Map` runs the real
  teleport machinery (map reload, access/BGM setup) on its next `#update`,
  rather than this scene hand-mutating `@state.x`/`@state.y` and leaving that
  machinery unrun.
- Still purely a runtime debug convenience: no writes to the on-disk
  project, so it can't collide with a real RPG Maker project or its own
  editor, matching the rest of the F9 debug menu.
- `event_at`/`draw_events` share one `each_event_position` helper so both
  agree on where an event actually is (live wandered position over authored
  spawn point).

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 762 checks pass, including 4 new
  ones covering entering/exiting Select mode, cursor tile reporting
  (coordinates, passability, events), the teleport's queued
  `[map_id, x, y, dir]` shape, and viewport auto-scroll while moving the
  cursor.

https://claude.ai/code/session_017C1i41GuWNEwKfPSHHUTra

---
_Generated by [Claude Code](https://claude.ai/code/session_017C1i41GuWNEwKfPSHHUTra)_