### PR TITLE
mv/mz: tap confirm to clear a blocking message before the move probe walks

### DIFF
--- a/changelog.d/mv-mz-move-probe-confirm-tap.changed.md
+++ b/changelog.d/mv-mz-move-probe-confirm-tap.changed.md
@@ -1,0 +1,9 @@
+- **MV/MZ move probe** (`--mv_move_test`/`--mz_move_test`, CI): now taps
+  confirm to clear a blocking message window before it starts holding a
+  direction, the way RGSS's own script-host driver already does. Previously
+  it started walking the instant `Scene_Map` appeared, so a real game whose
+  opening event shows text or choices the moment the map loads swallowed
+  every movement key and reported "did not move" — not because the engine
+  failed to walk the player, but because the probe never got a turn. The
+  check is conditional on `$gameMessage.isBusy()`, so a project with no
+  opening dialogue pays no extra time.

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -26,6 +26,35 @@ class MV
   MOVE_PROBE_DWELL = 20
   MOVE_PROBE_FRAMES = 80
 
+  # Settle window before the move probe starts holding a direction (see
+  # #maybe_move_test): only paid when $gameMessage is actually busy, and the
+  # confirm-key tap cadence within it.
+  #
+  # RGSS's own script-host driver (mruby-rpgxp/mrblib/script_host.rb) taps
+  # confirm every CONFIRM_EVERY frames from boot onward and only suppresses it
+  # once its move probe starts holding a direction; a real game's autorun
+  # opening dialogue (a Show Text/Show Choices sequence that runs the instant
+  # the map loads, before the player can act) gets cleared by one of those taps
+  # long before the probe needs to walk. MV/MZ's probe had no equivalent: it
+  # started holding a direction the instant Scene_Map appeared, so a blocking
+  # message window swallowed the input frame after frame and every real game
+  # with an opening cutscene reported "did not move" — not because the engine
+  # failed to walk the player, but because the probe never got a turn.
+  #
+  # A fixed-length settle window (paid on every run, dialogue or not) was
+  # tried first and reverted: measured against the real data/Lunatic-Core bed
+  # under CI's own tight `--timeout_ms=6000` budget, 60 extra frames of
+  # confirm-tapping were enough to blow straight through it with zero probe
+  # output, because a confirm tap that actually lands on a real game can
+  # advance real event logic (more loads, more rendering), not just close an
+  # empty window. #message_busy? makes the wait conditional instead: a game
+  # with no opening dialogue (message_busy? false the instant Scene_Map
+  # appears) pays nothing and moves exactly as before; MOVE_SETTLE_MAX_FRAMES
+  # is only a safety cap on a game that is genuinely still busy.
+  MOVE_SETTLE_MAX_FRAMES = 180
+  CONFIRM_TAP_EVERY = 20
+  CONFIRM_TAP_HOLD = 4
+
   # The files that unambiguously mark a directory as an RPG Maker MV project:
   # the core engine script and the system database. (MZ uses `js/rmmz_core.js`
   # instead and is a separate, later target — see ADR 0004, milestone M6.)
@@ -145,6 +174,33 @@ class MV
       dirs = [RGSS::Input::DOWN, RGSS::Input::RIGHT,
               RGSS::Input::UP, RGSS::Input::LEFT]
       dirs[(frame / MOVE_PROBE_DWELL) % dirs.length]
+    end
+
+    # Taps the confirm key (RGSS::Input::C, MV/MZ's "ok") once every
+    # CONFIRM_TAP_EVERY frames, held for CONFIRM_TAP_HOLD of them — enough to
+    # register as a press through #sync_input without holding it into the next
+    # tap's window. `frame` is the caller's own settle-window frame counter
+    # (0-based), not the global frame count, so a probe that starts settling
+    # later in the run still gets its first tap at the same relative offset.
+    def confirm_settle_tap(frame)
+      phase = frame % CONFIRM_TAP_EVERY
+      RGSS::Input.press(RGSS::Input::C) if phase == 0
+      RGSS::Input.release(RGSS::Input::C) if phase == CONFIRM_TAP_HOLD
+    end
+
+    # Whether $gameMessage currently holds text a Window_Message is (or is
+    # about to be) showing — the same read the message probe uses
+    # (#maybe_message_test) to avoid stacking its own message onto a game's.
+    # Used by the move probe's settle window to decide whether it has anything
+    # to wait out at all. `false` (not busy, or the engine is not up yet)
+    # whenever the read itself fails, so a probe never hangs waiting on this.
+    def message_busy?
+      MV::JS.eval(
+        "(typeof $gameMessage !== 'undefined' && $gameMessage && " \
+        "$gameMessage.isBusy()) ? true : false"
+      ) == true
+    rescue StandardError
+      false
     end
 
     # JS that pushes a pointer sample (canvas x/y, left-button pressed) into MV's
@@ -512,10 +568,31 @@ class MV
   # input actually walks the player, not just that the map renders. The input is
   # pushed into MV by next frame's #sync_input. One-shot; a no-op during normal
   # play (flag unset).
+  #
+  # Before any direction is held, the probe checks whether $gameMessage is
+  # already busy (see .message_busy?): a real game's opening autorun event can
+  # run a Show Text/Show Choices sequence the instant the map loads, and a
+  # blocking message window swallows movement input frame after frame — the
+  # probe would report "did not move" not because the engine failed to walk
+  # the player, but because it never got a turn against the game's own event.
+  # If it is, confirm gets tapped (see .confirm_settle_tap) until the message
+  # clears or MOVE_SETTLE_MAX_FRAMES runs out; if it never was busy to begin
+  # with, movement starts immediately, exactly as before this existed.
   def maybe_move_test
     return if @move_test_done
     return unless move_test_requested?
     return unless current_scene == "Scene_Map"
+
+    unless @move_settled
+      @move_settle_frame ||= 0
+      if self.class.message_busy? && @move_settle_frame < MOVE_SETTLE_MAX_FRAMES
+        self.class.confirm_settle_tap(@move_settle_frame)
+        @move_settle_frame += 1
+        return
+      end
+      RGSS::Input.release(RGSS::Input::C)
+      @move_settled = true
+    end
 
     @move_frame ||= 0
     if @move_frame.zero?

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -1299,6 +1299,17 @@ class MZ
   # are read by the next frame's #sync_input. One-shot; a no-op during normal
   # play. Mirrors MV#maybe_move_test, and reuses MV's probe cadence and direction
   # cycle so both runtimes are exercised the same way.
+  #
+  # Before any direction is held, the probe checks whether $gameMessage is
+  # already busy (see MV.message_busy?): a real game's opening autorun event
+  # can run a Show Text/Show Choices sequence the instant the map loads, and a
+  # blocking message window swallows movement input frame after frame — the
+  # probe would report "did not move" not because the engine failed to walk
+  # the player, but because it never got a turn against the game's own event.
+  # If it is, confirm gets tapped (see MV.confirm_settle_tap) until the
+  # message clears or MV::MOVE_SETTLE_MAX_FRAMES runs out; if it never was
+  # busy to begin with, movement starts immediately, exactly as before this
+  # existed.
   def maybe_move_test
     return if @move_test_done
     return unless move_test_requested?
@@ -1312,6 +1323,17 @@ class MZ
       @move_test_done = true
       $stderr.puts "[MZ-MOVE] never reached the map (scene #{current_scene})"
       return
+    end
+
+    unless @move_settled
+      @move_settle_frame ||= 0
+      if MV.message_busy? && @move_settle_frame < MV::MOVE_SETTLE_MAX_FRAMES
+        MV.confirm_settle_tap(@move_settle_frame)
+        @move_settle_frame += 1
+        return
+      end
+      RGSS::Input.release(RGSS::Input::C)
+      @move_settled = true
     end
 
     @move_frame ||= 0

--- a/mruby-mvjs/test/input_test.rb
+++ b/mruby-mvjs/test/input_test.rb
@@ -2,6 +2,46 @@
 # terminal backends) mapped onto MV's virtual buttons and pushed into MV's
 # `Input._currentState`, which its scenes read for navigation/confirm/cancel.
 
+assert 'MV.confirm_settle_tap presses confirm briefly once per cadence, then releases' do
+  RGSS::Input.release(RGSS::Input::C)
+
+  # No tap yet at a frame between cycles.
+  MV.confirm_settle_tap(1)
+  assert_false MV.pressed_buttons.include?("ok")
+
+  # Pressed at the start of a cycle...
+  MV.confirm_settle_tap(0)
+  assert_true MV.pressed_buttons.include?("ok")
+
+  # ...held through the frame before CONFIRM_TAP_HOLD...
+  MV.confirm_settle_tap(MV::CONFIRM_TAP_HOLD - 1)
+  assert_true MV.pressed_buttons.include?("ok")
+
+  # ...and released once CONFIRM_TAP_HOLD is reached.
+  MV.confirm_settle_tap(MV::CONFIRM_TAP_HOLD)
+  assert_false MV.pressed_buttons.include?("ok")
+
+  # The next cycle (frame == CONFIRM_TAP_EVERY) presses again, so a probe that
+  # calls this every frame keeps tapping for as long as the caller drives it.
+  MV.confirm_settle_tap(MV::CONFIRM_TAP_EVERY)
+  assert_true MV.pressed_buttons.include?("ok")
+ensure
+  RGSS::Input.release(RGSS::Input::C)
+end
+
+assert 'MV.message_busy? tracks $gameMessage.isBusy, and never raises' do
+  # Undefined engine global: the move probe's settle window must not hang
+  # waiting on a read that can never succeed.
+  MV::JS.eval("globalThis.$gameMessage = undefined;")
+  assert_false MV.message_busy?
+
+  MV::JS.eval("globalThis.$gameMessage = { isBusy: function(){ return true; } };")
+  assert_true MV.message_busy?
+
+  MV::JS.eval("globalThis.$gameMessage = { isBusy: function(){ return false; } };")
+  assert_false MV.message_busy?
+end
+
 assert 'MV maps RGSS input keys to MV virtual buttons' do
   # Start from a clean slate so unrelated state can't leak in.
   [RGSS::Input::C, RGSS::Input::B, RGSS::Input::UP, RGSS::Input::DOWN,


### PR DESCRIPTION
## Summary

- `--mv_move_test`/`--mz_move_test` started holding a direction the instant `Scene_Map` appeared. A real game whose opening autorun event shows text or choices immediately swallows every movement key frame after frame, so the probe reports "did not move" — not because movement is broken, but because it never got a turn against the game's own event. RGSS's own script-host driver (`mruby-rpgxp/mrblib/script_host.rb`) already handles this: it taps confirm periodically from boot and only suppresses it while its own move probe is walking. MV/MZ's probe had no equivalent.
- `MV.message_busy?` reads `$gameMessage.isBusy()` the same way the existing message probe (`#maybe_message_test`) already does, and `MV.confirm_settle_tap` taps confirm while it is — mirroring RGSS's cadence.
- A fixed-length settle window (paid unconditionally, dialogue or not) was tried first and reverted: measured against the real `data/Lunatic-Core` test bed under CI's own `--timeout_ms=6000` budget, a blind 60-frame wait blew straight through it with **zero** probe output, because a confirm tap on a real game can advance real event logic (more asset loads, more rendering), not just close an empty window. Making the wait conditional on `message_busy?` fixes that: a project with no opening dialogue (`message_busy?` false the instant the map appears) pays nothing and behaves exactly as before this change.

## Test plan

- [x] `rake test` (full mruby gem suite, includes new coverage for `MV.confirm_settle_tap` and `MV.message_busy?` in `input_test.rb`) — 1839 OK, 0 KO, 0 Crash.
- [x] `./build/rpg_maker_clone --timeout_ms=6000 --game_dir data/Lunatic-Core --test_play --mv_new_game --mv_move_test` — the exact command and budget CI's non-blocking "MV real-game play smoke test" step uses. Before this fix's final (conditional) form, a blind fixed settle window blew this budget with no `[MV-MOVE]` output at all; with the conditional check, `moved=true` at the same budget (Lunatic-Core has no blocking opening dialogue, so the settle window costs nothing).
- [x] `./build/rpg_maker_clone --timeout_ms=5000 --game_dir data/mv-sample --test_play --mv_new_game --mv_move_test` — unchanged `moved=true`, same CI budget.
- [x] `MZ_MODE=play scripts/mz_boot_check.bash` and `MZ_MODE=animation scripts/mz_boot_check.bash` — unchanged `OK`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_