### PR TITLE
Teleport picker Right/Left stop at the row edge instead of crossing it

### DIFF
--- a/changelog.d/teleport-picker-right-left-row-crossing.fixed.md
+++ b/changelog.d/teleport-picker-right-left-row-crossing.fixed.md
@@ -1,0 +1,5 @@
+- **Teleport destination picker:** With three or more registered
+  destinations, Right/Left now flow across a row boundary instead of
+  stopping at the row's own edge, matching RPG_RT -- the same fix already
+  applied to the item/skill lists, now propagated to this sibling list.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3130,6 +3130,29 @@ The work below is roughly ordered by the critical path to a walkable game
   784 checks failed: the corrected `Scene::ItemMenu` check and both
   `Scene::SkillMenu` Teleport checks, each expecting the still-first
   destination or its switch state instead of the second).
+  ✅ **Follow-up (2026-08-20): the fix just above copied the item/skill
+  grid's own then-current Right/Left row-boundary guard onto the Teleport
+  picker — and that pattern itself turned out to be wrong, corrected for
+  the item/skill grids by a later fix this same bullet chain never
+  revisited here.** Confirmed directly against RPG_RT's live source:
+  `Window_Teleport` defines no `Update()` of its own, so its cursor comes
+  entirely from `Window_Selectable::Update` (`src/window_selectable.cpp`),
+  whose real RIGHT/LEFT branches are a flat `index +- 1` bounded only by
+  the list's own absolute start/end (`index < item_max - 1` / `index >
+  0`), with no row-boundary term at all — the exact fact the item/skill
+  grid's own later fix already established, just never propagated to this
+  sibling list. `#update_teleport_target` (`mruby-rpg2k/mrblib/scene/
+  {item,skill}_menu.rb`) still gated RIGHT/LEFT on `% COLUMN_MAX`, so with
+  three or more registered destinations, RIGHT from a row's last cell
+  stayed put instead of flowing into the next row's first cell. Fixed by
+  dropping the `% COLUMN_MAX` guard, the same one-line change as the
+  item/skill grid fix — `#move_teleport_cursor`'s own existing bound
+  already matches the reference exactly. Two new
+  `scripts/rpg2k_scene_check.rb` checks (a third registered destination
+  added to each scene's existing two-target fixture, since two destinations
+  never reach a row boundary to cross): RIGHT from a row's last cell flows
+  into the next row's first cell; LEFT flows back — both confirmed to fail
+  against the pre-fix code (`expected 2, got 1`) before the fix.
 - ✅ **The battle-time skill variance is built now, for a recovery skill too —
   not just an attack one.** This line used to end "Left unbuilt still: the
   battle-time skill variance," describing only the missing half:

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -312,10 +312,17 @@ class RPG2k
           move_teleport_cursor(COLUMN_MAX)
         elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           move_teleport_cursor(-COLUMN_MAX)
+        # Right/Left cross a row boundary rather than stopping at the row's
+        # own edge -- the same fix as #update_items's identical RIGHT/LEFT
+        # handling (confirmed directly against `Window_Selectable::Update`,
+        # `src/window_selectable.cpp`: Right/Left are a flat `index +- 1`
+        # bounded only by the list's own absolute start/end, no
+        # row-boundary check), never propagated to this sibling list when
+        # that one was corrected.
         elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
-          move_teleport_cursor(1) if (@teleport_index + 1) % COLUMN_MAX != 0
+          move_teleport_cursor(1)
         elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
-          move_teleport_cursor(-1) if @teleport_index % COLUMN_MAX != 0
+          move_teleport_cursor(-1)
         elsif Input.trigger?(Input::C) && !targets.empty?
           play_system_se(SFX_DECISION)
           map_id, = targets[@teleport_index]

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -303,10 +303,17 @@ class RPG2k
           move_teleport_cursor(COLUMN_MAX)
         elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
           move_teleport_cursor(-COLUMN_MAX)
+        # Right/Left cross a row boundary rather than stopping at the row's
+        # own edge -- the same fix as #update_skills's identical RIGHT/LEFT
+        # handling (confirmed directly against `Window_Selectable::Update`,
+        # `src/window_selectable.cpp`: Right/Left are a flat `index +- 1`
+        # bounded only by the list's own absolute start/end, no
+        # row-boundary check), never propagated to this sibling list when
+        # that one was corrected.
         elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
-          move_teleport_cursor(1) if (@teleport_index + 1) % COLUMN_MAX != 0
+          move_teleport_cursor(1)
         elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
-          move_teleport_cursor(-1) if @teleport_index % COLUMN_MAX != 0
+          move_teleport_cursor(-1)
         elsif Input.trigger?(Input::C) && !targets.empty?
           play_system_se(SFX_DECISION)
           map_id, = targets[@teleport_index]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17268,6 +17268,41 @@ check 'Scene::ItemMenu: a special item invoking Teleport opens a destination ' \
   ok parent.pop_to_map_called
 end
 
+check 'Scene::ItemMenu: the Teleport destination list crosses a row ' \
+      'boundary on Right/Left rather than stopping at the row edge' do
+  # Confirmed directly against RPG_RT's live source: `Window_Selectable::
+  # Update` (src/window_selectable.cpp) -- Right/Left are a flat `index +-
+  # 1` bounded only by the list's own absolute start/end, no row-boundary
+  # check, the same shape already fixed for the item/skill grids. A third
+  # destination is needed here: with only two, both fit in the first row
+  # and Right/Left never reach a boundary to cross.
+  parent = fake_parent(fake_db)
+  state = escape_teleport_item_state
+  state.teleport_targets[30] = { x: 31, y: 32, switch_id: nil }
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the Teleport item
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  eq [[10, 'Map 10'], [20, 'Map 20'], [30, 'Map 30']], scene.send(:teleport_targets)
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second destination, same row
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@teleport_index)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # cross into the next row's first cell
+  scene.update
+  RGSS::Input.reset
+  eq 2, scene.instance_variable_get(:@teleport_index),
+     'Right from the row edge flows into the next row, not a no-op'
+  RGSS::Input.triggered = [RGSS::Input::LEFT]        # flow back into the previous row's last cell
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@teleport_index)
+end
+
 check 'Scene::ItemMenu: cancelling the Teleport destination list returns to the item list' do
   parent = fake_parent(fake_db)
   state = escape_teleport_item_state
@@ -17504,6 +17539,41 @@ check 'Scene::SkillMenu: a Teleport skill opens a destination list and queues th
   RGSS::Input.reset
   eq [20, 21, 22, 0], state.pending_teleport
   ok parent.pop_to_map_called
+end
+
+check 'Scene::SkillMenu: the Teleport destination list crosses a row ' \
+      'boundary on Right/Left rather than stopping at the row edge' do
+  # Confirmed directly against RPG_RT's live source: `Window_Selectable::
+  # Update` (src/window_selectable.cpp) -- Right/Left are a flat `index +-
+  # 1` bounded only by the list's own absolute start/end, no row-boundary
+  # check, the same shape already fixed for the item/skill grids. A third
+  # destination is needed here: with only two, both fit in the first row
+  # and Right/Left never reach a boundary to cross.
+  parent = fake_parent(fake_db)
+  state = escape_teleport_state
+  state.teleport_targets[30] = { x: 31, y: 32, switch_id: nil }
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto Teleport
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  eq [[10, 'Map 10'], [20, 'Map 20'], [30, 'Map 30']], scene.send(:teleport_targets)
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second destination, same row
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@teleport_index)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # cross into the next row's first cell
+  scene.update
+  RGSS::Input.reset
+  eq 2, scene.instance_variable_get(:@teleport_index),
+     'Right from the row edge flows into the next row, not a no-op'
+  RGSS::Input.triggered = [RGSS::Input::LEFT]        # flow back into the previous row's last cell
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@teleport_index)
 end
 
 check 'Scene::SkillMenu: a Teleport skill turns on the chosen destination\'s own switch, ' \


### PR DESCRIPTION
## Summary

- `Window_Teleport` defines no `Update()` of its own, so its cursor comes entirely from `Window_Selectable::Update` (`src/window_selectable.cpp`), whose real RIGHT/LEFT branches are a flat `index +- 1` bounded only by the list's own absolute start/end, no row-boundary term at all — the exact fact the item/skill grid's own later fix already established (#1129), just never propagated to this sibling list.
- `#update_teleport_target` (`mruby-rpg2k/mrblib/scene/{item,skill}_menu.rb`) still gated RIGHT/LEFT on `% COLUMN_MAX`, so with three or more registered destinations, RIGHT from a row's last cell stayed put instead of flowing into the next row's first cell.
- Fixed by dropping the `% COLUMN_MAX` guard, the same one-line change as the item/skill grid fix — `#move_teleport_cursor`'s own existing bound already matches the reference exactly.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks (a third registered destination added to each scene's existing two-target fixture, since two destinations never reach a row boundary to cross): Right from a row's last cell flows into the next row's first cell; Left flows back.
- [x] Verified via `git stash` on `item_menu.rb`/`skill_menu.rb` alone: both fail pre-fix (`expected 2, got 1`).
- [x] Full suite green: `rpg2k_scene_check.rb` 795 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_