### PR TITLE
battle: cursed-armor-forced states now locked in battle too

### DIFF
--- a/changelog.d/battle-permanent-state-lock.fixed.md
+++ b/changelog.d/battle-permanent-state-lock.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003 battles:** A state RPG2003 cursed armor is actively forcing on
+  an ally now also survives a lethal hit and resists curative skills/items
+  used in battle, matching RPG_RT — the same protection the state already
+  had outside battle. Previously an in-battle lethal hit could strip the
+  cursed state outright, and a battle-side Antidote or curative skill
+  could cure it while the armor was still equipped, both of which real
+  RPG_RT refuses. Covered by two new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8949,6 +8949,45 @@ not yet verified:
   inflicts a higher-priority Death, and still resists a subsequent Full
   Recovery — only unequipping the armor clears it), confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **The in-battle `#inflict_state`/`#cure_state` call sites the fix
+  above deliberately left out of scope turned out to be a genuine gap
+  too, not a design boundary: `Game_Battler::GetPermanentStates()` (base
+  class) always returns empty and `Game_Enemy` never overrides it, but
+  `Game_Actor::GetPermanentStates()` does — and every
+  `Game_BattleAlgorithm` subclass threads that same
+  `target->GetPermanentStates()` into every in-battle
+  `State::Add`/`State::Remove` call, exactly like the field-side paths
+  already fixed (2026-08-19).** Confirmed directly against RPG_RT's live
+  source across `src/game_battlealgorithm.cpp`,
+  `src/game_battler.cpp:65-66` (the base, always-empty
+  `GetPermanentStates`) and `src/game_actor.cpp:1446`/`src/game_enemy.{h,cpp}`
+  (the override that exists only on `Game_Actor`, confirming a monster
+  genuinely has no such concept, so only an ally's own back-referenced
+  `Actor` matters here). `Game::Battle#inflict_state`
+  (`mruby-rpg2k/mrblib/game.rb`) called `Game::States.prune` with no
+  `keep:` at all, so the exact same cursed state that now survives a
+  lethal hit and Full Recovery on the field could still be silently
+  stripped by a lethal *in-battle* hit or state infliction. `#cure_state`
+  had a second, independent gap the field-side fix's own citation already
+  named but didn't need to act on there: real RPG_RT's `State::Remove`
+  hard-refuses (`if (ps.Has(state_id)) { return false; }`) removing a
+  cursed-forced state at all, in battle or out — `Actor#remove_state`
+  already carries this lock, but `Game::Battle#cure_state` (used by every
+  in-battle curative skill/item) had none, so a battle-side Antidote or
+  curative skill could cure a state the worn armor was still actively
+  forcing, something no path on the field could ever do. Fixed by adding
+  a small `combatant_permanent_states(target)` helper (an ally
+  Combatant's own `.actor.permanent_states`, `[]` for an enemy with no
+  `:actor` at all) and threading it into both methods: `keep:` on
+  `#inflict_state`'s `prune` call, and an early refusal in `#cure_state`
+  mirroring `Actor#remove_state`'s own lock (with no
+  `always_remove_battle_states:`-style bypass, since RPG_RT's own
+  in-battle callers never pass one either). Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a cursed-armor-forced state
+  survives a lethal in-battle Death infliction; a battle-side
+  `#cure_state` call is refused on the same state while the armor stays
+  equipped), both confirmed to fail against the pre-fix code before the
+  fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12445,9 +12445,28 @@ module Game
       target.attr_ranks = {} if target.respond_to?(:attr_ranks=)
     end
 
+    # `target`'s live RPG2003 cursed-armor-forced states (`Actor
+    # #permanent_states`), or `[]` for an enemy Combatant (no `:actor` field
+    # at all) -- matching real RPG_RT's own split: `Game_Actor::
+    # GetPermanentStates` is overridden with the real cursed-armor set,
+    # while the base `Game_Battler::GetPermanentStates` (which `Game_Enemy`
+    # never overrides) always returns an empty `PermanentStates()`, so a
+    # monster never carries one at all. `#inflict_state`/`#cure_state` need
+    # this the same way every `Game_BattleAlgorithm` subclass's own state
+    # mutations do -- `target_perm_states = target->GetPermanentStates()`,
+    # threaded into every in-battle `State::Add`/`State::Remove`
+    # (`src/game_battlealgorithm.cpp`), not just the field-side equivalents
+    # (`Actor#knock_out!`, `Party#cast_skill`, `Interpreter#
+    # do_change_condition`) this codebase already fixed.
+    def combatant_permanent_states(target)
+      actor = target.respond_to?(:actor) ? target.actor : nil
+      actor && actor.respond_to?(:permanent_states) ? actor.permanent_states : []
+    end
+
     def inflict_state(target, sid)
       return if target.state?(sid)
-      target.states = Game::States.prune((target.states || []) + [sid], @states)
+      target.states = Game::States.prune((target.states || []) + [sid], @states,
+                                          keep: combatant_permanent_states(target))
       target.hp = 0 if sid == Game::States::DEATH_ID
       apply_knockout_reset(target)
     end
@@ -12461,8 +12480,17 @@ module Game
     # to false afterward -- since removing any *other* id can never change
     # whether `kDeathID` is still carried, checking `sid` itself is an
     # equivalent, simpler test for the same transition.
+    #
+    # A state one of `target`'s worn cursed items is still actively forcing
+    # cannot be cured this way either -- `State::Remove` (`src/state.cpp`)
+    # hard-refuses (`if (ps.Has(state_id)) { return false; }`) exactly like
+    # it does for `Actor#remove_state`'s own already-ported lock; unlike
+    # that method, this one has no `always_remove_battle_states:`
+    # equivalent to bypass it with, since RPG_RT's own in-battle callers
+    # never pass one either.
     def cure_state(target, sid)
       return unless target.state?(sid)
+      return if combatant_permanent_states(target).include?(sid)
       target.states = (target.states || []) - [sid]
       target.hp = 1 if sid == Game::States::DEATH_ID
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10029,6 +10029,48 @@ def combatant_mp(name, atk, dfn, agi, hp, mp)
   c
 end
 
+# The Actor-side checks above cover the field-side prune/cure paths; every
+# `Game_BattleAlgorithm` subclass's own state mutation
+# (src/game_battlealgorithm.cpp) threads the identical
+# `target->GetPermanentStates()` into every in-battle `State::Add`/
+# `State::Remove` too -- `Game::Battle#inflict_state`/`#cure_state` had no
+# such wiring at all, so the exact same cursed state that already survived
+# a lethal hit and resisted Full Recovery on the field could still be
+# stripped by a lethal in-battle hit, or cured outright by a curative
+# skill/item used in battle. `Game_Enemy` never overrides
+# `GetPermanentStates` at all (the base `Game_Battler` version always
+# returns empty), so only an ally Combatant's own back-referenced `Actor`
+# carries a real set here.
+check 'battle: a lethal state infliction does not strip a state RPG2003 ' \
+      'cursed armor is still forcing' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  situation = { 1 => fake_state(priority: 100), 4 => fake_state(priority: 50) }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, {}, {}, situation, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  c = Game::Battle.from_actor(a)
+  eq [4], c.states, 'the cursed state carried into battle with the actor'
+  bat = Game::Battle.new([c], [combatant('Foe', 0, 0, 5, 100)], Game::Rng.new(1), situation)
+  bat.send(:inflict_state, c, Game::States::DEATH_ID)
+  ok c.states.include?(1), 'sanity: Death landed'
+  ok c.states.include?(4),
+     "the cursed state survived Death's own in-battle crowding-out pass too"
+end
+
+check "battle: a curative state removal cannot cure a state RPG2003 " \
+      'cursed armor is still forcing' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, {}, {}, nil, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  c = Game::Battle.from_actor(a)
+  bat = Game::Battle.new([c], [combatant('Foe', 0, 0, 5, 100)], Game::Rng.new(1))
+  bat.send(:cure_state, c, 4)
+  eq [4], c.states, 'refused in battle too -- the armor is still equipped'
+end
+
 check 'to_lsd/from_lsd round-trips the latest battle\'s turn count' do
   # Field 41 ("turns passed in latest battle") used to stay deliberately
   # undecoded: there was no per-battle turn tracker on the Ruby side to


### PR DESCRIPTION
## Summary

- A prior PR gave `Game::States.prune` a `keep:` exemption for RPG2003 cursed-armor-forced states and wired it through the three Actor/field-side call sites, but deliberately left the in-battle `Game::Battle#inflict_state`/`#cure_state` call sites out of scope pending confirmation that real RPG_RT's battle side even has an equivalent concept.
- Confirmed it does: every `Game_BattleAlgorithm` subclass (`src/game_battlealgorithm.cpp`) threads `target->GetPermanentStates()` into every in-battle `State::Add`/`State::Remove` call, exactly like the field-side paths. `Game_Battler::GetPermanentStates()` (the base class, `src/game_battler.cpp:65-66`) always returns empty, and `Game_Enemy` never overrides it — only `Game_Actor::GetPermanentStates()` (`src/game_actor.cpp:1446`) does, confirming a monster genuinely has no such concept, so only an ally Combatant's own back-referenced `Actor` matters.
- Two gaps, both fixed:
  - `Game::Battle#inflict_state` called `Game::States.prune` with no `keep:` at all, so a cursed state that now survives a lethal hit on the field could still be silently stripped by a lethal *in-battle* hit or state infliction.
  - `Game::Battle#cure_state` had no permanent-states lock at all — real RPG_RT's `State::Remove` hard-refuses removing a cursed-forced state (`if (ps.Has(state_id)) { return false; }`), in battle or out, mirroring `Actor#remove_state`'s already-ported lock — so a battle-side Antidote or curative skill could cure a state the worn armor was still actively forcing, something no field-side path could ever do.
- Fixed by adding a small `combatant_permanent_states(target)` helper and threading it into both methods.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: a cursed-armor-forced state survives a lethal in-battle Death infliction; a battle-side `#cure_state` call is refused on the same state while the armor stays equipped.
- [x] Confirmed both new checks fail against the pre-fix code via `git stash`, and pass post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1051 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 758 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_