### PR TITLE
Dispose all scenes in stack when loading a save game

### DIFF
--- a/changelog.d/scene-stack-dispose-on-load.fixed.md
+++ b/changelog.d/scene-stack-dispose-on-load.fixed.md
@@ -1,0 +1,13 @@
+- **Loading a save no longer leaves a stray window/sprite from the scene it
+  was opened over.** `RPG2k#continue_game` and `#start_new_game` replaced
+  `@scenes` with the new `Scene::Map` after disposing only `@scenes.last`,
+  unlike `#return_to_title` / `#show_game_over`, which already dispose every
+  scene in the stack. Loading from the title screen's Continue (stack
+  `[Title, SaveLoad]`) dropped the `Title` scene's command window and
+  background sprite without disposing them, leaving them drawn on top of
+  every later scene, including a subsequent `RPG2k::Scene::Battle`. Loading
+  mid-battle via the Open Load Menu event command (stack
+  `[Map, SaveLoad]`, RPG2003's 5001) dropped the old `Scene::Map` instead,
+  so its live `@battle` was never disposed either, orphaning the whole
+  battle UI. Both methods now dispose every scene in `@scenes` before
+  swapping in the loaded map, matching `#return_to_title`.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -688,7 +688,7 @@ class RPG2k
     # Build the play scene first; only tear down the title once it succeeds so a
     # data problem leaves the title intact instead of a blank screen.
     scene = Scene::Map.new(self, state)
-    @scenes.last.dispose
+    @scenes.each { |s| s.dispose if s.respond_to?(:dispose) }
     @scenes = [scene]
     # A machine-readable marker so a headless run (see --rpg2k_new_game and
     # scripts/compare-nepheshel-wine.bash) can assert the map scene was really
@@ -842,7 +842,7 @@ class RPG2k
     # it as), which re-deriving from the current map's tree here would
     # silently discard. See Scene::Map#initialize's own comment.
     scene = Scene::Map.new(self, state, apply_access: false)
-    @scenes.last.dispose
+    @scenes.each { |s| s.dispose if s.respond_to?(:dispose) }
     @scenes = [scene]
     # Same marker start_new_game emits, so a headless run resuming a save (see
     # --rpg2k_continue) can assert which map it landed on -- which for a save


### PR DESCRIPTION
## Summary
Fixed a bug where loading a save game would leave stray windows and sprites from previously active scenes rendered on top of the loaded map. This occurred because only the last scene in the stack was being disposed instead of all scenes.

## Changes
- Modified `RPG2k#start_new_game` to dispose all scenes in `@scenes` before replacing the stack with the new `Scene::Map`
- Modified `RPG2k#continue_game` to dispose all scenes in `@scenes` before replacing the stack with the loaded `Scene::Map`
- Both methods now match the behavior of `#return_to_title` and `#show_game_over`, which already disposed the entire scene stack

## Details
The bug manifested in two scenarios:
1. **Loading from title screen** (Continue button): The `Title` scene's command window and background sprite were left undisposed, appearing on top of the loaded map and subsequent scenes
2. **Loading mid-battle** (Open Load Menu event command in RPG2003): The old `Scene::Map` and its associated `@battle` object were left undisposed, orphaning the entire battle UI

The fix ensures all scenes are properly disposed before loading a save, preventing any visual artifacts from persisting into the loaded game state.

https://claude.ai/code/session_014TkjcwHDDwjmWWoNVr2bd9