### PR TITLE
Shop quantity counter auto-repeats while a direction is held

### DIFF
--- a/changelog.d/shop-quantity-counter-auto-repeat.fixed.md
+++ b/changelog.d/shop-quantity-counter-auto-repeat.fixed.md
@@ -1,0 +1,4 @@
+- **Shops:** The quantity counter now auto-repeats while a direction is held
+  down, instead of only moving on a fresh key press, matching RPG_RT --
+  previously a player had to mash the button once per unit or ten instead of
+  holding it. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7456,6 +7456,24 @@ not yet verified:
   buy/sell-a-stack-of-three checks that used to press UP twice and now press
   RIGHT twice), all four confirmed to fail against the pre-fix code before
   the fix.
+  ✅ **Follow-up (2026-08-19): the shop quantity counter only moved on a
+  fresh key press, never auto-repeating while a direction was held.**
+  Confirmed directly against RPG_RT's live source: `Window_ShopNumber::
+  Update` (`src/window_shopnumber.cpp`) gates all four directions —
+  RIGHT/LEFT by one, UP/DOWN by ten — on `Input::IsRepeated`, the same
+  repeat-while-held semantics every other in-game list cursor uses (Show
+  Choices, the battle command/target/skill cursors, Equip's slot cursor),
+  never a bare `IsTriggered`. `shop_quantity_move`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) checked only `Input.trigger?` on each
+  branch, so a player had to mash the button once per unit or ten instead
+  of holding it down the way every other cursor in the game already
+  allowed. Fixed by adding `|| Input.repeat?(...)` to all four branches,
+  matching the `Input.trigger?(...) || Input.repeat?(...)` idiom this
+  codebase already uses everywhere else. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (`RGSS::Input.repeated`, not
+  `.triggered`, still steps the counter by one on Right and by ten on Up),
+  confirmed to fail against the pre-fix code (`expected 2, got 1`) before
+  the fix.
 - ✅ **Battle turn order now rolls a random Agility jitter each round, instead
   of sorting purely by raw Agility.** Confirmed against EasyRPG's actual
   `Scene_Battle_Rpg2k::CreateExecutionOrder` (`src/scene_battle_rpg2k.cpp`):

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4973,15 +4973,22 @@ class RPG2k
       end
 
       # Apply one frame of quantity input; returns whether the count changed.
+      # Every direction auto-repeats while held, not just a single fresh
+      # press -- confirmed against RPG_RT's own live source:
+      # `Window_ShopNumber::Update` (src/window_shopnumber.cpp) gates all
+      # four branches on `Input::IsRepeated`, the same repeat-while-held
+      # semantics every other in-game list cursor uses (see e.g.
+      # Scene::Battle's own `Input.trigger?(...) || Input.repeat?(...)`
+      # cursor idiom), not a bare `IsTriggered`.
       def shop_quantity_move(q)
         before = q[:count]
-        if Input.trigger?(Input::RIGHT)
+        if Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
           q[:count] += 1
-        elsif Input.trigger?(Input::LEFT)
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
           q[:count] -= 1
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           q[:count] += SHOP_QUANTITY_STEP
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           q[:count] -= SHOP_QUANTITY_STEP
         else
           return false

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6024,6 +6024,29 @@ check 'Open Shop scene: the counter steps by ten on the vertical axis' do
   eq 99, shop[:quantity][:count], 'clamped at the cap'
 end
 
+# `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold a
+# key across frames without it also reading as a fresh trigger.
+check 'Open Shop scene: holding a direction auto-repeats the quantity counter, ' \
+      'not just a fresh press' do
+  # Confirmed against RPG_RT's own live source: Window_ShopNumber::Update
+  # (src/window_shopnumber.cpp) gates all four directions on
+  # Input::IsRepeated, not IsTriggered -- the same repeat-while-held cursor
+  # semantics every other in-game list uses.
+  scene, _st = shop_quantity_scene(999_999)
+  shop = scene.instance_variable_get(:@shop)
+  eq 99, shop[:quantity][:max], 'rich enough to hit the item cap'
+
+  RGSS::Input.repeated = [RGSS::Input::RIGHT] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 2, shop[:quantity][:count], 'a held (repeated) Right still steps the count by one'
+
+  RGSS::Input.repeated = [RGSS::Input::UP]
+  scene.update
+  RGSS::Input.reset
+  eq 12, shop[:quantity][:count], 'a held (repeated) Up still steps the count by ten'
+end
+
 check 'Open Shop scene: confirming the counter buys the whole stack at once' do
   scene, st = shop_quantity_scene(500)
   press(scene, RGSS::Input::RIGHT)


### PR DESCRIPTION
## Summary

`Window_ShopNumber::Update` (`src/window_shopnumber.cpp`) gates all four directions -- RIGHT/LEFT by one, UP/DOWN by ten -- on `Input::IsRepeated`, the same repeat-while-held semantics every other in-game list cursor uses (Show Choices, the battle command/target/skill cursors, Equip's slot cursor), never a bare `IsTriggered`.

`shop_quantity_move` (`mruby-rpg2k/mrblib/scene/map.rb`) checked only `Input.trigger?` on each branch, so a player had to mash the button once per unit or ten instead of holding it down the way every other cursor in the game already allowed.

- Fixed by adding `|| Input.repeat?(...)` to all four branches, matching the `Input.trigger?(...) || Input.repeat?(...)` idiom this codebase already uses everywhere else.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: `RGSS::Input.repeated`, not `.triggered`, still steps the counter by one on Right and by ten on Up.
- Verified via `git stash` on `scene/map.rb` alone: only the new check fails pre-fix (`expected 2, got 1`).
- Full suite green: `rpg2k_scene_check.rb` 770 passed, `rpg2k_logic_check.rb` 1062 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_