### PR TITLE
field menu: the Skill menu now gates Decision on CheckEnable

### DIFF
--- a/changelog.d/skill-menu-checkenable-gate.fixed.md
+++ b/changelog.d/skill-menu-checkenable-gate.fixed.md
@@ -1,0 +1,6 @@
+- **Field menu:** Choosing a currently unusable skill (out of SP, or sealed
+  by a Silence/Seal-type state) in the field Skill menu now just buzzes and
+  stays on the list, matching RPG_RT -- previously it still played the
+  Decision sound and opened the full target-confirm screen (or cast a switch
+  skill outright), only reporting "It had no effect." afterward. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14362,6 +14362,42 @@ above are repeated here)
   a direct `#cast_skill` call, while leaving a purely physical skill
   castable), confirmed to fail against the pre-fix code (`expected false,
   got true`) before the fix.
+  ✅ **Follow-up (2026-08-19): the field Skill menu itself never consulted
+  `#can_cast?` at all — choosing a currently unaffordable or sealed skill
+  still played the Decision SE and opened the full target-confirm screen (or,
+  for a switch skill, cast it outright), with the refusal only ever
+  surfacing afterward as `#apply_skill`'s own "It had no effect." message,
+  instead of an immediate buzzer at the skill list the way RPG_RT shows for
+  a genuinely disabled entry.** Confirmed directly against RPG_RT's live
+  source: `Scene_Skill::vUpdate` (`src/scene_skill.cpp`) gates its entire
+  Decision branch — including the Decision SE itself — on `Window_Skill::
+  CheckEnable(skill_id)` (`IsSkillLearned && IsSkillUsable`,
+  `src/window_skill.cpp`), the same window class the field and battle skill
+  menus both use; only the `else` (disabled) branch plays Buzzer, and
+  nothing else happens — no `Scene_ActorTarget` push, no switch/Escape/
+  Teleport dispatch. `Scene::SkillMenu#choose_skill`
+  (`mruby-rpg2k/mrblib/scene/skill_menu.rb`) played `SFX_DECISION`
+  unconditionally and always dispatched to one of the switch/escape/
+  teleport/target-confirm branches — `Game::Party#can_cast?` is referenced
+  only in this file's own class doc comment, never actually called anywhere
+  in it. `#skills` (`Game::Party#field_skills`) already filters the listing
+  by `#field_skill?` — the same per-type availability RPG_RT's own
+  `Algo::IsSkillUsable` covers (Escape/Teleport access and a registered
+  target, a switch skill's own occasion flag, an ordinary skill's
+  affect-something check) — so `#can_cast?` (affordability, the seal, weapon-
+  Attribute gating) was the one remaining piece `Game_Battler::
+  IsSkillUsable`'s own pre-`Algo::IsSkillUsable` checks cover, and the one
+  piece this scene never checked. Fixed by gating `#choose_skill` on
+  `#can_cast?` before playing any SE or dispatching anywhere — a disabled
+  entry now just buzzes and stays on the list, matching `CheckEnable`'s own
+  ordering exactly (guarded `#respond_to?(:can_cast?)`, so a bare test-double
+  party naming no such method keeps its old always-enabled behavior).
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a party exposing a
+  real `#can_cast?`: the disabled skill buzzes only, opens no target-confirm
+  screen, and is never actually cast; the enabled skill right next to it
+  still plays Decision and opens the confirm screen normally), confirmed to
+  fail against the pre-fix code (`expected :skills, got :target`) before the
+  fix.
   ✅ **The all-enemies/all-allies-scope half is now implemented too,
   verified against EasyRPG Player's actual C++ source rather than the
   "on top of, not instead of" guess this entry originally carried — which

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -130,9 +130,30 @@ class RPG2k
           play_system_se(SFX_BUZZER)
           return
         end
-        play_system_se(SFX_DECISION)
         sid, = skills[@skill_index]
         sk = @state.party.db_skill(sid)
+        # A greyed-out (currently unusable) entry is selectable but not
+        # activatable -- EasyRPG's `Scene_Skill::vUpdate` (`src/scene_skill.cpp`)
+        # gates its whole Decision branch on `Window_Skill::CheckEnable`
+        # (`IsSkillLearned && IsSkillUsable`, `src/window_skill.cpp`) before
+        # playing any SE or pushing `Scene_ActorTarget`/dispatching a
+        # switch skill at all; the `else` (disabled) branch just buzzes and
+        # stays on the list. `#skills` (`Game::Party#field_skills`) already
+        # filters the listing by `#field_skill?` -- the same per-type
+        # availability `Algo::IsSkillUsable` covers on the reference's own
+        # `IsSkillUsable` -- so `Game::Party#can_cast?` (affordability, the
+        # 封印/Silence seal, weapon-Attribute gating) is everything left to
+        # check here, the same predicate `Game_Battler::IsSkillUsable`'s own
+        # pre-`Algo::IsSkillUsable` checks cover. Previously nothing gated
+        # this at all: choosing an unaffordable or sealed skill still played
+        # Decision and opened the full target-confirm screen (or, for a
+        # switch skill, cast it outright), with the failure only ever
+        # surfacing afterward as #apply_skill's "It had no effect." message.
+        if @state.party.respond_to?(:can_cast?) && !@state.party.can_cast?(caster, sid)
+          play_system_se(SFX_BUZZER)
+          return
+        end
+        play_system_se(SFX_DECISION)
         # A switch skill has no target at all; Escape warps straight to its one
         # registered target; Teleport opens a list of every registered target;
         # a self (2), all-ally (4) or single-ally (3) skill all open the same

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17004,6 +17004,74 @@ check 'Scene::SkillMenu: cancelling a self-scope skill\'s target-confirm screen 
   ok state.party.cast_skill_calls.empty?, 'nothing was cast'
 end
 
+# A party exposing a real #can_cast?, to prove Scene::SkillMenu now gates
+# Decision on it -- EasyRPG's `Scene_Skill::vUpdate` (`src/scene_skill.cpp`)
+# gates its whole Decision branch on `Window_Skill::CheckEnable`
+# (`IsSkillLearned && IsSkillUsable`) before playing any SE or opening the
+# target-confirm screen at all; the disabled case just buzzes and stays put.
+# Previously this scene never consulted `#can_cast?`, so choosing a currently
+# unusable skill (out of SP, or sealed by a Silence/Seal-type state) still
+# played Decision and opened the full confirm screen, with the failure only
+# surfacing afterward as `#apply_skill`'s own "It had no effect." message.
+class SkillGateStubParty < MenuStubParty
+  READY_SID = 80
+  SEALED_SID = 81
+
+  attr_reader :cast_skill_calls
+
+  def initialize
+    super
+    @cast_skill_calls = []
+  end
+
+  def field_skills(_actor, _state = nil); [[READY_SID, 3], [SEALED_SID, 5]]; end
+
+  def db_skill(id)
+    case id
+    when READY_SID  then OpenStruct.new(name: 'Heal', type: Game::Party::SKILL_NORMAL, scope: 2)
+    when SEALED_SID then OpenStruct.new(name: 'Bolt', type: Game::Party::SKILL_NORMAL, scope: 2)
+    end
+  end
+
+  def can_cast?(_caster, sid); sid == READY_SID; end
+
+  def cast_skill(caster, sid, target = nil, _free = false)
+    @cast_skill_calls << [caster, sid, target]
+    [caster].compact
+  end
+end
+
+check 'Scene::SkillMenu: choosing a currently-unusable skill just buzzes and stays ' \
+      'on the list, matching RPG_RT\'s own CheckEnable gate' do
+  parent = fake_parent(fake_db)
+  state = Game::State.new(SkillGateStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  party = state.party
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT] # move onto the sealed/unaffordable skill
+  scene.update
+  RGSS::Input.reset
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :skills, scene.instance_variable_get(:@mode), 'no target-confirm screen opens'
+  eq [], party.cast_skill_calls, 'the skill is never actually cast'
+  eq [['Buzzer1', 100, 100]], RGSS::Audio.se_calls, 'buzzer only -- no Decision SE plays at all'
+
+  # The castable skill right next to it still works normally.
+  RGSS::Input.triggered = [RGSS::Input::LEFT]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode), 'a usable skill still opens target-confirm'
+  eq [['Decision1', 100, 100]], RGSS::Audio.se_calls
+end
+
 # A party whose four field skills exercise #apply_switch_skill /
 # #apply_escape_skill's own `sound_effect` playback (schema.rb field 16) --
 # one Switch skill with a configured SE, one Switch skill with a blank one


### PR DESCRIPTION
## Summary
- RPG_RT's `Scene_Skill::vUpdate` (`src/scene_skill.cpp`) gates its entire Decision branch — including the Decision SE itself — on `Window_Skill::CheckEnable(skill_id)` (`IsSkillLearned && IsSkillUsable`, `src/window_skill.cpp`), the same window class the field and battle skill menus both use. Only the disabled (`else`) branch plays Buzzer, and nothing else happens: no `Scene_ActorTarget` push, no switch/Escape/Teleport dispatch.
- `Scene::SkillMenu#choose_skill` played `SFX_DECISION` unconditionally and always dispatched to one of the switch/escape/teleport/target-confirm branches — `Game::Party#can_cast?` was referenced only in this file's own class doc comment, never actually called. `#skills` (`Game::Party#field_skills`) already filters the listing by `#field_skill?`, the per-type availability equivalent of RPG_RT's own `Algo::IsSkillUsable`, so `#can_cast?` (affordability, the 封印/Silence seal from the immediately-preceding PR, weapon-Attribute gating) was the one remaining piece this scene never checked.
- Fixed by gating `#choose_skill` on `#can_cast?` before playing any SE or dispatching anywhere — a disabled entry now just buzzes and stays on the list, matching `CheckEnable`'s own ordering exactly. Guarded with `#respond_to?(:can_cast?)` so a bare test-double party naming no such method keeps its old always-enabled behavior.
- Documented in `docs/TODO.md` as a follow-up to the sibling field-menu seal fix, with full RPG_RT/EasyRPG citations.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a party exposing a real `#can_cast?` — the disabled skill buzzes only, opens no target-confirm screen, and is never actually cast; the enabled skill right next to it still plays Decision and opens the confirm screen normally.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `scene/skill_menu.rb` only) with `expected :skills, got :target`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 765 checks passed, no regressions.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1059 checks passed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_