### PR TITLE
Memorize BGM / save round-trip now carry a track's balance, not just volume

### DIFF
--- a/changelog.d/memorize-bgm-balance.fixed.md
+++ b/changelog.d/memorize-bgm-balance.fixed.md
@@ -1,0 +1,5 @@
+- **BGM:** Memorize BGM / Play Memorized BGM now stash and restore a track's
+  stereo balance too, not just volume and tempo, matching RPG_RT -- a
+  balance override also now survives a save/continue round-trip for the
+  current, memorized, and Change System BGM/SFX tracks alike. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11269,6 +11269,48 @@ not yet verified:
   reaches `bgm_pan` with that value; an omitted balance defaults to 50),
   confirmed to fail against the pre-fix code (`NoMethodError`/no `bgm_pan`
   call at all) before the fix.
+  ✅ **Follow-up (2026-08-19): the live-apply half of pan/balance was fixed
+  above, but the *tracking* half wasn't — Memorize BGM couldn't stash a
+  track's balance (it was never written into `current_bgm` in the first
+  place), so Play Memorized BGM never restored it, and the same shared
+  serializer gap silently dropped balance from the current-BGM/stored-BGM
+  and Change System BGM/SFX save-chunk round-trip too.** Confirmed
+  directly against RPG_RT's live source: `Game_System::MemorizeBGM`/
+  `PlayMemorizedBGM` (`src/game_system.h`) are `data.stored_music =
+  data.current_music;` / `BgmPlay(data.stored_music);` — the *whole*
+  `Music` struct is copied and replayed, balance included — and
+  `Game_System::BgmPlay` (`src/game_system.cpp`) re-applies
+  `Audio().BGM_Balance(...)` even on its own same-track path (`if
+  (previous_music.balance != data.current_music.balance) { ... }`).
+  `#play_audio`'s `:bgm` branch (`mruby-rpg2k/mrblib/interpreter.rb`)
+  already called `RGSS::Audio.bgm_pan(balance)` live on every Play BGM —
+  that part was correct — but built `@state.current_bgm` as `{ name:,
+  volume:, tempo: }` with no `balance:` key at all, so `#do_memorize_bgm`
+  (a bare `.dup` of `current_bgm`) had nothing to stash, and
+  `#do_play_memorized_bgm` never called `bgm_pan` regardless. The
+  identical gap existed a layer down in `Game::State#bgm_chunk`/
+  `.bgm_from_chunk` (`mruby-rpg2k/mrblib/game.rb` — the LCF chunk builder/
+  reader shared by the current-BGM (75) and stored-BGM (78) save slots),
+  which only wrote/read fields 1/3/4 (file/volume/pitch), silently
+  dropping field 5 (balance) — corrupting the `.lsd` round-trip even where
+  the in-memory hash *did* carry it correctly, as `#do_change_system_bgm`'s
+  own `system_bgm` hashes already do (`balance: cmd.param(4)`, confirmed
+  already correct). `#se_chunk`/`.se_from_chunk`, `#bgm_chunk`'s SE
+  counterpart used by every Change System SFX override slot, had the
+  identical field-5 gap. Fixed by adding `balance:` to `#play_audio`'s
+  `current_bgm` hash, an unconditional `RGSS::Audio.bgm_pan(bgm[:balance]
+  || 50)` call in `#do_play_memorized_bgm` (mirroring `#play_audio`'s own
+  placement outside the same-file branch), and `b[5]`/`s[5]` write plus
+  `chunk.balance` read in both chunk builder/reader pairs. Covered by two
+  new `scripts/rpg2k_logic_check.rb` checks (Play BGM "town" at balance
+  20, Memorize BGM, Play BGM "fanfare" at balance 90, Play Memorized BGM
+  restores balance 20 into state and re-applies it live — both to a
+  different track and to one that never stopped playing), plus balance
+  assertions added to the existing Change System BGM/SFX and current/
+  memorized-BGM `to_lsd`/`from_lsd` round-trip checks (using a non-centre
+  value, not just the default, so a chunk that silently fell back to 50
+  couldn't pass by accident), all confirmed to fail against the pre-fix
+  code before the fix.
 - ✅ **A map's own configured BGM now actually auto-plays, on the initial map
   load and every Transfer Player alike — a genuine, previously-undocumented
   gap found while cross-checking this same BGM cluster for anything else the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13727,26 +13727,38 @@ module Game
     end
 
     # Build a BGM chunk (an LCF::Array1D over the BGM schema) from our stored
-    # `{ name:, volume:, tempo: }` hash: file (1), volume (3) and pitch (4). Used
-    # for the system chunk's current-BGM (75) and stored-BGM (78) slots, and
-    # (below) every Change System BGM override slot.
+    # `{ name:, volume:, tempo:, balance: }` hash: file (1), volume (3), pitch
+    # (4) and balance (5). Used for the system chunk's current-BGM (75) and
+    # stored-BGM (78) slots, and (below) every Change System BGM override
+    # slot. Balance confirmed as a first-class field of RPG_RT's own `Music`
+    # struct via `Game_Interpreter::CommandPlayBGM` (`src/
+    # game_interpreter.cpp`: `music.balance = ValueOrVariableBitfield(com, 4,
+    # 4, 3);`), round-tripped whole by `Game_System::MemorizeBGM`/
+    # `PlayMemorizedBGM` (`src/game_system.h`) the same way every other field
+    # here already is.
     def bgm_chunk(bgm)
       b = LCF::Array1D.new('', { elements: LCF::Schema::BGM })
       b[1] = bgm[:name] || ''
       b[3] = bgm[:volume] || 100
       b[4] = bgm[:tempo] || 100
+      b[5] = bgm[:balance] || 50
       b
     end
 
     # Build an SE chunk (an LCF::Array1D over the SE schema) from our stored
-    # `{ name:, volume:, tempo: }` hash: file (1), volume (3) and pitch (4).
-    # #bgm_chunk's SE counterpart, used for every Change System SFX override
-    # slot.
+    # `{ name:, volume:, tempo:, balance: }` hash: file (1), volume (3),
+    # pitch (4) and balance (5). #bgm_chunk's SE counterpart, used for every
+    # Change System SFX override slot -- the same balance field #bgm_chunk's
+    # own fix just above restores, and `#do_change_system_sfx`
+    # (`mruby-rpg2k/mrblib/interpreter.rb`) already tracks it in-memory
+    # (`balance: cmd.param(3)`), so only this save-side round-trip was
+    # dropping it.
     def se_chunk(se)
       s = LCF::Array1D.new('', { elements: LCF::Schema::SE })
       s[1] = se[:name] || ''
       s[3] = se[:volume] || 100
       s[4] = se[:tempo] || 100
+      s[5] = se[:balance] || 50
       s
     end
 
@@ -14087,14 +14099,16 @@ module Game
       NO_CLOCK_TIMESTAMP
     end
 
-    # Rebuild our `{ name:, volume:, tempo: }` BGM hash from a parsed BGM chunk
-    # (an LCF::Array1D over the BGM schema). Returns nil for an absent chunk or an
-    # empty file name (the "use the database value" sentinel).
+    # Rebuild our `{ name:, volume:, tempo:, balance: }` BGM hash from a
+    # parsed BGM chunk (an LCF::Array1D over the BGM schema). Returns nil for
+    # an absent chunk or an empty file name (the "use the database value"
+    # sentinel).
     def self.bgm_from_chunk(chunk)
       return nil unless chunk
       name = chunk.file
       return nil if name.nil? || name.empty?
-      { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100 }
+      { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100,
+        balance: chunk.balance || 50 }
     end
 
     # #bgm_from_chunk's SE counterpart: rebuild our `{ name:, volume:, tempo: }`
@@ -14103,7 +14117,8 @@ module Game
       return nil unless chunk
       name = chunk.file
       return nil if name.nil? || name.empty?
-      { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100 }
+      { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100,
+        balance: chunk.balance || 50 }
     end
 
     # Rebuild a State from a saved hash. Actors are re-created from the database

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3771,6 +3771,13 @@ module Game
         @state.bgm_looped = false
         RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
       end
+      # Balance/pan is re-applied unconditionally, same-file-or-not, matching
+      # `#play_audio`'s own `:bgm` branch -- `Game_System::BgmPlay` (`src/
+      # game_system.cpp`) re-applies `Audio().BGM_Balance(...)` on the
+      # same-track path too (`if (previous_music.balance != data.current_
+      # music.balance) { ... }`), and the fresh-start path passes the whole
+      # `Music` struct straight to a new play call either way.
+      RGSS::Audio.bgm_pan(bgm[:balance] || 50)
       @state.current_bgm = bgm.dup
     rescue StandardError => e
       $stderr.puts "[RPG2k] memorized BGM playback failed: #{e.message}"
@@ -3814,8 +3821,11 @@ module Game
         # per-track state to restart.
         same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == name
         # Track what is playing so Memorize BGM can stash it (RPG_RT keeps this
-        # as the "current system BGM" regardless of whether playback succeeds).
-        @state.current_bgm = { name: name, volume: volume, tempo: pitch }
+        # as the "current system BGM" regardless of whether playback succeeds)
+        # -- balance included, since `Game_System::MemorizeBGM`
+        # (`src/game_system.h`) is a bare `data.stored_music =
+        # data.current_music`, copying the whole `Music` struct verbatim.
+        @state.current_bgm = { name: name, volume: volume, tempo: pitch, balance: balance }
         if same_file_already_playing
           RGSS::Audio.bgm_volume(volume)
         else

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3002,6 +3002,44 @@ check 'Memorize/Play Memorized BGM stashes and restores the current BGM' do
   eq %w[town fanfare town], names, 'the backend played town, fanfare, then town'
 end
 
+check 'Memorize/Play Memorized BGM stashes and re-applies the current ' \
+      'BGM\'s balance too, not just volume' do
+  # `Game_System::MemorizeBGM`/`PlayMemorizedBGM` (`src/game_system.h`) copy
+  # and replay RPG_RT's whole `Music` struct, balance included --
+  # `Game_System::BgmPlay` (`src/game_system.cpp`) re-applies
+  # `Audio().BGM_Balance(...)` even on its same-track path.
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100, 20], string: 'town'), # balance 20
+    FakeCmd.new(IC::MEMORIZE_BGM, []),
+    FakeCmd.new(IC::PLAY_BGM, [0, 100, 100, 90], string: 'fanfare'), # balance 90
+    FakeCmd.new(IC::PLAY_MEMORIZED_BGM, []),
+  ])
+  it.update
+  eq 20, st.current_bgm[:balance], 'the memorized balance is restored into state'
+  pans = RGSS::Audio.log.select { |e| e[0] == :bgm_pan }.map { |e| e[1] }
+  eq [20, 90, 20], pans, 'town, fanfare, then back to town -- each with its own balance'
+end
+
+check 'Play Memorized BGM re-applies its stashed balance even to a track ' \
+      'that never stopped playing' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100, 20], string: 'town'), # balance 20
+    FakeCmd.new(IC::MEMORIZE_BGM, []),
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100, 90], string: 'town'), # still town, balance bumped
+    FakeCmd.new(IC::PLAY_MEMORIZED_BGM, []),
+  ])
+  it.update
+  pans = RGSS::Audio.log.select { |e| e[0] == :bgm_pan }.map { |e| e[1] }
+  eq [20, 90, 20], pans, 'even a same-file replay re-applies the memorized balance live'
+  eq 20, st.current_bgm[:balance]
+end
+
 check 'Play Memorized BGM with nothing memorized does nothing' do
   RGSS::Audio.log = []
   st = new_state
@@ -3798,25 +3836,47 @@ check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrid
   # slot too, via SAVE_SYSTEM's BGM fields 72-74/79-82 and SE fields 91-102.
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
-  st.system_bgm[0] = { name: 'Battle1', fadein: 500, volume: 90, tempo: 110, balance: 50 }
+  st.system_bgm[0] = { name: 'Battle1', fadein: 500, volume: 90, tempo: 110, balance: 20 }
   st.system_bgm[6] = { name: 'GameOver1', fadein: 0, volume: 80, tempo: 100, balance: 50 }
-  st.system_sfx[0] = { name: 'Cursor1', volume: 95, tempo: 105, balance: 50 }
+  st.system_sfx[0] = { name: 'Cursor1', volume: 95, tempo: 105, balance: 80 }
   st.system_sfx[4] = { name: 'BattleStart1', volume: 85, tempo: 95, balance: 50 }
 
   round = Game::State.from_lsd(db, st.to_lsd)
   eq 'Battle1', round.system_bgm[0][:name], 'Change System BGM slot 0 (battle) round-trips'
   eq 90, round.system_bgm[0][:volume]
   eq 110, round.system_bgm[0][:tempo]
+  eq 20, round.system_bgm[0][:balance], 'a non-centre balance round-trips too, not just the default'
   eq 'GameOver1', round.system_bgm[6][:name], 'Change System BGM slot 6 (game over) round-trips'
   eq 'Cursor1', round.system_sfx[0][:name], 'Change System SFX slot 0 (cursor) round-trips'
   eq 95, round.system_sfx[0][:volume]
   eq 105, round.system_sfx[0][:tempo]
+  eq 80, round.system_sfx[0][:balance], 'SFX balance round-trips the same way'
   eq 'BattleStart1', round.system_sfx[4][:name], 'Change System SFX slot 4 (battle start) round-trips'
 
   # A slot never touched by Change System BGM/SFX stays absent, not a
   # spurious empty-string override.
   eq nil, round.system_bgm[1], 'an untouched BGM slot round-trips as absent, not an empty override'
   eq nil, round.system_sfx[1], 'an untouched SFX slot round-trips as absent, not an empty override'
+end
+
+check 'to_lsd/from_lsd round-trips the current and memorized BGM\'s balance, ' \
+      'not just name/volume/tempo' do
+  # #bgm_chunk/.bgm_from_chunk (the current-BGM/stored-BGM chunk 75/78
+  # round-trip) used to write/read only file (1), volume (3) and pitch (4) --
+  # balance (5) is a first-class field of RPG_RT's own `Music` struct
+  # (`Game_Interpreter::CommandPlayBGM`'s `music.balance =
+  # ValueOrVariableBitfield(...)`, `src/game_interpreter.cpp`), copied whole
+  # by `Game_System::MemorizeBGM`/`PlayMemorizedBGM` (`src/game_system.h`).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.current_bgm = { name: 'town', volume: 80, tempo: 100, balance: 30 }
+  st.memorized_bgm = { name: 'field', volume: 70, tempo: 90, balance: 60 }
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq 'town', round.current_bgm[:name], 'current BGM round-trips'
+  eq 30, round.current_bgm[:balance], 'and its balance round-trips too'
+  eq 'field', round.memorized_bgm[:name], 'memorized BGM round-trips'
+  eq 60, round.memorized_bgm[:balance], 'and its balance round-trips too'
 end
 
 check 'to_lsd/from_lsd round-trips both Timer Operation countdowns' do
@@ -4169,8 +4229,8 @@ check 'State save round-trips the message configuration' do
   st.message_config.face_index = 2
   st.menu_access = false
   st.save_access = false
-  st.current_bgm = { name: 'town', volume: 80, tempo: 100 }
-  st.memorized_bgm = { name: 'field', volume: 70, tempo: 90 }
+  st.current_bgm = { name: 'town', volume: 80, tempo: 100, balance: 30 }
+  st.memorized_bgm = { name: 'field', volume: 70, tempo: 90, balance: 60 }
   loaded = Game::State.load(db, st.to_h)
   eq true, loaded.message_config.transparent
   eq Game::MessageConfig::POS_TOP, loaded.message_config.position


### PR DESCRIPTION
## Summary

`Game_System::MemorizeBGM`/`PlayMemorizedBGM` (`src/game_system.h`) are `data.stored_music = data.current_music;` / `BgmPlay(data.stored_music);` -- the whole `Music` struct is copied and replayed, balance included -- and `Game_System::BgmPlay` (`src/game_system.cpp`) re-applies `Audio().BGM_Balance(...)` even on its own same-track path.

`#play_audio`'s `:bgm` branch (`mruby-rpg2k/mrblib/interpreter.rb`) already called `RGSS::Audio.bgm_pan(balance)` live on every Play BGM -- that part was correct -- but built `@state.current_bgm` as `{ name:, volume:, tempo: }` with no `balance:` key at all, so `#do_memorize_bgm` (a bare `.dup` of `current_bgm`) had nothing to stash, and `#do_play_memorized_bgm` never called `bgm_pan` regardless.

The identical gap existed a layer down in `Game::State#bgm_chunk`/`.bgm_from_chunk` (`mruby-rpg2k/mrblib/game.rb` -- the LCF chunk builder/reader shared by the current-BGM (75) and stored-BGM (78) save slots), which only wrote/read fields 1/3/4 (file/volume/pitch), silently dropping field 5 (balance) -- corrupting the `.lsd` round-trip even where the in-memory hash did carry it correctly, as `#do_change_system_bgm`'s own `system_bgm` hashes already do. `#se_chunk`/`.se_from_chunk`, `#bgm_chunk`'s SE counterpart used by every Change System SFX override slot, had the identical field-5 gap.

- Fixed by adding `balance:` to `#play_audio`'s `current_bgm` hash, an unconditional `RGSS::Audio.bgm_pan(bgm[:balance] || 50)` call in `#do_play_memorized_bgm` (mirroring `#play_audio`'s own placement outside the same-file branch), and `b[5]`/`s[5]` write plus `chunk.balance` read in both chunk builder/reader pairs.

## Test plan

- New `scripts/rpg2k_logic_check.rb` checks: Play BGM "town" at balance 20, Memorize BGM, Play BGM "fanfare" at balance 90, Play Memorized BGM restores balance 20 into state and re-applies it live -- both to a different track and to one that never stopped playing.
- Balance assertions added to the existing Change System BGM/SFX and current/memorized-BGM `to_lsd`/`from_lsd` round-trip checks, using a non-centre value so a chunk silently falling back to the default couldn't pass by accident.
- Verified via `git stash` on `interpreter.rb`/`game.rb` alone: all four affected checks fail pre-fix.
- Full suite green: `rpg2k_logic_check.rb` 1065 passed, `rpg2k_scene_check.rb` 778 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_