### PR TITLE
feat(rgss): implement bare module_function and Time#strftime for mruby

### DIFF
--- a/changelog.d/mruby-module-function-strftime.added.md
+++ b/changelog.d/mruby-module-function-strftime.added.md
@@ -1,0 +1,14 @@
+- **XP / VX / VX Ace** two more real mruby gaps found continuing to boot a
+  real VX Ace game's bundled community scripts, both fixed: bare
+  (argument-less) `module_function` — CRuby's "declaration mode", where every
+  `def` that follows in the same scope becomes both a private instance method
+  and a public singleton method — was a documented no-op in this mruby
+  version; a module built entirely under a bare declaration (e.g. a bundled
+  error-log utility whose public entry point is only ever reachable as
+  `SomeModule.method_name(...)`) silently defined no singleton methods at
+  all. Reimplemented via `method_added`, without touching the vendored mruby
+  core. `Time#strftime` did not exist — mruby-time never bound a Ruby-level
+  method taking a format string, so formatting a timestamp for a log line or
+  a save filename (completely ordinary) raised `NoMethodError`. Implemented
+  in pure Ruby over `Time`'s existing component accessors, covering the
+  common directive set real scripts use.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16013,10 +16013,24 @@ screen (544×416). Full rationale:
     just graphics) too small for this game's database alone — raised to
     256 MB — and filled in `Win32API`/`String#encode`/
     `Module#private_method_defined?` (and friends), which the game's bundled
-    community utility scripts assumed. **Still open:** bare (argument-less)
-    `module_function` is a documented no-op in this mruby version (upstream,
-    not project-specific — see the item 7 write-up), which still blocks this
-    same game's error-logging utility script.
+    community utility scripts assumed. Continuing the dig also fixed two more
+    real mruby gaps: bare (argument-less) `module_function` was a documented
+    no-op upstream (`3rd/mruby/src/class.c`'s own comment: `/* set MODFUNC
+    SCOPE if implemented */`) — reimplemented via `method_added`, without
+    touching the vendored core — and `Time#strftime` did not exist at all
+    (implemented in pure Ruby over `Time`'s existing component accessors).
+    **Still open, and deeper:** mruby's VM has no `$!` ("currently handled
+    exception") — `OP_EXCEPT` in vm.c copies the caught exception into a
+    bytecode register and clears `mrb->exc`, never writing it anywhere
+    Ruby-visible — so the same game's error-log utility, which reads `$!` as
+    a method's default argument and relies on bare `raise` re-raising it,
+    still crashes one step further in. Fixable only by wrapping
+    `Kernel#raise` itself (the sole point where the about-to-be-raised object
+    is observable), which would add overhead and stack depth to *every*
+    exception in the shared build across every maker and every platform
+    (PSP's stack headroom included) for what is mostly log-message fidelity
+    in one utility script — see the item 7 write-up for the full reasoning
+    on why that trade isn't taken here.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -378,24 +378,84 @@ engine's reach. `Module#private_method_defined?`/`#protected_method_defined?`/
 `#public_method_defined?` are filled in for real (mruby-metaprog already
 tracks the data `private_instance_methods` needs) rather than stubbed.
 
-**Still open: `module_function` with no arguments is a documented no-op in
-this mruby version.** CRuby's "declaration mode" `module_function` — call it
-bare, and every subsequent `def` in that scope becomes both a private
-instance method *and* a public singleton method — needs compiler-level
-"default definee" tracking that upstream mruby's own source marks
-unimplemented (`mrb_mod_module_function` in `3rd/mruby/src/class.c`: `if
-(argc == 0) { /* set MODFUNC SCOPE if implemented */ return mod; }`). The
-explicit-argument form (`module_function :name`, converting an
-already-defined method) works correctly and is what most RGSS scripts use for
-a single utility method, but a module built entirely under a bare
-`module_function` declaration — e.g. the same real game's bundled error-log
-utility, `TKG::ErrorLog`, whose `save` is only ever reachable as
-`TKG::ErrorLog.save(...)` — silently defines no singleton methods at all,
-raising `NoMethodError` the first time the game tries to call one. This is an
-upstream mruby limitation (reproduced and confirmed in isolation, not
-specific to this project's config or build), not something to patch in the
-vendored submodule for one script's sake; real content that needs it working
-would want this revisited.
+**Fixed: bare `module_function` was a documented no-op in this mruby
+version.** CRuby's "declaration mode" `module_function` — call it bare, and
+every subsequent `def` in that scope becomes both a private instance method
+*and* a public singleton method — needs compiler-level "default definee"
+tracking that upstream mruby's own source marks unimplemented
+(`mrb_mod_module_function` in `3rd/mruby/src/class.c`: `if (argc == 0) { /*
+set MODFUNC SCOPE if implemented */ return mod; }`). The explicit-argument
+form (`module_function :name`, converting an already-defined method) works
+correctly and is what most RGSS scripts use for a single utility method, but
+a module built entirely under a bare `module_function` declaration — e.g. the
+same real game's bundled error-log utility, `TKG::ErrorLog`, whose `save` is
+only ever reachable as `TKG::ErrorLog.save(...)` — silently defined no
+singleton methods at all, raising `NoMethodError` the first time the game
+tried to call one.
+
+Reimplemented without touching the vendored mruby core: `method_added` fires
+reliably for every `def` (the VM only skips calling it while it is still the
+built-in no-op — `mrb_method_added` in class.c — so overriding it once here
+costs nothing for classes that never trigger it), and the explicit-argument
+form already promotes an existing method correctly. Bare `module_function`
+now just flips a per-module flag; `method_added` — called after the method is
+already registered — hands the new name to the explicit-argument path to
+promote it, one step behind CRuby's compile-time version but the same
+result. Bare `private`/`public` (which this mruby version *does* implement
+correctly, via real per-scope visibility tracking — `find_visibility_scope`
+in class.c) end the declaration, so a script returning to ordinary instance
+methods afterward is not stuck being module_function forever. What this does
+not reproduce: CRuby's version is true lexical-scope state, reset on leaving
+the enclosing `module`/`class` body; this is a per-module flag that persists
+until explicitly turned off, so a script that reopens the *same* module later
+without an intervening bare `private` would see those methods wrongly
+promoted too — narrow in practice, since RGSS scripts overwrite this as one
+contiguous run.
+
+**Fixed: `Time#strftime` did not exist.** mruby-time uses the C library's
+`strftime()` internally for `Time#to_s`, but never bound a Ruby-level method
+taking a format string — and formatting a timestamp for a log line or a save
+filename is completely ordinary (the same error-log utility:
+`"Log/error_log" + Time.now.strftime("%Y%m%d%H%M%S") + ".txt"`). Implemented
+in pure Ruby over the component accessors `Time` already exposes
+(`year`/`mon`/`day`/`hour`/`min`/`sec`/`wday`/`yday`/`usec`/`utc_offset`),
+covering the common date/time directive set real scripts use — not the full
+CRuby spec (no `%V`/`%U`/`%W` week-of-year, no locale forms, no field-width
+modifiers). An unrecognised directive passes through literally.
+
+**Still open, and deeper than `module_function`: mruby's VM has no `$!`
+("currently handled exception") at all.** `rescue => e` binds the exception
+to the clause's own local variable, but the special global CRuby code
+routinely reads instead — `$!`, what `Exception#message`/`#backtrace`
+resolve through implicitly when a method's default argument or a nested
+`raise` (no arguments — CRuby re-raises `$!`) needs "whatever is currently
+being rescued" without it being threaded through as an explicit parameter —
+is simply never written anywhere accessible from Ruby. Traced to the VM
+opcode itself: `OP_EXCEPT` in `3rd/mruby/src/vm.c` copies the caught
+exception into a bytecode *register* (a local stack slot) and immediately
+clears `mrb->exc` to `NULL`, with no call to `mrb_gv_set` or any other
+globally-visible store. Confirmed with an isolated reproduction — even a bare
+`rescue => e; $! ...` inside the *same* method reads `nil`, so this is not
+specific to crossing a call boundary. It is why the same error-log utility's
+`save(filename = nil, exception = $!)` — called as `TKG::ErrorLog.save()`
+from directly inside `rescue; TKG::ErrorLog.save(); raise; end` — receives
+`exception = nil` and crashes on `exception.message`, one step past the
+`module_function` fix above. mruby's bare `raise` (no arguments) has the same
+root cause from the other side: real Ruby re-raises `$!`, but mruby's
+`mrb_f_raise` has no `$!` to fall back to, so a bare `raise` always raises a
+fresh, empty `RuntimeError` instead of re-raising what was actually caught.
+Both are fixable *only* by hooking `Kernel#raise` itself (there is no other
+point where the about-to-be-raised object is observable in time to stash it)
+— wrapping every `raise` call in the whole engine in an extra begin/rescue to
+capture and stash the exception before it propagates, on every platform this
+build targets, PSP included, where call-stack depth is already the tightest
+constraint. That blast radius — every exception, in every maker's runtime,
+sharing this one build — is a different order of risk than a script that
+opts into the bare `module_function` idiom or calls `Time#strftime`, for a
+fix whose payoff is mostly log-message fidelity in one utility script's
+crash handler. Left alone rather than patched; a project that genuinely needs
+`$!` semantics would want this revisited with its own scoped, targeted
+design rather than a global `raise` wrapper.
 
 ## What this means for turning the host on
 
@@ -409,5 +469,6 @@ tints, flashes and fades the screen, dissolves between scenes, unrolls and tints
 its windows, and — packed or loose — finds its graphics and its music, and
 reopens its own stock `RPG::` script sections without a superclass mismatch.
 Tilemap item 1's remaining polish (the flat "above characters" layer) is the
-only item left in the six sections above; item 7's `module_function` gap is
-the newest and, per a real release, potentially the most consequential.
+only item left in the six sections above; item 7's `$!`/bare-`raise` gap is
+the newest and, per a real release, the next (and likely last, for that one
+game's bundled utility scripts) wall.

--- a/mruby-rpgxp/mrblib/rgss_library.rb
+++ b/mruby-rpgxp/mrblib/rgss_library.rb
@@ -120,6 +120,163 @@ unless Module.method_defined?(:private_method_defined?)
   end
 end
 
+# Ruby's own bare (argument-less) `module_function` — CRuby's "declaration
+# mode", where every `def` that follows in the same scope becomes both a
+# private instance method and a public singleton method. This mruby version
+# ships the explicit-argument form (`module_function :name`, converting an
+# already-defined method — 3rd/mruby/src/class.c's `mrb_mod_module_function`)
+# but the bare form is a documented no-op there: `if (argc == 0) { /* set
+# MODFUNC SCOPE if implemented */ return mod; }`. A module built entirely
+# under a bare declaration — e.g. a bundled error-log utility whose public
+# entry point is only ever reachable as `TKG::ErrorLog.save(...)` — silently
+# defines no singleton methods at all, so the first call raises NoMethodError
+# and ends the whole script host.
+#
+# Reimplemented here without touching the vendored mruby core: mruby's
+# `method_added` hook *does* fire reliably for every `def` (the VM checks
+# whether it is still the built-in no-op before bothering to call it — see
+# `mrb_method_added` — so overriding it here has no cost for classes that
+# never trigger it), and the explicit-argument form already promotes an
+# existing method correctly. So `module_function` with no arguments just
+# flips a per-module flag, and `method_added` — called after the method is
+# already registered — hands the newly-added name to the real
+# explicit-argument path to promote it, exactly mirroring what CRuby does in
+# one step. `private`/`public` with no arguments (which this mruby build
+# implements correctly, via the same kind of scope tracking CRuby uses —
+# `find_visibility_scope` in class.c) end the declaration the same way they
+# do in CRuby, so a script that returns to normal instance methods after its
+# module-function block is not stuck being module_function forever.
+#
+# What this does not reproduce: CRuby's version is a true lexical-scope
+# state (reset on leaving the enclosing `module`/`class` body), where this is
+# a per-module flag that persists until explicitly turned off. A script that
+# reopens the *same* module later in the bundle, defining ordinary instance
+# methods without an intervening bare `private`, would see those wrongly
+# promoted too — a real gap, but a narrow one: RGSS scripts overwhelmingly
+# write a `module_function` block as one contiguous run, the way the bundled
+# utility this was found against does.
+unless Module.method_defined?(:__mrb_native_module_function)
+  class Module
+    alias_method :__mrb_native_module_function, :module_function
+
+    def module_function(*syms)
+      if syms.empty?
+        @__mrb_module_function_scope = true
+        self
+      else
+        @__mrb_module_function_scope = false
+        __mrb_native_module_function(*syms)
+      end
+    end
+
+    alias_method :__mrb_native_private, :private
+    def private(*syms)
+      @__mrb_module_function_scope = false if syms.empty?
+      __mrb_native_private(*syms)
+    end
+
+    alias_method :__mrb_native_public, :public
+    def public(*syms)
+      @__mrb_module_function_scope = false if syms.empty?
+      __mrb_native_public(*syms)
+    end
+
+    def method_added(name)
+      __mrb_native_module_function(name) if @__mrb_module_function_scope
+    end
+
+    # `module_function`/`private`/`public`/`method_added` are all private
+    # methods on `Module` in real Ruby (so e.g. `some_mod.private(:x)` from
+    # outside does not work); `def` here defaulted the overrides above to
+    # public, so restore that. This call goes through the override (explicit
+    # symbols, so it forwards straight to `__mrb_native_private`), which sets
+    # real visibility either way — the fix applies regardless of which
+    # `private` answers it.
+    private :module_function, :private, :public, :method_added
+  end
+end
+
+# Ruby's own `Time#strftime`, which this mruby build's Time (mruby-time) does
+# not expose — it uses the C library's strftime() internally for `#to_s`, but
+# never binds a Ruby-level method taking a format string, so any script that
+# formats a timestamp for a log line or a save filename (a very ordinary
+# thing to do — e.g. the same bundled error-log utility used above,
+# `"Log/error_log" + Time.now.strftime("%Y%m%d%H%M%S") + ".txt"`) hits
+# NoMethodError. Implemented in pure Ruby over the component accessors Time
+# already exposes (`year`/`mon`/`day`/`hour`/`min`/`sec`/`wday`/`yday`/
+# `usec`/`utc_offset`), covering the directives real scripts actually use —
+# the common date/time/zero-padded-numeric set, not the full CRuby spec
+# (no `%V`/`%U`/`%W` week-of-year, no locale-dependent forms, no field-width
+# modifiers). An unrecognised directive passes through literally rather than
+# raising, matching how a real `strftime("%Q")` degrades on an unknown
+# specifier being kinder than crashing the whole script host over a log
+# timestamp.
+unless Time.method_defined?(:strftime)
+  class Time
+    MONTHNAMES = [nil, "January", "February", "March", "April", "May", "June",
+                  "July", "August", "September", "October", "November",
+                  "December"].freeze
+    ABBR_MONTHNAMES = MONTHNAMES.map { |m| m && m[0, 3] }.freeze
+    DAYNAMES = %w[Sunday Monday Tuesday Wednesday Thursday Friday
+                  Saturday].freeze
+    ABBR_DAYNAMES = DAYNAMES.map { |d| d[0, 3] }.freeze
+
+    def strftime(fmt)
+      out = +""
+      i = 0
+      while i < fmt.length
+        c = fmt[i]
+        if c != "%" || i == fmt.length - 1
+          out << c
+          i += 1
+          next
+        end
+        spec = fmt[i + 1]
+        i += 2
+        case spec
+        when "Y" then out << year.to_s
+        when "y" then out << format("%02d", year % 100)
+        when "m" then out << format("%02d", mon)
+        when "d" then out << format("%02d", day)
+        when "e" then out << format("%2d", day)
+        when "H" then out << format("%02d", hour)
+        when "I" then out << format("%02d", ((hour % 12).zero? ? 12 : hour % 12))
+        when "M" then out << format("%02d", min)
+        when "S" then out << format("%02d", sec)
+        when "L" then out << format("%03d", usec / 1000)
+        when "N" then out << format("%09d", usec * 1000)
+        when "j" then out << format("%03d", yday)
+        when "p" then out << (hour < 12 ? "AM" : "PM")
+        when "P" then out << (hour < 12 ? "am" : "pm")
+        when "A" then out << DAYNAMES[wday]
+        when "a" then out << ABBR_DAYNAMES[wday]
+        when "B" then out << MONTHNAMES[mon]
+        when "b", "h" then out << ABBR_MONTHNAMES[mon]
+        when "z"
+          off = utc_offset
+          sign = off < 0 ? "-" : "+"
+          off = off.abs
+          out << format("%s%02d%02d", sign, off / 3600, (off / 60) % 60)
+        when "Z" then out << zone.to_s
+        when "%" then out << "%"
+        when "n" then out << "\n"
+        when "t" then out << "\t"
+        when "F" then out << strftime("%Y-%m-%d")
+        when "T", "X" then out << strftime("%H:%M:%S")
+        when "D", "x" then out << strftime("%m/%d/%y")
+        when "s" then out << to_i.to_s
+        else
+          # Unrecognised: pass the directive through literally rather than
+          # raising or silently dropping it, so the mistake is visible in the
+          # output instead of ending the script host.
+          out << "%" << spec.to_s
+        end
+      end
+      out
+    end
+  end
+end
+
 # Ruby's own `String#encode`, which this mruby build does not ship (no
 # mruby-encoding gem is vendored or configured — mruby strings carry no
 # per-instance encoding metadata at all). A Japanese project's scripts

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -580,4 +580,3 @@ assert "eval, Fiber and Kernel#exit / SystemExit are available for the script ho
   assert_equal :frame, f.resume
   assert_equal :done, f.resume
 end
-

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -361,6 +361,36 @@ assert "Module visibility-filtered method_defined? variants answer correctly" do
   assert_false m.private_method_defined?(:nope)
 end
 
+# Bare (argument-less) module_function -- CRuby's "declaration mode", where
+# every `def` that follows in the same scope becomes both a private instance
+# method and a public singleton method. Reimplemented via method_added (see
+# the comment above `class Module` / `alias_method :__mrb_native_module_
+# function` in rgss_library.rb, next to the private_method_defined? fix
+# above); the explicit-argument form (module_function :name) is native and
+# unchanged. A real bundled error-log utility script defines its entire
+# public surface (only ever reachable as `TKG::ErrorLog.save(...)`) this way.
+assert "bare module_function promotes subsequent defs to singleton methods" do
+  m = Module.new
+  m.module_eval do
+    module_function
+    def foo(x); x * 2; end
+    def bar(x); x * 3; end
+    public
+    def baz(x); x * 4; end
+  end
+
+  assert_equal 6, m.foo(3)
+  assert_equal 9, m.bar(3)
+  # `public` (bare) ends the module_function declaration, same as in CRuby --
+  # baz is an ordinary instance method, not reachable on the module itself.
+  assert_false m.respond_to?(:baz), "baz should not have become a module function"
+  assert_true m.respond_to?(:foo)
+  # module_function's own explicit-argument form still keeps working.
+  n = Module.new
+  n.module_eval { def qux(x); x + 1; end; module_function :qux }
+  assert_equal 6, n.qux(5)
+end
+
 # Win32API: real games bind Windows-only DLL calls unconditionally at script
 # load time (a very common pattern for an *optional* feature, e.g. CACAO's
 # widely bundled screenshot-saving utility binds MultiByteToWideChar/
@@ -507,6 +537,28 @@ assert "Time is available for the script host" do
   assert_true Time.at(1) > epoch
 end
 
+# strftime, filled in above in rgss_library.rb (mruby-time has no such method
+# — see the comment on `class Time` there). A real bundled utility script
+# (an error logger) formats both a save filename and a log line with it.
+assert "Time#strftime covers the directives real scripts use" do
+  # 2024-03-05 09:07:03 UTC, a Tuesday (picked so month/day/hour/minute/second
+  # are all distinguishable from each other and none needs padding dropped).
+  t = Time.utc(2024, 3, 5, 9, 7, 3)
+  assert_equal "20240305090703", t.strftime("%Y%m%d%H%M%S")
+  assert_equal "2024-03-05T09:07:03", t.strftime("%Y-%m-%dT%H:%M:%S")
+  assert_equal "24", t.strftime("%y")
+  assert_equal "Tue", t.strftime("%a")
+  assert_equal "Tuesday", t.strftime("%A")
+  assert_equal "Mar", t.strftime("%b")
+  assert_equal "March", t.strftime("%B")
+  assert_equal "AM", t.strftime("%p")
+  assert_equal "09:07:03", t.strftime("%T")
+  assert_equal "2024-03-05", t.strftime("%F")
+  assert_equal "100%done", t.strftime("100%%done")
+  # An unrecognised directive passes through literally rather than raising.
+  assert_equal "%Q", t.strftime("%Q")
+end
+
 assert "eval, Fiber and Kernel#exit / SystemExit are available for the script host" do
   # mruby-eval is what makes the whole host possible; script_host.rb calls
   # Kernel#eval unconditionally because this gem is a hard dependency
@@ -528,3 +580,4 @@ assert "eval, Fiber and Kernel#exit / SystemExit are available for the script ho
   assert_equal :frame, f.resume
   assert_equal :done, f.resume
 end
+


### PR DESCRIPTION
## Summary

Continues digging into the real VX Ace release from #1074, past the `RPG::BaseItem` superclass fix, into that game's own bundled community utility scripts. Two more real mruby gaps found, both fixed without touching the vendored mruby core:

- **Bare (argument-less) `module_function` was a documented no-op.** CRuby's "declaration mode" — call it bare, and every `def` that follows in the same scope becomes both a private instance method *and* a public singleton method — needs compiler-level "default definee" tracking that upstream mruby's own source literally marks unimplemented (`3rd/mruby/src/class.c`: `if (argc == 0) { /* set MODFUNC SCOPE if implemented */ return mod; }`). A module built entirely under a bare declaration — the same real game's bundled error-log utility, whose public entry point is only ever reachable as `TKG::ErrorLog.save(...)` — silently defined no singleton methods at all, so the first call raised `NoMethodError`.

  Reimplemented via `method_added` (which fires reliably for every `def` — the VM only skips calling it while it's still the built-in no-op, so overriding it once costs nothing elsewhere) combined with mruby's already-correct explicit-argument form. Bare `private`/`public` (which this mruby version does implement correctly, via real per-scope visibility tracking) end the declaration, matching CRuby.

- **`Time#strftime` did not exist.** mruby-time uses the C library's `strftime()` internally for `#to_s` but never bound a Ruby-level method taking a format string — so formatting a timestamp for a log line or save filename (completely ordinary) raised `NoMethodError`. Implemented in pure Ruby over `Time`'s existing component accessors, covering the common directive set real scripts use.

**Documented but explicitly not fixed**: continuing past both fixes, the same utility script's `exception = $!` default argument (and its own bare `raise` re-raise) surfaced that mruby's VM has no `$!` at all — `OP_EXCEPT` in `vm.c` copies the caught exception into a bytecode register and clears `mrb->exc`, never writing it anywhere Ruby-visible. Confirmed in isolation (even a same-method `rescue => e; $!` reads nil). The only fix point is wrapping `Kernel#raise` itself, which would add overhead and stack depth to *every* exception in the shared build, across every maker and every platform this engine targets — PSP's tight stack headroom included — for what's mostly log-message fidelity in one utility script's crash handler. Not a trade taken here; full reasoning in `docs/rpgvx-rgss-api-gap.md` item 7.

## Test plan
- [x] `./build/mruby/host/bin/mrbtest` — all passing, includes new regression tests for both fixes
- [x] `ruby scripts/rpgxp_testbed_check.rb data/PrayforYou` — OK
- [x] `ruby scripts/rpgvx_testbed_check.rb` — OK
- [x] `ruby scripts/rpgxp_script_host_check.rb` — OK (also proves the module_function/strftime additions don't break under real CRuby, which this script loads `rgss_library.rb` into)
- [x] `bash scripts/rpgxp_boot_check.bash` against both `data/OpenGame.exe/Testbed/XP` and `data/PrayforYou` — move/menu/battle/save all still pass
- [x] `bash scripts/rgssad_asset_check.bash` — OK
- [x] `bash scripts/mz_boot_check.bash` — OK (confirms no regression on the shared build's MZ/JS side)
- [x] Manual: the real VX Ace release now gets one script section further (past `TKG::ErrorLog.save` being callable at all) before hitting the newly-diagnosed `$!` wall
- [x] `docs/TODO.md` and `docs/rpgvx-rgss-api-gap.md` updated with the full diagnosis for both fixes and the new open item


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_