### PR TITLE
Equipping cursed armor respects the Ends-persistence gate on inflicted states

### DIFF
--- a/changelog.d/cursed-armor-equip-persistence-gate.fixed.md
+++ b/changelog.d/cursed-armor-equip-persistence-gate.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 cursed armor:** Equipping a cursed armor no longer inflicts one of
+  its forced states if that state's database Persistence is left at "Ends"
+  (the schema default) -- matching RPG_RT, which only lets *unequip*-triggered
+  cures bypass the normal persistence check, not *equip*-triggered inflictions.
+  Ordinary infliction (skills, attacks) is unaffected. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9210,6 +9210,57 @@ not yet verified:
   one more assertion — calling `#full_heal` right after the exemption lifts
   the state, armor still worn, restores it — confirmed to fail against the
   pre-fix code (`expected [4], got []`) before the fix.
+  ✅ **Follow-up (2026-08-19): equipping cursed armor unconditionally
+  inflicted its forced state, even when the state's own database
+  Persistence was left at its "Ends" default — real RPG_RT silently
+  refuses to add it in that exact case, and only that case.** Confirmed
+  directly against RPG_RT's live source: `Game_Actor::SetEquipment`
+  (`src/game_actor.cpp`) — the single function the equip menu, Change
+  Equipment, and even an actor's own starting-gear loop all funnel through
+  — hard-codes `allow_battle_states: false` on both of its own
+  `AdjustEquipmentStates` calls (`AdjustEquipmentStates(old_item, false,
+  false); AdjustEquipmentStates(new_item, true, false);`), which forwards
+  straight to `AddState(i + 1, allow_battle_states)`. `State::Add`
+  (`src/state.cpp`) opens with `if (!allow_battle_states && state->type ==
+  Persistence_ends) { return false; }` — `Persistence_ends` (0) is the
+  schema default most non-Poison-style states are left at. So equipping a
+  cursed item whose forced state was never explicitly flipped to
+  "Continues after battle" never actually inflicts anything in real
+  RPG_RT at all; only a state an author deliberately set to Persistence 1
+  lands from equipping alone. By contrast, ordinary in-battle/skill
+  infliction (`game_battlealgorithm.cpp`'s `AddState(se.state_id, true)`)
+  and the Change Condition event command (`game_interpreter.cpp`'s
+  `AddState(state_id, true)`) both always pass `true` — this restriction
+  is unique to the equip-triggered path, the add-side mirror of the
+  remove-side `always_remove_battle_states:` exemption two fixes above
+  already ports. `Game::Actor#add_state` (`mruby-rpg2k/mrblib/game.rb`)
+  had no persistence gate at all, and `#adjust_equipment_states`'s add
+  branch called it with nothing analogous to `allow_battle_states: false`
+  — confirmed by this codebase's own prior test coverage, which built a
+  cursed-armor state explicitly left at `type: 0` ("Ends", the schema
+  default, the exact case that should refuse) and then asserted equipping
+  *did* inflict it, the opposite of real RPG_RT. Fixed by giving
+  `#add_state` a new `allow_battle_states:` keyword (default `true`, so
+  `#knock_out!`, `#full_heal`, and `Party#cast_skill`'s target loop — the
+  other three call sites, all correctly wanting unrestricted infliction,
+  matching each one's own real-RPG_RT counterpart passing `true` — are
+  untouched) and passing `allow_battle_states: false` from
+  `#adjust_equipment_states`'s own add branch, mirroring `#remove_state`'s
+  existing, already-proven `state_persists_type?` pattern in the same
+  file. A state already present by *other* means (an ordinary in-battle
+  infliction, say) is still locked in the instant the cursed armor is
+  equipped regardless of its own Persistence — `#permanent_states` reads
+  only the currently-equipped item, not how the state actually landed —
+  so four existing checks that had relied on equipping alone to inflict an
+  `type: 0` state needed their setup adjusted (an explicit `#add_state`
+  before equipping, or — where the check was never about the Persistence
+  distinction at all — the fixture's state simply flipped to `type: 1`) to
+  keep testing what they were actually about. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (an "Ends"-type state is never
+  inflicted through equipping alone; a "continues after battle" one still
+  is, unchanged; a state already present by ordinary means is still locked
+  in by the armor either way), confirmed to fail against the pre-fix code
+  (`expected [], got [4]`) before the fix.
   ✅ **Change Battle Commands (1009) never validated an added command id
   against the database's own Battle Commands table, so any positive
   integer — however bogus — could occupy one of the six real slots

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1712,8 +1712,28 @@ module Game
 
     # Inflict a status condition (no-ops for an absent/duplicate id). Inflicting
     # the death state (戦闘不能) knocks the actor out, zeroing HP.
-    def add_state(state_id)
+    #
+    # `allow_battle_states:` mirrors EasyRPG's own `Game_Battler::AddState`'s
+    # identical-named parameter (`src/game_battler.cpp`) -- `false` refuses
+    # to add a state whose own database Persistence field is left at its
+    # "Ends" default (`#state_persists_type?`'s own inverse), the same test
+    # `#remove_state`'s `always_remove_battle_states:` already ports for the
+    # cure side. Only `#adjust_equipment_states`' equip branch passes
+    # `false`: RPG_RT's `Game_Actor::SetEquipment` (`src/game_actor.cpp`)
+    # hard-codes `allow_battle_states: false` on every equip-triggered
+    # `AdjustEquipmentStates` call (the equip menu, Change Equipment, and
+    # even an actor's own starting gear all funnel through it) -- so
+    # equipping a cursed item whose forced state was left at its default
+    # Persistence never actually inflicts it in real RPG_RT at all. Every
+    # other caller (`#knock_out!`, `#full_heal`, `Party#cast_skill`'s target
+    # loop) keeps the default `true`, matching EasyRPG's own ordinary
+    # in-battle/skill infliction paths (`game_battlealgorithm.cpp`'s
+    # `AddState(se.state_id, true)`) and Change Condition
+    # (`game_interpreter.cpp`'s `AddState(state_id, true)`), neither of
+    # which this restriction ever applies to.
+    def add_state(state_id, allow_battle_states: true)
       return if state_id.nil? || state_id == 0 || @states.include?(state_id)
+      return if !allow_battle_states && !state_persists_type?(state_id)
       @states.push(state_id)
       @hp = 0 if state_id == DEATH_STATE
     end
@@ -2012,7 +2032,9 @@ module Game
     # tries to cure the very state it inflicted, or the cure would refuse
     # itself.
     def adjust_equipment_states(item_id, add)
-      cursed_armor_state_ids(item_id).each { |id| add ? add_state(id) : remove_state(id) }
+      cursed_armor_state_ids(item_id).each do |id|
+        add ? add_state(id, allow_battle_states: false) : remove_state(id)
+      end
     end
 
     # The states an actor's currently-equipped cursed armor (see

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4319,7 +4319,12 @@ end
 # (armor field 68, reverse_state_effect) inflicts every state its own
 # state_set flags; unequipping cures them. Confirmed against the actual
 # C++: gated on `Player::IsRPG2k3()`, and `IsArmorType` excludes
-# `Type_weapon`, so a weapon never carries this effect either way.
+# `Type_weapon`, so a weapon never carries this effect either way. (This
+# fixture's own state row is a bare test double naming no Persistence field
+# at all -- `#state_persists_type?`'s own conservative "unknown reads as
+# persisting" default -- so it is unaffected by the equip-side Persistence
+# gate the check below this one covers; a real database row is never that
+# bare.)
 check 'equipping RPG2003 cursed armor inflicts its own states; unequipping cures them' do
   items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
@@ -4330,6 +4335,45 @@ check 'equipping RPG2003 cursed armor inflicts its own states; unequipping cures
   eq [4], a.states, 'the state came on the instant it was worn'
   a.unequip(2) # armor slot
   eq [], a.states, 'and left the instant it came off'
+end
+
+# EasyRPG's `Game_Actor::SetEquipment` (`src/game_actor.cpp`) -- the single
+# function the equip menu, Change Equipment, and even an actor's own
+# starting gear all funnel through -- hard-codes `allow_battle_states:
+# false` on every equip-triggered `AdjustEquipmentStates` call:
+# `AdjustEquipmentStates(old_item, false, false); AdjustEquipmentStates(
+# new_item, true, false);`. `AddState`'s own `allow_battle_states` guard
+# (`src/state.cpp`'s `State::Add`) is `if (!allow_battle_states &&
+# state->type == Persistence_ends) { return false; }` -- `Persistence_ends`
+# (0) is the schema default most non-Poison-style states are left at. So a
+# state whose own Persistence was simply never touched in the editor is
+# never actually inflicted by equipping cursed armor at all in real
+# RPG_RT, unlike a state explicitly flagged "Continues after battle" (1),
+# which equips normally.
+check 'equipping RPG2003 cursed armor does NOT inflict a state left at its ' \
+      'default ("Ends") Persistence, but does inflict one flagged "continues ' \
+      'after battle"' do
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  situation = { 4 => fake_state(type: 0) } # "Ends", the schema default
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, {}, {}, situation, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.equip_item(20)
+  eq [], a.states, 'an "Ends"-type state is never inflicted through equipping alone'
+
+  situation2 = { 4 => fake_state(type: 1) } # "continues after battle"
+  db2 = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                        [1], items, {}, {}, situation2, rpg2003: true)
+  a2 = Game::Party.new(db2).leader
+  a2.equip_item(20)
+  eq [4], a2.states, 'a "continues after battle" state is inflicted by equipping, as before'
+
+  # Once present by any other, ordinary means, the armor still locks it in
+  # -- #permanent_states reads the currently-equipped item alone, regardless
+  # of how the state actually landed.
+  a.add_state(4)
+  eq [4], a.states, 'an "Ends"-type state landed by ordinary infliction is still forced'
+  eq nil, a.remove_state(4), 'and an ordinary cure still cannot touch it while the armor is worn'
 end
 
 check 'RPG2003 cursed armor set as *starting* gear inflicts its state from the ' \
@@ -4422,7 +4466,12 @@ end
 check "a lethal hit does not strip a state RPG2003 cursed armor is still " \
       'forcing, even though the hit also inflicts a higher-priority Death' do
   items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
-  situation = { 1 => fake_state(priority: 100), 4 => fake_state(priority: 50) }
+  # type: 1 ("continues after battle") so equipping alone actually inflicts
+  # it -- an "Ends" (the schema default) state is never inflicted by
+  # equipping at all (RPG_RT's own SetEquipment always passes allow_
+  # battle_states: false; see the dedicated equip-side checks below), which
+  # is not what this check is about.
+  situation = { 1 => fake_state(priority: 100), 4 => fake_state(priority: 50, type: 1) }
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
                        [1], items, {}, {}, situation, rpg2003: true)
   a = Game::Party.new(db).leader
@@ -4461,6 +4510,14 @@ check '#remove_state can lift a cursed-armor-forced state outside battle, but ' 
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
                        [1], items, {}, {}, situation, rpg2003: true)
   a = Game::Party.new(db).leader
+  # An "Ends"-type state is never inflicted by equipping the cursed armor
+  # alone (RPG_RT's own SetEquipment always passes allow_battle_states:
+  # false -- see the dedicated equip-side checks below) -- get it on by
+  # ordinary means first (an unrestricted #add_state, the same as any real
+  # in-battle/skill infliction), then equip: #permanent_states locks it in
+  # regardless of how it landed, matching real RPG_RT's own equipment-only,
+  # infliction-agnostic PermanentStates check.
+  a.add_state(4)
   a.equip_item(20)
   eq [4], a.states
   eq nil, a.remove_state(4), 'still refused in battle (the default) -- armor is still equipped'
@@ -4499,6 +4556,10 @@ check "Interpreter#do_change_condition passes RPG_RT's own map-only cursed-armor
                        [1], items, {}, {}, situation, rpg2003: true)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   a = st.party.actor_by_id(1)
+  # An "Ends"-type state is never inflicted by equipping alone -- see the
+  # dedicated equip-side checks below -- so get it on first, the same way
+  # the #remove_state check right above this one does.
+  a.add_state(4)
   a.equip_item(20)
   eq [4], a.states
   ic = Game::Interpreter::Cmd
@@ -10165,7 +10226,8 @@ end
 check 'battle: a lethal state infliction does not strip a state RPG2003 ' \
       'cursed armor is still forcing' do
   items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
-  situation = { 1 => fake_state(priority: 100), 4 => fake_state(priority: 50) }
+  # type: 1 -- see the field-side crowding-out check's identical comment.
+  situation = { 1 => fake_state(priority: 100), 4 => fake_state(priority: 50, type: 1) }
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
                        [1], items, {}, {}, situation, rpg2003: true)
   a = Game::Party.new(db).leader


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Actor::SetEquipment` calls `AdjustEquipmentStates(item_id, true)` when a new item is worn, which loops the item's forced states through `State::Add(true)` -- passing `allow_battle_states=false`, exactly like an ordinary infliction. A state whose database Persistence field is left at "Ends" (the schema default, id 0) is therefore never actually applied by equipping alone; only a state explicitly flagged "continues after battle" sticks.

This engine already implements the mirror-image exemption on the *unequip* side (`always_remove_battle_states`, letting a cursed-armor removal strip a state regardless of Persistence), but the *equip*-side gate was missing entirely -- any state listed on a cursed armor was force-applied unconditionally, regardless of its Persistence flag.

- `Game::Actor#add_state` gains an `allow_battle_states:` keyword (default `true`, matching every ordinary infliction call site: skills, attacks, `full_heal`, `knock_out!`).
- `Game::Actor#adjust_equipment_states(item_id, add)` now calls `add_state(id, allow_battle_states: false)` on the add path, paralleling the existing `remove_state` exemption already used on the remove path.

## Test plan

- Four existing `rpg2k_logic_check.rb` tests implicitly relied on state 4's fixture defaulting to `fake_state(type: 0)` ("Ends") while still expecting it to be forced on equip. Two were adjusted to declare `type: 1` ("continues after battle") since persistence wasn't what they were actually testing; two were adjusted to inflict the state ordinarily (`a.add_state(4)`) before equipping, preserving their real intent (the map-only cursed-armor removal exemption).
- A new dedicated check proves an "Ends"-type state is *not* inflicted by equipping alone, a "continues after battle" one still is, and a state already landed by ordinary means stays locked in while the armor is worn.
- Verified via `git stash` on `game.rb` alone: only the new dedicated test fails pre-fix (`expected [], got [4]`); all four adjusted tests pass regardless of the fix, confirming clean isolation.
- Full suite green: `rpg2k_logic_check.rb` 1062 passed, `rpg2k_scene_check.rb` 766 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 13 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_