### PR TITLE
A :save confirm pops back with no "Game saved."/"Save failed." banner

### DIFF
--- a/changelog.d/save-menu-no-confirmation-banner.fixed.md
+++ b/changelog.d/save-menu-no-confirmation-banner.fixed.md
@@ -1,0 +1,4 @@
+- **Save screen:** Confirming a slot now pops straight back to the menu the
+  same frame, with no "Game saved."/"Save failed." banner to dismiss --
+  matching RPG_RT's `Scene_Save::Action`, which discards the save's own
+  success/failure result and pops unconditionally either way.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5100,6 +5100,35 @@ The work below is roughly ordered by the critical path to a walkable game
   `.lsd` sibling to disk is exactly what this fix itself now does at
   runtime. Confirmed to fail against the pre-fix code (`expected 4, got
   0`).
+  ✅ **A :save confirm showed a "Game saved."/"Save failed." banner the
+  player had to dismiss before returning to the menu -- real RPG_RT shows
+  no feedback at all, either way (2026-08-20).** This was this codebase's
+  own invention from the start: the screen's own class comment claimed the
+  banner was "the same feedback the menu used to show inline," but
+  `Scene_Menu::UpdateCommand`'s Save case (`src/scene_menu.cpp`) was
+  always just `Scene::Push(std::make_shared<Scene_Save>())` -- no inline
+  message ever existed to carry forward. Confirmed against RPG_RT's own
+  live source: `Scene_Save::Action` (`src/scene_save.cpp`) is `Save(fs,
+  index + 1); Scene::Pop();`, discarding `Save`'s own boolean result
+  outright -- there is no "Save failed." path in real RPG_RT at all, an
+  I/O failure pops exactly the same as a success, the same frame, with no
+  dismiss step. `Scene::SaveLoad#confirm_selection`'s `:save` branch
+  (`mruby-rpg2k/mrblib/scene/save_load.rb`) built a message window and
+  waited for a second Decision/Cancel press to pop, via its own `#drive_
+  message`/`#show_message`/`#close_message` trio (mirroring `Scene::Menu`'s
+  End Game confirmation, a genuinely different case with a real RPG_RT
+  message behind it). Fixed by dropping the message entirely: the `:save`
+  branch now plays Decision, calls `#save_game`, and pops straight back to
+  the parent in the same `#confirm_selection` call, matching `Scene_Save::
+  Action` exactly; `#drive_message`/`#show_message`/`#close_message` were
+  the message's only callers in this file (`:load`'s empty-slot case only
+  ever played Buzzer, no message), so they were removed as dead code along
+  with `@message`'s init/dispose wiring. Covered by three rewritten
+  `scripts/rpg2k_scene_check.rb` checks (a successful save pops back the
+  same frame with no message window built; a failed save pops back
+  identically, not a different "Save failed." path; the event-triggered
+  Open Save Menu picker's own confirm does the same), all confirmed to
+  fail against the pre-fix code.
   ✅ **The battle command/target/skill/item flow now plays system SE too --
   the same class of gap the field menu and title screen already had fixed,
   extended to a much larger interaction surface.** Confirmed against

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -10,8 +10,10 @@ class RPG2k
     #   * `:save`, from Scene::Menu's Save command, with the running
     #     Game::State to write out. Every slot -- occupied or not -- is
     #     selectable; confirming one calls RPG2k#save_game(state, slot) and
-    #     shows the same "Game saved." / "Save failed." feedback the menu
-    #     used to show inline, then returns to the menu.
+    #     pops straight back to the menu the same frame, no feedback of any
+    #     kind either way -- confirmed against RPG_RT's own live source,
+    #     `Scene_Save::Action` (`src/scene_save.cpp`), which discards
+    #     `Save`'s own boolean result outright.
     #   * `:load`, from Scene::Title's Continue entry, with `state` nil (there
     #     is no running game yet). Only an occupied slot is selectable;
     #     confirming one calls RPG2k#continue_game(slot), which tears down the
@@ -99,7 +101,6 @@ class RPG2k
         @index = initial_index
         @top = [@index - VISIBLE_SLOTS + 1, 0].max
         @arrow_anim = 0
-        @message = nil
         @slot_windows = []
         build_header_window
         build_slot_windows
@@ -107,7 +108,6 @@ class RPG2k
       end
 
       def dispose
-        close_message
         @header_window.dispose if @header_window
         @slot_windows.each(&:dispose)
         @up_arrow.dispose if @up_arrow
@@ -116,7 +116,6 @@ class RPG2k
 
       def update
         tick_arrows
-        return drive_message if @message
 
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
@@ -207,15 +206,24 @@ class RPG2k
         play_system_se(SFX_CURSOR)
       end
 
+      # A :save confirm pops straight back to the menu the same frame, with
+      # no feedback of any kind -- confirmed against RPG_RT's own live
+      # source: `Scene_Save::Action` (`src/scene_save.cpp`) is just `Save(fs,
+      # index + 1); Scene::Pop();`, discarding `Save`'s own boolean result
+      # outright -- there is no "Save failed." path in real RPG_RT at all,
+      # a save I/O failure pops exactly the same as a success. `Scene_Menu::
+      # UpdateCommand`'s own Save case (`src/scene_menu.cpp`) is just
+      # `Scene::Push(std::make_shared<Scene_Save>())`, so this class's own
+      # prior comment attributing the fabricated message to "the same
+      # feedback the menu used to show inline" cited no real RPG_RT source
+      # for that claim, only this codebase's own earlier code.
       def confirm_selection
         slot = @index + 1
         case @mode
         when :save
           play_system_se(SFX_DECISION)
-          ok = @parent.save_game(@state, slot)
-          @slots[@index] = @parent.load_save_state(slot) if ok
-          refresh_slot_windows
-          show_message(ok ? "Game saved." : "Save failed.")
+          @parent.save_game(@state, slot)
+          @parent.pop
         when :load
           # An empty slot has nothing to resume -- refused (Buzzer), like the
           # selection key on a title screen Continue with no save at all
@@ -448,35 +456,6 @@ class RPG2k
         cell
       end
 
-      # The "Game saved." / "Save failed." feedback banner, mirroring
-      # Scene::Menu's own #show_message/#drive_message/#close_message: shown
-      # after a :save confirm, dismissed by the player, and only then does
-      # this screen pop back to the menu -- so the message is never missed.
-      def drive_message
-        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        close_message
-        @parent.pop
-      end
-
-      def show_message(text)
-        return if @message
-        w = SCREEN_W - 40
-        win = Window.new(20, SCREEN_H - LINE_H - Window::BORDER * 2 - 4, w,
-                         LINE_H + Window::BORDER * 2)
-        win.z = 500
-        win.windowskin = @skin
-        c = Bitmap.new(w - Window::BORDER * 2, LINE_H)
-        c.font.color = Color.new(255, 255, 255, 255)
-        c.draw_text 0, 0, c.width, LINE_H, text
-        win.contents = c
-        @message = { window: win }
-      end
-
-      def close_message
-        return unless @message
-        @message[:window].dispose
-        @message = nil
-      end
     end
   end
 end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16719,25 +16719,24 @@ check 'Scene::SaveLoad: a member with no FaceSet draws no thumbnail; only the fi
      'only members 2/3/4 (of 5) draw a face'
 end
 
-check 'Scene::SaveLoad :save mode: confirming a slot saves through the parent, shows a ' \
-      'message, and returns to the menu once dismissed' do
+# Confirmed against RPG_RT's own live source: `Scene_Save::Action`
+# (`src/scene_save.cpp`) is just `Save(fs, index + 1); Scene::Pop();`,
+# discarding `Save`'s own boolean result outright -- a save I/O failure
+# pops exactly the same as a success, no "Save failed." path exists at
+# all, and there is no confirmation banner of any kind either way.
+check 'Scene::SaveLoad :save mode: confirming a slot saves through the ' \
+      'parent and pops back to the menu the same frame, no message at all' do
   st = wrap_menu_state
   scene, parent = save_load_scene(:save, st)
   RGSS::Input.triggered = [RGSS::Input::C] # confirm slot 1
   scene.update
   RGSS::Input.reset
   eq [[st, 1]], parent.saved, 'RPG2k#save_game was called for slot 1 with the running state'
-  ok window_texts(scene.instance_variable_get(:@message)[:window]).include?('Game saved.'),
-     'the confirmation banner shows'
-  ok parent.pop_called.nil?, 'the screen has not popped back to the menu yet -- the ' \
-                             'banner is still up'
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the banner
-  scene.update
-  RGSS::Input.reset
-  eq 1, parent.pop_called, 'dismissing the banner pops back to the menu'
+  eq 1, parent.pop_called, 'pops back to the menu the same frame, no dismiss step'
 end
 
-check 'Scene::SaveLoad :save mode: a failed save shows "Save failed." instead' do
+check 'Scene::SaveLoad :save mode: a failed save still pops back the same ' \
+      'way, no failure message' do
   st = wrap_menu_state
   parent = fake_parent(fake_db)
   parent.save_ok = false
@@ -16745,8 +16744,7 @@ check 'Scene::SaveLoad :save mode: a failed save shows "Save failed." instead' d
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.reset
-  ok window_texts(scene.instance_variable_get(:@message)[:window]).include?('Save failed.'),
-     'the failure banner shows instead of the success one'
+  eq 1, parent.pop_called, 'a failed save pops back to the menu exactly like a successful one'
 end
 
 check 'Scene::SaveLoad :load mode: an empty slot ignores the selection key' do
@@ -16958,12 +16956,7 @@ check 'Open Save Menu: confirming a slot in the pushed picker really saves throu
   picker.update
   RGSS::Input.reset
   eq [[st, 1]], parent.saved, 'RPG2k#save_game was called for slot 1 with the running state'
-  ok window_texts(picker.instance_variable_get(:@message)[:window]).include?('Game saved.'),
-     'the picker shows its own confirmation banner'
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the banner
-  picker.update
-  RGSS::Input.reset
-  eq 1, parent.pop_called, 'the picker popped itself once dismissed'
+  eq 1, parent.pop_called, 'the picker pops itself the same frame, no confirmation banner'
 end
 
 check 'Open Save Menu ignores a Change Save Access lock -- unlike Scene::Menu\'s ' \


### PR DESCRIPTION
## Summary

- `Scene_Save::Action` (`src/scene_save.cpp`) is `Save(fs, index + 1); Scene::Pop();`, discarding `Save`'s own boolean result outright — there is no "Save failed." path in real RPG_RT at all, an I/O failure pops exactly the same as a success, the same frame, with no dismiss step. `Scene_File::vUpdate` (`src/scene_file.cpp`) never builds a message window on Decision either.
- `Scene::SaveLoad#confirm_selection`'s `:save` branch (`mruby-rpg2k/mrblib/scene/save_load.rb`) built a "Game saved."/"Save failed." message window and waited for a second Decision/Cancel press before popping. The class's own comment attributed this to "the same feedback the menu used to show inline," but `Scene_Menu::UpdateCommand`'s Save case (`src/scene_menu.cpp`) was always just `Scene::Push(std::make_shared<Scene_Save>())` — no inline message ever existed to carry forward.
- Fixed by dropping the message entirely: the `:save` branch now plays Decision, calls `#save_game`, and pops straight back to the parent in the same `#confirm_selection` call, matching `Scene_Save::Action` exactly. `#drive_message`/`#show_message`/`#close_message` were the message's only callers in this file (`:load`'s empty-slot case only ever played Buzzer, no message), so they were removed as dead code along with `@message`'s init/dispose wiring.

## Test plan

- [x] Three rewritten `scripts/rpg2k_scene_check.rb` checks: a successful save pops back the same frame with no message window built; a failed save pops back identically, not a different "Save failed." path; the event-triggered Open Save Menu picker's own confirm does the same.
- [x] Verified via `git stash` on `save_load.rb` alone: all three fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 807 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_