### PR TITLE
events: Change Battle Commands validates the added id

### DIFF
--- a/changelog.d/change-battle-commands-validates-id.fixed.md
+++ b/changelog.d/change-battle-commands-validates-id.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 events:** Change Battle Commands (1009) now rejects a command
+  id the database's own Battle Commands table doesn't define, matching
+  RPG_RT. Previously any positive integer could occupy one of the six
+  command slots regardless of whether it named a real entry, so a handful
+  of stray invalid adds could silently starve a later, genuinely valid
+  add of a slot it should have had.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8988,6 +8988,40 @@ not yet verified:
   `#cure_state` call is refused on the same state while the armor stays
   equipped), both confirmed to fail against the pre-fix code before the
   fix.
+  ✅ **Change Battle Commands (1009) never validated an added command id
+  against the database's own Battle Commands table, so any positive
+  integer — however bogus — could occupy one of the six real slots
+  (2026-08-19).** This document's own earlier claim (well above, the
+  paragraph introducing Change Battle Commands) only credits "RPG_RT's
+  six-plus-Row capacity rule" as ported, never mentioning the existence
+  check that runs first. Confirmed directly against RPG_RT's live source:
+  `Game_Actor::ChangeBattleCommands` (`src/game_actor.cpp`) is `const
+  auto* cmd = GetElement(Data::battlecommands.commands, id); if (!cmd) {
+  Warning(...); return; }`, entirely before the capacity/duplicate checks
+  below it — an id the table doesn't define never occupies a slot at all.
+  `Game::Actor#change_battle_commands`
+  (`mruby-rpg2k/mrblib/game.rb`) only ever checked `id > 0` and
+  "already in the list," so a handful of adds naming ids the table
+  doesn't define could silently exhaust the six-slot capacity, starving a
+  later, genuinely valid add of a slot it should have had. Fixed by
+  reusing the already-existing `#battle_command_row(id)` (the exact
+  existence check this needs, ported for the menu's own display logic) as
+  an added guard on the `add` branch. As a side effect this also makes
+  the command correctly inert on a genuine RPG2000 database with no
+  `battlecommands` table at all — matching real RPG_RT's own
+  `Player::IsRPG2k3Commands()` gate on the event command itself, which
+  `Interpreter#do_change_battle_commands` does not separately enforce.
+  Two of the three existing `scripts/rpg2k_logic_check.rb` checks for this
+  command turned out to have been unknowingly relying on the bug: their
+  shared `class_state`/`class_db` fixture built no `battlecommands` table
+  at all, so every add the checks made was, under a faithful port, invalid
+  and should have been rejected outright — corrected by giving the
+  fixture a real table defining ids 1..8 (a genuine RPG2003 database
+  always carries one for any project that uses the command). Covered by a
+  new check (an id the table doesn't define never lands, and six bogus
+  adds cannot starve a later valid one of its slot), confirmed to fail
+  against the pre-fix code (`expected [1, 2, 0, -1, -1, -1, -1], got [1,
+  2, 99, 0]`) before the fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2926,10 +2926,24 @@ module Game
     # list back to Row alone. Ported from EasyRPG's
     # Game_Actor::ChangeBattleCommands, including its capacity rule: the list
     # holds at most six real commands plus Row, so a seventh add is dropped.
+    #
+    # An add also validates `id` against the database-wide Battle Commands
+    # table first -- EasyRPG's own source: `const auto* cmd =
+    # GetElement(Data::battlecommands.commands, id); if (!cmd) { Warning(...);
+    # return; }`, entirely before the capacity/duplicate checks. An id the
+    # table doesn't define never occupies a slot, unlike this port's own
+    # earlier version, which only checked `id > 0` and let any positive
+    # integer through -- a handful of bogus adds could silently exhaust the
+    # six-slot capacity, starving a later, genuinely valid add of a slot it
+    # should have had. Reusing #battle_command_row (already the exact
+    # existence check this needs) also makes the command correctly inert on
+    # a genuine RPG2000 database with no `battlecommands` table at all --
+    # matching `Player::IsRPG2k3Commands()`'s own gate on the real event
+    # command, which #do_change_battle_commands does not separately enforce.
     def change_battle_commands(add, id)
       cmds = battle_commands
       if add
-        return if id.nil? || id <= 0 || cmds.include?(id)
+        return if id.nil? || id <= 0 || cmds.include?(id) || !battle_command_row(id)
         kept = cmds.reject { |c| c == 0 || c == -1 }
         return if kept.size >= 6
         @battle_commands = kept + [id, 0]

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4756,7 +4756,14 @@ def class_db(class_id = 0, actor_learns = [[10, 1]])
     1 => JobRow.new('Warrior', job1, [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
     2 => JobRow.new('Mage', job2, [[31, 1]]),
   }
-  FakeActorDB.new(players, [1], {}, {}, jobs)
+  # A real Battle Commands table (chunk 29) defining ids 1..8, so
+  # #change_battle_commands' own existence check (see its citation) does
+  # not reject every add the Change Battle Commands checks below make --
+  # a genuine RPG2003 database always carries this table for any project
+  # that uses the command at all.
+  commands = (1..8).each_with_object({}) { |i, h| h[i] = FakeBattleCommand.new("Cmd#{i}", 1) }
+  FakeActorDB.new(players, [1], {}, {}, jobs, nil, nil,
+                  battlecommands: FakeBattleCommandsTable.new(commands, 0))
 end
 
 def class_state(class_id = 0, actor_learns = [[10, 1]])
@@ -5013,6 +5020,30 @@ check 'Change Battle Commands stops at six commands plus Row' do
   a = class_state.party.actor_by_id(1)
   (3..8).each { |id| a.change_battle_commands(true, id) }
   eq [1, 2, 3, 4, 5, 6, 0], a.battle_commands, 'the seventh add is dropped'
+end
+
+# RPG_RT's own `Game_Actor::ChangeBattleCommands` (src/game_actor.cpp)
+# looks `id` up in the database-wide Battle Commands table before anything
+# else: `const auto* cmd = GetElement(Data::battlecommands.commands, id);
+# if (!cmd) { Warning(...); return; }` -- an id the table does not define
+# never occupies a slot, entirely separate from the capacity/duplicate
+# checks below it. Previously #change_battle_commands only checked `id >
+# 0` and "already in the list", so a handful of bogus adds could silently
+# exhaust the six-slot capacity, starving a later genuinely valid add of a
+# slot it should have had.
+check "Change Battle Commands rejects an id the database's own table " \
+      "doesn't define, and can't be capacity-starved by bogus ids" do
+  a = class_state.party.actor_by_id(1)
+  eq nil, a.battle_command_row(99), 'sanity: id 99 is not in the table'
+  a.change_battle_commands(true, 99)
+  eq [1, 2, 0, -1, -1, -1, -1], a.battle_commands, 'an unknown id never lands at all'
+
+  # Six bogus adds (ids the table doesn't define) must not consume any of
+  # the six real slots -- a later valid add still has room.
+  (90..95).each { |id| a.change_battle_commands(true, id) }
+  eq [1, 2, 0, -1, -1, -1, -1], a.battle_commands, 'none of the six bogus ids landed'
+  a.change_battle_commands(true, 5)
+  eq [1, 2, 5, 0], a.battle_commands, 'a genuinely valid add still has a slot free'
 end
 
 check 'a class change takes the class battle commands' do


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_Actor::ChangeBattleCommands` (`src/game_actor.cpp`) looks the added id up in the database-wide Battle Commands table first — `const auto* cmd = GetElement(Data::battlecommands.commands, id); if (!cmd) { Warning(...); return; }` — entirely before the capacity/duplicate checks. An id the table doesn't define never occupies a slot. Confirmed by fetching the live source.
- `Game::Actor#change_battle_commands` (`mruby-rpg2k/mrblib/game.rb`) only ever checked `id > 0` and "already in the list," so a handful of bogus adds could silently exhaust the six-slot capacity, starving a later, genuinely valid add of a slot it should have had.
- Fixed by reusing the already-existing `#battle_command_row(id)` (the exact existence check this needs, already used by the menu's own display logic) as an added guard on the `add` branch. As a side effect this also makes the command correctly inert on a genuine RPG2000 database with no `battlecommands` table at all, matching RPG_RT's own `Player::IsRPG2k3Commands()` gate.
- Two of the three existing `scripts/rpg2k_logic_check.rb` checks for this command turned out to have been unknowingly relying on the bug: their shared `class_state`/`class_db` fixture built no `battlecommands` table at all, so every add they made was, under a faithful port, invalid and should have been rejected outright. Corrected by giving the fixture a real table defining ids 1..8 (a genuine RPG2003 database always carries one for any project that uses the command).

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: an id the table doesn't define never lands, and six bogus adds cannot starve a later valid one of its slot.
- [x] Confirmed the new check fails against the pre-fix code (`expected [1, 2, 0, -1, -1, -1, -1], got [1, 2, 99, 0]`) via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1052 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 762 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_