### PR TITLE
Right silently moves the cursor on a single-digit Input Number widget

### DIFF
--- a/changelog.d/number-input-single-digit-right-noop.fixed.md
+++ b/changelog.d/number-input-single-digit-right-noop.fixed.md
@@ -1,0 +1,4 @@
+- **Input Number widget:** On a single-digit prompt, Right no longer moves
+  the cursor or plays the Cursor sound effect -- matching RPG_RT, it is a
+  complete no-op there, while Left still plays the sound as before.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11794,6 +11794,26 @@ not yet verified:
   — all four confirmed to fail against the pre-fix code with the corrected
   expectation (`expected 1, got 10`) before the fix, and the dedicated
   logic-check test confirmed to fail on its own (`expected 2, got 0`) too.
+  ✅ **Follow-up (2026-08-19): Right silently moved the digit cursor and
+  played the Cursor SE on a single-digit Input Number widget, when real
+  RPG_RT treats Right as a complete no-op there — no move, no sound —
+  correcting this file's own previous bullet, which quoted Left/Right as
+  "genuine modulo wraparound... and its mirror" without noticing the two
+  are not actually symmetric.** Confirmed directly against RPG_RT's live
+  source: `Window_NumberInput::Update` (`src/window_numberinput.cpp`) gates
+  only its Right branch behind `if (digits_max >= 2) { ...SePlay...;
+  index = (index + 1) % ...; }` — Left has no such guard and always plays
+  `SFX_Cursor`, even on a one-digit widget where its own modulo leaves the
+  single-cell cursor unmoved either way. `#drive_number_input`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) treated Left/Right identically, so a
+  one-digit Input Number prompt (a common "pick 0-9" dialog) played the
+  cursor SE on every Right tap/repeat just like Left, when the reference
+  plays nothing at all for Right there. Fixed by gating the Right branch on
+  `model.digits >= 2`, leaving Left unconditional exactly as the reference
+  does. Covered by a new `scripts/rpg2k_scene_check.rb` check on a 1-digit
+  widget (Right plays no SE at all; Left still plays the cursor SE),
+  confirmed to fail against the pre-fix code (`expected [], got
+  [["Cursor1", ...]]`).
 - ✅ **A Face Graphic setting persists through the rest of the current event's
   execution content (not just the next message) and is auto-cleared when
   the event ends, but not before** — it must be explicitly "erased" to stop

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7574,7 +7574,14 @@ class RPG2k
           model.left
           draw_number_input
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
+        # Right is a no-op -- no move, no sound -- on a single-digit widget:
+        # confirmed against RPG_RT's own live source, `Window_NumberInput::
+        # Update` (src/window_numberinput.cpp) guards only its Right branch
+        # behind `if (digits_max >= 2)`; Left has no such guard and always
+        # plays the Cursor SE, even though its own modulo leaves a
+        # single-cell cursor unmoved either way. Not the symmetric pair a
+        # single `#left`/`#right` gate would suggest.
+        elsif (Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)) && model.digits >= 2
           model.right
           draw_number_input
           play_system_se(SFX_CURSOR)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3787,6 +3787,35 @@ check 'Input Number plays the Cursor SE on every digit move and Decision on conf
   eq 'Decision1', RGSS::Audio.se_calls.last&.first, 'confirming plays the decision SE'
 end
 
+check 'Input Number: on a single-digit widget, Right is a silent no-op but ' \
+      'Left still plays the cursor SE' do
+  # Confirmed against RPG_RT's own live source, Window_NumberInput::Update
+  # (src/window_numberinput.cpp): Right is guarded behind `if (digits_max >=
+  # 2)` -- no move, no sound, on a one-digit widget -- but Left has no such
+  # guard and always plays SFX_Cursor, even though its own modulo leaves a
+  # single-cell cursor unmoved either way. Not the symmetric pair the
+  # existing two-digit check above might suggest.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::INPUT_NUMBER, [1, 5])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+
+  ni = nil
+  12.times { scene.update; ni = scene.instance_variable_get(:@number_input); break if ni }
+  ok ni, 'the number-entry widget opened'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  eq [], RGSS::Audio.se_calls, 'Right on a single-digit widget plays nothing'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::LEFT]
+  scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first,
+     'Left still plays the cursor SE even on a single-digit widget'
+end
+
 check 'a message types out gradually, then a button completes and dismisses it' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Window_NumberInput::Update` (`src/window_numberinput.cpp`) gates only its Right branch behind `if (digits_max >= 2) { ...SePlay...; index = (index + 1) % ...; }`. Left has no such guard and always plays `SFX_Cursor`, even on a one-digit widget where its own modulo leaves the single-cell cursor unmoved either way — the two are not the symmetric pair a prior `docs/TODO.md` bullet's "genuine modulo wraparound... and its mirror" description suggested.
- `#drive_number_input` (`mruby-rpg2k/mrblib/scene/map.rb`) treated Left/Right identically, so a one-digit Input Number prompt (a common "pick 0-9" dialog) played the cursor SE on every Right tap/repeat just like Left, when real RPG_RT plays nothing at all for Right there.
- Fixed by gating the Right branch on `model.digits >= 2`, leaving Left unconditional exactly as the reference does.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check on a 1-digit widget: Right plays no SE at all, Left still plays the cursor SE.
- [x] Verified via `git stash` on `map.rb` alone: fails pre-fix (`expected [], got [["Cursor1", ...]]`).
- [x] Full suite green: `rpg2k_scene_check.rb` 788 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_