### PR TITLE
RPG2003 battles force every ally to the front row when it starts all-incapacitated

### DIFF
--- a/changelog.d/rpg2003-row-safety-net.fixed.md
+++ b/changelog.d/rpg2003-row-safety-net.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 front/back row:** A battle that starts with the whole front row
+  already incapacitated (dead or hidden) now forces every ally to the front
+  row, matching RPG_RT -- previously back-row survivors of a wiped-out front
+  line stayed stuck in the back, taking reduced damage dealt for the entire
+  fight with no way out short of the manual Row command. Covered by three new
+  `scripts/rpg2k3_battle_row_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9261,6 +9261,36 @@ not yet verified:
   is, unchanged; a state already present by ordinary means is still locked
   in by the armor either way), confirmed to fail against the pre-fix code
   (`expected [], got [4]`) before the fix.
+  ✅ **Follow-up (2026-08-19): an RPG2003 fight that started with every
+  front-row ally already incapacitated (dead/hidden) never snapped
+  back-row survivors to the front, leaving them fighting a whole battle
+  from the back row real RPG_RT would have moved them out of.** Confirmed
+  directly against RPG_RT's live source: `Scene_Battle_Rpg2k3::InitActors`
+  (`src/scene_battle_rpg2k3.cpp`) runs a "ROW ADJUSTMENT" pass before every
+  fight — `force_front_row` starts `true` and is cleared the instant any
+  actor is found `GetBattleRow() == RowType_front && !IsHidden() &&
+  CanActOrRecoverable()`; if it survives the loop over the whole party,
+  every actor's row is force-set to front (`SetBattleRow(RowType_front)`)
+  for the duration. `CanActOrRecoverable` (`src/game_battler.cpp`) is
+  false only for a state with `restriction == Restriction_do_nothing &&
+  auto_release_prob == 0` — the exact concept this codebase already models
+  as `#incapacitated?` (dead/hidden via `#out_of_play?`, plus the same
+  permanent-restriction check), just never wired into battle setup.
+  `Game::Battle#initialize` (`mruby-rpg2k/mrblib/game.rb`) seeded every
+  ally's row straight from the actor's persisted `#battle_row` with no
+  such safety net, so a party whose front line had wiped in a prior fight
+  stayed split forever — the back-row survivors kept the -25% damage-dealt
+  penalty (`#row_adjusted?`/ADR 0053 Phase 1) with no way back to front
+  short of the manual Row command. Fixed by adding the same check to
+  `#initialize`, RPG2003-only: if no ally is simultaneously front-row and
+  not `#incapacitated?`, every ally's row (and, mirroring the in-battle Row
+  command's own write-back — see Scene::Battle's `:row` handler — the
+  underlying `Game::Actor#battle_row`) is forced to front. Covered by three
+  new `scripts/rpg2k3_battle_row_check.rb` checks — an all-dead front row
+  forces a living back-row survivor to front; a front row with a living
+  member is left untouched; an RPG2000 (non-`rpg2003:`) battle never forces
+  rows at all — the first confirmed to fail against the pre-fix code
+  (`expected 0, got 1`) before the fix.
   ✅ **Change Battle Commands (1009) never validated an added command id
   against the database's own Battle Commands table, so any positive
   integer — however bogus — could occupy one of the six real slots

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9429,6 +9429,26 @@ module Game
       # fight rather than what the roster carried when the fight began.
       @escape_chance = compute_escape_chance
       @force_flee = false  # a battle page granted the party a guaranteed escape
+      # RPG2003 row safety net: if the fight would start with nobody in the
+      # front row able to act or eventually recover (every front-row ally is
+      # hidden, dead, or locked into a permanent do-nothing state), RPG_RT
+      # snaps every ally to the front row rather than leaving survivors
+      # stuck in the back -- EasyRPG's Scene_Battle_Rpg2k3::InitActors ("ROW
+      # ADJUSTMENT" comment): `force_front_row` starts true and is cleared
+      # the moment any ally is found `!IsHidden() && CanActOrRecoverable()`
+      # while in the front row; if the loop never clears it, every actor's
+      # row is force-set to front. `#incapacitated?` is this codebase's own
+      # `!(!hidden && CanActOrRecoverable)` (it already folds hidden/dead in
+      # via `#out_of_play?`, plus the same permanent-restriction check).
+      # The write is persistent the same way the in-battle Row command's own
+      # write-back is (`Game_Actor::SetBattleRow` -- see Scene::Battle's
+      # `:row` handler) -- RPG_RT does not undo it at battle end.
+      if @rpg2003 && @allies.none? { |a| a.row == ROW_FRONT && !incapacitated?(a) }
+        @allies.each do |a|
+          a.row = ROW_FRONT
+          a.actor.battle_row = ROW_FRONT if a.actor.respond_to?(:battle_row=)
+        end
+      end
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
       @pending = []  # extra hits of an all-target action, drained one per #step

--- a/scripts/rpg2k3_battle_row_check.rb
+++ b/scripts/rpg2k3_battle_row_check.rb
@@ -210,5 +210,53 @@ check 'from_actor leaves a battler in the front row by default' do
   eq false, c.back_row?
 end
 
+# -- row safety net (EasyRPG's Scene_Battle_Rpg2k3::InitActors "ROW
+#    ADJUSTMENT"): a fight that would start with nobody able to act in the
+#    front row forces everyone to the front, so back-row survivors are never
+#    stuck behind a wiped-out front row for the rest of the fight. ----------
+
+check 'an rpg2003 battle forces every ally to the front row when the whole ' \
+      'front row starts dead and only back-row allies are alive' do
+  dead_front = combatant('Front', 10, 5, 8, 100)
+  dead_front.row = Game::Battle::ROW_FRONT
+  dead_front.hp = 0
+  alive_back = combatant('Back', 10, 5, 8, 100)
+  alive_back.row = Game::Battle::ROW_BACK
+
+  Game::Battle.new([dead_front, alive_back], [combatant('Enemy', 5, 5, 5, 50)],
+                    Game::Rng.new(1), rpg2003: true)
+
+  eq Game::Battle::ROW_FRONT, dead_front.row, 'the dead front-row ally is left front'
+  eq Game::Battle::ROW_FRONT, alive_back.row, 'the living survivor is snapped to front'
+end
+
+check 'an rpg2003 battle leaves rows untouched when a living ally already ' \
+      'occupies the front row' do
+  alive_front = combatant('Front', 10, 5, 8, 100)
+  alive_front.row = Game::Battle::ROW_FRONT
+  alive_back = combatant('Back', 10, 5, 8, 100)
+  alive_back.row = Game::Battle::ROW_BACK
+
+  Game::Battle.new([alive_front, alive_back], [combatant('Enemy', 5, 5, 5, 50)],
+                    Game::Rng.new(1), rpg2003: true)
+
+  eq Game::Battle::ROW_FRONT, alive_front.row
+  eq Game::Battle::ROW_BACK, alive_back.row, 'a living front-row ally means no forcing happens'
+end
+
+check 'an rpg2000 (non-2003) battle never forces rows, even with an ' \
+      'all-dead front row' do
+  dead_front = combatant('Front', 10, 5, 8, 100)
+  dead_front.row = Game::Battle::ROW_FRONT
+  dead_front.hp = 0
+  alive_back = combatant('Back', 10, 5, 8, 100)
+  alive_back.row = Game::Battle::ROW_BACK
+
+  Game::Battle.new([dead_front, alive_back], [combatant('Enemy', 5, 5, 5, 50)],
+                    Game::Rng.new(1))
+
+  eq Game::Battle::ROW_BACK, alive_back.row, 'the row-forcing rule is 2003-only'
+end
+
 puts "rpg2k3 battle row check: #{$checks} checks, #{$failures} failures"
 exit($failures.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary

RPG_RT's `Scene_Battle_Rpg2k3::InitActors` runs a "ROW ADJUSTMENT" pass before every fight: if no ally is simultaneously front-row, not hidden, and `CanActOrRecoverable()`, every actor's row is forced to front for the duration. This is a standalone safety net, independent of the larger battle-condition (pincer/surround/back) system -- it exists so a party whose front line wiped out in a previous fight doesn't leave back-row survivors permanently stuck behind a dead front row, unable to reach full damage output without manually toggling Row every single fight.

`CanActOrRecoverable` is exactly this codebase's own `#incapacitated?` (dead/hidden via `#out_of_play?`, plus the same "permanent do-nothing state" check) -- it already existed, it just wasn't wired into battle setup.

- `Game::Battle#initialize` now runs the same check for `rpg2003:` battles: if `@allies.none? { |a| a.row == ROW_FRONT && !incapacitated?(a) }`, every ally's row (and, mirroring the in-battle Row command's own write-back, the underlying `Game::Actor#battle_row`) is forced to front.

## Test plan

- Three new `scripts/rpg2k3_battle_row_check.rb` checks: an all-dead front row forces a living back-row survivor to front; a front row with a living member is left untouched; an RPG2000 (non-`rpg2003:`) battle never forces rows.
- Verified via `git stash` on `game.rb` alone: only the first new check fails pre-fix (`expected 0, got 1`), proving isolation.
- Full suite green: `rpg2k_logic_check.rb` 1062 passed, `rpg2k_scene_check.rb` 766 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed (was 13).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_