### PR TITLE
Full Recovery re-inflicts a cursed-armor-forced state

### DIFF
--- a/changelog.d/full-heal-reinflicts-cursed-armor-state.fixed.md
+++ b/changelog.d/full-heal-reinflicts-cursed-armor-state.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 status effects:** Full Recovery now re-inflicts any state the
+  actor's currently-equipped cursed armor forces, matching RPG_RT --
+  previously a state a map-side Change Condition had legitimately lifted
+  (RPG_RT's own map-only exemption) stayed gone through a subsequent Full
+  Recovery instead of being restored. Covered by extending an existing
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9179,6 +9179,37 @@ not yet verified:
   `#cure_state` call is refused on the same state while the armor stays
   equipped), both confirmed to fail against the pre-fix code before the
   fix.
+  ✅ **Follow-up (2026-08-19): Full Recovery never re-inflicted a
+  cursed-armor-forced state the map-side Change Condition exemption above
+  had already lifted — every fix in this cluster only ever kept an id
+  already present, never re-added a missing one, and RPG_RT's own Full
+  Heal is the one path that does.** Confirmed directly against RPG_RT's
+  live source: `Game_Actor::FullHeal` (`src/game_actor.cpp`) is
+  `RemoveAllStates(); SetHp(GetMaxHp()); SetSp(GetMaxSp());
+  ResetEquipmentStates(true);` — its own comment on the trailing call:
+  "Emulates RPG_RT behavior of resetting even battle equipment states on
+  full heal." `ResetEquipmentStates(true)` walks every equipped slot
+  (Shield/Armor/Helmet/Accessory) and calls `AdjustEquipmentStates(item,
+  true, true)`, which unconditionally re-`AddState`s each of that item's
+  forced states regardless of whether it was already present — so a Full
+  Recovery in real RPG_RT always leaves every currently-cursed-armor-forced
+  state active, even one the map-only exemption two fixes above had just
+  lifted. `Game::Actor#full_heal` (`mruby-rpg2k/mrblib/game.rb`) only ever
+  called `#clear_states`, which (mirroring `RemoveAllStates`/`State::
+  RemoveAll`) can only *keep* an id already in `@states`, never re-add a
+  missing one — so a state a shrine/blessing map event had legitimately
+  lifted via Change Condition's own `always_remove_battle_states` exemption
+  stayed gone through a subsequent Full Recovery too, diverging from real
+  RPG_RT's unconditional re-inflict. Fixed by having `#full_heal` re-add
+  every `#permanent_states` id after `#clear_states`, mirroring
+  `ResetEquipmentStates(true)`'s own unconditional re-inflict; `RemoveAll
+  States`/`ResetEquipmentStates` are single-call-site in both the reference
+  (only `Game_Actor::FullHeal`) and this port (only `Interpreter#
+  do_full_heal`), so nothing else changes behavior. Covered by extending
+  the existing map-side-exemption `scripts/rpg2k_logic_check.rb` check with
+  one more assertion — calling `#full_heal` right after the exemption lifts
+  the state, armor still worn, restores it — confirmed to fail against the
+  pre-fix code (`expected [4], got []`) before the fix.
   ✅ **Change Battle Commands (1009) never validated an added command id
   against the database's own Battle Commands table, so any positive
   integer — however bogus — could occupy one of the six real slots

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2826,11 +2826,25 @@ module Game
     end
 
     # Restore HP and MP to their maxima and cure every status condition
-    # (RPG2000 Full Recovery).
+    # (RPG2000 Full Recovery). Then re-inflicts every #permanent_states id --
+    # EasyRPG's `Game_Actor::FullHeal` (`src/game_actor.cpp`) is
+    # `RemoveAllStates(); SetHp(GetMaxHp()); SetSp(GetMaxSp());
+    # ResetEquipmentStates(true);`, and that trailing call (its own comment:
+    # "Emulates RPG_RT behavior of resetting even battle equipment states on
+    # full heal") walks every equipped slot and unconditionally re-inflicts
+    # each state a worn RPG2003 cursed item forces, regardless of whether it
+    # was already present. `#clear_states` alone (mirroring `RemoveAllStates`)
+    # can only ever *keep* an id already in `@states`, never re-add a missing
+    # one -- so a state a map-side Change Condition had already lifted via
+    # its own `always_remove_battle_states` exemption (still cursed-armor
+    # locked in every other cure path) stayed gone through a Full Recovery
+    # too, until now, diverging from real RPG_RT's own unconditional
+    # re-inflict.
     def full_heal
       @hp = @max_hp
       @mp = @max_mp
       clear_states
+      permanent_states.each { |id| add_state(id) }
     end
 
     # Change Parameters base-stat types (the RPG2000 command's parameter field).

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4469,6 +4469,16 @@ check '#remove_state can lift a cursed-armor-forced state outside battle, but ' 
      "a map-side cure -- Change Condition run outside battle -- lifts it anyway, RPG_RT's own exemption"
   eq [], a.states
 
+  # A Full Recovery afterward re-inflicts it, still worn -- EasyRPG's
+  # `Game_Actor::FullHeal` unconditionally calls `ResetEquipmentStates(true)`
+  # after clearing states, which re-adds every state the actor's currently-
+  # equipped cursed armor forces regardless of whether it was already
+  # present, unlike `#clear_states` alone (mirroring `RemoveAllStates`),
+  # which can only ever *keep* an id already there, never re-add a missing
+  # one.
+  a.full_heal
+  eq [4], a.states, "Full Recovery re-inflicts the armor's forced state, matching RPG_RT"
+
   # The opposite case: a "Continues after battle" state gets no exemption
   # even outside battle.
   situation2 = { 4 => fake_state(type: 1) }


### PR DESCRIPTION
## Summary
- `Game_Actor::FullHeal` (`src/game_actor.cpp`) is `RemoveAllStates(); SetHp(GetMaxHp()); SetSp(GetMaxSp()); ResetEquipmentStates(true);` — its own comment on the trailing call: "Emulates RPG_RT behavior of resetting even battle equipment states on full heal." `ResetEquipmentStates(true)` walks every equipped slot and unconditionally re-`AddState`s each state that item forces, regardless of whether it was already present.
- `Game::Actor#full_heal` only ever called `#clear_states`, which (mirroring `RemoveAllStates`) can only *keep* an id already in `@states`, never re-add a missing one. So a state a map-side Change Condition had legitimately lifted via its own `always_remove_battle_states` exemption (a prior fix in this same investigation lineage) stayed gone through a subsequent Full Recovery too — diverging from real RPG_RT's unconditional re-inflict.
- Fixed by having `#full_heal` re-add every `#permanent_states` id after `#clear_states`, mirroring `ResetEquipmentStates(true)`. `RemoveAllStates`/`ResetEquipmentStates` are single-call-site in both the reference (only `Game_Actor::FullHeal`) and this port (only `Interpreter#do_full_heal`), so nothing else changes behavior.
- Documented in `docs/TODO.md` as a follow-up to the cursed-armor/permanent-states fix cluster, with full RPG_RT/EasyRPG citations.

## Test plan
- [x] Extended the existing map-side-exemption `scripts/rpg2k_logic_check.rb` check with one more assertion: calling `#full_heal` right after the exemption lifts the state, armor still worn, restores it.
- [x] Confirmed the extended check fails against the pre-fix code (`git stash` on `game.rb` only) with `expected [4], got []`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1059 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 766 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_