### PR TITLE
rgss: RGSS3's Audio.bgm_play pos argument now actually seeks

### DIFF
--- a/changelog.d/rgss-bgm-play-pos-seek.fixed.md
+++ b/changelog.d/rgss-bgm-play-pos-seek.fixed.md
@@ -1,0 +1,9 @@
+- **RGSS3 `Audio.bgm_play`'s `pos` argument** (mid-track resume) now actually
+  seeks instead of always playing a BGM from the beginning. Wired through
+  `Mix_SetMusicPosition` on both the loose-file and packed-archive playback
+  paths — the archive path is what a released game's resume actually reaches,
+  since its whole `Audio/` tree is packed into one encrypted archive. `pos` is
+  milliseconds, matching `Audio.bgm_pos`'s own return value, so
+  `Audio.bgm_play(f, v, p, Audio.bgm_pos)` round-trips exactly. A decoder that
+  cannot seek still plays from the track's own beginning rather than not
+  playing at all.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -526,14 +526,34 @@ way, one at a time, each hidden behind the identical crash until fixed:
   volume-control add-on script called directly — see the real
   `RPG::BGM#play` reopened by this same release's add-on). Every VX Ace
   game whose title screen calls `Audio.bgm_play` with 4 arguments raised
-  `ArgumentError` right there. Accepting the 4th argument needs no real fix
-  behind it — no backend here seeks a mid-stream start position, and this
-  engine's own `RPG::BGM` never calls the 4-arg form internally either (see
-  `mruby-rpgvx/mrblib/rgss2_runtime.rb`'s own `BGM.play_audio`, still
-  3-arg) — so `bgm_play` now accepts `pos = 0`, warns once that seeking is
-  unsupported when it is non-zero, and plays the track from its own
-  beginning, matching the real signature real scripts call with instead of
-  raising.
+  `ArgumentError` right there. First fixed by accepting `pos = 0` and
+  warning once that seeking was unsupported when it was non-zero — no
+  backend seeked a mid-stream start position at the time.
+
+  **Later, seeking itself was implemented**, once the fix above's own
+  warning made it an obvious next target: `pos` now threads through to
+  `Mix_SetMusicPosition` (`src/sdl_audio.cxx`'s `start_music`), on both the
+  loose-file and packed-archive paths (a released game's whole `Audio/`
+  tree is packed, so the archive path — `_bgm_play_mem`, not `_bgm_play` —
+  is what an actual game's resume reaches). `pos` is milliseconds, the same
+  unit `Audio.bgm_pos` already returns, so `Audio.bgm_play(f, v, p,
+  Audio.bgm_pos)` round-trips exactly through this engine's own two halves;
+  a real VX Ace script's own hardcoded literal may use a different native
+  unit (secondary sources disagree on RGSS3's own — one empirical report
+  put "a couple of seconds" at a raw value in the millions, ruling out
+  simple seconds-as-float or milliseconds-as-int, and none of the
+  authoritative sources could be reached to settle it), so this is a
+  best-effort match, not a confirmed one. A decoder that cannot seek (or
+  fails to) still plays from the track's own beginning rather than not
+  playing at all. Verified against the real `--rgss_audio_probe` CTest,
+  through SDL_mixer against a real (dummy-driver) audio device: seeking a
+  2-second synthetic WAV to 1000ms reads back `bgm_pos` near 1000 on both
+  the loose and packed paths (`seek_got`/`packed_seek_got` in its
+  `[RGSS-AUDIO]` log line) — not just accepted without raising, the
+  resume is real. `RPG::BGM#replay` (`mruby-rpgvx/mrblib/rgss2_runtime.rb`)
+  still does not pass its stored `pos` through — a separate, related gap
+  (resuming a map's BGM after a Music Effect interrupts it currently always
+  restarts the track) left for its own change.
 
 - **Fixed: `RPG::CommonEvent` had no `#autorun?` / `#parallel?`.** A real
   data-layer gap in `mruby-rpgvx/mrblib/rgss2_data.rb`: `CommonEvent` only

--- a/include/rgss_audio.hxx
+++ b/include/rgss_audio.hxx
@@ -33,8 +33,13 @@ extern "C" {
 // to outlive the call.
 struct RgssAudioBackend {
   // Background music: a single looping stream. Starting a new one replaces the
-  // current music.
-  void (*bgm_play)(const char* path, int volume, int pitch);
+  // current music. pos_ms is RGSS3's mid-track resume position, in
+  // milliseconds -- the same unit bgm_pos (below) reports in, so a caller that
+  // feeds bgm_pos's own return value back in here round-trips exactly. 0 plays
+  // from the beginning, as XP/VX's 3-argument form always did. A backend that
+  // cannot seek (or fails to) is expected to fall back to playing from the
+  // beginning rather than dropping the play.
+  void (*bgm_play)(const char* path, int volume, int pitch, int pos_ms);
   // Re-applies volume to the BGM stream already playing, with no restart --
   // unlike bgm_play, which always starts its track over. Used when a Play BGM
   // command re-triggers the file that is already current (RPG_RT re-applies
@@ -77,11 +82,15 @@ struct RgssAudioBackend {
   void (*update)(void);
 
   // The same four, from encoded bytes rather than a file. See the note above.
+  // bgm_play_mem's pos_ms is the same resume position as bgm_play's, above --
+  // this is how a released game (its whole Audio/ tree packed into one
+  // archive, nothing loose on disk) actually hears a mid-track resume.
   void (*bgm_play_mem)(const char* name,
                        const void* data,
                        int size,
                        int volume,
-                       int pitch);
+                       int pitch,
+                       int pos_ms);
   void (*bgs_play_mem)(const char* name,
                        const void* data,
                        int size,

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -444,6 +444,19 @@ module RGSS
     Audio.bgm_stop
     Graphics.update
     stopped = Audio.bgm_pos
+
+    # RGSS3's Audio.bgm_play pos (mid-track resume): seek 1000ms into the 2s
+    # probe tone and check bgm_pos reads back near there rather than near 0.
+    # Informational, not a pass/fail gate -- Mix_SetMusicPosition's decoder
+    # support varies (solid for OGG/FLAC, weaker for MOD/MIDI/some WAV
+    # decoders), and #bgm_play already falls back to playing from the
+    # beginning when it fails, exactly as it did before this existed. A
+    # decoder that cannot seek here is a real, known limitation, not a broken
+    # build.
+    Audio.bgm_play(path, 100, 100, 1000)
+    seek_got = wait_for_bgm_pos
+    Audio.bgm_stop
+    Graphics.update
     File.delete(path) if File.exist?(path)
 
     archive = Object.new
@@ -461,12 +474,21 @@ module RGSS
       packed = wait_for_bgm_pos
       Audio.se_play("Beep")
       Audio.bgm_stop
+      Graphics.update
+
+      # The same seek, through the packed/archived path this time (a released
+      # game's whole Audio/ tree is packed, so this -- not the loose path
+      # above -- is what an actual VX Ace game's mid-track resume reaches).
+      Audio.bgm_play("Probe", 100, 100, 1000)
+      packed_seek_got = wait_for_bgm_pos
+      Audio.bgm_stop
     ensure
       self.asset_archive = previous
     end
 
     $stderr.puts "[RGSS-AUDIO] loose=#{loose} stopped=#{stopped} " \
-                 "packed=#{packed}"
+                 "seek_requested=1000 seek_got=#{seek_got} packed=#{packed} " \
+                 "packed_seek_got=#{packed_seek_got}"
     if loose.zero?
       $stderr.puts "[RGSS-AUDIO] FAIL a loose file did not play (no audio " \
                    "device, or this SDL_mixer cannot report a position) — the " \
@@ -1037,19 +1059,19 @@ module RGSS
       # `pos` is RGSS3-only (VX Ace added it over XP/VX's 3-argument form) --
       # real scripts pass it to resume a BGM from where a prior track left
       # off (RPG::BGM#replay, a bare `Audio.bgm_play(f, v, p, pos)` in a
-      # volume-control add-on). No backend here seeks a mid-stream start
-      # position, so it is accepted (matching the real signature real
-      # scripts call with) and warned about once rather than raising
-      # ArgumentError on every VX Ace game that calls it -- the track still
-      # plays, just from its own beginning.
+      # volume-control add-on). Milliseconds, the same unit #bgm_pos reports
+      # in, so `Audio.bgm_play(f, v, p, Audio.bgm_pos)` round-trips exactly --
+      # a real VX Ace script's own hardcoded literal may use a different
+      # native unit (unconfirmed; SDL_mixer's own seek call takes seconds, and
+      # secondary sources disagree on RGSS3's), so a value from anywhere other
+      # than this engine's own #bgm_pos is not guaranteed to land on the same
+      # instant a real game would land on. Seeking can still fail (some
+      # decoders, e.g. MOD/MIDI, do not support it); a failed seek plays from
+      # the track's own beginning rather than not playing at all.
       def bgm_play(filename, volume = 100, pitch = 100, pos = 0)
-        RGSS.warn_once(
-          "Audio.bgm_play pos (mid-track resume) is not implemented yet " \
-          "(stub, plays from the beginning)"
-        ) unless pos == 0
         path = resolve(filename, MUSIC_DIRS)
-        return _bgm_play(path, volume, pitch) if path
-        play_packed(:bgm, filename, volume, pitch)
+        return _bgm_play(path, volume, pitch, pos) if path
+        play_packed(:bgm, filename, volume, pitch, pos)
       end
 
       # Re-applies volume to the already-playing BGM stream in place, with no
@@ -1148,7 +1170,14 @@ module RGSS
       #
       # Returns nil either way — RGSS's Audio.*_play has no return value, and a
       # miss here is the same "asset not found" silence the disk path gives.
-      def play_packed(kind, filename, volume, pitch)
+      #
+      # `pos` is BGM's own mid-track resume position (see #bgm_play); every
+      # other kind ignores it. It has to be threaded through here too, not
+      # just the disk path in #bgm_play, because a released game's whole
+      # Audio/ tree is packed into one encrypted archive with nothing loose on
+      # disk (see RGSS.asset_archive) -- this is the path that actually
+      # carries a resume for a released game.
+      def play_packed(kind, filename, volume, pitch, pos = 0)
         return nil if filename.nil? || filename.empty?
         archive = RGSS.asset_archive
         name, bytes = archive ? find_packed(archive, kind, filename) : nil
@@ -1169,7 +1198,7 @@ module RGSS
           return nil
         end
         case kind
-        when :bgm then _bgm_play_mem(name, bytes, volume, pitch)
+        when :bgm then _bgm_play_mem(name, bytes, volume, pitch, pos)
         when :bgs then _bgs_play_mem(name, bytes, volume, pitch)
         when :me then _me_play_mem(name, bytes, volume, pitch)
         else _se_play_mem(name, bytes, volume, pitch)

--- a/mruby-rgss/src/audio.cxx
+++ b/mruby-rgss/src/audio.cxx
@@ -53,10 +53,13 @@ mrb_value play_mem(mrb_state* M, PlayMemFn fn) {
 
 mrb_value bgm_play(mrb_state* M, mrb_value self) {
   const char* path;
-  mrb_int volume, pitch;
-  get_play_args(M, &path, &volume, &pitch);
+  mrb_int volume = 100, pitch = 100, pos_ms = 0;
+  // BGM alone takes a 4th (pos_ms) argument: RGSS3's mid-track resume, which
+  // BGS/ME/SE never had -- get_play_args (above) only reads the three they all
+  // share.
+  mrb_get_args(M, "z|iii", &path, &volume, &pitch, &pos_ms);
   if (g_backend.bgm_play)
-    g_backend.bgm_play(path, (int)volume, (int)pitch);
+    g_backend.bgm_play(path, (int)volume, (int)pitch, (int)pos_ms);
   return mrb_nil_value();
 }
 
@@ -176,7 +179,18 @@ mrb_value audio_update(mrb_state* M, mrb_value self) {
 }
 
 mrb_value bgm_play_mem(mrb_state* M, mrb_value self) {
-  return play_mem(M, g_backend.bgm_play_mem);
+  // Not the shared play_mem helper: BGM alone takes a 5th (pos_ms) argument
+  // (see bgm_play, above) -- this is the packed-archive path a released
+  // game's mid-track resume actually reaches (see RGSS.asset_archive).
+  const char* name;
+  const char* data;
+  mrb_int size;
+  mrb_int volume = 100, pitch = 100, pos_ms = 0;
+  mrb_get_args(M, "zs|iii", &name, &data, &size, &volume, &pitch, &pos_ms);
+  if (g_backend.bgm_play_mem && size > 0)
+    g_backend.bgm_play_mem(name, data, (int)size, (int)volume, (int)pitch,
+                           (int)pos_ms);
+  return mrb_nil_value();
 }
 
 mrb_value bgs_play_mem(mrb_state* M, mrb_value self) {
@@ -223,7 +237,7 @@ extern "C" void rgss_audio_frame(void) {
 void rgss_audio_define(mrb_state* M, RClass* rgss) {
   RClass* audio = mrb_define_module_under(M, rgss, "Audio");
   mrb_define_module_function(M, audio, "_bgm_play", bgm_play,
-                             MRB_ARGS_ARG(1, 2));
+                             MRB_ARGS_ARG(1, 3));
   mrb_define_module_function(M, audio, "_bgm_volume", bgm_volume,
                              MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_bgm_pan", bgm_pan, MRB_ARGS_REQ(1));
@@ -245,7 +259,7 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
   // Play from encoded bytes: how a release that packs its Audio/ tree into an
   // encrypted RGSSAD archive is heard at all (see RGSS.asset_archive).
   mrb_define_module_function(M, audio, "_bgm_play_mem", bgm_play_mem,
-                             MRB_ARGS_ARG(2, 2));
+                             MRB_ARGS_ARG(2, 3));
   mrb_define_module_function(M, audio, "_bgs_play_mem", bgs_play_mem,
                              MRB_ARGS_ARG(2, 2));
   mrb_define_module_function(M, audio, "_me_play_mem", me_play_mem,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1326,8 +1326,8 @@ assert "RGSS::Audio plays a packed track through RGSS.asset_archive" do
   class << RGSS::Audio
     alias _bgm_play_mem_orig _bgm_play_mem
     alias _can_play_mem_orig _can_play_mem?
-    def _bgm_play_mem(name, bytes, volume, pitch)
-      $audio_mem_capture = [name, bytes, volume, pitch]
+    def _bgm_play_mem(name, bytes, volume, pitch, pos = 0)
+      $audio_mem_capture = [name, bytes, volume, pitch, pos]
       nil
     end
     # No backend is installed in this binary, so pretend one is: without it the
@@ -1460,8 +1460,8 @@ assert "RGSS::Audio finds an upper-case extension in the archive" do
   class << RGSS::Audio
     alias _bgm_play_mem_orig2 _bgm_play_mem
     alias _can_play_mem_orig2 _can_play_mem?
-    def _bgm_play_mem(name, bytes, volume, pitch)
-      $audio_mem_capture = [name, bytes, volume, pitch]
+    def _bgm_play_mem(name, bytes, volume, pitch, pos = 0)
+      $audio_mem_capture = [name, bytes, volume, pitch, pos]
       nil
     end
     def _can_play_mem? = true

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -219,8 +219,8 @@ assert "a packed track plays through RGSS.asset_archive" do
     class << RGSS::Audio
       alias _bgm_play_mem_orig3 _bgm_play_mem
       alias _can_play_mem_orig3 _can_play_mem?
-      def _bgm_play_mem(name, bytes, volume, pitch)
-        $audio_arch_capture = [name, bytes, volume, pitch]
+      def _bgm_play_mem(name, bytes, volume, pitch, pos = 0)
+        $audio_arch_capture = [name, bytes, volume, pitch, pos]
         nil
       end
       # The test binary installs no audio backend; pretend one is there so the

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -255,8 +255,12 @@ void free_music(void) {
 
 // Start `music`, which has just been loaded. Shared tail of the two loaders
 // below. Note: for music, 1 (not 0) is the portable "play once" value — some
-// decoders treat 0 as "loop forever".
-bool start_music(const std::string& what, int volume, int loops) {
+// decoders treat 0 as "loop forever". pos_ms > 0 seeks to that position
+// (RGSS3's Audio.bgm_play resume point) once playback has actually started; a
+// decoder that cannot seek (or fails to) is left playing from the beginning
+// rather than treated as a load failure — the track is still audible, just not
+// resumed.
+bool start_music(const std::string& what, int volume, int loops, int pos_ms) {
   Mix_VolumeMusic(to_mix_volume(volume));
   if (Mix_PlayMusic(g_music, loops) < 0) {
     LOG(WARNING) << "Audio: failed to play music '" << what
@@ -272,6 +276,20 @@ bool start_music(const std::string& what, int volume, int loops) {
   if (seconds > 0.0)
     g_music_duration_ms = (int)(seconds * 1000.0);
 #endif
+  if (pos_ms > 0) {
+    // One-time seek at play start, not a per-frame poll -- unlike
+    // Mix_GetMusicPosition (see g_music_start_ms's comment), this is not on any
+    // hot path, so MIDI's cost there does not apply here.
+    if (Mix_SetMusicPosition(pos_ms / 1000.0) == 0) {
+      // Back-date the clock so bgm_pos() (elapsed since g_music_start_ms)
+      // reports the seeked position immediately, not 0.
+      g_music_start_ms -= (Uint64)pos_ms;
+    } else {
+      LOG(WARNING) << "Audio: could not seek music '" << what << "' to "
+                   << pos_ms
+                   << "ms, playing from the beginning: " << Mix_GetError();
+    }
+  }
   return true;
 }
 
@@ -298,7 +316,13 @@ void log_music_load_failure(const std::string& what, int size = -1) {
 
 // Free and replace the current music with a freshly loaded stream, then play it
 // (loops = -1 loops forever, 1 plays once). Returns false on load failure.
-bool play_music(const std::string& path, int volume, int loops) {
+// pos_ms defaults to 0 (play from the beginning) for the ME/replay callers
+// below, which never seek; bgm_play (the one caller a resume position reaches)
+// passes the real value through.
+bool play_music(const std::string& path,
+                int volume,
+                int loops,
+                int pos_ms = 0) {
   free_music();
   {
     // The music stream is opened on the game-loop thread. For MIDI this is the
@@ -311,7 +335,7 @@ bool play_music(const std::string& path, int volume, int loops) {
     log_music_load_failure(path);
     return false;
   }
-  return start_music(path, volume, loops);
+  return start_music(path, volume, loops, pos_ms);
 }
 
 // The same, from encoded bytes. The bytes are copied into g_music_bytes first:
@@ -321,7 +345,8 @@ bool play_music_mem(const std::string& name,
                     const void* data,
                     int size,
                     int volume,
-                    int loops) {
+                    int loops,
+                    int pos_ms = 0) {
   free_music();
   g_music_bytes.assign(static_cast<const char*>(data),
                        static_cast<size_t>(size));
@@ -342,7 +367,7 @@ bool play_music_mem(const std::string& name,
     g_music_bytes.clear();
     return false;
   }
-  return start_music(name, volume, loops);
+  return start_music(name, volume, loops, pos_ms);
 }
 
 // Replay the BGM, from wherever it came from. Used to resume after a music
@@ -356,13 +381,13 @@ bool replay_bgm(void) {
 
 // -- BGM --------------------------------------------------------------------
 
-void bgm_play(const char* path, int volume, int /*pitch*/) {
+void bgm_play(const char* path, int volume, int /*pitch*/, int pos_ms) {
   g_me_active = false;
   g_bgm_valid = true;
   g_bgm_path = path;
   g_bgm_bytes.clear();  // a file now, not archived bytes
   g_bgm_volume = volume;
-  play_music(g_bgm_path, volume, -1);
+  play_music(g_bgm_path, volume, -1, pos_ms);
 }
 
 // Live volume change for whichever BGM is currently playing, with no restart:
@@ -399,14 +424,15 @@ void bgm_play_mem(const char* name,
                   const void* data,
                   int size,
                   int volume,
-                  int /*pitch*/) {
+                  int /*pitch*/,
+                  int pos_ms) {
   g_me_active = false;
   g_bgm_valid = true;
   g_bgm_path = name;  // for diagnostics only; there is no file
   g_bgm_bytes.assign(static_cast<const char*>(data), static_cast<size_t>(size));
   g_bgm_volume = volume;
   if (!play_music_mem(g_bgm_path, g_bgm_bytes.data(), (int)g_bgm_bytes.size(),
-                      volume, -1))
+                      volume, -1, pos_ms))
     g_bgm_bytes.clear();
 }
 


### PR DESCRIPTION
## Summary

- `Audio.bgm_play`'s 4th (`pos`) argument was accepted (an earlier fix stopped it raising `ArgumentError`) but always ignored — the track played from its own beginning regardless, with a one-time warning that seeking was unsupported.
- `pos` now threads through to `Mix_SetMusicPosition` (`src/sdl_audio.cxx`'s `start_music`), on **both** the loose-file and packed-archive playback paths. The archive path matters most in practice: a released game's whole `Audio/` tree is packed into one encrypted archive with nothing loose on disk, so `_bgm_play_mem` (not `_bgm_play`) is what an actual game's resume reaches (`RPG::BGM#replay`, or a volume-control add-on's bare `Audio.bgm_play(f, v, p, pos)` call).
- `pos` is milliseconds, the same unit `Audio.bgm_pos` already returns, so `Audio.bgm_play(f, v, p, Audio.bgm_pos)` round-trips exactly through this engine's own two halves — what real VX Ace scripts commonly do. A real game's own hardcoded literal may use a different native unit; secondary sources disagree on RGSS3's own (I could not reach the authoritative ones to settle it — most relevant domains are blocked by this environment's egress proxy), so this is documented as a best-effort match rather than a confirmed one (see the expanded writeup in `docs/rpgvx-rgss-api-gap.md`).
- A decoder that cannot seek (or fails to) still plays from the track's own beginning rather than not playing at all — `Mix_SetMusicPosition` support varies by codec (solid for OGG/FLAC, weaker for MOD/MIDI).
- Out of scope, noted for a follow-up: `RPG::BGM#replay` (`mruby-rpgvx/mrblib/rgss2_runtime.rb`) still does not pass its stored `pos` through, so resuming a map's BGM after a Music Effect interrupts it still always restarts the track from the beginning. Distinct code path from this fix; left for its own change.

## Test plan

- [x] `rake test` (full mruby gem suite, including updated `_bgm_play_mem` stub overrides in `mruby-rgss/test/test.rb` and `mruby-rpgxp/test/rpgxp_test.rb` that now accept the 5th `pos` argument) — 1839 OK, 0 KO, 0 Crash.
- [x] `--rgss_audio_probe` (the real CTest that runs SDL_mixer against a real, dummy-driver audio device — the only place this is actually observable, since the mrbtest binary installs no audio backend): extended with a seek check on both the loose-file and packed-archive paths. Seeking a synthetic 2-second WAV to 1000ms reads `Audio.bgm_pos` back at **1017ms** (loose) and **1015ms** (packed) — not just accepted without raising, the resume is real and lands within the same small natural polling overshoot already visible in the probe's other arms.
- [x] `clang-format` run on the changed `.cxx`/`.hxx` files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_