### PR TITLE
Add a schema-checked binary/text converter for LCF project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,33 @@
   ./rpg_maker_clone --sixel --test_play --term_console_lines=8 --game_dir path/to/game
   ```
 
+### Editing project data as text
+
+- `scripts/lcf_text_convert.rb` converts a project's `.ldb` (database),
+  `.lmu` (map unit) or `.lsd` (save) between the original binary format and a
+  human-editable YAML text form, schema-checked against `mruby-lcf/mrblib/
+  schema.rb` in both directions — the map itself stays a visual, in-engine
+  edit (see the F9 debug menu's Map viewer above; tile painting has no good
+  text form), but everything else — actor/item/skill tables, map dimensions,
+  event pages, system settings — round-trips through text:
+
+  ```sh
+  ruby scripts/lcf_text_convert.rb to_text   RPG_RT.ldb database.yml
+  # edit database.yml in any text editor
+  ruby scripts/lcf_text_convert.rb check     database.yml   # validate without writing
+  ruby scripts/lcf_text_convert.rb to_binary database.yml   RPG_RT.ldb
+  ```
+
+  An unedited file round-trips byte-exact; an edited one is validated first
+  (unknown fields, wrong types, malformed event/move-command entries — every
+  problem found is reported, not just the first) and only written once it's
+  clean. This is still the *original* RPG Maker 2000/2003 LCF format on
+  disk — the text form is a local editing convenience, never a competing
+  project format. `.lmt` (the map tree) is text-exportable but not yet
+  binary-writable (see `docs/adr/0055-lcf-text-convert.md`). Covered end to
+  end, with no test-bed project required, by `scripts/
+  lcf_text_convert_check.rb`.
+
 ### Profiling
 
 - Debugging tooling, so it only runs during test play: either the project's

--- a/changelog.d/lcf-event-move-command-encoders.added.md
+++ b/changelog.d/lcf-event-move-command-encoders.added.md
@@ -1,0 +1,7 @@
+- **`LCF.encode` can now re-encode event-page command lists and move
+  routes** (`:event` / `:move_commands` schema types), the exact inverses of
+  the existing `LCF.parse_event_commands` / `LCF.parse_move_commands`
+  readers. Previously only scalar and simple-array fields could be edited
+  and written back through a schema (`Array1D#[]=`); these two container
+  types round-trip now too. Covered by new checks in `mruby-lcf/test/
+  lcf_test.rb`.

--- a/changelog.d/lcf-text-convert-tool.added.md
+++ b/changelog.d/lcf-text-convert-tool.added.md
@@ -1,0 +1,13 @@
+- **A binary <-> text converter for LCF project files**, `scripts/
+  lcf_text_convert.rb`. Converts a `.ldb` (database), `.lmu` (map unit) or
+  `.lsd` (save) to a human-editable YAML form (`to_text`) and back
+  (`to_binary`), schema-checked against `mruby-lcf/mrblib/schema.rb` in both
+  directions — an edited file is validated (unknown fields, wrong types,
+  malformed event/move-command entries, every problem reported at once) and
+  only written once it passes, and an unedited file round-trips byte-exact.
+  A `check` subcommand validates without writing. `.lmt` (the map tree) is
+  text-exportable but not yet binary-writable — its multi-section format has
+  no writer yet, reported plainly rather than attempted. See
+  `docs/adr/0055-lcf-text-convert.md`. Covered end to end, against synthetic
+  fixtures (no test-bed project required), by `scripts/
+  lcf_text_convert_check.rb`.

--- a/docs/adr/0055-lcf-text-convert.md
+++ b/docs/adr/0055-lcf-text-convert.md
@@ -1,0 +1,121 @@
+# 55. A schema-checked binary <-> text converter for LCF project files
+
+Date: 2026-08-19
+
+## Status
+
+Accepted
+
+## Context
+
+The debug tooling added under `mruby-rpg2k/mrblib/scene/` so far (the F9
+debug menu's Switch/Variable pages, the Map viewer and its Select-mode
+teleport) is deliberately read-only against the on-disk project: it edits
+`Game::State` for the current session and never touches a `.ldb`/`.lmu` file,
+so it cannot collide with a real RPG Maker project or its own editor.
+
+The next piece of debug/editor tooling is different in kind: editing a
+project's *parameters* (actor stats, item/skill tables, map dimensions,
+event pages, ...) directly, meant to persist. Doing that field-by-field
+inside the engine's own 320x240 window — the way the existing Variable
+editor's signed-number keypad works — does not scale to a whole database;
+a real text editor already does that job well. The map itself is the
+exception (tile painting has no good text form, hence the Map viewer/editor
+staying in-engine and visual), but everything else is naturally
+text-editable *if* there is a safe way to get it into and back out of text.
+
+The risk is the same one that shaped every debug-tool decision so far: RPG
+Maker 2000/2003's own `.ldb`/`.lmu`/`.lmt` format (LCF, a BER-length-prefixed
+chunk stream) is the *original* project format, not something this project
+invented. A converter that reads and writes it is not introducing a
+competing format — but a broken writer, or one that silently drops or
+misinterprets a field, absolutely could corrupt a real project. "Schema
+checking" — validating an edited text file against the same field
+definitions the runtime itself reads before ever touching the binary
+encoder — is what keeps that risk bounded.
+
+The binary codec itself did not need to be built new. `mruby-lcf/mrblib/
+lcf.rb`'s `Array1D#to_lcf` / `Array2D#to_lcf` / `File#to_lcf` already
+round-trip a real save (`.lsd`) byte-exact and support field-level edits
+through `LCF.encode`, proven by `scripts/lcf_save_roundtrip.rb` — the format
+is shared across every LCF file type (only the schema, from `mruby-lcf/
+mrblib/schema.rb`, differs), so that machinery generalises to `.ldb`/`.lmu`/
+`.lsd` directly. `LCF.encode` was missing two cases though: the `:event` and
+`:move_commands` container types (event-page command lists and move routes)
+had readers (`parse_event_commands`/`parse_move_commands`) but no writers —
+edits to those specific fields could not be re-encoded before this ADR. Both
+scalar tables *and* command lists needed to be editable for the converter to
+be more than a database-only tool, since event pages carry both.
+
+## Decision
+
+Two changes:
+
+1. **`LCF.encode_event_commands` / `LCF.encode_move_commands`** (`mruby-lcf/
+   mrblib/lcf.rb`), the exact inverses of the existing
+   `parse_event_commands`/`parse_move_commands` readers, wired into
+   `LCF.encode`'s `:event`/`:move_commands` cases. Covered by new assertions
+   in `mruby-lcf/test/lcf_test.rb` alongside the existing parser tests,
+   checked both for byte-exact inversion of a hand-built blob and for
+   round-tripping through `LCF.encode`/`.parse_*` together.
+
+2. **`scripts/lcf_text_convert.rb`**, a CLI tool with three subcommands:
+   - `to_text IN.ldb|lmu|lmt|lsd OUT.yml` — reads the binary file (its LCF
+     class picked by extension) and walks it with `schema.rb`'s field names,
+     not raw chunk ids, into a YAML document. Only chunks actually *present*
+     in the file are emitted (`Array1D#key?`), preserving the
+     absent-vs-default distinction the runtime itself cares about (chunk 23/
+     24 in a project that never named a switch, for one).
+   - `to_binary IN.yml OUT.ldb|lmu|lsd` — the inverse: validates the YAML
+     against the schema (unknown field names, wrong scalar types, malformed
+     event/move-command entries — collected and reported *all at once*, not
+     one-fix-per-run) and only then builds fresh `Array1D`/`Array2D` objects
+     through `[]=` (which itself re-encodes via `LCF.encode`) and writes them
+     with `File#save_to`.
+   - `check IN.yml` — the same validation pass with no write, for iterating
+     on an edit before committing it.
+
+   The YAML carries its own `type:` field (`database`/`map_unit`/
+   `save_data`/`map_tree`) rather than trusting a filename extension, so
+   `to_binary`'s output path doesn't have to match the source's original
+   extension.
+
+   `.lmt` (the map tree) is text-exportable but **not** binary-writable yet:
+   its root is a multi-section file (`LCF::Sections`, three parts — map
+   properties, tree order, initial party/vehicle position) and `File#to_lcf`
+   itself already raises `'section-based file serialization not
+   implemented'` for that shape. `to_binary`/`check` report this plainly as
+   a validation error rather than attempting an unproven encoder.
+
+   `scripts/lcf_text_convert_check.rb` proves the whole pipeline against
+   synthetic fixtures built the same from-scratch-`Array1D` way `mruby-lcf/
+   test/lcf_test.rb` does (no real test-bed project needed): byte-exact
+   round-trip for both `map_unit` and `database` — including a `move_route`
+   and an event-command page, so the two new encoders are covered
+   end-to-end, not just at the unit level — a semantic edit surviving a
+   reload with an untouched sibling field unaffected, schema-check rejection
+   of an unknown field and a type mismatch (reported together), and the
+   `.lmt` write-guard.
+
+## Consequences
+
+- Any RPG2000/2003 project's database and map-unit files can now be edited
+  as text (with real validation, not just "well-formed YAML") and written
+  back to the exact binary format `RPG_RT.exe` and the real editor read —
+  this project still speaks only the original format, so nothing about a
+  project edited this way is any less a genuine RPG Maker project.
+- `.lsd` saves gain a text-editing path as a side effect of the same tool
+  (same schema-driven machinery, `save_data` was already the proven case).
+- `.lmt` (map tree) is read/export only until a `Sections`/multi-section
+  writer exists — flagged, not silently broken. Follow-up work if a text
+  editor for the map tree (parent/child map organisation, per-map BGM/
+  teleport-escape-save flags) turns out to be wanted.
+- Event-page command lists and move routes are now genuinely re-encodable,
+  which is also the foundation the roadmapped in-engine event-command
+  browser (guarding against a text edit producing a structurally "valid" but
+  logically broken If/Else/Loop nesting) will need regardless of whether
+  editing happens through this text tool or that future browser.
+- The tool is offline (a `scripts/*.rb` CLI, loaded under CRuby exactly like
+  `lcf_save_roundtrip.rb`/`lcf_testbed_check.rb` already are) rather than
+  in-engine: no new runtime dependency, no game-loop cost, and it needs no
+  native build to run or test.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -128,6 +128,24 @@ module LCF
   MOVE_CHANGE_GRAPHIC = 34  # + charset name (string) + charset index
   MOVE_PLAY_SOUND = 35      # + file name (string) + volume, tempo, balance
 
+  # Encode a list of EventCommand (or {code:, indent:, string:, parameters:}
+  # Hashes -- what a text-authored event page decodes to) back to the packed
+  # blob #parse_event_commands reads. Its exact inverse: a list parsed then
+  # re-encoded without edits reproduces the original bytes.
+  def encode_event_commands(cmds)
+    out = String.new
+    cmds.each do |c|
+      code = c.respond_to?(:code) ? c.code : c[:code]
+      indent = c.respond_to?(:indent) ? c.indent : c[:indent]
+      str = binstr(utf8_to_cp932((c.respond_to?(:string) ? c.string : c[:string]) || ''))
+      params = c.respond_to?(:parameters) ? c.parameters : c[:parameters]
+      out = out + write_ber(code) + write_ber(indent) +
+            write_ber(str.bytesize) + str + write_ber(params.size)
+      params.each { |p| out = out + write_ber(p) }
+    end
+    out
+  end
+
   # Decode a packed move-command list (the `:move_commands` schema type used by
   # event-page and common-event move routes). Unlike event commands, each entry
   # is a bare command id optionally followed by a length-prefixed cp932 string
@@ -157,6 +175,34 @@ module LCF
       cmds.push MoveCommand.new(id, str, a, b, c)
     end
     cmds
+  end
+
+  # Encode a list of MoveCommand (or {command_id:, parameter_string:,
+  # parameter_a:, parameter_b:, parameter_c:} Hashes) back to the packed blob
+  # #parse_move_commands reads -- its exact inverse. Only the fields the
+  # command's own id actually carries get written, mirroring the reader's own
+  # `case id` dispatch (a bare command carries nothing past its id).
+  def encode_move_commands(cmds)
+    out = String.new
+    cmds.each do |c|
+      id = c.respond_to?(:command_id) ? c.command_id : c[:command_id]
+      str_field = c.respond_to?(:parameter_string) ? c.parameter_string : c[:parameter_string]
+      a = (c.respond_to?(:parameter_a) ? c.parameter_a : c[:parameter_a]) || 0
+      b = (c.respond_to?(:parameter_b) ? c.parameter_b : c[:parameter_b]) || 0
+      cc = (c.respond_to?(:parameter_c) ? c.parameter_c : c[:parameter_c]) || 0
+      out = out + write_ber(id)
+      case id
+      when MOVE_SWITCH_ON, MOVE_SWITCH_OFF
+        out = out + write_ber(a)
+      when MOVE_CHANGE_GRAPHIC
+        str = binstr(utf8_to_cp932(str_field || ''))
+        out = out + write_ber(str.bytesize) + str + write_ber(a)
+      when MOVE_PLAY_SOUND
+        str = binstr(utf8_to_cp932(str_field || ''))
+        out = out + write_ber(str.bytesize) + str + write_ber(a) + write_ber(b) + write_ber(cc)
+      end
+    end
+    out
   end
 
   # Holds the sequential sections of a multi-section file (e.g. the map tree,
@@ -373,13 +419,12 @@ module LCF
   end
 
   # Encode a Ruby value back to the raw chunk bytes for a schema field -- the
-  # inverse of to_rb. Only the scalar and simple-array types a save actually
-  # needs to be re-authored are handled; the packed command/tree types are still
-  # round-tripped as their original raw bytes (never re-encoded from decoded
-  # values), so they are intentionally left out. A nested :Array1D / :Array2D
-  # value is serialised through its own #to_lcf. Strings go back out as cp932 via
-  # LCF.utf8_to_cp932 (the build's uni-algo encoder; the CRuby harnesses provide
-  # a Windows-31J stand-in), mirroring cp932_to_utf8 on read.
+  # inverse of to_rb. A nested :Array1D / :Array2D value is serialised through
+  # its own #to_lcf. Strings go back out as cp932 via LCF.utf8_to_cp932 (the
+  # build's uni-algo encoder; the CRuby harnesses provide a Windows-31J
+  # stand-in), mirroring cp932_to_utf8 on read. :Tree is not handled here: it
+  # is a whole-file section type (LCF::MapTree's multi-section root), never a
+  # field type an Array1D chunk carries, so it never reaches #[]=.
   def encode value, type
     case type
     when :int ; write_ber value
@@ -391,6 +436,8 @@ module LCF
     when :int16_array ; pack_int16 value
     when :int32_array ; pack_int32 value
     when :string ; utf8_to_cp932 value
+    when :event ; encode_event_commands value
+    when :move_commands ; encode_move_commands value
     when :Array1D, :Array2D
       return binstr(value) if value.is_a? String
       value.to_lcf
@@ -400,7 +447,8 @@ module LCF
   end
 
   module_function :read_ber, :write_ber, :to_rb, :read_section,
-                  :parse_event_commands, :parse_move_commands,
+                  :parse_event_commands, :encode_event_commands,
+                  :parse_move_commands, :encode_move_commands,
                   :unpack_int32, :unpack_double, :pack_int32, :pack_int16,
                   :pack_double, :encode, :binstr
 

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -349,6 +349,42 @@ assert "LCF.parse_move_commands decodes bare and parameterised commands" do
   assert_equal 11, cmds[4].command_id
 end
 
+assert "LCF.encode_event_commands is the exact inverse of .parse_event_commands" do
+  def lcf_command(code, indent, str, params)
+    lcf_ber(code) + lcf_ber(indent) + lcf_ber(str.bytesize) + str +
+      lcf_ber(params.size) + params.map { |p| lcf_ber(p) }.join
+  end
+  cmds = [LCF::EventCommand.new(10110, 0, "Hi", [1, 2]),
+          LCF::EventCommand.new(10210, 1, "", [0, 3, 3, 0])]
+  expected = lcf_command(10110, 0, "Hi", [1, 2]) + lcf_command(10210, 1, "", [0, 3, 3, 0])
+  assert_equal expected, LCF.encode_event_commands(cmds)
+  # And through the generic dispatcher a schema's :event field actually uses.
+  back = LCF.parse_event_commands(LCF.encode(cmds, :event))
+  assert_equal 10110, back[0].code
+  assert_equal [1, 2], back[0].parameters
+  assert_equal "", back[1].string
+end
+
+assert "LCF.encode_move_commands is the exact inverse of .parse_move_commands, " \
+       "writing only the fields each command id carries" do
+  cmds = [LCF::MoveCommand.new(14, '', 0, 0, 0),         # bare
+          LCF::MoveCommand.new(32, '', 7, 0, 0),         # switch_on + id
+          LCF::MoveCommand.new(34, "Hero", 2, 0, 0),     # change_graphic + name/index
+          LCF::MoveCommand.new(35, "bell", 100, 80, 50), # play_sound + name/vol/tempo/balance
+          LCF::MoveCommand.new(11, '', 0, 0, 0)]         # bare
+  expected = lcf_ber(14) +
+             lcf_ber(32) + lcf_ber(7) +
+             lcf_ber(34) + lcf_ber("Hero".bytesize) + "Hero" + lcf_ber(2) +
+             lcf_ber(35) + lcf_ber("bell".bytesize) + "bell" +
+             lcf_ber(100) + lcf_ber(80) + lcf_ber(50) +
+             lcf_ber(11)
+  assert_equal expected, LCF.encode_move_commands(cmds)
+  back = LCF.parse_move_commands(LCF.encode(cmds, :move_commands))
+  assert_equal 5, back.size
+  assert_equal "bell", back[3].parameter_string
+  assert_equal 50, back[3].parameter_c
+end
+
 assert "LCF map-tree scroll bars decode as ints, not booleans" do
   # These chunks (5/6) hold the editor's signed scrollbar positions; a real game
   # stores multi-byte BER ints here, which the old :bool schema could not read.

--- a/scripts/lcf_text_convert.rb
+++ b/scripts/lcf_text_convert.rb
@@ -1,0 +1,378 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Bidirectional converter between RPG Maker 2000/2003's LCF binary project
+# files (.ldb database, .lmu map unit, .lsd save) and a human-editable YAML
+# text form, schema-checked against mruby-lcf/mrblib/schema.rb in both
+# directions -- this is the "text-based parameter editor" half of the debug
+# tooling in mruby-rpg2k/mrblib/scene/ (the Map viewer, see map_viewer.rb, is
+# the other half: some data is easier painted than typed).
+#
+# The binary <-> Ruby-tree codec is not reimplemented here -- it is
+# mruby-lcf/mrblib/lcf.rb's own LCF.to_rb / Array1D#to_lcf / LCF.encode, the
+# same machinery that already round-trips real .lsd saves byte-exact (see
+# scripts/lcf_save_roundtrip.rb). This script only adds the schema-driven
+# layer between that Ruby tree and text: field names instead of raw chunk
+# ids, and a validation pass that reports every problem in an edited file
+# before attempting to encode it, rather than a raw exception (or a silently
+# wrong write) from the encoder itself.
+#
+# Usage:
+#   ruby scripts/lcf_text_convert.rb to_text   IN.ldb|lmu|lmt|lsd  OUT.yml
+#   ruby scripts/lcf_text_convert.rb to_binary IN.yml              OUT.ldb|lmu|lsd
+#   ruby scripts/lcf_text_convert.rb check     IN.yml
+#
+# `to_text` reads the binary file and its type is taken from its extension.
+# The YAML it writes carries its own `type:` field (one of database/map_unit/
+# save_data/map_tree), so `to_binary`/`check` do not need to guess from a
+# filename -- OUT's extension only picks the output path, not the schema.
+#
+# `.lmt` (the map tree) is text-exportable but not yet writable: its file is a
+# multi-section format (map-properties table + tree order + party start
+# position) and mruby-lcf's own File#to_lcf does not implement serialising
+# that shape yet (see LCF::File#to_lcf's own comment in lcf.rb) -- a
+# `to_binary`/`check` on a map_tree document reports that plainly rather than
+# attempting something unproven.
+#
+# Exits non-zero on any schema violation (`check`/`to_binary`) or read/write
+# failure, printing every problem found, not just the first.
+
+require 'stringio'
+require 'yaml'
+
+module LCF
+  # uni-algo stand-ins, matching every other CRuby-hosted LCF script in this
+  # repo (e.g. scripts/lcf_save_roundtrip.rb) -- see that file's own comment
+  # for why both directions transcode through Windows-31J rather than the
+  # native uni-algo encoder this build would otherwise use.
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+
+  def utf8_to_cp932(s)
+    s.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+mrblib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(mrblib, 'lcf.rb')
+load File.join(mrblib, 'schema.rb')
+
+# type name (as it appears in the YAML `type:` field) -> [LCF file class, the
+# file extensions `to_text` recognises for it].
+FILE_TYPES = {
+  'database' => [LCF::Database, %w[.ldb]],
+  'map_unit' => [LCF::MapUnit, %w[.lmu]],
+  'save_data' => [LCF::SaveData, %w[.lsd]],
+  'map_tree' => [LCF::MapTree, %w[.lmt]],
+}.freeze
+
+def file_class_for_ext(ext)
+  FILE_TYPES.each { |name, (klass, exts)| return [name, klass] if exts.include?(ext) }
+  nil
+end
+
+# ---- binary -> text ---------------------------------------------------------
+
+# One Array1D/Array2D chunk-table walk shared by every record type: only
+# chunks actually present in the file are emitted (Array1D#key?), so an
+# absent-vs-empty-vs-default field stays distinguishable after a round trip
+# the same way it is at runtime (see mruby-rpg2k's own commentary on this,
+# e.g. Scene::DebugMenu#max_id).
+def array1d_to_text(obj, schema)
+  h = {}
+  schema[:elements].each do |idx, field|
+    next unless obj.key?(idx)
+    h[field[:name].to_s] = value_to_text(obj[idx], field)
+  end
+  h
+end
+
+def value_to_text(value, field)
+  case field[:type]
+  when :Array1D
+    array1d_to_text(value, field)
+  when :Array2D
+    h = {}
+    value.each { |id, row| h[id] = array1d_to_text(row, field) }
+    h
+  when :event
+    value.map { |c| { 'code' => c.code, 'indent' => c.indent, 'string' => c.string,
+                       'parameters' => c.parameters } }
+  when :move_commands
+    value.map do |c|
+      { 'command_id' => c.command_id, 'parameter_string' => c.parameter_string,
+        'parameter_a' => c.parameter_a, 'parameter_b' => c.parameter_b,
+        'parameter_c' => c.parameter_c }
+    end
+  when :int16_array
+    value.is_a?(Hash) ? value.each_with_object({}) { |(k, v), h| h[k.to_s] = v } : value
+  when :Tree
+    { 'selected_id' => value.selected_id, 'maps' => value.maps }
+  else
+    value
+  end
+end
+
+# A .lmt's root is LCF::Sections, not a single Array1D -- its own schema is an
+# Array of per-section schemas (LCF::Schema::MAP_TREE), each read
+# independently (see LCF.read_section). Walk that shape instead.
+def sections_to_text(file)
+  h = {}
+  file.schema.each do |s|
+    section = file.send(s[:name])
+    h[s[:name].to_s] =
+      case s[:type]
+      when :Array2D, :Array1D then array1d_or_2d_to_text(section, s)
+      when :Tree then { 'selected_id' => section.selected_id, 'maps' => section.maps }
+      else raise "unhandled map-tree section type: #{s[:type]}"
+      end
+  end
+  h
+end
+
+def array1d_or_2d_to_text(obj, schema)
+  return array1d_to_text(obj, schema) if schema[:type] == :Array1D
+  h = {}
+  obj.each { |id, row| h[id] = array1d_to_text(row, schema) }
+  h
+end
+
+def to_text(in_path, out_path)
+  ext = File.extname(in_path).downcase
+  type_name, klass = file_class_for_ext(ext)
+  unless klass
+    warn "unrecognised extension #{ext.inspect} -- expected one of " \
+         "#{FILE_TYPES.values.flat_map(&:last).join(', ')}"
+    exit 1
+  end
+  file = klass.new(StringIO.new(File.binread(in_path)))
+  data = type_name == 'map_tree' ? sections_to_text(file) : array1d_to_text(file, file.schema)
+  doc = { 'type' => type_name, 'data' => data }
+  File.write(out_path, YAML.dump(doc))
+  puts "wrote #{out_path} (#{type_name}, from #{in_path})"
+rescue StandardError => e
+  warn "failed to read #{in_path}: #{e.class}: #{e.message}"
+  exit 1
+end
+
+# ---- schema validation -------------------------------------------------------
+
+# Every problem found, each as one "path: message" string -- collected rather
+# than raised on the first one, so a single run reports everything wrong with
+# an edited file instead of a fix-one-rerun loop.
+def validate_array1d(value, schema, path, errors)
+  unless value.is_a?(Hash)
+    errors << "#{path}: expected a mapping of field name => value, got #{value.class}"
+    return
+  end
+  by_name = {}
+  schema[:elements].each { |idx, f| by_name[f[:name].to_s] = [idx, f] }
+  value.each do |name, v|
+    entry = by_name[name.to_s]
+    unless entry
+      errors << "#{path}.#{name}: unknown field (not in the #{schema[:name]} schema)"
+      next
+    end
+    validate_value(v, entry[1], "#{path}.#{name}", errors)
+  end
+end
+
+def validate_value(value, field, path, errors)
+  case field[:type]
+  when :int, :uint8
+    errors << "#{path}: expected an integer, got #{value.class}" unless value.is_a?(Integer)
+    errors << "#{path}: #{value} is out of range for uint8 (0..255)" \
+      if field[:type] == :uint8 && value.is_a?(Integer) && !(0..255).cover?(value)
+  when :bool
+    errors << "#{path}: expected true/false, got #{value.class}" \
+      unless [true, false].include?(value)
+  when :double
+    errors << "#{path}: expected a number, got #{value.class}" unless value.is_a?(Numeric)
+  when :string
+    errors << "#{path}: expected a string, got #{value.class}" unless value.is_a?(String)
+  when :int8_array, :int16_array, :int32_array
+    validate_int_array(value, path, errors)
+  when :bool_array
+    unless value.is_a?(Array) && value.all? { |v| [true, false].include?(v) }
+      errors << "#{path}: expected a list of true/false, got #{value.inspect}"
+    end
+  when :Array1D
+    validate_array1d(value, field, path, errors)
+  when :Array2D
+    unless value.is_a?(Hash)
+      errors << "#{path}: expected a mapping of id => row, got #{value.class}"
+    else
+      value.each { |id, row| validate_array1d(row, field, "#{path}[#{id}]", errors) }
+    end
+  when :event
+    validate_event_commands(value, path, errors)
+  when :move_commands
+    validate_move_commands(value, path, errors)
+  when :Tree
+    errors << "#{path}: expected a mapping with selected_id/maps" unless value.is_a?(Hash)
+  end
+end
+
+def validate_int_array(value, path, errors)
+  unless value.is_a?(Array)
+    return errors << "#{path}: expected a list of integers, got #{value.class}"
+  end
+  value.each_with_index do |v, i|
+    errors << "#{path}[#{i}]: expected an integer, got #{v.class}" unless v.is_a?(Integer)
+  end
+end
+
+def validate_event_commands(value, path, errors)
+  unless value.is_a?(Array)
+    return errors << "#{path}: expected a list of event commands, got #{value.class}"
+  end
+  value.each_with_index do |c, i|
+    row = "#{path}[#{i}]"
+    unless c.is_a?(Hash)
+      errors << "#{row}: expected a mapping with code/indent/string/parameters, got #{c.class}"
+      next
+    end
+    %w[code indent].each { |k| errors << "#{row}.#{k}: missing" unless c[k].is_a?(Integer) }
+    errors << "#{row}.string: missing or not a string" unless c['string'].is_a?(String)
+    errors << "#{row}.parameters: missing or not a list of integers" \
+      unless c['parameters'].is_a?(Array) && c['parameters'].all? { |p| p.is_a?(Integer) }
+  end
+end
+
+def validate_move_commands(value, path, errors)
+  unless value.is_a?(Array)
+    return errors << "#{path}: expected a list of move commands, got #{value.class}"
+  end
+  value.each_with_index do |c, i|
+    row = "#{path}[#{i}]"
+    unless c.is_a?(Hash)
+      errors << "#{row}: expected a mapping with command_id/parameter_*, got #{c.class}"
+      next
+    end
+    errors << "#{row}.command_id: missing" unless c['command_id'].is_a?(Integer)
+  end
+end
+
+def validate_document(doc)
+  errors = []
+  unless doc.is_a?(Hash) && doc['type'] && doc['data']
+    errors << "document: expected a mapping with 'type' and 'data' (as written by `to_text`)"
+    return errors
+  end
+  klass, = FILE_TYPES[doc['type']]
+  unless klass
+    errors << "document.type: #{doc['type'].inspect} is not one of " \
+              "#{FILE_TYPES.keys.join(', ')}"
+    return errors
+  end
+  if doc['type'] == 'map_tree'
+    errors << 'document: map_tree is text-exportable but not yet writable back to binary ' \
+               '(LCF::File#to_lcf does not implement the multi-section .lmt format yet)'
+    return errors
+  end
+  validate_array1d(doc['data'], klass.new.schema, 'data', errors)
+  errors
+end
+
+# ---- text -> binary ----------------------------------------------------------
+
+def build_array1d(hash, schema)
+  obj = LCF::Array1D.new('', schema)
+  by_name = {}
+  schema[:elements].each { |idx, f| by_name[f[:name].to_s] = [idx, f] }
+  hash.each do |name, value|
+    idx, field = by_name[name.to_s]
+    obj[idx] = build_value(value, field)
+  end
+  obj
+end
+
+def build_value(value, field)
+  case field[:type]
+  when :Array1D
+    build_array1d(value, field)
+  when :Array2D
+    obj = LCF::Array2D.new('', field)
+    value.each { |id, row| obj[id.to_i] = build_array1d(row, field) }
+    obj
+  when :event
+    value.map { |c| LCF::EventCommand.new(c['code'], c['indent'], c['string'],
+                                           c['parameters']) }
+  when :move_commands
+    value.map do |c|
+      LCF::MoveCommand.new(c['command_id'], c['parameter_string'],
+                            c['parameter_a'], c['parameter_b'], c['parameter_c'])
+    end
+  else
+    value
+  end
+end
+
+def to_binary(in_path, out_path)
+  doc = YAML.safe_load(File.read(in_path), permitted_classes: [Symbol])
+  errors = validate_document(doc)
+  unless errors.empty?
+    warn "#{in_path}: #{errors.size} schema problem(s):"
+    errors.each { |e| warn "  #{e}" }
+    exit 1
+  end
+  klass, = FILE_TYPES[doc['type']]
+  file = klass.new
+  by_name = {}
+  file.schema[:elements].each { |idx, f| by_name[f[:name].to_s] = [idx, f] }
+  doc['data'].each do |name, value|
+    idx, field = by_name[name.to_s]
+    file[idx] = build_value(value, field)
+  end
+  file.save_to(out_path)
+  puts "wrote #{out_path} (#{doc['type']}, from #{in_path})"
+rescue StandardError => e
+  warn "failed to write #{out_path}: #{e.class}: #{e.message}"
+  exit 1
+end
+
+def check(in_path)
+  doc = YAML.safe_load(File.read(in_path), permitted_classes: [Symbol])
+  errors = validate_document(doc)
+  if errors.empty?
+    puts "#{in_path}: OK, matches the #{doc['type']} schema"
+    exit 0
+  else
+    warn "#{in_path}: #{errors.size} schema problem(s):"
+    errors.each { |e| warn "  #{e}" }
+    exit 1
+  end
+end
+
+# ---- CLI ----------------------------------------------------------------------
+
+USAGE = <<~USAGE
+  Usage:
+    ruby scripts/lcf_text_convert.rb to_text   IN.ldb|lmu|lmt|lsd  OUT.yml
+    ruby scripts/lcf_text_convert.rb to_binary IN.yml              OUT.ldb|lmu|lsd
+    ruby scripts/lcf_text_convert.rb check     IN.yml
+USAGE
+
+case ARGV[0]
+when 'to_text'
+  in_path, out_path = ARGV[1], ARGV[2]
+  (warn USAGE; exit 1) unless in_path && out_path
+  to_text(in_path, out_path)
+when 'to_binary'
+  in_path, out_path = ARGV[1], ARGV[2]
+  (warn USAGE; exit 1) unless in_path && out_path
+  to_binary(in_path, out_path)
+when 'check'
+  in_path = ARGV[1]
+  (warn USAGE; exit 1) unless in_path
+  check(in_path)
+else
+  warn USAGE
+  exit 1
+end

--- a/scripts/lcf_text_convert_check.rb
+++ b/scripts/lcf_text_convert_check.rb
@@ -1,0 +1,221 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Regression test for scripts/lcf_text_convert.rb, the binary <-> YAML text
+# converter for LCF project files (.ldb/.lmu/.lsd).
+#
+# Unlike scripts/lcf_save_roundtrip.rb (which needs a real Save*.lsd on disk),
+# this builds its own synthetic .lmu/.ldb fixtures with the same
+# from-scratch-Array1D technique mruby-lcf/test/lcf_test.rb uses, so it runs
+# with no test-bed data required. It drives the converter as a subprocess --
+# the same `ruby scripts/lcf_text_convert.rb ...` invocation a user would
+# type -- rather than requiring its internals, so a CLI-argument regression
+# would be caught here too.
+#
+# Covers:
+#   1. Byte-exact round-trip (map_unit and database) through to_text/to_binary.
+#   2. A semantic edit survives: change a field's text value, convert back to
+#      binary, and an untouched sibling field/chunk is unaffected.
+#   3. Nested :event / :move_commands fields (the two container types
+#      LCF.encode gained alongside this tool) round-trip through text too.
+#   4. `check` rejects an unknown field, a type mismatch, and reports every
+#      problem in one run rather than stopping at the first.
+#   5. `to_binary`/`check` on a map_tree document reports the documented
+#      "not yet writable" limitation rather than crashing.
+#
+# Usage: ruby scripts/lcf_text_convert_check.rb
+# Exits non-zero if any check fails.
+
+require 'stringio'
+require 'tmpdir'
+require 'yaml'
+
+module LCF
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+
+  def utf8_to_cp932(s)
+    s.encode('Windows-31J', invalid: :replace, undef: :replace).force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+mrblib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(mrblib, 'lcf.rb')
+load File.join(mrblib, 'schema.rb')
+
+CONVERTER = File.expand_path('lcf_text_convert.rb', __dir__)
+
+$failures = 0
+def fail(msg)
+  $failures += 1
+  warn "  FAIL #{msg}"
+end
+
+def run(*args)
+  out = IO.popen(['ruby', CONVERTER, *args], err: [:child, :out], &:read)
+  [out, $?.exitstatus]
+end
+
+# A map_unit fixture with two events -- one carrying an authored event-command
+# page (exercises :event), the other a custom move route (exercises
+# :move_commands) -- so both of LCF.encode's new container types are on the
+# byte-exact-round-trip path, not just scalars.
+def build_map_unit_fixture
+  schema = LCF::Schema::MAP_UNIT
+  events_field = schema[:elements][81]
+  page_field = events_field[:elements][5]
+
+  talk_page = LCF::Array1D.new('', page_field)
+  talk_page[21] = 'Chara1'
+  talk_page[52] = [LCF::EventCommand.new(10120, 0, 'Hello', [1, 2]),
+                    LCF::EventCommand.new(20110, 0, '', [])]
+  talk_pages = LCF::Array2D.new('', page_field)
+  talk_pages[1] = talk_page
+  talker = LCF::Array1D.new('', events_field)
+  talker[1] = 'Talker'
+  talker[2] = 5
+  talker[3] = 3
+  talker[5] = talk_pages
+
+  move_route_field = page_field[:elements][41]
+  move_route = LCF::Array1D.new('', move_route_field)
+  move_route[12] = [LCF::MoveCommand.new(0, '', 0, 0, 0),   # move_down (bare)
+                     LCF::MoveCommand.new(32, '', 7, 0, 0),  # switch_on + id
+                     LCF::MoveCommand.new(35, 'bell', 90, 110, 0)] # play_sound
+  move_route[21] = true # repeat
+
+  walk_page = LCF::Array1D.new('', page_field)
+  walk_page[41] = move_route
+  walk_pages = LCF::Array2D.new('', page_field)
+  walk_pages[1] = walk_page
+  walker = LCF::Array1D.new('', events_field)
+  walker[1] = 'Walker'
+  walker[2] = 1
+  walker[3] = 1
+  walker[5] = walk_pages
+
+  events = LCF::Array2D.new('', events_field)
+  events[1] = talker
+  events[2] = walker
+
+  mu = LCF::MapUnit.new
+  mu[1] = 3   # chipset_id
+  mu[2] = 20  # width
+  mu[3] = 15  # height
+  mu[81] = events
+  mu
+end
+
+def build_database_fixture
+  schema = LCF::Schema::DATABASE
+  player_field = schema[:elements][11]
+  hero = LCF::Array1D.new('', player_field)
+  hero[1] = 'Hero'
+  hero[7] = 1
+  players = LCF::Array2D.new('', player_field)
+  players[1] = hero
+  db = LCF::Database.new
+  db[11] = players
+  db
+end
+
+Dir.mktmpdir('lcf-text-convert-check') do |dir|
+  # 1 + 3. Byte-exact round-trip, including the :event / :move_commands fields.
+  [['map_unit', build_map_unit_fixture, 'lmu'],
+   ['database', build_database_fixture, 'ldb']].each do |name, file, ext|
+    bin_path = File.join(dir, "fixture.#{ext}")
+    file.save_to(bin_path)
+    original = File.binread(bin_path)
+
+    yml_path = File.join(dir, "#{name}.yml")
+    out, status = run('to_text', bin_path, yml_path)
+    fail("#{name} to_text failed (exit #{status}): #{out}") unless status.zero?
+
+    rebuilt_path = File.join(dir, "#{name}_rebuilt.#{ext}")
+    out, status = run('to_binary', yml_path, rebuilt_path)
+    fail("#{name} to_binary failed (exit #{status}): #{out}") unless status.zero?
+
+    rebuilt = File.binread(rebuilt_path)
+    if rebuilt == original
+      puts "#{name}: byte-exact round-trip OK (#{original.bytesize} bytes)"
+    else
+      fail "#{name}: round-trip differs (orig #{original.bytesize}B, " \
+           "rebuilt #{rebuilt.bytesize}B)"
+    end
+  end
+
+  # 2. Semantic edit: bump map_unit's width in the text form, rebuild, reread,
+  # and confirm the edit landed while an untouched field (chipset_id) did not.
+  yml_path = File.join(dir, 'map_unit.yml')
+  doc = YAML.safe_load(File.read(yml_path))
+  doc['data']['width'] = 42
+  edited_path = File.join(dir, 'map_unit_edited.yml')
+  File.write(edited_path, YAML.dump(doc))
+
+  edited_bin = File.join(dir, 'map_unit_edited.lmu')
+  out, status = run('to_binary', edited_path, edited_bin)
+  fail("edit to_binary failed (exit #{status}): #{out}") unless status.zero?
+
+  reread_yml = File.join(dir, 'map_unit_edited_reread.yml')
+  run('to_text', edited_bin, reread_yml)
+  reread = YAML.safe_load(File.read(reread_yml))
+  if reread['data']['width'] == 42 && reread['data']['chipset_id'] == 3
+    puts 'semantic edit: width changed, chipset_id untouched, both survive a reload'
+  else
+    fail "semantic edit did not survive reload: #{reread['data'].slice('width', 'chipset_id')}"
+  end
+
+  # 4. Schema checking: unknown field, type mismatch, and both reported
+  # together in one run rather than stopping at the first.
+  bad_path = File.join(dir, 'bad.yml')
+  File.write(bad_path, YAML.dump({
+    'type' => 'map_unit',
+    'data' => { 'chipset_id' => 'not a number', 'width' => 20, 'ghost_field' => true },
+  }))
+  out, status = run('check', bad_path)
+  named_both = out.include?('ghost_field') && out.include?('chipset_id') &&
+               out.include?('expected an integer')
+  if status.zero?
+    fail 'check accepted a document with an unknown field and a type mismatch'
+  elsif named_both
+    puts "check: rejected an unknown field and a type mismatch, " \
+         "both reported -- #{out.lines.size} line(s)"
+  else
+    fail "check's error output did not name both problems: #{out}"
+  end
+
+  good_path = File.join(dir, 'good.yml')
+  File.write(good_path, YAML.dump({ 'type' => 'map_unit', 'data' => { 'chipset_id' => 1 } }))
+  out, status = run('check', good_path)
+  if status.zero?
+    puts 'check: accepts a schema-valid document'
+  else
+    fail "check rejected a valid document: #{out}"
+  end
+
+  # 5. map_tree is documented as text-exportable but not yet binary-writable;
+  # to_binary/check must say so plainly rather than raising.
+  tree_path = File.join(dir, 'tree.yml')
+  File.write(tree_path, YAML.dump({ 'type' => 'map_tree', 'data' => {} }))
+  out, status = run('to_binary', tree_path, File.join(dir, 'tree.lmt'))
+  if status.zero?
+    fail 'to_binary silently accepted a map_tree document -- the writer does not exist yet'
+  elsif out.include?('not yet writable')
+    puts 'map_tree to_binary: reports the documented limitation rather than crashing'
+  else
+    fail "map_tree to_binary failed for the wrong reason: #{out}"
+  end
+end
+
+if $failures.zero?
+  puts 'lcf text convert check: all checks passed'
+  exit 0
+else
+  warn "lcf text convert check: #{$failures} check(s) FAILED"
+  exit 1
+end


### PR DESCRIPTION
## Summary

First piece of the "text-first parameter editing" plan: a converter between RPG Maker 2000/2003's binary project files and a human-editable, schema-checked YAML form. The map itself stays a visual, in-engine edit (the F9 debug menu's Map viewer from #1049/#1075) since tile painting has no good text form, but everything else — actor/item/skill tables, map dimensions, event pages, system settings — round-trips through text now.

## Key Changes

- **`LCF.encode` gains `:event`/`:move_commands` support** (`mruby-lcf/mrblib/lcf.rb`): `encode_event_commands`/`encode_move_commands`, the exact inverses of the existing `parse_event_commands`/`parse_move_commands` readers. Event-page command lists and move routes were previously read-only through a schema; they can now be edited and written back too. Covered by new assertions in `mruby-lcf/test/lcf_test.rb`.

- **`scripts/lcf_text_convert.rb`**, a CLI tool:
  - `to_text IN.ldb|lmu|lmt|lsd OUT.yml` — dumps to YAML keyed by schema field name (not raw chunk ids); only chunks actually present in the file are emitted, preserving the absent-vs-default distinction the runtime cares about.
  - `to_binary IN.yml OUT.ldb|lmu|lsd` — validates against the schema first (unknown field names, wrong scalar types, malformed event/move-command entries — every problem reported at once, not one-fix-per-run) and only then writes.
  - `check IN.yml` — the same validation with no write, for iterating on an edit.

  It doesn't reimplement the binary codec — it reuses `mruby-lcf`'s existing `LCF.to_rb`/`Array1D#to_lcf`/`LCF.encode` machinery, already proven byte-exact for `.lsd` saves by `scripts/lcf_save_roundtrip.rb`.

- **`.lmt` (map tree) is text-exportable but not yet binary-writable** — its multi-section format has no writer in `LCF::File#to_lcf` yet. `to_binary`/`check` report this as a clear validation error rather than attempting something unproven.

- **`scripts/lcf_text_convert_check.rb`** proves the whole pipeline end-to-end against synthetic fixtures (no test-bed project needed): byte-exact round-trip for both `map_unit` and `database`, including a move route and an event-command page so the two new encoders are covered end-to-end; a semantic edit surviving reload with an untouched sibling field unaffected; aggregated schema-error reporting; and the `.lmt` write guard.

- `docs/adr/0055-lcf-text-convert.md` records the design rationale, and README documents the new tool.

## Implementation Details

Still the *original* RPG Maker 2000/2003 LCF format on disk throughout — the text form is a local editing convenience, never a competing project format, matching the same principle the existing F9 debug tooling (Switch/Variable/Map pages) was built on.

## Test plan

- [x] `ruby scripts/lcf_text_convert_check.rb` — all checks pass (byte-exact round-trip, semantic edit, schema-check rejection with aggregated errors, `.lmt` write guard)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 762 checks pass (unaffected by this change, run to confirm no regression)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1049 checks pass (same)
- [x] `ruby scripts/lcf_schema_coverage.rb` — passes against available test-bed data

https://claude.ai/code/session_017C1i41GuWNEwKfPSHHUTra

---
_Generated by [Claude Code](https://claude.ai/code/session_017C1i41GuWNEwKfPSHHUTra)_