### PR TITLE
A solo party's Equip screen plays a cursor SE for Right/Left anyway

### DIFF
--- a/changelog.d/equip-menu-solo-party-right-left-noop.fixed.md
+++ b/changelog.d/equip-menu-solo-party-right-left-noop.fixed.md
@@ -1,0 +1,4 @@
+- **Equip screen:** A solo-hero party no longer plays the cursor sound
+  effect or rebuilds the screen when Right/Left is pressed -- matching
+  RPG_RT, both are now silent no-ops with only one party member to switch
+  to. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4387,6 +4387,26 @@ The work below is roughly ordered by the critical path to a walkable game
   `debug_menu.rb`, `title.rb`, and every battle target/command list in
   `battle.rb` — each worth the same actual-source check `equip_menu.rb`
   just got, not an assumed blanket `|| #repeat?`.
+  ✅ **Follow-up (2026-08-19): a solo party's Equip screen still played the
+  cursor SE and rebuilt the whole screen on every Right/Left press, for no
+  visible change — the identical second condition `status_menu.rb`'s own
+  follow-up just caught in its sibling function, missed here too.**
+  Re-reading `Scene_Equip::UpdateEquipSelection` (`src/scene_equip.cpp`) in
+  full shows the same shape as `Scene_Status::vUpdate`: both the RIGHT and
+  LEFT branches are gated on `actors.size() > 1 && Input::IsTriggered(...)`
+  — a lone-hero party leaves RIGHT/LEFT silent no-ops, no SE, no
+  `Scene::Push` rebuild, a distinct condition from the already-checked
+  trigger-vs-repeat axis the earlier bullet above verified. `Scene::
+  EquipMenu#update_slots` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`)
+  processed RIGHT/LEFT unconditionally once a solo party's `@actor_index %=
+  1` left it harmlessly pinned at 0, so a solo party still heard a cursor
+  click and paid a full stats/slot-window rebuild for a press genuine
+  RPG_RT treats as if it never happened. Fixed by folding `party.size > 1
+  &&` into both branch conditions, mirroring `status_menu.rb`'s identical
+  fix. Covered by a new `scripts/rpg2k_scene_check.rb` check (a solo-actor
+  `menu_state` party: Right/Left neither move `@actor_index` nor play the
+  cursor SE), confirmed to fail against the pre-fix code (`expected [], got
+  [["Cursor1", ...]]`).
   ✅ **`status_menu.rb` checked next (2026-08-18) — confirmed already
   correct, no code change needed.** Unlike every screen fixed so far, this
   one has no list/grid cursor at all: it is a read-only single-member

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -118,12 +118,17 @@ class RPG2k
           @slot_index %= @slots.size
           refresh_slot_cursor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::RIGHT)
+        # A solo party leaves RIGHT/LEFT silent no-ops -- confirmed against
+        # RPG_RT's own live source: `Scene_Equip::UpdateEquipSelection`
+        # (`src/scene_equip.cpp`) gates both branches on `actors.size() >
+        # 1`, not just the trigger itself, so a lone hero's Equip screen
+        # plays no cursor SE and rebuilds nothing on either key.
+        elsif party.size > 1 && Input.trigger?(Input::RIGHT)
           @actor_index += 1
           @actor_index %= party.size
           rebuild_for_actor
           play_system_se(SFX_CURSOR)
-        elsif Input.trigger?(Input::LEFT)
+        elsif party.size > 1 && Input.trigger?(Input::LEFT)
           @actor_index -= 1
           @actor_index %= party.size
           rebuild_for_actor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18022,6 +18022,28 @@ check 'Scene::EquipMenu: holding Down auto-repeats the slot and candidate ' \
      'a held (repeated, not triggered) Down still moves the candidate cursor one step'
 end
 
+# Confirmed against RPG_RT's own live source: `Scene_Equip::
+# UpdateEquipSelection` (src/scene_equip.cpp) gates both the RIGHT and LEFT
+# branches on `actors.size() > 1`, not just the key trigger itself -- a solo
+# party's Equip screen plays no cursor SE and rebuilds nothing on either key.
+check 'Scene::EquipMenu: a solo party leaves Right/Left as silent no-ops' do
+  scene = menu_scene(RPG2k::Scene::EquipMenu, menu_state)
+  eq 0, scene.instance_variable_get(:@actor_index), 'starts on the only actor'
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@actor_index), 'Right has nowhere to move to'
+  eq [], RGSS::Audio.se_calls, 'a solo party plays no cursor SE on Right'
+
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::LEFT]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@actor_index), 'Left has nowhere to move to'
+  eq [], RGSS::Audio.se_calls, 'a solo party plays no cursor SE on Left'
+end
+
 check 'Scene::EquipMenu: 装備固定 refuses to open the item list for that actor' do
   state = wrap_menu_state
   state.party.actors.first.equipment_fixed_flag = true


### PR DESCRIPTION
## Summary

- `Scene_Equip::UpdateEquipSelection` (`src/scene_equip.cpp`) gates both the RIGHT and LEFT branches on `actors.size() > 1 && Input::IsTriggered(...)`, not just the trigger itself — a lone-hero party leaves RIGHT/LEFT silent no-ops, no SE, no `Scene::Push` rebuild. The same shape as `Scene_Status::vUpdate`'s identical guard, already fixed in `status_menu.rb` (#1126).
- `Scene::EquipMenu#update_slots` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) processed RIGHT/LEFT unconditionally once a solo party's `@actor_index %= 1` left it harmlessly pinned at 0, so a solo party still heard a cursor click and paid a full stats/slot-window rebuild for a press genuine RPG_RT treats as if it never happened.
- Fixed by folding `party.size > 1 &&` into both branch conditions, mirroring `status_menu.rb`'s identical fix.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a solo-actor `menu_state` party — Right/Left neither move `@actor_index` nor play the cursor SE.
- [x] Verified via `git stash` on `equip_menu.rb` alone: fails pre-fix (`expected [], got [["Cursor1", ...]]`).
- [x] Full suite green: `rpg2k_scene_check.rb` 791 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_