### PR TITLE
A special item invoking a Switch skill reports "It had no effect."

### DIFF
--- a/changelog.d/special-item-switch-skill.fixed.md
+++ b/changelog.d/special-item-switch-skill.fixed.md
@@ -1,0 +1,6 @@
+- **Field items:** A special (type 9) or `use_skill`-flagged equipment item
+  invoking a Switch-type skill now actually flips its switch and closes the
+  menu, matching RPG_RT -- previously it reported "It had no effect."
+  every time, since it fell through to logic with no notion of switches at
+  all. Covered by new `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3297,6 +3297,36 @@ The work below is roughly ordered by the critical path to a walkable game
   and queues the chosen one; cancelling the list returns to the item list),
   all confirmed to fail against the pre-fix code before the fix. Still
   untested by the real data, since neither test bed has such an item.
+  ✅ **Follow-up (2026-08-20): a special item invoking a Switch-type skill
+  was the one skill type this bullet's own routing never covered — reaching
+  `#cast_skill` (which has no notion of switches at all) and reporting "It
+  had no effect." on every use.** Confirmed directly against RPG_RT's live
+  source: `Scene_Item::vUpdate`'s `Type_switch` skill arm
+  (`src/scene_item.cpp`) sits right beside its already-ported Escape/
+  Teleport siblings — consuming the item, playing the skill's own sound
+  effect, and flipping `skill->switch_id` (the *skill's* own field, not the
+  item's) on the very same Decision press, no target/picker at all, no
+  `Game::State` needed unlike Escape/Teleport's registered-target lookup.
+  This is reachable, not a hypothetical: `#field_skill?`'s own `SKILL_
+  SWITCH` arm (`#field_occasion?(sk)`) already lets such an item appear in
+  the field bag list — `Scene::ItemMenu#choose_item` just had no branch for
+  it, falling through to an ordinary target-confirm or the scope-locked
+  `#apply_item`/`#cast_skill` path, neither of which can flip a switch.
+  Fixed by adding `Game::Party#use_special_switch_item` (mirroring `#use_
+  special_escape_item`'s exact shape: type-9/`use_skill` gate, `#item_
+  usable_by?`, `#consume_item_use`) through a new `free` parameter on
+  `#cast_switch_skill` (the identical pattern `#cast_escape_skill`/`#cast_
+  teleport_skill` already carry), and a new `SKILL_SWITCH` branch in
+  `#choose_item` calling a new `#apply_special_switch_item` that mirrors
+  `Scene::SkillMenu#apply_switch_skill`'s just-fixed shape exactly: no
+  message, straight to `@parent.pop_to_map`. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (`#use_special_switch_item` flips
+  the skill's own switch for free, consumes the item, and reads the field
+  list correctly with no state needed) and a new
+  `scripts/rpg2k_scene_check.rb` check (confirming the item flips the
+  switch and closes the whole menu stack with no message), both confirmed
+  to fail against the pre-fix code (`NoMethodError: undefined method
+  'use_special_switch_item'` / `expected true, got false`).
   **Dual-wield equipping is done too, the opposite rule to two-handed.** A
   weapon's own *combat* effect (a 二刀流 weapon swinging twice) was read
   already (ADR 0033); what remained was the *actor*-row 二刀流 (`double_hand`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4404,6 +4404,27 @@ module Game
       target
     end
 
+    # The same for a special item invoking a **Switch**-type skill: flip
+    # its switch for free (the item pays, not `actor`'s SP) and return the
+    # switch id to turn on, or nil when `id` does not name such an item or
+    # `actor` may not use it -- confirmed against RPG_RT's own live source:
+    # `Scene_Item::vUpdate`'s `Type_switch` skill arm (`src/scene_item.cpp`)
+    # sits right beside its Escape/Teleport siblings, unconditionally
+    # consuming the item and flipping `skill->switch_id` (the *skill's* own
+    # field, not the item's) on the very same Decision press, no `Game::
+    # State` needed unlike Escape/Teleport's registered-target lookup.
+    def use_special_switch_item(id, actor)
+      it = db_item(id)
+      return nil unless it &&
+                        (it.type == ITEM_SPECIAL ||
+                         (it.use_skill && (1..5).cover?(it.type))) &&
+                        actor && item_usable_by?(it, actor.id)
+      switch = cast_switch_skill(actor, it.skill_id, true)
+      return nil unless switch
+      consume_item_use(id)
+      switch
+    end
+
     # A single-target medicine (scope 0) heals `actor`; an all-ally medicine
     # (scope 1) heals the whole party regardless of `actor`. Applies the recovery
     # (clamped to each target's maxima) and cures the item's status conditions,
@@ -4849,10 +4870,14 @@ module Game
     # to turn on, so the caller can flip it (the switch table lives on the state,
     # not the party -- the same split #use_switch_item already uses). nil when
     # `sid` is not a switch skill the caster can cast, and then nothing is spent.
-    def cast_switch_skill(caster, sid)
-      return nil unless switch_skill?(sid) && can_cast?(caster, sid)
+    # `free`, when true, skips the SP-cost gate/spend entirely -- the same
+    # `free` flag `#cast_escape_skill`/`#cast_teleport_skill` already carry,
+    # for a special/use_skill item's invoked switch skill (the item pays,
+    # not the caster's SP; see #use_special_switch_item).
+    def cast_switch_skill(caster, sid, free = false)
+      return nil unless switch_skill?(sid) && (free ? !caster.nil? : can_cast?(caster, sid))
       sk = db_skill(sid)
-      caster.change_mp(-skill_cost(sk, caster))
+      caster.change_mp(-skill_cost(sk, caster)) unless free
       sk.switch_id
     end
 

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -175,6 +175,11 @@ class RPG2k
             @teleport_index = 0
             build_teleport_window
             refresh_desc
+          elsif sk && sk.type == Game::Party::SKILL_SWITCH
+            # A switch skill has no target and no confirmation message either
+            # -- mirroring Scene::SkillMenu#apply_switch_skill, a successful
+            # cast closes the whole menu stack at once.
+            apply_special_switch_item(id)
           elsif sk && (sk.scope == 2 || sk.scope == 4)
             # Unlike a medicine (whose all-ally scope needs no actor at all --
             # #use_medicine reads the whole party off `@actors`, ignoring the
@@ -266,6 +271,21 @@ class RPG2k
         target = @state.party.use_special_escape_item(id, @state.party.leader, @state)
         if target
           queue_teleport(target)
+        else
+          play_system_se(SFX_BUZZER)
+          show_message("It had no effect.")
+        end
+      end
+
+      # The same for a special item invoking a Switch-type skill: no target,
+      # no confirmation message -- a successful cast closes the whole menu
+      # stack at once, matching Scene::SkillMenu#apply_switch_skill (and
+      # this scene's own #apply_switch_item, the plain switch-item case).
+      def apply_special_switch_item(id)
+        switch = @state.party.use_special_switch_item(id, @state.party.leader)
+        if switch
+          @state.switches[switch] = true
+          @parent.pop_to_map
         else
           play_system_se(SFX_BUZZER)
           show_message("It had no effect.")

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6724,6 +6724,31 @@ check 'a special item invoking a Teleport skill offers every registered ' \
   eq 1, st.party.item_count(4), 'an unregistered destination consumes nothing'
 end
 
+check 'a special item invoking a Switch skill flips its switch and warps ' \
+      'nowhere, for free without spending an SP the item never had' do
+  # Confirmed against RPG_RT's own live source: `Scene_Item::vUpdate`'s
+  # `Type_switch` skill arm (src/scene_item.cpp) sits right beside its
+  # Escape/Teleport siblings -- consuming the item, playing the skill's own
+  # sound effect, and flipping `skill->switch_id` on the very same Decision
+  # press, no target/picker of any kind, the identical "no state, no SP"
+  # shape #use_special_escape_item/#use_special_teleport_item already have.
+  skills = { 8 => fake_skill(name: 'Scroll of Summon',
+                             type: Game::Party::SKILL_SWITCH, sp_cost: 5, switch_id: 22) }
+  items = { 6 => fake_item(type: 9, skill_id: 8, name: 'Scroll') }
+  st = skill_party(skills, items)
+  hero = st.party.actor_by_id(1)
+  ok !hero.knows_skill?(8), 'the item is the cost -- the caster need not know it'
+  st.party.gain_item(6, 2)
+  eq [[6, 2]], st.party.field_items(st), 'field_occasion alone is enough -- no state needed to appear'
+  before = hero.mp
+  eq 22, st.party.use_special_switch_item(6, hero), 'casting returns the switch to flip'
+  eq before, hero.mp, 'free -- the item pays, not the caster'
+  eq 1, st.party.item_count(6), 'one was consumed'
+  # An id that names no such item casts nothing and consumes nothing.
+  ok st.party.use_special_switch_item(999, hero).nil?
+  eq 1, st.party.item_count(6), 'unaffected'
+end
+
 check 'a use_skill equipment item invoking an Escape skill is menu-usable purely by ' \
       "scope, matching real RPG_RT's own use_skill shortcut -- access/target only " \
       'gate the cast itself, and a plain weapon is never treated as one' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17277,6 +17277,47 @@ def escape_teleport_item_state
   st
 end
 
+# A party whose only item is a special (type 9) one invoking a Switch skill --
+# Game::Party's own decision logic (#field_usable? / #use_special_switch_item)
+# is covered by scripts/rpg2k_logic_check.rb; this stub only has to hand the
+# scene something that behaves the same way, so this stays about the RGSS
+# wiring (does confirming the item actually flip the switch and close the
+# menu stack, with no message?).
+class SwitchSkillItemStubParty < MenuStubParty
+  SWITCH_ITEM_ID = 52
+
+  def leader; @actors.first; end
+  def field_items(_state = nil); [[SWITCH_ITEM_ID, 1]]; end
+
+  def db_item(id)
+    return nil unless id == SWITCH_ITEM_ID
+    OpenStruct.new(name: 'Summon Scroll', type: Game::Party::ITEM_SPECIAL, skill_id: 32)
+  end
+
+  def db_skill(id)
+    return nil unless id == 32
+    OpenStruct.new(name: 'Summon', type: Game::Party::SKILL_SWITCH)
+  end
+
+  def use_special_switch_item(id, _actor)
+    return nil unless id == SWITCH_ITEM_ID
+    99
+  end
+end
+
+check 'Scene::ItemMenu: a special item invoking a Switch skill flips its ' \
+      'switch and closes the whole menu stack, with no confirmation message' do
+  parent = fake_parent(fake_db)
+  state = Game::State.new(SwitchSkillItemStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm the only item
+  scene.update
+  RGSS::Input.reset
+  eq true, state.switches[99], 'the switch turned on'
+  ok parent.pop_to_map_called, 'the whole menu stack closes rather than staying open'
+  ok scene.instance_variable_get(:@message).nil?, 'no confirmation message, matching a switch item/skill'
+end
+
 check 'Scene::ItemMenu: a special item invoking Escape queues its target and ' \
       'closes the menu, with no confirmation message' do
   parent = fake_parent(fake_db)


### PR DESCRIPTION
## Summary

- `Scene_Item::vUpdate`'s `Type_switch` skill arm (`src/scene_item.cpp`) sits right beside its already-ported Escape/Teleport siblings — consuming the item, playing the skill's own sound effect, and flipping `skill->switch_id` on the very same Decision press, no target/picker at all, no `Game::State` needed unlike Escape/Teleport's registered-target lookup.
- This is reachable, not a hypothetical: `#field_skill?`'s own `SKILL_SWITCH` arm (`#field_occasion?(sk)`) already lets such an item appear in the field bag list — `Scene::ItemMenu#choose_item` just had no branch for it, falling through to an ordinary target-confirm or the scope-locked `#apply_item`/`#cast_skill` path, neither of which can flip a switch.
- Fixed by adding `Game::Party#use_special_switch_item` (mirroring `#use_special_escape_item`'s exact shape) through a new `free` parameter on `#cast_switch_skill` (the identical pattern `#cast_escape_skill`/`#cast_teleport_skill` already carry), and a new `SKILL_SWITCH` branch in `#choose_item` calling a new `#apply_special_switch_item` that mirrors `Scene::SkillMenu#apply_switch_skill`'s shape exactly: no message, straight to `@parent.pop_to_map`.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check (`#use_special_switch_item` flips the skill's own switch for free, consumes the item, and reads the field list correctly with no state needed).
- [x] New `scripts/rpg2k_scene_check.rb` check (the item flips the switch and closes the whole menu stack with no message).
- [x] Verified via `git stash` on `game.rb`/`item_menu.rb` alone: both fail pre-fix (`NoMethodError` / `expected true, got false`).
- [x] Full suite green: `rpg2k_scene_check.rb` 799 passed, `rpg2k_logic_check.rb` 1066 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_