### PR TITLE
Input Number's digit cursor starts rightmost and wraps, matching RPG_RT

### DIFF
--- a/changelog.d/number-input-cursor-start-and-wrap.fixed.md
+++ b/changelog.d/number-input-cursor-start-and-wrap.fixed.md
@@ -1,0 +1,5 @@
+- **Input Number:** The digit-entry cursor now starts on the rightmost
+  (least significant) digit and wraps cyclically when pressing Left/Right,
+  matching RPG_RT -- previously it started on the leftmost digit and clamped
+  at either end. Covered by an updated `scripts/rpg2k_logic_check.rb` check
+  and four corrected `scripts/rpg2k_scene_check.rb` integration checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11430,6 +11430,35 @@ not yet verified:
   into the same still-open window, `@number_input[:embedded]` true, and
   closes both the widget and the message together on confirm), both
   confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-19): Input Number's digit cursor started on the
+  leftmost (most significant) cell and clamped at either end, when real
+  RPG_RT starts it on the rightmost (least significant) cell and wraps
+  Left/Right cyclically instead.** Confirmed directly against RPG_RT's live
+  source: `Window_NumberInput::ResetIndex` (`src/window_numberinput.cpp`) is
+  `index = digits_max - 1 + int(show_operator)` — this widget never shows
+  the operator sign for the Input Number event command
+  (`show_operator = false` at construction, only ever flipped on
+  elsewhere), so this is unconditionally `digits_max - 1`, the last-drawn
+  (rightmost) cell. `Update()`'s own Left/Right handling is genuine modulo
+  wraparound (`index = (index + 1) % (digits_max + (int)show_operator)` and
+  its mirror), never a clamp. `Game::NumberInput`
+  (`mruby-rpg2k/mrblib/game.rb`) initialized `@cursor = 0` (leftmost) and
+  its `#left`/`#right` methods refused to move past either edge — so every
+  Input Number prompt (passwords, quiz answers, any variable-entry dialog)
+  edited the wrong digit by default, and arrow navigation could never wrap
+  the way the genuine engine does. Fixed by starting `@cursor` at
+  `d - 1` and having `#left`/`#right` wrap with modulo arithmetic instead of
+  clamping. The existing `scripts/rpg2k_logic_check.rb` `NumberInput` check
+  had baked the wrong behavior in as expected (`eq 0, m.cursor` on
+  construction, comments reading "already leftmost: no move" and "clamp at
+  the rightmost cell") and needed rewriting to the correct start/wrap
+  semantics; four `scripts/rpg2k_scene_check.rb` integration checks that
+  each pressed Up once on a fresh 2-digit widget and expected the *tens*
+  digit to have incremented (value 10) needed their expectation corrected
+  to the *ones* digit (value 1), since the cursor now starts there instead
+  — all four confirmed to fail against the pre-fix code with the corrected
+  expectation (`expected 1, got 10`) before the fix, and the dedicated
+  logic-check test confirmed to fail on its own (`expected 2, got 0`) too.
 - ✅ **A Face Graphic setting persists through the rest of the current event's
   execution content (not just the next message) and is auto-cleared when
   the event ends, but not before** — it must be explicitly "erased" to stop

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1368,7 +1368,14 @@ module Game
       d = MAX_DIGITS if d > MAX_DIGITS
       @digits = d
       @values = Array.new(d, 0)
-      @cursor = 0
+      # The rightmost (least significant) cell, not the leftmost -- confirmed
+      # against RPG_RT's actual behavior via EasyRPG Player's own C++ source,
+      # fetched live: `Window_NumberInput::ResetIndex` (src/
+      # window_numberinput.cpp) is `index = digits_max - 1 +
+      # int(show_operator)`, and this class always leaves `show_operator`
+      # false (the Input Number event command never shows a +/- sign cell) --
+      # `digits_max - 1` is the last-drawn, rightmost digit.
+      @cursor = d - 1
     end
 
     # The digit shown at position i (0 = most significant, leftmost).
@@ -1376,8 +1383,12 @@ module Game
 
     def inc; @values[@cursor] = (@values[@cursor] + 1) % 10; end
     def dec; @values[@cursor] = (@values[@cursor] + 9) % 10; end
-    def left;  @cursor -= 1 if @cursor > 0; end
-    def right; @cursor += 1 if @cursor < @digits - 1; end
+    # Left/Right wrap cyclically rather than clamp at either end -- RPG_RT's
+    # own `Update()` moves the cursor with `index = (index + 1) %
+    # digits_max` (Right) and `index = (index + digits_max - 1) %
+    # digits_max` (Left), never refusing to move past an edge cell.
+    def left;  @cursor = (@cursor + @digits - 1) % @digits; end
+    def right; @cursor = (@cursor + 1) % @digits; end
 
     # The entered value as a base-10 integer (leftmost cell is most significant).
     def value

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8181,15 +8181,16 @@ end
 check 'NumberInput edits digits and reads out the entered value' do
   m = Game::NumberInput.new(3)
   eq 3, m.digits
+  eq 2, m.cursor, 'starts on the rightmost (least significant) cell, matching RPG_RT'
+  m.right # wraps forward past the rightmost cell to the leftmost
   eq 0, m.cursor
-  m.left # already leftmost: no move
-  eq 0, m.cursor
-  m.inc; m.inc          # leftmost digit -> 2
-  m.right; m.inc        # middle digit  -> 1
-  m.right; m.right      # clamp at the rightmost cell
+  m.inc # leftmost digit -> 1
+  m.right; m.inc; m.inc # middle digit -> 2
+  m.right; m.dec # rightmost 0 -> 9 (wraps within the digit, not the cursor)
   eq 2, m.cursor
-  m.dec                 # rightmost 0 -> 9 (wraps)
-  eq 219, m.value
+  m.left; m.left; m.left # three lefts from a 3-digit field wraps back to it
+  eq 2, m.cursor
+  eq 129, m.value
 end
 
 check 'NumberInput clamps its digit count to the 1..7 range' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3628,13 +3628,14 @@ check 'Input Number opens a widget; confirming stores the entered value' do
   end
   ok ni, 'the number-entry widget opened'
 
-  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  RGSS::Input.triggered = [RGSS::Input::UP] # ones digit 0 -> 1 (value 1) -- the
+  # cursor starts on the rightmost/least-significant cell, matching RPG_RT
   scene.update
   RGSS::Input.triggered = [RGSS::Input::C]  # confirm
   scene.update
   ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
   5.times { RGSS::Input.reset; scene.update }
-  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  eq 1, st.variables[5], 'the entered value landed in variable 5'
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
@@ -3961,14 +3962,15 @@ check 'a Show Text keeps its window open when an Input Number follows directly' 
   ok scene.instance_variable_get(:@message)[:window].equal?(win),
      'the same window is reused, not closed and reopened'
 
-  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  RGSS::Input.triggered = [RGSS::Input::UP] # ones digit 0 -> 1 (value 1) -- the
+  # cursor starts on the rightmost/least-significant cell, matching RPG_RT
   scene.update
   RGSS::Input.triggered = [RGSS::Input::C]  # confirm
   scene.update
   ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
   ok !scene.instance_variable_get(:@message), 'and the message window closed with it'
   5.times { RGSS::Input.reset; scene.update }
-  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  eq 1, st.variables[5], 'the entered value landed in variable 5'
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
@@ -5255,13 +5257,14 @@ check "a Common Event Parallel Process's own standalone Input Number now actuall
   ok !st.switches[1],
      'the command after Input Number has not run yet -- the process is blocked on the widget'
 
-  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  RGSS::Input.triggered = [RGSS::Input::UP] # ones digit 0 -> 1 (value 1) -- the
+  # cursor starts on the rightmost/least-significant cell, matching RPG_RT
   scene.update
   RGSS::Input.triggered = [RGSS::Input::C] # confirm
   scene.update
   ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
   5.times { RGSS::Input.reset; scene.update }
-  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  eq 1, st.variables[5], 'the entered value landed in variable 5'
   ok st.switches[1], 'the Parallel Process resumed and ran the command after Input Number'
 end
 
@@ -5303,14 +5306,15 @@ check "a Map Event Parallel Process's own Show Text + Input Number merges into t
   ok ni[:embedded], 'merged onto the preceding Show Text, not a fresh standalone panel'
   ok scene.instance_variable_get(:@message), 'the message window is still the one carrying it'
 
-  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  RGSS::Input.triggered = [RGSS::Input::UP] # ones digit 0 -> 1 (value 1) -- the
+  # cursor starts on the rightmost/least-significant cell, matching RPG_RT
   scene.update
   RGSS::Input.triggered = [RGSS::Input::C] # confirm
   scene.update
   ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
   ok !scene.instance_variable_get(:@message), 'the merged message window closed with it'
   5.times { RGSS::Input.reset; scene.update }
-  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  eq 1, st.variables[5], 'the entered value landed in variable 5'
   ok st.switches[1], 'the Parallel Process resumed and ran the command after Input Number'
 end
 


### PR DESCRIPTION
## Summary

`Window_NumberInput::ResetIndex` (`src/window_numberinput.cpp`) is `index = digits_max - 1 + int(show_operator)` -- this widget never shows the operator sign for the Input Number event command (`show_operator = false` at construction, only ever flipped on elsewhere), so this is unconditionally `digits_max - 1`, the last-drawn (rightmost) cell. `Update()`'s own Left/Right handling is genuine modulo wraparound (`index = (index + 1) % (digits_max + (int)show_operator)` and its mirror), never a clamp.

`Game::NumberInput` (`mruby-rpg2k/mrblib/game.rb`) initialized `@cursor = 0` (leftmost) and its `#left`/`#right` methods refused to move past either edge -- so every Input Number prompt (passwords, quiz answers, any variable-entry dialog) edited the wrong digit by default, and arrow navigation could never wrap the way the genuine engine does.

- Fixed by starting `@cursor` at `d - 1` and having `#left`/`#right` wrap with modulo arithmetic instead of clamping.

## Test plan

- The existing `scripts/rpg2k_logic_check.rb` `NumberInput` check had baked the wrong behavior in as expected and needed rewriting to the correct start/wrap semantics.
- Four `scripts/rpg2k_scene_check.rb` integration checks that each pressed Up once on a fresh 2-digit widget and expected the *tens* digit to have incremented (value 10) needed their expectation corrected to the *ones* digit (value 1), since the cursor now starts there instead.
- Verified via `git stash` on `game.rb` alone: the logic-check test fails (`expected 2, got 0`) and all four scene-check tests fail with the corrected expectation (`expected 1, got 10`) pre-fix.
- Full suite green: `rpg2k_logic_check.rb` 1062 passed, `rpg2k_scene_check.rb` 767 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_