### PR TITLE
Save/Load screen opens on the most-recently-saved slot

### DIFF
--- a/changelog.d/save-load-initial-slot-recency.fixed.md
+++ b/changelog.d/save-load-initial-slot-recency.fixed.md
@@ -1,0 +1,4 @@
+- **Save/Load screen:** Now opens with the cursor on whichever slot was
+  saved most recently (scrolled into view), matching RPG_RT's
+  `Scene_File::Start`. Previously it always opened on slot 1 regardless of
+  which slot actually held the newest save.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5072,6 +5072,34 @@ The work below is roughly ordered by the critical path to a walkable game
   frame by frame confirms the down arrow starts on, flips off at exactly
   the 20th frame, and swaps places with the up arrow once scrolled to the
   last slot.
+  ✅ **This screen always opened with the cursor on slot 1, when real RPG_RT
+  opens on whichever slot was saved most recently (2026-08-20).** Confirmed
+  against EasyRPG's own live source: `Scene_File::Start` (`src/
+  scene_file.cpp`) sets `index = latest_slot; top_index = std::max(0, index
+  - 2);`, where `latest_slot`/`latest_time` (`UpdateLatestTimestamp`) track
+  whichever populated slot's `title.timestamp` (chunk 100 field 1) is the
+  largest, defaulting to slot 0 only when no save has one at all.
+  `Scene::SaveLoad#initialize` (`mruby-rpg2k/mrblib/scene/save_load.rb`)
+  hardcoded `@index = 0`/`@top = 0`. This codebase's own `Game::State#
+  to_lsd` already writes that exact field into every slot's exported
+  `Save<N>.lsd` sibling (`title[1] = timestamp.to_f`, defaulting to the
+  real save-time "now" -- see `Game::State#to_lsd`'s own comment and ADR
+  0021 for why that default matters at all) -- fixed by adding
+  `#initial_index`/`#slot_timestamp`, which read that
+  genuine on-disk field back via `parent.lsd_path(slot)` and
+  `LCF::SaveData`, the exact same field RPG_RT itself reads, not a
+  filesystem-mtime proxy. `@top` mirrors EasyRPG's own `max(0, index -
+  2)`, generalised to `VISIBLE_SLOTS` the same way the scroll-arrow fix
+  just above already generalises `top_index < max_index - 2`. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (two slots each carrying a
+  bare title-only `.lsd` with an explicit timestamp; the cursor opens on
+  the newer one, scrolled into view; an empty save directory still opens
+  on slot 1) -- the check needed `scripts/rpg2k_scene_check.rb` to load
+  `mruby-lcf/mrblib` for the first time (mirroring `rpg2k_logic_check.rb`'s
+  own `LCF.cp932_to_utf8`/`utf8_to_cp932` shim), since writing a real
+  `.lsd` sibling to disk is exactly what this fix itself now does at
+  runtime. Confirmed to fail against the pre-fix code (`expected 4, got
+  0`).
   ✅ **The battle command/target/skill/item flow now plays system SE too --
   the same class of gap the field menu and title screen already had fixed,
   extended to a much larger interaction surface.** Confirmed against

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -96,8 +96,8 @@ class RPG2k
         # One Game::State (or nil for an empty slot) per slot, read once so
         # scrolling the list never re-touches disk.
         @slots = (1..SLOT_COUNT).map { |slot| parent.load_save_state(slot) }
-        @index = 0
-        @top = 0
+        @index = initial_index
+        @top = [@index - VISIBLE_SLOTS + 1, 0].max
         @arrow_anim = 0
         @message = nil
         @slot_windows = []
@@ -159,6 +159,43 @@ class RPG2k
       # rather than cycling back around, the mirror image for Up at the
       # first slot. `#update` passes `allow_wrap:` true only for the frame a
       # direction is freshly pressed, matching that split exactly.
+      # RPG_RT opens this screen with the cursor already on whichever slot
+      # was saved most recently, not always slot 1 -- confirmed against
+      # EasyRPG's own live source: `Scene_File::Start` (`src/scene_file.cpp`)
+      # sets `index = latest_slot; top_index = std::max(0, index - 2);`,
+      # where `latest_slot`/`latest_time` (`UpdateLatestTimestamp`) track
+      # whichever populated slot's `title.timestamp` (chunk 100 field 1) is
+      # the largest, defaulting to slot 0 when no save has one at all.
+      # `Game::State#to_lsd` already writes that exact field into each
+      # slot's exported `Save<N>.lsd` sibling (`title[1] = timestamp.to_f`,
+      # defaulting to the real save-time "now") -- reading it back here is
+      # the same genuine on-disk field RPG_RT itself reads, not a
+      # filesystem-mtime proxy.
+      def initial_index
+        best = 0
+        best_time = -Float::INFINITY
+        (1..SLOT_COUNT).each do |slot|
+          ts = slot_timestamp(slot)
+          next unless ts && ts > best_time
+          best_time = ts
+          best = slot - 1
+        end
+        best
+      end
+
+      # A slot's `title.timestamp`, read straight from its exported
+      # `Save<N>.lsd` sibling -- nil for a slot with no `.lsd`, an unreadable
+      # one, or one with no title chunk at all (the same defensive shape
+      # `RPG2k#load_save_state` already uses for this exact file).
+      def slot_timestamp(slot)
+        path = parent.lsd_path(slot)
+        return nil unless path && File.exist?(path)
+        title = LCF::SaveData.new(File.open(path, "rb"))[100]
+        title && title.timestamp
+      rescue StandardError
+        nil
+      end
+
       def move_selection(delta, allow_wrap:)
         target = @index + delta
         return if (target == SLOT_COUNT || target == -1) && !allow_wrap

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -278,6 +278,28 @@ module RGSS
   class Timeout < StandardError; end
 end
 
+# `Game::State#to_lsd`'s only native dependency (LCF.cp932_to_utf8/
+# utf8_to_cp932, a string field's encode/decode) shimmed with Ruby's own
+# Windows-31J transcoder -- exactly as scripts/rpg2k_logic_check.rb and
+# scripts/rpg2k_save_load_check.rb already do for the same reason. Needed
+# so a check can write a real Save<N>.lsd sibling straight to disk (the
+# Scene::SaveLoad initial-slot-recency check below) without loading the
+# native LCF parser this CRuby harness has no access to.
+module LCF
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+  def utf8_to_cp932(s)
+    s.dup.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+end
+lcf_lib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(lcf_lib, 'lcf.rb')
+load File.join(lcf_lib, 'schema.rb')
+
 lib = File.expand_path('../mruby-rpg2k/mrblib', __dir__)
 load File.join(lib, 'game.rb')
 load File.join(lib, 'interpreter.rb')
@@ -16495,6 +16517,62 @@ end
 def save_load_scene(mode, state = nil, db = fake_db, parent: nil)
   parent ||= fake_parent(db)
   [RPG2k::Scene::SaveLoad.new(parent, state, mode), parent]
+end
+
+# A FakeParent whose #lsd_path points at a real tmpdir -- the only extra
+# thing #initial_index/#slot_timestamp need beyond FakeParent's own
+# #load_save_state, mirroring RPG2k#lsd_path's own zero-padded naming.
+class SaveLoadRecencyParent < FakeParent
+  def initialize(db, dir)
+    super(db) { |id| fake_map(id, {}) }
+    @dir = dir
+  end
+  def lsd_path(slot)
+    n = slot < 10 ? "0#{slot}" : slot.to_s
+    File.join(@dir, "Save#{n}.lsd")
+  end
+end
+
+# A bare Save<N>.lsd carrying only a title chunk (id 100) with the given
+# timestamp -- everything #slot_timestamp reads, without needing a
+# `Game::State#to_lsd`-compatible party fixture (MenuStubParty isn't one;
+# it is built for RGSS scene wiring, not LCF round-tripping).
+def write_title_only_lsd(path, timestamp)
+  save = LCF::SaveData.new
+  title = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_TITLE })
+  title[1] = timestamp
+  save[100] = title
+  save.save_to(path)
+end
+
+# Confirmed against RPG_RT's own live source: `Scene_File::Start`
+# (`src/scene_file.cpp`) sets `index = latest_slot; top_index = std::max(0,
+# index - 2);`, tracking whichever populated slot's `title.timestamp` is
+# the largest -- not always slot 1.
+check 'Scene::SaveLoad opens with the cursor on the most-recently-saved ' \
+      'slot, not always the first one' do
+  Dir.mktmpdir('rpg2k-save-recency') do |dir|
+    parent = SaveLoadRecencyParent.new(fake_db, dir)
+    # Slot 2 saved first (older timestamp), slot 5 saved second (newer) --
+    # explicit timestamps so ordering never depends on real wall-clock
+    # timing during the test run.
+    write_title_only_lsd(parent.lsd_path(2), 1000.0)
+    write_title_only_lsd(parent.lsd_path(5), 2000.0)
+
+    scene = RPG2k::Scene::SaveLoad.new(parent, nil, :load)
+    eq 4, scene.instance_variable_get(:@index),
+       'the cursor starts on slot 5 (index 4), the newer of the two timestamps'
+    eq 2, scene.instance_variable_get(:@top),
+       "scrolled so slot 5 is in view (top = index - #{RPG2k::Scene::SaveLoad::VISIBLE_SLOTS} + 1)"
+  end
+
+  # With no saves at all, RPG_RT's own `latest_slot` default (0) holds.
+  Dir.mktmpdir('rpg2k-save-recency-empty') do |dir|
+    parent = SaveLoadRecencyParent.new(fake_db, dir)
+    scene = RPG2k::Scene::SaveLoad.new(parent, nil, :load)
+    eq 0, scene.instance_variable_get(:@index), 'no saves at all still starts on slot 1'
+    eq 0, scene.instance_variable_get(:@top)
+  end
 end
 
 check 'Scene::SaveLoad: an empty slot shows only the file label, no placeholder text' do


### PR DESCRIPTION
## Summary

- `Scene_File::Start` (`src/scene_file.cpp`) sets `index = latest_slot; top_index = std::max(0, index - 2);`, where `latest_slot`/`latest_time` (`UpdateLatestTimestamp`) track whichever populated slot's `title.timestamp` (chunk 100 field 1) is the largest, defaulting to slot 0 only when no save has one at all. This applies to both the Save and Load screens (`Scene_File` is their shared base).
- `Scene::SaveLoad#initialize` (`mruby-rpg2k/mrblib/scene/save_load.rb`) hardcoded `@index = 0`/`@top = 0` — the cursor always opened on slot 1 regardless of which slot actually held the newest save.
- This codebase's own `Game::State#to_lsd` already writes the exact same field into every slot's exported `Save<N>.lsd` sibling (`title[1] = timestamp.to_f`, defaulting to the real save-time "now"). Fixed by adding `#initial_index`/`#slot_timestamp`, which read that genuine on-disk field back via `parent.lsd_path(slot)` and `LCF::SaveData` — the same field RPG_RT itself reads, not a filesystem-mtime proxy. `@top` mirrors EasyRPG's own `max(0, index - 2)`, generalised to `VISIBLE_SLOTS` the same way this screen's scroll-arrow logic already generalises `top_index < max_index - 2`.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: two slots each carrying a bare title-only `.lsd` with an explicit timestamp — the cursor opens on the newer one, scrolled into view; an empty save directory still opens on slot 1. (This needed `scripts/rpg2k_scene_check.rb` to load `mruby-lcf/mrblib` for the first time, mirroring `rpg2k_logic_check.rb`'s own `LCF.cp932_to_utf8`/`utf8_to_cp932` shim, since writing a real `.lsd` sibling to disk is exactly what this fix itself now does at runtime.)
- [x] Verified via `git stash` on `save_load.rb` alone: fails pre-fix (`expected 4, got 0`).
- [x] Full suite green: `rpg2k_scene_check.rb` 807 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_