### PR TITLE
Multiply basic-attack swing count by a weapon's 攻撃の回数 field

### DIFF
--- a/changelog.d/weapon-attack-times-multiplier.fixed.md
+++ b/changelog.d/weapon-attack-times-multiplier.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2003 battles:** A weapon's per-actor Battle Animation "Number of
+  Attacks" (攻撃の回数) setting now multiplies a basic Attack's swing count,
+  matching RPG_RT -- previously only 二刀流 (`dual_attack`) affected swing
+  count, so this field did nothing at all. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7331,6 +7331,43 @@ not yet verified:
   weapon plus one ordinary weapon summing to 3, not 2 — all three
   confirmed to fail against the pre-fix code before the fix (`#strike_count`
   did not exist at all).
+  ✅ **Follow-up (2026-08-19): `#strike_count` only ever ported half of the
+  EasyRPG function its own doc comment cites — RPG2003's 攻撃の回数 (Number of
+  Attacks) weapon field never multiplied anything at all.** Confirmed
+  directly against RPG_RT's live source: `Algo::GetNumberOfAttacks`
+  (`src/algo.cpp`) is `int hits = weapon.dual_attack ? 2 : 1; if
+  (Player::IsRPG2k3()) { auto& cba = weapon.animation_data; if (actor_id >=
+  1 && actor_id <= (int)cba.size()) { hits *= cba[actor_id - 1].attacks + 1;
+  } } return hits;` — the very function `#strike_count`'s own comment
+  already names, but only its `dual_attack` term had actually been ported;
+  the `IsRPG2k3()` branch reading each weapon's own per-actor Battle
+  Animation table (`animation_data`, item field 70, each row's `attacks`
+  field named `attack_times` in this schema, item field 7) was never
+  consulted anywhere — confirmed by grep, `attack_times` did not appear a
+  single time in `game.rb`. The field is genuine, already-parsed
+  RPG2000/2003 database data (`mruby-lcf/mrblib/schema.rb`), not an
+  unimplemented schema stub: any RPG2003 project using a weapon's Battle
+  Animation "Number of Attacks" setting to build a multi-hit weapon (stacks
+  with, and is independent of, 二刀流) got exactly `dual_attack?`'s 1-or-2
+  swings instead of RPG_RT's correctly multiplied count. Fixed with a new
+  `Actor#weapon_attack_multiplier(it)` (`(attack_times || 0) + 1` when
+  `rpg2003?` and this actor has a row in `it.animation_data`, else the
+  neutral `1`), multiplied into both of `#strike_count`'s existing terms —
+  the single-weapon `dual_attack? ? 2 : 1` and each weapon's own term in the
+  two-weapon sum, exactly mirroring `Algo::GetNumberOfAttacks` being called
+  once per weapon slot in both the single- and two-weapon
+  `Game_Actor::GetNumberOfAttacks` paths. `#swing_weapon_data`'s own
+  `w1_hits` split point (which of a two-weapon actor's swings the primary
+  vs. secondary weapon governs) needed the identical multiplier folded in,
+  or a CBA-boosted primary weapon's extra swings would have been
+  misattributed to the secondary weapon's own hit rate/attributes/crit once
+  the total swing count grew past the *unmultiplied* boundary. Covered by a
+  new `scripts/rpg2k_logic_check.rb` check (a weapon naming no row for this
+  actor is a no-op; a row's `attacks: 2` gives `(2 + 1)` swings that all
+  actually land; the identical row is inert on an RPG2000 database with no
+  Battle Animation table at all; a two-weapon actor sums each weapon's own
+  already-multiplied term), confirmed to fail against the pre-fix code
+  (`expected 3, got 1`) before the fix.
 - ✅ **A two-weapon actor's individual swings now each roll their own
   weapon's hit rate / elemental attributes / weapon states / crit chance,
   instead of every swing reusing the same value merged (max/union) across

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2283,11 +2283,35 @@ module Game
     # `Game_Actor::GetNumberOfAttacks`'s ordinary single-weapon max does --
     # so a two-weapon actor swings **at least twice** even when *neither*
     # individual weapon is itself flagged 二刀流, the common case for a
-    # dual-wield setup built from two ordinary weapons.
+    # dual-wield setup built from two ordinary weapons. Each weapon's own
+    # `#weapon_attack_multiplier` (RPG2003's 攻撃の回数 Battle Animation field)
+    # scales its own term before the two are summed, exactly as EasyRPG's
+    # `Algo::GetNumberOfAttacks` scales `dual_attack ? 2 : 1` by `cba_hits`
+    # before `Game_Actor::GetNumberOfAttacks` maxes/sums per weapon.
     def strike_count
       weapons = equipped_weapons
-      return dual_attack? ? 2 : 1 unless weapons.size >= 2
-      weapons[0, 2].reduce(0) { |s, it| s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) }
+      return (dual_attack? ? 2 : 1) * weapon_attack_multiplier(weapons.first) unless weapons.size >= 2
+      weapons[0, 2].reduce(0) do |s, it|
+        s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) * weapon_attack_multiplier(it)
+      end
+    end
+
+    # The RPG2003-only 攻撃の回数 (Number of Attacks) multiplier `it` (an
+    # equipped weapon, or nil when unarmed) contributes to this actor's own
+    # basic-attack swing count -- EasyRPG's `Algo::GetNumberOfAttacks`
+    # (`src/algo.cpp`): `Player::IsRPG2k3()` gates a lookup into the weapon's
+    # own per-actor Battle Animation table (`weapon.animation_data`, this
+    # schema's `attack_times` field on each row, keyed by actor id) and
+    # multiplies the swing count by `cba[actor_id - 1].attacks + 1` when this
+    # actor has a row there. RPG2000 has no such table at all, and a weapon
+    # naming no row for this actor (or no table at all) contributes no
+    # multiplier -- both read as the neutral `1`, matching a project that
+    # never touched the Battle Animation tab.
+    def weapon_attack_multiplier(it)
+      return 1 unless it && rpg2003?
+      table = it.respond_to?(:animation_data) ? it.animation_data : nil
+      row = table ? table[id] : nil
+      row && row.respond_to?(:attack_times) ? (row.attack_times || 0) + 1 : 1
     end
 
     # The equipped weapon-type items, in slot order (the weapon slot first,
@@ -2316,7 +2340,7 @@ module Game
       weapons = equipped_weapons
       return nil unless weapons.size >= 2
       w1, w2 = weapons[0, 2]
-      w1_hits = w1.respond_to?(:dual_attack) && w1.dual_attack ? 2 : 1
+      w1_hits = (w1.respond_to?(:dual_attack) && w1.dual_attack ? 2 : 1) * weapon_attack_multiplier(w1)
       weapon_roll_data(i < w1_hits ? w1 : w2)
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3305,7 +3305,14 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :uses,
                       # 消費SP (weapon field 16): the SP a basic Attack costs
                       # while this weapon is equipped (Actor#weapon_sp_cost).
-                      :sp_cost)
+                      :sp_cost,
+                      # animation_data (weapon field 70): the RPG2003-only,
+                      # per-actor Battle Animation table -- a `{actor_id =>
+                      # row}` Hash here (a real database's own Array2D reads
+                      # the same way via `#[]`), each row responding to
+                      # `attack_times` (field 7, 攻撃の回数 -- Actor#
+                      # weapon_attack_multiplier).
+                      :animation_data)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -3316,7 +3323,7 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
               cursed: false, raise_evasion: false, animation_id: nil,
               state_chance: 0, use_skill: false, class_set: nil, uses: 1,
-              sp_cost: 0)
+              sp_cost: 0, animation_data: nil)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
@@ -3324,8 +3331,11 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
                raise_evasion, animation_id, state_chance, use_skill, class_set,
-               uses, sp_cost)
+               uses, sp_cost, animation_data)
 end
+# A single row of a weapon's RPG2003 per-actor Battle Animation table --
+# `fake_item`'s own `animation_data:` Hash values.
+FakeCbaRow = Struct.new(:attack_times)
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
@@ -14972,6 +14982,51 @@ check 'battle: a 二刀流 weapon swings twice' do
   bat3 = Game::Battle.new([Game::Battle.from_actor(hero)], [dying], Game::Rng.new(1))
   e3 = bat3.send(:swing, bat3.allies[0], dying)
   ok e3.is_a?(Hash), 'a felled target is not struck again'
+end
+
+# 攻撃の回数 (weapon field 70's per-actor Battle Animation table, RPG2003
+# only): a basic Attack's swing count is now multiplied by
+# `Actor#weapon_attack_multiplier`, matching EasyRPG's `Algo::
+# GetNumberOfAttacks` (`cba[actor_id - 1].attacks + 1`). Previously
+# `Actor#strike_count` ported only the `dual_attack` term of that same
+# function, never reading `attack_times` at all (docs/TODO.md).
+check 'battle: RPG2003 攻撃の回数 multiplies a basic Attack\'s swing count' do
+  items = { 7 => fake_item(type: 1, atk: 5, animation_data: { 1 => FakeCbaRow.new(2) }),
+            8 => fake_item(type: 1, atk: 5) } # no animation_data row at all
+  row = CurveRow.new('Hero', '', 0, 1, [200, 50, 20, 10, 10, 10])
+  db = FakeActorDB.new({ 1 => row }, [1], items, {}, {}, nil, nil, rpg2003: true)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+
+  hero.equip([8, 0, 0, 0, 0])
+  eq 1, hero.strike_count, 'a weapon naming no row for this actor is a no-op multiplier'
+
+  hero.equip([7, 0, 0, 0, 0])
+  eq 3, hero.strike_count, 'attacks: 2 on this actor\'s own row -> (2 + 1) swings'
+  foe = combatant('Foe', 0, 0, 5, 10_000)
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  entries = bat.send(:swing, bat.allies[0], foe)
+  eq 3, entries.size, 'the extra swings actually land, not just #strike_count'
+
+  # RPG2000 (no Classes chunk) has no Battle Animation table at all -- the
+  # identical row is a no-op there, same as the un-rowed weapon above.
+  db2000 = FakeActorDB.new({ 1 => row }, [1], items)
+  st2000 = Game::State.new(Game::Party.new(db2000), 1, 0, 0)
+  hero2000 = st2000.party.leader
+  hero2000.equip([7, 0, 0, 0, 0])
+  eq 1, hero2000.strike_count, 'RPG2000: the same row is never consulted at all'
+
+  # A two-weapon (#double_hand?) actor: each weapon's own multiplier scales
+  # only its own term before the two are summed -- EasyRPG's `Normal::Init`
+  # sums `GetNumberOfAttacks(WeaponPrimary) + GetNumberOfAttacks
+  # (WeaponSecondary)`, each already including its own `cba_hits`.
+  items2 = { 7 => fake_item(type: 1, atk: 5, animation_data: { 1 => FakeCbaRow.new(2) }), # 3 hits
+             9 => fake_item(type: 1, atk: 5, dual_attack: true) } # 2 hits, no row
+  db2 = FakeActorDB.new({ 1 => row }, [1], items2, {}, {}, nil, nil, rpg2003: true)
+  st2 = Game::State.new(Game::Party.new(db2), 1, 0, 0)
+  dual = st2.party.leader
+  dual.equip([7, 9, 0, 0, 0])
+  eq 5, dual.strike_count, 'primary\'s own 3 (attack_times: 2) + secondary\'s own 2 (dual_attack)'
 end
 
 # 消費SP (weapon field 16): a basic Attack now spends the equipped weapon's


### PR DESCRIPTION
## Summary
- `Actor#strike_count`'s own doc comment already cites EasyRPG's `Algo::GetNumberOfAttacks` (`src/algo.cpp`), but only ever ported its `weapon.dual_attack ? 2 : 1` term. The function's own RPG2003-only branch — `if (Player::IsRPG2k3()) { ... hits *= cba[actor_id - 1].attacks + 1; }`, reading each weapon's own per-actor Battle Animation table (攻撃の回数, item field 70 `animation_data`, this schema's `attack_times` on each row) — was never consulted anywhere. Confirmed live against RPG_RT's real source; `attack_times` did not appear a single time in `game.rb` before this fix.
- Any RPG2003 project using a weapon's "Number of Attacks" Battle Animation setting to build a multi-hit weapon (stacks with, and is independent of, 二刀流) got exactly `dual_attack?`'s 1-or-2 swings instead of RPG_RT's correctly multiplied count.
- Fixed with a new `Actor#weapon_attack_multiplier(it)` (`(attack_times || 0) + 1` when `rpg2003?` and this actor has a row in `it.animation_data`, else the neutral `1`), multiplied into both of `#strike_count`'s existing terms. `#swing_weapon_data`'s own primary/secondary swing-boundary split needed the identical multiplier folded in, or a CBA-boosted primary weapon's extra swings would be misattributed to the secondary weapon's own hit rate/attributes/crit.
- Documented in `docs/TODO.md` as a follow-up to the original `#strike_count`/二刀流 entry, with full RPG_RT/EasyRPG citations.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a weapon naming no row for this actor is a no-op; a row's `attacks: 2` gives `(2 + 1)` swings that all actually land; the identical row is inert on an RPG2000 database with no Battle Animation table at all; a two-weapon actor sums each weapon's own already-multiplied term.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only) with `expected 3, got 1`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1056 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 764 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_