### PR TITLE
battle: Conditional Branch's "Hero uses the ... command" test now works

### DIFF
--- a/changelog.d/battle-conditional-branch-command-test.fixed.md
+++ b/changelog.d/battle-conditional-branch-command-test.fixed.md
@@ -1,0 +1,4 @@
+- **RPG2003 battle events:** The Conditional Branch (Battle) command's "Hero
+  uses the ... command" test now actually works, matching RPG_RT --
+  previously it always reported false regardless of the actor's chosen
+  command. Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13014,6 +13014,44 @@ not yet verified:
   editor always emits), and a combatant killed by plain HP loss (no
   explicit state ever inflicted) still fails it too — both confirmed to
   fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-19): the same command's test 5 ("Hero uses the
+  ... command") is now implemented too, correcting this entry's own stale
+  claim that it "reads live battle-UI state the runtime does not
+  model."** Confirmed directly against RPG_RT's live source: `Game_
+  Interpreter_Battle::CommandConditionalBranchBattle`'s `case 5` (`src/
+  game_interpreter_battle.cpp`) is `if (Player::IsRPG2k3Commands() &&
+  current_actor_id == com.parameters[1]) { ... result = actor->
+  GetLastBattleAction() == com.parameters[2]; }`, where `current_actor_id`
+  is set once per action, right before that action's own pre-action page
+  events run (`Scene_Battle_Rpg2k3::ProcessBattleActionBegin` calling
+  `interp.SetCurrentActingActorId(actor->GetId())` on the battle's single
+  shared interpreter). This turned out to need nothing new at all:
+  `Game::Battle#actor_command` (`mruby-rpg2k/mrblib/game.rb`) already
+  implements the identical actor-id-plus-source check, ported for the
+  page-level `command_actor` trigger condition the bullet just above this
+  one fixed — and `Scene::Battle#run_battle_events`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) already computes and threads the
+  exact per-battler `source` that check needs, right where it hands the
+  page's own commands to the interpreter (`ui[:events].battle =
+  ui[:battle]`) — it just never also handed that `source` to the
+  interpreter itself, so the in-body Conditional Branch command had no way
+  to read it. Fixed with a new `Interpreter#battle_source` accessor, set
+  alongside `#battle` in `#run_battle_events`, and a new `Interpreter
+  #battle_command_condition(cmd)` (`when 5` in `#eval_battle_condition`)
+  that simply calls `@battle.actor_command(cmd.param(1), battle_source) ==
+  cmd.param(2)` — reusing the existing method rather than duplicating its
+  logic. Test 4 ("the currently-targeted troop member is param1") remains
+  genuinely unimplemented: it needs the acting battler's queued
+  single-enemy target index (`target_enemy_index`/`targets_single_enemy`,
+  also set in `ProcessBattleActionBegin`), which has no counterpart
+  anywhere in this codebase yet — a distinct, separate piece of state from
+  `source` alone, left as its own follow-up. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (no `battle_source` set -- the else
+  branch runs; the acting battler's own chosen command matches; a
+  different command id on the same source does not; a source that is not
+  the named actor never matches), confirmed to fail against the pre-fix
+  code (`NoMethodError: undefined method 'battle_source='`) before the
+  fix.
 - ✅ **"Hero X is in the party" always addresses by database ID, not
   current seat/slot order; there is no built-in way to read a member's
   current seat position — confirmed correct.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -255,6 +255,17 @@ module Game
     # screen to notice on some later redraw. nil outside battle (same scope as
     # `@battle`), so the notification is a no-op there.
     attr_accessor :battle_screen
+    # The battler a *per-battler* battle-event page run happens for -- the
+    # same `source` `Scene::Battle#run_battle_events` already threads
+    # through to `Game::BattlePage.active?`'s own `command_actor`/`turn_*`
+    # gating (its own doc comment: "the battle's own #acting_battler at a
+    # battler's action boundary"), set alongside `@battle` so the page's own
+    # in-body Conditional Branch (Battle) command can read it too -- see
+    # `#battle_command_condition`. nil for a round-boundary page check (the
+    # only kind RPG2000's own battle scene ever has) and for a map/common
+    # event, both of which read as "no source" the same way `Game::Battle
+    # #actor_command` already does.
+    attr_accessor :battle_source
     # Answers tile queries for Store Terrain / Event ID: responds to
     # `terrain_id(x, y)` and `event_id_at(x, y)`. Set by the owning scene; nil
     # makes those commands store 0 (the map is not queryable without it).
@@ -2745,9 +2756,7 @@ module Game
     #   3 troop member param1 can act
     #   4 the currently-targeted troop member is param1
     #   5 actor param1's chosen command is param2
-    # Tests 4 and 5 read live battle-UI state the runtime does not model; they
-    # report false rather than guessing, so the else branch runs. Confirmed
-    # against EasyRPG's actual C++ source, fetched live:
+    # Confirmed against EasyRPG's actual C++ source, fetched live:
     # `Game_Interpreter_Battle::CommandConditionalBranchBattle`
     # (`src/game_interpreter_battle.cpp`) reads only `com.parameters[1]` (the
     # actor/enemy id) for cases 2 and 3 -- `result = actor->CanAct();` /
@@ -2759,6 +2768,20 @@ module Game
     # actor; "is present" / "afflicted by state" for an enemy) that has no
     # counterpart in the real command at all -- see #battle_actor_condition
     # for why.
+    #
+    # Test 5 is now implemented too -- see #battle_command_condition; it
+    # turned out to already have everything it needs (`Combatant#
+    # last_battle_action`, and `Game::Battle#actor_command`'s identical
+    # actor-id-plus-source check, already correct for the page-level
+    # `command_actor` trigger condition), just never threaded from
+    # `#run_battle_events`'s own `source` through to the interpreter that
+    # actually runs the page's in-body commands. Test 4 ("the currently-
+    # targeted troop member is param1") remains unimplemented: RPG_RT's own
+    # `target_enemy_index`/`targets_single_enemy` (set in `Scene_Battle_
+    # Rpg2k3::ProcessBattleActionBegin`, right before a page's pre-action
+    # events run) has no counterpart anywhere in this codebase yet -- a
+    # narrower, separate piece of state than `source` alone provides, left
+    # as its own follow-up.
     def do_conditional_battle(cmd)
       return if eval_battle_condition(cmd)
       skip_to([Cmd::ELSE_BRANCH_B, Cmd::END_BRANCH_B], cmd.indent)
@@ -2775,6 +2798,7 @@ module Game
         compare(variables[cmd.param(1)], rhs, cmd.param(4))
       when 2 then battle_actor_condition(cmd)
       when 3 then battle_enemy_condition(cmd)
+      when 5 then battle_command_condition(cmd)
       else false
       end
     end
@@ -2824,6 +2848,27 @@ module Game
     def battle_enemy_condition(cmd)
       foe = @battle && @battle.enemy(cmd.param(1))
       foe ? !foe.dead? && !@battle.do_nothing_restricted?(foe) : false
+    end
+
+    # Whether actor `cmd.param(1)`'s chosen command this round is
+    # `cmd.param(2)` -- EasyRPG's `Game_Interpreter_Battle::
+    # CommandConditionalBranchBattle` case 5, `if (Player::
+    # IsRPG2k3Commands() && current_actor_id == com.parameters[1]) { ...
+    # result = actor->GetLastBattleAction() == com.parameters[2]; }`, where
+    # `current_actor_id` is the acting battler for whichever action's own
+    # pre-action page events are running right now (`Scene_Battle_Rpg2k3::
+    # ProcessBattleActionBegin`). `#battle_source` is this port's own
+    # counterpart -- `#run_battle_events`'s own per-battler `source`,
+    # threaded onto the interpreter alongside `@battle` -- and `Game::Battle
+    # #actor_command` already implements the identical actor-id-plus-source
+    # check (ported for the page-level `command_actor` trigger condition),
+    # so this reuses it rather than duplicating the logic. A round-boundary
+    # page check (no source at all -- the only kind RPG2000's own battle
+    # scene ever has) or a page run for a *different* battler both read as
+    # "no match" the same way `#actor_command`'s own early returns do.
+    def battle_command_condition(cmd)
+      return false unless @battle
+      @battle.actor_command(cmd.param(1), battle_source) == cmd.param(2)
     end
 
     # -- conditional branch ---------------------------------------------------

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2309,6 +2309,7 @@ class RPG2k
         cmds = entry[1].event
         return run_battle_events(return_phase, source) if cmds.nil? || cmds.empty? # empty page: try the next
         ui[:events].battle = ui[:battle]
+        ui[:events].battle_source = source
         ui[:events].start(cmds)
         ui[:event_return_phase] = return_phase
         ui[:phase] = :event

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -16619,6 +16619,57 @@ check 'battle Conditional Branch actor sub-test 3 (can use battle command) match
   eq 1, st.variables[1], '...yet a confused ally likewise still "can act"'
 end
 
+# Test 5 ("actor uses the ... command") was previously left unimplemented
+# (docs/TODO.md), reporting false rather than reading live state the
+# runtime supposedly did not model -- but it turns out to need nothing new
+# at all: `Game::Battle#actor_command` already implements the identical
+# actor-id-plus-source check for the page-level `command_actor` trigger
+# condition (see the `command_actor`/`turn_*` checks above), and
+# `Interpreter#battle_source` is just that same `source`
+# `#run_battle_events` already threads through, now also set on the
+# interpreter that runs the page's own in-body commands.
+check 'battle Conditional Branch test 5 (actor uses the ... command) reads ' \
+      'Interpreter#battle_source' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.actor = FakeSourceActor.new(1)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  branch = lambda do |params|
+    [FakeCmd.new(IC::CONDITIONAL_B, params, indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+     FakeCmd.new(IC::ELSE_BRANCH_B, [], indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+     FakeCmd.new(IC::END_BRANCH_B, [], indent: 0)]
+  end
+  hero.last_battle_action = 3
+
+  # No source at all (a round-boundary check, the only kind RPG2000's own
+  # battle scene ever has) -- the condition cannot be answered.
+  it.start(branch.call([5, 1, 3]))
+  it.update
+  eq 2, st.variables[1], 'no battle_source set -- the else branch runs'
+
+  # The source is the named actor, whose chosen command matches.
+  it.battle_source = hero
+  it.start(branch.call([5, 1, 3]))
+  it.update
+  eq 1, st.variables[1], 'the acting battler who chose command 3 satisfies the condition'
+
+  # Same source, but a different command id.
+  it.start(branch.call([5, 1, 4]))
+  it.update
+  eq 2, st.variables[1], 'a different command id does not match'
+
+  # The source is a battler other than the one named -- must not match either.
+  it.battle_source = slime
+  it.start(branch.call([5, 1, 3]))
+  it.update
+  eq 2, st.variables[1], 'a source that is not the named actor never matches'
+end
+
 # Confirmed against EasyRPG's actual C++ source, fetched live:
 # `Game_Interpreter_Battle::CommandConditionalBranchBattle`
 # (src/game_interpreter_battle.cpp) reads only `com.parameters[1]` for its


### PR DESCRIPTION
## Summary
- `Game_Interpreter_Battle::CommandConditionalBranchBattle`'s `case 5` (`src/game_interpreter_battle.cpp`) is `if (Player::IsRPG2k3Commands() && current_actor_id == com.parameters[1]) { ... result = actor->GetLastBattleAction() == com.parameters[2]; }`, where `current_actor_id` is set once per action, right before that action's own pre-action page events run.
- This turned out to need nothing new at all: `Game::Battle#actor_command` already implements the identical actor-id-plus-source check, ported for the page-level `command_actor` trigger condition — and `Scene::Battle#run_battle_events` already computes and threads the exact per-battler `source` that check needs, right where it hands the page's own commands to the interpreter. It just never also handed that `source` to the interpreter itself, so the in-body Conditional Branch command had no way to read it.
- Fixed with a new `Interpreter#battle_source` accessor, set alongside `#battle` in `#run_battle_events`, and a new `Interpreter#battle_command_condition(cmd)` (`when 5` in `#eval_battle_condition`) that reuses `Game::Battle#actor_command` rather than duplicating its logic.
- Test 4 ("the currently-targeted troop member is param1") remains genuinely unimplemented — it needs the acting battler's queued single-enemy target index, which has no counterpart anywhere in this codebase yet, a distinct piece of state from `source` alone. Left as its own documented follow-up.
- Corrected this file's own stale claim ("reads live battle-UI state the runtime does not model") that predated this fix.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: no `battle_source` set → the else branch runs; the acting battler's own chosen command matches; a different command id on the same source does not; a source that is not the named actor never matches.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `interpreter.rb`/`scene/battle.rb` only) with `NoMethodError: undefined method 'battle_source='`, and passes after the fix.
- [x] Full suite: `ruby scripts/rpg2k_logic_check.rb` — 1061 checks passed.
- [x] Full suite: `ruby scripts/rpg2k_scene_check.rb` — 766 checks passed, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_