### PR TITLE
Shop command/item list cursors auto-repeat while a direction is held

### DIFF
--- a/changelog.d/shop-list-cursor-auto-repeat.fixed.md
+++ b/changelog.d/shop-list-cursor-auto-repeat.fixed.md
@@ -1,0 +1,4 @@
+- **Shops:** The Buy/Sell/Leave command list and the buy/sell item lists now
+  auto-repeat the cursor while Up/Down is held, instead of moving only on a
+  fresh key press, matching RPG_RT. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4046,6 +4046,27 @@ The work below is roughly ordered by the critical path to a walkable game
   hypothetical edge case. Covered by five new `scripts/rpg2k_scene_check.rb`
   checks across Inn and Shop's command list/buy list/quantity counter, all
   confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-19): the shop's own command list and buy/sell item
+  list only moved the cursor on a fresh key press, never auto-repeating
+  while Up/Down was held — the same class of gap the shop quantity
+  counter had, and missed by the very pass just above despite already
+  having `Window_Shop::Update`'s source in hand.** That earlier pass
+  quoted `Window_Shop::Update` (`src/window_shop.cpp`) for its SFX-on-move
+  behavior but never noticed the same quoted function gates its Up/Down
+  entirely on `Input::IsRepeated`, not `IsTriggered` — and the buy/sell
+  item lists (`Window_Selectable::Update`, `src/window_selectable.cpp`,
+  the base class both `Window_ShopBuy` and `Window_ShopSell` share) move
+  on `IsTriggered` *or* `IsRepeated` too, the same repeat-while-held
+  cursor every RPG2000 list window gets. `#shop_move_cursor`
+  (`mruby-rpg2k/mrblib/scene/map.rb`, shared by `#drive_shop_command` and
+  `#drive_shop_list`) checked only `Input.trigger?` on each direction, so
+  a player had to tap Up/Down once per line instead of holding it down.
+  Fixed by adding `|| Input.repeat?(...)` to both branches, matching the
+  idiom already used everywhere else in this file (including the shop
+  quantity counter's own fix just above). Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (`RGSS::Input.repeated`, not
+  `.triggered`, still moves the buy list cursor), confirmed to fail
+  against the pre-fix code (`expected 1, got 0`) before the fix.
   ✅ **A disabled Continue's own *rendering* — not just its SE — was also
   still wrong, found in a separate later pass: it drew a hardcoded flat gray
   instead of reading the windowskin's own disabled-colour swatch, unlike

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5011,15 +5011,21 @@ class RPG2k
       # field-menu SFX audit elsewhere in this file/docs/TODO.md) -- shared
       # by the command list and the buy/sell list alike, both backed by a
       # `Window_Selectable` subclass in real RPG_RT (`Window_Shop`/
-      # `Window_ShopBuy`/`Window_ShopSell`).
+      # `Window_ShopBuy`/`Window_ShopSell`). Both directions also auto-repeat
+      # while held, not just a fresh press -- confirmed against RPG_RT's own
+      # live source: `Window_Shop::Update` (`src/window_shop.cpp`, the
+      # command list) gates its Up/Down entirely on `Input::IsRepeated`, and
+      # `Window_Selectable::Update` (`src/window_selectable.cpp`, the
+      # buy/sell item lists) moves on `IsTriggered` *or* `IsRepeated` --
+      # every RPG2000 list cursor in real RPG_RT auto-repeats.
       def shop_move_cursor(lines)
-        if Input.trigger?(Input::DOWN) && !lines.empty?
+        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !lines.empty?
           @shop[:index] += 1
           @shop[:index] %= lines.length
           draw_shop
           play_system_se(SFX_CURSOR)
           true
-        elsif Input.trigger?(Input::UP) && !lines.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !lines.empty?
           @shop[:index] -= 1
           @shop[:index] %= lines.length
           draw_shop

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5961,6 +5961,33 @@ check 'Open Shop scene: the buy list cursor wraps around' do
   eq 0, shop[:index], 'Down from the last good wraps to the first'
 end
 
+# `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold a
+# key across frames without it also reading as a fresh trigger.
+check 'Open Shop scene: holding a direction auto-repeats the buy list ' \
+      'cursor, not just a fresh press' do
+  # Confirmed against RPG_RT's own live source: `Window_Shop::Update`
+  # (src/window_shop.cpp, the command list) and `Window_Selectable::Update`
+  # (src/window_selectable.cpp, the buy/sell item lists) both move the
+  # cursor on a held (repeated) Down/Up, not only a fresh trigger.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3, 5], indent: 0), # buy-only, goods 3/5
+    ECmd.new(ic::SHOP_END, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the shop opens straight to the buy list (buy-only)
+  shop = scene.instance_variable_get(:@shop)
+  eq 0, shop[:index], 'starts on the first good'
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, shop[:index], 'a held (repeated) Down still moves the buy list cursor'
+end
+
 # Open a buy-only shop stocking goods 3 (100g) and 5, with `gold` on hand, and
 # advance to the quantity counter for the first good.
 def shop_quantity_scene(gold)


### PR DESCRIPTION
## Summary

`Window_Shop::Update` (`src/window_shop.cpp`, the Buy/Sell/Leave command list) gates its Up/Down entirely on `Input::IsRepeated`, and `Window_Selectable::Update` (`src/window_selectable.cpp`, the base class both `Window_ShopBuy` and `Window_ShopSell` share) moves on `IsTriggered` *or* `IsRepeated` -- the same repeat-while-held cursor every RPG2000 list window gets.

`#shop_move_cursor` (`mruby-rpg2k/mrblib/scene/map.rb`, shared by `#drive_shop_command` and `#drive_shop_list`) checked only `Input.trigger?` on each direction, so a player had to tap Up/Down once per line instead of holding it down.

- Fixed by adding `|| Input.repeat?(...)` to both branches, matching the idiom already used everywhere else in this file (including the shop quantity counter's own recent fix in #1099).

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: `RGSS::Input.repeated`, not `.triggered`, still moves the buy list cursor.
- Verified via `git stash` on `scene/map.rb` alone: only the new check fails pre-fix (`expected 1, got 0`).
- Full suite green: `rpg2k_scene_check.rb` 771 passed, `rpg2k_logic_check.rb` 1062 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_