### PR TITLE
field menu: a sealing state now blocks casting a sealed skill too

### DIFF
--- a/changelog.d/field-skill-seal-check.fixed.md
+++ b/changelog.d/field-skill-seal-check.fixed.md
@@ -1,0 +1,5 @@
+- **Field menu:** A Silence/Seal-type status now blocks casting a sealed
+  skill from the field Skill menu too, matching RPG_RT -- previously the
+  seal (`restrict_skill`/`restrict_magic`) only bit inside a battle, so a
+  persistent seal state left the field cast wide open. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14328,6 +14328,40 @@ above are repeated here)
   both confirmed to fail against the pre-fix code before the fix (an
   unrelated-state target dodging/reflecting exactly like a genuinely flagged
   one would).
+  ✅ **Follow-up (2026-08-19): `#skill_sealed?`'s own seal — 封印 / Silence —
+  never reached the field (out-of-battle) Skill menu at all; only the
+  in-battle one enforced it.** Confirmed directly against RPG_RT's live
+  source: `Game_Battler::IsSkillUsable` (`src/game_battler.cpp`) checks
+  `restrict_skill`/`restrict_magic` unconditionally — there is no in-battle
+  guard anywhere around that loop — and `Window_Skill::CheckEnable`
+  (`src/window_skill.cpp`), the *one* window class the field and battle
+  skill menus both use, is simply `IsSkillLearned && IsSkillUsable` with no
+  context distinction either: a state that seals magic greys out and blocks
+  a skill identically whether the actor is in a fight or standing on the
+  map. `Game::Battle#skill_sealed?` already ports this correctly for the
+  in-battle menu, but `Game::Party#can_cast?` — the gate `#field_skill?`/
+  `#field_skills`, `#skill_effective?` and `#cast_skill`/`#cast_switch_skill`
+  all funnel through — never called it (nor anything that does); `Party` and
+  `Battle` are different classes with no shared seal check between them. So
+  an actor carrying a Silence/Seal-type state that persists outside battle
+  (`type` field 1, "also persists on the map" — see the state-type bullet
+  elsewhere in this file) could still see and successfully cast a magic-type
+  field skill from the menu, with the seal only ever biting once a fight
+  started. Fixed with a new `Game::Actor#skill_sealed?(sk)` (mirroring
+  `Battle#skill_sealed?`'s own `restrict_skill`/`restrict_magic`-vs-
+  `physical_rate`/`magical_rate` threshold check, reading `#state_table` the
+  same way `#can_act?` already does for its own state-table lookup), and a
+  new clause on `Party#can_cast?`. `#field_skills`/`#battle_skills` (the
+  listings) are unchanged, matching how the in-battle menu already worked:
+  a sealed skill stays listed, only casting it is refused — RPG_RT greys the
+  entry out rather than removing it, and this codebase's existing
+  battle-side behavior already matched that; only the field-side gate itself
+  had no check to grey it out *with*. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (an unafflicted actor casts freely; a
+  Silence-type state blocks the magic-type skill outright, including through
+  a direct `#cast_skill` call, while leaving a purely physical skill
+  castable), confirmed to fail against the pre-fix code (`expected false,
+  got true`) before the fix.
   ✅ **The all-enemies/all-allies-scope half is now implemented too,
   verified against EasyRPG Player's actual C++ source rather than the
   "on top of, not instead of" guess this entry originally carried — which

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1686,6 +1686,30 @@ module Game
       end
     end
 
+    # Whether one of this actor's own currently-inflicted states seals skill
+    # row `sk` -- RPG2000 gives a state two independent seals, each with a
+    # threshold: `restrict_skill` bars any skill whose `physical_rate` reaches
+    # `restrict_skill_level`, and `restrict_magic` bars any whose
+    # `magical_rate` reaches `restrict_magic_level` (EasyRPG's
+    # `Game_Battler::IsSkillUsable`, `src/game_battler.cpp` -- the same check
+    # `Game::Battle#skill_sealed?` already ports for the in-battle skill menu;
+    # this is its field-side twin, since `IsSkillUsable` runs identically for
+    # both -- `Window_Skill::CheckEnable` is one shared window class, and
+    # nothing in the reference gates this loop on being in a fight at all).
+    # 封印 / Silence are what these fields are *for*.
+    def skill_sealed?(sk)
+      return false unless sk
+      table = state_table
+      @states.any? do |sid|
+        d = Game::States.row(sid, table)
+        next false unless d
+        (d.respond_to?(:restrict_skill) && d.restrict_skill &&
+         (sk.physical_rate || 0) >= (d.respond_to?(:restrict_skill_level) ? (d.restrict_skill_level || 0) : 0)) ||
+        (d.respond_to?(:restrict_magic) && d.restrict_magic &&
+         (sk.magical_rate || 0) >= (d.respond_to?(:restrict_magic_level) ? (d.restrict_magic_level || 0) : 0))
+      end
+    end
+
     # Inflict a status condition (no-ops for an absent/duplicate id). Inflicting
     # the death state (戦闘不能) knocks the actor out, zeroing HP.
     def add_state(state_id)
@@ -4786,12 +4810,21 @@ module Game
     end
 
     # Whether `caster` can cast skill `sid` right now: it knows the skill, can
-    # pay its SP cost, and (see #weapon_attribute_ready?) is not missing a
-    # required weapon-type Attribute.
+    # pay its SP cost, (see #weapon_attribute_ready?) is not missing a
+    # required weapon-type Attribute, and (see Actor#skill_sealed?) is not
+    # currently under a state that seals it -- EasyRPG's `Game_Battler::
+    # IsSkillUsable` (`src/game_battler.cpp`) checks the identical seal
+    # unconditionally, in or out of a fight, and this is the field-menu's own
+    # gate through which every field skill-cast path (#field_skill?/
+    # #field_skills, #skill_effective?, #cast_skill/#cast_switch_skill)
+    # already funnels. `Game::Battle#skill_sealed?` is this method's own
+    # in-battle twin, already correct; a field-cast skill had no such check
+    # at all until now.
     def can_cast?(caster, sid)
       sk = db_skill(sid)
       !sk.nil? && caster && caster.knows_skill?(sid) &&
-        caster.mp >= skill_cost(sk, caster) && weapon_attribute_ready?(caster, sk)
+        caster.mp >= skill_cost(sk, caster) && weapon_attribute_ready?(caster, sk) &&
+        !(caster.respond_to?(:skill_sealed?) && caster.skill_sealed?(sk))
     end
 
     # Whether `caster` satisfies `sk`'s weapon-type Attribute requirement, if

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6787,6 +6787,35 @@ check "can_cast?: a weapon-type Attribute skill needs a weapon carrying it equip
   eq true, st.party.can_cast?(hero, 8)
 end
 
+# 封印 / Silence: EasyRPG's Game_Battler::IsSkillUsable (src/game_battler.cpp)
+# checks restrict_skill/restrict_magic unconditionally, in or out of a fight
+# -- Window_Skill::CheckEnable is one shared window class for the field and
+# battle skill menus alike. Game::Battle#skill_sealed? already ports this for
+# the in-battle menu; Game::Party#can_cast? -- the gate #field_skill?/
+# #field_skills, #skill_effective? and #cast_skill/#cast_switch_skill all
+# funnel through -- had no such check at all, so a sealed actor could still
+# cast a magic-type field skill from the menu; the seal only bit in battle.
+check 'can_cast?: a sealing state blocks a field skill above its threshold, ' \
+      'matching the battle-side seal' do
+  situation = { 12 => fake_state(restrict_magic: true, restrict_magic_level: 1) }
+  skills = { 7 => fake_skill(name: 'Fire', scope: 2, sp_cost: 1, power: 10,
+                             mrate: 3, prate: 0, hp: true),
+             8 => fake_skill(name: 'Slash', scope: 2, sp_cost: 1, power: 10,
+                             mrate: 0, prate: 4, hp: true) }
+  st = skill_party(skills, {}, situation: situation)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(7)
+  hero.learn_skill(8)
+  hero.change_hp(-50)
+
+  eq true, st.party.can_cast?(hero, 7), 'unafflicted: nothing is sealed'
+  hero.add_state(12)
+  eq false, st.party.can_cast?(hero, 7), 'silence seals the magic skill'
+  eq true, st.party.can_cast?(hero, 8), 'but not the purely physical one'
+  eq [], st.party.cast_skill(hero, 7), 'casting the sealed skill directly does nothing'
+  eq true, st.party.cast_skill(hero, 8).any?, 'the physical skill still casts normally'
+end
+
 check 'a special item invoking a weapon-Attribute-gated skill bypasses the ' \
       'equip gate entirely' do
   # デフォ戦bot: an ally *casting* a weapon-Attribute skill needs the matching


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Battler::IsSkillUsable` (`src/game_battler.cpp`) checks a state's `restrict_skill`/`restrict_magic` seal against the skill's `physical_rate`/`magical_rate` unconditionally — there is no in-battle guard anywhere around that loop. `Window_Skill::CheckEnable` (`src/window_skill.cpp`), the one window class the field and battle skill menus both use, is simply `IsSkillLearned && IsSkillUsable` with no context distinction either: a seal blocks a skill identically whether the actor is in a fight or standing on the map.
- `Game::Battle#skill_sealed?` already ports this correctly for the in-battle menu, but `Game::Party#can_cast?` — the gate `#field_skill?`/`#field_skills`, `#skill_effective?`, and `#cast_skill`/`#cast_switch_skill` all funnel through — never called it. `Party` and `Battle` are different classes with no shared seal check between them, so an actor carrying a persistent (map-surviving) Silence/Seal-type state could still see and successfully cast a magic-type field skill from the menu — the seal only ever bit once a fight started.
- Fixed with a new `Game::Actor#skill_sealed?(sk)` (mirroring `Battle#skill_sealed?`'s own threshold check, reusing `#state_table` the same way `#can_act?` already does), and a new clause on `Party#can_cast?`. The skill listings (`#field_skills`/`#battle_skills`) are unchanged — a sealed skill stays listed, only casting it is refused, matching how the in-battle menu already worked (RPG_RT greys the entry out rather than removing it).
- Documented in `docs/TODO.md` as a follow-up next to the existing `#skill_sealed?` fix, with full RPG_RT/EasyRPG citations.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: an unafflicted actor casts freely; a Silence-type state blocks the magic-type skill outright, including through a direct `#cast_skill` call, while leaving a purely physical skill castable.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only) with `expected false, got true`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1059 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 764 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_