### PR TITLE
A held Down/Up at the last/first save slot wrongly wraps the cursor

### DIFF
--- a/changelog.d/save-load-held-cursor-boundary-wrap.fixed.md
+++ b/changelog.d/save-load-held-cursor-boundary-wrap.fixed.md
@@ -1,0 +1,5 @@
+- **Save/Load screen:** Holding Down/Up at the last/first save slot no
+  longer wraps the cursor around while the key is still held -- matching
+  RPG_RT, it now freezes at the boundary slot until the key is released
+  and pressed again; a fresh tap still wraps immediately as before.
+  Covered by three new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4292,6 +4292,33 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check (`Input.repeated` set with
   `Input.triggered` empty still advances the cursor one slot), confirmed
   to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-19): a held (not freshly tapped) Down/Up at the
+  last/first save slot wrongly wrapped the cursor around, when real RPG_RT
+  freezes it there until the key is released and pressed again — a bug the
+  auto-repeat fix just above introduced by citing the wrong base class.**
+  That bullet's own citation of `Window_Selectable::Update` as "the base
+  class the real save/load file list is built on" was wrong: confirmed
+  against RPG_RT's live source, `Window_SaveFile` (`src/window_savefile.cpp`)
+  is a plain `Window_Base`, not a `Window_Selectable` — real RPG_RT's own
+  `Scene_File::vUpdate` (`src/scene_file.cpp`) hand-rolls this list's cursor
+  logic itself: `if (Input::IsRepeated(Input::DOWN) || ...) { if
+  (Input::IsTriggered(Input::DOWN) || ... || index < max_index) { ... index =
+  (index + 1) % file_windows.size(); } }` — the inner condition means a
+  *fresh* `IsTriggered` always advances and wraps unconditionally, but once
+  the key is merely auto-repeating (`IsRepeated` true, `IsTriggered` false),
+  the advance itself is skipped once `index` has nowhere to go but wrap
+  (`index == max_index`); Up mirrors this at `index == 0`. `#move_selection`
+  (`mruby-rpg2k/mrblib/scene/save_load.rb`) wrapped via plain modulo
+  regardless of which of `Input.trigger?`/`Input.repeat?` fired, so once
+  auto-repeat kicked in at the last slot, the cursor silently snapped back to
+  the first without the player releasing the key. Fixed by threading an
+  `allow_wrap:` flag (true only on `Input.trigger?`, matching `vUpdate`'s own
+  split) through `#move_selection`, skipping the advance entirely when it
+  would need to wrap and `allow_wrap` is false. Three new
+  `scripts/rpg2k_scene_check.rb` checks (a held Down at the last slot stays
+  put; a held Up at the first slot stays put; a fresh tap at the last slot
+  still wraps, unchanged) — the first two confirmed to fail against the
+  pre-fix code (`expected 14, got 0` / `expected 0, got 14`).
   ✅ **The same auto-repeat gap, lifted into `Scene::Menu` (the main field
   menu) next, as flagged above (2026-08-18).** All three of its own cursor
   spots only ever checked `Input.trigger?`: `#update_command` (the five

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -122,23 +122,25 @@ class RPG2k
           play_system_se(SFX_CANCEL)
           @parent.pop
         # Holding Down/Up auto-repeats the cursor after the initial delay, not
-        # just a single step per tap -- EasyRPG's `Window_Selectable::Update`
-        # (`src/window_selectable.cpp`), which this screen's file list is a
-        # subclass of, falls through to `Input::IsRepeated` right after its
-        # own `IsTriggered` check. The timing genuinely matches this build's
-        # own `Input.repeat?` already: EasyRPG's `start_repeat_time = 23`/
+        # just a single step per tap. `Window_SaveFile` (`src/window_savefile.cpp`)
+        # is a plain `Window_Base`, not a `Window_Selectable` -- real RPG_RT's
+        # own `Scene_File::vUpdate` (`src/scene_file.cpp`) hand-rolls this
+        # list's index/scroll logic itself, entirely separate from
+        # `Window_Selectable`'s generic cursor machinery every item/skill/
+        # message list goes through (correcting this comment's own earlier,
+        # mistaken citation). Its repeat timing still genuinely matches this
+        # build's own `Input.repeat?`: EasyRPG's `start_repeat_time = 23`/
         # `repeat_time = 4` (`src/input.cpp`) first fires once `press_time`
-        # reaches 24 (23 is not a multiple of 4, 24 is) and every 4 frames
-        # after, exactly the 24-then-every-4 timing `Input.repeat?`
-        # documents (`mruby-rgss/mrblib/lib.rb`), already measured against
-        # genuine RPG_RT.exe -- so this is a pure wiring gap, not a new
-        # timing to invent, matching the identical `#trigger? ||
-        # #repeat?` gate `Scene::Map#drive_number_input`'s Enter Number
-        # digit widget already uses for the same reason.
+        # reaches 24 and every 4 frames after, exactly the 24-then-every-4
+        # timing `Input.repeat?` documents (`mruby-rgss/mrblib/lib.rb`),
+        # already measured against genuine RPG_RT.exe. `#move_selection`'s
+        # own comment covers the one real nuance `vUpdate` adds on top of
+        # that timing: a *held* Down/Up does not wrap past the last/first
+        # slot, only a fresh tap does.
         elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
-          move_selection 1
+          move_selection(1, allow_wrap: Input.trigger?(Input::DOWN))
         elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
-          move_selection(-1)
+          move_selection(-1, allow_wrap: Input.trigger?(Input::UP))
         elsif Input.trigger?(Input::C)
           confirm_selection
         end
@@ -146,8 +148,21 @@ class RPG2k
 
       private
 
-      def move_selection(delta)
-        @index = (@index + delta) % SLOT_COUNT
+      # Move the slot cursor by `delta`, wrapping past the first/last slot
+      # only when `allow_wrap` is true. Confirmed against RPG_RT's own live
+      # source: `Scene_File::vUpdate` (`src/scene_file.cpp`) advances
+      # `index = (index + 1) % file_windows.size()` unconditionally on a
+      # fresh `IsTriggered(DOWN)` (so a tap at the last slot always wraps to
+      # the first), but on a bare `IsRepeated(DOWN)` (the key still held past
+      # the auto-repeat threshold) that same advance is gated on `index <
+      # max_index` -- a sustained hold simply stops moving at the last slot
+      # rather than cycling back around, the mirror image for Up at the
+      # first slot. `#update` passes `allow_wrap:` true only for the frame a
+      # direction is freshly pressed, matching that split exactly.
+      def move_selection(delta, allow_wrap:)
+        target = @index + delta
+        return if (target == SLOT_COUNT || target == -1) && !allow_wrap
+        @index = target % SLOT_COUNT
         @top = @index if @index < @top
         @top = @index - VISIBLE_SLOTS + 1 if @index >= @top + VISIBLE_SLOTS
         refresh_slot_windows

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16514,6 +16514,47 @@ check 'Scene::SaveLoad: holding Down auto-repeats the cursor, not just a ' \
      'a held (repeated, not triggered) Down still moves the cursor one slot'
 end
 
+# Confirmed directly against RPG_RT's live source: `Scene_File::vUpdate`
+# (`src/scene_file.cpp`) advances the index unconditionally on a fresh
+# `IsTriggered(DOWN)` -- a tap at the last slot always wraps to the first --
+# but a bare `IsRepeated(DOWN)` (the key already auto-repeating) gates that
+# same advance on `index < max_index`: a sustained hold simply stops at the
+# last slot rather than cycling back around, only wrapping once the player
+# releases and presses again. The mirror case holds for Up at the first
+# slot. `Window_SaveFile` is a plain `Window_Base`, not a `Window_Selectable`
+# -- this nuance is `Scene_File`'s own, not the generic list-cursor machinery
+# every other menu's `#repeat?` wiring goes through.
+check 'Scene::SaveLoad: a held (not freshly tapped) Down does not wrap past ' \
+      'the last slot' do
+  scene, = save_load_scene(:load)
+  scene.instance_variable_set(:@index, RPG2k::MAX_SAVE_SLOTS - 1)
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq RPG2k::MAX_SAVE_SLOTS - 1, scene.instance_variable_get(:@index),
+     'a held Down at the last slot stays put instead of wrapping to the first'
+end
+
+check 'Scene::SaveLoad: a held (not freshly tapped) Up does not wrap past ' \
+      'the first slot' do
+  scene, = save_load_scene(:load)
+  RGSS::Input.repeated = [RGSS::Input::UP] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@index),
+     'a held Up at the first slot stays put instead of wrapping to the last'
+end
+
+check 'Scene::SaveLoad: a fresh tap of Down still wraps past the last slot' do
+  scene, = save_load_scene(:load)
+  scene.instance_variable_set(:@index, RPG2k::MAX_SAVE_SLOTS - 1)
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # a fresh tap, not merely held
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@index),
+     'unlike a held repeat, a fresh tap at the last slot does wrap to the first'
+end
+
 check 'Scene::SaveLoad: cancelling (B) pops back without touching the parent app' do
   scene, parent = save_load_scene(:load)
   RGSS::Input.triggered = [RGSS::Input::B]


### PR DESCRIPTION
## Summary

- `Window_SaveFile` (`src/window_savefile.cpp`) is a plain `Window_Base`, not a `Window_Selectable` — a prior fix's own comment wrongly cited `Window_Selectable::Update` as the base this list is built on. Real RPG_RT's own `Scene_File::vUpdate` (`src/scene_file.cpp`) hand-rolls this list's cursor logic itself:
  ```cpp
  if (Input::IsRepeated(Input::DOWN) || ...) {
    if (Input::IsTriggered(Input::DOWN) || ... || index < max_index) {
      index = (index + 1) % file_windows.size();
    }
  }
  ```
  A fresh `IsTriggered` always advances and wraps unconditionally, but once the key is merely auto-repeating (`IsRepeated` true, `IsTriggered` false), the advance itself is skipped once `index` has nowhere to go but wrap. Up mirrors this at `index == 0`.
- `Scene::SaveLoad#move_selection` (`mruby-rpg2k/mrblib/scene/save_load.rb`) wrapped via plain modulo regardless of which of `Input.trigger?`/`Input.repeat?` fired, so once auto-repeat kicked in at the last slot, the cursor silently snapped back to the first without the player releasing the key.
- Fixed by threading an `allow_wrap:` flag (true only on `Input.trigger?`, matching `vUpdate`'s own split) through `#move_selection`, skipping the advance entirely when it would need to wrap and `allow_wrap` is false.

## Test plan

- [x] Three new `scripts/rpg2k_scene_check.rb` checks: a held Down at the last slot stays put; a held Up at the first slot stays put; a fresh tap at the last slot still wraps, unchanged.
- [x] Verified via `git stash` on `save_load.rb` alone: the first two checks fail pre-fix (`expected 14, got 0` / `expected 0, got 14`).
- [x] Full suite green: `rpg2k_scene_check.rb` 787 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_