### PR TITLE
feat(rgss): add Sprite#width/#height, RGSS3's addition over XP/VX

### DIFF
--- a/changelog.d/vxace-sprite-width-height.added.md
+++ b/changelog.d/vxace-sprite-width-height.added.md
@@ -1,0 +1,8 @@
+- **XP / VX / VX Ace** `RGSS::Sprite#width`/`#height` — RGSS3 (VX Ace) added
+  these over XP/VX's `Sprite`, read-only, mirroring the sprite's own
+  `bitmap` dimensions (`0` with none set). `Window` and `Graphics` both
+  already had `#width`/`#height`; only `Sprite` was missing them. Found
+  continuing to boot a real VX Ace release's bundled scripts: its own
+  speech-bubble add-on reads `@tail.height` (`@tail` a real `Sprite.new`) to
+  centre its tail sprite under a message window, which raised
+  `NoMethodError` the first time the game showed a message.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16517,12 +16517,18 @@ screen (544×416). Full rationale:
     `mruby-rpgvx/mrblib/rgss2_data.rb` and `mruby-rpgxp/mrblib/rgss_data.rb`;
     Marshal deserialization of existing `Data/*.rvdata(2)` (which bypasses
     `#initialize` entirely) is unaffected, confirmed by re-parsing 15,797 real
-    XP event commands cleanly afterward. A ninth masked exception is already
-    known this way and not yet fixed — inside a bundled community
-    bubble-window script's own text layout, past the game's first common
-    event call: `NoMethodError: undefined method 'height' for RGSS::Sprite`,
-    not yet diagnosed as an engine gap or a script bug (real RGSS3's own
-    `Sprite` API has no `#height` either). Fixing `$!` itself is
+    XP event commands cleanly afterward. `Sprite` had no `#width`/`#height`
+    at all — RGSS3 (VX Ace) added them over XP/VX's `Sprite`, read-only,
+    mirroring the sprite's own `bitmap` dimensions, which this same
+    release's bundled speech-bubble add-on reads directly to centre its
+    tail sprite (`self.y - @tail.height / 2`), raising `NoMethodError` the
+    first time the game showed a message. `Window` and `Graphics` both
+    already had `#width`/`#height`; only `Sprite` was missing them. Fixed
+    in `mruby-rgss/mrblib/lib.rb` by delegating to the sprite's own
+    `bitmap.width`/`bitmap.height` (`0` with none set). A tenth masked
+    exception is already known this way and not yet fixed — past the
+    bundled speech-bubble add-on's own text layout, not yet diagnosed.
+    Fixing `$!` itself is
     fixable only by wrapping `Kernel#raise` itself (the sole point where the
     about-to-be-raised object is observable), which would add overhead and
     stack depth to *every* exception in the shared build across every maker

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -592,21 +592,32 @@ way, one at a time, each hidden behind the identical crash until fixed:
   by `scripts/rpgxp_testbed_check.rb`/`rpgvx_testbed_check.rb` re-parsing
   real event-command data (15,797 XP event commands) cleanly afterward.
 
-With all eight gaps above closed, the same real VX Ace release now reaches
+- **Fixed: `Sprite` had no `#width` / `#height`.** A real gap in
+  `mruby-rgss/mrblib/lib.rb`: the native `Sprite` class binding
+  (`src/lib.cxx`) never exposed them, and neither did the mrblib
+  reopening that already fills in `x`/`y`/`z`/`opacity`/`ox`/`oy` and the
+  rest of what the native `#initialize` never sets. RGSS3 (VX Ace) added
+  `Sprite#width`/`#height` over XP/VX's `Sprite` — read-only, mirroring
+  the sprite's own `bitmap` dimensions, `0` with none set — so scripts can
+  position something relative to a sprite without tracking its bitmap
+  size separately. This same release's own bundled speech-bubble add-on
+  (`吹きだしウィンドウ`, "bubble window") does exactly that, centring its
+  tail sprite under a message window (`self.y - @tail.height / 2` in
+  `get_tale_pos_normal_updown`, `@tail` a real `Sprite.new`), which raised
+  `NoMethodError: undefined method 'height' for RGSS::Sprite` the first
+  time the game showed a message. `Window` and `Graphics` both already
+  had `#width`/`#height` — only `Sprite` was missing them. Fixed by
+  adding both, delegating to `bitmap.width`/`bitmap.height` when a bitmap
+  is set.
+
+With all nine gaps above closed, the same real VX Ace release now reaches
 past `Scene_Title`'s title-command window, its title music,
-`DataManager.setup_new_game`'s common-event setup, and its first common
-event call, into a bundled community bubble-window script's own text
-layout (`エラーログ出力` aside, the script host reaches
-`吹きだしウィンドウ`'s `get_tale_pos_normal_updown`) before hitting a ninth
-masked exception — `NoMethodError: undefined method 'height' for
-RGSS::Sprite`. Not yet diagnosed as an engine gap or a script bug: real
-RGSS3's own documented `Sprite` API has no `#height` either, so this may be
-the community script itself relying on something beyond stock RGSS (a
-different add-on's monkey-patch this release also bundles, perhaps) rather
-than a gap in this engine — left for a future pass to determine which. The
-pattern established here (temporary VM probe → real gap → mrblib or native
-fix → regression test) applies regardless. mruby's bare `raise` (no
-arguments) has the same
+`DataManager.setup_new_game`'s common-event setup, its first common event
+call, and the bundled speech-bubble add-on's own text layout — into
+further gameplay, before hitting a tenth masked exception, not yet
+diagnosed. The pattern established here (temporary VM probe → real gap →
+mrblib or native fix → regression test) applies to it too, left for a
+future pass. mruby's bare `raise` (no arguments) has the same
 root cause from the other side: real Ruby re-raises `$!`, but mruby's
 `mrb_f_raise` has no `$!` to fall back to, so a bare `raise` always raises a
 fresh, empty `RuntimeError` instead of re-raising what was actually caught.
@@ -638,11 +649,11 @@ Tilemap item 1's remaining polish (the flat "above characters" layer) is the
 only item left in the six sections above; item 7's `$!`/bare-`raise` gap
 stands, and per a real release it is the reason each fix above only reveals
 the *next* wall one at a time rather than the game running to completion in
-one pass. Eight real bugs have been found and fixed this way so far
+one pass. Nine real bugs have been found and fixed this way so far
 (`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
 `Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`,
-`Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`)
-without needing `$!` itself fixed — the temporary VM probe finds the real
-exception directly regardless. A ninth wall, inside a bundled community
-script's own text layout past the game's first common event call, is where
-the game stands now — not yet diagnosed as an engine gap or a script bug.
+`Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`,
+`Sprite#width`/`#height`) without needing `$!` itself fixed — the temporary
+VM probe finds the real exception directly regardless. A tenth wall, past
+the bundled speech-bubble add-on's own text layout, is where the game
+stands now — not yet diagnosed.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -723,6 +723,20 @@ module RGSS
   class Sprite
     attr_reader :bitmap
 
+    # RGSS3 (VX Ace) added these over XP/VX's Sprite: the graphic's own pixel
+    # size, read-only, 0 with no bitmap set. Real scripts read them to
+    # position something relative to a sprite without tracking its bitmap
+    # dimensions separately -- a real VX Ace release's own bundled
+    # speech-bubble add-on centres its tail sprite this way
+    # (`self.y - @tail.height / 2`).
+    def width
+      bitmap ? bitmap.width : 0
+    end
+
+    def height
+      bitmap ? bitmap.height : 0
+    end
+
     # The viewport the sprite was created in (the native #initialize stores it to
     # keep it alive). RPG::Sprite reads it to put its damage pop-up and animation
     # cells in the same viewport as the battler — RGSS exposes it, and without the

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -739,9 +739,26 @@ assert "RGSS::Sprite API surface" do
   # exercised by the game runs.
   %i[bitmap= x= y= z= visible visible= opacity= zoom_x= zoom_y= angle= mirror=
      tone= color= src_rect= update blend_type= bush_depth= flash dispose
-     disposed?].each do |m|
+     disposed? width height].each do |m|
     assert_true RGSS::Sprite.method_defined?(m), "Sprite##{m} missing"
   end
+end
+
+# RGSS3 (VX Ace) added width/height over XP/VX's Sprite -- the graphic's own
+# pixel size, mirroring its bitmap, 0 with none set. A real VX Ace release's
+# own bundled speech-bubble add-on centres its tail sprite this way
+# (`self.y - @tail.height / 2`), which raised NoMethodError before this.
+# Pure Ruby (mrblib), needs no live display -- unlike construction, reading
+# it back doesn't touch the native canvas.
+assert "RGSS::Sprite#width/#height mirror the bitmap, 0 with none set" do
+  sprite = RGSS::Sprite.allocate
+  assert_equal 0, sprite.width
+  assert_equal 0, sprite.height
+
+  bmp = RGSS::Bitmap.new(40, 24)
+  sprite.instance_variable_set(:@bitmap, bmp)
+  assert_equal 40, sprite.width
+  assert_equal 24, sprite.height
 end
 
 assert "RGSS::Font defaults" do


### PR DESCRIPTION
## Summary

Continues digging into the real VX Ace release from #1074/#1089/#1092/
#1100/#1103 (*Sanctuary Of the Ruler*), past the `Bitmap#draw_text`/
`RPG::EventCommand` fixes.

- **`Sprite` had no `#width` / `#height`.** A real gap in
  `mruby-rgss/mrblib/lib.rb`: the native `Sprite` class binding
  (`src/lib.cxx`) never exposed them, and neither did the mrblib
  reopening that already fills in `x`/`y`/`z`/`opacity`/`ox`/`oy` and the
  rest of what the native `#initialize` never sets. RGSS3 (VX Ace) added
  `Sprite#width`/`#height` over XP/VX's `Sprite` — read-only, mirroring
  the sprite's own `bitmap` dimensions, `0` with none set — so scripts
  can position something relative to a sprite without tracking its
  bitmap size separately. This same release's own bundled speech-bubble
  add-on (`吹きだしウィンドウ`, "bubble window") does exactly that,
  centring its tail sprite under a message window
  (`self.y - @tail.height / 2` in `get_tale_pos_normal_updown`, `@tail`
  a real `Sprite.new`), which raised `NoMethodError: undefined method
  'height' for RGSS::Sprite` the first time the game showed a message.
  `Window` and `Graphics` both already had `#width`/`#height` — only
  `Sprite` was missing them. Fixed by adding both, delegating to
  `bitmap.width`/`bitmap.height` when a bitmap is set.

  This was found last round (#1103) as a candidate ninth wall, but left
  undiagnosed because real RGSS3's own `Sprite` API documentation
  doesn't obviously list `#height` either — closer investigation this
  round (reading the full 43 KB bundled speech-bubble script) confirmed
  it's a genuine engine gap, not the community script relying on
  something beyond stock RGSS: `Window` and `Graphics` both already
  carry the same accessor in this engine, `Sprite` was simply the one
  class it was never added to.

**Diagnostic method, not shipped**: found by adding a temporary
`fprintf` at the `OP_EXCEPT` opcode in the local `3rd/mruby` submodule
checkout to read the real masked exception directly off the VM (reverted
before every commit here, never part of the diff) — mruby's
still-missing `$!` (item 7, `docs/rpgvx-rgss-api-gap.md`) continues to
mask every fatal exception this game hits behind an identical crash in
its own bundled error-log utility. With all nine gaps found so far
closed, the game now reaches past the bundled speech-bubble add-on's own
text layout into further gameplay before hitting a tenth masked
exception — not yet diagnosed, left for a follow-up.

## Test plan
- [x] `ctest -R mruby_test` — 100% passing, includes a new regression
      test for `Sprite#width`/`#height` (constructed via
      `RGSS::Sprite.allocate` rather than `.new`, since the accessors are
      pure Ruby reading only the `@bitmap` ivar and never touch the
      native canvas `.new` needs a live display for — confirmed safe:
      the full suite ran clean with no crash)
- [x] `ruby scripts/rpgxp_testbed_check.rb data/PrayforYou` — OK
- [x] `ruby scripts/rpgvx_testbed_check.rb` — OK
- [x] `bash scripts/rpgxp_boot_check.bash` — move/menu/battle/save all
      pass on both XP test beds (`Sprite` is used by nearly every
      character/battler, so this is the check most likely to catch a
      regression here)
- [x] Manual: the real VX Ace release now gets past the bundled
      speech-bubble add-on's tail-sprite positioning, into further
      gameplay
- [x] `docs/TODO.md` and `docs/rpgvx-rgss-api-gap.md` updated with the
      full diagnosis and the new (tenth) open item

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_