### PR TITLE
A Switch skill's successful cast shows a message and stays in the menu

### DIFF
--- a/changelog.d/switch-skill-closes-menu-no-message.fixed.md
+++ b/changelog.d/switch-skill-closes-menu-no-message.fixed.md
@@ -1,0 +1,4 @@
+- **Switch skills:** A successful cast now closes the whole menu stack at
+  once with no confirmation message, matching RPG_RT -- previously it
+  showed a "casts ..." message and returned to the skill list, leaving the
+  menu open. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3040,17 +3040,48 @@ The work below is roughly ordered by the critical path to a walkable game
   `#drive_message` has nothing left to dispatch on) and folding the item-list
   invalidate/rebuild/clamp `#refresh_after_use` used to do into
   `#leave_target_mode` itself, now the single path back to `:items` (reached
-  only via Cancel). `skill_menu.rb` keeps its `:cast` tag, since it still has
-  a second, genuine use — `#apply_switch_skill`'s successful cast, issued
-  straight from the skill list with no target screen to stay open on — but
-  `#apply_skill`'s own ordinary target-mode cast no longer passes it, and the
-  invalidate/rebuild `#refresh_after_cast` used to do folded into `#leave_
-  target` the same way. Covered by two new `scripts/rpg2k_scene_check.rb`
-  checks (a single-target medicine/skill, held or affordable twice over:
-  the target screen stays open through a successful use/cast and its message
-  dismiss, a second use/cast on a different target needs no re-navigation,
-  and only Cancel finally returns to the rebuilt list), both confirmed to
-  fail against the pre-fix code (`expected :target, got :items`/`:skills`).
+  only via Cancel). ~~`skill_menu.rb` keeps its `:cast` tag, since it still
+  has a second, genuine use — `#apply_switch_skill`'s successful cast, issued
+  straight from the skill list with no target screen to stay open on~~ —
+  **this parenthetical turned out wrong too, see the follow-up right below**
+  — but `#apply_skill`'s own ordinary target-mode cast no longer passes it,
+  and the invalidate/rebuild `#refresh_after_cast` used to do folded into
+  `#leave_target` the same way. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (a single-target medicine/skill,
+  held or affordable twice over: the target screen stays open through a
+  successful use/cast and its message dismiss, a second use/cast on a
+  different target needs no re-navigation, and only Cancel finally returns
+  to the rebuilt list), both confirmed to fail against the pre-fix code
+  (`expected :target, got :items`/`:skills`).
+  ✅ **Follow-up (2026-08-20): a Switch skill's successful cast showed a
+  "casts ..." message and returned to the skill list, when real RPG_RT
+  closes the whole menu stack at once with no message at all — the bullet
+  right above this one reasoned by analogy that `#apply_switch_skill` was a
+  "genuine" stay-in-the-menu case without actually checking its own cited
+  function's `Type_switch` arm.** Confirmed directly against RPG_RT's live
+  source: `Scene_Skill::vUpdate`'s `Type_switch` arm (`src/scene_skill.cpp`)
+  plays the skill's own sound effect and calls `Scene::PopUntil(Scene::Map)`
+  on the very same Decision press — no confirmation message, no second
+  Decision, the identical shape as the adjacent `Type_escape` arm, not the
+  ordinary target-mode cast's stay-open-and-show-a-message flow
+  (`Algo::IsNormalOrSubskill`'s own arm, which pushes a `Scene_ActorTarget`
+  instead — the case the bullet above genuinely does apply to).
+  `Scene::SkillMenu#apply_switch_skill` (`mruby-rpg2k/mrblib/scene/
+  skill_menu.rb`) showed `"#{caster.name} casts ...!"` and, via
+  `#drive_message`'s `:cast` dispatch, called `#leave_target` — staying
+  inside the Skill menu — instead of matching `Scene::ItemMenu#apply_
+  switch_item`'s already-correct shape (no message, straight to
+  `@parent.pop_to_map`), the field-menu switch-item's own identical
+  RPG_RT-verified pattern this method should have mirrored from the start.
+  Fixed by dropping the message and `:cast` tag from `#apply_switch_skill`
+  and calling `@parent.pop_to_map` directly, matching `#apply_escape_skill`
+  right below it exactly. With `:cast` now unused anywhere in the file,
+  `#drive_message`'s dispatch and `#show_message`'s `done:` parameter were
+  both dead weight and removed (mirroring the identical cleanup the bullet
+  above already did in `item_menu.rb`). Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a successful Switch skill cast
+  closes the whole menu stack and shows no message), confirmed to fail
+  against the pre-fix code (the stack stayed open).
 
   What decides usability is the **type**, not the occasion flags, and getting
   that wrong used to leave the battle skill menu **empty in both test beds** —

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -237,9 +237,9 @@ class RPG2k
       # on a repeat cast once SP runs out (an empty `affected`, the same
       # Buzzer path), matching the reference's own SP/HP check ahead of
       # `UseSkill` -- unaffordable buzzes, it does not auto-exit either.
-      # Unlike #apply_switch_skill just below, this one is never tagged
-      # `:cast` -- it has nowhere to "return to" until Cancel, so
-      # `#drive_message` has nothing extra to do once the message closes.
+      # Unlike #apply_switch_skill just below, this has nowhere to "return
+      # to" until Cancel -- #drive_message has nothing extra to do once the
+      # message closes.
       def apply_skill(sid, target)
         affected = @state.party.cast_skill(caster, sid, target)
         if affected.empty?
@@ -253,12 +253,22 @@ class RPG2k
       # A switch skill (type 3) spends its SP and turns on a game switch, with
       # nothing to target. This is how a Nepheshel player summons and dismisses a
       # companion — the switch is what its common event watches.
+      # A successful cast closes the whole menu stack at once, exactly like
+      # Scene::ItemMenu#apply_switch_item and this same class's own
+      # #apply_escape_skill just below -- confirmed against RPG_RT's own
+      # live source: `Scene_Skill::vUpdate`'s `Type_switch` arm
+      # (`src/scene_skill.cpp`) plays the skill's own sound effect and calls
+      # `Scene::PopUntil(Scene::Map)` on the very same Decision press, with
+      # no confirmation message at all -- the identical shape as `Type_
+      # escape` right below it, not the ordinary target-mode cast's
+      # stay-open-and-show-a-message flow (`Algo::IsNormalOrSubskill`'s own
+      # arm, which pushes a `Scene_ActorTarget` instead).
       def apply_switch_skill(sid)
         switch = @state.party.cast_switch_skill(caster, sid)
         if switch
           @state.switches[switch] = true
           play_skill_sound_effect(sid)
-          show_message("#{caster.name} casts #{skill_name(sid)}!", :cast)
+          @parent.pop_to_map
         else
           play_system_se(SFX_BUZZER)
           show_message("It had no effect.")
@@ -595,18 +605,10 @@ class RPG2k
 
       def drive_message
         return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        # `:cast` only ever tags #apply_switch_skill's message now (see
-        # #apply_skill's own comment) -- a switch skill is cast straight from
-        # the skill list, with no target screen to stay open on, so its own
-        # successful-cast message closes back into a rebuilt list, matching
-        # this same class's pre-existing #leave_target/#leave_teleport_target
-        # shape for "returning to the list."
-        done = @message[:done]
         close_message
-        leave_target if done == :cast
       end
 
-      def show_message(text, done = nil)
+      def show_message(text)
         return if @message
         w = SCREEN_W - 40
         win = Window.new(20, SCREEN_H - 40, w, 14 + Window::BORDER * 2)
@@ -616,7 +618,7 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         c.draw_text 0, 0, c.width, 14, text
         win.contents = c
-        @message = { window: win, done: done }
+        @message = { window: win }
       end
 
       def close_message

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17976,6 +17976,25 @@ check 'Scene::SkillMenu: a Switch skill plays its own sound_effect on a successf
      "the ordinary Decision SE (confirming the choice) then the skill's own sound_effect"
 end
 
+check 'Scene::SkillMenu: a successful Switch skill closes the whole menu ' \
+      'stack at once, with no confirmation message' do
+  # Confirmed against RPG_RT's own live source: `Scene_Skill::vUpdate`'s
+  # `Type_switch` arm (src/scene_skill.cpp) plays the skill's own sound
+  # effect and calls `Scene::PopUntil(Scene::Map)` on the very same Decision
+  # press, with no confirmation message at all -- the identical shape as
+  # `Type_escape`, not the ordinary target-mode cast's stay-open-and-show-a-
+  # message flow.
+  parent = fake_parent(fake_db)
+  state = skill_sound_effect_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm the switch skill
+  scene.update
+  RGSS::Input.reset
+  eq true, state.switches[17], 'the switch turned on'
+  ok parent.pop_to_map_called, 'the whole menu stack closes rather than staying open'
+  ok scene.instance_variable_get(:@message).nil?, 'no "casts ..." message, matching a switch item'
+end
+
 check 'Scene::SkillMenu: a Switch skill with a blank sound_effect plays nothing extra and does not error' do
   parent = fake_parent(fake_db)
   state = skill_sound_effect_state


### PR DESCRIPTION
## Summary

- `Scene_Skill::vUpdate`'s `Type_switch` arm (`src/scene_skill.cpp`) plays the skill's own sound effect and calls `Scene::PopUntil(Scene::Map)` on the very same Decision press — no confirmation message, no second Decision, the identical shape as the adjacent `Type_escape` arm, not the ordinary target-mode cast's stay-open-and-show-a-message flow.
- `Scene::SkillMenu#apply_switch_skill` (`mruby-rpg2k/mrblib/scene/skill_menu.rb`) showed `"#{caster.name} casts ...!"` and, via `#drive_message`'s `:cast` dispatch, called `#leave_target` — staying inside the Skill menu — instead of matching `Scene::ItemMenu#apply_switch_item`'s already-correct shape (no message, straight to `@parent.pop_to_map`).
- Fixed by dropping the message and `:cast` tag from `#apply_switch_skill` and calling `@parent.pop_to_map` directly, matching `#apply_escape_skill` right below it exactly. With `:cast` now unused anywhere in the file, `#drive_message`'s dispatch and `#show_message`'s `done:` parameter were both dead weight and removed.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a successful Switch skill cast closes the whole menu stack and shows no message.
- [x] Verified via `git stash` on `skill_menu.rb` alone: fails pre-fix (the stack stayed open).
- [x] Full suite green: `rpg2k_scene_check.rb` 798 passed, `rpg2k_logic_check.rb` 1065 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_