### PR TITLE
Field menu shows the party's own Gold

### DIFF
--- a/changelog.d/menu-shows-gold.fixed.md
+++ b/changelog.d/menu-shows-gold.fixed.md
@@ -1,0 +1,4 @@
+- **Field menu:** The top-level menu screen (Item/Skill/Equip/Save/End Game)
+  now shows the party's own Gold in the bottom-left corner, matching
+  RPG_RT's `Window_Gold`. Previously this screen showed the party list and
+  command menu but nothing about the party's money.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4205,6 +4205,26 @@ The work below is roughly ordered by the critical path to a walkable game
   that End Game "hands control back to the app immediately, with no
   confirmation message to dismiss first" -- now replaced). See
   `changelog.d/menu-end-game-confirmation.fixed.md`.
+  ✅ **The top-level field menu never showed the party's own Gold at all,
+  even though the Status screen's own identical gap was already found and
+  fixed (2026-08-20) — this screen still had nothing.** Confirmed against
+  EasyRPG Player's actual C++ source: `Scene_Menu::Start`
+  (`src/scene_menu.cpp`) creates a `Window_Gold` unconditionally (88x32,
+  bottom-left corner, no version or feature gate anywhere in the file) for
+  RPG2000 and RPG2003 alike, and `Scene_Menu::Continue` (fired when control
+  returns from a popped child screen) unconditionally calls `gold_window->
+  Refresh()` alongside `menustatus_window->Refresh()`. `Scene::Menu`
+  (`mruby-rpg2k/mrblib/scene/menu.rb`) built only `@command` (the command
+  list) and `@status` (the party list) — no gold anywhere. Fixed by adding a
+  `@gold` window (`#build_gold_window`/`#draw_gold_window`, same bottom-left
+  88x32 geometry and the identical no-space "amount then term" rendering
+  `Scene::StatusMenu`'s own Gold line already uses), wired into `#dispose`
+  and toggled alongside `@command`/`@status` in `#suspend`/`#resume` — and,
+  matching `Continue`'s own unconditional refresh, `#resume` redraws the
+  gold text too, not just its visibility. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (Gold renders on open; the panel
+  hides on `#suspend` and returns with a refreshed figure on `#resume`),
+  confirmed to fail against the pre-fix code.
   ✅ **The field menu screens now play RPG2000's four system sound effects
   (cursor-move, decision, cancel, buzzer), the "bigger, separate piece of
   work" the disabled-Save fix above left open.** Confirmed against three

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -105,6 +105,7 @@ class RPG2k
         @background.dispose if @background
         @command.dispose if @command
         @status.dispose if @status
+        @gold.dispose if @gold
       end
 
       # Hide this menu's own command list and status panel while a child
@@ -118,13 +119,23 @@ class RPG2k
       def suspend
         @command.visible = false if @command
         @status.visible = false if @status
+        @gold.visible = false if @gold
       end
 
       # Undo #suspend once the child screen above this menu is popped and it
-      # is active again -- called by RPG2k#pop.
+      # is active again -- called by RPG2k#pop. Redraws the gold panel too,
+      # matching EasyRPG's own `Scene_Menu::Continue` (`src/scene_menu.cpp`),
+      # which unconditionally calls `gold_window->Refresh()` (alongside the
+      # status panel's own `menustatus_window->Refresh()`, already mirrored
+      # by #refresh_status_cursor/rebuilds elsewhere) every time control
+      # returns from a popped child screen.
       def resume
         @command.visible = true if @command
         @status.visible = true if @status
+        if @gold
+          @gold.visible = true
+          draw_gold_window
+        end
       end
 
       def update
@@ -302,6 +313,34 @@ class RPG2k
         # while a window is inactive, the same mechanism the command list's
         # own cursor disappears through once focus leaves it.
         @status.active = false
+
+        build_gold_window
+      end
+
+      # The party's own Gold, bottom-left corner -- confirmed against
+      # RPG_RT's own live source: `Scene_Menu::Start` (`src/scene_menu.cpp`)
+      # creates a `Window_Gold` there unconditionally (88x32, no version or
+      # feature gate anywhere in the file), for both RPG2000 and RPG2003
+      # alike. `Window_Gold::Refresh` (`src/window_gold.cpp`) draws the
+      # amount then the `gold` term via `DrawCurrencyValue`
+      # (`src/window_base.cpp`) -- the identical no-space "amount then term"
+      # rendering `Scene::StatusMenu`'s own Gold line already uses.
+      GOLD_WINDOW_W = 88
+      GOLD_WINDOW_H = 32
+
+      def build_gold_window
+        @gold = Window.new(0, SCREEN_H - GOLD_WINDOW_H, GOLD_WINDOW_W, GOLD_WINDOW_H)
+        @gold.z = 400
+        @gold.windowskin = @skin
+        draw_gold_window
+      end
+
+      def draw_gold_window
+        inner_w = GOLD_WINDOW_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, LINE_H, "#{@state.party.gold}#{term(:gold, 'G')}"
+        @gold.contents = c
       end
 
       def refresh_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15903,6 +15903,30 @@ check 'the menu party list shows each member condition' do
   ok !texts.include?('Normal'), 'the normal term is replaced, not added to'
 end
 
+# RPG_RT's own `Window_Gold` on this screen -- confirmed against
+# `Scene_Menu::Start` (`src/scene_menu.cpp`), which creates one
+# unconditionally (88x32, bottom-left corner, no version/feature gate
+# anywhere in the file) for RPG2000 and RPG2003 alike, and
+# `Scene_Menu::Continue`, which refreshes it every time control returns from
+# a popped child screen (`Item`/`Skill`/`Equip`/`Status`/`Save`).
+check 'Scene::Menu shows the party\'s own Gold, and keeps it current across ' \
+      'a pushed child screen' do
+  st = menu_state
+  st.party.instance_variable_set(:@gold, 1234)
+  scene = menu_scene(RPG2k::Scene::Menu, st)
+  gold_win = scene.instance_variable_get(:@gold)
+  ok window_texts(gold_win).include?('1234G'), 'Gold is drawn on the field menu screen'
+
+  scene.suspend
+  ok !gold_win.visible, 'the gold panel hides while a child screen (Item/Skill/...) is on top'
+
+  st.party.instance_variable_set(:@gold, 5)
+  scene.resume
+  ok gold_win.visible, 'the gold panel returns once the child screen is popped'
+  ok window_texts(gold_win).include?('5G'),
+     "Gold is refreshed on resume, matching Scene_Menu::Continue's own gold_window->Refresh()"
+end
+
 check 'opening Scene::Menu auto-cancels an Erase Screen black-out (yado.tk)' do
   st = menu_state
   st.screen.erase(Game::Transition::FADE_OUT, 1) # settle fully erased


### PR DESCRIPTION
## Summary

- `Scene_Menu::Start` (`src/scene_menu.cpp`) creates a `Window_Gold` unconditionally (88x32, bottom-left corner, no version or feature gate anywhere in the file) for RPG2000 and RPG2003 alike, and `Scene_Menu::Continue` (fired when control returns from a popped child screen) unconditionally calls `gold_window->Refresh()` alongside `menustatus_window->Refresh()`.
- `Scene::Menu` (`mruby-rpg2k/mrblib/scene/menu.rb`) built only `@command` (the command list) and `@status` (the party list) — no gold anywhere on the top-level field menu screen (Item/Skill/Equip/Save/End Game), even though the Status sub-screen's own identical gap was already found and fixed in a previous PR.
- Fixed by adding a `@gold` window (`#build_gold_window`/`#draw_gold_window`, same bottom-left 88x32 geometry and the identical no-space "amount then term" rendering `Scene::StatusMenu`'s own Gold line already uses), wired into `#dispose` and toggled alongside `@command`/`@status` in `#suspend`/`#resume` — and, matching `Continue`'s own unconditional refresh, `#resume` redraws the gold text too, not just its visibility.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: Gold renders on open; the panel hides on `#suspend` and returns with a refreshed figure on `#resume`.
- [x] Verified via `git stash` on `menu.rb` alone: fails pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 806 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_