### PR TITLE
Fix vendored mruby compiler bug: `::Const = value` inside a nested module

### DIFF
--- a/changelog.d/mruby-colon3-top-level-const-assign.fixed.md
+++ b/changelog.d/mruby-colon3-top-level-const-assign.fixed.md
@@ -1,0 +1,10 @@
+- Fixed a real bug in the vendored mruby compiler: `::Const = value`, written
+  from inside a nested module or class body, silently defined the constant on
+  the *lexically enclosing* module instead of at the top level -- no
+  exception, just the wrong owner (`gen_colon3_assign` emitted `OP_SETCONST`,
+  which ignores the pushed base, instead of `OP_SETMCNST`). Found because a
+  real RPG Maker VX Ace game's bundled add-on relies on exactly this pattern
+  to publish its own top-level API and never finished setting up. Since this
+  project doesn't control the `3rd/mruby` submodule's upstream remote, the
+  fix ships as `patches/mruby-colon3-assign-setmcnst.patch`, applied
+  idempotently at build time by `scripts/apply_mruby_patch.bash`.

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -80,6 +80,26 @@ function(rpg2k_add_mruby)
       MRUBY_BUILD_DIR=${mruby_build_dir}
       PROJECT_BUILD_DIR=${ARG_PROJECT_BUILD_DIR} ${ARG_MRB_OPTS})
 
+  # Vendored mruby carries a real upstream compiler bug (patches/mruby-colon3-
+  # assign-setmcnst.patch's own preamble has the full trail): `::Const = value`
+  # written inside a nested module/class body silently defines the constant on
+  # the *lexically enclosing* module instead of at the top level -- no
+  # exception, just the wrong owner. Real, not vendor-specific: `ruby -e
+  # 'module Foo; ::Bar = 42; end; p Object.const_defined?(:Bar)'` prints true,
+  # mruby's does not. This submodule tracks upstream mruby/mruby directly (no
+  # fork this project controls to carry the fix on), so it is patched in place
+  # here instead, the same way patches/psp-fixup-imports-jal-relocation-aware.
+  # patch is applied to a fetched pspsdk checkout -- via a real script
+  # (scripts/apply_mruby_patch.bash), not a `patch` call embedded straight in
+  # this COMMAND: it needs a dry-run-first idempotency check across repeat
+  # configures/builds without re-cloning the submodule, and that redirect-
+  # heavy shell logic does not survive CMake's own command-line escaping
+  # reliably inline. The script itself fails loudly (not silently) if the
+  # patch stops applying, e.g. after a future submodule bump moves the
+  # patched code -- see its own preamble.
+  set(mruby_colon3_patch
+      "${ARG_REPO_ROOT}/patches/mruby-colon3-assign-setmcnst.patch")
+
   # Point mruby's rake at the vendored mgem-list (the mgem index) via symlinks
   # in its repos/ dir so it resolves gems locally instead of cloning from
   # GitHub. Both repos/host and repos/<TARGET_NAME> are linked: a cross build
@@ -92,6 +112,8 @@ function(rpg2k_add_mruby)
   # BSD/macOS) replaces the symlink in place instead.
   add_custom_command(
     OUTPUT "${libmruby_a}"
+    COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
+            "${mruby_colon3_patch}"
     COMMAND
       mkdir -p ${mruby_build_dir}/repos/host
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME} && ln -sfn
@@ -100,7 +122,8 @@ function(rpg2k_add_mruby)
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME}/mgem-list && ${mrb_opts} rake
       -v
     WORKING_DIRECTORY "${mruby_prefix}"
-    DEPENDS "${ARG_REPO_ROOT}/build_config.rb" ${mrb_files})
+    DEPENDS "${ARG_REPO_ROOT}/build_config.rb" "${mruby_colon3_patch}"
+            ${mrb_files})
   add_custom_target(mruby_build DEPENDS "${libmruby_a}")
   add_dependencies(mruby mruby_build)
 

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -84,19 +84,19 @@ function(rpg2k_add_mruby)
   # assign-setmcnst.patch's own preamble has the full trail): `::Const = value`
   # written inside a nested module/class body silently defines the constant on
   # the *lexically enclosing* module instead of at the top level -- no
-  # exception, just the wrong owner. Real, not vendor-specific: `ruby -e
-  # 'module Foo; ::Bar = 42; end; p Object.const_defined?(:Bar)'` prints true,
-  # mruby's does not. This submodule tracks upstream mruby/mruby directly (no
-  # fork this project controls to carry the fix on), so it is patched in place
-  # here instead, the same way patches/psp-fixup-imports-jal-relocation-aware.
-  # patch is applied to a fetched pspsdk checkout -- via a real script
+  # exception, just the wrong owner. Real, not vendor-specific: `ruby -e 'module
+  # Foo; ::Bar = 42; end; p Object.const_defined?(:Bar)'` prints true, mruby's
+  # does not. This submodule tracks upstream mruby/mruby directly (no fork this
+  # project controls to carry the fix on), so it is patched in place here
+  # instead, the same way patches/psp-fixup-imports-jal-relocation-aware. patch
+  # is applied to a fetched pspsdk checkout -- via a real script
   # (scripts/apply_mruby_patch.bash), not a `patch` call embedded straight in
   # this COMMAND: it needs a dry-run-first idempotency check across repeat
-  # configures/builds without re-cloning the submodule, and that redirect-
-  # heavy shell logic does not survive CMake's own command-line escaping
-  # reliably inline. The script itself fails loudly (not silently) if the
-  # patch stops applying, e.g. after a future submodule bump moves the
-  # patched code -- see its own preamble.
+  # configures/builds without re-cloning the submodule, and that redirect- heavy
+  # shell logic does not survive CMake's own command-line escaping reliably
+  # inline. The script itself fails loudly (not silently) if the patch stops
+  # applying, e.g. after a future submodule bump moves the patched code -- see
+  # its own preamble.
   set(mruby_colon3_patch
       "${ARG_REPO_ROOT}/patches/mruby-colon3-assign-setmcnst.patch")
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17304,7 +17304,23 @@ screen (544×416). Full rationale:
     and every platform (PSP's stack headroom included) for what is mostly
     log-message fidelity in one utility script — see the item 7 write-up for
     the full reasoning on why that trade isn't taken here; the temporary VM
-    probe keeps finding the real gaps without it.
+    probe keeps finding the real gaps without it. That tenth masked
+    exception is now fixed: the real bug was in the vendored mruby compiler
+    itself, not the class variable — `gen_colon3_assign`
+    (`3rd/mruby/mrbgems/mruby-compiler/core/codegen.c`), the codegen for an
+    explicit top-level `::Const = value`, emitted `OP_SETCONST` instead of
+    `OP_SETMCNST`, so the pushed `Object` base was silently ignored and the
+    constant landed on the lexically enclosing module instead (confirmed
+    against real CRuby, and against the real 516-line script run
+    unmodified: `Object.const_defined?(:MapFog)` now reads `true`). A
+    two-round name-collision theory formed while re-investigating (that the
+    nested module sharing a name with its top-level target mattered) was
+    disproven the same way the `@@cvar` theory was: renaming the nested
+    module left the failure identical. Since `3rd/mruby` tracks upstream
+    directly, the fix ships as
+    `patches/mruby-colon3-assign-setmcnst.patch`, applied at build time by
+    `scripts/apply_mruby_patch.bash`; see the item 7 write-up for the full
+    trace.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -687,45 +687,54 @@ that clearing it costs most of a short budget on its own. Raising
 below that, a `RGSS::Timeout` in a probe run means "give it more wall
 clock," not "something broke."
 
-**Found, not fixed, and only partly understood: a real VX Ace game's own
-bundled `マップフォグ` ("Map Fog") add-on never finishes setting up, and a
-later event's inline "Script" command that depends on it fails as a
-result.** The add-on's very first line, `module BMSP; @@includes ||= {}`,
-is the sole place in this release's whole 213-section bundle that touches
-`@@includes` — a fresh, never-before-set class variable. Real Ruby handles
-`@@cvar ||= value` on a variable like that without raising (confirmed
-directly: `ruby -e 'module Foo; @@x ||= {}; end'` runs clean), and mruby's
-own compiler has code specifically meant to match that
-(`3rd/mruby/mrbgems/mruby-compiler/core/codegen.c`, `codegen_op_asgn`,
-~line 5471: `||=`/`&&=` on a class variable or constant wraps the read in
-a compiler-generated rescue that turns the `NameError` into `false` rather
-than letting it escape, mirroring the CRuby behaviour exactly). The
-temporary `OP_EXCEPT` probe used throughout this document shows that
-generated rescue actually firing and catching the `NameError` — which
-first looked like proof the line was harmless, since the probe fires on
-*every* caught exception, this compiler-internal one included, and
-execution visibly continues well past it (an isolated run of the whole
-516-line script reaches a *different*, unrelated failure over 280 lines
-later). But a targeted check straight after running the same script
-in isolation — `Object.const_defined?(:MapFog)`, right where the script's
-own `module Interface; ::MapFog = self` sits between those two points —
-comes back `false`. So somewhere between the class-variable rescue
-catching cleanly and execution reaching that later, unrelated failure, a
-plain top-level constant assignment that runs in between stops taking
-effect, without raising anything of its own. In the real game this is
-what a later event's own inline `Script` command hits:
-`NameError: uninitialized constant
-TKG::ErrorLog::Extend_Interpreter::MapFog`, because `::MapFog` was never
-actually set. Two rounds of isolated reproduction (a minimal synthetic
-`@@cvar ||=`, the same through the real script host's own `eval` call,
-and finally the real script's full 516 lines run standalone) narrowed
-this down this far without fully explaining it — genuinely tracing it
-further needs mruby VM-level tooling (breakpoints, instruction-level
-tracing) beyond what a source read and a VM-opcode probe can resolve, and
-any real fix would live in the vendored `3rd/mruby` submodule regardless,
-the same category of call as `$!` below. Left alone rather than patched
-further; documented here at the depth it was actually traced to, rather
-than guessed past.
+**Found and fixed: a real VX Ace game's own bundled `マップフォグ` ("Map
+Fog") add-on used to never finish setting up, so a later event's inline
+"Script" command that depends on it failed.** The add-on's own
+`module Interface; ::MapFog = self` — an explicit *top-level* constant
+assignment, written from inside a nested module — silently landed on the
+lexically enclosing module instead of at the top level, no exception
+raised. (An earlier pass at this same failure suspected the add-on's
+preceding `module BMSP; @@includes ||= {}` — a fresh, never-before-set
+class variable — but that line is handled correctly: mruby's compiler
+already wraps `||=`/`&&=` on a class variable or constant in a
+compiler-generated rescue that turns the `NameError` into `false` rather
+than letting it escape, mirroring real Ruby exactly. That was a red
+herring; the actual bug has nothing to do with class variables, and a
+name-collision theory formed while re-investigating — that the nested
+module and the top-level target sharing a name (`MapFog`) mattered —
+was disproven the same way, by renaming the nested module and watching
+the failure persist identically.)
+
+The real bug is in `gen_colon3_assign`
+(`3rd/mruby/mrbgems/mruby-compiler/core/codegen.c`), the codegen for
+`::Const = value` (`NODE_COLON3` in assignment position): it pushes
+`Object` via `OP_OCLASS` — exactly mirroring `gen_colon2_assign`'s
+handling of the explicit-base form `Foo::Const = value`, which correctly
+finishes with `OP_SETMCNST` (the opcode that reads that pushed value as
+the constant's owner) — but then emits `OP_SETCONST` instead.
+`OP_SETCONST`'s own VM handler (`3rd/mruby/src/vm.c`) never reads that
+pushed value at all; it always targets
+`MRB_PROC_TARGET_CLASS(ci->proc)`, the current lexically enclosing
+class/module — exactly right for a *bare* `Const = value`, but wrong for
+`::Const = value`, whose entire point is to bypass the enclosing scope.
+The *read* path already gets this right — `codegen_colon3` pairs the same
+`OP_OCLASS` push with `OP_GETMCNST`, not `OP_GETCONST` — so this reads as
+a copy/paste slip in the assignment counterpart that was never given its
+own read/write symmetry check. Confirmed against real CRuby: `ruby -e
+'module Foo; ::Bar = 42; end; p Object.const_defined?(:Bar)'` prints
+`true`; mruby's did not.
+
+Since this submodule tracks upstream `mruby/mruby` directly (no fork
+this project controls to carry the fix on), the fix ships as
+`patches/mruby-colon3-assign-setmcnst.patch` (one line:
+`gen_colon3_assign` now finishes with `OP_SETMCNST`), applied
+idempotently at build time by `scripts/apply_mruby_patch.bash` — the
+same `patches/` + apply-script convention already used for the PSP
+toolchain's own patch. Verified against: a minimal synthetic repro
+matching the real semantics, the full mruby test suite (zero
+regressions from a compiler-level change), and the real, unmodified
+516-line script — `Object.const_defined?(:MapFog)` now returns `true`
+after it runs.
 
 mruby's bare `raise` (no arguments) has the same
 root cause from the other side: real Ruby re-raises `$!`, but mruby's
@@ -759,11 +768,11 @@ Tilemap item 1's remaining polish (the flat "above characters" layer) is the
 only item left in the six sections above; item 7's `$!`/bare-`raise` gap
 stands, and per a real release it is the reason each fix above only reveals
 the *next* wall one at a time rather than the game running to completion in
-one pass. Nine real bugs have been found and fixed this way so far
+one pass. Ten real bugs have been found and fixed this way so far
 (`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
 `Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`,
 `Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`,
-`Sprite#width`/`#height`) without needing `$!` itself fixed — the temporary
-VM probe finds the real exception directly regardless. A tenth wall, this
-one traced but not fixed (the `@@includes`/`::MapFog` class-variable and
-constant-assignment interaction above), is where the game stands now.
+`Sprite#width`/`#height`, and the `::Const = value` compiler bug above)
+without needing `$!` itself fixed — the temporary VM probe finds the real
+exception directly regardless. Where the next wall stands past the
+`マップフォグ` fix is not yet traced.

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -5,6 +5,21 @@
 GAME_DIR = "" unless Object.const_defined?(:GAME_DIR)
 RTP_DIR = "" unless Object.const_defined?(:RTP_DIR)
 
+# Regression test for the vendored mruby compiler bug fixed by
+# patches/mruby-colon3-assign-setmcnst.patch: `::Const = value`, written from
+# inside a nested module, used to silently land on the enclosing module
+# instead of at the top level. Discovered because a real VX Ace game's
+# bundled add-on (docs/rpgvx-rgss-api-gap.md, item 7) relies on exactly this
+# pattern to publish its own top-level API and never finished setting up.
+assert "nested `::Const = value` defines the constant at the top level" do
+  module RGSSTestColon3Outer
+    ::RGSSTestColon3Target = self
+  end
+  assert_true Object.const_defined?(:RGSSTestColon3Target)
+  assert_true RGSSTestColon3Target.equal?(RGSSTestColon3Outer)
+  Object.send(:remove_const, :RGSSTestColon3Target)
+end
+
 # From: https://github.com/uni-algo/uni-algo?tab=readme-ov-file#normalization-functions
 assert "RGSS.to_nfd" do
   assert_equal RGSS.to_nfd("Ŵ"), "W\u0302"

--- a/patches/mruby-colon3-assign-setmcnst.patch
+++ b/patches/mruby-colon3-assign-setmcnst.patch
@@ -1,0 +1,70 @@
+mruby bug: `::Const = value` (an explicit top-level constant assignment,
+written from inside a nested module or class body) silently defines the
+constant on the *lexically enclosing* module instead of at the top level
+-- no exception, no warning, just the wrong owner.
+
+Found investigating a real RPG Maker VX Ace game whose own bundled
+add-on never finished setting up (docs/rpgvx-rgss-api-gap.md, item 7):
+
+  module BMSP
+    module MapFog
+      module Interface
+        ::MapFog = self
+        ...
+
+Minimal repro (no class variables, no name collisions -- neither
+mattered, both were red herrings from an earlier, incomplete pass at
+this same bug):
+
+  module Foo
+    ::Bar = 42
+  end
+  Object.const_defined?(:Bar)   # => false, should be true
+  Foo.const_defined?(:Bar)      # => true -- landed here instead
+
+Root cause, in gen_colon3_assign (mruby-compiler/core/codegen.c), the
+codegen for `::Const = value` (NODE_COLON3 in assignment position):
+it pushes Object via OP_OCLASS -- exactly mirroring gen_colon2_assign's
+handling of the explicit-base form `Foo::Const = value`, which pushes
+the base object and correctly finishes with OP_SETMCNST (the opcode
+that takes that pushed value as the constant's owner, symmetric with
+OP_GETMCNST on the read side: `mrb_const_get(mrb, regs[a], ...)`) --
+but then emits **OP_SETCONST** instead. OP_SETCONST's own VM handler
+(src/vm.c) never reads that pushed value at all:
+
+  CASE(OP_SETCONST, BB) {
+    ci = mrb->c->ci;
+    struct RClass *c = MRB_PROC_TARGET_CLASS(ci->proc);
+    if (!c) c = mrb->object_class;
+    mrb_const_set(mrb, mrb_obj_value(c), irep->syms[b], regs[a]);
+    NEXT;
+  }
+
+It always targets MRB_PROC_TARGET_CLASS(ci->proc) -- the current
+lexically enclosing class/module -- which is exactly correct for a
+*bare* `Const = value` (NODE_CONST, compiled by gen_xvar_assignment,
+which never pushes an OP_OCLASS base to begin with) but wrong for the
+explicit `::Const = value` form, whose entire point is to bypass the
+enclosing scope. The *read* path already gets this right --
+codegen_colon3 pairs the same OP_OCLASS push with OP_GETMCNST, not
+OP_GETCONST -- so this looks like a copy/paste slip in the assignment
+counterpart that was never given its own read/write symmetry check.
+
+Confirmed against real CRuby: `ruby -e 'module Foo; ::Bar = 42; end;
+p Object.const_defined?(:Bar)'` prints `true`.
+
+Fix: gen_colon3_assign should finish with OP_SETMCNST, matching
+gen_colon2_assign and the OP_OCLASS/OP_GETMCNST pairing codegen_colon3
+already uses to *read* the same node type.
+
+--- a/mrbgems/mruby-compiler/core/codegen.c
++++ b/mrbgems/mruby-compiler/core/codegen.c
+@@ -3006,7 +3006,7 @@ gen_colon3_assign(codegen_scope *s, node *varnode, node *rhs, int sp, int val)
+   genop_1(s, OP_OCLASS, cursp());
+   push();
+   idx = sym_idx(s, n->name);
+-  gen_colon_assign_common(s, rhs, sp, val, idx, OP_SETCONST);
++  gen_colon_assign_common(s, rhs, sp, val, idx, OP_SETMCNST);
+ }
+
+ static void

--- a/scripts/apply_mruby_patch.bash
+++ b/scripts/apply_mruby_patch.bash
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Idempotently apply a patch to the 3rd/mruby submodule checkout, as part of
+# the mruby build (see cmake/build-mruby.cmake). A plain `patch -p1` call
+# embedded directly in a CMake COMMAND is fragile to quote/escape across
+# platforms once it needs a dry-run-first idempotency check (`>/dev/null 2>&1`
+# inside a `sh -c "..."` string does not survive CMake's own command-line
+# escaping reliably), so this is a real script instead, the same reasoning
+# scripts/build_psp_fixup_imports.bash already applies for the PSP toolchain
+# patch. Unlike that one, this patches a persistent, in-tree submodule
+# checkout rather than a scratch clone, so it must be safe to run on every
+# configure/build without re-cloning: a dry run first decides whether the
+# patch still needs applying (already applied, or genuinely fails to apply
+# because upstream mruby moved the patched code -- either way, do nothing and
+# say why) before ever touching the working tree, so a real apply attempt
+# never gets far enough to leave a stray *.rej file behind.
+#
+# Usage: apply_mruby_patch.bash MRUBY_DIR PATCH_FILE
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 MRUBY_DIR PATCH_FILE" >&2
+  exit 1
+fi
+
+MRUBY_DIR="$1"
+PATCH_FILE="$2"
+
+cd "$MRUBY_DIR"
+
+if patch -p1 -N --dry-run -s <"$PATCH_FILE" >/dev/null 2>&1; then
+  patch -p1 -N -s <"$PATCH_FILE"
+  echo "apply_mruby_patch: applied $(basename "$PATCH_FILE")"
+elif patch -p1 -R -N --dry-run -s <"$PATCH_FILE" >/dev/null 2>&1; then
+  : # Already applied (reverse-applies cleanly) -- nothing to do.
+else
+  echo "apply_mruby_patch: $(basename "$PATCH_FILE") no longer applies" \
+       "cleanly to $MRUBY_DIR (upstream mruby likely moved) -- the fix it" \
+       "carries is NOT in effect; see the patch file's own preamble" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `gen_colon3_assign` (`3rd/mruby/mrbgems/mruby-compiler/core/codegen.c`) compiled an explicit top-level constant assignment (`::Const = value`) written from inside a nested module/class body by pushing `Object` via `OP_OCLASS` — mirroring `gen_colon2_assign`'s handling of `Foo::Const = value` — but then emitted `OP_SETCONST` instead of `OP_SETMCNST`. `OP_SETCONST`'s VM handler ignores the pushed base entirely and always targets the current lexically enclosing class/module, so the constant silently landed on the wrong owner with no exception raised. The read path already got this right (`codegen_colon3` pairs `OP_OCLASS` with `OP_GETMCNST`), so this reads as a copy/paste slip in the write path.
- Found investigating a real VX Ace game (`Sanctuary_Of_the_Ruler`) whose bundled `マップフォグ` (Map Fog) add-on never finished setting up: its own `module Interface; ::MapFog = self` never took effect, so a later event's inline `Script` command depending on `MapFog` raised `NameError`.
- Since `3rd/mruby` tracks upstream `mruby/mruby` directly (no fork this project controls to carry the fix on), it ships as `patches/mruby-colon3-assign-setmcnst.patch`, applied idempotently at build time by `scripts/apply_mruby_patch.bash` — the same `patches/` + apply-script convention already used for the PSP toolchain — wired into both mruby build targets via `cmake/build-mruby.cmake`'s shared `rpg2k_add_mruby()`.
- Adds a permanent regression test in `mruby-rgss/test/test.rb` and updates `docs/rpgvx-rgss-api-gap.md` (item 7) and `docs/TODO.md` from "traced but not fixed" to the resolved root cause.

## Test plan

- [x] `rake test` (mrbtest) with the patch applied: 1841 OK, 0 KO, 0 Crash (includes the new regression test)
- [x] Confirmed against real CRuby: `ruby -e 'module Foo; ::Bar = 42; end; p Object.const_defined?(:Bar)'` prints `true`
- [x] Verified against the real, unmodified 516-line `マップフォグ` script extracted from the game archive: `Object.const_defined?(:MapFog)` now `true`
- [x] Full CMake reconfigure + `cmake --build build -t mruby_build` + `cmake --build build -t rpg_maker_clone` + `ctest`: 7/8 passed (the 1 failure, `exe_open`, is a missing test-data directory not present in this sandbox, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_