### PR TITLE
rgss: BGM resumes after a Music Effect, and RPG::BGM#replay resumes too

### DIFF
--- a/changelog.d/rgss-bgm-resume-after-me.fixed.md
+++ b/changelog.d/rgss-bgm-resume-after-me.fixed.md
@@ -1,0 +1,7 @@
+- **RGSS3 BGM resume after a Music Effect / `RPG::BGM#replay`**: a map's BGM
+  interrupted by `Audio.me_play` now resumes where it left off once the effect
+  ends, instead of always restarting from the beginning — matching real
+  RGSS3. `RPG::BGM#replay` (used after loading a save mid-track) now resumes
+  at its own stored `pos` too, since `Audio.bgm_play`'s `pos` argument
+  actually seeks. `RPG::BGS`/`RPG::ME`/`RPG::SE` are unaffected — only BGM's
+  backend can resume a position.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -550,10 +550,29 @@ way, one at a time, each hidden behind the identical crash until fixed:
   2-second synthetic WAV to 1000ms reads back `bgm_pos` near 1000 on both
   the loose and packed paths (`seek_got`/`packed_seek_got` in its
   `[RGSS-AUDIO]` log line) — not just accepted without raising, the
-  resume is real. `RPG::BGM#replay` (`mruby-rpgvx/mrblib/rgss2_runtime.rb`)
-  still does not pass its stored `pos` through — a separate, related gap
-  (resuming a map's BGM after a Music Effect interrupts it currently always
-  restarts the track) left for its own change.
+  resume is real.
+
+- **Fixed: BGM never resumed after a Music Effect, and `RPG::BGM#replay`
+  never passed its stored `pos` through.** The two related gaps the fix
+  above left open. `Audio.me_play`/`me_play_mem` (`src/sdl_audio.cxx`) now
+  capture the BGM's own position (`bgm_pos()`) the instant an ME
+  interrupts it — only on the first ME of a run, not one that replaces
+  another already playing, which would read 0 (`bgm_pos` reports 0 while
+  an ME is active) and lose the real resume point — and `me_stop`'s
+  `replay_bgm()` seeks there instead of always restarting the track,
+  matching real RGSS3 (an ME plays once over the map BGM, which picks back
+  up where it left off). `RPG::BGM#replay`
+  (`mruby-rpgvx/mrblib/rgss2_runtime.rb`) is now overridden on `BGM` itself
+  (the other three `AudioPlayback` channels keep the shared "just `#play`
+  again" default, since only BGM's backend can resume a position — `BGS`'s
+  own `pos` field exists for save-format fidelity, but its sample-channel
+  backend never reports one to resume from; `ME`/`SE` have no `pos` field
+  at all) to call `Audio.bgm_play` with its own stored `volume`/`pitch`/
+  `pos` — what a save loaded mid-track relies on. Verified against the
+  real `--rgss_audio_probe` CTest: playing a BGM, letting it advance past
+  500ms, interrupting it with an ME and stopping the ME reads `bgm_pos`
+  back near where it was (`pre_me`/`me_resumed` in its `[RGSS-AUDIO]` log
+  line), not reset to 0.
 
 - **Fixed: `RPG::CommonEvent` had no `#autorun?` / `#parallel?`.** A real
   data-layer gap in `mruby-rpgvx/mrblib/rgss2_data.rb`: `CommonEvent` only

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -457,6 +457,25 @@ module RGSS
     seek_got = wait_for_bgm_pos
     Audio.bgm_stop
     Graphics.update
+
+    # A Music Effect interrupting the BGM resumes it where it left off once
+    # the effect ends, not from the beginning (real RGSS3 behaviour; see
+    # me_stop -> replay_bgm in src/sdl_audio.cxx, which now threads the BGM's
+    # own captured position through the same seek this probe measured above).
+    # Informational, same reasoning as the seek checks above.
+    Audio.bgm_play(path)
+    # Run well past wait_for_bgm_pos's first nonzero read: pre_me and
+    # me_resumed both being small numbers could look like "resumed" even if
+    # the BGM had actually restarted, so give the BGM real ground to have
+    # covered before interrupting it.
+    30.times { Graphics.update }
+    pre_me = Audio.bgm_pos
+    Audio.me_play(path)
+    5.times { Graphics.update }
+    Audio.me_stop
+    me_resumed = wait_for_bgm_pos
+    Audio.bgm_stop
+    Graphics.update
     File.delete(path) if File.exist?(path)
 
     archive = Object.new
@@ -488,7 +507,8 @@ module RGSS
 
     $stderr.puts "[RGSS-AUDIO] loose=#{loose} stopped=#{stopped} " \
                  "seek_requested=1000 seek_got=#{seek_got} packed=#{packed} " \
-                 "packed_seek_got=#{packed_seek_got}"
+                 "packed_seek_got=#{packed_seek_got} pre_me=#{pre_me} " \
+                 "me_resumed=#{me_resumed}"
     if loose.zero?
       $stderr.puts "[RGSS-AUDIO] FAIL a loose file did not play (no audio " \
                    "device, or this SDL_mixer cannot report a position) — the " \

--- a/mruby-rpgvx/mrblib/rgss2_runtime.rb
+++ b/mruby-rpgvx/mrblib/rgss2_runtime.rb
@@ -40,10 +40,11 @@ module RPG
       end
     end
 
-    # Play this record again from its stored position. RGSS3's `RPG::BGM#replay`
-    # resumes at `pos` (the map BGM is replayed after a battle); the SDL_mixer
-    # backend cannot seek, so the position is kept for the save data and the
-    # track restarts. Same audible result for a looping BGM.
+    # Play this record again. RGSS3's `RPG::BGM#replay` resumes at `pos` (a
+    # map's BGM is replayed at its own position after a battle, or after a
+    # save loads); by default this is just `#play` restarting the track,
+    # since only BGM's backend can actually seek to a stored position -- see
+    # `BGM#replay` below, which overrides this to pass one through.
     def replay
       play
     end
@@ -94,8 +95,25 @@ module RPG
     include AudioPlayback
     extend AudioPlayback::ClassMethods
 
-    def self.play_audio(name, volume, pitch)
-      RGSS::Audio.bgm_play(name, volume, pitch)
+    def self.play_audio(name, volume, pitch, pos = 0)
+      RGSS::Audio.bgm_play(name, volume, pitch, pos)
+    end
+
+    # Resumes at this record's own stored `pos` (real RGSS3 behaviour), now
+    # that Audio.bgm_play's pos argument actually seeks instead of always
+    # restarting -- what a save's `$game_system.playing_bgm.replay` (loading a
+    # save mid-track) and a battle's interrupted map BGM both rely on. BGS/ME/
+    # SE inherit AudioPlayback#replay's plain #play instead: BGS's own `pos`
+    # field exists for save-format fidelity, but its sample-channel backend
+    # never reports one to resume from (see bgs_pos in src/sdl_audio.cxx), and
+    # ME/SE have no `pos` field at all.
+    def replay
+      if name.nil? || name.empty?
+        self.class.stop
+      else
+        self.class.play_audio(name, volume || 100, pitch || 100, pos || 0)
+        self.class.last = self
+      end
     end
 
     def self.stop_audio
@@ -107,8 +125,9 @@ module RPG
     end
 
     # RGSS3 stamps the playing position onto the record it hands back, which is
-    # what a save stores so the BGM resumes where it left off (the SDL_mixer
-    # backend cannot seek on replay, but the value round-trips).
+    # what a save stores so the BGM resumes where it left off -- and, since
+    # #replay above now actually seeks, where a battle's interrupted map BGM
+    # resumes too.
     def self.last
       record = (@last ||= new_empty)
       record.pos = RGSS::Audio.bgm_pos

--- a/mruby-rpgvx/test/rpgvx_test.rb
+++ b/mruby-rpgvx/test/rpgvx_test.rb
@@ -510,9 +510,9 @@ class << RGSS::Audio
   alias _vx_se_play_orig se_play
   alias _vx_me_play_orig me_play
 
-  def bgm_play(name, volume = 100, pitch = 100)
-    return _vx_bgm_play_orig(name, volume, pitch) unless $vx_audio.is_a?(Array)
-    $vx_audio << [:bgm_play, name, volume, pitch]
+  def bgm_play(name, volume = 100, pitch = 100, pos = 0)
+    return _vx_bgm_play_orig(name, volume, pitch, pos) unless $vx_audio.is_a?(Array)
+    $vx_audio << [:bgm_play, name, volume, pitch, pos]
     nil
   end
 
@@ -560,11 +560,12 @@ end
 
 assert "RPG::BGM plays itself through RGSS::Audio" do
   played = vx_capture_audio { vx_bgm("Theme1", 80, 110).play }
-  assert_equal [[:bgm_play, "Theme1", 80, 110]], played
+  # #play always starts fresh, pos 0 -- only #replay (below) resumes.
+  assert_equal [[:bgm_play, "Theme1", 80, 110, 0]], played
   # The record's own volume/pitch are the defaults, and a record with neither
   # falls back to RGSS's 100/100.
   played = vx_capture_audio { vx_bgm("Theme2").play }
-  assert_equal [[:bgm_play, "Theme2", 100, 100]], played
+  assert_equal [[:bgm_play, "Theme2", 100, 100, 0]], played
 end
 
 assert "RPG::BGM tracks the last played record" do
@@ -572,15 +573,34 @@ assert "RPG::BGM tracks the last played record" do
   assert_equal "Field1", RPG::BGM.last.name
   assert_equal 90, RPG::BGM.last.volume
 
-  # #replay plays the same record again (RGSS3 resumes the map BGM this way).
+  # #replay plays the same record again (RGSS3 resumes the map BGM this way),
+  # pos 0 here since nothing has set one.
   played = vx_capture_audio { RPG::BGM.last.replay }
-  assert_equal [[:bgm_play, "Field1", 90, 100]], played
+  assert_equal [[:bgm_play, "Field1", 90, 100, 0]], played
 
   # Fading or stopping the channel clears it, so `last.name` is readable and
   # empty rather than stale.
   played = vx_capture_audio { RPG::BGM.fade(1000) }
   assert_equal [[:bgm_fade, 1000]], played
   assert_equal "", RPG::BGM.last.name
+end
+
+assert "RPG::BGM#replay resumes at its own stored pos" do
+  # #last stamps the real playing position onto the record it hands back
+  # (RGSS::Audio.bgm_pos, in mruby-rpgvx/mrblib/rgss2_runtime.rb); simulate
+  # that here since this test build installs no native audio backend.
+  bgm = vx_bgm("Field1", 90, 100)
+  bgm.pos = 5000
+  played = vx_capture_audio { bgm.replay }
+  assert_equal [[:bgm_play, "Field1", 90, 100, 5000]], played
+
+  # A record with no stored pos (a fresh one, never played) resumes at 0 --
+  # not nil, which RGSS::Audio.bgm_play would reject.
+  played = vx_capture_audio { vx_bgm("Field2", 80, 100).replay }
+  assert_equal [[:bgm_play, "Field2", 80, 100, 0]], played
+
+  # A nameless record's replay stops the channel, same as #play.
+  assert_equal [[:bgm_stop]], vx_capture_audio { vx_bgm("").replay }
 end
 
 assert "a nameless RPG::BGM stops the channel instead of playing silence" do

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -173,7 +173,7 @@ module RGSS
     class << self
       attr_reader :played
       def reset = @played = []
-      def bgm_play(name, volume = 100, pitch = 100) = @played << [:bgm_play, name, volume, pitch]
+      def bgm_play(name, volume = 100, pitch = 100, pos = 0) = @played << [:bgm_play, name, volume, pitch, pos]
       def bgm_stop = @played << [:bgm_stop]
       def bgm_fade(time) = @played << [:bgm_fade, time]
       def bgm_pos = 0
@@ -1218,7 +1218,7 @@ class Checker
     # The RGSS2/RGSS3 built-ins the scripts called on the way: the title BGM
     # played itself through RPG::BGM#play (rgss2_runtime.rb) and is remembered
     # as the channel's last record.
-    expect(RGSS::Audio.played == [[:bgm_play, "Theme1", 100, 100]],
+    expect(RGSS::Audio.played == [[:bgm_play, "Theme1", 100, 100, 0]],
            "boot: title BGM did not reach Audio (got #{RGSS::Audio.played.inspect})")
     expect(RPG::BGM.last.name == "Theme1",
            "boot: RPG::BGM.last is #{RPG::BGM.last.name.inspect}, expected \"Theme1\"")

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -53,6 +53,12 @@ bool g_bgm_valid = false;      // a BGM is set and should resume after an ME
 std::string g_bgm_path;
 int g_bgm_volume = 100;
 bool g_me_active = false;  // an ME is playing over the (suspended) BGM
+// The BGM's own playback position (see bgm_pos) at the instant an ME
+// interrupted it, so replay_bgm can resume there instead of restarting the
+// track -- captured once per ME (see me_play/me_play_mem), not on a second ME
+// that replaces one already playing, which would otherwise read 0 (bgm_pos
+// reports 0 while g_me_active) and lose the original resume point.
+int g_bgm_resume_pos_ms = 0;
 // The BGM's encoded bytes when it came out of an encrypted archive rather than
 // a file (empty otherwise). update() replays the BGM after a music effect
 // finishes, and there is no path to replay from in that case, so the bytes have
@@ -372,11 +378,16 @@ bool play_music_mem(const std::string& name,
 
 // Replay the BGM, from wherever it came from. Used to resume after a music
 // effect ends; an archived BGM has no path, only the bytes kept in g_bgm_bytes.
+// Resumes at g_bgm_resume_pos_ms (see me_play/me_play_mem), matching real
+// RGSS: a Music Effect interrupts the map BGM and it picks back up where it
+// left off, not from the top.
 bool replay_bgm(void) {
+  const int pos_ms = g_bgm_resume_pos_ms;
+  g_bgm_resume_pos_ms = 0;
   if (!g_bgm_bytes.empty())
     return play_music_mem(g_bgm_path, g_bgm_bytes.data(),
-                          (int)g_bgm_bytes.size(), g_bgm_volume, -1);
-  return play_music(g_bgm_path, g_bgm_volume, -1);
+                          (int)g_bgm_bytes.size(), g_bgm_volume, -1, pos_ms);
+  return play_music(g_bgm_path, g_bgm_volume, -1, pos_ms);
 }
 
 // -- BGM --------------------------------------------------------------------
@@ -509,6 +520,11 @@ int bgs_pos(void) {
 
 void me_play(const char* path, int volume, int /*pitch*/) {
   // Play once over the BGM; update() restores the BGM when the effect ends.
+  // Capture the BGM's own position now, before g_me_active flips bgm_pos() to
+  // 0 -- but only on the first ME of a run, not one that replaces another
+  // already playing, which would capture 0 and lose the real resume point.
+  if (!g_me_active)
+    g_bgm_resume_pos_ms = bgm_pos();
   g_me_active = true;
   if (!play_music(path, volume, 1))
     g_me_active = false;  // load failed: nothing to wait for.
@@ -519,6 +535,8 @@ void me_play_mem(const char* name,
                  int size,
                  int volume,
                  int /*pitch*/) {
+  if (!g_me_active)
+    g_bgm_resume_pos_ms = bgm_pos();
   g_me_active = true;
   if (!play_music_mem(name, data, size, volume, 1))
     g_me_active = false;


### PR DESCRIPTION
## Summary

Two related gaps explicitly flagged as follow-ups in #1125 (the `Audio.bgm_play` pos-seek fix), now that its seek plumbing exists to build on.

- **BGM resume after a Music Effect.** `Audio.me_play` plays once over the map BGM, and in real RGSS3 the BGM picks back up where it left off once the effect ends. This engine always restarted the BGM from the beginning instead. `me_play`/`me_play_mem` (`src/sdl_audio.cxx`) now capture the BGM's own position (`bgm_pos()`) the instant an ME interrupts it — only on the *first* ME of a run, not one that replaces another already playing, which would read 0 (`bgm_pos` reports 0 while an ME is active) and lose the real resume point — and `me_stop`'s `replay_bgm()` seeks there instead of always restarting.
- **`RPG::BGM#replay`** (used after loading a save mid-track) never passed its stored `pos` through either — it just called `#play`, which always starts fresh. Overridden on `BGM` itself (the other three `AudioPlayback` channels — `BGS`/`ME`/`SE` — keep the shared "just `#play` again" default: only BGM's backend can resume a position; `BGS`'s own `pos` field exists for save-format fidelity but its sample-channel backend never reports one to resume from, and `ME`/`SE` have no `pos` field at all).

## Test plan

- [x] `rake test` (full mruby gem suite, including a new `mruby-rpgvx/test/rpgvx_test.rb` assert covering `RPG::BGM#replay` passing a stored `pos` through, and updated existing assertions for the trailing `pos` argument every `#play`/`#replay` call now sends) — 1840 OK, 0 KO, 0 Crash.
- [x] `--rgss_audio_probe` (the real CTest exercising SDL_mixer against a real, dummy-driver audio device) extended with an ME-interrupt-resume check: play a BGM, let it advance past 500ms, interrupt it with an ME, stop the ME, and read `bgm_pos` back. Measured `pre_me=557` / `me_resumed=573` (and `499`/`515` on a second run) — clearly resumed near where it was, not reset to 0.
- [x] `clang-format` run on the changed `.cxx` file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_