### PR TITLE
battle: an enemy's own Auto Destruction action plays its explosion SE

### DIFF
--- a/changelog.d/self-destruct-plays-se.fixed.md
+++ b/changelog.d/self-destruct-plays-se.fixed.md
@@ -1,0 +1,7 @@
+- **RPG2003 battles:** An enemy's own Auto Destruction (self-destruct)
+  basic action now plays its explosion sound effect, matching RPG_RT.
+  Previously a self-destructing monster played no sound at all — the
+  same fixed cue that always accompanies the "X explodes!" banner in
+  RPG_RT, regardless of whether the blast actually defeats a target, was
+  entirely missing. Covered by new `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9048,6 +9048,43 @@ not yet verified:
   double up with the party's own escape SE. Covered by a new
   `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
   pre-fix code before the fix.
+  ✅ **An enemy's own Auto Destruction (self-destruct) basic action played
+  no sound at all, unlike the sibling Escape fix just above — the same
+  missing per-algorithm `GetStartSe` dispatch, one function over
+  (2026-08-19).** Confirmed directly against RPG_RT's live source:
+  `Game_BattleAlgorithm::SelfDestruct::GetStartSe`
+  (`src/game_battlealgorithm.cpp`) is `return
+  &GetSystemSE(SFX_EnemyKill);` — unconditional, independent of whether
+  the blast actually defeats anyone, dispatched by the same generic
+  `ProcessBattleActionUsage` call every other action's start-SE already
+  goes through. `Game::Battle#enemy_autodestruct`
+  (`mruby-rpg2k/mrblib/game.rb`) already tags every entry it produces with
+  `autodestruct: true`, but `Scene::Battle#play_battle_action_se`'s only
+  `SFX_ENEMY_DEATH` line is `entry[:defeated] && !entry[:target_ally]` --
+  and every self-destruct target is a party member, so `target_ally` is
+  always true and that line can structurally never fire for a
+  self-destruct entry at all. A self-destructing monster in this codebase
+  played no sound whatsoever unless a target happened to take damage
+  (only `SFX_ACTOR_DAMAGE`, from the generic damage check) — the
+  explosion cue itself was entirely missing. The fix could not simply key
+  off `entry[:autodestruct]` directly the way the Escape fix keyed off
+  `entry[:fled]`, though: `enemy_autodestruct` can buffer several
+  entries, one per living target, each drained through
+  `#play_battle_action_se` separately (the same one-at-a-time queue a
+  dual-wield swing's two entries already share) — and `:autodestruct`
+  itself has to ride on *every* entry regardless, since it also drives
+  each target's own "blows itself up on" log line. Fixed with a second,
+  single-purpose flag, `:autodestruct_se`, set only on the first buffered
+  entry (or the lone fizzle entry when the blast finds no living target
+  at all) — the identical "SE plays once per action, not once per repeat"
+  idiom `#enemy_basic_action`'s own dual-attack arm already uses for
+  `attacker_ally`, just under a dedicated name here since `:autodestruct`
+  itself is multi-purpose. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a two-target self-destruct marks
+  only its first entry, not both; a target-less self-destruct still marks
+  its lone fizzle entry) and one new `scripts/rpg2k_scene_check.rb` check
+  (the `EnemyKill` SE actually plays), all three confirmed to fail against
+  the pre-fix code before the fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10966,7 +10966,7 @@ module Game
     # whatever HP it already had.
     def enemy_autodestruct(b)
       targets = @allies.reject(&:out_of_play?)
-      entries = targets.map do |t|
+      entries = targets.each_with_index.map do |t, i|
         dmg = effective_atk(b) - effective_def(t) / 2
         dmg = 0 if dmg < 0
         dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
@@ -10989,12 +10989,27 @@ module Game
         entry = { attacker: b.name, target: t.name, damage: dmg, critical: false,
                   autodestruct: true, target_hp: t.hp < 0 ? 0 : t.hp, defeated: t.dead?,
                   target_ally: ally?(t) }
+        # RPG_RT's own `SelfDestruct::GetStartSe` plays the explosion SE
+        # unconditionally, once per action, the instant it starts -- not once
+        # per target hit, and not gated on whether the blast actually kills
+        # anyone (`Scene_Battle_Rpg2k::ProcessBattleActionUsage` calls
+        # `GetStartSe()` a single time, before any target's own damage is
+        # even resolved). This multi-target action buffers one entry per
+        # target through the same one-at-a-time drain a dual-wield swing
+        # does, so only the first entry carries the trigger -- the identical
+        # "SE plays once per action, not once per repeat" idiom
+        # #enemy_basic_action's own dual-attack arm already uses (see its
+        # own comment on clearing `attacker_ally` on the second swing).
+        # `:autodestruct_se` is its own separate flag rather than reusing
+        # `:autodestruct` itself, since that one still has to ride on every
+        # entry for its own per-target "blows itself up on" log line.
+        entry[:autodestruct_se] = true if i.zero?
         entry[:woke] = woke unless woke.empty?
         entry
       end
       # Hidden, not killed -- see the method comment above.
       b.hidden = true
-      entries.empty? ? { attacker: b.name, autodestruct: true } : entries
+      entries.empty? ? { attacker: b.name, autodestruct: true, autodestruct_se: true } : entries
     end
 
     # A skill action (kind 1): cast through the same command pipeline the party

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -3418,6 +3418,19 @@ class RPG2k
         # so it is inherently enemy-only here -- no risk of double-playing
         # this alongside the party's own escape SE.
         play_system_se(SFX_ESCAPE) if entry[:fled]
+        # An enemy's own Auto Destruction basic action plays its own
+        # explosion cue unconditionally -- EasyRPG's own `SelfDestruct::
+        # GetStartSe` (src/game_battlealgorithm.cpp) is `return
+        # &GetSystemSE(SFX_EnemyKill);` with no gate on whether the blast
+        # actually defeats anyone, unlike the ordinary post-hit
+        # `SFX_ENEMY_DEATH` line just above (`entry[:defeated] &&
+        # !entry[:target_ally]`), which can never fire here at all since
+        # every self-destruct target is a party member (`target_ally` is
+        # always true). `entry[:autodestruct_se]` only ever rides on the
+        # first of a multi-target blast's buffered entries (see
+        # #enemy_autodestruct's own comment), so this plays exactly once
+        # per action, matching RPG_RT.
+        play_system_se(SFX_ENEMY_DEATH) if entry[:autodestruct_se]
       end
 
       # The conditions the action just landed or lifted, one sentence each under

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14149,6 +14149,36 @@ check 'battle: a self-destruct shakes loose a survivor\'s status the same as a b
   eq [8], entry[:woke]
 end
 
+# RPG_RT's own `SelfDestruct::GetStartSe` (src/game_battlealgorithm.cpp)
+# plays the explosion SE unconditionally, once per action, the instant it
+# starts -- not once per target hit. `Scene::Battle#play_battle_action_se`
+# reads `entry[:autodestruct_se]` for this, which must therefore ride on
+# exactly one of a multi-target blast's buffered entries, the same
+# "SE plays once per action, not once per repeat" idiom a dual-wield
+# attack's own entries already use for `attacker_ally`.
+check 'battle: a self-destruct against several targets marks only its ' \
+      'first entry for the explosion SE, not every one' do
+  bomber = combatant('Bomber', 40, 0, 5, 1)
+  a1 = combatant('A1', 0, 0, 5, 100)
+  a2 = combatant('A2', 0, 0, 5, 100)
+  bat = Game::Battle.new([a1, a2], [bomber], Game::Rng.new(1))
+  entries = bat.send(:enemy_autodestruct, bomber)
+  eq 2, entries.size, 'one entry per living target'
+  eq true, entries[0][:autodestruct_se], 'only the first entry triggers the SE'
+  eq nil, entries[1][:autodestruct_se], 'the second entry does not repeat it'
+end
+
+check "battle: a self-destruct that finds nobody still marks its lone " \
+      'fizzle entry for the explosion SE' do
+  bomber = combatant('Bomber', 40, 0, 5, 1)
+  fled = combatant('Fled', 0, 0, 5, 100)
+  fled.hidden = true
+  bat = Game::Battle.new([fled], [bomber], Game::Rng.new(1))
+  entry = bat.send(:enemy_autodestruct, bomber)
+  eq true, entry[:autodestruct_se],
+     'the blast still goes off even with no living target to hit'
+end
+
 # -- the state table's display side (Game::States) ----------------------------
 # The simulation acts on state *ids*; putting one on screen needs the row. These
 # pin the reading of the row the battle status window and action banner use.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13595,6 +13595,32 @@ check "an enemy's own AI-chosen Escape basic action plays the dedicated " \
      "matches RPG_RT's own Escape::GetStartSe for an enemy source"
 end
 
+# EasyRPG's `Game_BattleAlgorithm::SelfDestruct::GetStartSe` (src/
+# game_battlealgorithm.cpp) is `return &GetSystemSE(SFX_EnemyKill);` --
+# unconditional, unlike the ordinary post-hit death SE just above
+# (`entry[:defeated] && !entry[:target_ally]`), which can never fire for a
+# self-destruct entry at all since every target is a party member.
+# `entry[:autodestruct_se]` (`Game::Battle#enemy_autodestruct`'s own
+# first-entry-only flag) is this codebase's equivalent trigger.
+check "an enemy's own Auto Destruction basic action plays its own " \
+      'explosion SE too' do
+  scene, _st = battle_scene_with_pages({})
+  90.times do
+    ui = battle_ui(scene)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
+    scene.update
+    RGSS::Input.triggered = []
+    ui = battle_ui(scene)
+    break if ui && ui[:phase] == :command
+  end
+  battle = scene.instance_variable_get(:@battle)
+  RGSS::Audio.reset_se
+  battle.send(:play_battle_action_se, { attacker: 'Slime', autodestruct: true,
+                                         autodestruct_se: true })
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'EnemyKill' },
+     "matches RPG_RT's own SelfDestruct::GetStartSe"
+end
+
 check 'Enemy Encounter scene: Escape forbidden (the default escape_mode 0) plays ' \
       'Buzzer on Escape, and the options window stays open' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_BattleAlgorithm::SelfDestruct::GetStartSe` (`src/game_battlealgorithm.cpp`) is `return &GetSystemSE(SFX_EnemyKill);` — unconditional, independent of whether the blast actually defeats anyone, dispatched by the same generic `ProcessBattleActionUsage` call every other action's start-SE goes through. Confirmed by fetching the live source.
- `Game::Battle#enemy_autodestruct` already tags every entry it produces with `autodestruct: true`, but `Scene::Battle#play_battle_action_se`'s only `SFX_ENEMY_DEATH` line (`entry[:defeated] && !entry[:target_ally]`) can structurally never fire for a self-destruct entry — every self-destruct target is a party member, so `target_ally` is always true. A self-destructing monster played no sound whatsoever unless a target happened to take damage.
- The fix couldn't simply key off `entry[:autodestruct]` directly the way the sibling Escape fix keyed off `entry[:fled]`: `enemy_autodestruct` can buffer several entries (one per living target), each drained through `#play_battle_action_se` separately, and `:autodestruct` itself has to ride on *every* entry regardless since it also drives each target's own "blows itself up on" log line.
- Fixed with a second, single-purpose flag, `:autodestruct_se`, set only on the first buffered entry (or the lone fizzle entry when the blast finds no living target at all) — the identical "SE plays once per action, not once per repeat" idiom `#enemy_basic_action`'s own dual-attack arm already uses for `attacker_ally`.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: a two-target self-destruct marks only its first entry, not both; a target-less self-destruct still marks its lone fizzle entry.
- [x] New `scripts/rpg2k_scene_check.rb` check: the `EnemyKill` SE actually plays.
- [x] Confirmed all three new checks fail against the pre-fix code via `git stash`, and pass post-fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1054 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 764 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 13 checks, 0 failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_