### PR TITLE
The Teleport destination picker is a single column, not RPG_RT's grid

### DIFF
--- a/changelog.d/teleport-picker-two-column-grid.fixed.md
+++ b/changelog.d/teleport-picker-two-column-grid.fixed.md
@@ -1,0 +1,6 @@
+- **Teleport destination picker:** The list of registered Teleport
+  destinations (field Item/Skill menus) is now a two-column grid, matching
+  RPG_RT -- RIGHT/LEFT move between columns and DOWN/UP move a whole row
+  (a no-op with nothing above/below), instead of the list acting like a
+  single stacked column reachable only by DOWN/UP with no RIGHT/LEFT at
+  all. Covered by corrected and new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3098,6 +3098,38 @@ The work below is roughly ordered by the critical path to a walkable game
   turns on) and corrected pre-existing `scripts/rpg2k_logic_check.rb`
   exact-hash-equality checks (now including `switch_id:`), all confirmed to
   fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-19): the Teleport destination picker (the third
+  list this bullet chain describes above) laid its entries out and moved
+  its cursor as a single stacked column, when real RPG_RT's own list here is
+  a two-column grid, the same shape this codebase's own item/skill lists
+  already port.** Confirmed directly against RPG_RT's live source:
+  `Window_Teleport` (`src/window_teleport.cpp`) sets `column_max = 2` on
+  construction; `Window_Selectable::Update` (`src/window_selectable.cpp`)
+  moves DOWN/UP by a whole `column_max`-wide row (a no-op with no row
+  below/above) and only moves RIGHT/LEFT by one cell, gated on `column_max
+  >= wrap_limit` (`wrap_limit` defaults to 2, so a 2-column list qualifies).
+  `Scene::ItemMenu#update_teleport_target`/`Scene::SkillMenu#update_teleport_target`
+  (`mruby-rpg2k/mrblib/scene/{item,skill}_menu.rb`) instead wired only
+  DOWN/UP to a plain `%= targets.size` wrap, with no RIGHT/LEFT handling at
+  all — so with exactly two destinations (the repo's own existing test
+  fixture), DOWN reached the second one and RIGHT did nothing, the inverse
+  of genuine RPG_RT, where DOWN is the no-op and RIGHT reaches it; the
+  repo's own pre-existing test asserted this inverted behavior as correct,
+  with no citation of `window_teleport.cpp` (unlike the item-list grid test
+  right above it in the same file). Fixed by mirroring
+  `#move_item_cursor`/`#move_skill_cursor`'s already-correct, already
+  wine-verified grid-cursor pattern (both classes already define
+  `COLUMN_MAX = 2` for their own lists) into a new `#move_teleport_cursor`
+  in each scene, and laying `#build_teleport_window`'s entries out in the
+  same `(i % COLUMN_MAX) * col_w, (i / COLUMN_MAX) * LINE_H` grid the item/
+  skill windows already use. The repo's own pre-existing teleport-picker
+  tests (`scripts/rpg2k_scene_check.rb`, both `Scene::ItemMenu` and
+  `Scene::SkillMenu`) were corrected from DOWN to RIGHT to reach the second
+  destination, and a new assertion that DOWN is a no-op from the first
+  destination was added — confirmed to fail against the pre-fix code (3 of
+  784 checks failed: the corrected `Scene::ItemMenu` check and both
+  `Scene::SkillMenu` Teleport checks, each expecting the still-first
+  destination or its switch state instead of the second).
 - ✅ **The battle-time skill variance is built now, for a recovery skill too —
   not just an attack one.** This line used to end "Left unbuilt still: the
   battle-time skill variance," describing only the missing half:

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -278,26 +278,47 @@ class RPG2k
         @parent.pop_to_map
       end
 
+      # The destination list is a two-column grid too, not a single stacked
+      # column -- confirmed against genuine RPG_RT's own live source:
+      # `Window_Teleport` (`src/window_teleport.cpp`) sets `column_max = 2`
+      # (`Window_Selectable`'s `wrap_limit` default is also 2, the exact
+      # threshold `Window_Selectable::Update`'s RIGHT/LEFT handling gates on),
+      # the identical shape this class's own item list already ports (see
+      # `COLUMN_MAX`'s comment). With exactly two destinations, DOWN/UP are
+      # no-ops (nothing in the row below/above) and RIGHT reaches the second
+      # one -- not DOWN, which this scene wrongly wired to a single-column
+      # modulo wrap with no RIGHT/LEFT handling at all.
       def update_teleport_target
         targets = teleport_targets
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_teleport_target
-        elsif (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !targets.empty?
-          @teleport_index += 1
-          @teleport_index %= targets.size
-          refresh_teleport_cursor
-          play_system_se(SFX_CURSOR)
-        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !targets.empty?
-          @teleport_index -= 1
-          @teleport_index %= targets.size
-          refresh_teleport_cursor
-          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+          move_teleport_cursor(COLUMN_MAX)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+          move_teleport_cursor(-COLUMN_MAX)
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
+          move_teleport_cursor(1) if (@teleport_index + 1) % COLUMN_MAX != 0
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
+          move_teleport_cursor(-1) if @teleport_index % COLUMN_MAX != 0
         elsif Input.trigger?(Input::C) && !targets.empty?
           play_system_se(SFX_DECISION)
           map_id, = targets[@teleport_index]
           apply_teleport_item(@pending_item, map_id)
         end
+      end
+
+      # Move the teleport-target cursor by `delta` grid cells, ignored if that
+      # cell is off the grid -- mirrors #move_item_cursor exactly (see its
+      # own comment).
+      def move_teleport_cursor(delta)
+        targets = teleport_targets
+        return if targets.empty?
+        target = @teleport_index + delta
+        return if target < 0 || target >= targets.size
+        @teleport_index = target
+        refresh_teleport_cursor
+        play_system_se(SFX_CURSOR)
       end
 
       def leave_teleport_target
@@ -325,11 +346,18 @@ class RPG2k
         name.nil? || name.empty? ? "Map #{map_id}" : name
       end
 
+      # Column width for the teleport-destination grid (see #update_teleport_target's
+      # grid comment above; identical formula to #item_col_w).
+      def teleport_col_w
+        (SCREEN_W - Window::BORDER * 2) / COLUMN_MAX
+      end
+
       def build_teleport_window
         @teleport_window.dispose if @teleport_window
         rows = teleport_targets
         inner_w = SCREEN_W - Window::BORDER * 2
-        h = [rows.size, 1].max * LINE_H
+        grid_rows = [(rows.size / COLUMN_MAX.to_f).ceil, 1].max
+        h = grid_rows * LINE_H
         @teleport_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
                                       SCREEN_W, h + Window::BORDER * 2)
         @teleport_window.z = 450
@@ -339,8 +367,11 @@ class RPG2k
         if rows.empty?
           c.draw_text 0, 0, inner_w, LINE_H, "No destinations"
         else
+          col_w = teleport_col_w
           rows.each_with_index do |(_id, name), i|
-            c.draw_text 0, i * LINE_H, inner_w, LINE_H, name
+            x = (i % COLUMN_MAX) * col_w
+            y = (i / COLUMN_MAX) * LINE_H
+            c.draw_text x, y, col_w, LINE_H, name
           end
         end
         @teleport_window.contents = c
@@ -350,8 +381,9 @@ class RPG2k
       def refresh_teleport_cursor
         return unless @teleport_window
         h = teleport_targets.empty? ? 0 : LINE_H
-        @teleport_window.cursor_rect =
-          Rect.new(0, @teleport_index * LINE_H, @teleport_window.contents.width, h)
+        x = (@teleport_index % COLUMN_MAX) * teleport_col_w
+        y = (@teleport_index / COLUMN_MAX) * LINE_H
+        @teleport_window.cursor_rect = Rect.new(x, y, teleport_col_w, h)
       end
 
       def update_target

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -278,26 +278,47 @@ class RPG2k
         refresh_desc
       end
 
+      # The destination list is a two-column grid too, not a single stacked
+      # column -- confirmed against genuine RPG_RT's own live source:
+      # `Window_Teleport` (`src/window_teleport.cpp`) sets `column_max = 2`
+      # (`Window_Selectable`'s `wrap_limit` default is also 2, the exact
+      # threshold `Window_Selectable::Update`'s RIGHT/LEFT handling gates on),
+      # the identical shape this class's own skill list already ports (see
+      # `COLUMN_MAX`'s comment). With exactly two destinations, DOWN/UP are
+      # no-ops (nothing in the row below/above) and RIGHT reaches the second
+      # one -- not DOWN, which this scene wrongly wired to a single-column
+      # modulo wrap with no RIGHT/LEFT handling at all.
       def update_teleport_target
         targets = teleport_targets
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           leave_teleport_target
-        elsif (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !targets.empty?
-          @teleport_index += 1
-          @teleport_index %= targets.size
-          refresh_teleport_cursor
-          play_system_se(SFX_CURSOR)
-        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !targets.empty?
-          @teleport_index -= 1
-          @teleport_index %= targets.size
-          refresh_teleport_cursor
-          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+          move_teleport_cursor(COLUMN_MAX)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+          move_teleport_cursor(-COLUMN_MAX)
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
+          move_teleport_cursor(1) if (@teleport_index + 1) % COLUMN_MAX != 0
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
+          move_teleport_cursor(-1) if @teleport_index % COLUMN_MAX != 0
         elsif Input.trigger?(Input::C) && !targets.empty?
           play_system_se(SFX_DECISION)
           map_id, = targets[@teleport_index]
           apply_teleport_skill(@pending_skill, map_id)
         end
+      end
+
+      # Move the teleport-target cursor by `delta` grid cells, ignored if that
+      # cell is off the grid -- mirrors #move_skill_cursor exactly (see its
+      # own comment).
+      def move_teleport_cursor(delta)
+        targets = teleport_targets
+        return if targets.empty?
+        target = @teleport_index + delta
+        return if target < 0 || target >= targets.size
+        @teleport_index = target
+        refresh_teleport_cursor
+        play_system_se(SFX_CURSOR)
       end
 
       # Escape (type 1) warps to the single registered escape target with no
@@ -506,11 +527,18 @@ class RPG2k
         name.nil? || name.empty? ? "Map #{map_id}" : name
       end
 
+      # Column width for the teleport-destination grid (see #update_teleport_target's
+      # grid comment above; identical formula to #skill_col_w).
+      def teleport_col_w
+        (SCREEN_W - Window::BORDER * 2) / COLUMN_MAX
+      end
+
       def build_teleport_window
         @teleport_window.dispose if @teleport_window
         rows = teleport_targets
         inner_w = SCREEN_W - Window::BORDER * 2
-        h = [rows.size, 1].max * LINE_H
+        grid_rows = [(rows.size / COLUMN_MAX.to_f).ceil, 1].max
+        h = grid_rows * LINE_H
         @teleport_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
                                       SCREEN_W, h + Window::BORDER * 2)
         @teleport_window.z = 450
@@ -520,8 +548,11 @@ class RPG2k
         if rows.empty?
           c.draw_text 0, 0, inner_w, LINE_H, "No destinations"
         else
+          col_w = teleport_col_w
           rows.each_with_index do |(_id, name), i|
-            c.draw_text 0, i * LINE_H, inner_w, LINE_H, name
+            x = (i % COLUMN_MAX) * col_w
+            y = (i / COLUMN_MAX) * LINE_H
+            c.draw_text x, y, col_w, LINE_H, name
           end
         end
         @teleport_window.contents = c
@@ -531,8 +562,9 @@ class RPG2k
       def refresh_teleport_cursor
         return unless @teleport_window
         h = teleport_targets.empty? ? 0 : LINE_H
-        @teleport_window.cursor_rect =
-          Rect.new(0, @teleport_index * LINE_H, @teleport_window.contents.width, h)
+        x = (@teleport_index % COLUMN_MAX) * teleport_col_w
+        y = (@teleport_index / COLUMN_MAX) * LINE_H
+        @teleport_window.cursor_rect = Rect.new(x, y, teleport_col_w, h)
       end
 
       def drive_message

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17114,7 +17114,16 @@ check 'Scene::ItemMenu: a special item invoking Teleport opens a destination ' \
      'both registered destinations, ascending by map id (this fixture parent carries no map tree)'
   ok state.pending_teleport.nil?, 'opening the list does not warp yet'
 
-  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the second destination (map 20)
+  # The destination list is itself a two-column grid (confirmed against
+  # genuine RPG_RT's live source: `Window_Teleport` sets `column_max = 2`,
+  # `src/window_teleport.cpp`) -- with only two destinations, DOWN is a
+  # no-op (nothing in the row below) and RIGHT is what reaches the second
+  # one, not DOWN.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # no cell below -- a no-op
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@teleport_index), 'Down has nothing to move onto'
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second destination (map 20)
   scene.update
   RGSS::Input.reset
   RGSS::Input.triggered = [RGSS::Input::C]           # confirm it
@@ -17312,7 +17321,11 @@ check 'Scene::SkillMenu: a Teleport skill opens a destination list and queues th
      '(this fixture parent carries no map tree)'
   ok state.pending_teleport.nil?, 'opening the list does not warp yet'
 
-  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the second destination (map 20)
+  # The destination list is itself a two-column grid (confirmed against
+  # genuine RPG_RT's live source: `Window_Teleport` sets `column_max = 2`,
+  # `src/window_teleport.cpp`) -- RIGHT is what reaches the second
+  # destination, not DOWN.
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second destination (map 20)
   scene.update
   RGSS::Input.reset
   RGSS::Input.triggered = [RGSS::Input::C]           # confirm it
@@ -17334,7 +17347,7 @@ check 'Scene::SkillMenu: a Teleport skill turns on the chosen destination\'s own
   RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
   scene.update
   RGSS::Input.reset
-  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the second destination (map 20)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second destination (map 20)
   scene.update
   RGSS::Input.reset
   RGSS::Input.triggered = [RGSS::Input::C]           # confirm map 20, the one with a switch


### PR DESCRIPTION
## Summary

- `Window_Teleport` (`src/window_teleport.cpp`) sets `column_max = 2` on construction. `Window_Selectable::Update` (`src/window_selectable.cpp`) moves DOWN/UP by a whole `column_max`-wide row (a no-op with no row below/above) and only moves RIGHT/LEFT by one cell, gated on `column_max >= wrap_limit` (`wrap_limit` defaults to 2).
- `Scene::ItemMenu#update_teleport_target` / `Scene::SkillMenu`'s own copy (`mruby-rpg2k/mrblib/scene/{item,skill}_menu.rb`) instead wired only DOWN/UP to a plain `%= targets.size` wrap, with no RIGHT/LEFT handling at all — so with exactly two destinations (the repo's own existing test fixture), DOWN reached the second one and RIGHT did nothing, the inverse of genuine RPG_RT.
- Fixed by mirroring `#move_item_cursor`/`#move_skill_cursor`'s already wine-verified grid-cursor pattern (both classes already define `COLUMN_MAX = 2` for their own lists) into a new `#move_teleport_cursor` in each scene, and laying `build_teleport_window`'s entries out in the same grid the item/skill windows already use.

## Test plan

- [x] The repo's own pre-existing teleport-picker tests (`scripts/rpg2k_scene_check.rb`, both `Scene::ItemMenu` and `Scene::SkillMenu`) were corrected from DOWN to RIGHT to reach the second destination, and a new assertion that DOWN is a no-op from the first destination was added.
- [x] Verified via `git stash` on the two scene files alone: 3 of 784 `rpg2k_scene_check.rb` checks fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 784 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_