### PR TITLE
Note upstream status in the mruby colon3-assign patch preamble

### DIFF
--- a/patches/mruby-colon3-assign-setmcnst.patch
+++ b/patches/mruby-colon3-assign-setmcnst.patch
@@ -57,6 +57,20 @@ Fix: gen_colon3_assign should finish with OP_SETMCNST, matching
 gen_colon2_assign and the OP_OCLASS/OP_GETMCNST pairing codegen_colon3
 already uses to *read* the same node type.
 
+Upstream status (checked 2026-08-20): already fixed on mruby/mruby's
+default branch, but not as a targeted bugfix -- an incidental side
+effect of migrating the compiler's parser from the old bison-based one
+to Ruby's "prism" parser (mrbgems/mruby-compiler/src/codegen.c, moved
+from core/codegen.c). There, `Foo::Const = value` and `::Const = value`
+share one case (PM_CONSTANT_PATH_WRITE_NODE) that always finishes with
+OP_SETMCNST, so the old asymmetric gen_colon3_assign/gen_colon2_assign
+split this bug lived in doesn't exist any more. That fix is several
+months of commits ahead of mruby 4.0.0 (831da26, 2026-04-20, what
+3rd/mruby is pinned to here) on master, not in any tagged release yet --
+adopting it means adopting the whole parser rewrite, a far bigger and
+riskier change than this one-line patch. This patch stays until this
+project's own mruby pin moves past that rewrite.
+
 --- a/mrbgems/mruby-compiler/core/codegen.c
 +++ b/mrbgems/mruby-compiler/core/codegen.c
 @@ -3006,7 +3006,7 @@ gen_colon3_assign(codegen_scope *s, node *varnode, node *rhs, int sp, int val)


### PR DESCRIPTION
## Summary

- Documentation-only follow-up to #1144. Checked mruby/mruby's default branch directly: the `::Const = value` bug that patch fixes is already resolved there, but incidentally — as a side effect of migrating the compiler to Ruby's "prism" parser, not a targeted bugfix.
- That fix is several months of commits ahead of the mruby 4.0.0 release (`831da26`, 2026-04-20) this project's `3rd/mruby` submodule is pinned to, and isn't in any tagged release yet. Adopting it means adopting the whole parser rewrite — a far bigger, riskier change than this project's one-line patch.
- Adds a short note to `patches/mruby-colon3-assign-setmcnst.patch`'s preamble explaining this, so the patch isn't mistaken for something upstream will pick up on its own soon, or dropped prematurely.

## Test plan

- Documentation-only change (a comment block inside the patch file's prose preamble, not the diff itself) — no code or build behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_