### PR TITLE
Add F8 bug report hotkey for player diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,9 @@
   quit). `F9` opens the debug menu directly — most terminal emulators forward
   it as a real function-key escape sequence, the same way `F12`'s
   return-to-title already works here
+- `F8` (bug report, see "Map exploration" above) works here too, the same
+  function-key escape sequence as `F9`/`F12` — terminal key handling matches
+  the SDL desktop backend for the whole F5-F9/F12 set
 - `--sixel` works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm
   and Windows Terminal; `--iterm` works in iTerm2, WezTerm and VS Code
 - Either backend draws its emit rate (frame size, MB/s, fps) on-screen just

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@
   underneath — coordinates, passable/blocked, and any map event standing
   there — and warps the player onto it with C, through the same queued-warp
   mechanism a Teleport field skill uses rather than editing position by hand
+- **F8 dumps a bug report** — unlike the Test Play keys above this works in a
+  released game too, from any scene (map, menu, battle, ...): a Markdown block
+  with the current map id, the hero's x/y/direction, each party member's
+  HP/MP/level, every live event on the map (id, position, facing, graphic) and
+  the recent runtime log, printed to stderr between fence markers (so it can be
+  copied straight out of a terminal) and saved to a timestamped
+  `bugreport_<stamp>.md` next to the save data
 - `--rpg2k_preview_map=<id>` starts New Game on a chosen map, centred on its
   middle tile, instead of the database's configured start position — a quick
   way to inspect one map's rendering without a save file positioned there.

--- a/README.md
+++ b/README.md
@@ -59,10 +59,13 @@
 - **F8 dumps a bug report** — unlike the Test Play keys above this works in a
   released game too, from any scene (map, menu, battle, ...): a Markdown block
   with the current map id, the hero's x/y/direction, each party member's
-  HP/MP/level, every live event on the map (id, position, facing, graphic) and
-  the recent runtime log, printed to stderr between fence markers (so it can be
-  copied straight out of a terminal) and saved to a timestamped
-  `bugreport_<stamp>.md` next to the save data
+  HP/MP/level, the foreground interpreter's own state (running/waiting-on-what/
+  command index), every live event on the map (id, position, facing, graphic,
+  active page number, and its own running interpreter's position when a
+  Parallel Process or the foreground interpreter is driving it) and the recent
+  runtime log, printed to stderr between fence markers (so it can be copied
+  straight out of a terminal) and saved to a timestamped `bugreport_<stamp>.md`
+  next to the save data
 - `--rpg2k_preview_map=<id>` starts New Game on a chosen map, centred on its
   middle tile, instead of the database's configured start position — a quick
   way to inspect one map's rendering without a save file positioned there.

--- a/changelog.d/f8-bug-report-hotkey.added.md
+++ b/changelog.d/f8-bug-report-hotkey.added.md
@@ -1,0 +1,8 @@
+- **F8 dumps a bug report**, from any scene (map, menu, battle, ...) and
+  unlike the other debug hotkeys not gated on Test Play, so a real player can
+  use it too. It writes a Markdown block ("Paste this whole block into the
+  bug report") with the current map id, the hero's x/y/direction, each party
+  member's HP/MP/level, every live event on the map (id, x, y, direction,
+  graphic), and the recent runtime log — to a timestamped
+  `bugreport_<stamp>.md` next to the save data, and printed to stderr between
+  fence markers so a terminal player can copy it straight out.

--- a/changelog.d/f8-bug-report-hotkey.added.md
+++ b/changelog.d/f8-bug-report-hotkey.added.md
@@ -2,7 +2,11 @@
   unlike the other debug hotkeys not gated on Test Play, so a real player can
   use it too. It writes a Markdown block ("Paste this whole block into the
   bug report") with the current map id, the hero's x/y/direction, each party
-  member's HP/MP/level, every live event on the map (id, x, y, direction,
-  graphic), and the recent runtime log — to a timestamped
-  `bugreport_<stamp>.md` next to the save data, and printed to stderr between
-  fence markers so a terminal player can copy it straight out.
+  member's HP/MP/level, the foreground interpreter's own state (running/
+  waiting-on-what/command index), every live event on the map (id, x, y,
+  direction, graphic, active page number, and — if a Parallel Process or the
+  foreground interpreter is currently running its commands — that
+  interpreter's command index and Call Event depth too), and the recent
+  runtime log — to a timestamped `bugreport_<stamp>.md` next to the save
+  data, and printed to stderr between fence markers so a terminal player can
+  copy it straight out.

--- a/changelog.d/terminal-f-key-parity.added.md
+++ b/changelog.d/terminal-f-key-parity.added.md
@@ -1,0 +1,6 @@
+- **The terminal/sixel backend (`--iterm`/`--sixel`) now binds F5-F9 and F12**,
+  matching the SDL desktop backend (`src/sdl_input.cxx`) — previously only F9
+  and F12 were read from the CSI escape sequence a terminal sends for a
+  function key, so F8's new bug-report hotkey (and any future F5/F6/F7 use)
+  silently did nothing there. The on-screen control legend now lists `F8` for
+  Bug report alongside the existing Test Play debug-key hint.

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -51,6 +51,10 @@ enum Key {
   KEY_C = 6,
   KEY_SHIFT = 12,
   KEY_CTRL = 13,
+  KEY_F5 = 15,
+  KEY_F6 = 16,
+  KEY_F7 = 17,
+  KEY_F8 = 18,
   KEY_F9 = 19,
   KEY_F12 = 20,
   // RPG2003 Key Input Processing Numbers/Operators groups (RGSS::Input::N0..
@@ -525,7 +529,7 @@ void terminal_append_legend(std::string& s) {
   // faint to read on light themes.
   s += "\x1b[K\x1b[7m";
   s += "Move: Arrows/WASD  OK: Z/Enter/Space  Cancel: X/Esc  A: C  Quit: Q  "
-       "Debug(testplay): T=Ctrl F=Shift F9";
+       "Debug(testplay): T=Ctrl F=Shift F9  Bug report: F8";
   s += "\x1b[0m\r\n";
 }
 
@@ -658,12 +662,18 @@ void terminal_poll(mrb_state* M) {
   for (size_t i = 0; i < buf.size();) {
     const unsigned char c = static_cast<unsigned char>(buf[i]);
     if (c == 0x1b && i + 2 < buf.size() && buf[i + 1] == '[') {
-      // F9 and F12 -- RPG_RT's debug-menu and return-to-title hotkeys
-      // (RGSS::Input::F9/F12, read by mruby-rpg2k's Scene::Map and main_loop)
-      // -- arrive as a multi-digit CSI sequence terminated by '~' (`ESC [ 20
-      // ~` / `ESC [ 24 ~` in xterm and its descendants: foot, alacritty,
+      // F5-F9 and F12 -- RGSS::Input::F5..F9/F12, the same ids the SDL
+      // desktop backend binds (src/sdl_input.cxx's map_key); F9 is RPG_RT's
+      // debug-menu hotkey, F12 is return-to-title, F8 is this engine's own
+      // bug-report dump (read by mruby-rpg2k's Scene::Map and main_loop), and
+      // F5-F7 stand ready for whatever wants them next -- all six arrive as a
+      // multi-digit CSI sequence terminated by '~' (`ESC [ 15 ~` .. `ESC [ 20
+      // ~`, `ESC [ 24 ~` in xterm and its descendants: foot, alacritty,
       // kitty, gnome-terminal, wezterm, tmux, ...), unlike the single-letter
-      // arrow sequences below.
+      // arrow sequences below. F10/F11 are deliberately left out: xterm's own
+      // `ESC [ 21 ~` clashes with a real F10 in some terminals (it also sends
+      // a menu-bar toggle), and neither id is bound to anything in
+      // RGSS::Input today.
       if (buf[i + 2] >= '0' && buf[i + 2] <= '9') {
         size_t j = i + 2;
         int value = 0;
@@ -672,10 +682,28 @@ void terminal_poll(mrb_state* M) {
           ++j;
         }
         if (j < buf.size() && buf[j] == '~') {
-          if (value == 20)
-            hold_key(M, KEY_F9, now);
-          else if (value == 24)
-            hold_key(M, KEY_F12, now);
+          switch (value) {
+            case 15:
+              hold_key(M, KEY_F5, now);
+              break;
+            case 17:
+              hold_key(M, KEY_F6, now);
+              break;
+            case 18:
+              hold_key(M, KEY_F7, now);
+              break;
+            case 19:
+              hold_key(M, KEY_F8, now);
+              break;
+            case 20:
+              hold_key(M, KEY_F9, now);
+              break;
+            case 24:
+              hold_key(M, KEY_F12, now);
+              break;
+            default:
+              break;
+          }
           i = j + 1;
         } else {
           // No terminating '~' buffered yet; drop the digits read so far

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -638,6 +638,20 @@ module Game
       @index
     end
 
+    # Where this interpreter currently sits, for a diagnostic report
+    # (RPG2k#bug_report_text) rather than a resume point -- unlike
+    # #resumable_index this answers mid-Call-Event and mid-wait too, since a
+    # report wants "where is this thing stuck", not a safe place to restart
+    # from. `index`/`size` describe the *innermost* running list (a Call
+    # Event pushes the caller's list onto @call_stack and starts a fresh
+    # `@index` against the callee), `call_depth` is how many callers are
+    # stacked beneath it. nil for an interpreter that has never been given a
+    # command list at all.
+    def diagnostic_position
+      return nil if @list.empty? && @call_stack.empty?
+      { index: @index, size: @list.size, call_depth: @call_stack.size }
+    end
+
     # Start (or restart) at a previously #resumable_index-captured position
     # instead of the top of the list. `commands` must be the same command list
     # (or an equivalent rebuild of it, e.g. the same common event reloaded from

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -852,6 +852,86 @@ class RPG2k
     $stderr.puts "[RPG2k] Failed to continue: #{e.message}"
   end
 
+  # Fences around #bug_report_text so a reader (a human scrolling the log)
+  # can tell exactly where the block starts and ends -- the same idea as
+  # ERROR_DUMP_BEGIN/END (include/error_dump.hxx) for the crash-report path,
+  # kept as distinct strings so the two kinds of report are never confused.
+  BUG_REPORT_BEGIN = "----- BEGIN RPG MAKER CLONE BUG REPORT -----".freeze
+  BUG_REPORT_END = "----- END RPG MAKER CLONE BUG REPORT -----".freeze
+
+  # F8's report (see #main_loop): print the block between the fences above --
+  # so a terminal player can copy it straight out -- and also save it to a
+  # timestamped file next to the save data, for a player who cannot copy from
+  # the log (a bundled window with no attached console). Best-effort: a
+  # failure here must not take the game down over a report that only exists
+  # to describe some *other* problem.
+  def dump_bug_report
+    report = bug_report_text
+    $stderr.puts BUG_REPORT_BEGIN
+    $stderr.puts report
+    $stderr.puts BUG_REPORT_END
+    path = "#{GAME_DIR}/bugreport_#{bug_report_stamp}.md"
+    File.open(path, "w") { |f| f.write report }
+    $stderr.puts "[RPG2k] Bug report written to #{path}"
+  rescue StandardError => e
+    $stderr.puts "[RPG2k] Failed to write bug report: #{e.message}"
+  end
+
+  # The Markdown body itself: which map the hero is standing on and where,
+  # every live event on that map (Scene::Map#events -- id, position, facing,
+  # graphic), and the recent runtime log (RGSS::ErrorReport.log_tail, the same
+  # tee the crash-report path already carries -- see mruby-rgss/mrblib/
+  # error_report.rb) for whatever led up to the moment F8 was pressed. Reads
+  # `@scenes` for the current Scene::Map rather than assuming @scenes.last is
+  # one, since a menu/battle/debug-menu screen can be on top of it; a title or
+  # game-over screen has no Scene::Map at all, so that section is skipped
+  # rather than raising.
+  def bug_report_text
+    r = "# RPG Maker Clone bug report\n\n"
+    r += "Paste this whole block into the bug report.\n\n"
+    r += "## Run\n\n"
+    r += "- game: #{@title}\n"
+    r += "- test play: #{@test_play}\n\n"
+
+    map_scene = @scenes.find { |s| s.is_a?(Scene::Map) }
+    if map_scene
+      state = map_scene.state
+      r += "## Hero\n\n"
+      r += "- map: #{state.map_id}"
+      r += " (#{state.map.width}x#{state.map.height})" if state.map
+      r += "\n"
+      r += "- position: x=#{state.x} y=#{state.y} direction=#{state.direction}\n"
+      state.party.actors.each do |a|
+        r += "- #{a.name}: HP #{a.hp}/#{a.display_max_hp}" \
+             " MP #{a.mp}/#{a.display_max_mp} Lv#{a.level}\n"
+      end
+      r += "\n## Events on this map\n\n"
+      if map_scene.events.empty?
+        r += "(none)\n\n"
+      else
+        map_scene.events.each do |e|
+          ch = e[:char]
+          r += "- id=#{e[:id]} x=#{ch.x} y=#{ch.y} direction=#{ch.direction}" \
+               " graphic=#{ch.graphic_name.inspect}(#{ch.graphic_index})\n"
+        end
+        r += "\n"
+      end
+    else
+      r += "## Hero\n\nNo map is active (current scene: #{@scenes.last.class}).\n\n"
+    end
+
+    log = RGSS::ErrorReport.log_tail
+    r += "## Recent log\n\n```\n#{log}```\n\n" unless log.empty?
+    r
+  end
+
+  # "YYYYMMDD_HHMMSS", filesystem-safe and sortable, so repeated F8 presses in
+  # one session each get their own file instead of clobbering the last.
+  def bug_report_stamp
+    t = Time.now
+    "%04d%02d%02d_%02d%02d%02d" % [t.year, t.month, t.day, t.hour, t.min, t.sec]
+  end
+
   def main_loop
     RGSS::Profiler.frame do
       RGSS::Profiler.section("scene.update") do
@@ -861,6 +941,13 @@ class RPG2k
         # Reuses the same teardown/rebuild return_to_title already does for
         # the "End Game" menu command and the Game Over screen.
         return_to_title if Input.trigger?(Input::F12)
+        # F8 dumps a bug report -- checked here for the same reason as F12
+        # above (works from any scene). Unlike F9/Ctrl/Shift (see
+        # #try_open_debug_menu and Scene::Map's Test Play cheats) this is
+        # NOT gated on test_play: a released game's players are exactly who
+        # needs a way to hand over what the hero/map/events looked like when
+        # something went wrong.
+        dump_bug_report if Input.trigger?(Input::F8)
         @scenes.last.update
       end
       RGSS::Profiler.section("input.update") { Input.update }

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -885,7 +885,16 @@ class RPG2k
   # `@scenes` for the current Scene::Map rather than assuming @scenes.last is
   # one, since a menu/battle/debug-menu screen can be on top of it; a title or
   # game-over screen has no Scene::Map at all, so that section is skipped
-  # rather than raising.
+  # rather than raising. Each event line also carries its active page number
+  # (Scene::Map#events' page_number:) and which interpreter, if any, is
+  # currently running its commands (#bug_report_interp_text) -- a Parallel
+  # Process's own background one (Scene::Map#parallel_interpreter_for) or the
+  # foreground one (Scene::Map#interpreter) when this event is the one an On
+  # Touch/On Talk/auto-start trigger most recently started; a plain marker
+  # (page:, walking around) has neither and reads "idle". The foreground
+  # interpreter also gets its own summary line, since it can be stuck on a
+  # message/wait with no single event obviously to blame (a common event, a
+  # battle-event page).
   def bug_report_text
     r = "# RPG Maker Clone bug report\n\n"
     r += "Paste this whole block into the bug report.\n\n"
@@ -905,14 +914,27 @@ class RPG2k
         r += "- #{a.name}: HP #{a.hp}/#{a.display_max_hp}" \
              " MP #{a.mp}/#{a.display_max_mp} Lv#{a.level}\n"
       end
+      fg = map_scene.interpreter
+      r += "\n## Interpreter\n\n"
+      r += "- foreground: #{bug_report_interp_text(fg)}" \
+           " event=#{fg.running? ? (fg.event_id || "(none)") : "-"}\n"
       r += "\n## Events on this map\n\n"
       if map_scene.events.empty?
         r += "(none)\n\n"
       else
         map_scene.events.each do |e|
           ch = e[:char]
+          interp = map_scene.parallel_interpreter_for(e[:id])
+          kind = if interp
+                   "parallel"
+                 elsif fg.running? && fg.event_id == e[:id]
+                   interp = fg
+                   "foreground"
+                 end
           r += "- id=#{e[:id]} x=#{ch.x} y=#{ch.y} direction=#{ch.direction}" \
-               " graphic=#{ch.graphic_name.inspect}(#{ch.graphic_index})\n"
+               " graphic=#{ch.graphic_name.inspect}(#{ch.graphic_index})" \
+               " page=#{e[:page_number]}" \
+               " interpreter=#{kind ? "#{kind} #{bug_report_interp_text(interp)}" : "idle"}\n"
         end
         r += "\n"
       end
@@ -923,6 +945,19 @@ class RPG2k
     log = RGSS::ErrorReport.log_tail
     r += "## Recent log\n\n```\n#{log}```\n\n" unless log.empty?
     r
+  end
+
+  # "running idx=4/12 call_depth=0", "waiting(:message) idx=..." or "idle" for
+  # an interpreter that has never started / has nothing left to run --
+  # Game::Interpreter#diagnostic_position's raw [index, size, call_depth]
+  # turned into the one-line summary #bug_report_text puts next to the
+  # foreground interpreter and each event that owns one.
+  def bug_report_interp_text(interp)
+    return "idle" unless interp && interp.running?
+    pos = interp.diagnostic_position
+    return "idle" unless pos
+    state = interp.waiting? ? "waiting(#{interp.wait_kind})" : "running"
+    "#{state} idx=#{pos[:index]}/#{pos[:size]} call_depth=#{pos[:call_depth]}"
   end
 
   # "YYYYMMDD_HHMMSS", filesystem-safe and sortable, so repeated F8 presses in

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -319,6 +319,11 @@ class RPG2k
       end
 
       attr_reader :state
+      # The current map's live event list -- see #build_events for the shape
+      # of each entry ({ id:, char:, page:, ... }). Read by RPG2k
+      # #dump_bug_report (main.rb) to list every event's position/direction
+      # alongside the hero's.
+      attr_reader :events
 
       # Services Scene::Battle calls back into ----------------------------
       #

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4413,10 +4413,13 @@ class RPG2k
       # interpreter whichever specific symbols (:n3, :period, ...) actually
       # fired; Game::Interpreter::KEY_INPUT_GROUPS maps them back onto the
       # :numbers/:operators accept flag. Real key backing for
-      # RGSS::Input::N0..PERIOD exists only on the SDL desktop backend today
-      # (src/sdl_input.cxx) — on every other native backend (PSP, Wio
-      # Terminal, terminal/sixel) these ids are simply never pressed, the same
-      # way this build already leaves F5-F12 unbound there.
+      # RGSS::Input::N0..PERIOD: the SDL desktop backend binds every digit and
+      # operator (src/sdl_input.cxx); the terminal/sixel backend types them
+      # too, a real keyboard being able to produce them (mruby-rgss/src/
+      # terminal.cxx); the PSP backend binds only the first five digits
+      # (N0-N4) to its spare buttons; the Wio Terminal has no free pin left,
+      # so these ids stay unbound there — the same backend split F5-F9/F12
+      # follow (bound on SDL and terminal/sixel, unbound on PSP/Wio).
       NUMBER_KEY_BUTTONS = {
         n0: Input::N0, n1: Input::N1, n2: Input::N2, n3: Input::N3, n4: Input::N4,
         n5: Input::N5, n6: Input::N6, n7: Input::N7, n8: Input::N8, n9: Input::N9

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -320,10 +320,24 @@ class RPG2k
 
       attr_reader :state
       # The current map's live event list -- see #build_events for the shape
-      # of each entry ({ id:, char:, page:, ... }). Read by RPG2k
-      # #dump_bug_report (main.rb) to list every event's position/direction
-      # alongside the hero's.
+      # of each entry ({ id:, char:, page:, page_number:, ... }). Read by
+      # RPG2k #dump_bug_report (main.rb) to list every event's
+      # position/direction/page alongside the hero's.
       attr_reader :events
+      # The foreground interpreter -- the one On Touch/On Talk/auto-start
+      # triggers and Show Message run on, as opposed to a Parallel Process's
+      # own background one (see #parallel_interpreter_for). Read by RPG2k
+      # #dump_bug_report to show what it is stuck on, if anything.
+      attr_reader :interpreter
+
+      # The background Parallel Process interpreter currently running for map
+      # event `id`, or nil when none is (no Parallel Process trigger, or its
+      # page/conditions currently pick something else). Diagnostics only --
+      # RPG2k#dump_bug_report is the one caller today.
+      def parallel_interpreter_for(id)
+        p = @parallels.find { |pp| pp[:event] && pp[:event][:id] == id }
+        p && p[:interp]
+      end
 
       # Services Scene::Battle calls back into ----------------------------
       #
@@ -1167,8 +1181,9 @@ class RPG2k
                                             @state.variables, @state.party,
                                             @state.timer_seconds, @state.timer2_seconds)
           next unless selected
-          page = selected[1]
-          @events.push(build_event(id, ev, page, restore_route_index: restore_route_index))
+          page_number, page = selected
+          @events.push(build_event(id, ev, page, page_number,
+                                    restore_route_index: restore_route_index))
         end
         rebuild_event_tiles
       rescue StandardError => e
@@ -1178,7 +1193,7 @@ class RPG2k
         @event_tiles_by_pos = {}
       end
 
-      def build_event(id, ev, page, restore_route_index: true)
+      def build_event(id, ev, page, page_number, restore_route_index: true)
         dir = Game::EventGraphic.numpad_direction(page_direction(page))
         x, y = ev.x, ev.y
         # A saved wandered position (see #record_map_event_positions) wins over
@@ -1232,8 +1247,12 @@ class RPG2k
           route.resume_at(saved_index)
         end
         # `page` is kept so a refresh can tell whether the conditions still pick
-        # the same one (see #pages_changed?).
-        { id: id, char: ch, page: page, trigger: page_trigger(page),
+        # the same one (see #pages_changed?); `page_number` is the same page's
+        # 1-based slot in the event's own page list (Game::EventPage.select's
+        # first return value) -- diagnostics-only (RPG2k#bug_report_text),
+        # nothing here reads it back.
+        { id: id, char: ch, page: page, page_number: page_number,
+          trigger: page_trigger(page),
           commands: page_commands(page), guarded: page_guarded(page),
           move_type: move_type, route: route,
           move_timer: EVENT_MOVE_DELAY[ch.move_frequency] || 40,


### PR DESCRIPTION
## Summary
Adds an F8 hotkey that generates and saves a diagnostic bug report, accessible to players in released games (not just Test Play mode). The report captures the current game state and recent logs to help diagnose issues.

## Key Changes
- **New F8 hotkey handler** in `main_loop` that triggers `dump_bug_report` from any scene
- **`dump_bug_report` method** that outputs a formatted bug report to stderr between fence markers and saves it to a timestamped file (`bugreport_YYYYMMDD_HHMMSS.md`) next to save data
- **`bug_report_text` method** that generates Markdown-formatted diagnostic information:
  - Game title and test play status
  - Current map ID and dimensions (if on a map)
  - Hero position (x, y, direction) and party member stats (HP/MP/level)
  - All live events on the current map with their id, position, direction, and graphic
  - Recent runtime log tail from `RGSS::ErrorReport`
- **`bug_report_stamp` method** that generates sortable, filesystem-safe timestamps
- **Exposed `events` attribute** in `Scene::Map` for the bug report to access live event data
- **Documentation updates** in README.md and changelog explaining the feature

## Implementation Details
- Unlike F9/Ctrl/Shift debug keys, F8 is **not gated on test_play**, allowing released game players to generate reports
- Uses best-effort error handling so report generation failures don't crash the game
- Report is printed to stderr with clear fence markers (`----- BEGIN/END RPG MAKER CLONE BUG REPORT -----`) so terminal players can copy it directly
- Gracefully handles cases where no map is active (title screen, game over, etc.)
- Timestamped filenames prevent report clobbering on repeated F8 presses in one session

https://claude.ai/code/session_01LDmxj2aMUeJwByUaibr4b2