### PR TITLE
Deduct weapon SP cost on a basic Attack

### DIFF
--- a/changelog.d/weapon-attack-times-multiplier.fixed.md
+++ b/changelog.d/weapon-attack-times-multiplier.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2003 battles:** A weapon's per-actor Battle Animation "Number of
+  Attacks" (攻撃の回数) setting now multiplies a basic Attack's swing count,
+  matching RPG_RT -- previously only 二刀流 (`dual_attack`) affected swing
+  count, so this field did nothing at all. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/changelog.d/weapon-attack-times-multiplier.fixed.md
+++ b/changelog.d/weapon-attack-times-multiplier.fixed.md
@@ -1,5 +1,0 @@
-- **RPG2003 battles:** A weapon's per-actor Battle Animation "Number of
-  Attacks" (攻撃の回数) setting now multiplies a basic Attack's swing count,
-  matching RPG_RT -- previously only 二刀流 (`dual_attack`) affected swing
-  count, so this field did nothing at all. Covered by a new
-  `scripts/rpg2k_logic_check.rb` check.

--- a/changelog.d/weapon-sp-cost-basic-attack.fixed.md
+++ b/changelog.d/weapon-sp-cost-basic-attack.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2003 battles:** A basic Attack now spends the equipped weapon's own
+  SP cost (消費SP), once per action regardless of dual-wield's extra swing,
+  halved by MP消費半分 gear -- matching RPG_RT. Previously a weapon flagged to
+  cost SP was effectively free to swing forever. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9085,6 +9085,48 @@ not yet verified:
   its lone fizzle entry) and one new `scripts/rpg2k_scene_check.rb` check
   (the `EnemyKill` SE actually plays), all three confirmed to fail against
   the pre-fix code before the fix.
+  ✅ **A basic Attack never spent the equipped weapon's own SP cost —
+  every 消費SP-flagged weapon in the database was effectively free to swing,
+  forever (2026-08-19).** Confirmed directly against RPG_RT's live source:
+  `Game_BattleAlgorithm::Normal::vStart` (`src/game_battlealgorithm.cpp`) is
+  `source->ChangeSp(-source->CalculateWeaponSpCost(weapon));` — spent
+  unconditionally, once per action (called from `AlgorithmBase::Start()`
+  before any swing/repeat resolves), regardless of whether the swing hits or
+  misses. `Game_Actor::CalculateWeaponSpCost` (`src/game_actor.cpp`) sums
+  `sp_cost` over the weapon slot(s) `weapon` (`WeaponAll`, i.e. every
+  equipped weapon-type item, for an ordinary single-weapon actor; just the
+  weapon-slot item for a `#double_hand?` two-weapon actor, since
+  `Normal::GetWeapon()`'s `GetCurrentRepeat() >= weapon_style` check reads
+  `false` at the still-zero repeat count `vStart` runs at, resolving to
+  `WeaponPrimary`), then halves it (rounding up, `(cost + 1) / 2`) under
+  MP消費半分 gear (`HasHalfSpCost`) — the identical halving `Game_Battler::
+  CalculateSkillCost` already applies to a skill's own fixed SP cost, ported
+  here as `Game::Party#skill_cost`. `Game_Battler::CalculateWeaponSpCost`
+  (the base class) defaults to 0 and `Game_Enemy` never overrides it, so
+  this only ever fires for a party member. `sp_cost` (item field 16) and
+  `half_sp_cost` are genuine, already-parsed RPG2000/2003 database fields
+  (`mruby-lcf/mrblib/schema.rb`) — `Actor#half_sp_cost?`
+  (`mruby-rpg2k/mrblib/game.rb`) already existed and was already wired up,
+  but only ever consulted for a *skill's* own cost (`#skill_cost`); no
+  weapon-side accessor existed at all, and the basic-attack execution path
+  (`Game::Battle#command_attack`/`#swing`/`#deal_attack`) never deducted
+  anything for the attacker. Fixed with a new `Actor#weapon_sp_cost`
+  (`.first` of `#equipped_weapons`, its own weapon-slot-first ordering
+  already making that the correct item for both the single-weapon and
+  two-weapon cases), and a new `Game::Battle#pay_weapon_sp_cost(b)` called
+  once from each of `#strike`'s two attack-dispatch points — before the
+  combo hit count and 二刀流/`#double_hand?` swing count are even resolved,
+  matching `vStart`'s own once-per-action, not once-per-swing timing (a
+  二刀流 weapon's second swing must not double the bill, the same discipline
+  the sibling Escape/Auto Destruction SE fixes just above already
+  established for this codebase's own entry-flag plumbing). A no-op for an
+  enemy attacker (`b.actor` is nil) or a bare fixture Combatant with no
+  `#actor` link. Covered by a new `scripts/rpg2k_logic_check.rb` check (a
+  plain weapon's own `sp_cost`; MP消費半分 gear's rounded-up half; a 二刀流
+  weapon's cost spent exactly once despite both swings landing; an
+  unflagged weapon costing nothing; an enemy attacker's own SP left
+  untouched), confirmed to fail against the pre-fix code (`expected 44, got
+  50`) before the fix.
 - ✅ **RPG2003's Wait command "wait until the Decision key is pressed" mode
   is now implemented — it used to be silently treated as a zero-duration
   timed wait, letting the event continue instantly with no player

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7331,43 +7331,6 @@ not yet verified:
   weapon plus one ordinary weapon summing to 3, not 2 — all three
   confirmed to fail against the pre-fix code before the fix (`#strike_count`
   did not exist at all).
-  ✅ **Follow-up (2026-08-19): `#strike_count` only ever ported half of the
-  EasyRPG function its own doc comment cites — RPG2003's 攻撃の回数 (Number of
-  Attacks) weapon field never multiplied anything at all.** Confirmed
-  directly against RPG_RT's live source: `Algo::GetNumberOfAttacks`
-  (`src/algo.cpp`) is `int hits = weapon.dual_attack ? 2 : 1; if
-  (Player::IsRPG2k3()) { auto& cba = weapon.animation_data; if (actor_id >=
-  1 && actor_id <= (int)cba.size()) { hits *= cba[actor_id - 1].attacks + 1;
-  } } return hits;` — the very function `#strike_count`'s own comment
-  already names, but only its `dual_attack` term had actually been ported;
-  the `IsRPG2k3()` branch reading each weapon's own per-actor Battle
-  Animation table (`animation_data`, item field 70, each row's `attacks`
-  field named `attack_times` in this schema, item field 7) was never
-  consulted anywhere — confirmed by grep, `attack_times` did not appear a
-  single time in `game.rb`. The field is genuine, already-parsed
-  RPG2000/2003 database data (`mruby-lcf/mrblib/schema.rb`), not an
-  unimplemented schema stub: any RPG2003 project using a weapon's Battle
-  Animation "Number of Attacks" setting to build a multi-hit weapon (stacks
-  with, and is independent of, 二刀流) got exactly `dual_attack?`'s 1-or-2
-  swings instead of RPG_RT's correctly multiplied count. Fixed with a new
-  `Actor#weapon_attack_multiplier(it)` (`(attack_times || 0) + 1` when
-  `rpg2003?` and this actor has a row in `it.animation_data`, else the
-  neutral `1`), multiplied into both of `#strike_count`'s existing terms —
-  the single-weapon `dual_attack? ? 2 : 1` and each weapon's own term in the
-  two-weapon sum, exactly mirroring `Algo::GetNumberOfAttacks` being called
-  once per weapon slot in both the single- and two-weapon
-  `Game_Actor::GetNumberOfAttacks` paths. `#swing_weapon_data`'s own
-  `w1_hits` split point (which of a two-weapon actor's swings the primary
-  vs. secondary weapon governs) needed the identical multiplier folded in,
-  or a CBA-boosted primary weapon's extra swings would have been
-  misattributed to the secondary weapon's own hit rate/attributes/crit once
-  the total swing count grew past the *unmultiplied* boundary. Covered by a
-  new `scripts/rpg2k_logic_check.rb` check (a weapon naming no row for this
-  actor is a no-op; a row's `attacks: 2` gives `(2 + 1)` swings that all
-  actually land; the identical row is inert on an RPG2000 database with no
-  Battle Animation table at all; a two-weapon actor sums each weapon's own
-  already-multiplied term), confirmed to fail against the pre-fix code
-  (`expected 3, got 1`) before the fix.
 - ✅ **A two-weapon actor's individual swings now each roll their own
   weapon's hit rate / elemental attributes / weapon states / crit chance,
   instead of every swing reusing the same value merged (max/union) across

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7331,6 +7331,43 @@ not yet verified:
   weapon plus one ordinary weapon summing to 3, not 2 — all three
   confirmed to fail against the pre-fix code before the fix (`#strike_count`
   did not exist at all).
+  ✅ **Follow-up (2026-08-19): `#strike_count` only ever ported half of the
+  EasyRPG function its own doc comment cites — RPG2003's 攻撃の回数 (Number of
+  Attacks) weapon field never multiplied anything at all.** Confirmed
+  directly against RPG_RT's live source: `Algo::GetNumberOfAttacks`
+  (`src/algo.cpp`) is `int hits = weapon.dual_attack ? 2 : 1; if
+  (Player::IsRPG2k3()) { auto& cba = weapon.animation_data; if (actor_id >=
+  1 && actor_id <= (int)cba.size()) { hits *= cba[actor_id - 1].attacks + 1;
+  } } return hits;` — the very function `#strike_count`'s own comment
+  already names, but only its `dual_attack` term had actually been ported;
+  the `IsRPG2k3()` branch reading each weapon's own per-actor Battle
+  Animation table (`animation_data`, item field 70, each row's `attacks`
+  field named `attack_times` in this schema, item field 7) was never
+  consulted anywhere — confirmed by grep, `attack_times` did not appear a
+  single time in `game.rb`. The field is genuine, already-parsed
+  RPG2000/2003 database data (`mruby-lcf/mrblib/schema.rb`), not an
+  unimplemented schema stub: any RPG2003 project using a weapon's Battle
+  Animation "Number of Attacks" setting to build a multi-hit weapon (stacks
+  with, and is independent of, 二刀流) got exactly `dual_attack?`'s 1-or-2
+  swings instead of RPG_RT's correctly multiplied count. Fixed with a new
+  `Actor#weapon_attack_multiplier(it)` (`(attack_times || 0) + 1` when
+  `rpg2003?` and this actor has a row in `it.animation_data`, else the
+  neutral `1`), multiplied into both of `#strike_count`'s existing terms —
+  the single-weapon `dual_attack? ? 2 : 1` and each weapon's own term in the
+  two-weapon sum, exactly mirroring `Algo::GetNumberOfAttacks` being called
+  once per weapon slot in both the single- and two-weapon
+  `Game_Actor::GetNumberOfAttacks` paths. `#swing_weapon_data`'s own
+  `w1_hits` split point (which of a two-weapon actor's swings the primary
+  vs. secondary weapon governs) needed the identical multiplier folded in,
+  or a CBA-boosted primary weapon's extra swings would have been
+  misattributed to the secondary weapon's own hit rate/attributes/crit once
+  the total swing count grew past the *unmultiplied* boundary. Covered by a
+  new `scripts/rpg2k_logic_check.rb` check (a weapon naming no row for this
+  actor is a no-op; a row's `attacks: 2` gives `(2 + 1)` swings that all
+  actually land; the identical row is inert on an RPG2000 database with no
+  Battle Animation table at all; a two-weapon actor sums each weapon's own
+  already-multiplied term), confirmed to fail against the pre-fix code
+  (`expected 3, got 1`) before the fix.
 - ✅ **A two-weapon actor's individual swings now each roll their own
   weapon's hit rate / elemental attributes / weapon states / crit chance,
   instead of every swing reusing the same value merged (max/union) across

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2283,11 +2283,35 @@ module Game
     # `Game_Actor::GetNumberOfAttacks`'s ordinary single-weapon max does --
     # so a two-weapon actor swings **at least twice** even when *neither*
     # individual weapon is itself flagged 二刀流, the common case for a
-    # dual-wield setup built from two ordinary weapons.
+    # dual-wield setup built from two ordinary weapons. Each weapon's own
+    # `#weapon_attack_multiplier` (RPG2003's 攻撃の回数 Battle Animation field)
+    # scales its own term before the two are summed, exactly as EasyRPG's
+    # `Algo::GetNumberOfAttacks` scales `dual_attack ? 2 : 1` by `cba_hits`
+    # before `Game_Actor::GetNumberOfAttacks` maxes/sums per weapon.
     def strike_count
       weapons = equipped_weapons
-      return dual_attack? ? 2 : 1 unless weapons.size >= 2
-      weapons[0, 2].reduce(0) { |s, it| s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) }
+      return (dual_attack? ? 2 : 1) * weapon_attack_multiplier(weapons.first) unless weapons.size >= 2
+      weapons[0, 2].reduce(0) do |s, it|
+        s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) * weapon_attack_multiplier(it)
+      end
+    end
+
+    # The RPG2003-only 攻撃の回数 (Number of Attacks) multiplier `it` (an
+    # equipped weapon, or nil when unarmed) contributes to this actor's own
+    # basic-attack swing count -- EasyRPG's `Algo::GetNumberOfAttacks`
+    # (`src/algo.cpp`): `Player::IsRPG2k3()` gates a lookup into the weapon's
+    # own per-actor Battle Animation table (`weapon.animation_data`, this
+    # schema's `attack_times` field on each row, keyed by actor id) and
+    # multiplies the swing count by `cba[actor_id - 1].attacks + 1` when this
+    # actor has a row there. RPG2000 has no such table at all, and a weapon
+    # naming no row for this actor (or no table at all) contributes no
+    # multiplier -- both read as the neutral `1`, matching a project that
+    # never touched the Battle Animation tab.
+    def weapon_attack_multiplier(it)
+      return 1 unless it && rpg2003?
+      table = it.respond_to?(:animation_data) ? it.animation_data : nil
+      row = table ? table[id] : nil
+      row && row.respond_to?(:attack_times) ? (row.attack_times || 0) + 1 : 1
     end
 
     # The equipped weapon-type items, in slot order (the weapon slot first,
@@ -2316,7 +2340,7 @@ module Game
       weapons = equipped_weapons
       return nil unless weapons.size >= 2
       w1, w2 = weapons[0, 2]
-      w1_hits = w1.respond_to?(:dual_attack) && w1.dual_attack ? 2 : 1
+      w1_hits = (w1.respond_to?(:dual_attack) && w1.dual_attack ? 2 : 1) * weapon_attack_multiplier(w1)
       weapon_roll_data(i < w1_hits ? w1 : w2)
     end
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2372,6 +2372,29 @@ module Game
     # the weapon (Nepheshel's 賢者の指輪 is an accessory).
     def half_sp_cost?; equipment_flag?(:half_sp_cost); end
 
+    # The SP a basic Attack itself costs -- EasyRPG's
+    # `Game_Actor::CalculateWeaponSpCost` (`src/game_actor.cpp`), which
+    # `Normal::vStart` (`src/game_battlealgorithm.cpp`) spends unconditionally
+    # via `ChangeSp(-CalculateWeaponSpCost(weapon))` once per action, before
+    # any swing resolves -- not per swing, so a 二刀流 weapon's extra hit
+    # (`#strike_count`) never doubles the bill. `weapon` there is whichever
+    # slot governs the action's very first swing (`Normal::GetWeapon()`'s
+    # `GetCurrentRepeat() >= weapon_style` check reads false at the
+    # still-zero repeat count `vStart` runs at): the weapon-slot item alone
+    # for a `#double_hand?` two-weapon actor (this engine's only route to a
+    # real `weapon_style`, since ordinary single-weapon gear always leaves it
+    # at `WeaponAll`, which reduces to that one weapon's own cost anyway) --
+    # `#equipped_weapons`' own weapon-slot-first ordering, so `.first` is
+    # always the right item either way. Halved (rounding up, matching
+    # `#skill_cost`'s own fixed-cost branch) by the same MP消費半分 gear. 0 for
+    # an unarmed actor.
+    def weapon_sp_cost
+      it = equipped_weapons.first
+      return 0 unless it
+      cost = it.respond_to?(:sp_cost) ? (it.sp_cost || 0) : 0
+      half_sp_cost? ? (cost + 1) / 2 : cost
+    end
+
     # 地形ダメージ無効 — gear that makes its wearer immune to the damage a tile's
     # terrain deals as they walk over it (Party#apply_terrain_damage). Any slot:
     # mtf-meido-action's is a pair of boots, Nepheshel's four include a swimsuit.
@@ -10627,6 +10650,7 @@ module Game
         # one, same as an unforced Attack would (デフォ戦botまとめ: "Berserk
         # additionally collapses an 'attack all' weapon down to a single
         # target").
+        pay_weapon_sp_cost(b)
         hits = combo_hits(b, :attack)
         return swing_side(b, side_targets(target), hits) if r == RESTRICTION_ATTACK_ALLY && b.attack_all
         return swing(b, target, hits)
@@ -10661,9 +10685,23 @@ module Game
       end
       target = attack_target(b)
       return nil unless target
+      pay_weapon_sp_cost(b)
       hits = combo_hits(b, :attack)
       return swing_side(b, side_targets(target), hits) if b.attack_all
       swing(b, target, hits)
+    end
+
+    # Spend `b`'s own weapon SP cost for the basic Attack it is about to make
+    # -- EasyRPG's `Normal::vStart` (see `Actor#weapon_sp_cost`'s own doc
+    # comment), called exactly once per action from both of `#strike`'s
+    # attack-dispatch points, before the swing count (dual-wield, combo) is
+    # even resolved. A no-op for an enemy attacker (`b.actor` is nil --
+    # `Game_Battler::CalculateWeaponSpCost` defaults to 0 and `Game_Enemy`
+    # never overrides it) or a bare fixture Combatant with no `#actor` link
+    # at all.
+    def pay_weapon_sp_cost(b)
+      actor = b.respond_to?(:actor) ? b.actor : nil
+      actor.change_mp(-actor.weapon_sp_cost) if actor && actor.respond_to?(:weapon_sp_cost)
     end
 
     # -- RPG2003 battle combo (Enable Combo / 1007) -----------------------------

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2283,35 +2283,11 @@ module Game
     # `Game_Actor::GetNumberOfAttacks`'s ordinary single-weapon max does --
     # so a two-weapon actor swings **at least twice** even when *neither*
     # individual weapon is itself flagged 二刀流, the common case for a
-    # dual-wield setup built from two ordinary weapons. Each weapon's own
-    # `#weapon_attack_multiplier` (RPG2003's 攻撃の回数 Battle Animation field)
-    # scales its own term before the two are summed, exactly as EasyRPG's
-    # `Algo::GetNumberOfAttacks` scales `dual_attack ? 2 : 1` by `cba_hits`
-    # before `Game_Actor::GetNumberOfAttacks` maxes/sums per weapon.
+    # dual-wield setup built from two ordinary weapons.
     def strike_count
       weapons = equipped_weapons
-      return (dual_attack? ? 2 : 1) * weapon_attack_multiplier(weapons.first) unless weapons.size >= 2
-      weapons[0, 2].reduce(0) do |s, it|
-        s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) * weapon_attack_multiplier(it)
-      end
-    end
-
-    # The RPG2003-only 攻撃の回数 (Number of Attacks) multiplier `it` (an
-    # equipped weapon, or nil when unarmed) contributes to this actor's own
-    # basic-attack swing count -- EasyRPG's `Algo::GetNumberOfAttacks`
-    # (`src/algo.cpp`): `Player::IsRPG2k3()` gates a lookup into the weapon's
-    # own per-actor Battle Animation table (`weapon.animation_data`, this
-    # schema's `attack_times` field on each row, keyed by actor id) and
-    # multiplies the swing count by `cba[actor_id - 1].attacks + 1` when this
-    # actor has a row there. RPG2000 has no such table at all, and a weapon
-    # naming no row for this actor (or no table at all) contributes no
-    # multiplier -- both read as the neutral `1`, matching a project that
-    # never touched the Battle Animation tab.
-    def weapon_attack_multiplier(it)
-      return 1 unless it && rpg2003?
-      table = it.respond_to?(:animation_data) ? it.animation_data : nil
-      row = table ? table[id] : nil
-      row && row.respond_to?(:attack_times) ? (row.attack_times || 0) + 1 : 1
+      return dual_attack? ? 2 : 1 unless weapons.size >= 2
+      weapons[0, 2].reduce(0) { |s, it| s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) }
     end
 
     # The equipped weapon-type items, in slot order (the weapon slot first,
@@ -2340,7 +2316,7 @@ module Game
       weapons = equipped_weapons
       return nil unless weapons.size >= 2
       w1, w2 = weapons[0, 2]
-      w1_hits = (w1.respond_to?(:dual_attack) && w1.dual_attack ? 2 : 1) * weapon_attack_multiplier(w1)
+      w1_hits = w1.respond_to?(:dual_attack) && w1.dual_attack ? 2 : 1
       weapon_roll_data(i < w1_hits ? w1 : w2)
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3305,14 +3305,7 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :uses,
                       # 消費SP (weapon field 16): the SP a basic Attack costs
                       # while this weapon is equipped (Actor#weapon_sp_cost).
-                      :sp_cost,
-                      # animation_data (weapon field 70): the RPG2003-only,
-                      # per-actor Battle Animation table -- a `{actor_id =>
-                      # row}` Hash here (a real database's own Array2D reads
-                      # the same way via `#[]`), each row responding to
-                      # `attack_times` (field 7, 攻撃の回数 -- Actor#
-                      # weapon_attack_multiplier).
-                      :animation_data)
+                      :sp_cost)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -3323,7 +3316,7 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
               cursed: false, raise_evasion: false, animation_id: nil,
               state_chance: 0, use_skill: false, class_set: nil, uses: 1,
-              sp_cost: 0, animation_data: nil)
+              sp_cost: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
@@ -3331,11 +3324,8 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
                raise_evasion, animation_id, state_chance, use_skill, class_set,
-               uses, sp_cost, animation_data)
+               uses, sp_cost)
 end
-# A single row of a weapon's RPG2003 per-actor Battle Animation table --
-# `fake_item`'s own `animation_data:` Hash values.
-FakeCbaRow = Struct.new(:attack_times)
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
@@ -14982,51 +14972,6 @@ check 'battle: a 二刀流 weapon swings twice' do
   bat3 = Game::Battle.new([Game::Battle.from_actor(hero)], [dying], Game::Rng.new(1))
   e3 = bat3.send(:swing, bat3.allies[0], dying)
   ok e3.is_a?(Hash), 'a felled target is not struck again'
-end
-
-# 攻撃の回数 (weapon field 70's per-actor Battle Animation table, RPG2003
-# only): a basic Attack's swing count is now multiplied by
-# `Actor#weapon_attack_multiplier`, matching EasyRPG's `Algo::
-# GetNumberOfAttacks` (`cba[actor_id - 1].attacks + 1`). Previously
-# `Actor#strike_count` ported only the `dual_attack` term of that same
-# function, never reading `attack_times` at all (docs/TODO.md).
-check 'battle: RPG2003 攻撃の回数 multiplies a basic Attack\'s swing count' do
-  items = { 7 => fake_item(type: 1, atk: 5, animation_data: { 1 => FakeCbaRow.new(2) }),
-            8 => fake_item(type: 1, atk: 5) } # no animation_data row at all
-  row = CurveRow.new('Hero', '', 0, 1, [200, 50, 20, 10, 10, 10])
-  db = FakeActorDB.new({ 1 => row }, [1], items, {}, {}, nil, nil, rpg2003: true)
-  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
-  hero = st.party.leader
-
-  hero.equip([8, 0, 0, 0, 0])
-  eq 1, hero.strike_count, 'a weapon naming no row for this actor is a no-op multiplier'
-
-  hero.equip([7, 0, 0, 0, 0])
-  eq 3, hero.strike_count, 'attacks: 2 on this actor\'s own row -> (2 + 1) swings'
-  foe = combatant('Foe', 0, 0, 5, 10_000)
-  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
-  entries = bat.send(:swing, bat.allies[0], foe)
-  eq 3, entries.size, 'the extra swings actually land, not just #strike_count'
-
-  # RPG2000 (no Classes chunk) has no Battle Animation table at all -- the
-  # identical row is a no-op there, same as the un-rowed weapon above.
-  db2000 = FakeActorDB.new({ 1 => row }, [1], items)
-  st2000 = Game::State.new(Game::Party.new(db2000), 1, 0, 0)
-  hero2000 = st2000.party.leader
-  hero2000.equip([7, 0, 0, 0, 0])
-  eq 1, hero2000.strike_count, 'RPG2000: the same row is never consulted at all'
-
-  # A two-weapon (#double_hand?) actor: each weapon's own multiplier scales
-  # only its own term before the two are summed -- EasyRPG's `Normal::Init`
-  # sums `GetNumberOfAttacks(WeaponPrimary) + GetNumberOfAttacks
-  # (WeaponSecondary)`, each already including its own `cba_hits`.
-  items2 = { 7 => fake_item(type: 1, atk: 5, animation_data: { 1 => FakeCbaRow.new(2) }), # 3 hits
-             9 => fake_item(type: 1, atk: 5, dual_attack: true) } # 2 hits, no row
-  db2 = FakeActorDB.new({ 1 => row }, [1], items2, {}, {}, nil, nil, rpg2003: true)
-  st2 = Game::State.new(Game::Party.new(db2), 1, 0, 0)
-  dual = st2.party.leader
-  dual.equip([7, 9, 0, 0, 0])
-  eq 5, dual.strike_count, 'primary\'s own 3 (attack_times: 2) + secondary\'s own 2 (dual_attack)'
 end
 
 # 消費SP (weapon field 16): a basic Attack now spends the equipped weapon's

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3305,7 +3305,14 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :uses,
                       # 消費SP (weapon field 16): the SP a basic Attack costs
                       # while this weapon is equipped (Actor#weapon_sp_cost).
-                      :sp_cost)
+                      :sp_cost,
+                      # animation_data (weapon field 70): the RPG2003-only,
+                      # per-actor Battle Animation table -- a `{actor_id =>
+                      # row}` Hash here (a real database's own Array2D reads
+                      # the same way via `#[]`), each row responding to
+                      # `attack_times` (field 7, 攻撃の回数 -- Actor#
+                      # weapon_attack_multiplier).
+                      :animation_data)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -3316,7 +3323,7 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
               cursed: false, raise_evasion: false, animation_id: nil,
               state_chance: 0, use_skill: false, class_set: nil, uses: 1,
-              sp_cost: 0)
+              sp_cost: 0, animation_data: nil)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
@@ -3324,8 +3331,11 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
                raise_evasion, animation_id, state_chance, use_skill, class_set,
-               uses, sp_cost)
+               uses, sp_cost, animation_data)
 end
+# A single row of a weapon's RPG2003 per-actor Battle Animation table --
+# `fake_item`'s own `animation_data:` Hash values.
+FakeCbaRow = Struct.new(:attack_times)
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
@@ -14972,6 +14982,51 @@ check 'battle: a 二刀流 weapon swings twice' do
   bat3 = Game::Battle.new([Game::Battle.from_actor(hero)], [dying], Game::Rng.new(1))
   e3 = bat3.send(:swing, bat3.allies[0], dying)
   ok e3.is_a?(Hash), 'a felled target is not struck again'
+end
+
+# 攻撃の回数 (weapon field 70's per-actor Battle Animation table, RPG2003
+# only): a basic Attack's swing count is now multiplied by
+# `Actor#weapon_attack_multiplier`, matching EasyRPG's `Algo::
+# GetNumberOfAttacks` (`cba[actor_id - 1].attacks + 1`). Previously
+# `Actor#strike_count` ported only the `dual_attack` term of that same
+# function, never reading `attack_times` at all (docs/TODO.md).
+check 'battle: RPG2003 攻撃の回数 multiplies a basic Attack\'s swing count' do
+  items = { 7 => fake_item(type: 1, atk: 5, animation_data: { 1 => FakeCbaRow.new(2) }),
+            8 => fake_item(type: 1, atk: 5) } # no animation_data row at all
+  row = CurveRow.new('Hero', '', 0, 1, [200, 50, 20, 10, 10, 10])
+  db = FakeActorDB.new({ 1 => row }, [1], items, {}, {}, nil, nil, rpg2003: true)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+
+  hero.equip([8, 0, 0, 0, 0])
+  eq 1, hero.strike_count, 'a weapon naming no row for this actor is a no-op multiplier'
+
+  hero.equip([7, 0, 0, 0, 0])
+  eq 3, hero.strike_count, 'attacks: 2 on this actor\'s own row -> (2 + 1) swings'
+  foe = combatant('Foe', 0, 0, 5, 10_000)
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  entries = bat.send(:swing, bat.allies[0], foe)
+  eq 3, entries.size, 'the extra swings actually land, not just #strike_count'
+
+  # RPG2000 (no Classes chunk) has no Battle Animation table at all -- the
+  # identical row is a no-op there, same as the un-rowed weapon above.
+  db2000 = FakeActorDB.new({ 1 => row }, [1], items)
+  st2000 = Game::State.new(Game::Party.new(db2000), 1, 0, 0)
+  hero2000 = st2000.party.leader
+  hero2000.equip([7, 0, 0, 0, 0])
+  eq 1, hero2000.strike_count, 'RPG2000: the same row is never consulted at all'
+
+  # A two-weapon (#double_hand?) actor: each weapon's own multiplier scales
+  # only its own term before the two are summed -- EasyRPG's `Normal::Init`
+  # sums `GetNumberOfAttacks(WeaponPrimary) + GetNumberOfAttacks
+  # (WeaponSecondary)`, each already including its own `cba_hits`.
+  items2 = { 7 => fake_item(type: 1, atk: 5, animation_data: { 1 => FakeCbaRow.new(2) }), # 3 hits
+             9 => fake_item(type: 1, atk: 5, dual_attack: true) } # 2 hits, no row
+  db2 = FakeActorDB.new({ 1 => row }, [1], items2, {}, {}, nil, nil, rpg2003: true)
+  st2 = Game::State.new(Game::Party.new(db2), 1, 0, 0)
+  dual = st2.party.leader
+  dual.equip([7, 9, 0, 0, 0])
+  eq 5, dual.strike_count, 'primary\'s own 3 (attack_times: 2) + secondary\'s own 2 (dual_attack)'
 end
 
 # 消費SP (weapon field 16): a basic Attack now spends the equipped weapon's

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3302,7 +3302,10 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       # before it is spent, 0 meaning 無制限
                       # (Game::Party#consume_item_use). The schema's default is
                       # 1, which is what `fake_item` passes when it is not named.
-                      :uses)
+                      :uses,
+                      # 消費SP (weapon field 16): the SP a basic Attack costs
+                      # while this weapon is equipped (Actor#weapon_sp_cost).
+                      :sp_cost)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -3312,7 +3315,8 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
               cursed: false, raise_evasion: false, animation_id: nil,
-              state_chance: 0, use_skill: false, class_set: nil, uses: 1)
+              state_chance: 0, use_skill: false, class_set: nil, uses: 1,
+              sp_cost: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
@@ -3320,7 +3324,7 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
                raise_evasion, animation_id, state_chance, use_skill, class_set,
-               uses)
+               uses, sp_cost)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -14968,6 +14972,66 @@ check 'battle: a 二刀流 weapon swings twice' do
   bat3 = Game::Battle.new([Game::Battle.from_actor(hero)], [dying], Game::Rng.new(1))
   e3 = bat3.send(:swing, bat3.allies[0], dying)
   ok e3.is_a?(Hash), 'a felled target is not struck again'
+end
+
+# 消費SP (weapon field 16): a basic Attack now spends the equipped weapon's
+# own SP cost, matching EasyRPG's `Normal::vStart`
+# (`source->ChangeSp(-source->CalculateWeaponSpCost(weapon))`, unconditional
+# every action, hit or miss). Previously unwired entirely -- `Actor#half_sp_cost?`
+# only ever discounted a *skill's* SP, and no weapon-side accessor existed at
+# all (docs/TODO.md).
+check 'battle: a basic Attack spends its weapon\'s own SP cost, once per action' do
+  items = { 7 => fake_item(type: 1, atk: 5, sp_cost: 6),
+            8 => fake_item(type: 1, atk: 5, sp_cost: 5, half_sp_cost: true),
+            9 => fake_item(type: 1, atk: 5, sp_cost: 3, dual_attack: true),
+            10 => fake_item(type: 1, atk: 5) } # no sp_cost named -> 0
+  st = geared_party(items)
+  hero = st.party.leader
+  eq 50, hero.mp, 'starts at the level-1 curve\'s own max SP'
+
+  hero.equip([7, 0, 0, 0, 0])
+  foe = combatant('Foe', 0, 0, 5, 10_000) # never dies
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  bat.command_attack(bat.allies[0], foe)
+  bat.send(:strike, bat.allies[0])
+  eq 44, hero.mp, 'a single plain weapon: its own sp_cost, once'
+
+  # Halved (rounding up) by MP消費半分 gear, same as a skill's own #skill_cost.
+  hero.equip([8, 0, 0, 0, 0])
+  hero.mp = 50
+  foe2 = combatant('Foe', 0, 0, 5, 10_000)
+  bat2 = Game::Battle.new([Game::Battle.from_actor(hero)], [foe2], Game::Rng.new(1))
+  bat2.command_attack(bat2.allies[0], foe2)
+  bat2.send(:strike, bat2.allies[0])
+  eq 47, hero.mp, 'half_sp_cost rounds (5+1)/2 = 3 SP up, not down'
+
+  # A 二刀流 weapon still swings twice, but only pays once -- vStart runs
+  # before any swing, not once per hit.
+  hero.equip([9, 0, 0, 0, 0])
+  hero.mp = 50
+  foe3 = combatant('Foe', 0, 0, 5, 10_000)
+  bat3 = Game::Battle.new([Game::Battle.from_actor(hero)], [foe3], Game::Rng.new(1))
+  eq 2, bat3.allies[0].strike_count
+  bat3.command_attack(bat3.allies[0], foe3)
+  entries = bat3.send(:strike, bat3.allies[0])
+  eq 2, entries.size, 'both swings still land'
+  eq 47, hero.mp, 'the 二刀流 weapon\'s own sp_cost is spent exactly once, not per swing'
+
+  # An item naming no sp_cost costs nothing, same as being unarmed.
+  hero.equip([10, 0, 0, 0, 0])
+  hero.mp = 50
+  foe4 = combatant('Foe', 0, 0, 5, 10_000)
+  bat4 = Game::Battle.new([Game::Battle.from_actor(hero)], [foe4], Game::Rng.new(1))
+  bat4.command_attack(bat4.allies[0], foe4)
+  bat4.send(:strike, bat4.allies[0])
+  eq 50, hero.mp, 'no sp_cost named on the weapon -> no SP spent'
+
+  # An enemy's own basic Attack never spends SP at all (Game_Battler's own
+  # CalculateWeaponSpCost defaults to 0; Game_Enemy never overrides it).
+  attacker = combatant_mp('Foe', 20, 0, 999, 100, 30)
+  rev = Game::Battle.new([bat4.allies[0]], [attacker], Game::Rng.new(1))
+  rev.send(:strike, rev.enemies[0])
+  eq 30, attacker.mp, 'an enemy attacker\'s own SP is untouched'
 end
 
 check 'battle: a 必中 weapon ignores the target\'s evasion' do


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_BattleAlgorithm::Normal::vStart` (`src/game_battlealgorithm.cpp`) spends `source->ChangeSp(-source->CalculateWeaponSpCost(weapon))` unconditionally, once per basic Attack action, before any swing resolves — this codebase never deducted anything, so a weapon flagged with a 消費SP (`sp_cost`) database field was effectively free to swing forever.
- Added `Actor#weapon_sp_cost` (the equipped weapon's own `sp_cost`, halved rounding up by MP消費半分 gear, same as `#skill_cost`'s fixed-cost branch) and `Game::Battle#pay_weapon_sp_cost(b)`, called once from each of `#strike`'s two attack-dispatch points — before the combo/dual-wield swing count is resolved, so a 二刀流 weapon's extra swing never doubles the bill, matching `vStart`'s own once-per-action timing. A no-op for an enemy attacker, since `Game_Battler::CalculateWeaponSpCost` defaults to 0 and `Game_Enemy` never overrides it.
- Documented in `docs/TODO.md` with full RPG_RT/EasyRPG citations, alongside the sibling Escape/Auto Destruction SE fixes this same investigation lineage already covered.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check covering: a plain weapon's own `sp_cost`; MP消費半分 gear's rounded-up half; a 二刀流 weapon's cost spent exactly once despite both swings landing; an unflagged weapon costing nothing; an enemy attacker's own SP left untouched.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only) with `expected 44, got 50`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1055 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 764 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_