### PR TITLE
mz: replace silent Effekseer no-op with an honest diagnostic stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,13 +349,16 @@
   headless CI smoke is what the claim rests on, and it is not yet a blocking
   check
 - MZ **plays animations** too — with a caveat worth knowing, because MZ has two
-  animation systems and only one of them is reachable. `isMVAnimation` routes by
-  data shape: an animation carrying a `frames` array draws as sprite cells
+  animation systems and only one of them draws. `isMVAnimation` routes by data
+  shape: an animation carrying a `frames` array draws as sprite cells
   (`Sprite_AnimationMV`) and works end to end here, including the per-cell blend
-  modes; anything else goes to Effekseer, whose WASM runtime is started by the
-  `main.js` this host bypasses, so such an animation runs its sound and flash
-  timings on schedule and draws **no visuals**. Nothing hangs and nothing errors,
-  which is exactly why it is documented rather than left to be discovered
+  modes; anything else goes to Effekseer, whose real WASM runtime this host
+  cannot run (quickjs-ng has no WebAssembly support). Rather than staying
+  silent about it, `window.effekseer` is a diagnostic stub: it reads the real
+  `.efkefc` file off disk, confirms it looks like a real effect container, and
+  logs exactly what was skipped and why. The animation still runs its sound and
+  flash timings on schedule and still draws **no visuals** — nothing hangs and
+  nothing errors, and now nothing is silent either
 - MZ also **shows messages, opens the party menu, saves and fights**, each
   exercised headlessly the way the MV path is: a message queued through
   `$gameMessage` opens `Window_Message` over the map, `Scene_Map`'s own

--- a/changelog.d/mz-effekseer-diagnostic-stub.added.md
+++ b/changelog.d/mz-effekseer-diagnostic-stub.added.md
@@ -1,0 +1,9 @@
+- **RPG Maker MZ**: an animation whose `effectName` names a real Effekseer
+  effect no longer runs entirely silently. `window.effekseer` is now a
+  diagnostic stub instead of the unusable-here WASM runtime — it makes
+  `Graphics.effekseer` non-null so the engine's own load path actually runs,
+  reads the real `.efkefc` bytes off disk to confirm the file exists and
+  looks like a real effect container, and logs exactly what was skipped and
+  why. Sound/flash timings on the animation still fire and it still
+  completes normally; native particle rendering itself is not implemented
+  (tracked separately — see `docs/adr/0004-rpg-maker-mv-support.md` M6.2).

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -476,6 +476,35 @@ JavaScript loads and interprets the JSON.
       probe re-requests while the map is up so a burst is always on screen, and
       the screenshot waits for a frame with visible cells rather than firing on
       a frame count, or it would photograph the gaps between bursts.
+    - **M6.2 addendum — Effekseer diagnostic stub (landed), full rendering
+      (not attempted).** Investigated whether real particle rendering was
+      reachable: quickjs-ng has no WebAssembly support at all (confirmed —
+      `grep -rl WebAssembly 3rd/quickjs/*.c 3rd/quickjs/*.h` finds nothing),
+      so running the browser's `effekseer.min.js` + `.wasm` build is out
+      without writing a WASM interpreter first. The native Effekseer C++ core
+      (MIT-licensed, the same source the WASM build compiles from) is
+      designed for pluggable renderer backends, and `EffekseerRendererGL`
+      already targets GLES; the surfaceless-EGL/GLES3 context in
+      `mvgl.cxx`/`mvwebgl.cxx` could plausibly host it directly rather than
+      through the WebGL shim. But the real risk is elsewhere — reconciling
+      Effekseer's GL state and coordinate/matrix conventions against PIXI's
+      own without a browser reference to diff against, plus llvmpipe
+      fill-rate cost — and there is no real `.efkefc` file anywhere in this
+      repo to even smoke-test against, so it stayed unattempted rather than
+      guessed at.
+
+      What landed instead: `MZ::EFFEKSEER_SHIM_JS` replaces `window.effekseer`
+      with a stub that turns the *silent* no-op above into an *honest* one —
+      `Graphics.effekseer` goes non-null so `EffectManager.load` actually
+      runs, `loadEffect` reads the real file through the same
+      `__mv_existsSync`/`__mv_readFileBytes` natives every other asset uses,
+      validates the `"EFKEFC"` container magic, and logs what was skipped and
+      why (`console.warn`) before completing the load — a missing file still
+      reports through `onError` the way a real fetch failure would. `play()`
+      hands back a handle with a short fixed lifetime so `Sprite_Animation`
+      still ends the animation normally instead of waiting on a handle that
+      would otherwise never go away. No pixels are drawn; that half of the
+      gap is unchanged.
 
       The animation's cells are all the *same area*, differing only in colour.
       That is not the obvious choice — expanding rings look more like an

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -289,6 +289,77 @@ class MZ
     "addLoadListener: function(){}, volume: 0, pitch: 0, pan: 0, seek: 0 }; }; " \
     "})(globalThis);".freeze
 
+  # Replaces `window.effekseer` (defined by the vendored `effekseer.min.js`,
+  # still evaluated harmlessly as part of CORE_SCRIPTS) with a diagnostic stub.
+  #
+  # `Graphics._createEffekseerContext` (rmmz_core.js) already degrades
+  # gracefully when `effekseer.createContext()` returns null, which is exactly
+  # what the real library does when its WASM runtime was never initialised
+  # (see the CORE_SCRIPTS comment on M6.2): `Graphics.effekseer` stays
+  # undefined, `EffectManager.load` never calls `startLoading`, and
+  # `Sprite_Animation` takes its own no-handle branch — sound/flash timings
+  # still fire and the animation still completes, just with nothing drawn.
+  # That path is real and was traced end to end (rmmz_managers.js:986-1045,
+  # rmmz_sprites.js:1243-1330); it is also completely silent — an MZ project
+  # whose animations are all Effekseer looks like it is running fine with no
+  # indication anything was skipped.
+  #
+  # This stub does not draw particles (that needs a native Effekseer port
+  # targeting the WebGL bridge in mvgl.cxx/mvwebgl.cxx — a multi-week project
+  # of its own, tracked separately) but it does the two things a stub can do
+  # honestly in one step: it makes `Graphics.effekseer` non-null so the load
+  # path actually runs, and it reads the real `.efkefc` bytes off disk
+  # (through the same `__mv_existsSync`/`__mv_readFileBytes` natives every
+  # other asset uses) to confirm the file exists and looks like a real effect
+  # container (`"EFKEFC"` magic) before logging exactly what was skipped and
+  # why. A missing effect file still reports through `onError`/`checkErrors`
+  # the same way the real engine's fetch failure would (rmmz_managers.js's
+  # `EffectManager.throwLoadError`), rather than being swallowed twice over.
+  #
+  # `play()` hands back a handle with a short fixed lifetime (decremented by
+  # `update()`, which `SceneManager.updateEffekseer` already calls once a
+  # frame) so `Sprite_Animation.checkEnd` still sees `_handle.exists` go
+  # false and ends the animation normally instead of hanging on it forever.
+  EFFEKSEER_SHIM_JS =
+    "(function(g){ " \
+    "function makeContext(){ var ctx = { _handles: [] }; " \
+    "ctx.init = function(){}; " \
+    "ctx.loadEffect = function(url, mag, onLoad, onError){ " \
+    "var exists = (typeof g.__mv_existsSync === 'function') && " \
+    "g.__mv_existsSync(url); " \
+    "if (!exists) { if (onError) onError('not found', url); " \
+    "return { isLoaded: false, url: url }; } " \
+    "var bytes = new Uint8Array(g.__mv_readFileBytes(url)); " \
+    "var magic = 'EFKEFC'; var magicOk = bytes.length >= magic.length; " \
+    "for (var i = 0; magicOk && i < magic.length; i++) { " \
+    "if (bytes[i] !== magic.charCodeAt(i)) magicOk = false; } " \
+    "if (typeof console !== 'undefined' && console.warn) { " \
+    "console.warn('[Effekseer] effect requested but native particle ' + " \
+    "'rendering is not implemented: ' + url + ' (' + bytes.length + " \
+    "' bytes' + (magicOk ? '' : ', unrecognized format') + ')'); } " \
+    "if (onLoad) onLoad(); " \
+    "return { isLoaded: true, url: url, byteLength: bytes.length, " \
+    "magicOk: magicOk }; }; " \
+    "ctx.releaseEffect = function(){}; " \
+    "ctx.update = function(){ var alive = []; " \
+    "for (var i = 0; i < this._handles.length; i++) { " \
+    "var h = this._handles[i]; h._life--; " \
+    "if (h._life <= 0) h.exists = false; else alive.push(h); } " \
+    "this._handles = alive; }; " \
+    "ctx.stopAll = function(){ for (var i = 0; i < this._handles.length; i++) " \
+    "this._handles[i].exists = false; this._handles = []; }; " \
+    "ctx.play = function(){ var h = { exists: true, _life: 20, " \
+    "setLocation: function(){}, setRotation: function(){}, " \
+    "setScale: function(){}, setSpeed: function(){}, " \
+    "stop: function(){ this.exists = false; } }; " \
+    "this._handles.push(h); return h; }; " \
+    "ctx.beginDraw = function(){}; ctx.drawHandle = function(){}; " \
+    "ctx.endDraw = function(){}; ctx.setProjectionMatrix = function(){}; " \
+    "ctx.setCameraMatrix = function(){}; " \
+    "return ctx; } " \
+    "g.effekseer = { createContext: makeContext }; " \
+    "})(globalThis);".freeze
+
   # Installed only for headless/CI runs (see #render_skip_enabled?, gated on
   # the same --no_render_wait flag as RGSS::Graphics.update's frame-pacing
   # skip). Wraps PIXI's real render call so #main_loop can suppress it on
@@ -339,6 +410,12 @@ class MZ
     # the MZ-only overrides above (see AUDIO_BRIDGE_EXTRA_JS).
     def audio_bridge_js
       "#{MV::AUDIO_BRIDGE_JS}\n#{AUDIO_BRIDGE_EXTRA_JS}"
+    end
+
+    # The JS that replaces window.effekseer with the diagnostic stub (see
+    # EFFEKSEER_SHIM_JS) instead of the real, unusable-here WASM runtime.
+    def effekseer_shim_js
+      EFFEKSEER_SHIM_JS
     end
 
     # The subset of CORE_SCRIPTS the host reuse (M6.2) actually evaluates to
@@ -2512,6 +2589,11 @@ class MZ
     # even the title BGM a game starts with is queued rather than lost to the
     # silent Web Audio stub.
     MV::JS.eval(self.class.audio_bridge_js)
+
+    # Replaces window.effekseer with the diagnostic stub (see
+    # EFFEKSEER_SHIM_JS) before Graphics.initialize runs -- SceneManager.run
+    # below is what calls it, via Graphics._createEffekseerContext.
+    MV::JS.eval(self.class.effekseer_shim_js)
 
     # Replace catchException so a boot error is captured (not swallowed) and run
     # the boot. `SceneManager.run` starts PIXI's ticker and returns; the scene is

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -189,6 +189,91 @@ assert 'the MZ audio bridge queues ops and neutralises the eager preload' do
   assert_equal "audio/se/Beep", call[1]
 end
 
+assert 'MZ.effekseer_shim_js replaces window.effekseer with the diagnostic stub' do
+  js = MZ.effekseer_shim_js
+  assert_true js.include?("g.effekseer = { createContext: makeContext }")
+  assert_true js.include?("EFKEFC")
+end
+
+assert 'the Effekseer stub loads a real effect file and reports it, honestly' do
+  # Exercised against the real host and real files on disk, through the same
+  # __mv_existsSync/__mv_readFileBytes natives every other MZ asset uses.
+  MV::JS.base_dir = "mvjs_effekseer_fixture"
+  begin
+    Dir.mkdir("mvjs_effekseer_fixture") rescue nil
+    Dir.mkdir("mvjs_effekseer_fixture/effects") rescue nil
+    File.open("mvjs_effekseer_fixture/effects/Real.efkefc", "wb") do |f|
+      f.write("EFKEFC\x01\x00garbage")
+    end
+    File.open("mvjs_effekseer_fixture/effects/Bogus.efkefc", "wb") do |f|
+      f.write("not an effect file")
+    end
+
+    MV::JS.eval(MZ.effekseer_shim_js)
+    MV::JS.eval("globalThis.__ctx = effekseer.createContext(); __ctx.init();")
+
+    # A real, well-formed file: onLoad fires, isLoaded is true, and the magic
+    # check passes.
+    MV::JS.eval(
+      "globalThis.__loaded = false; globalThis.__errored = false; " \
+      "globalThis.__effect = __ctx.loadEffect('effects/Real.efkefc', 1, " \
+      "function(){ __loaded = true; }, function(){ __errored = true; });"
+    )
+    assert_equal true, MV::JS.eval("__loaded")
+    assert_equal false, MV::JS.eval("__errored")
+    assert_equal true, MV::JS.eval("__effect.isLoaded")
+    assert_equal true, MV::JS.eval("__effect.magicOk")
+
+    # A file that exists but is not an .efkefc container: still loaded (so the
+    # animation completes rather than throwing) but flagged, not silently
+    # treated as a real effect.
+    MV::JS.eval(
+      "globalThis.__effect2 = __ctx.loadEffect('effects/Bogus.efkefc', 1, " \
+      "function(){}, function(){});"
+    )
+    assert_equal true, MV::JS.eval("__effect2.isLoaded")
+    assert_equal false, MV::JS.eval("__effect2.magicOk")
+
+    # A genuinely missing effect reports through onError, same as the real
+    # engine's fetch failure would -- not swallowed twice over.
+    MV::JS.eval(
+      "globalThis.__loaded3 = false; globalThis.__errored3 = false; " \
+      "globalThis.__effect3 = __ctx.loadEffect('effects/Missing.efkefc', 1, " \
+      "function(){ __loaded3 = true; }, function(){ __errored3 = true; });"
+    )
+    assert_equal false, MV::JS.eval("__loaded3")
+    assert_equal true, MV::JS.eval("__errored3")
+    assert_equal false, MV::JS.eval("__effect3.isLoaded")
+  ensure
+    File.delete("mvjs_effekseer_fixture/effects/Real.efkefc") rescue nil
+    File.delete("mvjs_effekseer_fixture/effects/Bogus.efkefc") rescue nil
+    Dir.delete("mvjs_effekseer_fixture/effects") rescue nil
+    Dir.delete("mvjs_effekseer_fixture") rescue nil
+    MV::JS.base_dir = ""
+  end
+end
+
+assert 'the Effekseer stub retires play() handles instead of hanging forever' do
+  MV::JS.eval(MZ.effekseer_shim_js)
+  MV::JS.eval("globalThis.__ctx2 = effekseer.createContext(); __ctx2.init();")
+
+  # Sprite_Animation.checkEnd (rmmz_sprites.js) waits for handle.exists to go
+  # false before it considers the animation finished; without a bounded
+  # lifetime here that wait would never end.
+  MV::JS.eval("globalThis.__h = __ctx2.play({});")
+  assert_equal true, MV::JS.eval("__h.exists")
+
+  MV::JS.eval("for (var i = 0; i < 25; i++) __ctx2.update();")
+  assert_equal false, MV::JS.eval("__h.exists")
+
+  # stopAll (SceneManager.updateEffekseer, on scene change) retires every live
+  # handle immediately rather than waiting out their lifetimes.
+  MV::JS.eval("globalThis.__h2 = __ctx2.play({});")
+  assert_equal true, MV::JS.eval("__h2.exists")
+  MV::JS.eval("__ctx2.stopAll();")
+  assert_equal false, MV::JS.eval("__h2.exists")
+end
+
 assert 'MZ.render_skip_bridge_js only wraps once Graphics._app exists' do
   js = MZ.render_skip_bridge_js
   assert_true js.include?("Graphics._app")


### PR DESCRIPTION
## Summary

- An MZ animation whose `effectName` names a real Effekseer effect currently degrades completely silently: `Graphics.effekseer` stays `null` (the WASM runtime it needs is initialised by `main.js`, which the host deliberately bypasses per ADR 0004 M6.2), so the animation plays its sound/flash timings and draws nothing, with no indication anything was skipped.
- `window.effekseer` is now a diagnostic stub instead of the unusable-here WASM runtime: `Graphics.effekseer` goes non-null so the engine's own load path actually runs, `loadEffect` reads the real `.efkefc` bytes off disk through the same `__mv_existsSync`/`__mv_readFileBytes` natives every other asset uses, validates the `"EFKEFC"` container magic, and logs exactly what was skipped and why (`console.warn`). A genuinely missing effect file still reports through `onError`, the same way a real fetch failure would — not swallowed twice over. `play()` handles retire on a short fixed lifetime so `Sprite_Animation.checkEnd` still sees the handle go away and ends the animation normally instead of waiting on it forever.
- Full native particle rendering was investigated and is **not** attempted here: quickjs-ng has zero WebAssembly support (rules out running the browser's `effekseer.min.js` + `.wasm` build), and while native Effekseer's C++ core is MIT-licensed with a pluggable GL renderer backend that could plausibly target the existing surfaceless-EGL/GLES3 bridge (`mvgl.cxx`/`mvwebgl.cxx`), reconciling its GL state and coordinate/matrix conventions against PIXI's own is open-ended risk with no reference to diff against, and there is no real `.efkefc` file anywhere in this repo to even smoke-test against. Documented as an addendum to ADR 0004's M6.2 section rather than guessed at.

## Test plan

- [x] `rake test` (full mruby gem suite, includes the new `mz_test.rb` coverage: shim JS shape, real-file load + magic validation via a fixture `.efkefc`/non-`.efkefc` pair, missing-file `onError` path, and `play()`/`update()`/`stopAll()` handle lifetime) — 1837 OK, 0 KO, 0 Crash.
- [x] `MZ_MODE=animation scripts/mz_boot_check.bash` against `data/mz-sample` (MV-format animation, no `.efkefc`) — unchanged `OK`, confirming no regression to the existing MV-animation path.
- [x] `MZ_MODE=play scripts/mz_boot_check.bash` — unchanged `OK`, confirming no regression to basic boot/movement.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_