### PR TITLE
A successful item use / skill cast wrongly drops back to the list

### DIFF
--- a/changelog.d/item-skill-target-screen-stays-open-on-success.fixed.md
+++ b/changelog.d/item-skill-target-screen-stays-open-on-success.fixed.md
@@ -1,0 +1,6 @@
+- **Item/Skill menus:** A successful use or cast no longer drops back to
+  the item/skill list -- matching RPG_RT, the target screen stays open so
+  the same item or skill can be used on further targets right away (e.g.
+  healing several allies with a stack of Potions without re-opening the
+  item list each time). Only Cancel now returns to the (refreshed) list.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3012,6 +3012,45 @@ The work below is roughly ordered by the critical path to a walkable game
   screen opens instead of an immediate cast; the lock holds against UP/DOWN;
   Decision on the locked screen casts; Cancel backs out with nothing spent),
   all confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-20): a successful use/cast on this same target
+  screen unconditionally dropped back to the item/skill list, when real
+  RPG_RT stays put and lets the player keep using the same item/skill on
+  further targets — this bullet's own citation of `UpdateSkill()`/
+  `UpdateItem()` already established the fact, just never drew the
+  conclusion.** Re-reading `Scene_ActorTarget::UpdateItem`/`UpdateSkill`
+  (`src/scene_actortarget.cpp`) in full: on a successful Decision, both just
+  call `status_window->Refresh(); target_window->Refresh();` and return — the
+  **only** `Scene::Pop()` anywhere in the file is `vUpdate`'s own Cancel
+  branch, identical for a no-effect Decision and a successful one alike.
+  `Scene::ItemMenu#drive_message`/`Scene::SkillMenu#drive_message`
+  (`mruby-rpg2k/mrblib/scene/{item,skill}_menu.rb`) instead tagged a
+  successful use/cast's message `:used`/`:cast` and called `#refresh_after_
+  use`/`#refresh_after_cast` on dismiss, forcing `@mode` back to `:items`/
+  `:skills` and rebuilding the list — so healing three party members with a
+  stack of Potions meant re-opening the item list and re-selecting Potion
+  after every single use, an extra round trip real RPG_RT never asks for; a
+  no-effect use already correctly stayed put (nothing tagged it), which is
+  what let this asymmetry hide in plain sight. `#use_item`'s/`#cast_skill`'s
+  own existing count/affordability gates already answer what a *repeat* use
+  does once the item runs out or SP is short — an empty `affected`, the same
+  Buzzer path — matching the reference's own `GetItemCount(id) <= 0`/SP-cost
+  check ahead of `UseItem`/`UseSkill`: depletion buzzes, it does not
+  auto-exit either. Fixed by dropping the `:used` tag entirely in
+  `item_menu.rb` (a plain, always-untagged `show_message` now, so
+  `#drive_message` has nothing left to dispatch on) and folding the item-list
+  invalidate/rebuild/clamp `#refresh_after_use` used to do into
+  `#leave_target_mode` itself, now the single path back to `:items` (reached
+  only via Cancel). `skill_menu.rb` keeps its `:cast` tag, since it still has
+  a second, genuine use — `#apply_switch_skill`'s successful cast, issued
+  straight from the skill list with no target screen to stay open on — but
+  `#apply_skill`'s own ordinary target-mode cast no longer passes it, and the
+  invalidate/rebuild `#refresh_after_cast` used to do folded into `#leave_
+  target` the same way. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a single-target medicine/skill, held or affordable twice over:
+  the target screen stays open through a successful use/cast and its message
+  dismiss, a second use/cast on a different target needs no re-navigation,
+  and only Cancel finally returns to the rebuilt list), both confirmed to
+  fail against the pre-fix code (`expected :target, got :items`/`:skills`).
 
   What decides usability is the **type**, not the occasion flags, and getting
   that wrong used to leave the battle skill menu **empty in both test beds** —

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -433,7 +433,17 @@ class RPG2k
       # ineffective status cure, ...) plays Buzzer rather than a second
       # Decision -- matching RPG_RT's own invalid-use handling elsewhere in
       # `Scene_Item` (a rejected action gets the same SE as a confirm on an
-      # empty list or a disabled command, not a silent no-op).
+      # empty list or a disabled command, not a silent no-op). A *successful*
+      # use stays on this same target screen too, exactly like a no-effect
+      # one -- confirmed against RPG_RT's own live source:
+      # `Scene_ActorTarget::UpdateItem` (`src/scene_actortarget.cpp`) never
+      # calls `Scene::Pop()` on Decision, success or failure alike; the only
+      # `Scene::Pop()` in the whole file is `vUpdate`'s own Cancel branch.
+      # `#use_item`'s own `item_count(id) > 0` gate already answers what
+      # happens on a repeat use once the item runs out (an empty `affected`,
+      # the same Buzzer path), matching the reference's own `GetItemCount(id)
+      # <= 0` check ahead of `UseItem` -- depletion buzzes, it does not
+      # auto-exit either.
       def apply_item(id, actor)
         affected = @state.party.use_item(id, actor)
         if affected.empty?
@@ -441,10 +451,15 @@ class RPG2k
           show_message("It had no effect.")
         else
           names = affected.map { |a| a.name.to_s }.join(", ")
-          show_message("Used on #{names}.", :used)
+          show_message("Used on #{names}.")
         end
       end
 
+      # Back to the item list, rebuilt so it reflects whatever changed while
+      # target mode was open (a count fell, a depleted item dropped out) --
+      # only reached via Cancel now that a successful use no longer forces
+      # this on its own (see #apply_item). Keeps the cursor in range when the
+      # last of an item was used up.
       def leave_target_mode
         @pending_item = nil
         @target_lock = nil
@@ -453,18 +468,11 @@ class RPG2k
           @target_window.dispose
           @target_window = nil
         end
-        refresh_desc
-      end
-
-      # After a successful use, drop back to the item list and rebuild it (the
-      # count fell, and a depleted item leaves the list). Keeps the cursor in
-      # range when the last item is used up.
-      def refresh_after_use
-        leave_target_mode
         invalidate_items
         @item_index = items.size - 1 if @item_index >= items.size
         @item_index = 0 if @item_index < 0
         build_item_window
+        refresh_desc
       end
 
       # The highlighted item's flavour text, in a one-line banner across the
@@ -590,14 +598,10 @@ class RPG2k
 
       def drive_message
         return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        done = @message[:done]
         close_message
-        # A successful use drops back to the (rebuilt) item list; a no-effect use
-        # stays in the current mode so the player can pick another target/item.
-        refresh_after_use if done == :used
       end
 
-      def show_message(text, done = nil)
+      def show_message(text)
         return if @message
         w = SCREEN_W - 40
         win = Window.new(20, SCREEN_H - 40, w, 14 + Window::BORDER * 2)
@@ -607,7 +611,7 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         c.draw_text 0, 0, c.width, 14, text
         win.contents = c
-        @message = { window: win, done: done }
+        @message = { window: win }
       end
 
       def close_message

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -226,15 +226,27 @@ class RPG2k
         end
       end
 
-      # A cast that changed nothing plays Buzzer rather than a second Decision
-      # -- see Scene::ItemMenu#apply_item's identical reasoning.
+      # A cast that changed nothing plays Buzzer rather than a second
+      # Decision -- see Scene::ItemMenu#apply_item's identical reasoning. A
+      # *successful* cast stays on this same target screen too, exactly like
+      # a no-effect one -- confirmed against RPG_RT's own live source:
+      # `Scene_ActorTarget::UpdateSkill` (`src/scene_actortarget.cpp`) never
+      # calls `Scene::Pop()` on Decision, success or failure alike; the only
+      # `Scene::Pop()` in the whole file is `vUpdate`'s own Cancel branch.
+      # `#cast_skill`'s own affordability gate already answers what happens
+      # on a repeat cast once SP runs out (an empty `affected`, the same
+      # Buzzer path), matching the reference's own SP/HP check ahead of
+      # `UseSkill` -- unaffordable buzzes, it does not auto-exit either.
+      # Unlike #apply_switch_skill just below, this one is never tagged
+      # `:cast` -- it has nowhere to "return to" until Cancel, so
+      # `#drive_message` has nothing extra to do once the message closes.
       def apply_skill(sid, target)
         affected = @state.party.cast_skill(caster, sid, target)
         if affected.empty?
           play_system_se(SFX_BUZZER)
           show_message("It had no effect.")
         else
-          show_message("#{caster.name} casts #{skill_name(sid)}!", :cast)
+          show_message("#{caster.name} casts #{skill_name(sid)}!")
         end
       end
 
@@ -273,6 +285,11 @@ class RPG2k
         $stderr.puts "[RPG2k] skill SE '#{name}' playback failed: #{e.message}"
       end
 
+      # Back to the skill list, rebuilt so it reflects whatever changed while
+      # target mode was open (SP fell; a now-unaffordable skill drops out) --
+      # only reached via Cancel now that a successful cast no longer forces
+      # this on its own (see #apply_skill). Keeps the cursor in range if the
+      # list shrank.
       def leave_target
         @pending_skill = nil
         @target_lock = nil
@@ -281,6 +298,10 @@ class RPG2k
           @target_window.dispose
           @target_window = nil
         end
+        @skills = nil
+        @skill_index = skills.size - 1 if @skill_index >= skills.size
+        @skill_index = 0 if @skill_index < 0
+        build_skill_window
         refresh_desc
       end
 
@@ -386,14 +407,6 @@ class RPG2k
 
       # After a successful cast, drop back to the skill list and rebuild it (SP
       # fell; a now-unaffordable skill drops out).
-      def refresh_after_cast
-        leave_target
-        @skills = nil
-        @skill_index = skills.size - 1 if @skill_index >= skills.size
-        @skill_index = 0 if @skill_index < 0
-        build_skill_window
-      end
-
       # Column width for the skill grid (see Scene::ItemMenu#item_col_w,
       # which this mirrors).
       def skill_col_w
@@ -582,9 +595,15 @@ class RPG2k
 
       def drive_message
         return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        # `:cast` only ever tags #apply_switch_skill's message now (see
+        # #apply_skill's own comment) -- a switch skill is cast straight from
+        # the skill list, with no target screen to stay open on, so its own
+        # successful-cast message closes back into a rebuilt list, matching
+        # this same class's pre-existing #leave_target/#leave_teleport_target
+        # shape for "returning to the list."
         done = @message[:done]
         close_message
-        refresh_after_cast if done == :cast
+        leave_target if done == :cast
       end
 
       def show_message(text, done = nil)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16960,6 +16960,68 @@ class SwitchItemStubParty < MenuStubParty
   end
 end
 
+# A single-target medicine (scope != 1, so #use_medicine reads the chosen
+# actor rather than the whole party) held x3 -- enough to use twice and still
+# have one left, so a repeat use without leaving the target screen is
+# actually observable.
+class MedicineItemStubParty < WrapMenuParty
+  MEDICINE_ID = 40
+  def field_items(_state = nil); [[MEDICINE_ID, 3]]; end
+  def db_item(id)
+    return nil unless id == MEDICINE_ID
+    OpenStruct.new(name: 'Potion', type: Game::Party::ITEM_MEDICINE, scope: 3)
+  end
+  def use_item(id, actor = nil)
+    return [] unless id == MEDICINE_ID && actor
+    [actor]
+  end
+end
+
+check 'Scene::ItemMenu: a successful use stays on the target screen, ' \
+      'matching RPG_RT, instead of dropping back to the item list' do
+  # Confirmed against RPG_RT's own live source: `Scene_ActorTarget::
+  # UpdateItem` (src/scene_actortarget.cpp) never calls `Scene::Pop()` on
+  # Decision, success or failure alike -- only `vUpdate`'s own Cancel branch
+  # does. A successful use lets the player keep using the same item on
+  # further targets without leaving this screen.
+  state = Game::State.new(MedicineItemStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::ItemMenu, state)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the item -- opens target selection
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+
+  RGSS::Input.triggered = [RGSS::Input::C] # use it on the first target
+  scene.update
+  RGSS::Input.reset
+  ok scene.instance_variable_get(:@message), 'a "Used on ..." message is shown'
+  eq :target, scene.instance_variable_get(:@mode), 'still in target mode while the message is up'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the message
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode), 'stays on the target screen after a successful use'
+  ok scene.instance_variable_get(:@pending_item), 'the pending item is still set, ready for another target'
+
+  # Use it again immediately on the second target -- no re-navigation needed.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+
+  # Cancelling finally returns to the (rebuilt) item list.
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  eq :items, scene.instance_variable_get(:@mode)
+end
+
 check 'Scene::ItemMenu: a switch item flips its switch, consumes one, and closes ' \
       'the whole menu stack, with no confirmation message' do
   parent = fake_parent(fake_db)
@@ -17618,6 +17680,67 @@ check 'Scene::SkillMenu: cancelling the destination list returns to the skill li
   eq :skills, scene.instance_variable_get(:@mode)
   ok state.pending_teleport.nil?
   ok !parent.pop_to_map_called
+end
+
+# A single-target skill (scope != 2/4, so the target cursor is not locked)
+# the caster can afford twice over, so a repeat cast without leaving the
+# target screen is actually observable.
+class NormalTargetSkillStubParty < WrapMenuParty
+  SKILL_ID = 50
+  def field_skills(_actor, _state = nil); [[SKILL_ID, 5]]; end
+  def db_skill(id)
+    return nil unless id == SKILL_ID
+    OpenStruct.new(name: 'Heal', type: Game::Party::SKILL_NORMAL, scope: 3)
+  end
+  def cast_skill(caster, sid, target = nil, _free = false)
+    return [] unless sid == SKILL_ID && target
+    [target]
+  end
+end
+
+check 'Scene::SkillMenu: a successful cast stays on the target screen, ' \
+      'matching RPG_RT, instead of dropping back to the skill list' do
+  # Confirmed against RPG_RT's own live source: `Scene_ActorTarget::
+  # UpdateSkill` (src/scene_actortarget.cpp) never calls `Scene::Pop()` on
+  # Decision, success or failure alike -- only `vUpdate`'s own Cancel branch
+  # does. A successful cast lets the player keep casting the same skill on
+  # further targets without leaving this screen.
+  state = Game::State.new(NormalTargetSkillStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::SkillMenu, state)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the skill -- opens target selection
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+
+  RGSS::Input.triggered = [RGSS::Input::C] # cast on the first target
+  scene.update
+  RGSS::Input.reset
+  ok scene.instance_variable_get(:@message), 'a "casts ..." message is shown'
+  eq :target, scene.instance_variable_get(:@mode), 'still in target mode while the message is up'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the message
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode), 'stays on the target screen after a successful cast'
+  ok scene.instance_variable_get(:@pending_skill), 'the pending skill is still set, ready for another target'
+
+  # Cast it again immediately on the second target -- no re-navigation needed.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+
+  # Cancelling finally returns to the (rebuilt) skill list.
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  eq :skills, scene.instance_variable_get(:@mode)
 end
 
 # A party whose two field skills are self (2) and all-ally (4) scope -- real


### PR DESCRIPTION
## Summary

- `Scene_ActorTarget::UpdateItem`/`UpdateSkill` (`src/scene_actortarget.cpp`), on a successful Decision, just call `status_window->Refresh(); target_window->Refresh();` and return. The only `Scene::Pop()` anywhere in the file is `vUpdate`'s own Cancel branch, identical for a no-effect Decision and a successful one alike.
- `Scene::ItemMenu#drive_message` / `Scene::SkillMenu#drive_message` (`mruby-rpg2k/mrblib/scene/{item,skill}_menu.rb`) instead tagged a successful use/cast's message `:used`/`:cast` and rebuilt the list on dismiss, forcing `@mode` back to `:items`/`:skills` — so healing three party members with a stack of Potions meant re-opening the item list and re-selecting Potion after every single use. A no-effect use already correctly stayed put, which is what let this asymmetry hide.
- `#use_item`'s/`#cast_skill`'s own existing count/affordability gates already answer what a repeat use does once the item runs out or SP is short — an empty `affected`, the same Buzzer path — so no extra guard is needed there.
- Fixed by dropping the `:used` tag entirely in `item_menu.rb` and folding the item-list invalidate/rebuild `#refresh_after_use` used to do into `#leave_target_mode` itself, now the single path back to `:items` (Cancel only). `skill_menu.rb` keeps its `:cast` tag for `#apply_switch_skill`'s own successful cast (issued straight from the skill list, no target screen to stay open on), but `#apply_skill`'s ordinary target-mode cast no longer passes it, and `#refresh_after_cast`'s rebuild folded into `#leave_target` the same way.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks: a single-target medicine/skill held or affordable twice over stays on the target screen through a successful use/cast and its message dismiss, casts again on a different target with no re-navigation, and only Cancel finally returns to the rebuilt list.
- [x] Verified via `git stash` on `item_menu.rb`/`skill_menu.rb` alone: both fail pre-fix (`expected :target, got :items`/`:skills`).
- [x] Full suite green: `rpg2k_scene_check.rb` 797 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_