### PR TITLE
A field-usable state-only skill ignores whether its state persists

### DIFF
--- a/changelog.d/field-skill-state-persistence.fixed.md
+++ b/changelog.d/field-skill-state-persistence.fixed.md
@@ -1,0 +1,5 @@
+- **Field skill menu:** A state-only skill (curing status conditions, no
+  HP/SP effect) is now correctly hidden from the field menu when every
+  state it touches is battle-only ("Continues after battle" unchecked),
+  matching RPG_RT -- it remains a perfectly ordinary skill in battle.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3988,6 +3988,37 @@ The work below is roughly ordered by the critical path to a walkable game
   own comment already notes they gate switch skills only *in this engine's
   own port*, which this result casts some doubt on as the full RPG_RT
   picture).
+  ✅ **Follow-up (2026-08-20): the narrower rule was found, from source
+  alone, with no wine needed after all -- it was never about the
+  `occasion_field`/`occasion_battle` flags this earlier attempt suspected.**
+  Confirmed directly against RPG_RT's live source: `Algo::IsSkillUsable`
+  (`src/algo.cpp`) takes a `require_states_persist` parameter, and
+  `Game_Battler::IsSkillUsable` — the function that actually backs
+  `Window_Skill::CheckEnable` for the field Skill list — always calls it
+  `true`. Inside, a state-only skill (no `affect_hp`/`affect_sp`) only
+  counts a `state_effects` entry when `state->type ==
+  Persistence_persists`: `for (...) { if (inflict) { const auto* state =
+  ...GetElement(...); if (state && (!require_states_persist ||
+  state->type == Persistence_persists)) { affects_state = true; break; }
+  } }` — a battle-only state (the schema default, `Persistence_persists`'s
+  own inverse) never makes the skill field-usable, even though it is a
+  perfectly ordinary skill in battle (states self-clear at battle end
+  regardless, so a battle-only cure genuinely has nothing left to do once
+  the field menu is even reachable). `Game::Party#field_skill?`'s else-arm
+  (`mruby-rpg2k/mrblib/game.rb`) read `skill_state_ids(sk)` unconditionally
+  — no persistence filter at all — even though this codebase already had
+  the exact concept implemented and named elsewhere (`Actor#state_
+  persists_type?`, `Battle::STATE_PERSISTS_ON_MAP`, matching liblcf's
+  `Persistence_persists`/`Persistence_ends`), just never threaded into this
+  one gate. Fixed by filtering `skill_state_ids(sk)` down to the ones whose
+  `situation` row reads `type == Battle::STATE_PERSISTS_ON_MAP`, via
+  `Game::States.row` and the existing `#state_table` accessor (a
+  dangling/unknown state id fails the same way the reference's own `state
+  &&` guard does). Covered by a new `scripts/rpg2k_logic_check.rb` check (a
+  skill curing only a battle-only state is hidden from the field list while
+  a perfectly ordinary battle-list entry; a sibling skill curing only a
+  persisting state is offered in both), confirmed to fail against the
+  pre-fix code (`expected [[13, 2]], got [[12, 2], [13, 2]]`).
   ✅ **Confirmed via EasyRPG Player's source instead, once the wine
   reference runtime itself stopped rendering past Continue this session
   (see the harness-quirk notes above), and now fixed.** `Window_Skill`'s

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4760,8 +4760,23 @@ module Game
         return false unless sk.scope >= 2
         # The raw state set, not #skill_inflicted_states: a plain antidote cures
         # rather than inflicts (`reverse_state_effect` off), and curing poison
-        # between fights is the whole point of the field skill menu.
-        sk.affect_hp || sk.affect_sp || !skill_state_ids(sk).empty?
+        # between fights is the whole point of the field skill menu. A
+        # state-only skill (no affect_hp/affect_sp) only counts if at least
+        # one of the states it touches actually "Continues after battle" --
+        # confirmed against RPG_RT's own live source: `Algo::IsSkillUsable`
+        # (`src/algo.cpp`), called from `Game_Battler::IsSkillUsable` with
+        # `require_states_persist` hard-`true` for this exact purpose, only
+        # counts a `state_effects` entry when `state->type ==
+        # Persistence_persists` -- a battle-only state (the schema default,
+        # `Battle::STATE_PERSISTS_ON_MAP`'s own inverse) never makes the
+        # skill field-usable, even though it's a perfectly ordinary skill in
+        # battle. A dangling/unknown state id fails the same way the
+        # reference's own `state &&` guard does -- not usable.
+        sk.affect_hp || sk.affect_sp ||
+          skill_state_ids(sk).any? do |id|
+            row = Game::States.row(id, state_table)
+            row.respond_to?(:type) && (row.type || 0) == Battle::STATE_PERSISTS_ON_MAP
+          end
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6886,6 +6886,34 @@ check 'field_skills lists only known field-usable ally skills; can_cast? checks 
   eq false, st.party.can_cast?(hero, 99)       # unknown skill
 end
 
+check "field_skill? excludes a state-only skill whose state is battle-only, " \
+      "not flagged to continue after battle" do
+  # Confirmed against RPG_RT's own live source: `Algo::IsSkillUsable`
+  # (src/algo.cpp), called from `Game_Battler::IsSkillUsable` with
+  # `require_states_persist` hard-`true` for this exact purpose, only
+  # counts a `state_effects` entry when `state->type ==
+  # Persistence_persists` -- a battle-only state (the schema default) never
+  # makes the skill field-usable, even though it is a perfectly ordinary
+  # skill in battle (states self-clear at battle end regardless, so there
+  # is nothing left to cure once the field menu is even reachable).
+  situation = {
+    3 => fake_state(type: 0), # battle-only (the schema default)
+    4 => fake_state(type: 1), # "Continues after battle"
+  }
+  skills = {
+    12 => fake_skill(name: 'Wake Up', scope: 3, sp_cost: 2, state_effects: [0, 0, 1]),
+    13 => fake_skill(name: 'Refresh', scope: 3, sp_cost: 2, state_effects: [0, 0, 0, 1]),
+  }
+  st = skill_party(skills, {}, situation: situation)
+  hero = st.party.actor_by_id(1)
+  [12, 13].each { |s| hero.learn_skill(s) }
+  caster = Game::Battle.from_actor(hero)
+  eq [[12, 2], [13, 2]], st.party.battle_skills(hero, caster),
+     'both are perfectly ordinary skills in battle'
+  eq [[13, 2]], st.party.field_skills(hero),
+     'the battle-only state cure is hidden from the field menu; the persisting one is offered'
+end
+
 # A database shrink can leave a caster's learned skill id dangling -- shown
 # as "?" in the editor, docs/TODO.md's runtime error catalog. #db_skill
 # silently resolves that to nil, and #field_skill? just as silently excludes


### PR DESCRIPTION
## Summary

- `Algo::IsSkillUsable` (`src/algo.cpp`) takes a `require_states_persist` parameter, and `Game_Battler::IsSkillUsable` — the function that actually backs `Window_Skill::CheckEnable` for the field Skill list — always calls it `true`. Inside, a state-only skill (no `affect_hp`/`affect_sp`) only counts a `state_effects` entry when `state->type == Persistence_persists`: a battle-only state (the schema default) never makes the skill field-usable, even though it is a perfectly ordinary skill in battle — states self-clear at battle end regardless, so a battle-only cure has nothing left to do once the field menu is even reachable.
- `Game::Party#field_skill?`'s else-arm (`mruby-rpg2k/mrblib/game.rb`) read `skill_state_ids(sk)` unconditionally — no persistence filter at all — even though this codebase already had the exact concept implemented and named elsewhere (`Actor#state_persists_type?`, `Battle::STATE_PERSISTS_ON_MAP`), just never threaded into this one gate.
- Fixed by filtering `skill_state_ids(sk)` down to the ones whose `situation` row reads `type == Battle::STATE_PERSISTS_ON_MAP`, via `Game::States.row` and the existing `#state_table` accessor.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a skill curing only a battle-only state is hidden from the field list while a perfectly ordinary battle-list entry; a sibling skill curing only a persisting state is offered in both.
- [x] Verified via `git stash` on `game.rb` alone: fails pre-fix (`expected [[13, 2]], got [[12, 2], [13, 2]]`).
- [x] Full suite green: `rpg2k_scene_check.rb` 799 passed, `rpg2k_logic_check.rb` 1067 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_