### PR TITLE
events: batch Control Variables indirect operand re-reads live per id

### DIFF
--- a/changelog.d/control-vars-indirect-live-reread.fixed.md
+++ b/changelog.d/control-vars-indirect-live-reread.fixed.md
@@ -1,0 +1,6 @@
+- **Events:** A batch (range) Control Variables write through an indirect
+  ("pointer") operand now re-reads its target live for every variable in the
+  range, matching RPG_RT -- previously the value was frozen once and
+  broadcast, so a self-referencing pointer whose target fell inside the
+  destination range no longer cascaded the just-written value forward.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5282,6 +5282,42 @@ following this paragraph as the original record.
   (`expected [20, 20, 20, 30, 30], got [20, 20, 20, 20, 20]`) before the fix.
   Covered by a new `scripts/rpg2k_logic_check.rb` check (a wide-range batch
   assign must not produce the same value in every variable).
+  ✅ **Follow-up (2026-08-19): an *indirect*-variable operand (type 2, `Var[Var
+  [A]]`) has the identical live-per-id re-read this same bullet already fixed
+  for a direct-variable operand (type 1) — it was never given the same
+  treatment, so a batch write through a self-referencing pointer still froze
+  its value once and broadcast it, instead of cascading.** Confirmed directly
+  against RPG_RT's live source: `Game_Interpreter::CommandControlVariables`
+  (`src/game_interpreter.cpp`) dispatches operand type 2 over a range to
+  `Game_Variables::SetRangeVariableIndirect`/`AddRangeVariableIndirect`/etc.
+  (`src/game_variables.cpp`), each a thin wrapper calling the *generic*
+  `WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); },
+  op)` — unlike type 1's own `WriteRangeVariable`, which closes over one
+  frozen value per (up to two) split half, `WriteRange` itself
+  (`Game_Variables::WriteRange`) calls its value lambda **fresh, once per
+  loop iteration** (`v = Clamp(op(v, value()), _min, _max);`), so `Get(Get
+  (var_id))` re-resolves against whatever the table holds *right now* on
+  every single id. If the pointer's own resolved target id falls inside the
+  destination range, a later id in the same batch sees the value an earlier
+  id in that same batch just wrote — the identical "does not stay frozen at
+  its original value" behavior already fixed for type 1 with its own
+  two-pass split, except type 2 needs no split at all: every id, not just
+  the ones after the source, re-reads live. `Game::Interpreter#do_control_
+  vars` only special-cased `random` (type 3) for this live-per-id
+  re-evaluation and left type 2 falling into the generic once-up-front-value
+  path alongside every operand type that genuinely should stay frozen
+  (constant, item, actor, event, other, enemy — none of these can read their
+  own about-to-be-written destination back, so a single up-front read is
+  correct for them). Fixed by folding type 2 into the same live-evaluation
+  branch type 3 already uses (`live = cmd.param(4) == 3 || cmd.param(4) ==
+  2`); every other operand type, and the existing type-1 two-pass split, are
+  untouched. Covered by a new `scripts/rpg2k_logic_check.rb` check (a
+  pointer variable resolving to an id inside the destination range cascades
+  the just-written value forward through the rest of the batch; the
+  identical batch with the pointer resolving outside the range is
+  unaffected, still broadcasting one live-but-unchanging value), confirmed
+  to fail against the pre-fix code (`expected [2, 2, 2], got [2, 1, 1]`)
+  before the fix.
 - ✅ **Indirect ("pointer") target addressing now no-ops on a resolved id
   ≤0**, instead of writing switch/variable slot 0 or a negative one.
   `Game::Interpreter#range`'s mode-2 (indirect) branch resolves the pointer

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1593,15 +1593,25 @@ module Game
       op = cmd.param(3)  # 0 =, 1 +, 2 -, 3 *, 4 /, 5 %
       # A random operand (type 3) rolls independently for each variable in the
       # range, matching RPG_RT -- a batch "Var[1..5] = random 1~6" is five
-      # separate dice, not one roll broadcast to all five. Every other operand
-      # type is evaluated once up front, as before -- except a direct-variable
-      # operand (type 1) applied to a genuine multi-id range, which needs its
-      # own split below (a variable-A-ops-B batch reading its own operand out
-      # of the same range it writes).
-      random = cmd.param(4) == 3
-      return do_control_vars_range_variable(cmd, a, b, op) if !random && cmd.param(4) == 1 && a < b
-      val = operand_value(cmd) unless random
-      (a..b).each { |id| variables[id] = apply(op, variables[id], random ? operand_value(cmd) : val) }
+      # separate dice, not one roll broadcast to all five. An indirect-variable
+      # operand (type 2, Var[Var[A]]) re-reads live for every id in the range
+      # too -- EasyRPG's `Game_Variables::WriteRange` (`src/game_variables.cpp`)
+      # calls its lambda fresh once per loop iteration, and `*RangeVariable
+      # Indirect`'s own lambda is `Get(Get(var_id))`, evaluated against
+      # whatever the table holds *right now* -- so if the pointer's own
+      # resolved target id falls inside the destination range, a later id in
+      # the same batch sees the value an earlier id in that same batch just
+      # wrote (a genuine intra-batch cascade), unlike the frozen-once-and-
+      # broadcast reading a direct variable (type 1, `WriteRangeVariable`'s own
+      # closed-over `value`) or any other operand type gets. Every other
+      # operand type is evaluated once up front, as before -- except a
+      # direct-variable operand applied to a genuine multi-id range, which
+      # needs its own split below (a variable-A-ops-B batch reading its own
+      # operand out of the same range it writes).
+      live = cmd.param(4) == 3 || cmd.param(4) == 2
+      return do_control_vars_range_variable(cmd, a, b, op) if !live && cmd.param(4) == 1 && a < b
+      val = operand_value(cmd) unless live
+      (a..b).each { |id| variables[id] = apply(op, variables[id], live ? operand_value(cmd) : val) }
     end
 
     # A batch (range) Control Variables write whose operand is itself a plain

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7288,6 +7288,43 @@ check 'Control Variables batch operand reading its own destination range splits 
      'a self-referential Set still broadcasts the source value to the whole range'
 end
 
+check 'Control Variables batch indirect operand re-reads live for every id, cascading ' \
+      'when its own resolved target falls inside the destination range' do
+  # EasyRPG's Game_Variables::WriteRange (src/game_variables.cpp) calls its
+  # value lambda fresh once per loop iteration; *RangeVariableIndirect's own
+  # lambda is `Get(Get(var_id))`, read against whatever the table holds right
+  # now -- unlike a direct-variable operand (type 1), whose own
+  # WriteRangeVariable closes over one frozen value per split half. So an
+  # indirect operand (type 2) whose resolved target id falls inside the
+  # destination range cascades: a later id in the same batch sees the value
+  # an earlier id in that same batch just wrote.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  st.variables[10] = 5                        # the pointer: Var[Var[10]] = Var[5]
+  st.variables[5] = 1
+  st.variables[6] = 0
+  st.variables[7] = 0
+  # mode 1 (range): ids 5..7, op 1 (+=), operand type 2 (indirect), pointer var 10.
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [1, 5, 7, 1, 2, 10])])
+  it.update
+  # id 5: Get(Get(10))=Get(5)=1 -> 1+1=2. id 6: Get(5) is *now* 2 -> 0+2=2.
+  # id 7: Get(5) is still 2 -> 0+2=2. Not [2, 1, 1], the single-frozen-read result.
+  eq [2, 2, 2], [st.variables[5], st.variables[6], st.variables[7]],
+     'each id re-reads the pointer\'s live target, cascading the just-written value forward'
+
+  # Control: the identical batch with the pointer's own target *outside* the
+  # destination range is unaffected either way (nothing in the range changes
+  # what it resolves to), matching the ordinary single-broadcast result.
+  st2 = new_state
+  it2 = Game::Interpreter.new(st2)
+  st2.variables[10] = 20
+  st2.variables[20] = 7
+  it2.start([FakeCmd.new(IC::CONTROL_VARS, [1, 5, 7, 1, 2, 10])])
+  it2.update
+  eq [7, 7, 7], [st2.variables[5], st2.variables[6], st2.variables[7]],
+     'a target outside the destination range still broadcasts the same live value to each id'
+end
+
 check 'a variable clamps to +-999999 instead of overflowing' do
   # RPG_RT never lets a variable's stored value leave +-999999 in RPG2000
   # (+-9999999 in RPG2003, LCF.var_max/var_min) -- a Control Variables write


### PR DESCRIPTION
## Summary
- `Game_Interpreter::CommandControlVariables` (`src/game_interpreter.cpp`) dispatches a range write with an indirect operand (type 2, `Var[Var[A]]`) to `Game_Variables::SetRangeVariableIndirect`/`AddRangeVariableIndirect`/etc. (`src/game_variables.cpp`), each a thin wrapper over the generic `WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); }, op)`. `Game_Variables::WriteRange` calls its value lambda **fresh, once per loop iteration** (`v = Clamp(op(v, value()), _min, _max)`), so `Get(Get(var_id))` re-resolves against the table's current state on every id — unlike a direct-variable operand (type 1), whose own `WriteRangeVariable` closes over one frozen value per split half.
- `Game::Interpreter#do_control_vars` only gave this live-per-id re-evaluation to the random operand (type 3); the indirect operand (type 2) fell into the generic once-up-front-value path, so a self-referencing pointer whose resolved target id fell inside the destination range never cascaded the just-written value forward the way real RPG_RT does.
- Fixed by folding type 2 into the same live-evaluation branch type 3 already uses. Every other operand type (constant, plain variable, item, actor, event, other, enemy), and the existing type-1 two-pass split, are untouched.
- Documented in `docs/TODO.md` as a follow-up to the sibling Control Variables batch-operand fixes, with full RPG_RT/EasyRPG citations.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a pointer variable resolving to an id inside the destination range cascades the just-written value forward through the rest of the batch (`[2, 2, 2]`, not the frozen-read `[2, 1, 1]`); the identical batch with the pointer resolving outside the range is unaffected.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `interpreter.rb` only) with `expected [2, 2, 2], got [2, 1, 1]`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1058 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 764 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_