### PR TITLE
fix(rgss): Dir.glob, Color/Tone zero-arg construction, and a second LVGL heap bump

### DIFF
--- a/changelog.d/desktop-lvgl-heap-512mb.changed.md
+++ b/changelog.d/desktop-lvgl-heap-512mb.changed.md
@@ -1,0 +1,9 @@
+- **Desktop build** the LVGL memory pool grows again, 256 MB → 512 MB (see
+  `changelog.d/desktop-lvgl-heap-256mb.changed.md` for why it backs
+  everything, not just graphics). The first bump only covered a real VX Ace
+  release's database load; past that and the `Dir.glob`/`Color`/`Tone` fixes
+  in this same release, the script host reaches actual scene construction —
+  the title screen's own windows, sprites and bitmaps — a second, larger
+  consumer 256 MB did not cover, aborting with `NoMemoryError` mid-boot even
+  with a fully loaded database. The PSP and Wio builds keep their own
+  separately-tuned pools; this only raises the desktop ceiling.

--- a/changelog.d/mruby-dir-glob.added.md
+++ b/changelog.d/mruby-dir-glob.added.md
@@ -1,0 +1,9 @@
+- **XP / VX / VX Ace** `Dir.glob` now works. The vendored `mruby-dir` gem
+  never implements it at any layer — only `#each`/`#each_child`/`.foreach`/
+  `.open`/`.chdir` — so a real project's stock `DataManager` (the
+  Continue-screen check, `Dir.glob('Save0*.rvdata2')`), `Game_System` (a
+  shared options file) and a released game's own packed-vs-unpacked check
+  (`Dir.glob('Game.rgss3a')`) all failed the script host with
+  `NoMethodError` before a single frame drew. Implemented in pure Ruby over
+  `Dir.entries` and a glob → `Regexp` translator covering literal names,
+  `*`, `?` and `[...]` character classes.

--- a/changelog.d/rgss-color-tone-zero-arg-construction.fixed.md
+++ b/changelog.d/rgss-color-tone-zero-arg-construction.fixed.md
@@ -1,0 +1,10 @@
+- **XP / VX / VX Ace** `RGSS::Color.new` and `RGSS::Tone.new` no longer
+  require arguments. This was a bug in the engine's own native binding, not
+  a script gap: real RGSS3's stock, unmodified `Game_Screen#clear_tone` /
+  `#clear_flash` — present in every VX Ace project's default
+  `Scripts.rvdata2` — call `Tone.new` and `Color.new` with zero arguments,
+  relying on every component defaulting to 0. The native constructors
+  wrongly demanded 3 required arguments, so `ArgumentError: wrong number of
+  arguments (given 0, expected 3..4)` fired on every VX Ace game that
+  constructs a `Game_Screen` — in practice, every VX Ace game the script
+  host boots far enough to reach it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16212,18 +16212,35 @@ screen (544×416). Full rationale:
     SCOPE if implemented */`) — reimplemented via `method_added`, without
     touching the vendored core — and `Time#strftime` did not exist at all
     (implemented in pure Ruby over `Time`'s existing component accessors).
+    Continuing further, past a `NoMemoryError` the game's own error-log
+    utility could not report either (same `$!` gap, see below): the desktop
+    LVGL heap needed a second bump, 256 MB → 512 MB, this time for scene
+    construction rather than database load; `Dir.glob` turned out to not
+    exist anywhere in the vendored `mruby-dir` gem at all (fixed in pure
+    Ruby over `Dir.entries`), which blocked the stock `DataManager`'s own
+    Continue-screen check; and `Color.new`/`Tone.new` wrongly required 3
+    arguments in `mruby-rgss`'s native binding, when RGSS3's own stock
+    `Game_Screen#clear_tone`/`#clear_flash` — in *every* VX Ace project, not
+    a community script — call both with zero, which is likely the single
+    most-hit gap of the lot since it fires on any VX Ace game reaching
+    `Game_Screen.new`.
     **Still open, and deeper:** mruby's VM has no `$!` ("currently handled
     exception") — `OP_EXCEPT` in vm.c copies the caught exception into a
     bytecode register and clears `mrb->exc`, never writing it anywhere
     Ruby-visible — so the same game's error-log utility, which reads `$!` as
     a method's default argument and relies on bare `raise` re-raising it,
-    still crashes one step further in. Fixable only by wrapping
-    `Kernel#raise` itself (the sole point where the about-to-be-raised object
-    is observable), which would add overhead and stack depth to *every*
-    exception in the shared build across every maker and every platform
-    (PSP's stack headroom included) for what is mostly log-message fidelity
-    in one utility script — see the item 7 write-up for the full reasoning
-    on why that trade isn't taken here.
+    crashes on *every* fatal exception the game hits, masking each one in
+    turn behind the same `NoMethodError: undefined method 'message' for
+    NilClass`. All three fixes above were found this way — a temporary,
+    never-committed VM-level probe read the real masked exception one at a
+    time. A fourth is already known this way and not yet fixed:
+    `NoMethodError: undefined method 'dispose' for NilClass`. Fixable only
+    by wrapping `Kernel#raise` itself (the sole point where the
+    about-to-be-raised object is observable), which would add overhead and
+    stack depth to *every* exception in the shared build across every maker
+    and every platform (PSP's stack headroom included) for what is mostly
+    log-message fidelity in one utility script — see the item 7 write-up for
+    the full reasoning on why that trade isn't taken here.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -423,6 +423,56 @@ covering the common date/time directive set real scripts use — not the full
 CRuby spec (no `%V`/`%U`/`%W` week-of-year, no locale forms, no field-width
 modifiers). An unrecognised directive passes through literally.
 
+**Fixed: `Dir.glob` did not exist.** `Dir` is present in this build at all
+only incidentally — `build_config.rb`'s `enable_test` pulls the vendored
+`mruby-dir` gem in as a host-build test dependency, and the same shared
+`libmruby.a` backs the actual game binary too — but `mruby-dir` itself
+(`3rd/mruby/mrbgems/mruby-dir`) never implements `.glob` at any layer: its
+mrblib only supplies `#each`, `#each_child`, `.foreach`, `.open` and
+`.chdir`; its C HAL only wraps opendir/readdir/mkdir/rmdir. `Dir.glob` is not
+an obscure feature real scripts reach for on purpose: the stock RPG Maker VX
+Ace `DataManager` checks `!Dir.glob('Save0*.rvdata2').empty?` to decide
+whether the title screen offers "Continue", `Game_System` globs a shared
+options file the same way, and a released game routinely adds a
+`Dir.glob('Game.rgss3a').empty?` check to tell a packed release apart from
+an unpacked project — none of that is optional or RTP-shaped, so
+`NoMethodError` here failed the whole script host before a single frame
+drew. Implemented in pure Ruby (`mruby-rpgxp/mrblib/rgss_library.rb`) over
+`Dir.entries` (which the HAL does supply) and a glob → `Regexp` translator
+covering literal names, `*`, `?` and `[...]` character classes — not the
+full glob spec (no `**`, brace expansion or flags) — walking a pattern one
+`/`-separated path component at a time so a prefix like
+`Data/Map[0-9]*[0-9].rvdata2` only lists `Data/`'s own entries.
+
+**Fixed: `Color.new` / `Tone.new` wrongly required arguments.** Not a script
+gap at all — this is a bug in `mruby-rgss`'s own native binding
+(`mruby-rgss/src/lib.cxx`), the class library this engine supplies natively
+rather than through mrblib. Real RGSS3's *own* stock, unmodified
+`Game_Screen#clear_tone` / `#clear_flash` — present in every VX Ace
+project's default `Scripts.rvdata2`, not a community add-on — call
+`Tone.new` and `Color.new` with **zero** arguments, relying on every
+component defaulting to 0 (opaque black / no tone shift). `color_init` and
+`tone_init` read their arguments with `mrb_get_args(M, "fff|f", …)` — 3
+required, 1 optional — so `Color.new`/`Tone.new` raised
+`ArgumentError: wrong number of arguments (given 0, expected 3..4)` on
+every VX Ace game that constructs a `Game_Screen`, which is to say every VX
+Ace game the script host boots far enough to reach it. The C++ locals
+already had the right defaults (`r = g = b = 0`) sitting dead behind the
+argument-count check; changed the format to `"|ffff"` (all four optional)
+and the `MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1)` declarations to
+`MRB_ARGS_OPT(4)` for both `initialize`s. `Color#set` / `Tone#set` are
+untouched — real scripts always call those with explicit arguments.
+
+**Changed: the desktop LVGL heap grows again, 256 MB → 512 MB.** The first
+bump (`changelog.d/desktop-lvgl-heap-256mb.changed.md`) was measured against
+this same real VX Ace release's *database* load alone. Past the two fixes
+above, the script host now reaches actual scene construction — building the
+title screen's own windows, sprites and bitmaps — which is a second, larger
+memory consumer 256 MB did not cover: the game aborted with
+`NoMemoryError` mid-boot even with a fully loaded database. 512 MB cleared
+it. Desktop-only, same as before (`include/lv_conf.h`; the PSP and Wio
+builds keep their own separately-tuned pools).
+
 **Still open, and deeper than `module_function`: mruby's VM has no `$!`
 ("currently handled exception") at all.** `rescue => e` binds the exception
 to the clause's own local variable, but the special global CRuby code
@@ -439,8 +489,24 @@ globally-visible store. Confirmed with an isolated reproduction — even a bare
 specific to crossing a call boundary. It is why the same error-log utility's
 `save(filename = nil, exception = $!)` — called as `TKG::ErrorLog.save()`
 from directly inside `rescue; TKG::ErrorLog.save(); raise; end` — receives
-`exception = nil` and crashes on `exception.message`, one step past the
-`module_function` fix above. mruby's bare `raise` (no arguments) has the same
+`exception = nil` and crashes on `exception.message`.
+
+That `SceneManager.run` rescue wraps the game's *entire* run loop, so this is
+not a one-time cosmetic loss: every fatal exception this game hits, of any
+origin, is masked behind the identical `NoMethodError: undefined method
+'message' for NilClass` crash in the error-log utility, until whatever real
+exception triggered it is fixed and the *next* one takes its place. Diagnosing
+each of the fixes above required a temporary, never-committed `fprintf` at
+the `OP_EXCEPT` opcode itself (in the local `3rd/mruby` submodule checkout,
+reverted before every commit) to read the masked exception directly off the
+VM — the `Dir.glob` and `Color.new`/`Tone.new` gaps above were both found
+this way, one at a time, three separate real bugs in a row hidden behind the
+same crash. A fourth is already known and not yet fixed: with all three
+gaps above closed, the game now reaches
+`NoMethodError: undefined method 'dispose' for NilClass`, masked the same
+way. Left for a future pass — the pattern established here (temporary VM
+probe → real gap → mrblib or native fix → regression test) applies to it
+too. mruby's bare `raise` (no arguments) has the same
 root cause from the other side: real Ruby re-raises `$!`, but mruby's
 `mrb_f_raise` has no `$!` to fall back to, so a bare `raise` always raises a
 fresh, empty `RuntimeError` instead of re-raising what was actually caught.
@@ -469,6 +535,8 @@ tints, flashes and fades the screen, dissolves between scenes, unrolls and tints
 its windows, and — packed or loose — finds its graphics and its music, and
 reopens its own stock `RPG::` script sections without a superclass mismatch.
 Tilemap item 1's remaining polish (the flat "above characters" layer) is the
-only item left in the six sections above; item 7's `$!`/bare-`raise` gap is
-the newest and, per a real release, the next (and likely last, for that one
-game's bundled utility scripts) wall.
+only item left in the six sections above; item 7's `$!`/bare-`raise` gap
+stands, and per a real release it is the reason each fix above only reveals
+the *next* wall one at a time rather than the game running to completion in
+one pass — `NoMethodError: undefined method 'dispose' for NilClass`, found
+but not yet fixed, is where it stands now.

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -42,7 +42,7 @@
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
     /*Size of the memory available for `lv_malloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (256 * 1024U * 1024U)          /*[bytes]*/
+    #define LV_MEM_SIZE (512 * 1024U * 1024U)          /*[bytes]*/
 
     /*Size of the memory expand for `lv_malloc()` in bytes*/
     #define LV_MEM_POOL_EXPAND_SIZE 0

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -289,7 +289,7 @@ void unpack_doubles(const char* p, mrb_int len, double* out, int n) {
 
 mrb_value color_init(mrb_state* M, V self) {
   mrb_float r = 0, g = 0, b = 0, a = 255;
-  mrb_get_args(M, "fff|f", &r, &g, &b, &a);
+  mrb_get_args(M, "|ffff", &r, &g, &b, &a);
   Color& c = DataType<Color>::alloc_obj(M, self);
   c.red = clamp255(r);
   c.green = clamp255(g);
@@ -359,7 +359,7 @@ mrb_value color_load(mrb_state* M, V self) {
 
 mrb_value tone_init(mrb_state* M, V self) {
   mrb_float r = 0, g = 0, b = 0, gray = 0;
-  mrb_get_args(M, "fff|f", &r, &g, &b, &gray);
+  mrb_get_args(M, "|ffff", &r, &g, &b, &gray);
   Tone& t = DataType<Tone>::alloc_obj(M, self);
   t.red = clamp_signed255(r);
   t.green = clamp_signed255(g);
@@ -6564,8 +6564,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
 
   RClass* color = mrb_define_class_under(M, m, "Color", M->object_class);
   MRB_SET_INSTANCE_TT(color, MRB_TT_DATA);
-  mrb_define_method(M, color, "initialize", color_init,
-                    MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, color, "initialize", color_init, MRB_ARGS_OPT(4));
   // #clone / #dup, which a game's scripts use on these constantly.
   mrb_define_method(M, color, "initialize_copy", data_init_copy<Color>,
                     MRB_ARGS_REQ(1));
@@ -6597,8 +6596,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
 
   RClass* tone = mrb_define_class_under(M, m, "Tone", M->object_class);
   MRB_SET_INSTANCE_TT(tone, MRB_TT_DATA);
-  mrb_define_method(M, tone, "initialize", tone_init,
-                    MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, tone, "initialize", tone_init, MRB_ARGS_OPT(4));
   mrb_define_method(M, tone, "initialize_copy", data_init_copy<Tone>,
                     MRB_ARGS_REQ(1));
   mrb_define_method(M, tone, "set", tone_set,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -67,6 +67,24 @@ assert "RGSS::Tone basics and clamping" do
   assert_true loaded == t
 end
 
+# RGSS3's own stock Game_Screen#clear_tone / #clear_flash — present in every
+# VX Ace project's default Scripts.rvdata2, not a community add-on — call
+# `Tone.new` and `Color.new` with zero arguments: real RGSS defaults every
+# component to 0 (opaque black / no tone shift) rather than requiring them.
+assert "RGSS::Color.new and RGSS::Tone.new default to all-zero with no args" do
+  c = RGSS::Color.new
+  assert_equal 0.0, c.red
+  assert_equal 0.0, c.green
+  assert_equal 0.0, c.blue
+  assert_equal 255.0, c.alpha # alpha's own default, same as the 3-arg form
+
+  t = RGSS::Tone.new
+  assert_equal 0.0, t.red
+  assert_equal 0.0, t.green
+  assert_equal 0.0, t.blue
+  assert_equal 0.0, t.gray
+end
+
 assert "RGSS::Rect basics" do
   r = RGSS::Rect.new(1, 2, 3, 4)
   assert_equal 1, r.x

--- a/mruby-rpgxp/mrblib/rgss_library.rb
+++ b/mruby-rpgxp/mrblib/rgss_library.rb
@@ -301,6 +301,112 @@ unless String.method_defined?(:encode)
   end
 end
 
+# `Dir.glob`, which the vendored `mruby-dir` gem (3rd/mruby/mrbgems/mruby-dir)
+# never implements at any layer — its mrblib only supplies #each, #each_child,
+# .foreach, .open and .chdir; its C HAL only opendir/readdir/mkdir/rmdir; no
+# pattern matching anywhere. `Dir` is only present at all here because
+# build_config.rb's `enable_test` pulls it in as a test-suite dependency of the
+# host build, incidentally linking it into the shared game binary too — a real
+# project never opts into it, but several bundled community scripts assume the
+# full `Dir` a real Ruby install has. The stock RPG Maker VX Ace `DataManager`
+# checks `!Dir.glob('Save0*.rvdata2').empty?` to decide whether to draw
+# "Continue" on the title screen, `Game_System` globs a shared options file the
+# same way, and released games routinely add a `Dir.glob('Game.rgss3a').empty?`
+# check to tell a packed release apart from an unpacked project (e.g. to
+# disable a test-mode menu) — none of that is optional or RTP-shaped, so
+# `NoMethodError` here fails the whole script host before a single frame draws.
+#
+# Implemented over `Dir.entries` (which the HAL does supply) and a glob ->
+# Regexp translator covering what these scripts actually write: literal
+# names, `*` (any run of characters, one path component), `?` (one character)
+# and `[...]` character classes — not the full glob spec (no `**`, brace
+# expansion, or flags). A pattern is split on `/` and walked one directory
+# level at a time so a prefix like `Data/Map[0-9]*[0-9].rvdata2` only lists
+# `Data/`'s own entries, not every subdirectory the way a single flattened
+# regex over the whole path would. Dotfiles are excluded unless the pattern's
+# own component starts with a literal `.`, matching Ruby's default.
+unless Dir.respond_to?(:glob)
+  class Dir
+    class << self
+      private
+
+      def __rgss_glob_translate(part)
+        out = +"\\A"
+        i = 0
+        while i < part.length
+          c = part[i]
+          case c
+          when "*"
+            out << ".*"
+          when "?"
+            out << "."
+          when "["
+            close = part.index("]", i + 1)
+            if close
+              out << part[i..close]
+              i = close
+            else
+              out << "\\["
+            end
+          else
+            out << Regexp.escape(c)
+          end
+          i += 1
+        end
+        out << "\\z"
+        Regexp.new(out)
+      end
+
+      def __rgss_glob_walk(base, parts)
+        part = parts[0]
+        rest = parts[1..-1]
+        dir = base.empty? ? "." : base
+        return [] unless FileTest.directory?(dir)
+
+        if part =~ /[*?\[]/
+          re = __rgss_glob_translate(part)
+          names = Dir.entries(dir).select do |name|
+            next false if name == "." || name == ".."
+            next false if name.start_with?(".") && !part.start_with?(".")
+            re.match?(name)
+          end.sort
+        else
+          names = Dir.entries(dir).include?(part) ? [part] : []
+        end
+
+        if rest.empty?
+          names.map { |name| base.empty? ? name : "#{base}/#{name}" }
+        else
+          # Not `flat_map`: mruby-array-ext does not carry it, and neither
+          # does the Enumerable mixin reach Array's own natively-implemented
+          # methods in this build.
+          result = []
+          names.each do |name|
+            result.concat(__rgss_glob_walk(base.empty? ? name : "#{base}/#{name}", rest))
+          end
+          result
+        end
+      end
+    end
+
+    def self.glob(pattern, flags = 0, &block)
+      if pattern.is_a?(Array)
+        result = []
+        pattern.each { |p| result.concat(glob(p, flags)) }
+        return result
+      end
+
+      results = __rgss_glob_walk("", pattern.split("/")).sort
+      if block
+        results.each(&block)
+        nil
+      else
+        results
+      end
+    end
+  end
+end
+
 # RGSS's Win32API: a general FFI mechanism for calling arbitrary Win32 DLL
 # entry points by name, which a project routinely uses for one *optional*
 # Windows-only feature — e.g. CACAO's widely bundled 画像保存

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -580,3 +580,49 @@ assert "eval, Fiber and Kernel#exit / SystemExit are available for the script ho
   assert_equal :frame, f.resume
   assert_equal :done, f.resume
 end
+
+assert "Dir.glob covers the patterns real scripts use for save/protect checks" do
+  root = "tmp_rgss_glob_test"
+  Dir.mkdir(root) unless FileTest.directory?(root)
+  begin
+    ["Save01.rvdata2", "Save02.rvdata2", "SaveOption.rvdata2",
+     "Other.txt"].each do |name|
+      File.open("#{root}/#{name}", "w") { |f| f.print "x" }
+    end
+    Dir.mkdir("#{root}/Data") unless FileTest.directory?("#{root}/Data")
+    ["Map001.rvdata2", "Map012.rvdata2", "System.rvdata2"].each do |name|
+      File.open("#{root}/Data/#{name}", "w") { |f| f.print "x" }
+    end
+
+    # Literal name, no wildcard: matches iff the file exists (the released-game
+    # packed-archive check's shape, `Dir.glob('Game.rgss3a').empty?`).
+    assert_equal ["#{root}/SaveOption.rvdata2"],
+                  Dir.glob("#{root}/SaveOption.rvdata2")
+    assert_equal [], Dir.glob("#{root}/NoSuchFile.rvdata2")
+
+    # `*` wildcard: DataManager's own continue-screen check, `Dir.glob('Save0*
+    # .rvdata2')`.
+    assert_equal ["#{root}/Save01.rvdata2", "#{root}/Save02.rvdata2"],
+                  Dir.glob("#{root}/Save0*.rvdata2").sort
+
+    # `[0-9]` character class combined with `*`, spanning a literal directory
+    # prefix: an event-log utility's own `Dir.glob("Data/Map[0-9]*[0-9]
+    # .rvdata2")`.
+    assert_equal ["#{root}/Data/Map001.rvdata2", "#{root}/Data/Map012.rvdata2"],
+                  Dir.glob("#{root}/Data/Map[0-9]*[0-9].rvdata2").sort
+
+    # Block form returns nil and yields each match, like real Dir.glob.
+    seen = []
+    result = Dir.glob("#{root}/Save0*.rvdata2") { |path| seen << path }
+    assert_true result.nil?
+    assert_equal ["#{root}/Save01.rvdata2", "#{root}/Save02.rvdata2"], seen.sort
+  ensure
+    ["Save01.rvdata2", "Save02.rvdata2", "SaveOption.rvdata2",
+     "Other.txt"].each { |name| File.delete("#{root}/#{name}") }
+    ["Map001.rvdata2", "Map012.rvdata2", "System.rvdata2"].each do |name|
+      File.delete("#{root}/Data/#{name}")
+    end
+    Dir.delete("#{root}/Data")
+    Dir.delete(root)
+  end
+end


### PR DESCRIPTION
## Summary

Continues digging into the real VX Ace release from #1074/#1089
(*Sanctuary Of the Ruler*), past the `module_function`/`Time#strftime`
fixes. Three more real gaps found, each by getting the game one step
further through its own script host:

- **`Dir.glob` never existed anywhere in the vendored `mruby-dir` gem.**
  `Dir` is only present in this build at all because `build_config.rb`'s
  `enable_test` pulls it in as a host-build test dependency, and the
  same shared `libmruby.a` backs the game binary — but `mruby-dir`
  itself (mrblib and its C HAL both) never implements `.glob`. A real
  project's stock `DataManager` (`Dir.glob('Save0*.rvdata2')`, the
  Continue-screen check), `Game_System` (a shared options file) and a
  released game's own packed-vs-unpacked check
  (`Dir.glob('Game.rgss3a')`) all call it directly, so `NoMethodError`
  failed the whole script host before a single frame drew. Implemented
  in pure Ruby (`mruby-rpgxp/mrblib/rgss_library.rb`) over `Dir.entries`
  and a glob → `Regexp` translator (literal names, `*`, `?`, `[...]`
  character classes — not the full glob spec).

- **`Color.new`/`Tone.new` wrongly required 3 arguments.** Not a script
  gap — a bug in `mruby-rgss`'s own native binding
  (`mruby-rgss/src/lib.cxx`). Real RGSS3's *own* stock, unmodified
  `Game_Screen#clear_tone`/`#clear_flash` — present in every VX Ace
  project's default `Scripts.rvdata2`, not a community add-on — call
  both with **zero** arguments, defaulting every component to 0.
  `color_init`/`tone_init` demanded 3 required args
  (`mrb_get_args(M, "fff|f", …)`), so `ArgumentError` fired on every VX
  Ace game that constructs a `Game_Screen` — in practice, every VX Ace
  game the script host boots far enough to reach it. Loosened to
  `"|ffff"` / `MRB_ARGS_OPT(4)` for both `initialize`s; `#set` is
  untouched since real scripts always pass it explicit arguments.

- **The desktop LVGL heap grows again, 256 MB → 512 MB.** The first
  bump (#1074) was measured against this same release's *database*
  load alone. Past the two fixes above, the script host reaches real
  scene construction — the title screen's own windows, sprites and
  bitmaps — a second, larger memory consumer 256 MB did not cover,
  aborting with `NoMemoryError` mid-boot even with a fully-loaded
  database. Desktop-only; PSP and Wio keep their own separately-tuned
  pools.

**Diagnostic method, not shipped**: mruby's still-missing `$!` (item 7,
`docs/rpgvx-rgss-api-gap.md`) masks *every* fatal exception this game
hits behind an identical crash in its own bundled error-log utility —
`SceneManager.run`'s top-level rescue calls `TKG::ErrorLog.save()`,
whose `exception = $!` default is always `nil`. All three fixes above
were found by adding a temporary `fprintf` at the `OP_EXCEPT` opcode in
the local `3rd/mruby` submodule checkout to read the real masked
exception directly off the VM — reverted before every commit here, never
part of the diff. A fourth masked exception is already known this way
and **not** fixed in this PR:
`NoMethodError: undefined method 'dispose' for NilClass` — left for a
follow-up, per the existing reasoning against a global `Kernel#raise`
wrapper (blast radius across every maker and platform, PSP's stack
headroom included).

## Test plan
- [x] `ctest -R mruby_test` — 100% passing, includes new regression
      tests for `Dir.glob` and `Color.new`/`Tone.new`
- [x] `ruby scripts/rpgxp_testbed_check.rb data/PrayforYou` — OK
- [x] `ruby scripts/rpgvx_testbed_check.rb` — OK
- [x] `ruby scripts/rpgxp_script_host_check.rb` — OK (proves the
      `Dir.glob` addition doesn't break under real CRuby too)
- [x] `bash scripts/rpgxp_boot_check.bash` — move/menu/battle/save all
      still pass on both XP test beds
- [x] Manual: the real VX Ace release now gets past `Dir.glob`,
      `Color.new`/`Tone.new` and the 256 MB heap ceiling, into scene
      construction, before hitting the next (already-known,
      not-yet-fixed) masked exception
- [x] `docs/TODO.md` and `docs/rpgvx-rgss-api-gap.md` updated with the
      full diagnosis for all three fixes and the new open item

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_