### PR TITLE
Shop status/gold panels hide on the sell list, not the quantity counter

### DIFF
--- a/changelog.d/shop-status-gold-panel-visibility.fixed.md
+++ b/changelog.d/shop-status-gold-panel-visibility.fixed.md
@@ -1,0 +1,7 @@
+- **Shop screen:** The status and gold side panels now follow RPG_RT's own
+  visibility rule (`Scene_Shop::SetMode`): visible on the buy list, the
+  quantity counter and the purchase/sale confirmation; hidden on the
+  command menu and the sell list. Previously they went dark for the
+  quantity counter and confirmation (the opposite of RPG_RT) and the gold
+  panel never hid at all. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1052,8 +1052,44 @@ The work below is roughly ordered by the critical path to a walkable game
   `Game_Party::GetEquippedItemCount` / `Game_Actor::GetItemCount` slot-equality
   scan — a copy currently equipped no longer counts toward the bag, so the
   two rows move independently). It refreshes with the list's own cursor and
-  is torn down for the command menu, the quantity counter and the
-  purchase/sale confirmation, none of which highlight a single item.
+  ~~is torn down for the command menu, the quantity counter and the
+  purchase/sale confirmation, none of which highlight a single item~~ —
+  ✅ **wrong for two of those three screens, corrected below (2026-08-20):**
+  RPG_RT keeps the status panel (and the gold panel) up through the quantity
+  counter and the purchase/sale confirmation, tearing it down only for the
+  command menu and the *sell* list.
+  ✅ **The shop's status and gold panels used "highlights a single item" as
+  their visibility rule, backwards for three of the five shop screens
+  (2026-08-20).** `#shop_status_item_id` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  showed the panel for `:buy` and `:sell` and hid it everywhere else;
+  `#draw_shop_gold` never toggled visibility at all, drawing the gold panel
+  on every screen including the command menu. Confirmed against EasyRPG
+  Player's actual source: `Scene_Shop::SetMode`'s "Right-hand panels" switch
+  (`src/scene_shop.cpp`, fetched and read in full) —
+  `case BuySellLeave: case BuySellLeave2: case Sell: party_window->
+  SetVisible(false); status_window->SetVisible(false); gold_window->
+  SetVisible(false); break; case Buy: case BuyHowMany: case SellHowMany:
+  case Bought: case Sold: party_window->SetVisible(true); status_window->
+  SetVisible(true); gold_window->SetVisible(true); break;` — shows both
+  panels for Buy, the quantity counter (`BuyHowMany`/`SellHowMany`) and the
+  purchase/sale confirmation (`Bought`/`Sold`), and hides them for the
+  command menu (`BuySellLeave`/`BuySellLeave2`) *and the Sell list*, not
+  "whichever screen highlights a single item" (which would show it for Sell
+  and hide it for the quantity/confirmation screens — backwards on both
+  counts). Fixed by widening `#shop_status_item_id`'s screen set to
+  `:buy`/`:quantity`/`:purchased`/`:sold` (dropping `:sell`) and adding a
+  matching `visible=` toggle to `#draw_shop_gold`, both driven by one shared
+  `SHOP_PANELS_VISIBLE_ON` list. The quantity counter and confirmation
+  screens need the highlighted item's id from `@shop[:quantity]`, which
+  `#drive_shop_quantity` used to null out the instant a transaction
+  committed — moved that reset into `#drive_shop_confirm` (where the screen
+  actually leaves `:purchased`/`:sold` back to `:buy`/`:sell`) so the id
+  survives through the confirmation screen. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (the status panel stays visible,
+  showing the same item, through the quantity counter and purchase
+  confirmation; the gold panel hides on the command menu and the sell list
+  and shows on the quantity counter), both confirmed to fail against the
+  pre-fix code before the fix.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4905,7 +4905,18 @@ class RPG2k
         draw_shop_status(lines)
       end
 
+      # The gold and status panels share one visible/hidden set: RPG_RT's
+      # right-hand panels (Scene_Shop::SetMode, src/scene_shop.cpp) are shown
+      # for Buy, BuyHowMany/SellHowMany and Bought/Sold, and hidden for
+      # BuySellLeave and Sell -- not "whichever screen highlights one item",
+      # the reasoning a prior pass here used, which got the Sell list and the
+      # quantity/confirmation screens backwards.
+      SHOP_PANELS_VISIBLE_ON = %i[buy quantity purchased sold].freeze
+
       def draw_shop_gold
+        visible = SHOP_PANELS_VISIBLE_ON.include?(@shop[:screen])
+        @shop[:gold].visible = visible
+        return unless visible
         gw = 88
         c = Bitmap.new(gw - Window::BORDER * 2, SHOP_LINE_H)
         c.font.color = Color.new(255, 255, 255, 255)
@@ -4919,14 +4930,20 @@ class RPG2k
       # SHOP_LINE_H label line each, plus the ordinary window border.
       SHOP_STATUS_W = 136
 
-      # The item id the status panel should describe: whichever row the
-      # cursor sits on in the buy or sell list. The command menu, the
-      # quantity counter and the purchase/sale confirmation don't highlight
-      # a single item, so there is nothing for the panel to show there.
+      # The item id the status panel should describe. On the buy list it is
+      # whichever row the cursor sits on; on the quantity counter and the
+      # purchase/sale confirmation it is the item the counter was opened for
+      # (kept alive in `@shop[:quantity]` through the confirmation screen --
+      # see #drive_shop_quantity / #drive_shop_confirm). The command menu and
+      # the sell list get no status panel at all, matching SHOP_PANELS_VISIBLE_ON.
       def shop_status_item_id(lines)
-        return nil unless @shop[:screen] == :buy || @shop[:screen] == :sell
-        return nil if lines.nil? || lines.empty?
-        lines[@shop[:index]][1]
+        case @shop[:screen]
+        when :buy
+          return nil if lines.nil? || lines.empty?
+          lines[@shop[:index]][1]
+        when :quantity, :purchased, :sold
+          @shop[:quantity] && @shop[:quantity][:id]
+        end
       end
 
       # The status panel beside the buy/sell list: the `possessed_items` /
@@ -5019,6 +5036,7 @@ class RPG2k
       def drive_shop_confirm
         return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
         @shop[:screen] = @shop[:screen] == :purchased ? :buy : :sell
+        @shop[:quantity] = nil
         draw_shop
       end
 
@@ -5054,7 +5072,9 @@ class RPG2k
           model = @shop[:model]
           mode = q[:mode]
           mode == :buy ? model.buy(q[:id], q[:count]) : model.sell(q[:id], q[:count])
-          @shop[:quantity] = nil
+          # @shop[:quantity] survives into :purchased/:sold -- the status
+          # panel there still needs its item id (see #shop_status_item_id) --
+          # and is only cleared once #drive_shop_confirm leaves the screen.
           @shop[:screen] = mode == :buy ? :purchased : :sold
           draw_shop
           play_system_se(SFX_DECISION)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13777,7 +13777,8 @@ check 'Open Shop scene: selling shows the shop_sold confirmation, then returns '
 end
 
 check 'Open Shop scene: the status panel shows the highlighted item\'s possessed ' \
-      'and equipped counts, and disappears off the buy/sell list' do
+      'and equipped counts, and stays visible through the quantity counter and ' \
+      'purchase confirmation' do
   ic = Game::Interpreter::Cmd
   db = fake_db
   db.term.possessed_items = '所持数'
@@ -13821,14 +13822,75 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   RGSS::Input.triggered = []
   shop = scene.instance_variable_get(:@shop)
   eq :quantity, shop[:screen]
-  ok shop[:status].nil?, 'the quantity counter highlights no single list row -- no panel'
+  # Scene_Shop::SetMode (src/scene_shop.cpp) keeps the right-hand panels
+  # visible through BuyHowMany/Bought just like Buy itself -- the panel
+  # still describes the item the counter was opened for, not "no panel".
+  ok !shop[:status].nil?, 'the quantity counter keeps the status panel visible, for the same item'
+  texts = window_texts(shop[:status])
+  ok texts.include?('0'), 'still describing the Herb the counter was opened for'
 
-  RGSS::Input.triggered = [RGSS::Input::B] # back to the buy list
+  RGSS::Input.triggered = [RGSS::Input::C] # commit the purchase
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :purchased, shop[:screen]
+  ok !shop[:status].nil?,
+     'the purchase confirmation keeps the status panel visible too (Scene_Shop::SetMode\'s Bought case)'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the confirmation, back to the buy list
   scene.update
   RGSS::Input.triggered = []
   shop = scene.instance_variable_get(:@shop)
   eq :buy, shop[:screen]
   ok !shop[:status].nil?, 'the panel returns once a good is highlighted again'
+
+  RGSS::Input.triggered = [RGSS::Input::B] # back to the command menu
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  ok shop[:status].nil?, 'the command menu still shows no panel'
+end
+
+# Scene_Shop::SetMode's own right-hand-panel switch (src/scene_shop.cpp)
+# hides the party/status/gold panels for BuySellLeave and Sell alike, and
+# shows them for Buy, BuyHowMany/SellHowMany and Bought/Sold -- the gold
+# panel follows the exact same visible/hidden set as the status panel
+# checked just above (see SHOP_PANELS_VISIBLE_ON, mruby-rpg2k/mrblib/
+# scene/map.rb), not "always on".
+check 'Open Shop scene: the gold panel hides on the command menu and the ' \
+      'sell list, matching the status panel' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0)] # buy+sell
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  party = ShopStubParty.new(500)
+  party.gain_item(3, 1)
+  state.instance_variable_set(:@party, party)
+  3.times { scene.update } # the command menu opens (mode 0: buy+sell)
+
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  ok !shop[:gold].visible, 'the command menu hides the gold panel'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move to Sell
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Sell
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :sell, shop[:screen]
+  ok !shop[:gold].visible, 'the sell list hides the gold panel too'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # open the quantity counter for the held Potion
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :quantity, shop[:screen]
+  ok shop[:gold].visible, 'the quantity counter shows the gold panel'
 end
 
 check 'Enemy Encounter scene: the result window shows the database Victory term' do


### PR DESCRIPTION
## Summary

- `Scene_Shop::SetMode`'s "Right-hand panels" switch (`src/scene_shop.cpp`) shows the party/status/gold panels for `Buy`, `BuyHowMany`/`SellHowMany` and `Bought`/`Sold`, and hides them for `BuySellLeave`/`BuySellLeave2` and `Sell` — RPG_RT keeps the status and gold panels up through the quantity counter and the purchase/sale confirmation, tearing them down only for the command menu and the *sell* list.
- `#shop_status_item_id` (`mruby-rpg2k/mrblib/scene/map.rb`) had this backwards for three of the five shop screens: visible for `:buy`/`:sell`, hidden for the command menu, quantity counter, and confirmation. `#draw_shop_gold` never toggled visibility at all, drawing the gold panel unconditionally on every screen including the command menu.
- Fixed by widening `#shop_status_item_id`'s screen set to `:buy`/`:quantity`/`:purchased`/`:sold` (dropping `:sell`) and adding a matching `visible=` toggle to `#draw_shop_gold`, both driven by one shared `SHOP_PANELS_VISIBLE_ON` list. The quantity counter and confirmation screens need the highlighted item's id from `@shop[:quantity]`, which `#drive_shop_quantity` used to null out the instant a transaction committed — moved that reset into `#drive_shop_confirm` (where the screen actually leaves `:purchased`/`:sold` back to `:buy`/`:sell`) so the id survives through the confirmation screen.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks: the status panel stays visible (showing the same item) through the quantity counter and purchase confirmation; the gold panel hides on the command menu and the sell list and shows on the quantity counter.
- [x] Verified via `git stash` on `map.rb` alone: both new checks fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 802 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_