### PR TITLE
Fix below/above-layer touch events blocking party movement

### DIFF
--- a/changelog.d/below-layer-touch-event-blocks-step.fixed.md
+++ b/changelog.d/below-layer-touch-event-blocks-step.fixed.md
@@ -1,0 +1,15 @@
+- **A below/above-characters Player Touch or Event Touch event no longer
+  blocks the party's own step.** `Scene::Map#step_movement` started the
+  touched event's commands and unconditionally returned before ever setting
+  `@moving`/`@dest_x`/`@dest_y`, so the party's step never completed even
+  though `#passable?`/`#char_passable?` never treat a `LAYER_BELOW`/
+  `LAYER_ABOVE` event as an obstacle anywhere else — matching real RPG_RT's
+  `CheckEventTriggerHere` firing once the party has already arrived on the
+  tile, not `CheckEventTriggerThere`'s bump-and-hold behaviour reserved for a
+  genuinely blocking (`LAYER_SAME`) event. The common "invisible SE tile"
+  pattern — a transparent below-characters event that plays a sound as the
+  party crosses it, often gated on an item-possession/equip page condition —
+  read as a solid wall instead. Covered by new `scripts/rpg2k_scene_check.rb`
+  checks for both touch triggers on a below-characters event (the party still
+  walks onto its tile) alongside the existing same-layer checks (still no
+  move), updated to set `layer:` explicitly.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7500,8 +7500,10 @@ class RPG2k
           # events (you cannot trigger them from the water / air).
           return unless vehicle_passable?(nx, ny, dir, @state.boarded)
         else
-          # Walking into a touch event runs it instead of moving. **Both** touch
-          # triggers answer here: RPG_RT tests them as one set on every
+          # Walking into a touch event runs it; whether that also blocks the
+          # step depends on the event's layer (see the `LAYER_SAME` check
+          # below). **Both** touch triggers answer here: RPG_RT tests them as
+          # one set on every
           # player-side path (EasyRPG's `{Trigger_touched, Trigger_collision}` in
           # `Game_Player::Update` / `UpdateMovement`), so the asymmetry is not
           # the one the trigger names suggest — an "event touch" (2) event fires
@@ -7528,7 +7530,14 @@ class RPG2k
           if touched && touch_trigger?(touched[:trigger]) && touched[:commands] &&
              !touched[:crossed_hero_this_frame]
             start_event(touched)
-            return
+            # A same-layer touch event blocks like a closed door: it fires but
+            # the party stays put, exactly as before. A below/above-characters
+            # touch event (the common "invisible SE tile" pattern) is a
+            # decoration, not an obstacle -- #passable?/#char_passable? never
+            # let it block movement elsewhere, so falling through to the
+            # ordinary passability check below lets the party keep walking
+            # onto its tile while the event's commands run alongside.
+            return if touched[:layer] == LAYER_SAME
           end
           # Through Mode (see @player_through) bypasses collision the same way
           # it does for an event's own #char_passable? -- touch triggers still

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1619,9 +1619,14 @@ check 'an autostart event Calls a call-only common event through the scene' do
   ok st.switches[7], 'call-only common event ran via Call Event'
 end
 
-check 'player-touch (trigger 1): walking into an event runs it, no move' do
+check 'player-touch (trigger 1) on a same-layer event: walking into it runs ' \
+      'it, no move' do
   ic = Game::Interpreter::Cmd
-  pg = page(trigger: 1) # player touch
+  # Same-layer only: like a closed door, the event blocks like any other
+  # LAYER_SAME obstacle, so the touch fires as a bump (EasyRPG's
+  # `CheckEventTriggerThere`) and the party stays put. A below/above-
+  # characters touch event is the opposite case, see the check just below.
+  pg = page(trigger: 1, layer: RPG2k::Scene::Map::LAYER_SAME) # player touch
   pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
   scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
   RGSS::Input.dir_value = 6 # hold right, into the event at (1,0)
@@ -1631,12 +1636,34 @@ check 'player-touch (trigger 1): walking into an event runs it, no move' do
   eq [0, 0], [st.x, st.y], 'player did not step onto the event'
 end
 
-check 'event-touch (trigger 2) also fires when the player walks into it' do
+check 'player-touch (trigger 1) on a below-characters event: it fires but ' \
+      'the party still walks onto its tile' do
+  # The common "invisible SE tile" pattern (a transparent below-characters
+  # event that plays a sound as the party crosses it) is a decoration, not an
+  # obstacle -- #passable?/#char_passable? never let LAYER_BELOW/LAYER_ABOVE
+  # block movement elsewhere, and real RPG_RT fires this via
+  # `CheckEventTriggerHere` once the party has already arrived on the tile
+  # (see docs/TODO.md's `CheckEventTriggerHere({Trigger_touched,
+  # Trigger_collision}, false)` citation), not as a bump that holds the party
+  # back like the same-layer case above.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 1, layer: RPG2k::Scene::Map::LAYER_BELOW) # player touch
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # hold right, onto the event at (1,0)
+  12.times { scene.update } # a full tile slide takes more than 6 frames, see the below/above passability checks above
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[6], 'player-touch event ran'
+  eq [1, 0], [st.x, st.y], 'the party still walked onto the below-characters event'
+end
+
+check 'event-touch (trigger 2) also fires when the player walks into it, ' \
+      'same-layer version blocks the move' do
   # RPG_RT tests both touch triggers as one set on the player's own move — so a
   # trigger-2 event fires from either side, which is how Nepheshel's roaming
   # monsters (9,637 trigger-2 pages) start a fight when you walk into them.
   ic = Game::Interpreter::Cmd
-  pg = page(trigger: 2) # event touch, standing still
+  pg = page(trigger: 2, layer: RPG2k::Scene::Map::LAYER_SAME) # event touch, standing still
   pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
   scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
   RGSS::Input.dir_value = 6 # hold right, into the event at (1,0)
@@ -1644,6 +1671,19 @@ check 'event-touch (trigger 2) also fires when the player walks into it' do
   st = scene.instance_variable_get(:@state)
   ok st.switches[6], 'walking into an event-touch event ran it'
   eq [0, 0], [st.x, st.y], 'and the party did not step onto it'
+end
+
+check 'event-touch (trigger 2) on a below-characters event still lets the ' \
+      'party walk onto its tile' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 2, layer: RPG2k::Scene::Map::LAYER_BELOW)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # hold right, onto the event at (1,0)
+  12.times { scene.update } # a full tile slide takes more than 6 frames, see the below/above passability checks above
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[6], 'walking into an event-touch event ran it'
+  eq [1, 0], [st.x, st.y], 'the party still walked onto the below-characters event'
 end
 
 check 'an action event is not set off by walking into it' do


### PR DESCRIPTION
## Summary
Below/above-characters layer touch events (both Player Touch and Event Touch triggers) were incorrectly blocking the party's movement, when they should only be decorative obstacles like invisible sound tiles. This fix ensures the party can walk onto tiles with below/above-layer touch events while their commands still execute.

## Changes
- **Fixed `Scene::Map#step_movement` logic**: Modified the touch event handling to only return early (blocking movement) when the touched event is on the `LAYER_SAME` layer. Below/above-layer touch events now allow the party to continue walking onto the tile while their commands execute.

- **Updated test coverage**: Expanded `scripts/rpg2k_scene_check.rb` with comprehensive test cases:
  - Clarified existing same-layer player-touch test with explicit `layer:` parameter and detailed comments
  - Added new test for below-characters player-touch events (party walks onto tile)
  - Updated event-touch test to explicitly test same-layer behavior (blocks movement)
  - Added new test for below-characters event-touch events (party walks onto tile)

- **Added changelog entry**: Documented the fix with explanation of the behavioral difference between layer types and the real RPG_RT behavior (`CheckEventTriggerHere` vs `CheckEventTriggerThere`).

## Implementation Details
The fix distinguishes between two touch event behaviors based on layer:
- **`LAYER_SAME` events**: Act as solid obstacles (like closed doors) — fire the event but block the party's step
- **`LAYER_BELOW`/`LAYER_ABOVE` events**: Act as decorations (like invisible sound tiles) — fire the event but allow the party to walk onto the tile

This matches real RPG_RT behavior where passability checks never treat below/above-layer events as obstacles, and touch triggers on these layers fire via `CheckEventTriggerHere` (after arrival) rather than `CheckEventTriggerThere` (bump-and-hold).

https://claude.ai/code/session_01G9neLJ86VS1QT2kXzJ9oHc