### PR TITLE
Equip screen previews each battle stat independently, not a summed arrow

### DIFF
--- a/changelog.d/equip-per-stat-preview.fixed.md
+++ b/changelog.d/equip-per-stat-preview.fixed.md
@@ -1,0 +1,7 @@
+- **Equip screen:** The candidate item list no longer draws a summed
+  Up/Same/Down arrow (it never existed in RPG_RT). The status panel above it
+  now previews each of the four battle stats independently while browsing
+  candidates -- `Atk 20 -> 25`, colour-coded from the windowskin's own
+  swatches -- matching RPG_RT's `Window_EquipStatus::DrawParameter`. A
+  candidate trading Atk for Def now visibly shows both movements at once.
+  Covered by new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15052,12 +15052,12 @@ above are repeated here)
   upper tile still deferring to a blocked lower tile). The simplified
   ○/×/★/□ editor icon's own "at least one of 4 directions" semantics is a
   content-authoring/editor-display fact with no runtime code to check.
-- ✅ **The equip-menu comparison arrow (Up/Same/Down) is computed from the
+- ~~The equip-menu comparison arrow (Up/Same/Down) is computed from the
   sum of all four stat deltas between the currently-equipped and candidate
-  item, not evaluated per-stat.** (The bullet's own wording says "shop", but
+  item, not evaluated per-stat.~~ (The bullet's own wording says "shop", but
   RPG2000 shops never compare equipment stats — only the field Equip screen's
   own candidate list does; `01_shoshin`/`11_db` both describe this same
-  indicator on that screen.) `Scene::EquipMenu#build_cand_window`
+  indicator on that screen.) ~~`Scene::EquipMenu#build_cand_window`
   (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) drew each candidate as a bare
   name + bag count, with no comparison of any kind. Fixed by summing each
   side's `atk_points1`/`def_points1`/`spi_points1`/`agi_points1` fields (the
@@ -15068,12 +15068,52 @@ above are repeated here)
   which is the actual yado.tk claim (a candidate trading `-2` Atk for `+3`
   Def still draws a single Up arrow). RPG_RT draws small triangle icons here;
   this build has no icon-cell blit for them yet, so a plain glyph stands in
-  — a later, purely-visual refinement, not a behaviour gap. The "Remove"
-  entry draws no arrow (nothing to compare an empty slot's combined points
-  against is confirmed either way). Covered by a new
-  `scripts/rpg2k_scene_check.rb` check (a strictly-better, a strictly-worse
-  and an exactly-equal candidate against a fixed worn item each draw the
-  right glyph), confirmed to fail against the pre-fix code before the fix.
+  — a later, purely-visual refinement, not a behaviour gap.~~ ✅ **Wrong
+  outright, not just visually rough — corrected below (2026-08-20): RPG_RT's
+  candidate list never draws a comparison indicator of any kind, summed or
+  otherwise, and the real per-stat comparison lives entirely in the status
+  panel above it, which this codebase's own earlier pass never actually read
+  in full (`Scene_Equip::UpdateStatusWindow`, `src/scene_equip.cpp`) before
+  taking the yado.tk fan-wiki description of the candidate-list arrow at face
+  value.**
+- ✅ **The Equip screen's candidate-list "sum all four stats into one arrow"
+  design was wrong outright; RPG_RT compares each battle stat independently
+  in the status panel above the list, not the list itself (2026-08-20).**
+  Confirmed against EasyRPG Player's actual C++ source, read in full this
+  time: `Window_EquipItem::CheckInclude` (`src/window_equipitem.cpp`) and the
+  inherited `Window_Item::DrawItem` draw only a candidate's name and stock
+  count — no comparison glyph anywhere. `Scene_Equip::UpdateStatusWindow`
+  (`src/scene_equip.cpp`) instead recomputes `atk`/`def`/`spi`/`agi`
+  independently every frame the item list is active (summing every equipped
+  item, subtracting the old slot item and, if either it or the candidate is
+  両手持ち, the other hand's item too) and hands all four to
+  `Window_EquipStatus::SetNewParameters`; `DrawParameter`
+  (`src/window_equipstatus.cpp`) then draws each stat as its own
+  `value → new_value` pair, coloured by `GetNewParameterColor` (0 unchanged /
+  2 up / 3 down) — four independent verdicts shown at once, never folded into
+  a single net arrow (a candidate trading `-2` Atk for `+3` Def shows *both*
+  movements, not one combined Up). Fixed by removing the summed-arrow column
+  from `Scene::EquipMenu#build_cand_window` (candidates now draw name + count
+  only) and giving `#build_stats_window`'s combat-stat line a preview mode:
+  a new `#draw_stat_row` draws each of the four stats as a plain
+  `label value` block while browsing the slot list, or, while browsing
+  candidates (`#refresh_cand_cursor` now rebuilds the stats window on every
+  cursor move), a `label value > new_value` block per stat, the new value
+  coloured via the same windowskin-swatch convention `#draw_system_text`
+  already uses elsewhere in this codebase (index 0/2/3, the identical
+  `Game::MessagePalette` cells `GetNewParameterColor` maps to). The existing
+  `#item_stat_sum`/`#equip_delta` two-handed math was generalised into a new
+  per-field `#item_stat`/`#stat_field_delta` pair rather than discarded —
+  `#equip_delta` is now `#stat_field_delta` summed across all four fields,
+  identical to its own prior behaviour, so its existing direct-call tests
+  needed no changes. Covered by four new/rewritten `scripts/rpg2k_scene_check.rb`
+  checks (the candidate list draws no glyph at all; the stats window shows
+  the correct per-stat preview for a better/worse/unchanged candidate and
+  reverts once the list is left; a 両手持ち candidate previews Atk rising and
+  Def falling *at once*, the exact case a single summed verdict could only
+  ever show one side of; the preview colour comes from the loaded
+  windowskin's own swatch cells, not a hardcoded RGB value), all four
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A State's own configured display-color field is a pointer into the
   same shared message-colour palette every `\c[n]` code draws from —
   confirmed already correct, no code change needed.** There is only one

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -146,7 +146,7 @@ class RPG2k
             play_system_se(SFX_DECISION)
             @cand_index = 0
             @mode = :items
-            build_cand_window
+            build_cand_window # rebuilds the stats window's preview too, via #refresh_cand_cursor
           end
         end
       end
@@ -199,6 +199,7 @@ class RPG2k
           @cand_window.dispose
           @cand_window = nil
         end
+        build_stats_window
         refresh_desc
       end
 
@@ -252,10 +253,59 @@ class RPG2k
         c.draw_text 0, LINE_H, inner_w, LINE_H,
                     "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
                     "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
-        c.draw_text 0, LINE_H * 2, inner_w, LINE_H,
-                    "#{term(:attack, 'Atk')} #{a.atk}  #{term(:defense, 'Def')} #{a.def}  " \
-                    "#{term(:mind, 'Int')} #{a.int}  #{term(:agility, 'Agi')} #{a.agi}"
+        draw_stat_row(c, a)
         @stats_window.contents = c
+      end
+
+      # RPG2000 term / equip-bonus field / actor-accessor triples for the four
+      # battle stats, in the order EasyRPG's own `Window_EquipStatus::
+      # DrawParameter` (`src/window_equipstatus.cpp`) draws them (Atk/Def/
+      # Spirit/Agility -- this codebase's own `term(:mind, ...)`/`#int` name
+      # RPG2000's "Spirit" stat "Int" instead, matching status_menu.rb).
+      STAT_DEFS = [
+        [:attack, 'Atk', :atk_points1, :atk],
+        [:defense, 'Def', :def_points1, :def],
+        [:mind, 'Int', :spi_points1, :int],
+        [:agility, 'Agi', :agi_points1, :agi]
+      ].freeze
+
+      # Gap, in pixels, between one stat's block and the next on the combat
+      # stat line.
+      STAT_GAP = 8
+
+      # The combat-stat line: four independent "label value" blocks while
+      # browsing the slot list, or, while browsing candidates, four
+      # independent "label value > new_value" comparisons -- confirmed
+      # against EasyRPG's actual `Window_EquipStatus::DrawParameter`, which
+      # draws one row per stat, each an old value, an arrow, and a new value
+      # coloured by `GetNewParameterColor` (0 unchanged / 2 up / 3 down),
+      # never a single combined verdict for the whole item (see
+      # #build_cand_window's own history for the summed-arrow this replaced).
+      def draw_stat_row(c, a)
+        y = LINE_H * 2
+        x = 0
+        previewing = @mode == :items
+        cand_id = previewing ? candidates[@cand_index].first : nil
+        STAT_DEFS.each do |term_key, label, field, accessor|
+          value = a.send(accessor)
+          text = "#{term(term_key, label)} #{value}"
+          c.font.color = Color.new(255, 255, 255, 255)
+          w = c.text_size(text).width
+          c.draw_text x, y, w, LINE_H, text
+          x += w
+          if previewing
+            delta = stat_field_delta(cand_id, field)
+            arrow_w = c.text_size('>').width
+            draw_system_text c, x, y, arrow_w, LINE_H, '>', @skin, 1
+            x += arrow_w
+            new_text = (value + delta).to_s
+            new_w = c.text_size(new_text).width
+            color_idx = delta.zero? ? 0 : (delta.positive? ? 2 : 3)
+            draw_system_text c, x, y, new_w, LINE_H, new_text, @skin, color_idx
+            x += new_w
+          end
+          x += STAT_GAP
+        end
       end
 
       def build_slot_window
@@ -284,35 +334,24 @@ class RPG2k
         refresh_desc
       end
 
-      # yado.tk: the equip-list comparison arrow is the *sum* of all four
-      # combat-stat deltas between a candidate and whatever currently
-      # occupies the slot, not four separate per-stat verdicts -- a weapon
-      # that trades -2 Atk for +3 Def still draws a single Up arrow (net +1),
-      # never a mixed per-stat readout. The four fields are RPG2000's own
-      # "points1" equip-bonus set (`Game::Actor::EQUIP_BONUS_FIELD`'s combat
-      # quarter -- max HP/SP have no comparison arrow, only the four battle
-      # stats do).
+      # RPG2000's own "points1" equip-bonus set (`Game::Actor::
+      # EQUIP_BONUS_FIELD`'s combat quarter -- max HP/SP have no comparison
+      # preview, only the four battle stats do), in `STAT_DEFS`' own order.
       STAT_POINT_FIELDS = [:atk_points1, :def_points1, :spi_points1, :agi_points1].freeze
 
-      # The summed equip-bonus points of item `id` (0 for an empty slot, a
-      # missing database row, or a fixture item lacking these fields).
-      def item_stat_sum(id)
+      # Item `id`'s raw `field` value (0 for an empty slot, a missing
+      # database row, or a fixture item lacking the field).
+      def item_stat(id, field)
         return 0 if id.nil? || id == 0
         row = @state.party.db_item(id)
         return 0 unless row
-        STAT_POINT_FIELDS.reduce(0) do |s, f|
-          s + ((row.respond_to?(f) ? row.send(f) : nil) || 0)
-        end
+        (row.respond_to?(field) ? row.send(field) : nil) || 0
       end
 
-      # '^' the candidate's combined stat points beat what is equipped now,
-      # 'v' it falls short, '-' the two are equal (RPG_RT draws small
-      # triangle icons here; plain glyphs stand in since this build has no
-      # icon-cell blit for them yet).
-      def equip_compare_arrow(delta)
-        return '^' if delta > 0
-        return 'v' if delta < 0
-        '-'
+      # The summed equip-bonus points of item `id` across all four battle
+      # stats -- #equip_delta's own total, kept for that method's use.
+      def item_stat_sum(id)
+        STAT_POINT_FIELDS.reduce(0) { |s, f| s + item_stat(id, f) }
       end
 
       # The other hand's own current item id when browsing the weapon (0) or
@@ -326,9 +365,9 @@ class RPG2k
         end
       end
 
-      # The candidate's real net stat-point delta against what is equipped
-      # now -- not just the two items landing in *this* slot. Confirmed
-      # against EasyRPG's actual C++ source: `Scene_Equip::
+      # The candidate's real net delta for one raw database `field` against
+      # what is equipped now -- not just the two items landing in *this*
+      # slot. Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
       # UpdateStatusWindow` (`src/scene_equip.cpp`) also subtracts the
       # *other* hand's item when either it or the candidate is a 両手持ち
       # weapon (`Actor#two_handed?`), since equipping either one forces the
@@ -336,14 +375,23 @@ class RPG2k
       # `#free_two_handed_slot` already applies for real, which this preview
       # ignored (id 0, "Remove", never triggers it either way, matching
       # EasyRPG's own `current_item &&` guard -- removing an item never
-      # forces anything off the other hand).
-      def equip_delta(id)
-        delta = item_stat_sum(id) - item_stat_sum(actor.equipment[@slot_index])
+      # forces anything off the other hand). #draw_stat_row calls this once
+      # per battle stat; #equip_delta below is its sum across all four.
+      def stat_field_delta(id, field)
+        delta = item_stat(id, field) - item_stat(actor.equipment[@slot_index], field)
         other = other_hand_item
         if id != 0 && other && (actor.two_handed?(other) || actor.two_handed?(id))
-          delta -= item_stat_sum(other)
+          delta -= item_stat(other, field)
         end
         delta
+      end
+
+      # The candidate's combined net stat-point delta across all four battle
+      # stats -- #stat_field_delta summed, not a display value in its own
+      # right any more (see #draw_stat_row's per-stat preview, which replaced
+      # the single summed comparison arrow this method used to drive).
+      def equip_delta(id)
+        STAT_POINT_FIELDS.reduce(0) { |s, f| s + stat_field_delta(id, f) }
       end
 
       def build_cand_window
@@ -361,9 +409,7 @@ class RPG2k
           if id == 0
             c.draw_text 0, i * LINE_H, inner_w, LINE_H, "(Remove)"
           else
-            c.draw_text 0, i * LINE_H, inner_w - 80, LINE_H, item_name(id)
-            c.draw_text inner_w - 80, i * LINE_H, 40, LINE_H,
-                        equip_compare_arrow(equip_delta(id))
+            c.draw_text 0, i * LINE_H, inner_w - 40, LINE_H, item_name(id)
             c.draw_text inner_w - 40, i * LINE_H, 40, LINE_H, ":#{count}"
           end
         end
@@ -375,6 +421,7 @@ class RPG2k
         return unless @cand_window
         @cand_window.cursor_rect =
           Rect.new(0, @cand_index * LINE_H, @cand_window.contents.width, LINE_H)
+        build_stats_window
         refresh_desc
       end
     end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18505,20 +18505,68 @@ class EquipCompareParty < MenuStubParty
   def equip_candidates(_slot, _actor = nil); [[2, 1], [3, 1], [4, 1]]; end
 end
 
-check 'Scene::EquipMenu: the candidate arrow sums all four stat deltas against the worn item (yado.tk)' do
+# Confirmed against EasyRPG's actual C++ source: `Window_EquipItem::
+# CheckInclude` (`src/window_equipitem.cpp`) and the inherited `Window_Item::
+# DrawItem` draw only the item's name and stock count, no comparison glyph of
+# any kind -- the summed arrow this candidate list used to draw next to each
+# row (attributed to a fan wiki, yado.tk, rather than ever reading
+# `scene_equip.cpp` in full) never existed in real RPG_RT. The comparison
+# lives entirely in the stats window instead, checked below.
+check 'Scene::EquipMenu: the candidate list draws only a name and count, no comparison glyph' do
   state = Game::State.new(EquipCompareParty.new, 1, 0, 0)
   state.party.actors.first.equipment[0] = 1 # weapon slot already holds item 1 (atk 10)
   scene = menu_scene(RPG2k::Scene::EquipMenu, state)
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
   texts = window_texts(scene.instance_variable_get(:@cand_window))
-  # Row 0 is "(Remove)" (one draw_text call); each candidate row after it is
-  # three calls -- name, arrow, count -- so the arrows land at 2, 5, 8.
-  eq '^', texts[2], 'a candidate with strictly more combined points draws Up'
-  eq 'v', texts[5], 'one with strictly fewer draws Down'
-  eq '-', texts[8], 'an exact match draws Same, not counted per-stat'
+  # Row 0 is "(Remove)" (one call); each candidate row after it is exactly
+  # two calls -- name, count -- so a summed arrow would show up as a third.
+  eq ['(Remove)', 'Better', ':1', 'Worse', ':1', 'Same', ':1'], texts,
+     'no arrow glyph anywhere in the candidate list'
 end
 
+# Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
+# UpdateStatusWindow` (`src/scene_equip.cpp`) recomputes each of the four
+# battle stats independently and hands them to `Window_EquipStatus::
+# SetNewParameters`, which `DrawParameter` (`src/window_equipstatus.cpp`)
+# draws as its own old -> new pair -- never folded into one net verdict, so
+# a candidate that trades Atk for Def shows both movements at once.
+check 'Scene::EquipMenu: the stats window previews each battle stat ' \
+      'independently while browsing candidates' do
+  state = Game::State.new(EquipCompareParty.new, 1, 0, 0)
+  actor = state.party.actors.first
+  actor.equipment[0] = 1 # weapon slot: Worn (atk 10); actor's own Atk stub is 20
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  scene.instance_variable_set(:@mode, :items)
+  scene.send(:build_cand_window)
+  # #candidates leads with a "(Remove)" entry (id 0), so index 1 is the
+  # first real candidate: [0 Remove, 1 Better(id 2), 2 Worse(id 3), 3 Same(id 4)].
+  scene.instance_variable_set(:@cand_index, 1) # Better (id 2, atk 15)
+  scene.send(:refresh_cand_cursor)
+  texts = window_texts(scene.instance_variable_get(:@stats_window))
+  ok texts.include?('25'), 'Better\'s own delta (15 - 10 = +5) applied on top: 20 + 5 = 25'
+
+  scene.instance_variable_set(:@cand_index, 2) # Worse (id 3, atk 5)
+  scene.send(:refresh_cand_cursor)
+  texts = window_texts(scene.instance_variable_get(:@stats_window))
+  ok texts.include?('15'), 'Worse\'s own delta (5 - 10 = -5) applied: 20 - 5 = 15'
+
+  scene.instance_variable_set(:@cand_index, 3) # Same (id 4, atk 10)
+  scene.send(:refresh_cand_cursor)
+  texts = window_texts(scene.instance_variable_get(:@stats_window))
+  ok texts.include?('20'), 'no delta (10 - 10 = 0): the new value equals the old one (20)'
+
+  scene.send(:leave_items)
+  texts = window_texts(scene.instance_variable_get(:@stats_window))
+  eq false, texts.include?('>'), 'back on the slot list, the preview arrow is gone entirely'
+end
+
+# The same per-stat preview, but through the 両手持ち forced-unequip case a
+# single summed verdict used to collapse into one arrow: Atk rises (+40 the
+# claymore, -20 the old sword) while Def falls at the same time (-25 the
+# shield the claymore forces off) -- two independent movements on one
+# candidate, exactly what #draw_stat_row's per-stat preview (and real
+# RPG_RT) shows and a single combined arrow never could.
 # An actor whose weapon-slot Claymore (id 2) is 両手持ち; MenuStubActor's own
 # stub always answers false, so a check exercising the forced-unequip side
 # effect needs this richer one instead.
@@ -18541,16 +18589,17 @@ class TwoHandedEquipParty < MenuStubParty
   def equip_candidates(_slot, _actor = nil); [[2, 1]]; end
 end
 
-check 'Scene::EquipMenu: a 両手持ち candidate also drops the other hand\'s ' \
-      'stat bonus from the preview, matching what actually equipping it does' do
-  # Confirmed against EasyRPG's actual C++ source: Scene_Equip::
-  # UpdateStatusWindow (src/scene_equip.cpp) also subtracts the *other*
-  # hand's item when either it or the candidate is 両手持ち, since equipping
-  # either one forces the opposite slot empty -- the exact side effect
-  # Actor#equip_item / #free_two_handed_slot already applies for real. A
-  # preview that only diffs the two items landing in the browsed slot would
-  # show the Claymore's own +20 Atk (40 - 20) and draw Up, even though the
-  # true net (+20 Atk, -25 Def from the forced-off Shield) is -5.
+# Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
+# UpdateStatusWindow` also subtracts the *other* hand's item when either it
+# or the candidate is 両手持ち, since equipping either one forces the
+# opposite slot empty -- the exact side effect `Actor#equip_item` /
+# `#free_two_handed_slot` already applies for real. The per-stat preview
+# shows this as two independent movements on the SAME candidate (Atk rises,
+# Def falls at once) rather than one net verdict -- a single combined arrow
+# could only ever show one of the two, or worse, cancel them into "Up" and
+# hide the shield loss entirely.
+check 'Scene::EquipMenu: a 両手持ち candidate previews Atk rising and Def ' \
+      'falling at once, not one summed verdict' do
   state = Game::State.new(TwoHandedEquipParty.new, 1, 0, 0)
   actor = state.party.actors.first
   actor.equipment[0] = 1 # weapon slot: Sword, atk 20
@@ -18558,11 +18607,44 @@ check 'Scene::EquipMenu: a 両手持ち candidate also drops the other hand\'s '
   scene = menu_scene(RPG2k::Scene::EquipMenu, state)
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
-  texts = window_texts(scene.instance_variable_get(:@cand_window))
-  # Row 0 is "(Remove)"; the one candidate (Claymore) follows it, arrow at 2.
-  eq 'v', texts[2],
-     'net -5 (claymore +40 atk, sword -20 atk, forced-off shield -25 def), ' \
-     'not a naive +20 that ignores the shield the claymore forces off'
+  # #candidates leads with a "(Remove)" entry (id 0); the Claymore is index 1.
+  scene.instance_variable_set(:@cand_index, 1)
+  scene.send(:refresh_cand_cursor)
+  texts = window_texts(scene.instance_variable_get(:@stats_window))
+  ok texts.include?('40'),
+     'Atk rises: stub actor\'s own 20 + delta (claymore 40 - sword 20 = 20) = 40'
+  ok texts.include?('-13'),
+     'Def falls in the same preview: stub actor\'s own 12 + delta (0 - forced-off ' \
+     "shield's 25 = -25) = -13"
+end
+
+# EasyRPG's `Window_EquipStatus::DrawParameter` (`src/window_equipstatus.cpp`)
+# colours the new value via `GetNewParameterColor` (0 unchanged / 2 up / 3
+# down), blended from the windowskin's own system-colour swatches -- the same
+# convention the disabled title-menu label and the shop status panel already
+# use elsewhere in this codebase -- not a hardcoded green/red.
+check 'Scene::EquipMenu: the stats window\'s preview colour comes from the ' \
+      'windowskin\'s own swatches, not a hardcoded colour' do
+  db = fake_db
+  db.system.system_graphic = 'Skin1' # non-empty -> load_windowskin returns a real Bitmap
+  state = Game::State.new(EquipCompareParty.new, 1, 0, 0)
+  state.party.actors.first.equipment[0] = 1
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state, db)
+  scene.instance_variable_set(:@mode, :items)
+  scene.send(:build_cand_window)
+
+  scene.instance_variable_set(:@cand_index, 1) # Better (id 2) -- Atk rises
+  scene.send(:refresh_cand_cursor)
+  bc = scene.instance_variable_get(:@stats_window).contents.blend_calls || []
+  # swatch cell (idx % 10 * 16, idx / 10 * 16 + 48) -- see Game::MessagePalette.
+  ok bc.any? { |call| call[6] == 32 && call[7] == 48 },
+     'a rising stat blends from swatch index 2 (32, 48)'
+
+  scene.instance_variable_set(:@cand_index, 2) # Worse (id 3) -- Atk falls
+  scene.send(:refresh_cand_cursor)
+  bc = scene.instance_variable_get(:@stats_window).contents.blend_calls || []
+  ok bc.any? { |call| call[6] == 48 && call[7] == 48 },
+     'a falling stat blends from swatch index 3 (48, 48)'
 end
 
 check "Scene::EquipMenu: browsing the shield slot with a 両手持ち weapon " \


### PR DESCRIPTION
## Summary

- `Window_EquipItem::CheckInclude` (`src/window_equipitem.cpp`) and the inherited `Window_Item::DrawItem` draw only a candidate's name and stock count — no comparison glyph of any kind. The real comparison lives entirely in the status panel above the list: `Scene_Equip::UpdateStatusWindow` (`src/scene_equip.cpp`) recomputes `atk`/`def`/`spi`/`agi` independently every frame the item list is active (with the same two-handed forced-unequip adjustment this codebase already had right) and hands all four to `Window_EquipStatus::SetNewParameters`; `DrawParameter` (`src/window_equipstatus.cpp`) then draws each stat as its own `value → new_value` pair, coloured by `GetNewParameterColor` (0 unchanged / 2 up / 3 down) — four independent verdicts, never folded into one net arrow.
- `Scene::EquipMenu#build_cand_window` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) instead summed all four stat deltas into a single `^`/`v`/`-` glyph next to each candidate — attributed to a fan wiki (yado.tk) rather than ever reading `scene_equip.cpp` in full, per a `docs/TODO.md` bullet this PR corrects.
- Fixed by removing the summed-arrow column from the candidate list (name + count only now) and giving `#build_stats_window`'s combat-stat line a preview mode: while browsing candidates, each of the four stats draws as `label value > new_value`, colour-coded from the windowskin's own swatches (the same `#draw_system_text` convention used elsewhere in this codebase). The existing two-handed math (`#item_stat_sum`/`#equip_delta`) was generalised into a per-field `#item_stat`/`#stat_field_delta` pair the preview reuses — `#equip_delta` is now `#stat_field_delta` summed across all four fields, identical to its own prior behavior, so its existing direct-call tests needed no changes.

## Test plan

- [x] Four new/rewritten `scripts/rpg2k_scene_check.rb` checks: the candidate list draws no comparison glyph at all; the stats window shows the correct per-stat preview for a better/worse/unchanged candidate and reverts once the list is left; a 両手持ち candidate previews Atk rising and Def falling *at once* (the case a single summed verdict could only ever show one side of); the preview colour comes from the loaded windowskin's own swatch cells, not a hardcoded RGB value.
- [x] Verified via `git stash` on `equip_menu.rb` alone: all four fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 804 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_