### PR TITLE
Title cursor starts on Continue instead of New Game when a save exists

### DIFF
--- a/changelog.d/title-cursor-starts-on-continue.fixed.md
+++ b/changelog.d/title-cursor-starts-on-continue.fixed.md
@@ -1,0 +1,4 @@
+- **Title screen:** The cursor now starts on Continue instead of New Game
+  when a save exists, matching RPG_RT (`Scene_Title::Refresh`'s
+  `command_window->SetIndex(1)`). Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4373,6 +4373,26 @@ The work below is roughly ordered by the critical path to a walkable game
   file already does), confirmed to fail against the pre-fix code (zero
   matching blend calls, since the flat-gray branch never blends at all)
   before the fix.
+  ✅ **The title cursor's *starting position* ignored whether a save exists,
+  a separate gap from either fix just above (2026-08-20).** `Scene::Title#initialize`
+  (`mruby-rpg2k/mrblib/scene/title.rb`) hardcoded `@selected_index = 0` before
+  `@continue_available` was even computed, so the cursor always opened on New
+  Game regardless of save data. Confirmed against EasyRPG Player's actual
+  source: `Scene_Title::Refresh` (`src/scene_title.cpp`) —
+  `continue_enabled = FileFinder::HasSavegame(); if (continue_enabled)
+  command_window->SetIndex(1);` — moves the cursor to Continue (index 1)
+  whenever a save exists, unconditionally alongside (not instead of)
+  `SetItemEnabled(1, continue_enabled)`; `Refresh()` runs from
+  `CreateCommandWindow()` on every title build, and `CommandIndices` fixes
+  `continue_game = 1` regardless of which optional entries (Import/Settings/
+  Translate) exist, so `SetIndex(1)` always targets Continue specifically.
+  Fixed by reordering so `@continue_available` is computed first, then
+  `@selected_index = @continue_available ? 1 : 0`; `#refresh_cursor`, already
+  called at the end of `initialize`, draws the cursor on the correct entry
+  with no other change needed. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a save present starts the cursor on Continue; no save data still
+  starts it on New Game), the first confirmed to fail against the pre-fix
+  code (`expected 1, got 0`) before the fix.
   ✅ **The same disabled-swatch gap existed on the save/load file-select
   screen too, and there every line was flat, not just the disabled one
   (2026-08-18).** `Scene::SaveLoad#draw_slot_box` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -34,7 +34,6 @@ class RPG2k
           term(:continue, 'Continue'),
           term(:shutdown, 'Shutdown')
         ]
-        @selected_index = 0
 
         # RPG_RT grays out and skips over Continue when there is no save to
         # resume. `any_save_exists?` (main.rb) covers both our own Marshal
@@ -42,6 +41,14 @@ class RPG2k
         # across every one of the MAX_SAVE_SLOTS slots -- which one, if any,
         # is now Scene::SaveLoad's own question to ask once Continue opens it.
         @continue_available = continue_available?
+
+        # RPG_RT starts the cursor on Continue, not New Game, whenever a save
+        # exists -- confirmed against EasyRPG's own `Scene_Title::Refresh`
+        # (`src/scene_title.cpp`): `if (continue_enabled)
+        # command_window->SetIndex(1);` fires unconditionally alongside (not
+        # instead of) `SetItemEnabled(1, continue_enabled)`, so a save's
+        # presence moves the initial selection, not just the grayed-out look.
+        @selected_index = @continue_available ? 1 : 0
 
         # RPG_RT sizes the window to the widest label plus one border on each
         # side — no extra padding — and one 16px row per entry.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12035,6 +12035,24 @@ check 'a save exists: Continue is flagged available and its selection key opens 
   eq :load, pushed.instance_variable_get(:@mode), 'opened in :load mode'
 end
 
+# `Scene_Title::Refresh` (src/scene_title.cpp) calls `command_window->SetIndex(1)`
+# whenever a save exists, unconditionally alongside `SetItemEnabled` -- the
+# cursor starts on Continue, not New Game, so a returning player does not have
+# to move down manually before resuming.
+check 'a save exists: the title cursor starts on Continue, not New Game' do
+  parent = TitleParent.new(fake_db, nil, false, true)
+  scene = RPG2k::Scene::Title.new(parent)
+  eq 1, scene.instance_variable_get(:@selected_index),
+     'RPG_RT starts the cursor on Continue when a save exists (Scene_Title::Refresh)'
+end
+
+check 'no save data: the title cursor still starts on New Game' do
+  parent = TitleParent.new(fake_db, nil, false, false)
+  scene = RPG2k::Scene::Title.new(parent)
+  eq 0, scene.instance_variable_get(:@selected_index),
+     'with nothing to resume, the cursor starts on New Game as before'
+end
+
 # -- screen fade / flash overlays ---------------------------------------------
 #
 # Erase/Show Screen and Flash Screen are drawn as two full-screen colour sprites


### PR DESCRIPTION
## Summary

- `Scene_Title::Refresh` (`src/scene_title.cpp`) sets `continue_enabled = FileFinder::HasSavegame()` and, when true, calls `command_window->SetIndex(1)` — unconditionally alongside (not instead of) `SetItemEnabled(1, continue_enabled)`. `Refresh()` runs from `CreateCommandWindow()` on every title build, and `CommandIndices` fixes `continue_game = 1` regardless of which optional entries (Import/Settings/Translate) exist, so `SetIndex(1)` always targets Continue specifically — RPG_RT starts the cursor on Continue, not New Game, whenever a save exists.
- `Scene::Title#initialize` (`mruby-rpg2k/mrblib/scene/title.rb`) hardcoded `@selected_index = 0` before `@continue_available` was even computed, so the cursor always opened on New Game regardless of save data — a returning player had to move the cursor down manually before resuming.
- Fixed by reordering so `@continue_available` is computed first, then `@selected_index = @continue_available ? 1 : 0`. `#refresh_cursor`, already called at the end of `initialize`, draws the cursor on the correct entry with no other change needed.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks: a save present starts the cursor on Continue; no save data still starts it on New Game.
- [x] Verified via `git stash` on `title.rb` alone: the first check fails pre-fix (`expected 1, got 0`).
- [x] Full suite green: `rpg2k_scene_check.rb` 801 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_