### PR TITLE
A vehicle's forced Move Route frequency reverts once the route finishes

### DIFF
--- a/changelog.d/vehicle-route-frequency-revert.fixed.md
+++ b/changelog.d/vehicle-route-frequency-revert.fixed.md
@@ -1,0 +1,5 @@
+- **Vehicle move routes:** A boat/ship/airship's Move Frequency now reverts
+  to whatever it was before a forced Move Route started, once that route
+  finishes, instead of staying permanently overwritten by a Frequency Up/
+  Down sub-command or the route's own frequency parameter, matching RPG_RT.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -402,6 +402,38 @@ The work below is roughly ordered by the critical path to a walkable game
   Change Event Location repositioning a vehicle; Proceed With Movement
   waiting on a vehicle route; the Change Graphic override reverting on
   Transfer Player), each confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-19): a vehicle's forced Move Route left its Move
+  Frequency permanently overwritten once the route finished, instead of
+  reverting to whatever it was before the route started — the exact same
+  gap this write-up's own scope already fixed for a map event's forced
+  route, just never mirrored onto vehicles.** Confirmed directly against
+  RPG_RT's live source: `Game_Character::ForceMoveRoute`
+  (`src/game_character.cpp`) snapshots the frequency in effect before the
+  route starts overriding it (`if (!IsMoveRouteOverwritten())
+  original_move_frequency = GetMoveFrequency();`), and `CancelMoveRoute`
+  restores it (`SetMoveFrequency(original_move_frequency)`) the instant a
+  non-repeating route's last command lands (`UpdateMovement`, the same
+  place `#step_event`'s own "revert to page movement" comment already
+  cites). `Game_Vehicle` inherits both methods unchanged — a single,
+  unconditional code path, no version gating — so a boat/ship/airship
+  gets this restore for free in real RPG_RT, identical to the player or a
+  map event. `#force_vehicle_route`/`#step_vehicle_route`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) had no equivalent: a Frequency Up/
+  Down sub-command (or the route's own explicit frequency parameter)
+  permanently overwrote the persistent per-type mirror's
+  `move_frequency`, since `@vehicle_chars[type]` is memoized for as long
+  as the map stays loaded and nothing ever wrote it back. Fixed by adding
+  `@vehicle_orig_freq`, snapshotted in `#force_vehicle_route` only when a
+  route is not already running (mirroring `!IsMoveRouteOverwritten()`, so
+  a second Set Move Route issued mid-route doesn't clobber the *original*
+  pre-route value with whatever the first route's own Frequency Up/Down
+  had already left behind), and restored in `#step_vehicle_route` the
+  instant a non-repeating route's `#done?` goes true. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (force a boat's route at frequency
+  8, run it to completion, confirm the mirror's frequency reverts to its
+  pre-route value of 3 rather than sticking at 8), confirmed to fail
+  against the pre-fix code (`NoMethodError`, since `@vehicle_orig_freq`
+  did not exist at all) before the fix.
   ✅ **A ridden vehicle now walk-cycles with the party**, closing half of the
   walk-cycle gap the paragraph above flagged. `#draw_vehicle_frame` always
   passed pattern `1` (the standing frame) to `Game::CharSet.frame_rect`, so a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -282,6 +282,7 @@ class RPG2k
         @vehicle_chars = {}
         @vehicle_routes = {}
         @vehicle_route_timers = {}
+        @vehicle_orig_freq = {}
         # Move Event targets that resolved to a currently-hidden map event
         # (see #apply_move_request) -- once stuck, permanently so, matching a
         # freeze that never clears on its own.
@@ -3810,6 +3811,14 @@ class RPG2k
         ch.x = v.x
         ch.y = v.y
         ch.direction = v.direction
+        # Snapshot the frequency in effect before this route starts overriding
+        # it -- but only if a route is not already running, matching RPG_RT's
+        # own `if (!IsMoveRouteOverwritten()) original_move_frequency =
+        # GetMoveFrequency();` (`Game_Character::ForceMoveRoute`, `src/
+        # game_character.cpp`) -- so a second Set Move Route issued mid-route
+        # does not clobber the *original* pre-route value with whatever the
+        # first route's own Frequency Up/Down had already left behind.
+        @vehicle_orig_freq[type] = ch.move_frequency unless @vehicle_routes[type]
         ch.move_frequency = valid_move_freq(freq) || ch.move_frequency
         @vehicle_routes[type] = route
         @vehicle_route_timers[type] = 0
@@ -3838,7 +3847,21 @@ class RPG2k
         v.x = ch.x
         v.y = ch.y
         v.direction = ch.direction
-        @vehicle_routes[type] = nil if route.done?
+        if route.done?
+          @vehicle_routes[type] = nil
+          # The frequency in effect before this route started reasserts
+          # itself the instant a non-repeating route finishes -- matching
+          # `Game_Character::CancelMoveRoute`'s own `SetMoveFrequency(
+          # original_move_frequency)` (`src/game_character.cpp`), fired the
+          # moment the last command of a non-repeating route lands
+          # (`UpdateMovement`). A Frequency Up/Down sub-command inside that
+          # route must not go on pacing the vehicle once control reverts,
+          # only for the duration of the route that issued it -- the same
+          # rule #step_event already applies to a Move Event's own forced
+          # route.
+          orig = @vehicle_orig_freq.delete(type)
+          ch.move_frequency = orig if orig
+        end
       rescue StandardError => e
         $stderr.puts "[RPG2k] vehicle move route failed: #{e.message}"
         @vehicle_routes[type] = nil # drop a broken route so Proceed does not hang
@@ -6628,6 +6651,7 @@ class RPG2k
         @vehicle_chars = {}
         @vehicle_routes = {}
         @vehicle_route_timers = {}
+        @vehicle_orig_freq = {}
         @stuck_move_targets = [] # a stuck target was on the map being left
         # Both are per-visit: an Erase Event does not follow the party to the
         # next map, and the destination's pages are chosen fresh.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7954,6 +7954,34 @@ check 'Move Event drives an unboarded boat along a route, respecting vehicle_pas
   eq 6, boat.direction, 'facing the direction it moved (MOVE_RIGHT)'
 end
 
+check "a vehicle's forced Move Route frequency reverts once the (non-" \
+      "repeating) route finishes, not stuck forever" do
+  # Confirmed against RPG_RT's own live source: `Game_Character::
+  # ForceMoveRoute` (src/game_character.cpp) snapshots the frequency in
+  # effect before the route starts (`if (!IsMoveRouteOverwritten())
+  # original_move_frequency = GetMoveFrequency();`), and `CancelMoveRoute`
+  # restores it (`SetMoveFrequency(original_move_frequency)`) the instant a
+  # non-repeating route's last command lands. `Game_Vehicle` inherits both
+  # unchanged, so a boat/ship/airship gets this restore for free just like
+  # a map event already does here (#step_event's own "revert to page
+  # movement" comment).
+  scene = new_scene({}, player: [5, 0], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  route = Game::MoveRoute.new([Game::MoveCommand.new(R::MOVE_RIGHT)],
+                              repeat: false, skippable: true)
+  scene.send(:force_vehicle_route, :boat, route, 8) # freq 8, faster than the default 3
+  ch = scene.instance_variable_get(:@vehicle_chars)[:boat]
+  eq 3, scene.instance_variable_get(:@vehicle_orig_freq)[:boat],
+     "the pre-route frequency (the mirror's own default, 3) was snapshotted"
+  40.times { scene.update }
+  eq nil, scene.instance_variable_get(:@vehicle_routes)[:boat], 'the route finished'
+  eq 3, ch.move_frequency, 'frequency reverted to what it was before the route, not stuck at 8'
+end
+
 check "a boat's move route is blocked by terrain the same way ordinary sailing is" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

`Game_Character::ForceMoveRoute` (`src/game_character.cpp`) snapshots the frequency in effect before the route starts overriding it (`if (!IsMoveRouteOverwritten()) original_move_frequency = GetMoveFrequency();`), and `CancelMoveRoute` restores it (`SetMoveFrequency(original_move_frequency)`) the instant a non-repeating route's last command lands. `Game_Vehicle` inherits both methods unchanged -- a single, unconditional code path, no version gating -- so a boat/ship/airship gets this restore for free in real RPG_RT, identical to the player or a map event (which this codebase already gets right, per `#step_event`'s own "revert to page movement" comment).

`#force_vehicle_route`/`#step_vehicle_route` (`mruby-rpg2k/mrblib/scene/map.rb`) had no equivalent: a Frequency Up/Down sub-command (or the route's own explicit frequency parameter) permanently overwrote the persistent per-type mirror's `move_frequency`, since `@vehicle_chars[type]` is memoized for as long as the map stays loaded and nothing ever wrote it back.

- Fixed by adding `@vehicle_orig_freq`, snapshotted in `#force_vehicle_route` only when a route is not already running (mirroring `!IsMoveRouteOverwritten()`, so a second Set Move Route issued mid-route doesn't clobber the *original* pre-route value with whatever the first route's own Frequency Up/Down had already left behind), and restored in `#step_vehicle_route` the instant a non-repeating route's `#done?` goes true.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: force a boat's route at frequency 8, run it to completion, confirm the mirror's frequency reverts to its pre-route value of 3 rather than sticking at 8.
- Verified via `git stash` on `map.rb` alone: the new check fails pre-fix (`NoMethodError`, since `@vehicle_orig_freq` did not exist at all).
- Full suite green: `rpg2k_scene_check.rb` 781 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_