### PR TITLE
events: Enable Combo requires the actor to be in the current party

### DIFF
--- a/changelog.d/enable-combo-requires-party-membership.fixed.md
+++ b/changelog.d/enable-combo-requires-party-membership.fixed.md
@@ -1,0 +1,4 @@
+- **RPG2003 events:** Enable Combo (1007) no longer arms a battle combo on a
+  roster actor who isn't currently in the active party, matching RPG_RT --
+  unlike every other fixed-id battle-page command, Enable Combo specifically
+  requires the named actor to be a current party member.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15133,6 +15133,41 @@ above are repeated here)
   party` runs, and a subsequent fight's own `Combatant` reads no combo
   bonus at all), confirmed to fail against the pre-fix code before the
   fix.
+  ✅ **Follow-up (2026-08-19): Enable Combo skipped RPG_RT's own "actor must
+  be a current party member" gate, unlike every other fixed-id battle-page
+  command — a combo targeted at a roster actor who simply wasn't in the
+  active party was armed anyway.** Confirmed directly against RPG_RT's
+  live source: `Game_Interpreter_Battle::CommandEnableCombo` (`src/
+  game_interpreter_battle.cpp`) is `if (!Main_Data::game_party->
+  IsActorInParty(actor_id)) { return true; }`, checked before
+  `Game_Actors::GetActor` is even consulted — unlike Change Class, Change
+  Battle Commands, and Change Actor Name/Title/Sprite/Face, which all
+  resolve their fixed-id actor through the roster alone (so an away
+  companion is still renamed/re-dressed/re-classed and has it waiting when
+  they rejoin, `Interpreter#identity_target`'s own doc comment), Enable
+  Combo is the *one* identity-targeted command with this extra membership
+  requirement. `IsActorInParty` appears in exactly one other place in the
+  whole reference — the Conditional Branch "actor in party" test, already
+  correctly ported as `Game::Party#include_actor?` and wired to that
+  command — confirming this is a narrow, deliberate exception rather than
+  a general rule this port simply generalized correctly elsewhere.
+  `Interpreter#do_enable_combo` reused `#identity_target` unmodified, the
+  same roster-only resolution every *other* identity command correctly
+  uses, so a combo named by a genuine roster actor id who wasn't currently
+  in the party was armed anyway — and since nothing clears a `battle_combo`
+  for an actor who was never `@allies` in the fight that armed it (the
+  fix directly above this one only clears it for actual fight
+  participants), it sat unconsumed until that actor eventually joined the
+  party for real, at which point it would incorrectly fire in a battle
+  real RPG_RT never armed it for at all. Fixed by adding `return unless
+  party.include_actor?(cmd.param(0))` ahead of the existing roster lookup.
+  Covered by rewriting the existing `scripts/rpg2k_logic_check.rb` check,
+  which had used a dangling id (99, absent from the fake database
+  entirely) that only exercised the pre-existing "no such actor in the
+  roster at all" nil-guard, not this membership gate — replaced with a
+  genuine second roster actor who exists but is deliberately left out of
+  the active party, confirmed to fail against the pre-fix code (`expected
+  nil, got {command_id: 1, multiple: 2}`) before the fix.
   ✅ **A living-but-afflicted party member's own alternate-battle-layout
   sprite (RPG2003's per-actor battler graphic, `db.battleranimations`) now
   shows that state's own configured pose, not always plain Idle

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2650,15 +2650,31 @@ module Game
     end
 
     # Enable Combo (1007), RPG2003-only: arm actor param0's battle command param1
-    # to repeat param2 times. The actor is named by id, so it resolves through the
-    # roster like the other fixed-id commands. Recorded on the actor; the battle
-    # resolution spends it -- a combo'd attack or skill hits `multiple` times
-    # (Game::Battle#combo_hits, ADR 0054's combo work; EasyRPG's
-    # `ProcessBattleActionCombo`). Matches EasyRPG's own `Game_Interpreter_Battle::
-    # CommandEnableCombo` (src/game_interpreter_battle.cpp), the same
-    # `IsRPG2k3Commands()` gate as Force Flee above.
+    # to repeat param2 times. Recorded on the actor; the battle resolution spends
+    # it -- a combo'd attack or skill hits `multiple` times (Game::Battle
+    # #combo_hits, ADR 0054's combo work; EasyRPG's `ProcessBattleActionCombo`).
+    # Matches EasyRPG's own `Game_Interpreter_Battle::CommandEnableCombo`
+    # (src/game_interpreter_battle.cpp), the same `IsRPG2k3Commands()` gate as
+    # Force Flee above -- but unlike every *other* fixed-id command in this
+    # group (Change Class, Change Battle Commands, Change Actor Name/Title/
+    # Sprite/Face), which all resolve through the roster alone
+    # (`#identity_target`'s own doc comment) so an away companion is still
+    # affected, this one command additionally requires the named actor to be a
+    # *current* party member: `if (!Main_Data::game_party->IsActorInParty
+    # (actor_id)) { return true; }`, checked before `Game_Actors::GetActor` is
+    # even consulted. `IsActorInParty` appears in exactly one other place in
+    # the whole reference (the Conditional Branch "actor in party" test,
+    # already ported as `Game::Party#include_actor?` and wired to that
+    # command) -- this is its only other call site, and it was never carried
+    # over here. A combo armed on a bench/unrecruited actor id used to be
+    # recorded anyway, sitting on `Actor#battle_combo` unconsumed (nothing
+    # clears a combo for an actor who was never `@allies` in the fight that
+    # armed it) until they eventually joined the party for real, at which
+    # point it would incorrectly fire in a battle real RPG_RT never armed it
+    # for at all.
     def do_enable_combo(cmd)
       return unless @battle && @state.party.rpg2003?
+      return unless party.include_actor?(cmd.param(0))
       actor = identity_target(cmd)
       return unless actor
       actor.set_battle_combo(cmd.param(1), cmd.param(2))

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -16854,16 +16854,38 @@ check 'Force Flee target 1 empties the troop and ends the fight' do
   eq :victory, b.result
 end
 
-check 'Enable Combo arms a battle combo on a party actor' do
-  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
-                       [1], rpg2003: true)
+# Unlike every *other* fixed-id battle-page command (Change Class, Change
+# Battle Commands, Change Actor Name/Title/Sprite/Face -- see
+# `Interpreter#identity_target`'s own doc comment), which all resolve
+# through the roster alone so an away companion is still affected, Enable
+# Combo additionally requires the named actor to be a *current* party
+# member. Confirmed directly against RPG_RT's live source:
+# `Game_Interpreter_Battle::CommandEnableCombo` (`src/
+# game_interpreter_battle.cpp`) is `if (!Main_Data::game_party->
+# IsActorInParty(actor_id)) { return true; }`, checked before
+# `Game_Actors::GetActor` is even consulted -- `IsActorInParty` appears in
+# exactly one other place in the whole reference (the Conditional Branch
+# "actor in party" test, already ported as `Game::Party#include_actor?`),
+# and this is its only other call site. A combo targeted at a genuine
+# roster actor (id 2 below, unlike the old id-99 fixture this check used to
+# name, which merely tested a dangling roster lookup no different from any
+# other identity command's own nil-guard) who simply isn't in the current
+# party used to be armed anyway.
+check 'Enable Combo arms a battle combo on a party actor, but not on a ' \
+      'roster actor who is not currently in the party' do
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100),
+                         2 => FakePlayerRow.new('Bench', '', 0, 5, max_hp: 100) },
+                       [1], rpg2003: true) # only actor 1 is in the active party
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   it = Game::Interpreter.new(st)
   it.battle = battle_with
+  ok !st.party.include_actor?(2), 'sanity: actor 2 exists in the roster but is not in the party'
   it.start([FakeCmd.new(IC::ENABLE_COMBO, [1, 4, 3]),
-            FakeCmd.new(IC::ENABLE_COMBO, [99, 1, 2])]) # not in the party
+            FakeCmd.new(IC::ENABLE_COMBO, [2, 1, 2])]) # a genuine roster actor, just not in the party
   it.update
   eq({ command_id: 4, multiple: 3 }, st.party.actor_by_id(1).battle_combo)
+  eq nil, st.party.roster[2].battle_combo,
+     'a roster actor who is not currently in the party is never armed'
 end
 
 check 'Call Common Event runs the common event and returns to the page' do


### PR DESCRIPTION
## Summary
- `Game_Interpreter_Battle::CommandEnableCombo` (`src/game_interpreter_battle.cpp`) checks `if (!Main_Data::game_party->IsActorInParty(actor_id)) { return true; }` before `Game_Actors::GetActor` is even consulted — unlike Change Class, Change Battle Commands, and Change Actor Name/Title/Sprite/Face, which all resolve their fixed-id actor through the roster alone (so an away companion is still affected), Enable Combo is the one identity-targeted command with this extra membership requirement. `IsActorInParty` appears in exactly one other place in the whole reference (the Conditional Branch "actor in party" test, already correctly ported as `Game::Party#include_actor?`).
- `Interpreter#do_enable_combo` reused `#identity_target` unmodified — the same roster-only resolution every *other* identity command correctly uses — so a combo named by a genuine roster actor id who wasn't currently in the party was armed anyway. Since nothing clears a `battle_combo` for an actor who was never `@allies` in the fight that armed it, it sat unconsumed until that actor eventually joined the party for real, at which point it would incorrectly fire in a battle real RPG_RT never armed it for.
- Fixed by adding `return unless party.include_actor?(cmd.param(0))` ahead of the existing roster lookup.
- Documented in `docs/TODO.md` as a follow-up to the sibling battle-combo-persistence fix, with full RPG_RT/EasyRPG citations.

## Test plan
- [x] Rewrote the existing `scripts/rpg2k_logic_check.rb` check, which had used a dangling id (99, absent from the fake database entirely) that only exercised the pre-existing "no such actor in the roster at all" nil-guard — replaced with a genuine second roster actor who exists but is deliberately left out of the active party.
- [x] Confirmed the rewritten check fails against the pre-fix code (`git stash` on `interpreter.rb` only) with `expected nil, got {command_id: 1, multiple: 2}`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1060 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 766 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_