### PR TITLE
Field item/skill use on a target plays no confirmation message

### DIFF
--- a/changelog.d/item-skill-target-no-message.fixed.md
+++ b/changelog.d/item-skill-target-no-message.fixed.md
@@ -1,0 +1,7 @@
+- **Item/skill use on the field:** Using an item or casting a skill on a
+  party member no longer pops up a "Used on X."/"X casts Y!" message that
+  blocked further input until dismissed -- RPG_RT shows no message at all,
+  just the item's own success sound (or the invoked skill's own animation
+  sound effect) and the immediately-updated HP/MP/state numbers. Healing
+  several allies with a stack of Potions no longer needs an extra dismiss
+  press between each use.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3088,7 +3088,15 @@ The work below is roughly ordered by the critical path to a walkable game
   successful use/cast and its message dismiss, a second use/cast on a
   different target needs no re-navigation, and only Cancel finally returns
   to the rebuilt list), both confirmed to fail against the pre-fix code
-  (`expected :target, got :items`/`:skills`).
+  (`expected :target, got :items`/`:skills`). ✅ **Still wrong even after this
+  fix, caught in a later pass (2026-08-20): a "Used on X."/"casts Y!" message
+  survived on every successful use/cast, when `UpdateItem`/`UpdateSkill`'s own
+  cited source, quoted just above, never builds a message window at all —
+  only `SePlay`/`Refresh`. This bullet caught the *stay-open* half of that
+  citation but missed the *no-message* half sitting in the very same two
+  lines — the identical right-conclusion-wrong-detail shape the switch-skill
+  follow-up right below also shows for `#apply_switch_skill`. See the full
+  correction after it.**
   ✅ **Follow-up (2026-08-20): a Switch skill's successful cast showed a
   "casts ..." message and returned to the skill list, when real RPG_RT
   closes the whole menu stack at once with no message at all — the bullet
@@ -3118,6 +3126,45 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check (a successful Switch skill cast
   closes the whole menu stack and shows no message), confirmed to fail
   against the pre-fix code (the stack stayed open).
+  ✅ **Follow-up (2026-08-20): the ordinary item/skill target-confirm screen's
+  successful-use message ("Used on X."/"X casts Y!") never existed in real
+  RPG_RT either — the two bullets above this one fixed the *stay-open* half
+  of `UpdateItem`/`UpdateSkill`'s cited behavior but kept the message the
+  first bullet's own quote of those same two functions already showed had no
+  message-window call anywhere.** Confirmed against EasyRPG Player's actual
+  C++ source, `Scene_ActorTarget::UpdateItem`/`UpdateSkill`
+  (`src/scene_actortarget.cpp`), read in full again: on a successful
+  Decision, `UpdateItem` plays the invoked skill's own `animation_id`-derived
+  SE for a `Type_special` item or a `use_skill`-flagged equipment item, or
+  the database's own Item SE (`SFX_UseItem`) otherwise; `UpdateSkill` always
+  plays the cast skill's own `animation_id`-derived SE. Neither ever
+  constructs a message window — success and failure alike are conveyed by
+  sound effect plus the immediately-refreshed HP/MP/state numbers already
+  visible in the target list, and the very next Decision press acts again
+  with no dismiss step at all. `#update_target` in both scenes also
+  unconditionally played the ordinary Decision-click SE ahead of dispatch,
+  which matches neither the success nor the failure branch. A repo-wide
+  search of EasyRPG's own source for the string "no effect" turns up no
+  match outside unrelated files, corroborating that the fabricated dialog is
+  exactly that — invented here, not ported from anywhere. Fixed by dropping
+  both `show_message` calls from `Scene::ItemMenu#apply_item`/
+  `Scene::SkillMenu#apply_skill` and the stray `SFX_DECISION` from each
+  `#update_target`; a new shared `Scene::Base#play_animation_se` (mirroring
+  EasyRPG's own `Game_System::SePlay(const RPG::Animation&)`, which plays
+  only the *first* of an animation's `timings` carrying a real SE, not every
+  one) resolves the skill's own success cue via its `animation_id`, and a new
+  `Scene::ItemMenu#play_item_use_se` picks between that and `SFX_ITEM` using
+  the identical `do_skill` condition (`type == ITEM_SPECIAL || (use_skill &&
+  (1..5).cover?(type))`) `Game::Party#use_special_escape_item` already
+  established for its own free-use gate. `show_message`/`drive_message`/
+  `close_message` are untouched otherwise — the Switch/Escape/Teleport
+  special-item and special-skill failure paths this same file/its sibling
+  still use them for are a separate `Scene_Skill::vUpdate` code path, not
+  `Scene_ActorTarget`, and were not re-verified here. Covered by two rewritten
+  `scripts/rpg2k_scene_check.rb` checks (a successful use/cast plays the
+  item's own SE or the skill's animation SE, shows no message, and lets the
+  very next Decision act on a different target with no dismiss press in
+  between), both confirmed to fail against the pre-fix code.
 
   What decides usability is the **type**, not the occasion flags, and getting
   that wrong used to leave the battle skill menu **empty in both test beds** —

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -246,6 +246,33 @@ class RPG2k
         { name: name, volume: (se.respond_to?(:volume) ? se.volume : 100),
           tempo: (se.respond_to?(:pitch) ? se.pitch : 100) }
       end
+
+      # Plays a battle_anime row's own sound effect -- confirmed against
+      # EasyRPG's actual C++ source: `Game_System::SePlay(const RPG::
+      # Animation&)` (`src/game_system.cpp`) walks the animation's own
+      # `timings` and plays only the *first* one with a real SE, then
+      # returns; it never plays every timing's SE, and never draws the
+      # animation itself (no Show Battle Animation flash/shake/sprite here --
+      # this is the field item/skill success cue, which real RPG_RT plays as
+      # sound only). A no-op for a nil/dangling animation id, an animation
+      # with no timings, or (mirroring `#play_skill_sound_effect`'s own
+      # simpler convention elsewhere in this codebase) every timing's SE
+      # being blank.
+      def play_animation_se(anim_id)
+        return unless anim_id
+        table = db.respond_to?(:battle_anime) ? db.battle_anime : nil
+        anim = table && table[anim_id]
+        return unless anim && anim.timings
+        anim.timings.each do |_id, t|
+          se = t.respond_to?(:se) ? t.se : nil
+          name = se && se.file
+          next if name.nil? || name.empty?
+          Audio.se_play name, se.volume, se.pitch
+          return
+        end
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] animation ##{anim_id} SE playback failed: #{e.message}"
+      end
     end
 
     # Adapter that exposes the running map to the movement engine

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -444,14 +444,13 @@ class RPG2k
           refresh_target_cursor
           play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
-          play_system_se(SFX_DECISION)
           apply_item(@pending_item, party[@target_index])
         end
       end
 
       # A used item that changed nothing (everyone already full, an
-      # ineffective status cure, ...) plays Buzzer rather than a second
-      # Decision -- matching RPG_RT's own invalid-use handling elsewhere in
+      # ineffective status cure, ...) plays Buzzer rather than the item's own
+      # success cue -- matching RPG_RT's own invalid-use handling elsewhere in
       # `Scene_Item` (a rejected action gets the same SE as a confirm on an
       # empty list or a disabled command, not a silent no-op). A *successful*
       # use stays on this same target screen too, exactly like a no-effect
@@ -464,14 +463,41 @@ class RPG2k
       # the same Buzzer path), matching the reference's own `GetItemCount(id)
       # <= 0` check ahead of `UseItem` -- depletion buzzes, it does not
       # auto-exit either.
+      #
+      # No confirmation message either way -- `UpdateItem`'s own success/
+      # failure branches only ever call `SePlay`/`Refresh`, never build a
+      # message window; this class used to show "Used on X."/"It had no
+      # effect." here (and `#update_target` played a Decision-click SE ahead
+      # of every use, matching neither branch), a fabricated dialog this
+      # runtime invented that also forced an extra dismiss press before the
+      # next target could be picked -- a genuine slowdown a screen this
+      # runtime already got right for the Switch/Escape/Teleport special
+      # items (`#apply_special_switch_item` etc.) never had.
       def apply_item(id, actor)
         affected = @state.party.use_item(id, actor)
         if affected.empty?
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         else
-          names = affected.map { |a| a.name.to_s }.join(", ")
-          show_message("Used on #{names}.")
+          play_item_use_se(id)
+        end
+      end
+
+      # The item's own success cue -- confirmed against RPG_RT's own live
+      # source: `Scene_ActorTarget::UpdateItem` plays the invoked skill's own
+      # animation SE for a Type_special item or a `use_skill`-flagged
+      # weapon/shield/armor/helmet/accessory item (the identical `do_skill`
+      # condition `Game::Party#use_special_escape_item` already mirrors for
+      # its own free-use gate), and the database's own Item system SE
+      # (`SFX_UseItem`) for every other item type.
+      def play_item_use_se(id)
+        it = @state.party.db_item(id)
+        do_skill = it && (it.type == Game::Party::ITEM_SPECIAL ||
+                           (it.use_skill && (1..5).cover?(it.type)))
+        if do_skill
+          sk = @state.party.db_skill(it.skill_id)
+          play_animation_se(sk && sk.animation_id)
+        else
+          play_system_se(SFX_ITEM)
         end
       end
 

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -221,15 +221,14 @@ class RPG2k
           refresh_target_cursor
           play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
-          play_system_se(SFX_DECISION)
           apply_skill(@pending_skill, party[@target_index])
         end
       end
 
-      # A cast that changed nothing plays Buzzer rather than a second
-      # Decision -- see Scene::ItemMenu#apply_item's identical reasoning. A
-      # *successful* cast stays on this same target screen too, exactly like
-      # a no-effect one -- confirmed against RPG_RT's own live source:
+      # A cast that changed nothing plays Buzzer rather than the skill's own
+      # animation SE -- see Scene::ItemMenu#apply_item's identical reasoning.
+      # A *successful* cast stays on this same target screen too, exactly
+      # like a no-effect one -- confirmed against RPG_RT's own live source:
       # `Scene_ActorTarget::UpdateSkill` (`src/scene_actortarget.cpp`) never
       # calls `Scene::Pop()` on Decision, success or failure alike; the only
       # `Scene::Pop()` in the whole file is `vUpdate`'s own Cancel branch.
@@ -237,16 +236,22 @@ class RPG2k
       # on a repeat cast once SP runs out (an empty `affected`, the same
       # Buzzer path), matching the reference's own SP/HP check ahead of
       # `UseSkill` -- unaffordable buzzes, it does not auto-exit either.
-      # Unlike #apply_switch_skill just below, this has nowhere to "return
-      # to" until Cancel -- #drive_message has nothing extra to do once the
-      # message closes.
+      #
+      # No confirmation message either way -- `UpdateSkill`'s own success/
+      # failure branches only ever call `SePlay`/`Refresh`, playing the
+      # skill's own `animation_id`-derived SE (`#play_animation_se`) on
+      # success, never building a message window; this class used to show
+      # "X casts Y!"/"It had no effect." here (and `#update_target` played a
+      # Decision-click SE ahead of every cast, matching neither branch), a
+      # fabricated dialog this runtime invented that also forced an extra
+      # dismiss press before the next target could be picked.
       def apply_skill(sid, target)
         affected = @state.party.cast_skill(caster, sid, target)
         if affected.empty?
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         else
-          show_message("#{caster.name} casts #{skill_name(sid)}!")
+          sk = @state.party.db_skill(sid)
+          play_animation_se(sk && sk.animation_id)
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17062,8 +17062,9 @@ check 'Scene::ItemMenu: a successful use stays on the target screen, ' \
   # Confirmed against RPG_RT's own live source: `Scene_ActorTarget::
   # UpdateItem` (src/scene_actortarget.cpp) never calls `Scene::Pop()` on
   # Decision, success or failure alike -- only `vUpdate`'s own Cancel branch
-  # does. A successful use lets the player keep using the same item on
-  # further targets without leaving this screen.
+  # does, and it never builds a message window either: only `SePlay`/
+  # `Refresh`. A successful use lets the player keep using the same item on
+  # further targets immediately, with no extra dismiss press in between.
   state = Game::State.new(MedicineItemStubParty.new, 1, 0, 0)
   scene = menu_scene(RPG2k::Scene::ItemMenu, state)
   RGSS::Input.triggered = [RGSS::Input::C] # confirm the item -- opens target selection
@@ -17071,28 +17072,25 @@ check 'Scene::ItemMenu: a successful use stays on the target screen, ' \
   RGSS::Input.reset
   eq :target, scene.instance_variable_get(:@mode)
 
+  RGSS::Audio.reset_se
   RGSS::Input.triggered = [RGSS::Input::C] # use it on the first target
   scene.update
   RGSS::Input.reset
-  ok scene.instance_variable_get(:@message), 'a "Used on ..." message is shown'
-  eq :target, scene.instance_variable_get(:@mode), 'still in target mode while the message is up'
-
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the message
-  scene.update
-  RGSS::Input.reset
+  ok scene.instance_variable_get(:@message).nil?, 'no confirmation message is ever shown'
+  eq 'ItemUse', RGSS::Audio.se_calls.last&.first, 'the item\'s own success SE plays instead'
   eq :target, scene.instance_variable_get(:@mode), 'stays on the target screen after a successful use'
   ok scene.instance_variable_get(:@pending_item), 'the pending item is still set, ready for another target'
 
-  # Use it again immediately on the second target -- no re-navigation needed.
+  # Use it again immediately on the second target -- no dismiss step, no
+  # re-navigation, just DOWN then the next Decision.
   RGSS::Input.triggered = [RGSS::Input::DOWN]
   scene.update
   RGSS::Input.reset
+  RGSS::Audio.reset_se
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.reset
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss
-  scene.update
-  RGSS::Input.reset
+  eq 'ItemUse', RGSS::Audio.se_calls.last&.first, 'the second use plays the same success SE, no click first'
   eq :target, scene.instance_variable_get(:@mode)
 
   # Cancelling finally returns to the (rebuilt) item list.
@@ -17805,13 +17803,16 @@ end
 
 # A single-target skill (scope != 2/4, so the target cursor is not locked)
 # the caster can afford twice over, so a repeat cast without leaving the
-# target screen is actually observable.
+# target screen is actually observable. `animation_id` 12 names the
+# `battle_anime` row the check below installs its own success SE on.
 class NormalTargetSkillStubParty < WrapMenuParty
   SKILL_ID = 50
+  ANIMATION_ID = 12
   def field_skills(_actor, _state = nil); [[SKILL_ID, 5]]; end
   def db_skill(id)
     return nil unless id == SKILL_ID
-    OpenStruct.new(name: 'Heal', type: Game::Party::SKILL_NORMAL, scope: 3)
+    OpenStruct.new(name: 'Heal', type: Game::Party::SKILL_NORMAL, scope: 3,
+                   animation_id: ANIMATION_ID)
   end
   def cast_skill(caster, sid, target = nil, _free = false)
     return [] unless sid == SKILL_ID && target
@@ -17824,37 +17825,42 @@ check 'Scene::SkillMenu: a successful cast stays on the target screen, ' \
   # Confirmed against RPG_RT's own live source: `Scene_ActorTarget::
   # UpdateSkill` (src/scene_actortarget.cpp) never calls `Scene::Pop()` on
   # Decision, success or failure alike -- only `vUpdate`'s own Cancel branch
-  # does. A successful cast lets the player keep casting the same skill on
-  # further targets without leaving this screen.
+  # does, and it never builds a message window either: only `SePlay`/
+  # `Refresh`, playing the invoked skill's own `animation_id`-derived SE. A
+  # successful cast lets the player keep casting the same skill on further
+  # targets immediately, with no extra dismiss press in between.
+  db = fake_db
+  db.battle_anime = { NormalTargetSkillStubParty::ANIMATION_ID => OpenStruct.new(
+    timings: { 1 => OpenStruct.new(
+      se: OpenStruct.new(file: 'HealCast', volume: 90, pitch: 110)) }
+  ) }
   state = Game::State.new(NormalTargetSkillStubParty.new, 1, 0, 0)
-  scene = menu_scene(RPG2k::Scene::SkillMenu, state)
+  scene = menu_scene(RPG2k::Scene::SkillMenu, state, db)
   RGSS::Input.triggered = [RGSS::Input::C] # confirm the skill -- opens target selection
   scene.update
   RGSS::Input.reset
   eq :target, scene.instance_variable_get(:@mode)
 
+  RGSS::Audio.reset_se
   RGSS::Input.triggered = [RGSS::Input::C] # cast on the first target
   scene.update
   RGSS::Input.reset
-  ok scene.instance_variable_get(:@message), 'a "casts ..." message is shown'
-  eq :target, scene.instance_variable_get(:@mode), 'still in target mode while the message is up'
-
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the message
-  scene.update
-  RGSS::Input.reset
+  ok scene.instance_variable_get(:@message).nil?, 'no confirmation message is ever shown'
+  eq 'HealCast', RGSS::Audio.se_calls.last&.first,
+     "the skill's own animation SE plays instead"
   eq :target, scene.instance_variable_get(:@mode), 'stays on the target screen after a successful cast'
   ok scene.instance_variable_get(:@pending_skill), 'the pending skill is still set, ready for another target'
 
-  # Cast it again immediately on the second target -- no re-navigation needed.
+  # Cast it again immediately on the second target -- no dismiss step, no
+  # re-navigation, just DOWN then the next Decision.
   RGSS::Input.triggered = [RGSS::Input::DOWN]
   scene.update
   RGSS::Input.reset
+  RGSS::Audio.reset_se
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.reset
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss
-  scene.update
-  RGSS::Input.reset
+  eq 'HealCast', RGSS::Audio.se_calls.last&.first, 'the second cast plays the same SE, no click first'
   eq :target, scene.instance_variable_get(:@mode)
 
   # Cancelling finally returns to the (rebuilt) skill list.


### PR DESCRIPTION
## Summary

- `Scene_ActorTarget::UpdateItem`/`UpdateSkill` (`src/scene_actortarget.cpp`), read in full, never construct a message window on a successful Decision — only `SePlay(...)` (the invoked skill's own `animation_id`-derived SE for a `Type_special` item or a `use_skill`-flagged equipment item, the database's own Item SE otherwise; always the cast skill's own animation SE for `UpdateSkill`) and `status_window->Refresh(); target_window->Refresh();`. A repo-wide search of EasyRPG's own source for "no effect" turns up no match outside unrelated files.
- `Scene::ItemMenu#apply_item`/`Scene::SkillMenu#apply_skill` (`mruby-rpg2k/mrblib/scene/{item,skill}_menu.rb`) showed a fabricated "Used on X."/"X casts Y!" message on every successful use/cast, which also forced an extra dismiss press before the next target could be picked; `#update_target` in both scenes additionally played the ordinary Decision-click SE ahead of every dispatch, matching neither the success nor failure branch. This corrects a gap two earlier PRs in this same area (fixing the target screen's stay-open behavior) both missed — each caught the *stay-open* half of the cited function but kept the message the same citation already showed didn't exist.
- Fixed by dropping both `show_message` calls and the stray `SFX_DECISION`. A new shared `Scene::Base#play_animation_se` mirrors `Game_System::SePlay(const RPG::Animation&)` (plays only the *first* of an animation's `timings` carrying a real SE, not every one) to resolve a skill's own success cue via its `animation_id`; a new `Scene::ItemMenu#play_item_use_se` picks between that and `SFX_ITEM` using the identical `do_skill` condition `Game::Party#use_special_escape_item` already established for its own free-use gate. The Switch/Escape/Teleport special-item/-skill failure paths (a separate `Scene_Skill::vUpdate` code path, not `Scene_ActorTarget`) still use `show_message` and were not touched.

## Test plan

- [x] Two rewritten `scripts/rpg2k_scene_check.rb` checks: a successful use/cast plays the item's own SE or the skill's animation SE, shows no message, and lets the very next Decision act on a different target with no dismiss press in between.
- [x] Verified via `git stash` on `base.rb`/`item_menu.rb`/`skill_menu.rb` alone: both fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 804 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_