### PR TITLE
rgss: Graphics.brightness=/fadeout/fadein now actually darken the screen

### DIFF
--- a/changelog.d/rgss-graphics-brightness-fade.fixed.md
+++ b/changelog.d/rgss-graphics-brightness-fade.fixed.md
@@ -1,0 +1,8 @@
+- **`Graphics.brightness=`/`fadeout`/`fadein`** now actually darken the
+  screen instead of only tracking the value. VX/VX Ace already faded visibly
+  through `@viewport3.color`, but RMXP's own stock scripts (`Scene_Gameover`,
+  `Scene_End`, several post-battle screens) call `Graphics.fadeout`/`fadein`
+  directly, and previously saw no visual change at all. Drawn with the same
+  full-screen overlay technique `Graphics.transition` already uses for its
+  own dissolve. `fadeout`/`fadein` also now step one frame at a time instead
+  of running all their frames first and jumping to the end value.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -174,8 +174,27 @@ RPG2000 side can adopt it rather than growing its own.
 
 Not covered: `Window` (its contents are composed by a different path, and RGSS
 puts windows in their own viewport, so a map tint does not tint the message
-window anyway) and `Graphics.brightness`, which stays tracked-not-drawn — VX
-fades through `@viewport3.color`, which does draw.
+window anyway).
+
+**`Graphics.brightness`/`fadeout`/`fadein` are drawn too, now** — a real gap
+found and fixed independently of the VX viewport-color work above, on the XP
+side: VX/VX Ace fade through `@viewport3.color` (drawn, as above), but RMXP's
+own stock scripts (`Scene_Gameover`, `Scene_End`, several post-battle screens)
+call plain `Graphics.fadeout`/`fadein` directly, and `Graphics.brightness=`
+(`mruby-rgss/mrblib/lib.rb`) only ever tracked the value — a real XP game
+would previously show no visual fade at all in those spots. Fixed with the
+same overlay technique `Graphics.transition` already uses for its own
+full-screen dissolve (proven, native, tested): a full-screen black `Sprite`
+at `BRIGHTNESS_Z` (just under `TRANSITION_Z`), created once and kept alive,
+whose opacity is `255 - brightness`. `fadeout`/`fadein` themselves needed a
+second, related fix once brightness was real: they ran all `duration` frames
+first and only set the end value afterward, which had been an invisible bug
+(brightness was never drawn either way) that would have become a visible
+"nothing happens, then instant cut to black" the moment the overlay existed —
+now each fades one step per frame. Verified against the real
+`--rgss_effect_probe` CTest, through a live display: `Graphics.brightness = 0`
+darkens `frame_mean` to `[0, 0, 0]` from a `[128, 128, 128]` base, and
+`Graphics.brightness = 255` restores it exactly.
 
 ### 3. `Graphics.freeze` / `transition` / `snap_to_bitmap` — scene transitions dissolve ✅
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -199,6 +199,28 @@ module RGSS
                    "did not shape the dissolve"
       ok = false
     end
+
+    # Graphics.brightness=: the grey sprite (still up, per Graphics.transition
+    # above leaving it visible = false -- bring it back first) darkened toward
+    # black, then restored, against the same base frame_mean read at the top.
+    sprite.visible = true
+    Graphics.update
+    Graphics.brightness = 0
+    Graphics.update
+    dark = frame_mean
+    Graphics.brightness = 255
+    Graphics.update
+    restored = frame_mean
+    $stderr.puts "[RGSS-PROBE] dark=#{dark.inspect} restored=#{restored.inspect}"
+    unless dark[0] < base[0] - 40 && dark[1] < base[1] - 40 && dark[2] < base[2] - 40
+      $stderr.puts "[RGSS-PROBE] FAIL Graphics.brightness=0 did not darken the frame"
+      ok = false
+    end
+    if (restored[0] - base[0]).abs > 10
+      $stderr.puts "[RGSS-PROBE] FAIL Graphics.brightness=255 did not restore the frame"
+      ok = false
+    end
+
     sprite.dispose
     bitmap.dispose
     viewport.dispose
@@ -1316,6 +1338,11 @@ module RGSS
     # object; RGSS z values are ordinary integers, so pick one past anything a
     # game would set.
     TRANSITION_Z = 0x40000000
+    # The brightness fade overlay sits just under the transition's own
+    # full-screen sprite (above every game object either way; #transition
+    # forces brightness back to 255 before it runs, so in practice the two
+    # never need to be visible at once).
+    BRIGHTNESS_Z = TRANSITION_Z - 1
 
     class << self
       attr_accessor :frame_count, :frame_rate
@@ -1333,27 +1360,50 @@ module RGSS
         duration.to_i.times { update }
       end
 
-      # 0 (black) .. 255 (normal). Stored so a script's fade bookkeeping is
-      # consistent; the value is not applied to what is drawn yet — that needs
-      # the same native screen-tone support the RPG2000 tint is waiting on, so
-      # say so once rather than pretending the screen darkened.
+      # 0 (black) .. 255 (normal). Drawn as a full-screen black overlay above
+      # every game object (see #brightness_sprite) whose opacity is
+      # `255 - value` — the same technique #transition already uses for its
+      # own full-screen dissolve, just a plain fade instead of a shaped one.
       def brightness=(value)
         value = 0 if value < 0
         value = 255 if value > 255
-        RGSS.warn_stub("Graphics.brightness= (tracked, not drawn)") unless value == 255
         @brightness = value
+        if value >= 255
+          brightness_sprite.opacity = 0 if @brightness_sprite
+        else
+          brightness_sprite.opacity = 255 - value
+        end
       end
 
-      # RGSS2+ fades: run the frames the fade would take (so the game's timing
-      # is right) and leave the brightness at its end value.
+      # RGSS2+ fades: step brightness from its current value to the target (0
+      # for fadeout, 255 for fadein) over `duration` frames, one Graphics.update
+      # per step — not run the frames first and jump to the end value, which
+      # would hold the screen at its *starting* brightness for the whole fade
+      # and only change it on the last frame. `duration <= 0` jumps straight to
+      # the target with no frame pumped, same as RGSS's own instant case.
       def fadeout(duration)
-        wait(duration)
-        self.brightness = 0
+        start = @brightness
+        if duration <= 0
+          self.brightness = 0
+          return
+        end
+        duration.times do |i|
+          self.brightness = start - (start * (i + 1) / duration)
+          update
+        end
       end
 
       def fadein(duration)
-        wait(duration)
-        self.brightness = 255
+        start = @brightness
+        if duration <= 0
+          self.brightness = 255
+          return
+        end
+        diff = 255 - start
+        duration.times do |i|
+          self.brightness = start + (diff * (i + 1) / duration)
+          update
+        end
       end
 
       # RGSS's scene change: `freeze` grabs the current screen and `transition`
@@ -1380,7 +1430,10 @@ module RGSS
       def transition(duration = 8, filename = nil, vague = 40)
         frozen = @frozen
         @frozen = nil
-        @brightness = 255
+        # Through the setter, not a raw ivar write: a scene change always
+        # starts from full brightness, and the brightness overlay (if a
+        # previous fadeout left it visible) has to be hidden again too.
+        self.brightness = 255
         return wait(duration) if frozen.nil? || duration <= 0
 
         map = _transition_map(filename)
@@ -1426,6 +1479,30 @@ module RGSS
         nil
       end
 
+      private
+
+      # The full-screen black sprite #brightness= fades in and out of view,
+      # created once and kept alive at BRIGHTNESS_Z (opacity 0, i.e.
+      # invisible, whenever brightness is 255) rather than allocated fresh on
+      # every fade -- a game commonly fades in and out many times a session
+      # (every battle, every map transfer). Recreated if the screen size
+      # changes out from under it (#resize_screen is normally called once at
+      # boot, before any fade, but nothing stops a script calling it again).
+      def brightness_sprite
+        if @brightness_sprite && @brightness_sprite.bitmap &&
+           @brightness_sprite.bitmap.width == width &&
+           @brightness_sprite.bitmap.height == height
+          return @brightness_sprite
+        end
+        @brightness_sprite.dispose if @brightness_sprite
+        bmp = Bitmap.new(width, height)
+        bmp.fill_rect(0, 0, width, height, Color.new(0, 0, 0, 255))
+        @brightness_sprite = Sprite.new
+        @brightness_sprite.bitmap = bmp
+        @brightness_sprite.z = BRIGHTNESS_Z
+        @brightness_sprite.opacity = 0
+        @brightness_sprite
+      end
     end
   end
 

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1712,6 +1712,23 @@ assert "RGSS::Input::N0..N9/PLUS..PERIOD are distinct ids continuing past F12" d
   end
 end
 
+# Graphics.brightness= drives a real Sprite/Bitmap (the fade overlay) since it
+# actually draws now, and Sprite.new needs a live display the headless test
+# binary lacks (see the Sprite/Tilemap note above) -- so every brightness=
+# exercised as plain Ruby logic below stubs the private #brightness_sprite out
+# for a fake that just remembers the opacity it was given, the same way other
+# native calls are stubbed elsewhere in this file. The real overlay is
+# exercised by RGSS.effect_probe (native, against a live display).
+class << RGSS::Graphics
+  alias _brightness_sprite_orig brightness_sprite
+  def brightness_sprite
+    return @fake_brightness_sprite if @fake_brightness_sprite
+    o = Object.new
+    def o.opacity=(v); @opacity = v; end
+    @fake_brightness_sprite = o
+  end
+end
+
 assert "RGSS::Graphics reports and resizes the screen" do
   # RGSS2 added Graphics.width/height; each maker's boot shell declares its own
   # resolution, and the stock VX Ace scripts compute camera and window layouts


### PR DESCRIPTION
## Summary

- `Graphics.brightness=` only ever tracked the value in an ivar (`RGSS.warn_stub("Graphics.brightness= (tracked, not drawn)")`). VX/VX Ace scripts fade visibly through `@viewport3.color` (already drawn, native), but RMXP's own stock scripts (`Scene_Gameover`, `Scene_End`, several post-battle screens) call `Graphics.fadeout`/`fadein` directly — a real XP game previously showed no visual fade at all in those spots.
- Fixed with the same technique `Graphics.transition` already uses for its own full-screen dissolve: a full-screen black `Sprite` at `BRIGHTNESS_Z` (just under `TRANSITION_Z`), created once and kept alive rather than allocated fresh on every fade, whose opacity is `255 - brightness`. `#transition` now sets brightness through the setter (not a raw ivar write) so a previous fadeout's overlay is hidden again when a scene change starts.
- `fadeout`/`fadein` needed a second, related fix once brightness was real: both ran all `duration` frames first and only set the end value afterward — an invisible bug while brightness was untracked, which would have become a visible "nothing happens, then an instant cut to black" the moment the overlay existed. Both now step one frame at a time, matching how `#transition` itself already paces its own dissolve.

## Test plan

- [x] `rake test` (full mruby gem suite). The plain mrbtest binary has no live display (`Sprite.new` needs one), so the existing brightness/fadeout unit tests now stub the new private `#brightness_sprite` the same way other native calls are stubbed elsewhere in the suite — 1840 OK, 0 KO, 0 Crash.
- [x] `--rgss_effect_probe` (the real CTest exercising the native renderer against a live display), extended with a brightness arm: `Graphics.brightness = 0` darkens `frame_mean` to `[0, 0, 0]` from a `[128, 128, 128]` base, and `Graphics.brightness = 255` restores it exactly.
- [x] `ruby scripts/rpgxp_testbed_check.rb`, `ruby scripts/rpgxp_script_host_check.rb`, `ruby scripts/rpgvx_testbed_check.rb` (the CRuby-side checks that load the real mrblib sources against real XP/VX/VX Ace test-bed projects) — all `OK`, no regression.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_