### PR TITLE
battle: a switch skill cast in a fight now flips its switch

### DIFF
--- a/changelog.d/battle-switch-skill-flips-switch.fixed.md
+++ b/changelog.d/battle-switch-skill-flips-switch.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2003 battles:** A Switch-type skill cast from the battle Skill menu now
+  actually flips its configured switch, matching RPG_RT -- previously it only
+  ever spent its SP and did nothing else, unlike the identical field-menu
+  cast (which already worked) and a battle switch *item* (fixed earlier).
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4983,6 +4983,39 @@ The work below is roughly ordered by the critical path to a walkable game
   `Game::Party#item_effective?` already does for the field menu). Covered by
   a new `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
   pre-fix code (the switch stayed off, the item still vanished) before the fix.
+  ✅ **Follow-up (2026-08-19): a battle-cast switch *skill* had the identical
+  gap the switch item just above did — its `switch_id` never reached the
+  command at all, so a fight-cast "summon companion" skill spent its SP and
+  did nothing.** Confirmed directly against RPG_RT's live source: `Game_
+  BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`) is `if
+  (skill.type == Type_switch) { SetAffectedSwitch(skill.switch_id); return
+  SetIsSuccess(); }` — checked before any of the ordinary hit/damage/state
+  logic, so a switch skill's only real effect, cast from a fight exactly as
+  from the field menu (`#cast_switch_skill`, already correct), is turning on
+  its configured switch after paying its SP. `Game::Party#battle_skill_
+  command` (`mruby-rpg2k/mrblib/game.rb`) had no such case at all and fell
+  into the ordinary self/ally-scope branch, producing a command with `cured:
+  []`/`inflict: []`/`hp: 0`/`mp: 0` and no `switch_id` key anywhere — the
+  consuming side already existed and already worked (`Game::Battle#apply_
+  skill_hit`'s recovery branch already read `cmd[:switch_id]` onto its log
+  entry, and `Scene::Battle#drive_battle_animate` already flipped
+  `@state.switches[entry[:switch_id]]` the moment an entry lands, both wired
+  up by the switch-item fix directly above), but nothing ever set `cmd[:
+  switch_id]` for a Skill. Fixed with an early return in `#battle_skill_
+  command` (`{ cost:, switch_id: sk.switch_id }` for `sk.type == SKILL_
+  SWITCH`, mirroring `#command_item`'s existing `switch_id:` field for a
+  switch item) and a new `switch_id:` keyword on `Game::Battle#command_skill`,
+  threaded from `Scene::Battle#apply_pending_skill`. `#command_skill_all` was
+  left alone, matching `#command_item_all`'s own precedent — a switch
+  skill/item is a self-only, no-target effect in both this port and the
+  reference, so the all-target volley path never legitimately carries one.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check exercising the full
+  `battle_skill_command` → `command_skill` → `step_action` pipeline (the
+  command carries exactly `{cost:, switch_id:}`, no HP/SP/state fields at
+  all; the produced log entry carries the switch through; the SP is still
+  spent), confirmed to fail against the pre-fix code (`expected {cost: 6,
+  switch_id: 17}, got {cost: 6, hp: 0, mp: 0, ...}`, no `switch_id` key at
+  all) before the fix.
 - ✅ **物理回避率アップ** (the item row's `raise_evasion`, field 26) — unread, so
   a shield/armour/helmet/accessory bought specifically for its evasion bonus
   was purely a stat stick against a normal attack. `ruby

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5349,6 +5349,19 @@ module Game
     # instead of the caster's own SP, never both.
     def battle_skill_command(sk, caster, target, free: false)
       cost = free ? 0 : skill_cost(sk, caster)
+      # A **switch** skill (type 3) has no HP/SP/state effect at all -- its
+      # only job, in battle exactly as on the field (`#cast_switch_skill`), is
+      # turning on its configured switch once cast. EasyRPG's `Game_
+      # BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`)
+      # special-cases this before any of the ordinary hit/damage/state logic:
+      # `if (skill.type == Type_switch) { SetAffectedSwitch(skill.switch_id);
+      # return SetIsSuccess(); }`. `switch_id` rides the command the same way
+      # `#command_item`'s own does for a switch item -- `Game::Battle#apply_
+      # skill_hit`'s recovery branch already reads `cmd[:switch_id]` onto its
+      # log entry, and `Scene::Battle#drive_battle_animate` already flips it
+      # the same moment it does for a switch item; only the battle-cast
+      # switch-skill command itself never carried one.
+      return { cost: cost, switch_id: sk.switch_id } if sk.type == SKILL_SWITCH
       base = skill_effect(sk, caster)
       # Attribute-defence shifting isn't scoped to attack skills -- a "raise
       # my own resistance" buff and a "lower the enemy's" debuff are both this
@@ -10199,7 +10212,7 @@ module Game
                       chance: 100, variance: 0, attributes: nil, skill_id: nil,
                       absorb: false, attr_shift: nil, attr_ids: nil,
                       stat_mod_keys: nil, stat_effect: 0, cured: nil, attack: nil,
-                      physical_rate: 0, item_id: nil)
+                      physical_rate: 0, item_id: nil, switch_id: nil)
       ally.command = { kind: :skill, target: target, name: name,
                        skill_id: skill_id, item_id: item_id, absorb: absorb, attack: attack,
                        cost: cost, hp: hp, mp: mp,
@@ -10215,7 +10228,13 @@ module Game
                        # Was silently dropped here entirely until this field
                        # existed: #shake_off_states always rolled against 0,
                        # so no skill's physical-rate cure ever fired.
-                       physical_rate: physical_rate || 0 }
+                       physical_rate: physical_rate || 0,
+                       # A **switch** skill's own switch, the same ride-along
+                       # `#command_item`'s identical field is for a switch item
+                       # -- `#apply_skill_hit`'s recovery branch already reads
+                       # `cmd[:switch_id]` onto the produced log entry, and
+                       # `Scene::Battle#drive_battle_animate` flips it there.
+                       switch_id: switch_id }
       ally.action = nil; ally.defending = false
     end
 

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1720,7 +1720,8 @@ class RPG2k
                                           stat_mod_keys: c[:stat_mod_keys],
                                           stat_effect: c[:stat_effect] || 0,
                                           cured: c[:cured],
-                                          physical_rate: c[:physical_rate] || 0)
+                                          physical_rate: c[:physical_rate] || 0,
+                                          switch_id: c[:switch_id])
         @ui[:pending] = nil
         @ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10987,6 +10987,35 @@ end
    eq 90, c[:chance]                            # no agility term, just skill.hit
  end
 
+ # 3 (Switch): EasyRPG's `Game_BattleAlgorithm::Skill::vExecute`
+ # (`src/game_battlealgorithm.cpp`) special-cases a switch skill before any of
+ # the ordinary hit/damage/state logic -- `SetAffectedSwitch(skill.switch_id);
+ # return SetIsSuccess();` -- so casting one in a fight, exactly like on the
+ # field (`#cast_switch_skill`), only ever spends its SP and flips its switch.
+ # `Game::Party#battle_skill_command` previously had no such case at all and
+ # fell into the ordinary self/ally-scope branch, producing a command with no
+ # `switch_id` anywhere on it -- a battle-cast switch skill spent its SP and
+ # did nothing else.
+ check 'a switch skill cast in battle only ever spends its SP and flips its switch' do
+   skills = { 7 => fake_skill(name: 'Summon', type: 3, sp_cost: 6, switch_id: 17) }
+   st = skill_party(skills)
+   hero = st.party.actor_by_id(1)
+   hero.learn_skill(7)
+   caster = Game::Battle.from_actor(hero)
+   foe = combatant('Foe', 0, 0, 5, 100)
+
+   c = st.party.battle_skill_command(st.party.db_skill(7), caster, caster)
+   eq({ cost: 6, switch_id: 17 }, c, 'no HP/SP/state effect at all -- just the switch and its cost')
+
+   b = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+   b.command_skill(caster, caster, name: 'Summon', cost: c[:cost], switch_id: c[:switch_id])
+   b.begin_round
+   before = caster.mp
+   e = b.step_action
+   eq 17, e[:switch_id], 'the produced log entry carries the switch through to the scene'
+   eq before - 6, caster.mp, 'and the SP is spent, same as any other skill'
+ end
+
  # `hit == -1` is a sentinel meaning "use the caster's own weapon-based hit
  # chance" -- EasyRPG's Algo::CalcSkillToHit reads it unconditionally, as its
  # very first line, for every skill (not gated behind any EasyRPG-only


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`) special-cases a switch skill (type 3) before any of the ordinary hit/damage/state logic: `if (skill.type == Type_switch) { SetAffectedSwitch(skill.switch_id); return SetIsSuccess(); }`. Its only real effect, cast from a fight exactly as from the field menu, is turning on its configured switch after paying its SP.
- `Game::Party#battle_skill_command` had no such case at all and fell into the ordinary self/ally-scope branch, producing a command with `hp: 0`/`mp: 0`/`cured: []`/`inflict: []` and no `switch_id` key anywhere. The consuming side already existed and already worked — `Game::Battle#apply_skill_hit`'s recovery branch already read `cmd[:switch_id]` onto its log entry, and `Scene::Battle#drive_battle_animate` already flipped `@state.switches[entry[:switch_id]]` the moment an entry lands, both wired up by an earlier fix for battle switch *items* — but nothing ever set `cmd[:switch_id]` for a Skill, so a battle-cast "summon companion" skill spent its SP and did nothing else.
- Fixed with an early return in `#battle_skill_command` (`{ cost:, switch_id: sk.switch_id }` for a switch skill, mirroring `#command_item`'s existing `switch_id:` field for a switch item) and a new `switch_id:` keyword on `Game::Battle#command_skill`, threaded from `Scene::Battle#apply_pending_skill`. `#command_skill_all` was left alone, matching `#command_item_all`'s own precedent — a switch skill/item is a self-only, no-target effect in both this port and the reference.
- Documented in `docs/TODO.md` as a follow-up to the sibling battle-switch-item fix, with full RPG_RT/EasyRPG citations.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check exercising the full `battle_skill_command` → `command_skill` → `step_action` pipeline: the command carries exactly `{cost:, switch_id:}` with no HP/SP/state fields at all; the produced log entry carries the switch through to the scene; the SP is still spent.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb`/`scene/battle.rb` only) with no `switch_id` key on the command at all, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1057 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 764 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_