### PR TITLE
A solo party's Status screen plays a cursor SE for Right/Left anyway

### DIFF
--- a/changelog.d/status-menu-solo-party-right-left-noop.fixed.md
+++ b/changelog.d/status-menu-solo-party-right-left-noop.fixed.md
@@ -1,0 +1,4 @@
+- **Status screen:** A solo-hero party no longer plays the cursor sound
+  effect or rebuilds the panel when Right/Left is pressed -- matching
+  RPG_RT, both are now silent no-ops with only one party member to switch
+  to. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4403,6 +4403,23 @@ The work below is roughly ordered by the critical path to a walkable game
   already stood (no fix landed, since none was needed). **Still open**:
   `order.rb`, `debug_menu.rb`, `title.rb`, and every battle target/command
   list in `battle.rb`.
+  ✅ **Follow-up (2026-08-19): a solo party's Status screen still played the
+  cursor SE and rebuilt the whole panel on every Right/Left press, for no
+  visible change — a second condition this bullet's own trigger-vs-repeat
+  check never surfaced.** Re-reading `Scene_Status::vUpdate` (`src/
+  scene_status.cpp`) in full shows both branches gated on two conditions,
+  not one: `actors.size() > 1 && Input::IsTriggered(Input::RIGHT)` (and the
+  `LEFT` mirror) — a lone-hero party leaves RIGHT/LEFT silent no-ops, no SE,
+  no `Scene::Push` rebuild, distinct from the already-checked trigger-vs-
+  repeat axis. `Scene::StatusMenu#update` (`mruby-rpg2k/mrblib/scene/
+  status_menu.rb`) processed RIGHT/LEFT unconditionally, so a solo party
+  heard a cursor click and paid a full window rebuild for a press that
+  genuine RPG_RT treats as if it never happened. Fixed by folding `party.
+  size > 1 &&` into both branch conditions. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a solo-actor `menu_state` party:
+  Right/Left neither move `@actor_index` nor play the cursor SE),
+  confirmed to fail against the pre-fix code (`expected [], got
+  [["Cursor1", ...]]`).
   ✅ **`order.rb` (RPG2003's party-reordering screen) next (2026-08-18) —
   back to needing the fix, both of its cursors this time.** Confirmed
   against EasyRPG Player's actual source: `Scene_Order::vUpdate` (`src/

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -44,12 +44,17 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           @parent.pop
-        elsif Input.trigger?(Input::RIGHT)
+        # A solo party leaves RIGHT/LEFT silent no-ops -- confirmed against
+        # RPG_RT's own live source: `Scene_Status::vUpdate`
+        # (`src/scene_status.cpp`) gates both branches on `actors.size() >
+        # 1`, not just the trigger itself, so a lone hero's Status screen
+        # plays no cursor SE and rebuilds nothing on either key.
+        elsif party.size > 1 && Input.trigger?(Input::RIGHT)
           @actor_index += 1
           @actor_index %= party.size
           build_window
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::LEFT)
+        elsif party.size > 1 && Input.trigger?(Input::LEFT)
           @actor_index -= 1
           @actor_index %= party.size
           build_window

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18242,6 +18242,28 @@ check 'Scene::StatusMenu: holding Right does NOT auto-cycle the actor -- ' \
      'a held (repeated, not triggered) Right does not cycle the actor'
 end
 
+# Confirmed against RPG_RT's own live source: `Scene_Status::vUpdate`
+# (src/scene_status.cpp) gates both the RIGHT and LEFT branches on
+# `actors.size() > 1`, not just the key trigger itself -- a solo party's
+# Status screen plays no cursor SE and rebuilds nothing on either key.
+check 'Scene::StatusMenu: a solo party leaves Right/Left as silent no-ops' do
+  scene = menu_scene(RPG2k::Scene::StatusMenu, menu_state)
+  eq 0, scene.instance_variable_get(:@actor_index), 'starts on the only actor'
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@actor_index), 'Right has nowhere to move to'
+  eq [], RGSS::Audio.se_calls, 'a solo party plays no cursor SE on Right'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::LEFT]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@actor_index), 'Left has nowhere to move to'
+  eq [], RGSS::Audio.se_calls, 'a solo party plays no cursor SE on Left'
+end
+
 check 'Scene::StatusMenu: a dangling equipped item id logs once, not per rebuild, ' \
       'while the slot still shows the "Item #<id>" placeholder' do
   state = Game::State.new(DanglingItemParty.new, 1, 0, 0)


### PR DESCRIPTION
## Summary

- `Scene_Status::vUpdate` (`src/scene_status.cpp`) gates both the RIGHT and LEFT branches on `actors.size() > 1 && Input::IsTriggered(...)`, not just the trigger itself — a lone-hero party leaves RIGHT/LEFT silent no-ops, no SE, no `Scene::Push` rebuild.
- `Scene::StatusMenu#update` (`mruby-rpg2k/mrblib/scene/status_menu.rb`) processed RIGHT/LEFT unconditionally, so a solo party heard a cursor click and paid a full window rebuild for a press that genuine RPG_RT treats as if it never happened.
- Fixed by folding `party.size > 1 &&` into both branch conditions.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a solo-actor `menu_state` party — Right/Left neither move `@actor_index` nor play the cursor SE.
- [x] Verified via `git stash` on `status_menu.rb` alone: fails pre-fix (`expected [], got [["Cursor1", ...]]`).
- [x] Full suite green: `rpg2k_scene_check.rb` 790 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_