### PR TITLE
Enter Hero Name's character-grid cursor auto-repeats while held

### DIFF
--- a/changelog.d/name-input-grid-auto-repeat.fixed.md
+++ b/changelog.d/name-input-grid-auto-repeat.fixed.md
@@ -1,0 +1,4 @@
+- **Enter Hero Name:** The character-grid cursor (both the ASCII and
+  hiragana/katakana pages) now auto-repeats while a direction is held,
+  instead of moving only on a fresh key press, matching RPG_RT. Covered by
+  two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3999,6 +3999,31 @@ The work below is roughly ordered by the critical path to a walkable game
   move, character confirm, Cancel-with-a-character, Cancel-with-none, and
   an overflowing character's Decision-then-Buzzer pair all get their
   correct SE), confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-19): the same widget's character-grid cursor only
+  moved on a fresh key press, never auto-repeating while a direction was
+  held — the SE pass just above already had `Window_Keyboard::Update` open
+  and quoted its `play_cursor` flag, but never noticed the same function
+  gates every grid move on `Input::IsRepeated` alone.** Confirmed directly
+  against RPG_RT's live source: `Window_Keyboard::Update`
+  (`src/window_keyboard.cpp`) is four `if (Input::IsRepeated(...))` checks,
+  one per direction, with no `IsTriggered` anywhere — and
+  `Input::UpdateSystem` (`src/input.cpp`) defines `repeated[i] =
+  press_time[i] == 1 || (press_time[i] >= start_repeat_time && ...)`, so
+  `IsRepeated` alone fires on both the very first pressed frame and the
+  later repeat cadence — exactly the union this codebase's own split
+  `Input.trigger?` (fresh press only) / `Input.repeat?` (delayed
+  auto-repeat, never frame 1) idiom already covers everywhere else (see the
+  shop quantity counter and shop list cursor fixes elsewhere in this
+  document). `#handle_name_input`/`#handle_kana_name_input`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) checked only `Input.trigger?` on each
+  of the four directions, so a player had to tap each arrow once per cell
+  instead of holding it down the way real RPG_RT's name-entry grid already
+  allows. Fixed by adding `|| Input.repeat?(...)` to all four direction
+  branches in both methods. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (`RGSS::Input.repeated`, not
+  `.triggered`, still moves both the ASCII and kana grid cursors), both
+  confirmed to fail against the pre-fix code (`expected 1, got 0`) before
+  the fix.
 - ✅ **The same "silent embedded widget" family, found once more: Open Shop
   and Show Inn played zero sound effects at all (2026-08-18).** Verified
   against RPG_RT's actual behavior via EasyRPG Player's own C++ source,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5394,25 +5394,35 @@ class RPG2k
       # (which real RPG_RT's own keyboard grid has no equivalent of): it
       # erases one character with its own Cancel SE, or Buzzer with nothing
       # to erase -- see #name_input_cancel.
+      # Every direction auto-repeats while held, not just a fresh press --
+      # confirmed against RPG_RT's own live source: `Window_Keyboard::Update`
+      # (src/window_keyboard.cpp) gates all four grid directions on
+      # `Input::IsRepeated` alone, which (`Input::UpdateSystem`, src/
+      # input.cpp: `repeated[i] = press_time[i] == 1 || (press_time[i] >=
+      # start_repeat_time && ...)`) fires both on the very first pressed
+      # frame and on the later repeat cadence -- exactly the union this
+      # codebase's own split `Input.trigger?` (fresh press only) /
+      # `Input.repeat?` (delayed auto-repeat, never frame 1) idiom already
+      # covers everywhere else.
       def handle_name_input
         ui = @name_ui
         row = ui[:sel] / NAME_COLS
         col = ui[:sel] % NAME_COLS
         rows = (NAME_CELLS.length + NAME_COLS - 1) / NAME_COLS
-        if Input.trigger?(Input::RIGHT)
+        if Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
           ui[:sel] = row * NAME_COLS + (col + 1) % name_row_len(row)
           draw_name_input
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::LEFT)
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
           ui[:sel] = row * NAME_COLS + (col - 1) % name_row_len(row)
           draw_name_input
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           new_row = (row + 1) % rows
           ui[:sel] = new_row * NAME_COLS + col % name_row_len(new_row)
           draw_name_input
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           new_row = (row - 1) % rows
           ui[:sel] = new_row * NAME_COLS + col % name_row_len(new_row)
           draw_name_input
@@ -5506,25 +5516,28 @@ class RPG2k
         page == :katakana ? NAME_KATAKANA_ROWS : NAME_HIRAGANA_ROWS
       end
 
+      # Auto-repeats while held, exactly like #handle_name_input above --
+      # same `Window_Keyboard::Update` source, one grid widget in real
+      # RPG_RT for both the ASCII and kana pages.
       def handle_kana_name_input
         ui = @name_ui
         rows = name_kana_rows(ui[:page])
         row = ui[:sel] / NAME_KANA_COLS
         col = ui[:sel] % NAME_KANA_COLS
-        if Input.trigger?(Input::RIGHT)
+        if Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
           ui[:sel] = row * NAME_KANA_COLS + (col + 1) % rows[row].length
           draw_kana_name_input
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::LEFT)
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
           ui[:sel] = row * NAME_KANA_COLS + (col - 1) % rows[row].length
           draw_kana_name_input
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::DOWN)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           new_row = (row + 1) % rows.length
           ui[:sel] = new_row * NAME_KANA_COLS + col % rows[new_row].length
           draw_kana_name_input
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           new_row = (row - 1) % rows.length
           ui[:sel] = new_row * NAME_KANA_COLS + col % rows[new_row].length
           draw_kana_name_input

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7577,6 +7577,37 @@ check 'Enter Hero Name: the character grid cursor wraps around' do
   eq 66, ui[:sel], 'Up from row 0 wraps to row 5, column 10 % 3 == 1'
 end
 
+# `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold a
+# key across frames without it also reading as a fresh trigger.
+check 'Enter Hero Name: holding a direction auto-repeats the character grid ' \
+      'cursor, not just a fresh press' do
+  # Confirmed against RPG_RT's own live source: `Window_Keyboard::Update`
+  # (src/window_keyboard.cpp) gates all four grid directions on
+  # `Input::IsRepeated` alone, which fires on both the first pressed frame
+  # and every later repeat tick.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::NAME_INPUT, [1, 2, 0], indent: 0), # actor 1, letters, no seed
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  6.times do
+    scene.update
+    break if scene.instance_variable_get(:@name_ui)
+  end
+  ui = scene.instance_variable_get(:@name_ui)
+  ok ui, 'the name-entry widget opened'
+  eq 0, ui[:sel], 'starts on the first cell'
+
+  RGSS::Input.repeated = [RGSS::Input::RIGHT] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, ui[:sel], 'a held (repeated) Right still moves the grid cursor'
+end
+
 check 'Enter Hero Name: hiragana/katakana grid opens on the requested page, seeded' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
@@ -7753,6 +7784,28 @@ check 'Enter Hero Name: the kana grid cursor wraps around' do
   scene.update
   RGSS::Input.triggered = []
   eq last_row * cols + 1, ui[:sel], 'Up from row 0 wraps to the last row, column 9 % 8 == 1'
+end
+
+check 'Enter Hero Name: holding a direction auto-repeats the kana grid ' \
+      'cursor too' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::NAME_INPUT, [1, 0, 0], indent: 0)]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  6.times do
+    scene.update
+    break if scene.instance_variable_get(:@name_ui)
+  end
+  ui = scene.instance_variable_get(:@name_ui)
+  ok ui, 'the name-entry widget opened'
+  eq 0, ui[:sel], 'starts on the first cell'
+
+  RGSS::Input.repeated = [RGSS::Input::RIGHT] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, ui[:sel], 'a held (repeated) Right still moves the kana grid cursor'
 end
 
 # A party whose actor levels up on demand, for the level-up-message check.


### PR DESCRIPTION
## Summary

`Window_Keyboard::Update` (`src/window_keyboard.cpp`) is four `if (Input::IsRepeated(...))` checks, one per direction, with no `IsTriggered` anywhere -- and `Input::UpdateSystem` (`src/input.cpp`) defines `repeated[i] = press_time[i] == 1 || (press_time[i] >= start_repeat_time && ...)`, so `IsRepeated` alone fires on both the very first pressed frame and the later repeat cadence -- exactly the union this codebase's own split `Input.trigger?` (fresh press only) / `Input.repeat?` (delayed auto-repeat, never frame 1) idiom already covers everywhere else.

`#handle_name_input`/`#handle_kana_name_input` (`mruby-rpg2k/mrblib/scene/map.rb`) checked only `Input.trigger?` on each of the four directions, so a player had to tap each arrow once per cell instead of holding it down the way real RPG_RT's name-entry grid already allows.

- Fixed by adding `|| Input.repeat?(...)` to all four direction branches in both methods.

## Test plan

- Two new `scripts/rpg2k_scene_check.rb` checks: `RGSS::Input.repeated`, not `.triggered`, still moves both the ASCII and kana grid cursors.
- Verified via `git stash` on `scene/map.rb` alone: only the two new checks fail pre-fix (`expected 1, got 0`).
- Full suite green: `rpg2k_scene_check.rb` 775 passed, `rpg2k_logic_check.rb` 1062 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_