### PR TITLE
Save slot level/HP draw at RPG_RT's own fixed columns, not a gapped string

### DIFF
--- a/changelog.d/save-slot-level-hp-fixed-columns.fixed.md
+++ b/changelog.d/save-slot-level-hp-fixed-columns.fixed.md
@@ -1,0 +1,6 @@
+- **Save/Load screen:** A save slot's level and HP now draw at RPG_RT's own
+  fixed pixel columns, each number space-padded to a fixed width -- a
+  leader's level going from one digit to two used to shift the "HP" label
+  sideways, since the line drew as a single string with a literal gap
+  instead of separately positioned fields. Covered by new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4158,6 +4158,37 @@ The work below is roughly ordered by the critical path to a walkable game
   cell geometry the same way the title-screen check above does),
   confirmed to fail against the pre-fix code (the occupied-slot assertion
   failed first, since neither slot ever blended anything) before the fix.
+  ✅ **Follow-up (2026-08-19): the level/HP line's own layout was still
+  wrong even after the swatch-blend fix above — it drew as one
+  interpolated string with a literal gap, so a leader's level going from
+  one digit to two shifted the "HP" label sideways, something real
+  RPG_RT's fixed-column layout never does.** Confirmed directly against
+  RPG_RT's live source: `Window_SaveFile::Refresh`
+  (`src/window_savefile.cpp`) draws the level and HP fields as four
+  separate `TextDraw` calls at fixed pixel columns — the level label at
+  x=4, the HP label always at x=46 regardless of what came before it — each
+  number space-padded to a fixed width (`std::setw(2)` for level,
+  `std::setw(Player::IsRPG2k3() ? 4 : 3)` for HP, the only version branch
+  in the whole function and a harmless width-only one, not a behavior
+  fork). The two short-label terms (`lvl_short`/`hp_short`, "Lv"/"HP" by
+  default) are likewise clamped to exactly 2 characters
+  (`if (lvl_short.size() != 2) lvl_short.resize(2, ' ')`), regardless of
+  what a project's own database terms table names them.
+  `#draw_slot_box`'s level/HP line (`mruby-rpg2k/mrblib/scene/
+  save_load.rb`) was one `#draw_system_text` call on a Ruby-interpolated
+  `"Lv#{level}    HP#{hp}"` string — no padding on either number, and the
+  literal four-space gap only coincidentally lined up for a single-digit
+  level. Fixed by splitting the line into a new `#draw_level_hp` helper:
+  four separate `#draw_system_text` calls at RPG_RT's own x=4/x=46
+  columns, `level.to_s.rjust(2)` and `hp.to_s.rjust(rpg2003? ? 4 : 3)` for
+  the numbers, and a new `#fixed_width_term` clamping the short labels to
+  exactly 2 characters the same way. Covered by rewriting the existing
+  level/HP `scripts/rpg2k_scene_check.rb` check to expect the four split,
+  padded strings instead of one combined one, plus two new checks (the
+  "HP" label call lands at the fixed x=46 column for a two-digit level,
+  proving the position doesn't shift; an RPG2003 party pads HP to 4
+  characters instead of 3), all three confirmed to fail against the
+  pre-fix code before the fix.
   ✅ **`Scene::SaveLoad`'s own cursor never auto-repeated while Down/Up was
   held — one slot per tap only, forever, no matter how long the key stayed
   down (2026-08-18).** Confirmed against EasyRPG Player's actual source:

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -312,9 +312,8 @@ class RPG2k
           level = leader ? leader.level : 0
           hp = leader ? leader.hp : 0
           draw_system_text c, 0, LINE_H, inner_w, LINE_H, name, @skin
-          draw_system_text c, 0, LINE_H * 2, inner_w, LINE_H,
-                            "#{term(:level_short, 'Lv')}#{level}    " \
-                            "#{term(:hp_short, 'HP')}#{hp}", @skin
+          rpg2003 = state.party.respond_to?(:rpg2003?) && state.party.rpg2003?
+          draw_level_hp(c, LINE_H * 2, level, hp, rpg2003)
           draw_slot_faces(c, inner_w, state.party.actors)
         end
         win.contents = c
@@ -323,6 +322,35 @@ class RPG2k
                            else
                              Rect.new(0, 0, 0, 0)
                            end
+      end
+
+      # The level/HP line at RPG_RT's own fixed pixel columns (x=4 for the
+      # level label, x=46 for HP), not proportioned to the label text --
+      # confirmed against RPG_RT's live source: `Window_SaveFile::Refresh`
+      # (`src/window_savefile.cpp`) is four separate `TextDraw` calls at
+      # those exact x-coordinates, each number space-padded to a fixed
+      # width (`std::setw(2)` for level, `std::setw(Player::IsRPG2k3() ? 4
+      # : 3)` for HP) -- so a level 9 vs. 99 leader never shifts where "HP"
+      # sits on screen, unlike a single interpolated string with a literal
+      # gap between the two halves.
+      def draw_level_hp(c, y, level, hp, rpg2003)
+        lvl_label = fixed_width_term(:level_short, 'Lv')
+        hp_label = fixed_width_term(:hp_short, 'HP')
+        draw_system_text c, 4, y, c.width, LINE_H, lvl_label, @skin
+        lx = c.text_size(lvl_label).width
+        draw_system_text c, 4 + lx, y, c.width, LINE_H, level.to_s.rjust(2), @skin
+        draw_system_text c, 46, y, c.width, LINE_H, hp_label, @skin
+        hx = c.text_size(hp_label).width
+        draw_system_text c, 46 + hx, y, c.width, LINE_H, hp.to_s.rjust(rpg2003 ? 4 : 3), @skin
+      end
+
+      # Clamp a database term string to exactly 2 characters, space-padded
+      # if shorter -- matches RPG_RT's own `lvl_short`/`hp_short` handling
+      # (`Window_SaveFile::Refresh`: `if (lvl_short.size() != 2)
+      # lvl_short.resize(2, ' ')`).
+      def fixed_width_term(name, fallback)
+        s = term(name, fallback)
+        s.length > 2 ? s[0, 2] : s.ljust(2)
       end
 
       # Up to `MAX_SLOT_FACES` party face thumbnails, right-anchored within

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16229,10 +16229,50 @@ check 'Scene::SaveLoad: an occupied slot shows the leader, level and HP -- no go
   scene, = save_load_scene(:load, nil, fake_db, parent: parent)
   texts = window_texts(scene.instance_variable_get(:@slot_windows)[0])
   ok texts.include?('Hero'), 'the leader name gets its own line'
-  ok texts.any? { |t| t.include?('Lv5') && t.include?('HP80') },
-     'level and current HP together on the third line'
+  # Level and HP each draw as their own label + space-padded number, not one
+  # combined string -- see the fixed-column check below for why.
+  ok texts.include?('Lv'), 'the level label draws on its own'
+  ok texts.include?(' 5'), 'the level number is space-padded to width 2'
+  ok texts.include?('HP'), 'the HP label draws on its own'
+  ok texts.include?(' 80'), 'the HP number is space-padded to width 3 on RPG2000'
   ok !texts.any? { |t| t.include?('250G') }, 'no gold shown -- confirmed absent from the ' \
                                               'reference capture, unlike this screen\'s old layout'
+end
+
+# Confirmed against RPG_RT's own live source: `Window_SaveFile::Refresh`
+# (src/window_savefile.cpp) draws the level and HP fields as four separate
+# `TextDraw` calls at fixed pixel columns (x=4, x=46), each number
+# `std::setw`-padded to a fixed width -- so the "HP" label never shifts
+# sideways depending on how many digits the level has, unlike a single
+# interpolated string with a literal gap between the two halves.
+check 'Scene::SaveLoad: the HP label sits at a fixed column regardless of ' \
+      'how many digits the level has' do
+  st = menu_state
+  st.party.leader = st.party.actors.first
+  st.party.leader.instance_variable_set(:@level, 99) # two digits, same as the fixture default
+  parent = fake_parent(fake_db)
+  parent.save_states[1] = st
+  scene, = save_load_scene(:load, nil, fake_db, parent: parent)
+  c = scene.instance_variable_get(:@slot_windows)[0].contents
+  calls = (c.draw_calls || []) + (c.blend_calls || [])
+  hp_label_call = calls.find { |a| a[4] == 'HP' }
+  ok hp_label_call, 'the HP label was drawn'
+  eq 46, hp_label_call[0], 'the HP label sits at RPG_RT\'s own fixed x=46, ' \
+                            'unmoved by the level\'s own two digits'
+end
+
+class SaveLoadRpg2003StubParty < MenuStubParty
+  def rpg2003?; true; end
+end
+
+check 'Scene::SaveLoad: HP is space-padded to width 4 on RPG2003, not 3' do
+  st = Game::State.new(SaveLoadRpg2003StubParty.new, 1, 0, 0)
+  st.party.leader = st.party.actors.first
+  parent = fake_parent(fake_db)
+  parent.save_states[1] = st
+  scene, = save_load_scene(:load, nil, fake_db, parent: parent)
+  texts = window_texts(scene.instance_variable_get(:@slot_windows)[0])
+  ok texts.include?('  80'), 'RPG2003 widens the HP field to 4 characters, not 3'
 end
 
 # EasyRPG's Window_SaveFile::Refresh (src/window_savefile.cpp) draws every


### PR DESCRIPTION
## Summary

`Window_SaveFile::Refresh` (`src/window_savefile.cpp`) draws the level and HP fields as four separate `TextDraw` calls at fixed pixel columns -- the level label at x=4, the HP label always at x=46 regardless of what came before it -- each number space-padded to a fixed width (`std::setw(2)` for level, `std::setw(Player::IsRPG2k3() ? 4 : 3)` for HP, the only version branch in the whole function and a harmless width-only one). The two short-label terms (`lvl_short`/`hp_short`, "Lv"/"HP" by default) are likewise clamped to exactly 2 characters regardless of what a project's own database terms table names them.

`#draw_slot_box`'s level/HP line (`mruby-rpg2k/mrblib/scene/save_load.rb`) was one `#draw_system_text` call on a Ruby-interpolated `"Lv#{level}    HP#{hp}"` string -- no padding on either number, and the literal four-space gap only coincidentally lined up for a single-digit level. A leader's level going from one digit to two shifted the "HP" label sideways, something real RPG_RT's fixed-column layout never does.

- Fixed by splitting the line into a new `#draw_level_hp` helper: four separate `#draw_system_text` calls at RPG_RT's own x=4/x=46 columns, `level.to_s.rjust(2)` and `hp.to_s.rjust(rpg2003? ? 4 : 3)` for the numbers, and a new `#fixed_width_term` clamping the short labels to exactly 2 characters the same way.

## Test plan

- Rewrote the existing level/HP `scripts/rpg2k_scene_check.rb` check to expect the four split, padded strings instead of one combined one.
- Two new checks: the "HP" label call lands at the fixed x=46 column for a two-digit level (proving the position doesn't shift), and an RPG2003 party pads HP to 4 characters instead of 3.
- Verified via `git stash` on `save_load.rb` alone: all three affected checks fail pre-fix.
- Full suite green: `rpg2k_scene_check.rb` 780 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_