### PR TITLE
Battle Item/Skill lists are a two-column grid, not a wrapping column

### DIFF
--- a/changelog.d/battle-item-skill-grid-cursor.fixed.md
+++ b/changelog.d/battle-item-skill-grid-cursor.fixed.md
@@ -1,0 +1,5 @@
+- **Battle Item/Skill lists:** Now a genuine two-column grid, matching
+  RPG_RT's `Window_Item`/`Window_Skill` (`column_max = 2`). Down/Up move by
+  a row and stop rather than wrap past either end, and Right/Left now work,
+  moving one cell at a time across row boundaries. Previously these lists
+  behaved as a single wrapping column with no Right/Left handling at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4825,6 +4825,39 @@ The work below is roughly ordered by the critical path to a walkable game
   to the last, same as Up; Right from the last ally wraps to the first,
   same as Down), confirmed to fail against the pre-fix code (`expected 1,
   got 0`).
+  ✅ **Follow-up (2026-08-20): the battle Item/Skill lists were single-column
+  wrapping lists, when real RPG_RT's own `Window_Item`/`Window_Skill` are a
+  genuine two-column grid — the bullet above checked `target_window` (the
+  enemy list) and `Window_BattleStatus` (the ally list) but never checked
+  `item_window`/`skill_window`'s own `column_max`.** Confirmed against
+  EasyRPG Player's actual C++ source: `Window_Item`/`Window_Skill`
+  (`src/window_item.cpp`/`src/window_skill.cpp`) both set `column_max = 2`
+  in their own constructors, and `Window_BattleSkill` (`src/window_skill.h`,
+  what `Scene_Battle::CreateUi`, `src/scene_battle.cpp`, actually backs the
+  battle skill list with) inherits `Window_Skill` unchanged — the identical
+  2-column grid the field `Scene::ItemMenu`/`Scene::SkillMenu` already have,
+  just never propagated to their battle counterparts. `#drive_battle_skill`/
+  `#drive_battle_item` (`mruby-rpg2k/mrblib/scene/battle.rb`) moved
+  `@ui[:skill_i]`/`@ui[:item_i]` by 1 with a modulo wrap on Down/Up and had
+  no Right/Left handling at all — with only two skills/items (a common
+  case), Down/Up cycled between them like a single column, and Right/Left
+  did nothing, when real RPG_RT's `Window_Selectable::Update`
+  (`src/window_selectable.cpp`) genuinely column-locks Down/Up (`index <
+  item_max - column_max`, blocked rather than wrapped past either end) and
+  moves Right/Left by a flat `index +- 1` bounded only by the list's
+  absolute ends, no row-boundary term — the exact shape already ported to
+  the field grid and the Teleport picker. Fixed by adding a `column_max:`
+  parameter to the shared `#battle_list_window` draw helper (row-major
+  layout and matching cursor-rect math, with `column_max: 1`'s existing
+  callers — the enemy-target and ally-target lists — unchanged by
+  construction) and a new `#move_battle_list_index`/`#move_battle_skill_
+  cursor`/`#move_battle_item_cursor` trio mirroring `Scene::ItemMenu#move_
+  item_cursor`'s own no-wrap bound exactly. Covered by two rewritten
+  `scripts/rpg2k_scene_check.rb` checks (a three-skill/three-item party:
+  Up at the top and Down/Right at the list's own end are no-ops, Down/Right
+  correctly cross into and back out of the partial second row), plus a
+  navigation fix in an existing check that assumed the old single-column
+  wrap, all confirmed to fail against the pre-fix code.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1626,18 +1626,33 @@ class RPG2k
         draw_battle_skill
       end
 
+      # Move a battle Item/Skill list cursor by `delta` cells (a row for
+      # +-BATTLE_LIST_COLUMN_MAX, a column for +-1), left in place if the
+      # target cell is off the grid -- confirmed against RPG_RT's own live
+      # source: `Window_Selectable::Update` (`src/window_selectable.cpp`)
+      # bounds Down/Up by `index < item_max - column_max`/`index >=
+      # column_max` (blocked rather than wrapped past either end, genuinely
+      # column-locked) and Right/Left by the flat `index < item_max -
+      # 1`/`index > 0` (no row-boundary term at all) -- the identical
+      # mechanism `Scene::ItemMenu#move_item_cursor` already uses for the
+      # field item/skill grid, which never propagated to battle's own
+      # Item/Skill lists.
+      def move_battle_list_index(index, delta, size)
+        target = index + delta
+        return nil if target.negative? || target >= size
+        target
+      end
+
       def drive_battle_skill
         skills = @ui[:skills]
         if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !skills.empty?
-          @ui[:skill_i] += 1
-          @ui[:skill_i] %= skills.length
-          draw_battle_skill
-          play_system_se(SFX_CURSOR)
+          move_battle_skill_cursor(BATTLE_LIST_COLUMN_MAX)
         elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !skills.empty?
-          @ui[:skill_i] -= 1
-          @ui[:skill_i] %= skills.length
-          draw_battle_skill
-          play_system_se(SFX_CURSOR)
+          move_battle_skill_cursor(-BATTLE_LIST_COLUMN_MAX)
+        elsif (Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)) && !skills.empty?
+          move_battle_skill_cursor(1)
+        elsif (Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)) && !skills.empty?
+          move_battle_skill_cursor(-1)
         elsif Input.trigger?(Input::C)
           confirm_battle_skill
         elsif Input.trigger?(Input::B)
@@ -1646,6 +1661,14 @@ class RPG2k
           @ui[:phase] = :command
           draw_battle_command
         end
+      end
+
+      def move_battle_skill_cursor(delta)
+        target = move_battle_list_index(@ui[:skill_i], delta, @ui[:skills].length)
+        return unless target
+        @ui[:skill_i] = target
+        draw_battle_skill
+        play_system_se(SFX_CURSOR)
       end
 
       # Choose the highlighted skill: if the caster cannot afford its SP, or is
@@ -1783,15 +1806,13 @@ class RPG2k
       def drive_battle_item
         items = @ui[:items]
         if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !items.empty?
-          @ui[:item_i] += 1
-          @ui[:item_i] %= items.length
-          draw_battle_item
-          play_system_se(SFX_CURSOR)
+          move_battle_item_cursor(BATTLE_LIST_COLUMN_MAX)
         elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !items.empty?
-          @ui[:item_i] -= 1
-          @ui[:item_i] %= items.length
-          draw_battle_item
-          play_system_se(SFX_CURSOR)
+          move_battle_item_cursor(-BATTLE_LIST_COLUMN_MAX)
+        elsif (Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)) && !items.empty?
+          move_battle_item_cursor(1)
+        elsif (Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)) && !items.empty?
+          move_battle_item_cursor(-1)
         elsif Input.trigger?(Input::C)
           play_system_se(SFX_DECISION)
           item_id, _count = @ui[:items][@ui[:item_i]]
@@ -1848,6 +1869,14 @@ class RPG2k
           @ui[:phase] = :command
           draw_battle_command
         end
+      end
+
+      def move_battle_item_cursor(delta)
+        target = move_battle_list_index(@ui[:item_i], delta, @ui[:items].length)
+        return unless target
+        @ui[:item_i] = target
+        draw_battle_item
+        play_system_se(SFX_CURSOR)
       end
 
       # -- Ally target (heal skill / medicine) --------------------------------
@@ -3005,6 +3034,18 @@ class RPG2k
       # long skill list) scrolls: the panel's fixed 64px content area (80 minus
       # the 8px border on each side) divided by the 16px row height.
       BATTLE_VISIBLE_ROWS = 4
+      # The battle Item/Skill lists are a two-column grid, not a single
+      # stacked column -- confirmed against RPG_RT's own live source:
+      # `Window_Item`/`Window_Skill` (`src/window_item.cpp`/
+      # `src/window_skill.cpp`) both set `column_max = 2` in their own
+      # constructors, and `Window_BattleSkill` (`src/window_skill.h`)
+      # inherits `Window_Skill` unchanged -- `Scene_Battle::CreateUi`
+      # (`src/scene_battle.cpp`) backs the battle screen's item/skill windows
+      # with exactly these classes. The enemy-target list (`Window_Command`,
+      # `column_max = 1`) and the ally-target list (`Window_BattleStatus`,
+      # hand-rolled) are correctly single-column already -- this constant is
+      # only for #draw_battle_item/#draw_battle_skill.
+      BATTLE_LIST_COLUMN_MAX = 2
 
       # Column origins within the status panel's contents, in the order RPG_RT's
       # battle status window uses them: who, what condition they are in, then the
@@ -3338,26 +3379,35 @@ class RPG2k
       # A bottom-anchored list window of `labels` with the cursor on `sel`, at
       # left edge `x` and width `w`, fixed to the panel's own height (80px, the
       # shape every RPG_RT battle list window shares) — the shared shape of the
-      # Skill / Item / target / ally-target menus. A list longer than
-      # `BATTLE_VISIBLE_ROWS` scrolls, keeping `sel` in view, the way
+      # Skill / Item / target / ally-target menus. `column_max` (1 for every
+      # caller except #draw_battle_item/#draw_battle_skill, see
+      # `BATTLE_LIST_COLUMN_MAX`) lays `labels` out row-major across that many
+      # columns instead of one; a list longer than `BATTLE_VISIBLE_ROWS`
+      # *rows* scrolls, keeping `sel`'s own row in view, the way
       # `Window_Selectable`'s own scrolling does for an oversized troop or
       # skill list.
-      def battle_list_window(x, w, labels, sel, z)
+      def battle_list_window(x, w, labels, sel, z, column_max: 1)
         rows = BATTLE_VISIBLE_ROWS
-        scroll = labels.length > rows ? [[sel - rows + 1, 0].max, labels.length - rows].min : 0
+        inner_w = w - Window::BORDER * 2
+        col_w = inner_w / column_max
+        row_count = column_max > 1 ? [(labels.length / column_max.to_f).ceil, 1].max : labels.length
+        sel_row = sel / column_max
+        scroll = row_count > rows ? [[sel_row - rows + 1, 0].max, row_count - rows].min : 0
         win = Window.new(x, BATTLE_PANEL_Y, w, BATTLE_PANEL_H)
         win.z = z
         win.windowskin = windowskin
-        inner_w = w - Window::BORDER * 2
         c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
         c.font.color = Color.new(255, 255, 255, 255)
         labels.each_with_index do |label, i|
-          next if i < scroll || i >= scroll + rows
-          c.draw_text 0, (i - scroll) * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
+          row = i / column_max
+          next if row < scroll || row >= scroll + rows
+          col = i % column_max
+          c.draw_text col * col_w, (row - scroll) * BATTLE_LINE_H, col_w, BATTLE_LINE_H, label
         end
         win.contents = c
         unless labels.empty?
-          win.cursor_rect = Rect.new(0, (sel - scroll) * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
+          sel_col = sel % column_max
+          win.cursor_rect = Rect.new(sel_col * col_w, (sel_row - scroll) * BATTLE_LINE_H, col_w, BATTLE_LINE_H)
         end
         win
       end
@@ -3373,7 +3423,8 @@ class RPG2k
           sk = @state.party.db_skill(sid)
           "#{sk ? sk.name : "Skill #{sid}"}  #{cost}"
         end
-        @ui[:skill_win] = battle_list_window(0, SCREEN_W, labels, @ui[:skill_i], 325)
+        @ui[:skill_win] = battle_list_window(0, SCREEN_W, labels, @ui[:skill_i], 325,
+                                             column_max: BATTLE_LIST_COLUMN_MAX)
       end
 
       def close_battle_skill
@@ -3389,7 +3440,8 @@ class RPG2k
           it = @state.party.db_item(id)
           "#{it ? it.name : "Item #{id}"}  x#{count}"
         end
-        @ui[:item_win] = battle_list_window(0, SCREEN_W, labels, @ui[:item_i], 325)
+        @ui[:item_win] = battle_list_window(0, SCREEN_W, labels, @ui[:item_i], 325,
+                                            column_max: BATTLE_LIST_COLUMN_MAX)
       end
 
       def close_battle_item

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10755,7 +10755,11 @@ check 'Enemy Encounter scene: a special item invoking an enemy-scope skill ' \
   press_key(scene, RGSS::Input::DOWN) # Defend -> Item
   press_key(scene, RGSS::Input::C)    # open the item list
   eq :item, ui[:phase]
-  press_key(scene, RGSS::Input::DOWN) # Potion (id 5) -> Fire Bomb (id 7, sorted second)
+  # Potion (id 5, row 0 col 0) -> Fire Bomb (id 7, sorted second, row 0 col 1)
+  # -- the battle item list is a two-column grid (BATTLE_LIST_COLUMN_MAX),
+  # so with only two items Right crosses to the second one, not Down (there
+  # is no second row for two items to wrap across).
+  press_key(scene, RGSS::Input::RIGHT)
   press_key(scene, RGSS::Input::C)    # choose the Fire Bomb
   eq :target, ui[:phase], 'an enemy-scope item skill prompts for an enemy, not an ally'
 
@@ -11132,63 +11136,106 @@ check "Enemy Encounter scene: a battle-command list of Row alone falls back to t
      'is not a usable list on its own, so this falls back to the fixed four'
 end
 
-# A hero with two battle skills, so the skill-list cursor has more than one row
-# to wrap across (BattleMagicParty above only carries one).
-class BattleTwoSkillParty < BattleMagicParty
+# A hero with three battle skills, so the skill-list cursor (a two-column
+# grid, see BATTLE_LIST_COLUMN_MAX) has a genuine second row to cross into
+# (BattleMagicParty above only carries one, and two would both sit in the
+# same row).
+class BattleThreeSkillParty < BattleMagicParty
   def initialize
     super()
-    @hero.instance_variable_set(:@skills, [1, 2])
+    @hero.instance_variable_set(:@skills, [1, 2, 3])
   end
   def battle_skills(actor, _caster); actor.skills.map { |sid| [sid, 3] }; end
   def db_skill(id); OpenStruct.new(name: "Skill#{id}", scope: 0); end
 end
 
-check 'Enemy Encounter scene: the skill list cursor wraps around' do
+# The battle Item/Skill lists are a genuine two-column grid -- confirmed
+# against RPG_RT's own live source: `Window_Item`/`Window_Skill`
+# (`src/window_item.cpp`/`src/window_skill.cpp`) both set `column_max = 2`,
+# and `Window_BattleSkill` inherits that unchanged. `Window_Selectable::
+# Update`'s own Down/Up are genuinely column-locked (`index < item_max -
+# column_max`, blocked rather than wrapped) while Right/Left are a flat
+# `index +- 1` bounded only by the list's absolute ends, no row-boundary
+# term -- the identical shape the field item/skill grid already has.
+check 'Enemy Encounter scene: the skill list cursor is a column-locked ' \
+      'two-column grid, not a single wrapping column' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic)
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
-  st.instance_variable_set(:@party, BattleTwoSkillParty.new)
+  st.instance_variable_set(:@party, BattleThreeSkillParty.new)
   ui = battle_to_command(scene)
   press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
   press_key(scene, RGSS::Input::C)    # open the skill list
   eq :skill, ui[:phase]
-  eq 0, ui[:skill_i], 'starts on the first skill'
+  eq 0, ui[:skill_i], 'starts on the first skill (row 0, col 0)'
+
   press_key(scene, RGSS::Input::UP)
-  eq 1, ui[:skill_i], 'Up from the first skill wraps to the last (2 skills)'
+  eq 0, ui[:skill_i], 'Up from row 0 does not move -- there is no row above'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 1, ui[:skill_i], 'Right moves within the row (col 0 -> col 1)'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 2, ui[:skill_i], 'Right crosses the row boundary into row 1 -- flat, no row-edge stop'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 2, ui[:skill_i], 'Right at the list\'s own end does not wrap'
+
   press_key(scene, RGSS::Input::DOWN)
-  eq 0, ui[:skill_i], 'Down from the last skill wraps to the first'
+  eq 2, ui[:skill_i], 'Down does not move -- column 0 (index 2) has nothing below it'
+
+  press_key(scene, RGSS::Input::LEFT)
+  press_key(scene, RGSS::Input::LEFT)
+  eq 0, ui[:skill_i], 'Left flows back across the row boundary the same way'
 end
 
-# A hero with two battle items, so the item-list cursor has more than one row
-# to wrap across (BattleMagicParty above only carries one).
-class BattleTwoItemParty < BattleMagicParty
+# A hero with three battle items, mirroring BattleThreeSkillParty above.
+class BattleThreeItemParty < BattleMagicParty
   def initialize
     super()
-    @items = { 5 => 2, 6 => 1 }
+    @items = { 5 => 2, 6 => 1, 7 => 1 }
   end
   def db_item(id); OpenStruct.new(name: "Item#{id}"); end
 end
 
-check 'Enemy Encounter scene: the item list cursor wraps around' do
+check 'Enemy Encounter scene: the item list cursor is a column-locked ' \
+      'two-column grid, not a single wrapping column' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic)
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
-  st.instance_variable_set(:@party, BattleTwoItemParty.new)
+  st.instance_variable_set(:@party, BattleThreeItemParty.new)
   ui = battle_to_command(scene)
   press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
   press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
   press_key(scene, RGSS::Input::DOWN) # Defend -> Item
   press_key(scene, RGSS::Input::C)    # open the item list
   eq :item, ui[:phase]
-  eq 0, ui[:item_i], 'starts on the first item'
+  eq 0, ui[:item_i], 'starts on the first item (row 0, col 0)'
+
   press_key(scene, RGSS::Input::UP)
-  eq 1, ui[:item_i], 'Up from the first item wraps to the last (2 items)'
+  eq 0, ui[:item_i], 'Up from row 0 does not move -- there is no row above'
+
   press_key(scene, RGSS::Input::DOWN)
-  eq 0, ui[:item_i], 'Down from the last item wraps to the first'
+  eq 2, ui[:item_i], 'Down crosses into row 1 -- column 0 has a third item below it'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 2, ui[:item_i], 'Right at the list\'s own end does not wrap -- row 1 has only one cell'
+
+  press_key(scene, RGSS::Input::UP)
+  eq 0, ui[:item_i], 'Up flows back to row 0'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 1, ui[:item_i], 'Right moves within the row (col 0 -> col 1)'
+
+  press_key(scene, RGSS::Input::DOWN)
+  eq 1, ui[:item_i], 'Down does not move -- column 1 has nothing below it with only 3 items'
+
+  press_key(scene, RGSS::Input::LEFT)
+  eq 0, ui[:item_i], 'Left moves back to column 0'
 end
 
 # A two-actor party, so the ally-target cursor (heal skill / medicine) has


### PR DESCRIPTION
## Summary

- `Window_Item`/`Window_Skill` (`src/window_item.cpp`/`src/window_skill.cpp`) both set `column_max = 2` in their own constructors, and `Window_BattleSkill` (`src/window_skill.h`, what `Scene_Battle::CreateUi` actually backs the battle skill list with) inherits `Window_Skill` unchanged — the identical 2-column grid the field `Scene::ItemMenu`/`Scene::SkillMenu` already have, just never propagated to their battle counterparts.
- `#drive_battle_skill`/`#drive_battle_item` (`mruby-rpg2k/mrblib/scene/battle.rb`) moved `@ui[:skill_i]`/`@ui[:item_i]` by 1 with a modulo wrap on Down/Up and had no Right/Left handling at all — with only two skills/items (a common case), Down/Up cycled between them like a single column, and Right/Left did nothing. Real RPG_RT's `Window_Selectable::Update` (`src/window_selectable.cpp`) genuinely column-locks Down/Up (`index < item_max - column_max`, blocked rather than wrapped past either end) and moves Right/Left by a flat `index +- 1` bounded only by the list's absolute ends, no row-boundary term.
- Fixed by adding a `column_max:` parameter to the shared `#battle_list_window` draw helper (row-major layout and matching cursor-rect math; `column_max: 1`'s existing callers — the enemy-target and ally-target lists, both genuinely single-column in real RPG_RT — are unchanged by construction) and a new `#move_battle_list_index`/`#move_battle_skill_cursor`/`#move_battle_item_cursor` trio mirroring `Scene::ItemMenu#move_item_cursor`'s own no-wrap bound exactly.

## Test plan

- [x] Two rewritten `scripts/rpg2k_scene_check.rb` checks (a three-skill/three-item party: Up at the top and Down/Right at the list's own end are no-ops, Down/Right correctly cross into and back out of the partial second row), plus a navigation fix in an existing check that assumed the old single-column wrap.
- [x] Verified via `git stash` on `battle.rb` alone: all three affected checks fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 805 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_