### PR TITLE
Let the action button start a faced Player Touch/Event Touch event

### DIFF
--- a/changelog.d/rpg2k-action-button-touch-event.fixed.md
+++ b/changelog.d/rpg2k-action-button-touch-event.fixed.md
@@ -1,0 +1,20 @@
+- **The action button now also answers a same-layer Player Touch / Event
+  Touch event on the faced tile**, not only a Trigger-0 (Action) one.
+  `Scene::Map#try_action_trigger` only ever started a plain Trigger-0 event
+  from the tile the party faces; matching EasyRPG's own
+  `Game_Player::CheckActionEvent` (`src/game_player.cpp`), whose first check —
+  `CheckEventTriggerThere({Trigger_touched, Trigger_collision}, ...,
+  triggered_by_decision_key: true)` — runs against the faced tile *before* it
+  ever looks at a same-tile Trigger_action event there, pressing the action
+  button while facing a same-layer touch-triggered event now starts it too,
+  with "the decision key started this event" (Conditional Branch type 8) true
+  instead of false. This is the "face a disguised wall and press confirm to
+  search" idiom real RPG2000 content leans on: an event authored with a
+  Player Touch trigger so walking into it also works, whose own commands gate
+  the actual reveal (a sound effect, a self-targeted Move Event that opens it
+  and switches Through Mode on) behind that exact condition. Previously the
+  action-button path never started such an event at all, so any content built
+  this way — Nepheshel's own copy-pasted "HiddenDoor" event, on well over a
+  hundred of its maps — never played its reveal animation and never became
+  passable, no matter how the player approached it. Covered by a new check in
+  `scripts/rpg2k_scene_check.rb`.

--- a/changelog.d/rpg2k-through-mode-blocker-exemption.fixed.md
+++ b/changelog.d/rpg2k-through-mode-blocker-exemption.fixed.md
@@ -1,0 +1,18 @@
+- **A blocker's own Through Mode now exempts it from collision** in
+  `Scene::Map#passable?`, `#char_passable?`, and `#step_movement`'s
+  touch-trigger dispatch — matching EasyRPG's own `WouldCollide`
+  (`src/game_map.cpp`): `if (self.GetThrough() || other.GetThrough()) return
+  false;`, *either* side's flag, not only the mover's own (already handled).
+  Previously only a character's own Through Mode let *it* cross obstacles;
+  another character (the party included) walking up to *it* still collided
+  with a same-layer event even after that event switched its own Through
+  Mode on via a Move Route sub-command. This is exactly how an RPG2000
+  "hidden door" idiom opens itself — a same-layer Player Touch event that,
+  once triggered, sends itself through a Move Event: Through Mode on, step
+  aside, done — and Nepheshel's own copy-pasted "HiddenDoor" event (well over
+  a hundred maps) used exactly this shape. The reveal fired correctly, but
+  the party stayed walled off by a stale layer check `#passable?`'s own,
+  now-matching exemption would already have let pass. Covered by two new
+  checks in `scripts/rpg2k_scene_check.rb`, one per direction (the party
+  crossing a Through Mode event, and an ordinary map event's own custom-route
+  movement crossing one).

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4094,9 +4094,18 @@ class RPG2k
         return false unless @map.in_bounds?(nx, ny)
         return false if nx == @state.x && ny == @state.y && character.layer == LAYER_SAME
         hero = character.event_id == MOVE_TARGET_PLAYER
+        # A blocker with its own Through Mode on collides with nothing,
+        # matching EasyRPG's own `WouldCollide` (`src/game_map.cpp`):
+        # `if (self.GetThrough() || other.GetThrough()) return false;` --
+        # *either* side's flag exempts the pair, not only the mover's own
+        # (already handled above). A Move Route's own Through Mode ON sub-
+        # command is how content stages "step into the wall, then let the
+        # party through" -- Nepheshel's own copy-pasted hidden-door events
+        # (~120 maps) send themselves through it as part of opening.
         return false if blockers_at(nx, ny).any? do |b|
-          b[:layer] == character.layer ||
-            (!hero && (character.overlap_forbidden || b[:overlap_forbidden]))
+          !b[:char].through &&
+            (b[:layer] == character.layer ||
+             (!hero && (character.overlap_forbidden || b[:overlap_forbidden])))
         end
         return false if vehicle_blocks?(nx, ny, block_airship: !hero)
         return true if @chipset.nil?
@@ -7599,8 +7608,13 @@ class RPG2k
             # decoration, not an obstacle -- #passable?/#char_passable? never
             # let it block movement elsewhere, so falling through to the
             # ordinary passability check below lets the party keep walking
-            # onto its tile while the event's commands run alongside.
-            return if touched[:layer] == LAYER_SAME
+            # onto its tile while the event's commands run alongside. Nor does
+            # a same-layer one that has put itself through Through Mode (see
+            # #passable?'s own matching exemption) -- a hidden-door event that
+            # just opened is exactly this shape, and the party must be able to
+            # step through it the instant it fires, not stay walled off by a
+            # stale layer check that #passable? below would already let pass.
+            return if touched[:layer] == LAYER_SAME && !touched[:char].through
           end
           # Through Mode (see @player_through) bypasses collision the same way
           # it does for an event's own #char_passable? -- touch triggers still
@@ -7887,8 +7901,16 @@ class RPG2k
         # the fuller citation). Every event on the tile gets a say
         # (#blockers_at), not just one of them: a below-characters decal and
         # a same-as-characters NPC can share a tile, and the NPC must still
-        # block even though the decal alone would not.
-        return false if blockers_at(x, y).any? { |b| b[:layer] == LAYER_SAME }
+        # block even though the decal alone would not. A blocker with its own
+        # Through Mode on is exempted -- EasyRPG's own `WouldCollide`
+        # (`src/game_map.cpp`) checks `self.GetThrough() || other.GetThrough()`,
+        # either side's flag, not only the mover's (the player's own is
+        # checked separately by #step_movement's `@player_through` guard
+        # around this call). A Move Route's own Through Mode ON sub-command is
+        # how content stages "step into the wall, then let the party through"
+        # -- Nepheshel's own copy-pasted hidden-door events (~120 maps) send
+        # themselves through it as part of opening.
+        return false if blockers_at(x, y).any? { |b| b[:layer] == LAYER_SAME && !b[:char].through }
         # An unridden boat/ship blocks the hero on foot exactly like a
         # same-layer event would (see #vehicle_blocks?); an unridden airship
         # never does, on foot or otherwise (block_airship: false — the hero

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2143,7 +2143,7 @@ class RPG2k
         # only way in.
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
         ev = event_at(fx, fy)
-        return start_event(ev, true) if actionable?(ev) && ev[:layer] == LAYER_SAME
+        return start_event(ev, true) if action_button_faced?(ev)
 
         # Nothing on the faced tile: if it is a **counter** — a shop or inn
         # counter, marked in the chipset's upper-layer passage table — look
@@ -2157,9 +2157,34 @@ class RPG2k
         nil
       end
 
-      # Whether an event can answer the action button.
+      # Whether an event can answer the action button from the tile the party
+      # is standing on, or (via the counter-tile reach) a tile it is facing:
+      # a plain Trigger-0 event only, matching EasyRPG's own `CheckActionEvent`
+      # (`src/game_player.cpp`), which restricts both its `CheckEventTriggerHere`
+      # call and its counter-reach loop to `{Trigger_action}`.
       def actionable?(ev)
         ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands] ? true : false
+      end
+
+      # Whether the *faced* tile's event answers the action button: an
+      # ordinary Trigger-0 event, or -- matching EasyRPG's own
+      # `CheckActionEvent` (`src/game_player.cpp`), whose first check is
+      # `CheckEventTriggerThere({Trigger_touched, Trigger_collision}, ...,
+      # triggered_by_decision_key: true)` against the immediate front tile,
+      # before it ever looks at Trigger_action there -- a same-layer Player
+      # Touch / Event Touch event. Pressing the action button while facing one
+      # starts it exactly like walking into it would, except with "the
+      # decision key started this event" (Conditional Branch type 8) true
+      # instead of false: the idiom behind an RPG2000 "face it and press
+      # confirm to search" hidden passage, which a same-shaped Trigger_touched
+      # page also answers by simply walking into it (#touch_trigger?). Only the
+      # immediate front tile gets this -- the counter-tile reach loop in
+      # #try_action_trigger stays Trigger_action-only, matching EasyRPG's own
+      # separate, action-only `got_action` search.
+      def action_button_faced?(ev)
+        return false unless ev && ev[:commands] && ev[:layer] == LAYER_SAME
+        ev[:trigger] == TRIGGER_ACTION || ev[:trigger] == TRIGGER_PLAYER_TOUCH ||
+          ev[:trigger] == TRIGGER_EVENT_TOUCH
       end
 
       # Whether a trigger is one the party can set off by walking into the event

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19656,6 +19656,54 @@ check 'battle_scene_class treats an edition-less database as RPG2000' do
      'a fixture database with no #rpg2003? keeps the 2000 scene'
 end
 
+# A same-layer Player Touch / Event Touch event, faced (not stood on) and
+# started via the action button, now also answers with "the decision key
+# started this event" (Conditional Branch type 8, #do_conditional's own
+# `@triggered_by_decision_key`) true -- matching EasyRPG's own
+# `Game_Player::CheckActionEvent` (`src/game_player.cpp`), whose first check
+# is `CheckEventTriggerThere({Trigger_touched, Trigger_collision}, ...,
+# triggered_by_decision_key: true)` against the tile the player faces, before
+# it ever looks at a same-tile Trigger_action event. This is the "face the
+# hidden wall and press confirm to search" idiom real RPG2000 content uses
+# (Nepheshel's own copy-pasted "HiddenDoor" event, ~120 maps, does exactly
+# this): the page is authored with a *Player Touch* trigger so walking into it
+# also works, but its own commands gate the reveal (SE, a self-Move Event
+# opening it, Through Mode) behind this exact condition. `#action_button_faced?`
+# used to recognise only Trigger_action there, so the action-button path never
+# started a same-shaped Trigger_touched/Trigger_event_touch page at all -- the
+# door only ever ran with `@triggered_by_decision_key` false, so its reveal
+# branch was unreachable and it stayed a solid, unopened wall forever.
+check 'facing a same-layer Player Touch event and pressing the action button ' \
+      'starts it with "decision key started this event" true' do
+  ic = Game::Interpreter::Cmd
+  door = page(trigger: RPG2k::Scene::Map::TRIGGER_PLAYER_TOUCH,
+              layer: RPG2k::Scene::Map::LAYER_SAME)
+  door.event_commands = [
+    ECmd.new(ic::CONDITIONAL, [8, 0, 0, 0, 0, 0, 0, 0, 0], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::END_BRANCH, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(1, 0, door) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  # Walking straight into it (mere collision) must NOT set the switch: real
+  # RPG_RT's own touch/collision check always passes triggered_by_decision_key
+  # false (Game_Player::Update, both CheckEventTriggerHere/There call sites).
+  RGSS::Input.dir_value = 6 # hold right, into the event at (1,0)
+  10.times { scene.update }
+  ok !st.switches[1], 'a plain walk-in never counts as "decision key started this"'
+  eq [0, 0], [st.x, st.y], 'and the same-layer event still blocks the step'
+
+  # Facing it and pressing the action button must set the switch.
+  RGSS::Input.dir_value = 0
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  5.times { scene.update }
+  ok st.switches[1], 'facing it and pressing the action button reaches the ' \
+                      '"decision key started this event" branch'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19759,6 +19759,83 @@ check "a custom-route event crosses another event that has switched its own " \
                "(got x=#{c.x}, still stuck behind it at 0 would mean the fix regressed)"
 end
 
+# Nepheshel's own "HiddenDoor" event (Map0022 event 24, Map0023 event 29,
+# byte-identical, ~120 maps total) is not gated shut behind a switch once
+# opened -- it stays a Player Touch/Trigger_action page forever, and its own
+# two Conditional Branches (type 6, orientation) are how it tells "about to
+# open" from "already open": while it still faces up (direction 0, its
+# authored starting facing) AND the decision key started this trigger, it
+# plays its reveal SE and Move Event (Through Mode on, step down, face
+# right); once it faces right (direction 1 -- exactly what that Move Event's
+# own Face Right sub-command leaves it facing), any further trigger instead
+# runs the second branch: Erase Screen / Teleport / Show Screen. So pressing
+# the action button on it again after it has opened is expected to still be
+# possible (the page is never erased) -- what must NOT happen is the first
+# branch running a second time (which would mean the door's own facing
+# state, and therefore its progress, never actually advanced, and it stays
+# stuck replaying its own reveal instead of ever letting the party through).
+# Mirrors real Map0022 event 24 command-for-command (comment stripped).
+check 'a HiddenDoor-shaped event advances past its "about to open" branch ' \
+      'once opened, instead of replaying the reveal SE on a second trigger' do
+  ic = Game::Interpreter::Cmd
+  door = page(trigger: RPG2k::Scene::Map::TRIGGER_PLAYER_TOUCH,
+              layer: RPG2k::Scene::Map::LAYER_SAME, direction: 0, # numpad-up
+              animation_type: 4) # Fixed Graphic: real event 24's own page 1
+  door.event_commands = [
+    ECmd.new(ic::CONDITIONAL, [6, 10005, 0, 0, 0, 0, 0, 0, 0], indent: 0),
+    ECmd.new(ic::CONDITIONAL, [8, 0, 0, 0, 0, 0, 0, 0, 0], indent: 1),
+    ECmd.new(ic::PLAY_SE, [100, 100, 50, 0, 0, 0, 0, 0, 0], indent: 2),
+    ECmd.new(ic::MOVE_EVENT, [10005, 8, 0, 1, 36, 2, 13], indent: 2),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, [], indent: 2),
+    ECmd.new(ic::END_EVENT, [], indent: 2),
+    ECmd.new(ic::END_BRANCH, [], indent: 1),
+    ECmd.new(ic::END_BRANCH, [], indent: 0),
+    ECmd.new(ic::CONDITIONAL, [6, 10005, 1, 0, 0, 0, 0, 0, 0], indent: 0),
+    ECmd.new(ic::ERASE_SCREEN, [-1, 0, 0, 0, 0, 0, 0, 0, 0], indent: 1),
+    ECmd.new(ic::TELEPORT, [51, 10, 5, 0, 0, 0, 0, 0, 0], indent: 1),
+    ECmd.new(ic::SHOW_SCREEN, [-1, 0, 0, 0, 0, 0, 0, 0, 0], indent: 1),
+    ECmd.new(ic::END_BRANCH, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(1, 0, door) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  # Face the door and let the plain walk-touch it fires (triggered_by_decision_key
+  # false, per the committed check above) fully settle -- a same-frame action
+  # button press would otherwise race the leftover touch dispatch's own
+  # deferred command execution and never even reach #try_action_trigger.
+  RGSS::Input.dir_value = 6 # hold right, facing the event at (1,0)
+  10.times { scene.update }
+  RGSS::Input.dir_value = 0
+  10.times { scene.update }
+
+  # Press the action button once: the reveal branch runs.
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  20.times { scene.update }
+  d = chars(scene)[1]
+  eq 6, d.direction, "the Move Event's Face Right sub-command left the " \
+                      'door facing right (its own "now open" marker)'
+  ok d.through, 'the Move Event also left the door in Through Mode'
+
+  # The reveal moved the door itself out of the party's way (down, off the
+  # original tile it blocked) rather than erasing it -- exactly the
+  # HiddenDoor idiom's own "walk through it" payoff (see the Through Mode
+  # exemption checks above). Continue toward where it now sits: stepping
+  # onto its tile fires its Player Touch trigger again, and since the door
+  # itself no longer faces up, this must run the *second* branch (the
+  # teleport) rather than replay the first (its own SE a second time).
+  RGSS::Input.dir_value = 6 # onto the vacated (1,0) tile
+  40.times { scene.update; break if st.x >= 1 }
+  RGSS::Input.dir_value = 2 # down onto the door's new tile at (1,1)
+  40.times { scene.update; break if st.y >= 1 }
+  RGSS::Input.dir_value = 0
+  10.times { scene.update }
+  eq 51, st.map_id, 'stepping onto the door\'s new tile advanced to the ' \
+                     'teleport branch instead of replaying the reveal ' \
+                     '(stuck facing up forever)'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19704,6 +19704,61 @@ check 'facing a same-layer Player Touch event and pressing the action button ' \
                       '"decision key started this event" branch'
 end
 
+# A same-layer touch event that sets its own Through Mode on (a Move Event
+# sub-command, the way a hidden-door reveal opens itself) used to still block
+# the party forever: #passable? / #char_passable? already exempted a Through
+# Mode blocker from collision (matching EasyRPG's own `WouldCollide`,
+# `src/game_map.cpp`: `if (self.GetThrough() || other.GetThrough()) return
+# false;` -- *either* side, not only the mover's own), but #step_movement's
+# own touch-trigger dispatch had an earlier, unconditional
+# `return if touched[:layer] == LAYER_SAME` that never consulted the touched
+# event's own Through flag at all, so the party stayed walled off by a stale
+# layer check even after the very Through Mode ON the event's own commands
+# just set. Nepheshel's own copy-pasted hidden-door events (~120 maps) open
+# themselves exactly this way -- the reveal fired, but the party could never
+# actually step through the (nominally opened) door.
+check 'a same-layer Player Touch event that switches its own Through Mode on ' \
+      'lets the party step onto its tile instead of staying blocked' do
+  ic = Game::Interpreter::Cmd
+  door = page(trigger: RPG2k::Scene::Map::TRIGGER_PLAYER_TOUCH,
+              layer: RPG2k::Scene::Map::LAYER_SAME)
+  door.event_commands = [
+    # Move Event targeting "this event" (10005), frequency 8, no repeat,
+    # skippable, running a single bare Through Mode ON sub-command (36).
+    ECmd.new(ic::MOVE_EVENT, [RPG2k::Scene::Map::MOVE_TARGET_THIS, 8, 0, 1, 36], indent: 0),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(1, 0, door) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  RGSS::Input.dir_value = 6 # hold right, into the event at (1,0)
+  20.times { scene.update }
+  eq [1, 0], [st.x, st.y],
+     'the party walked onto the (now Through Mode) event tile instead of staying blocked'
+end
+
+# The same exemption on the *mover* side: an ordinary map event's own
+# autonomous/forced movement must also be free to cross a Through Mode
+# blocker, matching `WouldCollide`'s symmetric either-side check.
+check "a custom-route event crosses another event that has switched its own " \
+      'Through Mode on' do
+  ic = Game::Interpreter::Cmd
+  blocker = one_shot_auto(page(trigger: RPG2k::Scene::Map::TRIGGER_AUTO_START,
+                               layer: RPG2k::Scene::Map::LAYER_SAME))
+  blocker.event_commands = [
+    ECmd.new(ic::MOVE_EVENT, [RPG2k::Scene::Map::MOVE_TARGET_THIS, 8, 0, 1, 36], indent: 0),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, [], indent: 0)
+  ]
+  mover = page(x_move_type: Game::MoveType::CUSTOM,
+               route: move_route([R::MOVE_RIGHT]),
+               layer: RPG2k::Scene::Map::LAYER_SAME)
+  scene = new_scene({ 1 => event(1, 1, blocker), 2 => event(0, 1, mover) }, player: [5, 5])
+  40.times { scene.update }
+  c = chars(scene)[2]
+  ok c.x >= 1, "the mover crossed the blocker's tile once it switched Through Mode on " \
+               "(got x=#{c.x}, still stuck behind it at 0 would mean the fix regressed)"
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
Scene::Map#try_action_trigger only ever started a plain Trigger-0
(Action) event from the faced tile. Real RPG_RT's own
Game_Player::CheckActionEvent (src/game_player.cpp) checks the faced
tile for {Trigger_touched, Trigger_collision} with
triggered_by_decision_key: true before it ever looks at Trigger_action
there, so pressing the action button while facing a same-layer
Player Touch/Event Touch event also starts it, with Conditional
Branch type 8 ("decision key started this event") true.

This is the "face a disguised wall and press confirm to search"
idiom real RPG2000 content relies on: an event authored with a
Player Touch trigger (so walking into it also works) whose own
commands gate the actual reveal - sound effect, a self-targeted Move
Event that opens it and switches Through Mode on - behind exactly
this condition. Nepheshel's own copy-pasted "HiddenDoor" event
(well over a hundred maps) never played its reveal animation and
never became passable, because the action-button path never started
it with the decision-key flag true.

Verified end to end against a real HiddenDoor event pulled from
Nepheshel's own Map0022.lmu/RPG_RT.ldb (the fix flips it from stuck
solid to playing its SE and switching Through Mode on), then reduced
to a synthetic regression check in scripts/rpg2k_scene_check.rb that
needs no downloaded game data.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018JH26g689dY6SZvYjkthTA