### PR TITLE
Weather rain/snow particles move at RPG_RT's own per-frame rate

### DIFF
--- a/changelog.d/weather-particle-fall-rate.fixed.md
+++ b/changelog.d/weather-particle-fall-rate.fixed.md
@@ -1,0 +1,4 @@
+- **Weather effects:** Rain now falls and drifts at RPG_RT's own per-frame
+  rate instead of exactly double it, and snow now drifts only ever leftward
+  instead of bouncing back and forth. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11074,6 +11074,31 @@ not yet verified:
   "heavier is denser" ordering assertion to the three exact real counts,
   confirmed to fail against the pre-fix code (`144` instead of `100` at
   heavy strength) before the fix.
+  ✅ **Follow-up (2026-08-19): rain fell and drifted at exactly double
+  RPG_RT's own per-frame rate, and snow's own sideways drift bounced back
+  and forth in a symmetric wave instead of only ever nudging left.**
+  Confirmed directly against RPG_RT's live source:
+  `Game_Screen::UpdateRain`/`UpdateSnow` (`src/game_screen.cpp`) — rain is
+  `p.y += 4; p.x -= 1` every frame it's alive, snow is `p.y += Rand(2, 3);
+  p.x -= Rand(0, 1)`. Both only ever subtract from `x`; neither engine
+  effect ever drifts a particle rightward. `Scene::Map
+  #draw_weather_particle` (`mruby-rpg2k/mrblib/scene/map.rb`) moved rain
+  `@anim_frame * 8` down and `@anim_frame * 2` left — exactly 2x real
+  RPG_RT on both axes — and `#weather_drift`'s own triangle wave added a
+  value that grew 0→4 then shrank back to 0 every 64 frames, oscillating
+  snow side to side rather than drifting one direction the way real RPG_RT
+  does. Fixed by halving rain's per-frame deltas to `@anim_frame * 4`
+  (down) and `@anim_frame` (left, i.e. multiplier 1), and replacing
+  `#weather_drift`'s triangle wave with a monotonically-increasing `(
+  @anim_frame + i * 3) / 2` — averaging the same ~0.5px/frame `Rand(0,
+  1)` draws real RPG_RT's snow rolls, without needing a per-frame RNG
+  draw of its own, and now subtracted from `x` (never added) so a flake
+  only ever ends up further left as it falls. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (rain's exact per-frame fall/drift
+  distance at a sampled frame; snow's drift strictly increasing between
+  two frames the old triangle wave would have had reverse between),
+  confirmed to fail against the pre-fix code (`expected 20, got 40`)
+  before the fix.
 
 **BGM / SE**
 - ✅ BGM has a **single channel** — a new Play BGM force-stops whatever's

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -869,24 +869,33 @@ class RPG2k
       # A single particle's on-screen cell, spread across the screen by a cheap
       # hash of its index and falling as @anim_frame advances (wrapping at the
       # bottom). Rain is a slanted streak; snow a small fleck that also drifts.
+      # Per-frame motion confirmed against RPG_RT's own live source:
+      # `Game_Screen::UpdateRain`/`UpdateSnow` (src/game_screen.cpp) --
+      # rain falls `p.y += 4; p.x -= 1` every frame it's alive, and snow
+      # falls `p.y += Rand(2, 3)` while drifting `p.x -= Rand(0, 1)`, i.e.
+      # leftward only, never rightward.
       def draw_weather_particle(type, i)
         x0 = (i * 97) % SCREEN_W
         y0 = (i * 59) % SCREEN_H
         if type == WEATHER_RAIN
-          y = (y0 + @anim_frame * 8) % SCREEN_H
-          x = (x0 - @anim_frame * 2) % SCREEN_W
+          y = (y0 + @anim_frame * 4) % SCREEN_H
+          x = (x0 - @anim_frame) % SCREEN_W
           @weather_bmp.fill_rect x, y, 1, 6, RAIN_COLOR
         else
           y = (y0 + @anim_frame * 3) % SCREEN_H
-          x = (x0 + weather_drift(i)) % SCREEN_W
+          x = (x0 - weather_drift(i)) % SCREEN_W
           @weather_bmp.fill_rect x, y, 2, 2, SNOW_COLOR
         end
       end
 
-      # A small side-to-side snow drift, from a triangle wave over @anim_frame.
+      # A small leftward-only snow drift, approximating RPG_RT's own average
+      # rate (`p.x -= Rand::GetRandomNumber(0, 1)` per frame, ~0.5px/frame)
+      # without needing a per-frame RNG draw -- monotonically increasing
+      # (never wrapping back down) so a flake only ever nudges further left
+      # as it falls, the same one-way drift real RPG_RT's snow has, unlike
+      # a bouncing side-to-side wave.
       def weather_drift(i)
-        phase = (@anim_frame / 8 + i) % 8
-        phase < 4 ? phase : 8 - phase
+        (@anim_frame + i * 3) / 2
       end
 
       # Apply a Tint Screen tone (`[r, g, b, sat]`, each 0..200 with 100 neutral)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9814,6 +9814,33 @@ check 'Weather draws a particle overlay when active and hides it when clear' do
   ok !wsp.visible, 'clearing weather hides the overlay'
 end
 
+check 'Weather rain falls and drifts at RPG_RT\'s own per-frame rate, and ' \
+      'snow only ever drifts left, never bounces back right' do
+  # Confirmed against RPG_RT's own live source: Game_Screen::UpdateRain/
+  # UpdateSnow (src/game_screen.cpp) -- rain falls 4px down and 1px left
+  # every frame it's alive (`p.y += 4; p.x -= 1`), snow drifts leftward
+  # only, never rightward (`p.x -= Rand::GetRandomNumber(0, 1)`).
+  scene = new_scene({})
+  bmp = scene.instance_variable_get(:@weather_bmp)
+  h = RPG2k::Scene::Map::SCREEN_H
+  w = RPG2k::Scene::Map::SCREEN_W
+
+  scene.instance_variable_set(:@anim_frame, 5)
+  scene.send(:draw_weather_particle, RPG2k::Scene::Map::WEATHER_RAIN, 0)
+  x, y, = bmp.fill_calls.last
+  eq (5 * 4) % h, y, 'rain falls 4px/frame down, not double that'
+  eq (-5) % w, x, 'rain drifts 1px/frame left, not double that'
+
+  # The old drift was a triangle wave that bounced back down; sample two
+  # frames where that wave would have reversed (32 -> back near 64) and
+  # confirm the real, monotonic-leftward drift never does.
+  scene.instance_variable_set(:@anim_frame, 32)
+  d32 = scene.send(:weather_drift, 0)
+  scene.instance_variable_set(:@anim_frame, 64)
+  d64 = scene.send(:weather_drift, 0)
+  ok d64 > d32, 'snow drift only ever grows (further left), never reverses'
+end
+
 check 'the timer draws M:SS as digit-sprite cells cut from the System graphic, and hides when never shown' do
   scene = new_scene({})
   scene.instance_variable_set(:@windowskin, RGSS::Bitmap.new('System/skin'))


### PR DESCRIPTION
## Summary

`Game_Screen::UpdateRain`/`UpdateSnow` (`src/game_screen.cpp`): rain is `p.y += 4; p.x -= 1` every frame it's alive, snow is `p.y += Rand(2, 3); p.x -= Rand(0, 1)`. Both only ever subtract from `x`; neither engine effect ever drifts a particle rightward.

`Scene::Map#draw_weather_particle` (`mruby-rpg2k/mrblib/scene/map.rb`) moved rain `@anim_frame * 8` down and `@anim_frame * 2` left -- exactly 2x real RPG_RT on both axes -- and `#weather_drift`'s own triangle wave added a value that grew 0→4 then shrank back to 0 every 64 frames, oscillating snow side to side rather than drifting one direction the way real RPG_RT does.

- Fixed by halving rain's per-frame deltas to `@anim_frame * 4` (down) and `@anim_frame` (left), and replacing `#weather_drift`'s triangle wave with a monotonically-increasing `(@anim_frame + i * 3) / 2` -- averaging the same ~0.5px/frame `Rand(0, 1)` draws real RPG_RT's snow rolls, without needing a per-frame RNG draw of its own, and now subtracted from `x` (never added) so a flake only ever ends up further left as it falls.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: rain's exact per-frame fall/drift distance at a sampled frame, and snow's drift strictly increasing between two frames the old triangle wave would have had reverse between.
- Verified via `git stash` on `scene/map.rb` alone: the new check fails pre-fix (`expected 20, got 40`).
- Full suite green: `rpg2k_scene_check.rb` 776 passed, `rpg2k_logic_check.rb` 1062 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_