### PR TITLE
fix(rgss): Bitmap#draw_text non-String args, RPG::EventCommand constructor

### DIFF
--- a/changelog.d/vxace-draw-text-coercion-eventcommand-init.fixed.md
+++ b/changelog.d/vxace-draw-text-coercion-eventcommand-init.fixed.md
@@ -1,0 +1,11 @@
+- **XP / VX / VX Ace** two more real gaps found continuing to boot a real
+  VX Ace game past its previous walls, both fixed: `Bitmap#draw_text`
+  raised `TypeError` when passed a non-`String` text argument, when real
+  RGSS3 accepts any object and implicitly stringifies it — a real game's
+  own stock `Window_Gold#refresh` draws its gold total (an `Integer`)
+  directly, so every VX Ace game whose `Scene_Map` builds its
+  `Window_Message` (which builds a `Window_Gold` among its child windows)
+  hit this. `RPG::EventCommand` had no constructor at all, so the
+  documented `EventCommand.new(code = 0, indent = 0, parameters = [])`
+  form real scripts use to synthesize event commands directly (a real
+  game's own error-log utility does exactly this) raised `ArgumentError`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16451,10 +16451,32 @@ screen (544×416). Full rationale:
     directly — every VX Ace game raised `NoMethodError` the moment a player
     pressed New Game. Fixed by adding both predicates
     (`mruby-rpgvx/mrblib/rgss2_data.rb`; confirmed XP's own stock scripts
-    never call either, so the fix is VX/VX Ace-only). A seventh masked
-    exception is already known this way and not yet fixed — past
-    `DataManager.setup_new_game`, into actual gameplay (`Graphics.brightness=`
-    is the next stub the game calls before it). Fixing `$!` itself is
+    never call either, so the fix is VX/VX Ace-only). Continuing further,
+    two more: `Bitmap#draw_text` raised `TypeError` on a non-`String` text
+    argument — real RGSS3 accepts any object (games routinely `draw_text` an
+    `Integer` directly, like this same release's own stock
+    `Window_Gold#refresh`), relying on implicit `#to_s`. Fixed in
+    `mruby-rgss/src/lib.cxx`'s `bmp_draw_text` by parsing the text argument
+    as a generic object and coercing via `mrb_obj_as_string` only after that
+    single parse completes — the first attempt instead grabbed a raw `argv`
+    pointer, coerced through it, then re-parsed with a second
+    `mrb_get_args` call, and **segfaulted**: the coercion can run arbitrary
+    Ruby and grow the VM's value stack, leaving that pointer dangling by the
+    second call. Caught by `scripts/rpgxp_boot_check.bash`. `RPG::EventCommand`
+    had no `#initialize` at all, falling back to `Object`'s zero-argument
+    default — real RGSS documents `EventCommand.new(code = 0, indent = 0,
+    parameters = [])` for scripts that synthesize event commands directly,
+    which this same release's error-log utility does to stamp a synthetic
+    command onto every common event's own list. Fixed in both
+    `mruby-rpgvx/mrblib/rgss2_data.rb` and `mruby-rpgxp/mrblib/rgss_data.rb`;
+    Marshal deserialization of existing `Data/*.rvdata(2)` (which bypasses
+    `#initialize` entirely) is unaffected, confirmed by re-parsing 15,797 real
+    XP event commands cleanly afterward. A ninth masked exception is already
+    known this way and not yet fixed — inside a bundled community
+    bubble-window script's own text layout, past the game's first common
+    event call: `NoMethodError: undefined method 'height' for RGSS::Sprite`,
+    not yet diagnosed as an engine gap or a script bug (real RGSS3's own
+    `Sprite` API has no `#height` either). Fixing `$!` itself is
     fixable only by wrapping `Kernel#raise` itself (the sole point where the
     about-to-be-raised object is observable), which would add overhead and
     stack depth to *every* exception in the shared build across every maker

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -496,11 +496,11 @@ not a one-time cosmetic loss: every fatal exception this game hits, of any
 origin, is masked behind the identical `NoMethodError: undefined method
 'message' for NilClass` crash in the error-log utility, until whatever real
 exception triggered it is fixed and the *next* one takes its place. Diagnosing
-each of the fixes above (and the three below) required a temporary,
+each of the fixes above (and the five below) required a temporary,
 never-committed `fprintf` at the `OP_EXCEPT` opcode itself (in the local
 `3rd/mruby` submodule checkout, reverted before every commit) to read the
-masked exception directly off the VM — six separate real bugs found this way,
-one at a time, each hidden behind the identical crash until fixed:
+masked exception directly off the VM — eight separate real bugs found this
+way, one at a time, each hidden behind the identical crash until fixed:
 
 - **Fixed: `Window#contents` started `nil` instead of a real `Bitmap`.**
   Another native `mruby-rgss` binding bug (`window_init` in
@@ -550,14 +550,63 @@ one at a time, each hidden behind the identical crash until fixed:
   against both XP test beds, never call either predicate — the fix is
   scoped to `mruby-rpgvx` only.
 
-With all six gaps above closed, the same real VX Ace release now reaches
-past `Scene_Title`'s title-command window, its title music, and
-`DataManager.setup_new_game`'s common-event setup, into actual gameplay
-(`Graphics.brightness=`, a scene-transition primitive, is the next stub it
-calls) before hitting a seventh masked exception — not yet diagnosed. The
+- **Fixed: `Bitmap#draw_text` raised `TypeError` on a non-`String` text
+  argument.** A native `mruby-rgss` binding bug (`bmp_draw_text` in
+  `mruby-rgss/src/lib.cxx`). Real RGSS3 accepts *any* object as the text
+  argument — games routinely `draw_text` an `Integer` directly, exactly as
+  this same release's own stock `Window_Gold#refresh` →
+  `#draw_currency_value` does (`draw_text(x, y, w, h, $game_party.gold,
+  2)`), relying on the same implicit `#to_s` real Ruby's `String()` gives
+  it. `mrb_get_args`' `"s"` format demands an actual `String`, so every VX
+  Ace game whose `Scene_Map` builds its `Window_Message` (which builds a
+  `Window_Gold` among its child windows) raised `TypeError: Integer cannot
+  be converted to String` right there. Fixed by parsing the text argument
+  as a generic object (`"o"`) instead of `"s"`, coercing it via
+  `mrb_obj_as_string` only after that single parse completes if it is not
+  already a `String`. **Not** by grabbing a raw `argv` pointer via
+  `mrb_get_args(M, "*", …)`, coercing in place, then calling
+  `mrb_get_args` a *second* time with the strict format against that same
+  pointer — the first attempt at this fix did exactly that, and segfaulted:
+  `mrb_obj_as_string` can run arbitrary Ruby (`#to_s`) and potentially grow
+  the VM's value stack, which would leave the first `argv` pointer
+  dangling, and the second `mrb_get_args` call read through it. Caught by
+  `scripts/rpgxp_boot_check.bash`, which every windowed screen a real
+  project draws exercises directly.
+
+- **Fixed: `RPG::EventCommand` had no `#initialize` at all.** A real
+  data-layer gap in both `mruby-rpgvx/mrblib/rgss2_data.rb` and
+  `mruby-rpgxp/mrblib/rgss_data.rb`: `EventCommand` only ever carried a
+  bare `attr_accessor` for `code`/`indent`/`parameters`, falling back to
+  `Object`'s own zero-argument default constructor. Real RGSS documents
+  `EventCommand.new(code = 0, indent = 0, parameters = [])` for scripts
+  that synthesize new event commands directly — this same release's own
+  error-log utility does exactly that
+  (`RPG::EventCommand.new(355, 0, ["@commonevent_id = #{@id}"])`, stamping
+  a synthetic "script call" onto the front of every common event's own
+  `#list` so a crash can name which one was running), which raised
+  `ArgumentError: wrong number of arguments (given 3, expected 0)` the
+  first time any VX Ace game calls a common event. Fixed by adding the real
+  constructor to both makers' `EventCommand`; Marshal deserialization of
+  existing `Data/*.rvdata(2)` — which allocates and restores instance
+  variables directly, never calling `#initialize` — is unaffected, confirmed
+  by `scripts/rpgxp_testbed_check.rb`/`rpgvx_testbed_check.rb` re-parsing
+  real event-command data (15,797 XP event commands) cleanly afterward.
+
+With all eight gaps above closed, the same real VX Ace release now reaches
+past `Scene_Title`'s title-command window, its title music,
+`DataManager.setup_new_game`'s common-event setup, and its first common
+event call, into a bundled community bubble-window script's own text
+layout (`エラーログ出力` aside, the script host reaches
+`吹きだしウィンドウ`'s `get_tale_pos_normal_updown`) before hitting a ninth
+masked exception — `NoMethodError: undefined method 'height' for
+RGSS::Sprite`. Not yet diagnosed as an engine gap or a script bug: real
+RGSS3's own documented `Sprite` API has no `#height` either, so this may be
+the community script itself relying on something beyond stock RGSS (a
+different add-on's monkey-patch this release also bundles, perhaps) rather
+than a gap in this engine — left for a future pass to determine which. The
 pattern established here (temporary VM probe → real gap → mrblib or native
-fix → regression test) applies to it too, left for a future pass. mruby's
-bare `raise` (no arguments) has the same
+fix → regression test) applies regardless. mruby's bare `raise` (no
+arguments) has the same
 root cause from the other side: real Ruby re-raises `$!`, but mruby's
 `mrb_f_raise` has no `$!` to fall back to, so a bare `raise` always raises a
 fresh, empty `RuntimeError` instead of re-raising what was actually caught.
@@ -589,10 +638,11 @@ Tilemap item 1's remaining polish (the flat "above characters" layer) is the
 only item left in the six sections above; item 7's `$!`/bare-`raise` gap
 stands, and per a real release it is the reason each fix above only reveals
 the *next* wall one at a time rather than the game running to completion in
-one pass. Six real bugs have been found and fixed this way so far
+one pass. Eight real bugs have been found and fixed this way so far
 (`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
-`Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`)
+`Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`,
+`Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`)
 without needing `$!` itself fixed — the temporary VM probe finds the real
-exception directly regardless. A seventh wall, past
-`DataManager.setup_new_game` and into actual gameplay, is where the game
-stands now: not yet diagnosed.
+exception directly regardless. A ninth wall, inside a bundled community
+script's own text layout past the game's first common event call, is where
+the game stands now — not yet diagnosed as an engine gap or a script bug.

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2651,21 +2651,34 @@ void measure_text(std::string_view s, int& width, unsigned& height) {
 mrb_value bmp_draw_text(mrb_state* M, mrb_value self) {
   auto& bmp = bmp_self(M, self);
 
-  mrb_int x, y, w, h, len;
+  // Real RGSS3 accepts any object as the text argument, not just a String --
+  // games routinely draw_text an Integer directly (HP/MP/gold: this game's
+  // own stock Window_Gold#refresh -> #draw_currency_value among them),
+  // relying on the same implicit #to_s Ruby's own String() gives it. Parsed
+  // as a generic object ("o") rather than mrb_get_args' own "s" (which
+  // demands an actual String) and coerced after: mrb_obj_as_string can run
+  // arbitrary Ruby (#to_s) and possibly grow the VM's value stack, which
+  // would leave a raw argv pointer obtained before it dangling -- calling
+  // mrb_get_args a second time to re-parse against such a pointer read
+  // freed memory. One parse, then a local mrb_value, sidesteps that.
+  mrb_int x, y, w, h;
   mrb_int align = 0;
-  const char* s;
+  mrb_value text_obj;
   if (mrb_get_argc(M) <= 3) {
     V r;
-    mrb_get_args(M, "os|i", &r, &s, &len, &align);
+    mrb_get_args(M, "oo|i", &r, &text_obj, &align);
     Rect& rc = DataType<Rect>::get(M, r);
     x = rc.x;
     y = rc.y;
     w = rc.width;
     h = rc.height;
   } else {
-    mrb_get_args(M, "iiiis|i", &x, &y, &w, &h, &s, &len, &align);
+    mrb_get_args(M, "iiiio|i", &x, &y, &w, &h, &text_obj, &align);
   }
-  const std::string_view sv(s, len);
+  if (!mrb_string_p(text_obj)) {
+    text_obj = mrb_obj_as_string(M, text_obj);
+  }
+  const std::string_view sv(RSTRING_PTR(text_obj), RSTRING_LEN(text_obj));
 
   // Prefer the game's TrueType font (RPG Maker XP/VX ship one under Fonts/),
   // rasterising at the font's pixel size. Fall back to the fixed-size shinonome

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -812,6 +812,19 @@ assert "RGSS::Bitmap#draw_text takes a Rect as well as x/y/width/height" do
   assert_true pixels.call(plain).size > 0, "the 2-argument Rect form drew nothing"
 end
 
+# Real RGSS3 accepts any object as the text argument, not just a String --
+# games routinely draw_text an Integer directly (HP/MP/gold, the way this
+# real VX Ace release's own stock Window_Gold#refresh ->
+# #draw_currency_value calls `draw_text(x, y, w, h, $game_party.gold, 2)`),
+# relying on implicit #to_s. Both call-signature branches this coerces in.
+assert "RGSS::Bitmap#draw_text accepts a non-String text argument" do
+  numbers = RGSS::Bitmap.new(64, 24)
+  assert_equal numbers, numbers.draw_text(0, 0, 64, 24, 42)
+
+  via_rect = RGSS::Bitmap.new(64, 24)
+  assert_equal via_rect, via_rect.draw_text(RGSS::Rect.new(0, 0, 64, 24), 42)
+end
+
 # The fallback for projects that ship no font. RGSS.default_font_path finds the
 # bundled default font (assets/fonts) — downloaded rather than committed, so nil
 # is a normal answer here — and Font.default_path is the opt-in switch each

--- a/mruby-rpgvx/mrblib/rgss2_data.rb
+++ b/mruby-rpgvx/mrblib/rgss2_data.rb
@@ -336,6 +336,16 @@ module RPG
 
   class EventCommand
     attr_accessor :code, :indent, :parameters
+
+    # Real RGSS documents this constructor -- scripts synthesize new event
+    # commands with it directly (this same release's error-log utility
+    # inserts a `EventCommand.new(355, 0, [...])` "script call" at the front
+    # of every common event's own list, to stamp its id before running).
+    def initialize(code = 0, indent = 0, parameters = [])
+      @code = code
+      @indent = indent
+      @parameters = parameters
+    end
   end
 
   class MoveRoute

--- a/mruby-rpgvx/test/rpgvx_test.rb
+++ b/mruby-rpgvx/test/rpgvx_test.rb
@@ -665,3 +665,20 @@ assert "RPG::CommonEvent#autorun?/#parallel? read the trigger field" do
   assert_false parallel.autorun?
   assert_true parallel.parallel?
 end
+
+# Real RGSS documents this constructor -- scripts synthesize new event
+# commands with it directly (this same release's error-log utility calls
+# `EventCommand.new(355, 0, [...])` to stamp a common event's id before
+# running it), which raised ArgumentError when EventCommand had no
+# #initialize at all (Object's own default takes zero arguments).
+assert "RPG::EventCommand.new takes the real code/indent/parameters constructor" do
+  cmd = RPG::EventCommand.new(355, 2, ["@commonevent_id = 7"])
+  assert_equal 355, cmd.code
+  assert_equal 2, cmd.indent
+  assert_equal ["@commonevent_id = 7"], cmd.parameters
+
+  defaulted = RPG::EventCommand.new
+  assert_equal 0, defaulted.code
+  assert_equal 0, defaulted.indent
+  assert_equal [], defaulted.parameters
+end

--- a/mruby-rpgxp/mrblib/rgss_data.rb
+++ b/mruby-rpgxp/mrblib/rgss_data.rb
@@ -170,6 +170,14 @@ module RPG
   # list whose shape depends on the code.
   class EventCommand
     attr_accessor :code, :indent, :parameters
+
+    # Real RGSS documents this constructor -- scripts synthesize new event
+    # commands with it directly.
+    def initialize(code = 0, indent = 0, parameters = [])
+      @code = code
+      @indent = indent
+      @parameters = parameters
+    end
   end
 
   # A movement script: a list of MoveCommands with repeat/skippable flags.

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -626,3 +626,19 @@ assert "Dir.glob covers the patterns real scripts use for save/protect checks" d
     Dir.delete(root)
   end
 end
+
+# Real RGSS documents this constructor -- scripts synthesize new event
+# commands with it directly. EventCommand had no #initialize at all
+# (Object's own default takes zero arguments), so the 3-argument form
+# real scripts call raised ArgumentError.
+assert "RPG::EventCommand.new takes the real code/indent/parameters constructor" do
+  cmd = RPG::EventCommand.new(355, 2, ["@commonevent_id = 7"])
+  assert_equal 355, cmd.code
+  assert_equal 2, cmd.indent
+  assert_equal ["@commonevent_id = 7"], cmd.parameters
+
+  defaulted = RPG::EventCommand.new
+  assert_equal 0, defaulted.code
+  assert_equal 0, defaulted.indent
+  assert_equal [], defaulted.parameters
+end


### PR DESCRIPTION
## Summary

Continues digging into the real VX Ace release from #1074/#1089/#1092/#1100
(*Sanctuary Of the Ruler*), past the `Window#contents`/`Audio.bgm_play`/
`RPG::CommonEvent` predicate fixes. Two more real gaps found, each by
getting the game one step further through its own script host:

- **`Bitmap#draw_text` raised `TypeError` on a non-`String` text
  argument.** A native `mruby-rgss` binding bug (`bmp_draw_text` in
  `mruby-rgss/src/lib.cxx`). Real RGSS3 accepts *any* object as the text
  argument — games routinely `draw_text` an `Integer` directly, exactly as
  this same release's own stock `Window_Gold#refresh` →
  `#draw_currency_value` does (`draw_text(x, y, w, h, $game_party.gold,
  2)`), relying on the same implicit `#to_s` real Ruby's `String()` gives
  it. `mrb_get_args`' `"s"` format demands an actual `String`, so every VX
  Ace game whose `Scene_Map` builds its `Window_Message` (which builds a
  `Window_Gold` among its child windows) raised `TypeError: Integer cannot
  be converted to String` right there. Fixed by parsing the text argument
  as a generic object (`"o"`) instead of `"s"`, coercing it via
  `mrb_obj_as_string` only after that single parse completes if it is not
  already a `String`.

  **Not** by grabbing a raw `argv` pointer via `mrb_get_args(M, "*", …)`,
  coercing in place, then calling `mrb_get_args` a *second* time with the
  strict format against that same pointer — the first attempt at this fix
  did exactly that, and **segfaulted**: `mrb_obj_as_string` can run
  arbitrary Ruby (`#to_s`) and potentially grow the VM's value stack,
  which would leave the first `argv` pointer dangling, and the second
  `mrb_get_args` call read through it. Caught by
  `scripts/rpgxp_boot_check.bash`, which every windowed screen a real
  project draws exercises directly — the rewritten version parses once
  and coerces a local `mrb_value` afterward instead.

- **`RPG::EventCommand` had no `#initialize` at all.** A real data-layer
  gap in both `mruby-rpgvx/mrblib/rgss2_data.rb` and
  `mruby-rpgxp/mrblib/rgss_data.rb`: `EventCommand` only ever carried a
  bare `attr_accessor`, falling back to `Object`'s own zero-argument
  default constructor. Real RGSS documents `EventCommand.new(code = 0,
  indent = 0, parameters = [])` for scripts that synthesize new event
  commands directly — this same release's own error-log utility does
  exactly that (`RPG::EventCommand.new(355, 0, ["@commonevent_id =
  #{@id}"])`, stamping a synthetic "script call" onto the front of every
  common event's own `#list` so a crash can name which one was running),
  which raised `ArgumentError: wrong number of arguments (given 3,
  expected 0)` the first time any VX Ace game calls a common event. Fixed
  by adding the real constructor to both makers' `EventCommand`; Marshal
  deserialization of existing `Data/*.rvdata(2)` — which allocates and
  restores instance variables directly, never calling `#initialize` — is
  unaffected, confirmed by re-parsing real event-command data (15,797 XP
  event commands) cleanly afterward.

**Diagnostic method, not shipped**: both fixes were found by adding a
temporary `fprintf` at the `OP_EXCEPT` opcode in the local `3rd/mruby`
submodule checkout to read the real masked exception directly off the VM
(reverted before every commit here, never part of the diff) — mruby's
still-missing `$!` (item 7, `docs/rpgvx-rgss-api-gap.md`) continues to
mask every fatal exception this game hits behind an identical crash in
its own bundled error-log utility. With all eight gaps found so far
closed, the game now reaches past `DataManager.setup_new_game` and its
first common event call, into a bundled community bubble-window script's
own text layout, before hitting a ninth masked exception —
`NoMethodError: undefined method 'height' for RGSS::Sprite`. Not yet
diagnosed as an engine gap or a script bug (real RGSS3's own `Sprite` API
has no `#height` either, so this may be the community script relying on
something beyond stock RGSS rather than a gap here) — left for a
follow-up.

## Test plan
- [x] `ctest -R mruby_test` — 100% passing, includes new regression tests
      for `Bitmap#draw_text` accepting a non-`String` argument (both
      call-signature branches) and `RPG::EventCommand.new`'s real
      constructor (in both `mruby-rgss`/`mruby-rpgvx`/`mruby-rpgxp` test
      suites)
- [x] `ruby scripts/rgss_cruby_test_check.rb` — OK
- [x] `ruby scripts/rpgxp_script_host_check.rb` — OK
- [x] `ruby scripts/rpgxp_testbed_check.rb data/PrayforYou` — OK (15,797
      event commands re-parsed cleanly, confirming Marshal deserialization
      of `EventCommand` is unaffected by the new `#initialize`)
- [x] `ruby scripts/rpgvx_testbed_check.rb` — OK
- [x] `bash scripts/rpgxp_boot_check.bash` — move/menu/battle/save all
      pass on both XP test beds; this is what caught the segfault in the
      first version of the `draw_text` fix, and confirms it clean now
- [x] Manual: the real VX Ace release now gets past `Window_Gold`'s own
      construction and its first common event call, into a community
      script's text layout
- [x] `docs/TODO.md` and `docs/rpgvx-rgss-api-gap.md` updated with the
      full diagnosis for both fixes and the new (ninth) open item

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_