### PR TITLE
Show Choices / Show Inn cursor auto-repeats while a direction is held

### DIFF
--- a/changelog.d/choice-window-cursor-auto-repeat.fixed.md
+++ b/changelog.d/choice-window-cursor-auto-repeat.fixed.md
@@ -1,0 +1,5 @@
+- **Show Choices / Show Inn:** The message-attached choice cursor -- Show
+  Choices, and the Show Inn Accept/Cancel prompt built on the identical
+  mechanism -- now auto-repeats while Up/Down is held, instead of moving
+  only on a fresh key press, matching RPG_RT. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11700,6 +11700,34 @@ not yet verified:
   window's own available width rather than the full string), both confirmed
   to fail against the pre-fix code (a `NoMethodError`, and the full
   unclipped string) before the fix.
+- ✅ **The message-attached choice cursor (Show Choices, and the Show Inn
+  Accept/Cancel prompt built on the identical mechanism) only moved on a
+  fresh key press, never auto-repeating while Up/Down was held — the same
+  gap already fixed this pass on the shop lists, hero-name grid, and
+  quantity counter, just never checked on the choice list itself
+  (2026-08-19).** Confirmed directly against RPG_RT's live source:
+  `Window_Message` (`src/window_message.h`) is a plain `Window_Selectable`
+  subclass, and `Window_Message::Update` (`src/window_message.cpp`) calls
+  the base `Window_Selectable::Update()` unconditionally every frame,
+  before ever dispatching to its own choice-specific `InputChoice` — so a
+  held Down/Up scrolls the choice cursor exactly like any other list
+  window (`Window_Selectable::Update`, `src/window_selectable.cpp`, gates
+  on `Input::IsRepeated`, `endless_scrolling = true` by default and never
+  overridden for messages). `Game_Interpreter_Map::CommandShowInn`
+  (`src/game_interpreter_map.cpp`) builds its Accept/Cancel prompt as an
+  ordinary choice pair (`pm.PushChoice(ToString(accept), can_afford);
+  pm.PushChoice(ToString(cancel));`), so it inherits the identical
+  behavior. `Scene::Map#drive_message`'s choice branch and `#drive_inn`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) both checked only `Input.trigger?`
+  on Up/Down, so a player had to tap the direction once per option
+  instead of holding it down — arguably the highest-impact instance of
+  this bug class this session, since Show Choices appears in nearly every
+  RPG Maker game's dialogue. Fixed by adding `|| Input.repeat?(...)` to
+  both direction branches in each method. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (`RGSS::Input.repeated`, not
+  `.triggered`, still moves both the Show Choices and the Inn Accept/
+  Cancel cursor), both confirmed to fail against the pre-fix code
+  (`expected 1, got 0`) before the fix.
 
 **Battle system (default)**
 - ✅ **Battle pages are checked far more often than once per turn** — the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4518,12 +4518,19 @@ class RPG2k
           open_inn_window(req) # opened this frame; take input from the next one
           return
         end
-        if Input.trigger?(Input::DOWN)
+        # Auto-repeats while held, same as #drive_message's own choice
+        # cursor just above -- real RPG_RT implements this exact Accept/
+        # Cancel prompt as an ordinary Show Choices pair
+        # (`Game_Interpreter_Map::CommandShowInn`, `src/
+        # game_interpreter_map.cpp`: `pm.PushChoice(ToString(accept),
+        # can_afford); pm.PushChoice(ToString(cancel));`), so it inherits
+        # the identical `Window_Selectable`-backed auto-repeat.
+        if Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           @inn_choice += 1
           @inn_choice %= 2
           set_inn_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::UP)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           @inn_choice -= 1
           @inn_choice %= 2
           set_inn_cursor
@@ -7210,13 +7217,23 @@ class RPG2k
               return
             end
           end
-          if Input.trigger?(Input::DOWN)
+          # Both directions auto-repeat while held, not just a fresh press --
+          # RPG_RT's own `Window_Message` (`src/window_message.h`) is a plain
+          # `Window_Selectable` subclass, and `Window_Message::Update`
+          # (`src/window_message.cpp`) calls the base `Window_Selectable::
+          # Update()` unconditionally every frame, before ever dispatching
+          # to its own choice-specific `InputChoice` -- so a held Down/Up
+          # scrolls the choice cursor exactly like any other list window
+          # (`Window_Selectable::Update`, `src/window_selectable.cpp`, gates
+          # on `Input::IsRepeated`, with `endless_scrolling = true` by
+          # default and never overridden here).
+          if Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
             @choice_index += 1
             @choice_index %= @message[:count]
             page_to_choice
             set_choice_cursor
             play_system_se(SFX_CURSOR)
-          elsif Input.trigger?(Input::UP)
+          elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
             @choice_index -= 1
             @choice_index %= @message[:count]
             page_to_choice

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2872,6 +2872,22 @@ check 'Show Inn scene: the Accept / Cancel cursor wraps around' do
   eq 0, scene.instance_variable_get(:@inn_choice), 'Down from Cancel wraps back to Accept'
 end
 
+check 'Show Inn scene: the Accept / Cancel cursor auto-repeats while held, ' \
+      'not just a fresh press' do
+  # Real RPG_RT implements this exact prompt as an ordinary Show Choices
+  # pair (`Game_Interpreter_Map::CommandShowInn`, `src/
+  # game_interpreter_map.cpp`), so it inherits the same `Window_Selectable`
+  # auto-repeat every other list cursor gets.
+  scene, _st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  5.times { scene.update } # inn command runs; the greeting prompt opens
+  eq 0, scene.instance_variable_get(:@inn_choice), 'affordable: cursor starts on Accept'
+
+  RGSS::Input.repeated = [RGSS::Input::UP] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@inn_choice), 'a held (repeated) Up still moves the cursor'
+end
+
 check 'Show Inn scene: inn BGM plays on entry, field BGM resumes after a stay' do
   scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
   st.current_bgm = { name: 'Field', volume: 100, tempo: 100 } # the map's own BGM
@@ -9636,6 +9652,38 @@ check 'the choice window cursor wraps around, like Scene::Title (98dad9b)' do
   scene.update
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@choice_index), 'Down from the last choice wraps to the first'
+end
+
+# `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold a
+# key across frames without it also reading as a fresh trigger.
+check 'the choice window cursor auto-repeats while a direction is held, ' \
+      'not just a fresh press' do
+  # Confirmed against RPG_RT's own live source: `Window_Message` (`src/
+  # window_message.h`) is a plain `Window_Selectable` subclass, and
+  # `Window_Message::Update` (`src/window_message.cpp`) calls the base
+  # `Window_Selectable::Update()` unconditionally every frame before its
+  # own choice-specific dispatch -- so a held Down/Up scrolls the choice
+  # cursor exactly like any other list window.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_CHOICES, [], indent: 0),
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'Yes'),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'No'),
+    ECmd.new(ic::CHOICE_OPTION, [2], indent: 0, string: 'Maybe'),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg && msg[:choice] }
+  ok(msg && msg[:choice], 'choice window opened')
+  eq 0, scene.instance_variable_get(:@choice_index), 'starts on the first choice'
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@choice_index),
+     'a held (repeated) Down still moves the choice cursor'
 end
 
 check 'character_screen_position measures against the live camera' do


### PR DESCRIPTION
## Summary

`Window_Message` (`src/window_message.h`) is a plain `Window_Selectable` subclass, and `Window_Message::Update` (`src/window_message.cpp`) calls the base `Window_Selectable::Update()` unconditionally every frame, before ever dispatching to its own choice-specific `InputChoice` -- so a held Down/Up scrolls the choice cursor exactly like any other list window (`Window_Selectable::Update`, `src/window_selectable.cpp`, gates on `Input::IsRepeated`, `endless_scrolling = true` by default and never overridden for messages).

`Game_Interpreter_Map::CommandShowInn` (`src/game_interpreter_map.cpp`) builds its Accept/Cancel prompt as an ordinary choice pair (`pm.PushChoice(ToString(accept), can_afford); pm.PushChoice(ToString(cancel));`), so it inherits the identical behavior.

`Scene::Map#drive_message`'s choice branch and `#drive_inn` (`mruby-rpg2k/mrblib/scene/map.rb`) both checked only `Input.trigger?` on Up/Down, so a player had to tap the direction once per option instead of holding it down -- arguably the highest-impact instance of this bug class fixed this session, since Show Choices appears in nearly every RPG Maker game's dialogue.

- Fixed by adding `|| Input.repeat?(...)` to both direction branches in each method.

## Test plan

- Two new `scripts/rpg2k_scene_check.rb` checks: `RGSS::Input.repeated`, not `.triggered`, still moves both the Show Choices and the Inn Accept/Cancel cursor.
- Verified via `git stash` on `scene/map.rb` alone: both new checks fail pre-fix (`expected 1, got 0`).
- Full suite green: `rpg2k_scene_check.rb` 778 passed, `rpg2k_logic_check.rb` 1062 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_