### PR TITLE
fix(rgss): Window#contents nil, Audio.bgm_play pos, RPG::CommonEvent predicates

### DIFF
--- a/changelog.d/vxace-window-contents-bgm-pos-commonevent-predicates.fixed.md
+++ b/changelog.d/vxace-window-contents-bgm-pos-commonevent-predicates.fixed.md
@@ -1,0 +1,16 @@
+- **XP / VX / VX Ace** three more real gaps found continuing to boot a real
+  VX Ace game past its previous walls, all fixed: a freshly constructed
+  `Window`'s `contents` started as Ruby `nil` in `mruby-rgss`'s native
+  `window_init` instead of a real `Bitmap`, so real RGSS3's own stock
+  `Window_Base#create_contents` (`contents.dispose`, run by every `Window`
+  a game ever builds) raised `NoMethodError` on the very first window any
+  VX Ace game constructs. `Audio.bgm_play` rejected RGSS3's 4th (`pos`,
+  resume-playback-position) argument that a real `RPG::BGM#replay` and
+  volume-control add-on scripts call with — now accepted and warned about
+  once rather than raising `ArgumentError` (no backend here seeks a
+  mid-track position, so the track plays from its own beginning).
+  `RPG::CommonEvent` had no `#autorun?`/`#parallel?`, which real RGSS3's own
+  stock `Game_Map#setup_autorun_common_event`/`#parallel_common_events` call
+  directly — every VX Ace game raised `NoMethodError` the moment a player
+  pressed New Game (VX Ace-only; confirmed XP's own stock scripts never call
+  either predicate).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16388,14 +16388,33 @@ screen (544×416). Full rationale:
     turn behind the same `NoMethodError: undefined method 'message' for
     NilClass`. All three fixes above were found this way — a temporary,
     never-committed VM-level probe read the real masked exception one at a
-    time. A fourth is already known this way and not yet fixed:
-    `NoMethodError: undefined method 'dispose' for NilClass`. Fixable only
-    by wrapping `Kernel#raise` itself (the sole point where the
+    time — and the same probe found three more past them: `Window#contents`
+    started `nil` instead of a real `Bitmap` in `mruby-rgss`'s native
+    `window_init`, so real RGSS3's own stock `Window_Base#create_contents`
+    (`contents.dispose`, its first line, run by every `Window` a game ever
+    constructs) raised `NoMethodError` on the very first window any VX Ace
+    game builds — `Scene_Title`'s own title-command window. Fixed by
+    constructing a real 1×1 `Bitmap` there instead. `Audio.bgm_play` rejected
+    RGSS3's 4th (`pos`, resume-playback-position) argument that a real
+    `RPG::BGM#replay` and a volume-control add-on script both call with —
+    fixed by accepting `pos = 0` and warning once that seeking is
+    unsupported rather than raising `ArgumentError`. `RPG::CommonEvent` had
+    no `#autorun?`/`#parallel?`, which real RGSS3's own stock
+    `Game_Map#setup_autorun_common_event`/`#parallel_common_events` call
+    directly — every VX Ace game raised `NoMethodError` the moment a player
+    pressed New Game. Fixed by adding both predicates
+    (`mruby-rpgvx/mrblib/rgss2_data.rb`; confirmed XP's own stock scripts
+    never call either, so the fix is VX/VX Ace-only). A seventh masked
+    exception is already known this way and not yet fixed — past
+    `DataManager.setup_new_game`, into actual gameplay (`Graphics.brightness=`
+    is the next stub the game calls before it). Fixing `$!` itself is
+    fixable only by wrapping `Kernel#raise` itself (the sole point where the
     about-to-be-raised object is observable), which would add overhead and
     stack depth to *every* exception in the shared build across every maker
     and every platform (PSP's stack headroom included) for what is mostly
     log-message fidelity in one utility script — see the item 7 write-up for
-    the full reasoning on why that trade isn't taken here.
+    the full reasoning on why that trade isn't taken here; the temporary VM
+    probe keeps finding the real gaps without it.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -496,17 +496,68 @@ not a one-time cosmetic loss: every fatal exception this game hits, of any
 origin, is masked behind the identical `NoMethodError: undefined method
 'message' for NilClass` crash in the error-log utility, until whatever real
 exception triggered it is fixed and the *next* one takes its place. Diagnosing
-each of the fixes above required a temporary, never-committed `fprintf` at
-the `OP_EXCEPT` opcode itself (in the local `3rd/mruby` submodule checkout,
-reverted before every commit) to read the masked exception directly off the
-VM — the `Dir.glob` and `Color.new`/`Tone.new` gaps above were both found
-this way, one at a time, three separate real bugs in a row hidden behind the
-same crash. A fourth is already known and not yet fixed: with all three
-gaps above closed, the game now reaches
-`NoMethodError: undefined method 'dispose' for NilClass`, masked the same
-way. Left for a future pass — the pattern established here (temporary VM
-probe → real gap → mrblib or native fix → regression test) applies to it
-too. mruby's bare `raise` (no arguments) has the same
+each of the fixes above (and the three below) required a temporary,
+never-committed `fprintf` at the `OP_EXCEPT` opcode itself (in the local
+`3rd/mruby` submodule checkout, reverted before every commit) to read the
+masked exception directly off the VM — six separate real bugs found this way,
+one at a time, each hidden behind the identical crash until fixed:
+
+- **Fixed: `Window#contents` started `nil` instead of a real `Bitmap`.**
+  Another native `mruby-rgss` binding bug (`window_init` in
+  `mruby-rgss/src/lib.cxx`), not a script gap. Real RGSS3's own stock,
+  unmodified `Window_Base#create_contents` — called from `#initialize`, so
+  every single `Window` a game ever constructs runs it once immediately —
+  starts with a bare `contents.dispose`, on the assumption a freshly built
+  `Window` already owns a (trivial) disposable `Bitmap`. This engine's
+  `window_init` set `@contents` to Ruby `nil` instead, so the very first
+  `Window_Base`-derived window any VX Ace game ever constructs —
+  `Scene_Title`'s own `Window_TitleCommand` — raised `NoMethodError:
+  undefined method 'dispose' for NilClass` before a single frame of the
+  title screen drew. Fixed by having `window_init` construct a real 1×1
+  `RGSS::Bitmap` (the same `DataType<Bitmap>::make` helper
+  `window_ensure_canvas` already uses a few lines below it) and store that
+  instead of `mrb_nil_value()`.
+
+- **Fixed: `Audio.bgm_play` rejected RGSS3's 4th (`pos`) argument.** A real
+  gap, not a bug — `mruby-rgss/mrblib/lib.rb`'s `bgm_play(filename, volume =
+  100, pitch = 100)` never grew the `pos` parameter RGSS3 added over
+  XP/VX's 3-argument form (VX Ace resumes a BGM's playback position — a
+  save's `RPG::BGM#replay`, or a bare `Audio.bgm_play(f, v, p, pos)` a
+  volume-control add-on script called directly — see the real
+  `RPG::BGM#play` reopened by this same release's add-on). Every VX Ace
+  game whose title screen calls `Audio.bgm_play` with 4 arguments raised
+  `ArgumentError` right there. Accepting the 4th argument needs no real fix
+  behind it — no backend here seeks a mid-stream start position, and this
+  engine's own `RPG::BGM` never calls the 4-arg form internally either (see
+  `mruby-rpgvx/mrblib/rgss2_runtime.rb`'s own `BGM.play_audio`, still
+  3-arg) — so `bgm_play` now accepts `pos = 0`, warns once that seeking is
+  unsupported when it is non-zero, and plays the track from its own
+  beginning, matching the real signature real scripts call with instead of
+  raising.
+
+- **Fixed: `RPG::CommonEvent` had no `#autorun?` / `#parallel?`.** A real
+  data-layer gap in `mruby-rpgvx/mrblib/rgss2_data.rb`: `CommonEvent` only
+  ever exposed the raw `trigger` integer (0 none, 1 autorun, 2 parallel).
+  Real RGSS3's own stock, unmodified `Game_Map#setup_autorun_common_event`
+  and `#parallel_common_events` call the predicates directly rather than
+  comparing `trigger` themselves, so `DataManager.setup_new_game` →
+  `Game_Map#setup` → `#setup_events` raised `NoMethodError: undefined
+  method 'parallel?' for RPG::CommonEvent` on every VX Ace game that starts
+  a new game — every VX Ace game reaches this the moment a player presses
+  New Game, VX Ace's own "Parallel Process" trigger having no XP/VX
+  equivalent means this was invisible on every project this host had
+  reached new-game setup on before. XP's own stock scripts, confirmed
+  against both XP test beds, never call either predicate — the fix is
+  scoped to `mruby-rpgvx` only.
+
+With all six gaps above closed, the same real VX Ace release now reaches
+past `Scene_Title`'s title-command window, its title music, and
+`DataManager.setup_new_game`'s common-event setup, into actual gameplay
+(`Graphics.brightness=`, a scene-transition primitive, is the next stub it
+calls) before hitting a seventh masked exception — not yet diagnosed. The
+pattern established here (temporary VM probe → real gap → mrblib or native
+fix → regression test) applies to it too, left for a future pass. mruby's
+bare `raise` (no arguments) has the same
 root cause from the other side: real Ruby re-raises `$!`, but mruby's
 `mrb_f_raise` has no `$!` to fall back to, so a bare `raise` always raises a
 fresh, empty `RuntimeError` instead of re-raising what was actually caught.
@@ -538,5 +589,10 @@ Tilemap item 1's remaining polish (the flat "above characters" layer) is the
 only item left in the six sections above; item 7's `$!`/bare-`raise` gap
 stands, and per a real release it is the reason each fix above only reveals
 the *next* wall one at a time rather than the game running to completion in
-one pass — `NoMethodError: undefined method 'dispose' for NilClass`, found
-but not yet fixed, is where it stands now.
+one pass. Six real bugs have been found and fixed this way so far
+(`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
+`Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`)
+without needing `$!` itself fixed — the temporary VM probe finds the real
+exception directly regardless. A seventh wall, past
+`DataManager.setup_new_game` and into actual gameplay, is where the game
+stands now: not yet diagnosed.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1020,7 +1020,19 @@ module RGSS
     }.freeze
 
     class << self
-      def bgm_play(filename, volume = 100, pitch = 100)
+      # `pos` is RGSS3-only (VX Ace added it over XP/VX's 3-argument form) --
+      # real scripts pass it to resume a BGM from where a prior track left
+      # off (RPG::BGM#replay, a bare `Audio.bgm_play(f, v, p, pos)` in a
+      # volume-control add-on). No backend here seeks a mid-stream start
+      # position, so it is accepted (matching the real signature real
+      # scripts call with) and warned about once rather than raising
+      # ArgumentError on every VX Ace game that calls it -- the track still
+      # plays, just from its own beginning.
+      def bgm_play(filename, volume = 100, pitch = 100, pos = 0)
+        RGSS.warn_once(
+          "Audio.bgm_play pos (mid-track resume) is not implemented yet " \
+          "(stub, plays from the beginning)"
+        ) unless pos == 0
         path = resolve(filename, MUSIC_DIRS)
         return _bgm_play(path, volume, pitch) if path
         play_packed(:bgm, filename, volume, pitch)

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -5444,7 +5444,16 @@ mrb_value window_init(mrb_state* M, mrb_value self) {
   register_zobj(M, self);
   lv_obj_set_pos(c, 0, 0);
   mrb_iv_set(M, self, mrb_intern_lit(M, "@viewport"), vp);
-  mrb_iv_set(M, self, mrb_intern_lit(M, "@contents"), mrb_nil_value());
+  // RGSS3's own stock Window_Base#create_contents (every VX Ace project ships
+  // it unmodified) calls `contents.dispose` unconditionally as its first line
+  // -- real RGSS never leaves a freshly constructed Window's `contents` nil,
+  // it starts as a real (if trivial) Bitmap so that always-safe first dispose
+  // has something to act on.
+  RClass* initial_contents_bmp_class =
+      mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Bitmap");
+  const mrb_value initial_contents = DataType<Bitmap>::make(
+      M, initial_contents_bmp_class, 1, 1, LV_COLOR_FORMAT_ARGB8888);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@contents"), initial_contents);
   mrb_iv_set(M, self, mrb_intern_lit(M, "@width"), mrb_fixnum_value(0));
   mrb_iv_set(M, self, mrb_intern_lit(M, "@height"), mrb_fixnum_value(0));
   mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(0));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1479,6 +1479,15 @@ assert "RGSS::Audio survives an archive that raises" do
   end
 end
 
+# RGSS3's own `pos` argument (VX Ace added it over XP/VX's 3-argument form),
+# used to resume a BGM from where a prior track left off -- a real VX Ace
+# volume-control add-on calls `Audio.bgm_play(name, vol, pitch, pos)`
+# directly, and the 4th argument raised ArgumentError before this method
+# accepted it.
+assert "RGSS::Audio.bgm_play accepts RGSS3's 4th (pos) argument" do
+  assert_nothing_raised { RGSS::Audio.bgm_play("Theme1", 80, 90, 5) }
+end
+
 assert "RGSS::Audio.se_play resolves a name to a real file" do
   # Capture what the public API forwards to the native primitive so we can
   # assert the filename was resolved (extension appended) and volume/pitch

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1485,7 +1485,7 @@ end
 # directly, and the 4th argument raised ArgumentError before this method
 # accepted it.
 assert "RGSS::Audio.bgm_play accepts RGSS3's 4th (pos) argument" do
-  assert_nothing_raised { RGSS::Audio.bgm_play("Theme1", 80, 90, 5) }
+  assert_nil RGSS::Audio.bgm_play("Theme1", 80, 90, 5)
 end
 
 assert "RGSS::Audio.se_play resolves a name to a real file" do

--- a/mruby-rpgvx/mrblib/rgss2_data.rb
+++ b/mruby-rpgvx/mrblib/rgss2_data.rb
@@ -273,6 +273,18 @@ module RPG
 
   class CommonEvent
     attr_accessor :id, :name, :trigger, :switch_id, :list
+
+    # `trigger`: 0 none, 1 autorun, 2 parallel -- real RGSS3's stock
+    # Game_Map#setup_autorun_common_event/#parallel_common_events call these
+    # predicates directly rather than comparing `trigger` themselves, and
+    # every VX Ace project's default Game_Map does so unmodified.
+    def autorun?
+      @trigger == 1
+    end
+
+    def parallel?
+      @trigger == 2
+    end
   end
 
   class MapInfo

--- a/mruby-rpgvx/test/rpgvx_test.rb
+++ b/mruby-rpgvx/test/rpgvx_test.rb
@@ -643,3 +643,25 @@ assert "a VX Ace database survives its .rgss3a (v3) archive" do
   assert_equal "Packed Ace", loaded.game_title
   assert_equal 7, loaded.start_map_id
 end
+
+# Real RGSS3's own stock Game_Map#setup_autorun_common_event/
+# #parallel_common_events call these predicates directly rather than
+# comparing `trigger` themselves -- every VX/VX Ace project's default
+# Game_Map does so unmodified, so a missing predicate fails common events
+# in every real game the script host reaches new-game setup on.
+assert "RPG::CommonEvent#autorun?/#parallel? read the trigger field" do
+  none = RPG::CommonEvent.new
+  none.trigger = 0
+  assert_false none.autorun?
+  assert_false none.parallel?
+
+  autorun = RPG::CommonEvent.new
+  autorun.trigger = 1
+  assert_true autorun.autorun?
+  assert_false autorun.parallel?
+
+  parallel = RPG::CommonEvent.new
+  parallel.trigger = 2
+  assert_false parallel.autorun?
+  assert_true parallel.parallel?
+end


### PR DESCRIPTION
## Summary

Continues digging into the real VX Ace release from #1074/#1089/#1092
(*Sanctuary Of the Ruler*), past the `Dir.glob`/`Color.new`/`Tone.new`/heap
fixes. Three more real gaps found, each by getting the game one step
further through its own script host:

- **`Window#contents` started `nil` instead of a real `Bitmap`.** A native
  `mruby-rgss` binding bug (`window_init` in `mruby-rgss/src/lib.cxx`), not
  a script gap. Real RGSS3's own stock, unmodified `Window_Base#create_contents`
  — called from `#initialize`, so every single `Window` a game ever
  constructs runs it once immediately — starts with a bare
  `contents.dispose`, on the assumption a freshly built `Window` already
  owns a (trivial) disposable `Bitmap`. This engine's `window_init` set
  `@contents` to Ruby `nil` instead, so the very first `Window_Base`-derived
  window any VX Ace game ever constructs — `Scene_Title`'s own
  `Window_TitleCommand` — raised `NoMethodError: undefined method 'dispose'
  for NilClass` before a single frame of the title screen drew. Fixed by
  having `window_init` construct a real 1×1 `RGSS::Bitmap` (the same
  `DataType<Bitmap>::make` helper `window_ensure_canvas` already uses a few
  lines below it) and store that instead of `mrb_nil_value()`.

- **`Audio.bgm_play` rejected RGSS3's 4th (`pos`) argument.** A real gap,
  not a bug — `mruby-rgss/mrblib/lib.rb`'s `bgm_play(filename, volume = 100,
  pitch = 100)` never grew the `pos` parameter RGSS3 added over XP/VX's
  3-argument form (VX Ace resumes a BGM's playback position — a save's
  `RPG::BGM#replay`, or a bare `Audio.bgm_play(f, v, p, pos)` a
  volume-control add-on script in this same release calls directly). Every
  VX Ace game whose title screen calls `Audio.bgm_play` with 4 arguments
  raised `ArgumentError` right there. No backend here seeks a mid-stream
  start position, and this engine's own `RPG::BGM` never calls the 4-arg
  form internally either — so `bgm_play` now accepts `pos = 0`, warns once
  that seeking is unsupported when it is non-zero, and plays the track from
  its own beginning, matching the real signature real scripts call with
  instead of raising.

- **`RPG::CommonEvent` had no `#autorun?` / `#parallel?`.** A real
  data-layer gap in `mruby-rpgvx/mrblib/rgss2_data.rb`: `CommonEvent` only
  ever exposed the raw `trigger` integer (0 none, 1 autorun, 2 parallel).
  Real RGSS3's own stock, unmodified `Game_Map#setup_autorun_common_event`
  and `#parallel_common_events` call the predicates directly rather than
  comparing `trigger` themselves, so `DataManager.setup_new_game` →
  `Game_Map#setup` → `#setup_events` raised `NoMethodError: undefined
  method 'parallel?' for RPG::CommonEvent` on every VX Ace game that
  starts a new game. Fixed (VX/VX Ace only — confirmed XP's own stock
  scripts never call either predicate against both XP test beds).

**Diagnostic method, not shipped**: mruby's still-missing `$!` (item 7,
`docs/rpgvx-rgss-api-gap.md`) masks *every* fatal exception this game hits
behind an identical crash in its own bundled error-log utility —
`SceneManager.run`'s top-level rescue calls `TKG::ErrorLog.save()`, whose
`exception = $!` default is always `nil`. All three fixes above were found
by adding a temporary `fprintf` at the `OP_EXCEPT` opcode in the local
`3rd/mruby` submodule checkout to read the real masked exception directly
off the VM — reverted before every commit here, never part of the diff.
With all six gaps found so far closed (this PR's three plus #1092's
three), the game now reaches past `DataManager.setup_new_game` into actual
gameplay (`Graphics.brightness=` is the next stub it calls) before hitting
a seventh masked exception — not yet diagnosed, left for a follow-up.

## Test plan
- [x] `ctest -R mruby_test` — 100% passing, includes new regression tests
      for `Audio.bgm_play`'s `pos` argument and
      `RPG::CommonEvent#autorun?`/`#parallel?` (`Window#contents` has no
      unit test — like `Sprite`/`Plane`/`Window`'s existing method-surface
      tests note, real construction needs a live display the headless test
      binary lacks; covered by the boot checks below instead)
- [x] `ruby scripts/rpgxp_testbed_check.rb data/PrayforYou` — OK
- [x] `ruby scripts/rpgvx_testbed_check.rb` — OK
- [x] `bash scripts/rpgxp_boot_check.bash` — move/menu/battle/save all
      still pass on both XP test beds (this exercises real `Window`
      construction most heavily of any existing check)
- [x] Manual: the real VX Ace release now gets past `Scene_Title`'s
      title-command window, its title music, and
      `DataManager.setup_new_game`'s common-event setup, into actual
      gameplay
- [x] `docs/TODO.md` and `docs/rpgvx-rgss-api-gap.md` updated with the full
      diagnosis for all three fixes and the new (seventh) open item

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_