### PR TITLE
The Row command's front-row headcount wrongly dropped a KO'd ally

### DIFF
--- a/changelog.d/row-command-kod-ally-headcount.fixed.md
+++ b/changelog.d/row-command-kod-ally-headcount.fixed.md
@@ -1,0 +1,6 @@
+- **RPG2003 Row command:** A lone living front-row ally may now step back
+  even when its only front-row companion is dead, instead of being
+  wrongly refused with a Buzzer -- the "don't empty the front row" guard
+  now counts a KO'd front-row ally toward the headcount the same way
+  RPG_RT's own unfiltered check does. Covered by two new
+  `scripts/rpg2k3_battle_row_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9512,6 +9512,30 @@ not yet verified:
   member is left untouched; an RPG2000 (non-`rpg2003:`) battle never forces
   rows at all — the first confirmed to fail against the pre-fix code
   (`expected 0, got 1`) before the fix.
+  ✅ **Follow-up (2026-08-19): the in-battle Row command's own "don't empty
+  the front row" guard wrongly dropped a KO'd front-row ally from its
+  headcount, so a lone living front-row ally could be blocked from
+  stepping back even though real RPG_RT would have let it.** Confirmed
+  directly against RPG_RT's live source: `Scene_Battle_Rpg2k3::RowSelected`
+  (`src/scene_battle_rpg2k3.cpp`) counts `front_row_battlers` with a raw
+  loop over `Main_Data::game_party->GetActors()` — an unfiltered walk of
+  `Game_Party`'s roster (`src/game_party.cpp`) with no HP or hidden check
+  anywhere; a dead ally's stored `GetBattleRow()` still counts.
+  `Game::Battle#can_leave_front_row?` (`mruby-rpg2k/mrblib/game.rb`)
+  instead ran `allies.reject(&:out_of_play?)` first, which drops any
+  `dead?`/`hidden` ally before counting — so a 2-member front row with one
+  KO'd member read as "only 1 (myself) in front" and refused the survivor's
+  toggle with a Buzzer, when the reference's own unfiltered headcount would
+  have allowed it. Fixed by counting on `#member?` alone (still excluding
+  an ally who has actually left the live party mid-battle — the one case
+  this codebase's `@allies` array can hold that the reference's
+  `data.party`-backed `GetActors()` never would), matching
+  `RowSelected`'s own unfiltered semantics for HP and hidden state. Two new
+  `scripts/rpg2k3_battle_row_check.rb` checks: a living front-row ally may
+  step back when its only front-row companion is dead; a lone front-row
+  ally still can't step back with no other front-row ally at all (dead or
+  alive) — the first confirmed to fail against the pre-fix code (`expected
+  true, got false`) before the fix.
   ✅ **Change Battle Commands (1009) never validated an added command id
   against the database's own Battle Commands table, so any positive
   integer — however bogus — could occupy one of the six real slots

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9756,11 +9756,14 @@ module Game
     # `IsDirectionFlipped()` (a battler-mirroring mechanic this engine does
     # not model, and which no ordinary actor ever sets in the reference
     # either -- it always reads false there), so the surviving, always-true
-    # part of the condition is exactly "at least one *other* in-play ally is
-    # still in front" -- moving from back to front never needs this check at
-    # all, since it can only ever add to the front row.
+    # part of the condition is exactly "at least one *other* ally is still in
+    # front" -- moving from back to front never needs this check at all,
+    # since it can only ever add to the front row. RowSelected's own headcount
+    # loop walks `Game_Party::GetActors()` unfiltered -- a KO'd or hidden
+    # ally still counts toward keeping the front row non-empty, same as
+    # `@allies` here; only #member?-false (left the live party) is excluded.
     def can_leave_front_row?(ally)
-      allies.reject(&:out_of_play?).count { |a| a != ally && !a.back_row? } >= 1
+      allies.reject { |a| !a.member? }.count { |a| a != ally && !a.back_row? } >= 1
     end
 
     # The RPG2003 **Row** battle command: flip `ally` between front and back

--- a/scripts/rpg2k3_battle_row_check.rb
+++ b/scripts/rpg2k3_battle_row_check.rb
@@ -97,6 +97,40 @@ check 'setting ROW_BACK makes back_row? true' do
   eq false, front.back_row?
 end
 
+# -- can_leave_front_row?/toggle_row (RowSelected's front_row_battlers
+#    headcount, EasyRPG's own `Game_Party::GetActors()` loop -- unfiltered by
+#    HP/hidden, only a party member who has actually left the roster drops
+#    out) -------------------------------------------------------------------
+check 'a KO\'d front-row ally still counts toward keeping the front row ' \
+      'non-empty, so a living front-row ally may still step back' do
+  alive = combatant('Alive', 10, 5, 8, 100)
+  alive.row = Game::Battle::ROW_FRONT
+  dead = combatant('Dead', 10, 5, 8, 100)
+  dead.row = Game::Battle::ROW_FRONT
+  dead.hp = 0
+
+  bat = Game::Battle.new([alive, dead], [combatant('Enemy', 5, 5, 5, 50)], Game::Rng.new(1))
+
+  eq true, bat.can_leave_front_row?(alive)
+  eq true, bat.toggle_row(alive)
+  eq Game::Battle::ROW_BACK, alive.row
+end
+
+check 'a lone living front-row ally may not step back merely because a ' \
+      'dead ally is also nominally front-row' do
+  alive = combatant('Alive', 10, 5, 8, 100)
+  alive.row = Game::Battle::ROW_FRONT
+  dead = combatant('Dead', 10, 5, 8, 100)
+  dead.row = Game::Battle::ROW_BACK
+  dead.hp = 0
+
+  bat = Game::Battle.new([alive, dead], [combatant('Enemy', 5, 5, 5, 50)], Game::Rng.new(1))
+
+  eq false, bat.can_leave_front_row?(alive)
+  eq false, bat.toggle_row(alive)
+  eq Game::Battle::ROW_FRONT, alive.row
+end
+
 # -- row_adjusted? (the Algo::IsRowAdjusted port) ----------------------------
 # An actor-backed attacker in the front row is row-adjusted; a back-row actor
 # attacker and every enemy attacker are not; a back-row defender is.


### PR DESCRIPTION
## Summary

- `Scene_Battle_Rpg2k3::RowSelected` (`src/scene_battle_rpg2k3.cpp`) counts `front_row_battlers` with a raw loop over `Main_Data::game_party->GetActors()` — an unfiltered walk of `Game_Party`'s roster (`src/game_party.cpp`) with no HP or hidden check anywhere. A dead ally's stored `GetBattleRow()` still counts toward keeping the front row non-empty in real RPG_RT.
- `Game::Battle#can_leave_front_row?` instead ran `allies.reject(&:out_of_play?)` first, dropping any `dead?`/`hidden` ally before counting — so a 2-member front row with one KO'd member read as "only 1 (myself) in front" and refused the living survivor's Row toggle with a Buzzer, when real RPG_RT's own unfiltered headcount would have allowed it.
- Fixed by counting on `#member?` alone — still excluding an ally who has actually left the live party mid-battle (the one case this codebase's `@allies` array can hold that the reference's `data.party`-backed `GetActors()` never would) — matching `RowSelected`'s own unfiltered semantics for HP and hidden state.

## Test plan

- [x] Two new `scripts/rpg2k3_battle_row_check.rb` checks: a living front-row ally may step back when its only front-row companion is dead; a lone front-row ally still can't step back with no other front-row ally at all.
- [x] Verified via `git stash` on `game.rb` alone that the first new check fails pre-fix (`expected true, got false`).
- [x] Full suite green: `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k_scene_check.rb` 784 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_