### PR TITLE
battle: an enemy's own AI Escape action plays the escape SE too

### DIFF
--- a/changelog.d/enemy-escape-plays-se.fixed.md
+++ b/changelog.d/enemy-escape-plays-se.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2003 battles:** An enemy that chooses its own AI "Escape" basic
+  action now plays the same system escape sound the party hears on a
+  successful Escape command, matching RPG_RT. Previously the monster
+  correctly fled the fight, but no sound played at all. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9022,6 +9022,32 @@ not yet verified:
   adds cannot starve a later valid one of its slot), confirmed to fail
   against the pre-fix code (`expected [1, 2, 0, -1, -1, -1, -1], got [1,
   2, 99, 0]`) before the fix.
+  ✅ **An enemy's own AI-chosen Escape basic action left the fight in
+  total silence, unlike the party's own successful Escape command, which
+  already plays the dedicated cue (2026-08-19).** Confirmed directly
+  against RPG_RT's live source: `Game_BattleAlgorithm::Escape::
+  GetStartSe` (`src/game_battlealgorithm.cpp`) is `if (source->GetType()
+  == Type_Ally) { return AlgorithmBase::GetStartSe(); } return
+  &GetSystemSE(SFX_Escape);` — an enemy source plays the system escape
+  cue, distinct from an ally's own Escape (silent here, since the party's
+  own escape sound is a separate trigger the scene already plays
+  elsewhere). `Scene_Battle_Rpg2k::ProcessBattleActionUsage`
+  (`src/scene_battle_rpg2k.cpp`) calls `GetStartSe()` unconditionally for
+  every action, the same generic dispatch every other action's start-SE
+  already goes through. `Game::Battle#enemy_basic_action`'s
+  `BASIC_ESCAPE` arm (`mruby-rpg2k/mrblib/game.rb`) already produces an
+  `entry[:fled]` flag, but `Scene::Battle#play_battle_action_se`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) — the method that already reads
+  every other field this same entry hash can carry — never once checked
+  it, even though the `SFX_ESCAPE` constant and its `play_system_se`
+  plumbing were already wired up for the other two flee contexts (the
+  party's own successful Escape command, and a battle page's scripted
+  Force Flee). Fixed by adding `play_system_se(SFX_ESCAPE) if
+  entry[:fled]`; `entry[:fled]` is only ever produced by the enemy-only
+  `BASIC_ESCAPE` arm, so no ally-side entry can ever trigger it and
+  double up with the party's own escape SE. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -3408,6 +3408,16 @@ class RPG2k
         end
         play_system_se(SFX_ENEMY_DEATH) if entry[:defeated] && !entry[:target_ally]
         play_system_se(SFX_ITEM) if entry[:item_id]
+        # An enemy's own AI-chosen Escape basic action plays the same system
+        # escape cue the party hears on its own successful Escape command --
+        # EasyRPG's `Game_BattleAlgorithm::Escape::GetStartSe` returns
+        # `SFX_Escape` whenever the algorithm's *source* is an enemy (an
+        # ally's own Escape defers to the base class's silent default
+        # instead, played separately by #try_battle_escape). `entry[:fled]`
+        # is only ever produced by `#enemy_basic_action`'s BASIC_ESCAPE arm,
+        # so it is inherently enemy-only here -- no risk of double-playing
+        # this alongside the party's own escape SE.
+        play_system_se(SFX_ESCAPE) if entry[:fled]
       end
 
       # The conditions the action just landed or lifted, one sentence each under

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13569,6 +13569,32 @@ check 'Enemy Encounter scene: a successful Flee shows the database escape_succes
      'a successful escape also plays the dedicated Escape SE'
 end
 
+# EasyRPG's `Game_BattleAlgorithm::Escape::GetStartSe` (src/
+# game_battlealgorithm.cpp) returns `SFX_Escape` whenever the algorithm's
+# own *source* is an enemy (an ally's own Escape defers to the base
+# class's silent default instead, played separately by the check just
+# above) -- a distinct trigger from the party's own successful-escape SE.
+# `entry[:fled]` (`Game::Battle#enemy_basic_action`'s BASIC_ESCAPE arm) is
+# only ever produced for an enemy's own AI-chosen Escape action, so it is
+# inherently enemy-only here.
+check "an enemy's own AI-chosen Escape basic action plays the dedicated " \
+      'Escape SE too' do
+  scene, _st = battle_scene_with_pages({})
+  90.times do
+    ui = battle_ui(scene)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
+    scene.update
+    RGSS::Input.triggered = []
+    ui = battle_ui(scene)
+    break if ui && ui[:phase] == :command
+  end
+  battle = scene.instance_variable_get(:@battle)
+  RGSS::Audio.reset_se
+  battle.send(:play_battle_action_se, { attacker: 'Slime', fled: true })
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Escape1' },
+     "matches RPG_RT's own Escape::GetStartSe for an enemy source"
+end
+
 check 'Enemy Encounter scene: Escape forbidden (the default escape_mode 0) plays ' \
       'Buzzer on Escape, and the options window stays open' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_BattleAlgorithm::Escape::GetStartSe` (`src/game_battlealgorithm.cpp`) is `if (source->GetType() == Type_Ally) { return AlgorithmBase::GetStartSe(); } return &GetSystemSE(SFX_Escape);` — an enemy source plays the system escape cue, distinct from an ally's own Escape (silent here; the party's own escape sound is a separate trigger played elsewhere). `Scene_Battle_Rpg2k::ProcessBattleActionUsage` calls `GetStartSe()` unconditionally for every action, the same generic dispatch every other action's start-SE already goes through. Both confirmed by fetching the live source.
- `Game::Battle#enemy_basic_action`'s `BASIC_ESCAPE` arm already produces an `entry[:fled]` flag, but `Scene::Battle#play_battle_action_se` — which already reads every other field this entry hash can carry — never once checked it, even though the `SFX_ESCAPE` constant and its `play_system_se` plumbing were already wired up for the other two flee contexts (the party's own successful Escape command, and a battle page's scripted Force Flee).
- Fixed by adding `play_system_se(SFX_ESCAPE) if entry[:fled]`. `entry[:fled]` is only ever produced by the enemy-only `BASIC_ESCAPE` arm, so no ally-side entry can ever trigger it and double up with the party's own escape SE.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check calling `play_battle_action_se` directly on a live battle with a synthetic `{ fled: true }` entry, asserting the `Escape1` SE plays.
- [x] Confirmed the new check fails against the pre-fix code via `git stash`, and passes post-fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 763 checks passed.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1052 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_