### PR TITLE
A failed boat/ship disembark falls through to the action-trigger check

### DIFF
--- a/changelog.d/boat-disembark-failure-falls-through-to-action.fixed.md
+++ b/changelog.d/boat-disembark-failure-falls-through-to-action.fixed.md
@@ -1,0 +1,7 @@
+- **Vehicles:** Pressing the action button aboard a boat or ship that fails to
+  disembark -- an NPC standing on the landing tile, for instance -- now falls
+  through to the ordinary action-trigger check on that same tile instead of
+  just swallowing the button press, matching RPG_RT. This lets a shore NPC be
+  talked to directly from the boat. The airship is unaffected, since RPG_RT
+  never runs that fallback while flying regardless. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6449,6 +6449,42 @@ Everything below is unverified against the codebase.
   facing hero to face left; the control case confirms boarding a boat never
   touches facing at all), the airship one confirmed to fail against the
   pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-19): a Decision press aboard a boat/ship that fails
+  to disembark — an NPC standing on the landing tile, say — was always
+  swallowed outright, instead of falling through to the ordinary
+  action-trigger check on that same tile the way RPG_RT's own press does.**
+  Confirmed directly against RPG_RT's live source: `Game_Player::Update`
+  (`src/game_player.cpp`) is `if (Input::IsTriggered(Input::DECISION)) { if
+  (!GetOnOffVehicle()) { CheckActionEvent(); } }` — the action-trigger check
+  only runs when the on/off-vehicle attempt itself *failed*.
+  `GetOffVehicle`'s boat/ship branch returns `false` right away when
+  `!Game_Map::CanDisembarkShip(*this, front_x, front_y)`, and
+  `CanDisembarkShip` (`src/game_map.cpp`) itself returns `false` whenever an
+  active same-layer event occupies the landing tile — exactly the case
+  meant to fall through to `CheckActionEvent`, letting a shore NPC be
+  talked to directly from the boat. (The airship needs no equivalent fix:
+  `CheckActionEvent` opens with an unconditional `if (IsFlying()) { return
+  false; }`, so an airship rider's press never reaches the action check
+  regardless of whether `GetOffVehicle` succeeds — this build's existing
+  always-swallow behavior for the airship was already accidentally
+  correct.) `Scene::Map#try_board_vehicle`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) hardcoded `true` on its boat/ship
+  disembark branch regardless of whether `#disembark_vehicle` actually
+  succeeded, so its own caller (`try_action_trigger unless
+  try_board_vehicle`) never ran the fallback — and `#disembark_vehicle`'s
+  own boat/ship success path had no explicit `true` return to give that
+  caller anyway (its implicit return was whatever
+  `#restore_pre_vehicle_bgm` happened to return). Fixed by having
+  `#disembark_vehicle` return an explicit `false`/`true` for the boat/ship
+  branch, and `#try_board_vehicle` return that value directly instead of a
+  hardcoded `true` — while still always claiming the button for the
+  airship branch, since `#try_action_trigger`'s own callers gain nothing
+  from a real success signal there. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check: boarding a boat, then facing a
+  shore NPC and pressing Decision, leaves the party aboard (disembarking
+  failed) but still runs the NPC's event — confirmed to fail against the
+  pre-fix code (the NPC's Control Switches command never ran) before the
+  fix.
 - ✅ **Battle Event** — separate command set from Map/Common events
   entirely (`Game::Interpreter`'s battle-only opcodes — `CHANGE_MONSTER_HP`/
   `MP`/`CONDITION`, `SHOW_HIDDEN_MONSTER`, `FORCE_FLEE`, `TERMINATE_BATTLE`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2179,8 +2179,21 @@ class RPG2k
         return false if event_busy?
         return false unless Input.trigger?(Input::C)
         if @state.boarded?
-          disembark_vehicle
-          true # aboard, the action button belongs to the vehicle
+          airship = @state.boarded == :airship
+          disembarked = disembark_vehicle
+          # RPG_RT's action-trigger check (`Game_Player::CheckActionEvent`,
+          # src/game_player.cpp) opens with an unconditional `IsFlying()`
+          # bail, so an airship rider's Decision press never falls through
+          # to it regardless of whether landing actually succeeded -- the
+          # button is consumed either way. A boat/ship rider gets no such
+          # blanket suppression: `Game_Player::Update` only skips
+          # `CheckActionEvent` when `GetOnOffVehicle` (in turn
+          # `GetOffVehicle` / `Game_Map::CanDisembarkShip`) actually
+          # succeeds; a failed disembark -- a blocked landing tile, or an
+          # active same-layer event standing right on the shore -- falls
+          # through to the ordinary action-trigger check on that same
+          # tile, letting a shore NPC be talked to directly from the boat.
+          airship || disembarked
         else
           board_vehicle
         end
@@ -2229,6 +2242,9 @@ class RPG2k
       # party stays aboard). Disembarking the airship also snaps the hero to
       # face left, mirroring `Game_Player::GetOffVehicle`'s own unconditional
       # `SetFacing(Left)` right before `StartDescent()` -- see #board_as.
+      # Returns whether the boat/ship actually got off (the airship branch's
+      # own return is never read -- see #try_board_vehicle's own comment on
+      # why the airship needs no such signal).
       def disembark_vehicle
         if @state.boarded == :airship
           return unless airship_landable?(@state.x, @state.y)
@@ -2239,12 +2255,13 @@ class RPG2k
           return
         end
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
-        return unless passable?(fx, fy, @state.direction)
+        return false unless passable?(fx, fy, @state.direction)
         follow_vehicle # the vehicle is left where the party is getting off
         @state.x = fx
         @state.y = fy
         @state.boarded = nil
         restore_pre_vehicle_bgm # the map BGM resumes
+        true
       end
 
       # Whether the airship may land on tile (x, y): the database terrain's

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9927,6 +9927,48 @@ check 'disembarking back onto a map with no field BGM stops the vehicle music th
   eq nil, st.current_bgm
 end
 
+check 'a failed boat disembark (blocked by a shore NPC) falls through to the ' \
+      'action-trigger check on that tile, instead of just swallowing the ' \
+      'button press' do
+  # RPG_RT's own `Game_Player::Update` only skips `CheckActionEvent` when
+  # `GetOnOffVehicle` actually succeeds (`if (!GetOnOffVehicle())
+  # CheckActionEvent();`, src/game_player.cpp) -- and disembarking a boat/
+  # ship fails outright when an active same-layer event occupies the
+  # landing tile (`Game_Map::CanDisembarkShip`, src/game_map.cpp, loops
+  # `GetEvents()` for exactly that before ever checking terrain
+  # passability). A failed disembark press must therefore fall through to
+  # the ordinary action-trigger check on that same tile, the same way it
+  # would have if the party had never tried to board at all -- letting a
+  # shore NPC be talked to directly from the boat.
+  ic = Game::Interpreter::Cmd
+  npc = page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_SAME) # a shore NPC
+  npc.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  # The NPC stands on the shore tile the party starts on and boards away
+  # from -- boarding looks only at the boat's own tile, so the party's
+  # starting tile being otherwise occupied does not interfere with it.
+  scene = new_scene({ 1 => event(2, 0, npc) }, player: [2, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face the boat one tile south
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 2
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat ahead'
+  eq [2, 1], [st.x, st.y], 'stepped onto the boat'
+
+  st.direction = 8 # face back north, toward the NPC's shore tile
+  RGSS::Input.triggered = [RGSS::Input::C] # try to disembark onto the NPC's tile
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'the NPC blocks the landing tile, so disembarking failed'
+  5.times { scene.update } # let the started event actually run its commands
+  ok st.switches[4], 'the button press fell through and talked to the shore NPC instead'
+end
+
 check 'Enemy Encounter scene: the round animates action by action, not at once' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Player::Update` is `if (Input::IsTriggered(Input::DECISION)) { if (!GetOnOffVehicle()) { CheckActionEvent(); } }` -- the action-trigger check only runs when the on/off-vehicle attempt itself failed. `GetOffVehicle`'s boat/ship branch returns `false` right away when `!Game_Map::CanDisembarkShip(*this, front_x, front_y)`, and `CanDisembarkShip` itself returns `false` whenever an active same-layer event occupies the landing tile -- exactly the case meant to fall through to `CheckActionEvent`, letting a shore NPC be talked to directly from the boat.

The airship needs no equivalent fix: `CheckActionEvent` opens with an unconditional `IsFlying()` bail, so an airship rider's press never reaches the action check regardless of whether `GetOffVehicle` succeeds -- this build's existing always-swallow behavior for the airship was already accidentally correct.

`Scene::Map#try_board_vehicle` hardcoded `true` on its boat/ship disembark branch regardless of whether `#disembark_vehicle` actually succeeded, so its own caller (`try_action_trigger unless try_board_vehicle`) never ran the fallback -- and `#disembark_vehicle`'s own boat/ship success path had no explicit `true` return to give that caller anyway (its implicit return was whatever `#restore_pre_vehicle_bgm` happened to return).

- `#disembark_vehicle` now returns an explicit `false`/`true` for the boat/ship branch.
- `#try_board_vehicle` returns that value directly instead of a hardcoded `true` -- while still always claiming the button for the airship branch.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: boarding a boat, then facing a shore NPC and pressing Decision, leaves the party aboard (disembarking failed) but still runs the NPC's event.
- Verified via `git stash` on `scene/map.rb` alone: only the new check fails pre-fix (the NPC's Control Switches command never ran).
- Full suite green: `rpg2k_scene_check.rb` 767 passed, `rpg2k_logic_check.rb` 1062 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_