### PR TITLE
Battle status/options window layout parity: column clipping + left-docked options window

### DIFF
--- a/changelog.d/battle-options-window-left-docked.fixed.md
+++ b/changelog.d/battle-options-window-left-docked.fixed.md
@@ -1,0 +1,12 @@
+- **RPG2000 battle:** The Battle/Auto Battle/Escape options window now docks
+  to the *left* edge of the screen, with the party status panel pushed to its
+  right — not the status panel fixed on the left with the options list on the
+  right, which is what every phase of the fight drew before. Ported from
+  EasyRPG Player's own `Scene_Battle_Rpg2k::SetCommandWindowsX`: the options
+  window and the per-actor Attack/Skill/Defend/Item command window share the
+  same 76px shape and never show at once, but they dock to *opposite* edges —
+  the options window before the status window, the per-actor command window
+  after it — so the status panel itself now slides between `x=0` (beside the
+  command window, unchanged) and `x=76` (beside the options window, the fix)
+  depending on which phase is active. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/changelog.d/battle-status-hp-mp-column-overlap.fixed.md
+++ b/changelog.d/battle-status-hp-mp-column-overlap.fixed.md
@@ -1,0 +1,11 @@
+- **RPG2000 battle:** The party status panel's HP/SP text no longer overlaps
+  or bleeds off the panel for a well-stocked party member — an ally's name,
+  condition, HP or SP text drew unclipped past its own column (`Bitmap
+  #draw_text`/`#blend_text` only use their `w`/`h` for centre/right alignment,
+  never to clip), so a wide HP value ran into the SP column and SP's own text
+  routinely ran off the panel's 26px-wide column entirely. `#battle_status_
+  window` now clips every segment to the gap before its own neighbour (or the
+  panel's inner edge, for SP) via the shared `#clip_text_to_width` helper —
+  previously local to the message window's own face-graphic clipping, now
+  moved onto `Scene::Base` so both share it. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -73,6 +73,35 @@ class RPG2k
         bmp.blend_text x, y, w, h, text, skin, sx, sy, cell, cell, align
       end
 
+      # Slice `text` down to however many leading characters fit within `w`
+      # pixels of `c`'s own font metrics, dropping the rest outright -- RPG_RT
+      # truncates an overlong run rather than wrapping it. Walks one character
+      # (not byte) at a time so a multi-byte codepoint is never split mid-way.
+      #
+      # Neither `Bitmap#draw_text` nor `#blend_text` (mruby-rgss/src/lib.cxx)
+      # clip to the `w`/`h` they are given -- those only ever feed centre/right
+      # alignment math -- so nothing stops an overflowing run from drawing
+      # straight past its own column's boundary and onto whatever sits beyond
+      # it. Originally written for the message window's face-graphic margin
+      # (Scene::Map#draw_message_run, where an overflowing line used to draw
+      # straight over the portrait instead of stopping at the text column's own
+      # edge); shared here because the battle status panel's fixed name/state/
+      # HP/MP columns (Scene::Battle#battle_status_window) hit the exact same
+      # gap -- an oversized name or a 3-digit HP/MP pair drawing unclipped
+      # straight into its neighbour's column, rather than the neighbour's own
+      # text simply overlapping it.
+      def clip_text_to_width(c, text, w)
+        return '' if w <= 0
+        return text if c.text_size(text).width <= w
+        out = ''
+        text.each_char do |ch|
+          candidate = out + ch
+          break if c.text_size(candidate).width > w
+          out = candidate
+        end
+        out
+      end
+
       # The condition a battler carrying `states` shows, as [text, palette colour
       # index]: the significant state's name in its own colour, or the database's
       # "normal" term when there is none. A state the database does not name

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2997,6 +2997,17 @@ class RPG2k
       # `draw_text` of a whole line cannot do. (EasyRPG's
       # `Window_BattleStatus::Refresh`, RPG2k branch: name at 4, state at 86,
       # HP at 142, SP at 202 for a party with no maxima over 999.)
+      #
+      # "For a party with no maxima over 999" is a real ceiling, not a rounding
+      # note: the panel itself is a fixed 244px (`BATTLE_STATUS_W`, RPG_RT's own
+      # screen width minus its fixed 76px command box), so the SP column only
+      # ever has `inner content width (228) - 202 = 26px` before the panel's own
+      # right border -- nowhere near "SP 999/999"'s ~66px, and not even quite
+      # enough for a plain "SP 50/50". `#battle_status_window` clips every
+      # column's text to the gap before the *next* column (or the panel's own
+      # edge, for SP) rather than trusting it to fit, so an actor with generous
+      # HP/SP -- or simply a widescreen font -- truncates cleanly instead of
+      # spilling into its neighbour's cell.
       STATUS_NAME_X  = 4
       STATUS_STATE_X = 86
       STATUS_HP_X    = 142
@@ -3563,6 +3574,16 @@ class RPG2k
       # no windowskin) — the way RPG_RT colours a state name. Fixed at the
       # bottom-left of the panel (`Window_BattleStatus`'s own rect), with a
       # cursor on `cursor_idx`'s row when the acting actor is one of these rows.
+      #
+      # Each segment is clipped (`#clip_text_to_width`, Scene::Base) to the gap
+      # before the *next* segment in the same row, not to the panel's own right
+      # edge — `draw_system_text`'s own `w`/`h` only ever feed centre/right
+      # alignment (see its comment), so an uncapped width let an actor's name,
+      # state or HP text run straight through its neighbour's column instead of
+      # stopping at it. `battle_status_row`/`battle_state_segment` always
+      # returns these four segments in ascending-x order, so "the next
+      # segment's x" is always the next column's own origin; the last segment
+      # (SP) clips to the panel's own inner edge instead, same as before.
       def battle_status_window(rows, cursor_idx = nil)
         inner_w = BATTLE_STATUS_W - Window::BORDER * 2
         win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
@@ -3571,9 +3592,12 @@ class RPG2k
         c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
         c.font.color = Color.new(255, 255, 255, 255)
         rows.each_with_index do |segments, i|
-          segments.each do |text, x, color|
-            draw_system_text c, x, i * BATTLE_LINE_H, inner_w - x,
-                             BATTLE_LINE_H, text.to_s, windowskin, color
+          segments.each_with_index do |(text, x, color), j|
+            next_x = j + 1 < segments.size ? segments[j + 1][1] : inner_w
+            w = next_x - x
+            draw_system_text c, x, i * BATTLE_LINE_H, w, BATTLE_LINE_H,
+                             clip_text_to_width(c, text.to_s, w), windowskin,
+                             color
           end
         end
         win.contents = c

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2976,14 +2976,18 @@ class RPG2k
       BATTLE_LINE_H = 16
       BATTLE_PANEL_Y = SCREEN_H - 80
       BATTLE_PANEL_H = 80
-      # The actor-command window is a fixed 76px (`option_command_mov` in
-      # EasyRPG), docked to the right edge; the status window takes the rest of
-      # the row (`MENU_WIDTH - option_command_mov`).
+      # The actor-command window (and the Battle/Auto Battle/Escape options
+      # window, which shares its rect) is a fixed 76px (`option_command_mov`
+      # in EasyRPG); the status window takes the rest of the row (`MENU_WIDTH
+      # - option_command_mov`).
       BATTLE_CMD_W = 76
       BATTLE_STATUS_W = SCREEN_W - BATTLE_CMD_W
       # The enemy target list (`CreateBattleTargetWindow`) is a fixed 136px, and
-      # only ever covers the status window's footprint -- the command window
-      # stays on screen beside it.
+      # only ever covers the status window's footprint -- the per-actor command
+      # window stays on screen beside it. Target selection only ever happens
+      # from the per-actor command phase (Attack/a targeted Skill/Item), never
+      # from the options window, so the status window's footprint here is
+      # always its command-phase one (#battle_status_x's `0`).
       BATTLE_TARGET_W = 136
       # How many rows show at once before a longer list (an 8-monster troop, a
       # long skill list) scrolls: the panel's fixed 64px content area (80 minus
@@ -3012,6 +3016,21 @@ class RPG2k
       STATUS_STATE_X = 86
       STATUS_HP_X    = 142
       STATUS_MP_X    = 202
+
+      # The status panel's own x, mirroring EasyRPG's `SetCommandWindowsX`:
+      # three windows -- the options window, the status window, then the
+      # per-actor command window -- sit left-to-right, but only one of the
+      # two 76px command-shaped windows is ever showing at once, so the
+      # status window slides to whichever side is free. During the top-level
+      # Battle/Auto Battle/Escape choice (`@ui[:phase] == :battle_options`)
+      # the options window takes the left slot (x=0) and the status window
+      # is pushed to `BATTLE_CMD_W`; once an actor is choosing Attack/Skill/
+      # Defend/Item the per-actor command window takes the *right* slot
+      # instead (`#draw_battle_command`'s own `BATTLE_STATUS_W`) and the
+      # status window returns to x=0.
+      def battle_status_x
+        @ui[:phase] == :battle_options ? BATTLE_CMD_W : 0
+      end
 
       # Rebuild the status panel: the party's HP and SP, each with the one
       # condition RPG_RT shows — the significant state, or the database's
@@ -3104,7 +3123,7 @@ class RPG2k
         return nil unless system2
         inner_w = BATTLE_STATUS_W - Window::BORDER * 2
         inner_h = BATTLE_PANEL_H - Window::BORDER * 2
-        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
+        win = Window.new(battle_status_x, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
         win.z = 300
         win.transparent = true
         c = Bitmap.new(inner_w, inner_h)
@@ -3258,14 +3277,20 @@ class RPG2k
         refresh_battle_status
       end
 
-      # The Battle/Auto Battle/Escape options window -- the same panel and
-      # rect the per-actor command window uses (only one of the two is ever
-      # on screen at a time), just with `#battle_option_rows`' three entries
-      # instead of the usual four.
+      # The Battle/Auto Battle/Escape options window -- the same 76px shape
+      # the per-actor command window uses (only one of the two is ever on
+      # screen at a time), with `#battle_option_rows`' three entries instead
+      # of the usual four, but docked to the *left* edge (x=0) rather than
+      # the command window's right one -- EasyRPG's `SetCommandWindowsX` lays
+      # the options window before the status window (`options_window->SetX`
+      # first, then `status_window->SetX` past it), while the per-actor
+      # command window comes after the status window instead. See
+      # `#battle_status_x`, which pushes the status panel to `BATTLE_CMD_W`
+      # to make room for this window here.
       def draw_battle_options
         @ui[:cmd_win].dispose if @ui[:cmd_win]
         labels = battle_option_rows.map { |r| r[:label] }
-        win = Window.new(BATTLE_STATUS_W, BATTLE_PANEL_Y, BATTLE_CMD_W, BATTLE_PANEL_H)
+        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_CMD_W, BATTLE_PANEL_H)
         win.z = 320
         win.windowskin = windowskin
         inner_w = BATTLE_CMD_W - Window::BORDER * 2
@@ -3571,8 +3596,9 @@ class RPG2k
       # segments rather than one string, so a row can mix colours. Drawn through
       # `draw_system_text`, which fills the glyphs from the System graphic's own
       # palette swatch (and falls back to flat white text when the project ships
-      # no windowskin) — the way RPG_RT colours a state name. Fixed at the
-      # bottom-left of the panel (`Window_BattleStatus`'s own rect), with a
+      # no windowskin) — the way RPG_RT colours a state name. Docked to
+      # `#battle_status_x` (0, beside the per-actor command window, or
+      # `BATTLE_CMD_W`, beside the options window -- see that method), with a
       # cursor on `cursor_idx`'s row when the acting actor is one of these rows.
       #
       # Each segment is clipped (`#clip_text_to_width`, Scene::Base) to the gap
@@ -3586,7 +3612,7 @@ class RPG2k
       # (SP) clips to the panel's own inner edge instead, same as before.
       def battle_status_window(rows, cursor_idx = nil)
         inner_w = BATTLE_STATUS_W - Window::BORDER * 2
-        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
+        win = Window.new(battle_status_x, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
         win.z = 300
         win.windowskin = windowskin
         c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7076,8 +7076,10 @@ class RPG2k
       # Graphic (`#open_message`'s `text_w`) leaves `FACE_SIZE + FACE_MARGIN` of
       # *bitmap* width beyond the intended text boundary for the portrait,
       # so an overflowing run kept drawing straight over it instead of
-      # disappearing there. `#clip_text_to_width` measures and slices the run
-      # to `w` itself before either draw path ever sees it, matching the
+      # disappearing there. `#clip_text_to_width` (Scene::Base -- shared with
+      # Scene::Battle's status panel, which hits the same unclipped-overflow
+      # gap between its own name/state/HP/MP columns) measures and slices the
+      # run to `w` itself before either draw path ever sees it, matching the
       # boundary this codebase's own message layout defines rather than
       # whatever the contents bitmap happens to be sized to.
       def draw_message_run(c, x, y, w, seg)
@@ -7089,22 +7091,6 @@ class RPG2k
           c.font.color = message_color(idx)
           c.draw_text x, y, w, MSG_LINE_H, text
         end
-      end
-
-      # Slice `text` down to however many leading characters fit within `w`
-      # pixels of `c`'s own font metrics, dropping the rest outright -- RPG_RT
-      # truncates an overlong line rather than wrapping it. Walks one character
-      # (not byte) at a time so a multi-byte codepoint is never split mid-way.
-      def clip_text_to_width(c, text, w)
-        return '' if w <= 0
-        return text if c.text_size(text).width <= w
-        out = ''
-        text.each_char do |ch|
-          candidate = out + ch
-          break if c.text_size(candidate).width > w
-          out = candidate
-        end
-        out
       end
 
       # Blit the already-cropped (and possibly mirrored, see #build_face_cell)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14275,6 +14275,32 @@ check 'the battle status panel clips each column to the gap before its own neigh
      'rather than bleeding off the panel'
 end
 
+check 'the status panel swaps sides with whichever 76px window is showing beside it' do
+  battle_mod = RPG2k::Scene::Battle
+  # During the top-level Battle/Auto Battle/Escape choice, EasyRPG's
+  # SetCommandWindowsX lays the options window at x=0 and pushes the status
+  # window to its right (BATTLE_CMD_W); the per-actor command window (off
+  # screen here) would take the *far* right slot instead, past the status
+  # window.
+  scene, = battle_scene_with_pages(nil, party: BattleStubParty.new)
+  ui = battle_until_phase(scene, :battle_options)
+  ok ui, 'the battle opened'
+  eq 0, ui[:cmd_win].x, 'the options window (Fight/Auto Battle/Escape) docks to the left edge'
+  eq battle_mod::BATTLE_CMD_W, ui[:status_win].x,
+     'the status window is pushed right, out of the options window\'s 76px'
+  eq battle_mod::BATTLE_CMD_W, ui[:cmd_win].width,
+     'the options window keeps the same 76px shape the per-actor command window uses'
+
+  # Once an actor is choosing Attack/Skill/Defend/Item instead, the roles
+  # swap: the command window takes the *right* slot the same way it always
+  # has, and the status window returns to x=0.
+  scene, ui2 = battle_at_command(nil, party: BattleStubParty.new)
+  ok ui2, 'the fight reached the per-actor command phase'
+  eq 0, ui2[:status_win].x, 'the status window returns to the left edge, beside the command window'
+  eq battle_mod::BATTLE_STATUS_W, ui2[:cmd_win].x,
+     'the per-actor command window docks to the right edge, unlike the options window'
+end
+
 check 'Change Monster Condition on a battle page updates the troop, off-panel' do
   ic = Game::Interpreter::Cmd
   # Inflict state 3 (Poison) on troop member 0 the moment the fight opens.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14224,6 +14224,57 @@ check 'the condition shown is the significant state, in the state colour' do
   eq 4, Game::States.color(4, scene.db.situation), 'Sleep in colour 4'
 end
 
+check 'the battle status panel clips each column to the gap before its own neighbour, not the panel edge' do
+  battle_mod = RPG2k::Scene::Battle
+  inner_w = battle_mod::BATTLE_STATUS_W - RPG2k::Window::BORDER * 2
+  hp_gap = battle_mod::STATUS_MP_X - battle_mod::STATUS_HP_X
+  mp_gap = inner_w - battle_mod::STATUS_MP_X
+  # A generous HP/SP pair (RPG2000's own 999 ceiling) so both columns'
+  # "current/max" text is longer than either gap -- the exact shape of the
+  # bleed the screenshot this fix comes from showed, an ally's "HP xxx/xxx"
+  # running into "SP" and "SP xxx/xxx" running off the panel's own edge.
+  actor = BattleStubActor.new(hp: 999, mp: 999)
+  party = BattleStubParty.new(actor)
+  scene, ui = battle_at_command(nil, party: party)
+  # #refresh_battle_status throws its old status window away and builds a
+  # fresh Bitmap for the new one (see #battle_status_window) -- unlike the
+  # message window's own long-lived contents bitmap, there is no single
+  # instance to patch #text_size onto ahead of the draw, so the stub class
+  # itself is patched for the duration of this check instead. The shared
+  # stub's own #text_size is a flat 0px (see #clip_text_to_width's own check
+  # above), which would never trigger a clip either way.
+  original_text_size = RGSS::Bitmap.instance_method(:text_size)
+  RGSS::Bitmap.send(:define_method, :text_size) { |s| RGSS::Rect.new(0, 0, s.length * 6, 0) }
+  begin
+    scene.instance_variable_get(:@battle).send(:refresh_battle_status)
+  ensure
+    RGSS::Bitmap.send(:define_method, :text_size, original_text_size)
+  end
+  calls = ui[:status_win].contents.draw_calls
+  hp_call = calls.find { |a| a[4].start_with?('HP') }
+  mp_call = calls.find { |a| a[4].start_with?('MP') }
+  ok hp_call, 'the HP segment was drawn'
+  ok mp_call, 'the SP segment was drawn'
+
+  eq hp_gap, hp_call[2],
+     "HP's own width is the #{hp_gap}px gap up to the SP column, not the panel's own edge"
+  eq mp_gap, mp_call[2],
+     "SP's own width is the #{mp_gap}px gap up to the panel's own inner edge"
+
+  ok hp_call[4].length * 6 <= hp_gap,
+     "HP's drawn text (#{hp_call[4].inspect}) was sliced to fit its own #{hp_gap}px column " \
+     "instead of overrunning into SP's"
+  ok mp_call[4].length * 6 <= mp_gap,
+     "SP's drawn text (#{mp_call[4].inspect}) was sliced to fit its own tiny #{mp_gap}px " \
+     'column instead of running off the panel'
+  eq 'HP 999/999', hp_call[4],
+     "HP's own 60px column is exactly enough for RPG2000's own 999 ceiling -- " \
+     "the comment on STATUS_NAME_X's own block -- so this drew whole, untruncated"
+  ok mp_call[4].length < 'MP 999/999'.length,
+     "SP 999/999 does not fit #{mp_gap}px at 6px/character, so it was genuinely truncated " \
+     'rather than bleeding off the panel'
+end
+
 check 'Change Monster Condition on a battle page updates the troop, off-panel' do
   ic = Game::Interpreter::Cmd
   # Inflict state 3 (Poison) on troop member 0 the moment the fight opens.


### PR DESCRIPTION
## Summary

Two related fixes to the RPG2000 battle screen's bottom panel, both driven by real screenshots of the battle UI:

1. **HP/SP column overlap/clipping.** `Bitmap#draw_text`/`#blend_text` (`mruby-rgss`) never clip to the `w`/`h` rect they're given — those are only used for centre/right alignment — so `Scene::Battle#battle_status_window`'s four fixed-x columns (name@4, state@86, HP@142, SP@202 in a 244px-wide, 8px-bordered panel) had nothing stopping an overlong run from drawing straight through its neighbour's column. The HP column has only 60px before SP starts, and SP has only 26px before the panel's own inner edge — nowhere near enough for values like RPG2000's own 999 HP/SP ceiling. Fixed by moving `#clip_text_to_width` (previously local to the message window's own face-graphic clipping fix) onto `Scene::Base` so `Scene::Battle` can share it, and clipping each status-row segment to the gap before its own neighbour before drawing.

2. **Options window docked to the wrong side.** Every phase of a fight built the status panel fixed at `x=0` (left) with whichever 76px command-shaped window was showing at `x=BATTLE_STATUS_W` (right) — including the top-level Battle/Auto Battle/Escape options window. Real RPG_RT (EasyRPG's `Scene_Battle_Rpg2k::SetCommandWindowsX`, verified against the actual EasyRPG Player source) lays three windows left-to-right: the options window, then the status window, then the per-actor command window — so the options window actually docks to the **left** edge with the status panel pushed right beside it, while the per-actor Attack/Skill/Defend/Item command window keeps the status panel on the left and takes the right slot itself. Added `#battle_status_x` (`0` during the per-actor command phase, `BATTLE_CMD_W` during `:battle_options`) and used it for both status window variants (gauge-card and text); moved `draw_battle_options`'s own window to `x=0` to match.

Both are covered by new `scripts/rpg2k_scene_check.rb` checks.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 769 checks passed (767 existing + 2 new)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1062 checks passed (unchanged)
- [ ] Visual verification against a real screenshot was not performed for the first fix — the native C++ build's git submodules were not checked out in this environment. The second fix (options-window docking) was diagnosed directly from real screenshots the reporter provided of the actual battle screen (before: options-left/status-right during the options phase but with garbled HP/MP text; after the first fix: status-left/options-right, which the reporter confirmed was still wrong) plus the real EasyRPG Player source for `SetCommandWindowsX`.