### PR TITLE
Right/Left do nothing during battle ally-target selection

### DIFF
--- a/changelog.d/battle-ally-target-right-left-cursor.fixed.md
+++ b/changelog.d/battle-ally-target-right-left-cursor.fixed.md
@@ -1,0 +1,4 @@
+- **Battle ally-target selection:** Right/Left now move the cursor exactly
+  like Down/Up when choosing which ally to heal or use an item on, matching
+  RPG_RT -- previously they did nothing at all. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4475,6 +4475,38 @@ The work below is roughly ordered by the critical path to a walkable game
   same `|| Input.repeat?(...)` way or explicitly confirmed (with a citation
   and a regression test) to be correctly discrete-only, except
   `debug_menu.rb`, left open pending a genuine classic-F9-menu reference.
+  ✅ **Follow-up (2026-08-19): Right/Left did nothing at all during
+  ally-target selection, when real RPG_RT treats them as full equivalents
+  of Down/Up there — correcting this bullet's own claim that
+  `status_window` is "a genuine `Window_Selectable`" driven by "the
+  standard trigger-then-repeat."** Confirmed directly against RPG_RT's live
+  source: `Window_BattleStatus::Update` (`src/window_battlestatus.cpp`)
+  opens with its own comment — `// Window Selectable update logic skipped
+  on purpose (breaks up/down-logic)` — and never calls
+  `Window_Selectable::Update()` at all; it hand-rolls the cursor itself,
+  gating the "next ally" step on `IsRepeated(DOWN) || IsRepeated(RIGHT) ||
+  IsTriggered(SCROLL_DOWN)` and the "previous ally" step on the Up/Left/
+  SCROLL_UP mirror — deliberately folding Right/Left onto the same up/down
+  axis, unlike every genuine `Window_Selectable`-based list in this same
+  series. `#drive_battle_ally_target` (`mruby-rpg2k/mrblib/scene/
+  battle.rb`) only ever checked `Input::DOWN`/`Input::UP` (the earlier fix
+  above added `#repeat?` to both, but never noticed `Window_BattleStatus`
+  wasn't the `Window_Selectable` it was assumed to be), so pressing
+  Right/Left while choosing which ally to heal or use an item on did
+  nothing — no cursor movement, no cursor SE — when real RPG_RT moves the
+  cursor exactly as if Down/Up had been pressed. `#drive_battle_target`
+  (the *enemy*-target cursor, a separate method) was checked too and left
+  alone: real RPG_RT's enemy list is a plain `Window_Command` (`target_
+  window`, a single-column `Window_Selectable`, confirmed via `src/
+  scene_battle.h`), whose own `column_max` of 1 means Right/Left are
+  genuine no-ops there too — this fix is `Window_BattleStatus`-specific,
+  not a blanket "add Right/Left everywhere" change. Fixed by folding
+  `Input.trigger?(RIGHT) || Input.repeat?(RIGHT)` into the existing
+  Down branch and the `LEFT` equivalent into the Up branch. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (Left from the first ally wraps
+  to the last, same as Up; Right from the last ally wraps to the first,
+  same as Down), confirmed to fail against the pre-fix code (`expected 1,
+  got 0`).
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1852,14 +1852,26 @@ class RPG2k
 
       # -- Ally target (heal skill / medicine) --------------------------------
 
+      # Right/Left move the ally-target cursor exactly like Down/Up --
+      # confirmed against RPG_RT's own live source: `Window_BattleStatus::
+      # Update` (`src/window_battlestatus.cpp`), the window that drives this
+      # cursor (`Scene_Battle::status_window`, active during ally-target
+      # selection), gates its "next ally" step on `IsRepeated(DOWN) ||
+      # IsRepeated(RIGHT) || IsTriggered(SCROLL_DOWN)` and its "previous
+      # ally" step on the Up/Left/SCROLL_UP mirror -- deliberately
+      # bypassing the generic `Window_Selectable::Update` cursor logic
+      # ("skipped on purpose (breaks up/down-logic)", the function's own
+      # comment) to fold Right/Left into the same single up/down axis.
       def drive_battle_ally_target
         allies = battle_ally_targets
-        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !allies.empty?
+        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN) ||
+            Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)) && !allies.empty?
           @ui[:ally_i] += 1
           @ui[:ally_i] %= allies.length
           draw_battle_ally_target
           play_system_se(SFX_CURSOR)
-        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !allies.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP) ||
+               Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)) && !allies.empty?
           @ui[:ally_i] -= 1
           @ui[:ally_i] %= allies.length
           draw_battle_ally_target

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11222,6 +11222,34 @@ check 'Enemy Encounter scene: the ally target cursor wraps around' do
   eq 0, ui[:ally_i], 'Down from the last ally wraps to the first'
 end
 
+check 'Enemy Encounter scene: Right/Left move the ally target cursor exactly ' \
+      'like Down/Up' do
+  # Confirmed against RPG_RT's own live source: `Window_BattleStatus::Update`
+  # (src/window_battlestatus.cpp) -- the window driving this cursor while
+  # ally-target selection is active -- gates its "next ally" step on
+  # `IsRepeated(DOWN) || IsRepeated(RIGHT) || IsTriggered(SCROLL_DOWN)` and
+  # its "previous ally" step on the Up/Left/SCROLL_UP mirror, deliberately
+  # skipping the generic Window_Selectable cursor logic to fold Right/Left
+  # onto the same up/down axis.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleTwoAllyParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  press_key(scene, RGSS::Input::C)    # choose the Potion -> ally target
+  eq 0, ui[:ally_i], 'starts on the first ally'
+  press_key(scene, RGSS::Input::LEFT)
+  eq 1, ui[:ally_i], 'Left from the first ally wraps to the last, same as Up'
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 0, ui[:ally_i], 'Right from the last ally wraps to the first, same as Down'
+end
+
 # Two actors (distinct ids) with an item_usable_by? that restricts the
 # Potion (item 5) to actor 1 only -- a real Game::Party derives this from the
 # item's 使用可能キャラ / actor_set field (Game::Party#item_usable_by?); this


### PR DESCRIPTION
## Summary

- `Window_BattleStatus::Update` (`src/window_battlestatus.cpp`) opens with its own comment — "Window Selectable update logic skipped on purpose (breaks up/down-logic)" — and never calls `Window_Selectable::Update()` at all; it hand-rolls the cursor itself, gating the "next ally" step on `IsRepeated(DOWN) || IsRepeated(RIGHT) || IsTriggered(SCROLL_DOWN)` and the "previous ally" step on the Up/Left/SCROLL_UP mirror, deliberately folding Right/Left onto the same up/down axis.
- `#drive_battle_ally_target` (`mruby-rpg2k/mrblib/scene/battle.rb`) only ever checked `Input::DOWN`/`Input::UP`, so pressing Right/Left while choosing which ally to heal or use an item on did nothing — no cursor movement, no cursor SE — when real RPG_RT moves the cursor exactly as if Down/Up had been pressed.
- `#drive_battle_target` (the enemy-target cursor, a separate method) was checked too and left alone: real RPG_RT's enemy list is a plain `Window_Command` (a single-column `Window_Selectable`, confirmed via `src/scene_battle.h`), whose `column_max` of 1 means Right/Left are genuine no-ops there too — this fix is `Window_BattleStatus`-specific.
- Fixed by folding `Input.trigger?(RIGHT) || Input.repeat?(RIGHT)` into the existing Down branch and the `LEFT` equivalent into the Up branch.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: Left from the first ally wraps to the last, same as Up; Right from the last ally wraps to the first, same as Down.
- [x] Verified via `git stash` on `battle.rb` alone: fails pre-fix (`expected 1, got 0`).
- [x] Full suite green: `rpg2k_scene_check.rb` 789 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_