### PR TITLE
Status screen shows the party's own Gold

### DIFF
--- a/changelog.d/status-screen-shows-gold.fixed.md
+++ b/changelog.d/status-screen-shows-gold.fixed.md
@@ -1,0 +1,3 @@
+- **Status screen:** Now shows the party's own Gold, matching RPG_RT's
+  `Window_Gold` (always drawn, including at 0). Previously the field Status
+  screen showed everything except the party's money.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14524,6 +14524,25 @@ Covered by two new `scripts/rpg2k_scene_check.rb` checks (one per screen), each
 equipping a fixture actor with a dangling item id, asserting the diagnostic
 fires exactly once across construction and repeated rebuilds while the
 placeholder label still renders correctly.
+✅ **The field Status screen never showed the party's own Gold at all
+(2026-08-20).** `Scene::StatusMenu`'s own class comment (this file, above)
+described a "read-only per-member detail (name/title, level, EXP and
+EXP-to-next, HP/MP, the six stats and the equipped items)" — accurate as far
+as it went, but never mentioned Gold because the screen never drew it.
+Confirmed against EasyRPG Player's actual C++ source: `Scene_Status::Start`
+(`src/scene_status.cpp`) creates a `Window_Gold` unconditionally alongside
+the actor-info/status/equip windows, and `vUpdate` updates it every frame
+with no visibility gate anywhere in the file; `Window_Gold::Refresh`
+(`src/window_gold.cpp`) calls `DrawCurrencyValue(Main_Data::game_party->
+GetGold(), ...)` — the party's current Gold, always shown, including at 0.
+`Scene::StatusMenu#build_window` (`mruby-rpg2k/mrblib/scene/status_menu.rb`)
+had no Gold line anywhere in its flat single-bitmap layout. Fixed by adding
+one more line after the equipment slots, `"#{@state.party.gold}#{term(:gold,
+'G')}"` — matching `DrawCurrencyValue`'s own "amount then term, no extra
+label" rendering, the identical no-space convention `Scene::Map`'s shop gold
+panel already uses. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+nonzero Gold figure renders as its own line; Gold still shows at exactly 0),
+confirmed to fail against the pre-fix code.
 ✅ **A dangling battle-animation id no longer draws nothing with no trace** —
 the "battle animation" case from the "invalid hero, skill, item, enemy,
 enemy group, battle animation, terrain, chipset, common event" list above.

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -122,6 +122,14 @@ class RPG2k
         ]
         eqp = a.equipment
         @slots.each_with_index { |label, i| lines.push("#{label}: #{item_name(eqp[i])}") }
+        # RPG_RT always shows the party's own Gold on this screen -- its own
+        # `Window_Gold` (`src/window_gold.cpp`) sits right under the
+        # actor-info box, drawn unconditionally by `Scene_Status::Start`
+        # (`src/scene_status.cpp`, no visibility gate anywhere in the file) --
+        # confirmed missing here entirely, not merely mispositioned.
+        # `DrawCurrencyValue` (`src/window_base.cpp`) draws just the amount
+        # and the term, no extra label of its own.
+        lines.push("#{@state.party.gold}#{term(:gold, 'G')}")
         lines.each_with_index do |line, i|
           c.draw_text 0, i * LINE_H, inner_w, LINE_H, line
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18725,6 +18725,24 @@ check 'the status screen gives the condition a labelled row' do
   ok texts.include?('Down'), 'a downed actor reads as such, not merely HP 0'
 end
 
+# RPG_RT's own `Window_Gold` (`src/window_gold.cpp`), created unconditionally
+# by `Scene_Status::Start` (`src/scene_status.cpp`, no visibility gate
+# anywhere in the file) -- confirmed missing here entirely.
+check 'the status screen shows the party\'s own Gold' do
+  st = menu_state
+  st.party.instance_variable_set(:@gold, 1234)
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
+                         .instance_variable_get(:@window))
+  ok texts.include?('1234G'), "Gold is drawn as its own line, got: #{texts.inspect}"
+
+  # RPG_RT's Window_Gold draws unconditionally, including at 0 -- not only
+  # once the party has money.
+  st.party.instance_variable_set(:@gold, 0)
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
+                         .instance_variable_get(:@window))
+  ok texts.include?('0G'), "zero Gold still shows, got: #{texts.inspect}"
+end
+
 check 'Scene::StatusMenu: the actor cursor wraps around' do
   scene = menu_scene(RPG2k::Scene::StatusMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@actor_index), 'starts on the first actor'


### PR DESCRIPTION
## Summary

- `Scene_Status::Start` (`src/scene_status.cpp`) creates a `Window_Gold` unconditionally alongside the actor-info/status/equip windows, and `vUpdate` updates it every frame with no visibility gate anywhere in the file. `Window_Gold::Refresh` (`src/window_gold.cpp`) calls `DrawCurrencyValue(Main_Data::game_party->GetGold(), ...)` — the party's current Gold, always shown, including at 0.
- `Scene::StatusMenu#build_window` (`mruby-rpg2k/mrblib/scene/status_menu.rb`) had no Gold line anywhere in its flat single-bitmap layout — a player checking a character's Status screen had no way to see the party's money there at all.
- Fixed by adding one more line after the equipment slots, `"#{@state.party.gold}#{term(:gold, 'G')}"` — matching `DrawCurrencyValue`'s own "amount then term, no extra label" rendering, the identical no-space convention `Scene::Map`'s shop gold panel already uses elsewhere in this codebase.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a nonzero Gold figure renders as its own line; Gold still shows at exactly 0.
- [x] Verified via `git stash` on `status_menu.rb` alone: fails pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 805 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_