### PR TITLE
A Skill Book/Seed does nothing on a downed actor

### DIFF
--- a/changelog.d/skill-book-seed-dead-actor.fixed.md
+++ b/changelog.d/skill-book-seed-dead-actor.fixed.md
@@ -1,0 +1,4 @@
+- **Skill Books and Seeds:** Using one on a downed party member now
+  silently does nothing -- matching RPG_RT -- instead of teaching the
+  skill or raising stats anyway; the item is not consumed either.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5461,6 +5461,30 @@ The work below is roughly ordered by the critical path to a walkable game
   excludes the second actor: the picker offers only the first, and moving
   the cursor has nowhere to go), confirmed to fail against the pre-fix code
   before the fix.
+  ✅ **Follow-up (2026-08-20): a Skill Book or Seed used on a downed party
+  member taught the skill / raised the stats anyway, when real RPG_RT
+  silently does nothing.** Confirmed directly against RPG_RT's live source:
+  `Game_Actor::UseItem` (`src/game_actor.cpp`) only reaches its `Type_book`/
+  `Type_material` branches inside an `if (!IsDead())` guard; falling
+  through to `Game_Battler::UseItem` (`src/game_battler.cpp`) for a dead
+  actor lands on neither type at all — only Medicine/Switch/skill-invoking
+  items are handled there — so the item is silently never consumed and
+  nothing changes. Unlike Medicine, the one item type genuinely meant to
+  work on the dead (`#ko_only_blocked?`'s own `it.ko_only` case, and the
+  reverse: an ordinary non-`ko_only` medicine on a dead actor is *also*
+  refused, per `Game_Battler::UseItem`'s own `IsDead()` branch, already
+  correctly ported), Book/Seed have no such exception anywhere in the
+  reference. `Game::Party#use_skill_book`/`#use_seed`
+  (`mruby-rpg2k/mrblib/game.rb`) had no `actor.dead?` check at all — only
+  `#item_usable_by?` (`actor_set`) — even though `Actor#dead?` already
+  existed and backs the sibling `#ko_only_blocked?` gate. Fixed by adding
+  `!actor.dead?` to both methods' guards, and to `#item_effective?`'s
+  matching `ITEM_SKILL_BOOK`/`ITEM_SEED` branches for the same reason
+  (keeping "would this do anything" consistent with what `#use_item` itself
+  now does). Covered by two new `scripts/rpg2k_logic_check.rb` checks (a
+  Skill Book/Seed used on a downed actor teaches nothing, changes no stat,
+  and consumes nothing), both confirmed to fail against the pre-fix code
+  (`expected false, got true`).
 - ✅ **A battle switch item now actually flips its switch.** A switch item
   (type 10) was already listed in the battle Item command
   (`Game::Party#battle_usable?` / `#battle_items` both include `ITEM_SWITCH`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4228,9 +4228,9 @@ module Game
           item_cured_states(it).any? { |s| actor.state?(s) }
       when ITEM_SKILL_BOOK
         s = it.skill_id
-        !s.nil? && s != 0 && !actor.knows_skill?(s)
+        !actor.dead? && !s.nil? && s != 0 && !actor.knows_skill?(s)
       when ITEM_SEED
-        seed_boosts(it).any? { |b| b != 0 }
+        !actor.dead? && seed_boosts(it).any? { |b| b != 0 }
       when ITEM_SWITCH
         true # a switch item always flips its switch
       when ITEM_SPECIAL
@@ -4465,9 +4465,19 @@ module Game
     # A skill book teaches its skill (item field 53) to `actor` if the actor does
     # not already know it, consuming one book. A book with no skill, or used on an
     # actor who already knows the skill, does nothing and is not consumed.
+    # A Skill Book/Seed does nothing on a downed actor -- confirmed against
+    # RPG_RT's own live source: `Game_Actor::UseItem` (`src/game_actor.cpp`)
+    # only reaches its `Type_book`/`Type_material` branches inside an
+    # `if (!IsDead())` guard; falling through to `Game_Battler::UseItem`
+    # (`src/game_battler.cpp`) for a dead actor lands on neither type at
+    # all (only Medicine/Switch/skill-invoking items are handled there), so
+    # the item is silently never consumed and nothing changes -- unlike
+    # Medicine, the one item type genuinely meant to work on the dead
+    # (`#ko_only_blocked?`'s own `it.ko_only` case), Book/Seed have no such
+    # exception.
     def use_skill_book(it, id, actor)
       skill = it.skill_id
-      return [] unless actor && item_usable_by?(it, actor.id) &&
+      return [] unless actor && !actor.dead? && item_usable_by?(it, actor.id) &&
                        skill && skill != 0 && !actor.knows_skill?(skill)
       actor.learn_skill(skill)
       consume_item_use(id)
@@ -4488,8 +4498,11 @@ module Game
     # A seed permanently raises `actor`'s base stats by seed_boosts (each applied
     # through Actor#change_param, so RPG2000's stat caps hold). Consumes one when
     # it carries any boost; a seed with no boost does nothing and is not consumed.
+    # A Seed does nothing on a downed actor -- see #use_skill_book's own
+    # comment for the full RPG_RT citation; this shares the identical
+    # `if (!IsDead())` gate in `Game_Actor::UseItem`.
     def use_seed(it, id, actor)
-      return [] unless actor && item_usable_by?(it, actor.id)
+      return [] unless actor && !actor.dead? && item_usable_by?(it, actor.id)
       boosts = seed_boosts(it)
       return [] unless boosts.any? { |b| b != 0 }
       boosts.each_index { |i| actor.change_param(i, boosts[i]) if boosts[i] != 0 }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6366,6 +6366,24 @@ check 'a skill book on an actor who already knows the skill does nothing' do
   eq 1, st.party.item_count(8)                 # not consumed
 end
 
+check 'a skill book does nothing on a downed actor -- unlike Medicine, ' \
+      'Book/Seed have no ko_only-style exception' do
+  # Confirmed against RPG_RT's own live source: Game_Actor::UseItem
+  # (src/game_actor.cpp) only reaches its Type_book/Type_material branches
+  # inside an `if (!IsDead())` guard; falling through to
+  # Game_Battler::UseItem (src/game_battler.cpp) for a dead actor lands on
+  # neither type at all (only Medicine/Switch/skill-invoking items are
+  # handled there), so the item is silently never consumed.
+  st = item_party({ 8 => fake_item(type: 7, skill_id: 42) })
+  st.party.gain_item(8, 1)
+  hero = st.party.leader
+  hero.change_hp(-9999)                        # KO
+  eq false, st.party.item_effective?(8, hero)
+  eq [], st.party.use_item(8, hero)
+  eq false, hero.knows_skill?(42), 'nothing learned'
+  eq 1, st.party.item_count(8)                 # not consumed
+end
+
 check 'a seed permanently raises the target stats (points2 set) and is consumed' do
   st = item_party({ 9 => fake_item(type: 8, mhp: 50, atk2: 5) })
   st.party.gain_item(9, 2)
@@ -6375,6 +6393,19 @@ check 'a seed permanently raises the target stats (points2 set) and is consumed'
   eq 150, hero.max_hp                           # +50 base max HP
   eq 15, hero.atk                               # +5 base attack (atk_points2)
   eq 1, st.party.item_count(9)                  # one seed consumed
+end
+
+check 'a seed does nothing on a downed actor -- the identical Game_Actor::' \
+      'UseItem `if (!IsDead())` gate as a skill book' do
+  st = item_party({ 9 => fake_item(type: 8, mhp: 50, atk2: 5) })
+  st.party.gain_item(9, 1)
+  hero = st.party.leader                        # max_hp 100, atk 10
+  hero.change_hp(-9999)                         # KO
+  eq false, st.party.item_effective?(9, hero)
+  eq [], st.party.use_item(9, hero)
+  eq 100, hero.max_hp, 'no stat change'
+  eq 10, hero.atk, 'no stat change'
+  eq 1, st.party.item_count(9)                  # not consumed
 end
 
 check 'field_items includes seeds; a seed with no boost is ineffective' do


### PR DESCRIPTION
## Summary

- `Game_Actor::UseItem` (`src/game_actor.cpp`) only reaches its `Type_book`/`Type_material` (Skill Book/Seed) branches `if (!IsDead())`; falling through to `Game_Battler::UseItem` (`src/game_battler.cpp`) for a dead actor hits neither type — only Medicine/Switch/skill-invoking items are handled there. Medicine has its own explicit dead-actor semantics (`ko_only`/revive-state check), but a Skill Book or Seed used on a downed actor silently does nothing in RPG_RT.
- `Game::Party#use_skill_book` and `#use_seed` (`mruby-rpg2k/mrblib/game.rb`) had no such gate — both would apply their effect (learn a skill / apply stat boosts) to a KO'd actor.
- Fixed by adding a matching `!actor.dead?` guard to both methods. `#item_effective?`'s `ITEM_SKILL_BOOK`/`ITEM_SEED` branches (which represent "would this item do anything") got the identical guard so they stay consistent with `use_item`'s corrected behavior.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: a KO'd actor's Skill Book/Seed use is a no-op (`item_effective?` false, `use_item` empty, no skill learned / no stat change, item not consumed).
- [x] Verified via `git stash` on `game.rb` alone: fails pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 799 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_