### PR TITLE
The action button also answers a same-layer touch event it is only facing

### DIFF
--- a/changelog.d/action-button-answers-touch-events.fixed.md
+++ b/changelog.d/action-button-answers-touch-events.fixed.md
@@ -1,0 +1,6 @@
+- **Map events:** The action button now also answers a same-layer Player
+  Touch or Event Touch NPC standing one tile ahead, not just an Action
+  (trigger 0) event -- previously such an NPC could only be reached by
+  physically walking onto its tile, matching RPG_RT's own unconditional
+  touch-trigger check on the faced tile. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6370,7 +6370,35 @@ Everything below is unverified against the codebase.
   `#drive_parallel_wait`'s "background: ignore message/choice requests"
   branch — `:teleport` no longer falls into it, see the "a Transfer Player
   command issued from a Parallel Process..." fix just above), confirmed to
-  fail against the pre-fix code before the fix. ✅ **A Battle Processing
+  fail against the pre-fix code before the fix. ✅ **The action button also
+  answers a same-layer Player Touch / Event Touch event it is only facing,
+  not standing on — not just a trigger-0 (Action) event
+  (2026-08-19).** Confirmed directly against RPG_RT's live source:
+  `Game_Player::CheckActionEvent` (`src/game_player.cpp`) is
+  `result |= CheckEventTriggerThere({Trigger_touched, Trigger_collision},
+  front_x, front_y, true); result |= CheckEventTriggerHere({Trigger_action},
+  true);` — the touch-trigger check on the faced tile runs unconditionally,
+  before the action-trigger check ever does, a single, unconditional line
+  with no version gating. `CheckEventTriggerThere` itself requires
+  `ev.GetLayer() == Layers_same`, the identical restriction this codebase's
+  own action-trigger check already applies. `Scene::Map#try_action_trigger`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) only ever tested `#actionable?`
+  (trigger 0) on the faced tile, so a Player Touch or Event Touch NPC
+  standing one tile ahead could only ever be reached by physically walking
+  onto its tile — pressing the action button while facing it did nothing,
+  when real RPG_RT answers it exactly the way walking into it would. Fixed
+  by adding a new `#action_touch_trigger?` predicate — deliberately
+  narrower than the existing `#touch_trigger?` (which also covers Parallel
+  Process, for hero-*contact* purposes only): Parallel is not in RPG_RT's
+  own `{Trigger_touched, Trigger_collision}` set here — and checking it
+  alongside `#actionable?` on the immediate faced tile only, not extended
+  through the counter-tile chain (which stays action-only, matching the
+  reference's own separate `got_action` loop). Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (a same-layer Player Touch event
+  answers the action button when only faced, not stepped onto; the same for
+  Event Touch; a below-characters touch event still needs actual overlap,
+  not just facing it), the first two confirmed to fail against the pre-fix
+  code before the fix. ✅ **A Battle Processing
   (Enemy Encounter) command issued from a Parallel Process now actually
   opens and drives a real fight**, instead of being silently skipped
   outright — the last member of this exact defect-class family left

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2169,6 +2169,22 @@ class RPG2k
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
         ev = event_at(fx, fy)
         return start_event(ev, true) if actionable?(ev) && ev[:layer] == LAYER_SAME
+        # A same-layer Player Touch / Event Touch event on the faced tile
+        # answers the action button too, not just an action-triggered one --
+        # confirmed against RPG_RT's own live source: `Game_Player::
+        # CheckActionEvent` (src/game_player.cpp) checks
+        # `{Trigger_touched, Trigger_collision}` on the front tile
+        # unconditionally, before it ever looks for an action-triggered
+        # event there (`result |= CheckEventTriggerThere({Trigger_touched,
+        # Trigger_collision}, front_x, front_y, true);`, a single,
+        # unconditional line, no version gating). Unlike #touch_trigger?
+        # (which also answers hero *contact*, walking onto the tile),
+        # Parallel Process is not in this set -- it never answers the
+        # action button, only the two touch triggers do. This check is
+        # local to the immediate front tile only, not extended through the
+        # counter-tile chain below (which stays action-only, matching the
+        # reference's own separate `got_action` loop).
+        return start_event(ev, true) if action_touch_trigger?(ev)
 
         # Nothing on the faced tile: if it is a **counter** — a shop or inn
         # counter, marked in the chipset's upper-layer passage table — look
@@ -2185,6 +2201,16 @@ class RPG2k
       # Whether an event can answer the action button.
       def actionable?(ev)
         ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands] ? true : false
+      end
+
+      # Whether a same-layer Player Touch / Event Touch event on the faced
+      # tile can also answer the action button -- see #try_action_trigger's
+      # own citation. Deliberately narrower than #touch_trigger? (which also
+      # covers Parallel Process, for hero-*contact* purposes): Parallel is
+      # not in RPG_RT's own `{Trigger_touched, Trigger_collision}` set here.
+      def action_touch_trigger?(ev)
+        ev && ev[:layer] == LAYER_SAME && ev[:commands] &&
+          (ev[:trigger] == TRIGGER_PLAYER_TOUCH || ev[:trigger] == TRIGGER_EVENT_TOUCH) ? true : false
       end
 
       # Whether a trigger is one the party can set off by walking into the event

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1848,6 +1848,58 @@ check 'action (trigger 0) does not fire on mere contact' do
   ok !st.switches[4], 'a trigger-0 event must not run just from being bumped'
 end
 
+# Confirmed against RPG_RT's own live source: `Game_Player::CheckActionEvent`
+# (src/game_player.cpp) checks `{Trigger_touched, Trigger_collision}`
+# (Player Touch / Event Touch) on the faced tile unconditionally, before it
+# ever looks for an action-triggered event there -- a same-layer touch event
+# the party is merely facing, not standing on, still answers the action
+# button, not just Decision-key-only (trigger 0) events.
+check 'the action button also answers a same-layer Player Touch (trigger 1) ' \
+      'event it is only facing, not standing on' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 1, layer: RPG2k::Scene::Map::LAYER_SAME)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 6 # face east, toward (1, 0)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  5.times { scene.update }
+  ok st.switches[4], 'the action button reached the Player Touch event it was facing'
+  eq [0, 0], [st.x, st.y], 'the party never stepped onto its tile'
+end
+
+check 'the action button also answers a same-layer Event Touch (trigger 2) ' \
+      'event it is only facing, not standing on' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 2, layer: RPG2k::Scene::Map::LAYER_SAME)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 6
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  5.times { scene.update }
+  ok st.switches[4], 'the action button reached the Event Touch event it was facing'
+end
+
+check 'the action button does not answer a below-characters touch event ' \
+      'from an adjacent facing tile, only same-layer' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 1, layer: RPG2k::Scene::Map::LAYER_BELOW) # not LAYER_SAME
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 6
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  5.times { scene.update }
+  ok !st.switches[4], 'a below-characters touch event needs actual overlap, not just facing it'
+end
+
 # A scene on a map with counter tiles, for the talk-across-a-counter checks.
 def counter_scene(events, counters, player:)
   db = fake_db


### PR DESCRIPTION
## Summary

`Game_Player::CheckActionEvent` (`src/game_player.cpp`) is:
```cpp
result |= CheckEventTriggerThere({Trigger_touched, Trigger_collision}, front_x, front_y, true);
result |= CheckEventTriggerHere({Trigger_action}, true);
```
-- the touch-trigger check on the faced tile runs unconditionally, before the action-trigger check ever does, a single, unconditional line with no version gating. `CheckEventTriggerThere` itself requires `ev.GetLayer() == Layers_same`, the identical restriction this codebase's own action-trigger check already applies.

`Scene::Map#try_action_trigger` (`mruby-rpg2k/mrblib/scene/map.rb`) only ever tested `#actionable?` (trigger 0) on the faced tile, so a Player Touch or Event Touch NPC standing one tile ahead could only ever be reached by physically walking onto its tile -- pressing the action button while facing it did nothing, when real RPG_RT answers it exactly the way walking into it would.

- Fixed by adding a new `#action_touch_trigger?` predicate -- deliberately narrower than the existing `#touch_trigger?` (which also covers Parallel Process, for hero-contact purposes only): Parallel is not in RPG_RT's own `{Trigger_touched, Trigger_collision}` set here -- and checking it alongside `#actionable?` on the immediate faced tile only, not extended through the counter-tile chain (which stays action-only, matching the reference's own separate `got_action` loop).

## Test plan

- Three new `scripts/rpg2k_scene_check.rb` checks: a same-layer Player Touch event answers the action button when only faced, not stepped onto; the same for Event Touch; a below-characters touch event still needs actual overlap, not just facing it.
- Verified via `git stash` on `map.rb` alone: the first two checks fail pre-fix.
- Full suite green: `rpg2k_scene_check.rb` 784 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_gauge_check.rb` 15 passed, `rpg2k3_battle_row_check.rb` 16 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_