### PR TITLE
Timer Operation "set" is not clamped to 99:59, correcting a prior fix

### DIFF
--- a/changelog.d/timer-clamp-5999-via-variable.fixed.md
+++ b/changelog.d/timer-clamp-5999-via-variable.fixed.md
@@ -1,7 +1,0 @@
-- **A Timer Operation "set" sourced from a Variable now clamps to 99:59
-  (5999 s) instead of loading the raw value unbounded.** `Game::Timer#set`
-  had no upper bound, and Control Variables can feed it an arbitrary
-  player-reachable value through `Game::Interpreter#do_timer`. Real RPG_RT's
-  timer display never grows past two minute digits, so it caps a set that
-  high rather than wrapping. Added `Game::Timer::MAX_SECONDS = 5999` and a
-  clamp in `#set`, with regression coverage in `scripts/rpg2k_logic_check.rb`.

--- a/changelog.d/timer-set-not-clamped.fixed.md
+++ b/changelog.d/timer-set-not-clamped.fixed.md
@@ -1,0 +1,6 @@
+- **Timer:** A Timer Operation "set" sourced from a Variable is no longer
+  clamped to 99:59 (5999 s) -- a prior fix's own reasoning turned out
+  backwards on closer inspection: real RPG_RT's `Game_Party::SetTimer` has no
+  upper bound at all, and its display genuinely garbles past 99 minutes
+  rather than capping cleanly. Removed `Game::Timer::MAX_SECONDS` and the
+  clamp in `#set`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6799,6 +6799,36 @@ not yet verified:
   bundled with this bullet (battle damage cap, HP recovery cap, switch/
   variable caps and ranges, recursion ceiling, party/stack/picture caps, move
   speed, transparency steps) remain unverified — see below.
+  ✅ **Correction (2026-08-19): that clamp was wrong — real RPG_RT's Timer
+  Operation "set" is not clamped at all, even from an out-of-range
+  Control Variable.** The bullet just above reasoned from "RPG_RT's timer
+  display never grows past two minute digits" without ever checking the
+  actual `Game_Party::SetTimer` source, and that reasoning turns out
+  backwards: confirmed directly against RPG_RT's live source,
+  `Game_Party::SetTimer` (`src/game_party.cpp`) is `data.timer1_frames =
+  seconds * DEFAULT_FPS + (DEFAULT_FPS - 1);` with no upper bound
+  whatsoever, and `Game_Interpreter::CommandTimerOperation`
+  (`src/game_interpreter.cpp`) passes its `ValueOrVariable`-sourced
+  seconds straight through with no clamp either. Real RPG_RT's own
+  display genuinely doesn't cap cleanly past 99 minutes either —
+  `Sprite_Timer::Draw` (`src/sprite_timer.cpp`) indexes its digit strip
+  at an unbounded `32 + 8 * (mins / 10)`, so a timer set past 99:59
+  garbles the drawn minutes tiles rather than showing a clean "99:59".
+  This port's own pixel-digit renderer (`Scene::Map
+  #draw_timer_digits`, `mruby-rpg2k/mrblib/scene/map.rb`) already
+  indexes its windowskin digit strip the identical unbounded way — it
+  was never given its own separate bound, so removing `Game::Timer`'s
+  clamp reproduces the same garbled-past-99 quirk for free, matching
+  this codebase's established pattern of faithfully keeping known
+  RPG_RT overflow quirks (Break Loop's nesting bug, `flash_sat`/
+  `flash_period` not being saved) rather than "fixing" them into
+  cleaner-than-real behavior. Fixed by removing `Game::Timer::
+  MAX_SECONDS` and the clamp in `#set` entirely. The existing
+  `scripts/rpg2k_logic_check.rb` check was rewritten to assert the
+  opposite of its old claim (a Timer Operation "set" of 9999, direct or
+  variable-sourced, lands at exactly 9999 s / `9999 * FPS + (FPS - 1)`
+  frames, not clamped to 5999), confirmed to fail against the pre-fix
+  code (`expected 9999, got 5999`) before the fix.
 - ✅ **Special-skill HP recovery is capped at 999 per use** — the same
   fixed-3-digit-popup reasoning as the battle damage cap above, for the
   opposite direction. `Game::Battle#apply_skill_hit`'s recovery branch

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12896,13 +12896,6 @@ module Game
   class Timer
     FPS = 60
 
-    # RPG_RT's timer display never grows past two minute digits, so 99:59
-    # (5999 s) is the largest value it can show; a Timer Operation "set"
-    # sourced from a Control Variables value (arbitrary, player-reachable —
-    # e.g. an accidental or intentional overflowed computation) is clamped to
-    # this ceiling rather than wrapping or overflowing the frame counter.
-    MAX_SECONDS = 5999
-
     # Remaining time in frames; whether it is counting; whether it is drawn; and
     # whether it keeps counting (and drawing) during a battle — the Timer
     # Operation start command's second flag.
@@ -12915,11 +12908,25 @@ module Game
       @in_battle = false
     end
 
-    # Timer Operation, "set": load the timer with `seconds` (see the note above
-    # about the extra 59 frames). Clamped to MAX_SECONDS (99:59) since this can
-    # be fed an out-of-range Variable value via Control Variables.
+    # Timer Operation, "set": load the timer with `seconds` (see the note
+    # above about the extra 59 frames). Not clamped -- confirmed against
+    # RPG_RT's own live source: `Game_Party::SetTimer` (`src/game_party.cpp`)
+    # is `data.timer1_frames = seconds * DEFAULT_FPS + (DEFAULT_FPS - 1);`
+    # with no upper bound at all, and `Game_Interpreter::
+    # CommandTimerOperation` (`src/game_interpreter.cpp`) passes its
+    # `ValueOrVariable`-sourced seconds straight through with no clamp
+    # either -- so a Control Variables value above 99:59 (5999 s, an
+    # arbitrary, player-reachable overflow) genuinely reaches the frame
+    # counter uncapped in real RPG_RT. `Sprite_Timer::Draw`
+    # (`src/sprite_timer.cpp`) indexes its digit strip at an unbounded
+    # `32 + 8 * (mins / 10)` with no ceiling either, so real RPG_RT's own
+    # on-screen minutes display genuinely garbles past 99 rather than
+    # capping cleanly -- this port's own pixel-digit renderer
+    # (`Scene::Map#draw_timer_digits`, `mruby-rpg2k/mrblib/scene/map.rb`)
+    # already indexes its own windowskin digit strip the identical
+    # unbounded way, so it reproduces the same garbled-past-99 quirk for
+    # free once this class stops clamping first.
     def set(seconds)
-      seconds = MAX_SECONDS if seconds > MAX_SECONDS
       @frames = seconds * FPS + (FPS - 1)
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2728,28 +2728,26 @@ check 'a timer only counts in battle when it carries the battle flag' do
   ok t.drawn?(true), 'and keeps drawing'
 end
 
-check 'Timer Operation "set" clamps to 99:59 (5999 s) when a Variable feeds it an out-of-range value' do
+check 'Timer Operation "set" is not clamped to 99:59, even when a Variable ' \
+      'feeds it a value past it -- confirmed against RPG_RT\'s own ' \
+      'Game_Party::SetTimer, which has no upper bound at all' do
   t = Game::Timer.new
-  # Direct clamp check: RPG_RT's timer display never grows past two minute
-  # digits, so a value above the 99:59 ceiling is clamped, not wrapped.
   t.set(9999)
-  eq 5999, t.seconds, '9999 s clamps down to the 99:59 ceiling'
-  eq '99:59', t.display_text
-  eq Game::Timer::MAX_SECONDS * 60 + 59, t.frames
+  eq 9999, t.seconds, '9999 s lands exactly, not clamped down to 99:59'
+  eq 9999 * Game::Timer::FPS + (Game::Timer::FPS - 1), t.frames
 
   st = new_state
   st.variables[1] = 9999 # a Control Variables value the player could reach
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::TIMER_OPERATION, [0, 1, 1])]) # set = var 1
   it.update
-  eq 5999, st.timer(0).seconds, 'a variable-sourced set clamps the same way'
-  eq '99:59', st.timer_display_text
+  eq 9999, st.timer(0).seconds, 'a variable-sourced set is unclamped the same way'
 
-  # An ordinary in-range set (constant or variable) is unaffected.
+  # An ordinary in-range set (constant or variable) still works as before.
   st.variables[2] = 30
   it.start([FakeCmd.new(IC::TIMER_OPERATION, [0, 1, 2])]) # set = var 2
   it.update
-  eq 30, st.timer(0).seconds, 'a normal small value is untouched by the clamp'
+  eq 30, st.timer(0).seconds, 'a normal small value is unaffected'
 end
 
 check "Timer Operation addresses RPG2003's second timer through param5" do


### PR DESCRIPTION
## Summary

A prior fix reasoned that RPG_RT's timer display never grows past two minute digits, so it must clamp a Timer Operation "set" fed an out-of-range Control Variable -- but that reasoning was never checked against the actual `Game_Party::SetTimer` source, and turns out backwards.

Confirmed directly against RPG_RT's live source: `Game_Party::SetTimer` (`src/game_party.cpp`) is `data.timer1_frames = seconds * DEFAULT_FPS + (DEFAULT_FPS - 1);` with no upper bound whatsoever, and `Game_Interpreter::CommandTimerOperation` (`src/game_interpreter.cpp`) passes its `ValueOrVariable`-sourced seconds straight through with no clamp either.

Real RPG_RT's own display genuinely doesn't cap cleanly past 99 minutes either -- `Sprite_Timer::Draw` (`src/sprite_timer.cpp`) indexes its digit strip at an unbounded `32 + 8 * (mins / 10)`, so a timer set past 99:59 garbles the drawn minutes tiles. This port's own pixel-digit renderer (`Scene::Map#draw_timer_digits`, `mruby-rpg2k/mrblib/scene/map.rb`) already indexes its windowskin digit strip the identical unbounded way, so removing the clamp reproduces the same garbled-past-99 quirk for free -- matching this codebase's established pattern of keeping known RPG_RT overflow quirks rather than "fixing" them into cleaner-than-real behavior.

- Fixed by removing `Game::Timer::MAX_SECONDS` and the clamp in `#set` entirely.

## Test plan

- The existing `scripts/rpg2k_logic_check.rb` check was rewritten to assert the opposite of its old claim (a Timer Operation "set" of 9999, direct or variable-sourced, lands at exactly 9999 s, not clamped to 5999).
- Verified via `git stash` on `game.rb` alone: the rewritten check fails pre-fix (`expected 9999, got 5999`).
- Full suite green: `rpg2k_logic_check.rb` 1062 passed, `rpg2k_scene_check.rb` 778 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_