### PR TITLE
Fix: Escape/Teleport skills and invoking items stay listed when unavailable

### DIFF
--- a/changelog.d/escape-teleport-always-listed.fixed.md
+++ b/changelog.d/escape-teleport-always-listed.fixed.md
@@ -1,0 +1,9 @@
+- **Field menu:** A known Escape/Teleport skill (or a special item invoking
+  one) now stays listed in the field Skill/Item menu even when it is not
+  castable right now -- access off, no registered target, or flying --
+  matching RPG_RT, which only greys such an entry rather than hiding it.
+  Choosing it while unavailable just buzzes, with no "It had no effect."
+  message and no stray Decision-sound beep beforehand. Previously the whole
+  entry vanished from the list outright once it stopped being castable.
+  Covered by rewriting the four `scripts/rpg2k_logic_check.rb` checks that
+  had asserted the old hidden-when-unavailable behavior.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3706,6 +3706,58 @@ The work below is roughly ordered by the critical path to a walkable game
   file), `Scene::ItemMenu`'s choose-item dispatch
   (`mruby-rpg2k/mrblib/scene/item_menu.rb`), and the battle scene's own item
   selection flow (`mruby-rpg2k/mrblib/scene/battle.rb`).
+- ✅ **An Escape/Teleport skill was hidden from the field Skill list outright
+  whenever it was not castable right now — access off, no registered
+  target, or flying — instead of staying listed and disabled, and the same
+  gap made a special item invoking one of those skills vanish from the
+  field Item list too (2026-08-20).** Confirmed directly against RPG_RT's
+  live source: `Window_Skill::CheckInclude` (`src/window_skill.cpp`) is
+  `if (!Game_Battle::IsBattleRunning()) return true;` outside battle — every
+  known skill is listed, full stop, with no per-type filter at all.
+  `Algo::IsSkillUsable`'s Escape/Teleport arms (access flag, a registered
+  target, not flying) back only `Window_Skill::CheckEnable` — greying the
+  entry and gating `Scene_Skill::vUpdate`'s Decision handler (buzz, no
+  attempt, when disabled) — a genuinely separate check from list membership.
+  `Game::Party#field_skill?` (`mruby-rpg2k/mrblib/game.rb`) conflated the
+  two, routing `SKILL_ESCAPE`/`SKILL_TELEPORT` through
+  `#escape_skill_available?`/`#teleport_skill_available?` for *inclusion*,
+  not just castability — so an Escape/Teleport skill a party had learned but
+  could not currently use disappeared from the menu rather than appearing
+  greyed. Fixed by making `#field_skill?` return `true` unconditionally for
+  both types (list membership only), and moving the availability check to
+  `Scene::SkillMenu#choose_skill`, which now Buzzes and does nothing —
+  matching `Scene_Skill::vUpdate`'s CheckEnable gate — instead of silently
+  reaching a caster/skill pair that was never castable to begin with.
+  Because `Game::Party#field_usable?`'s `ITEM_SPECIAL` branch already
+  deferred to `#field_skill?` for a special item invoking a skill (see the
+  `use_skill` fix two entries above), this same change also makes a special
+  item invoking an unavailable Escape/Teleport skill listed-but-disabled
+  rather than hidden — independently confirmed against `Window_Item::
+  CheckInclude` (`src/window_item.cpp`, a trivial `item_id > 0` check with
+  no skill-usability test of any kind) and `Scene_Item::vUpdate`
+  (`src/scene_item.cpp`), which gates its *entire* per-type dispatch behind
+  `item_window->CheckEnable(item_id)` before ever reaching the Escape/
+  Teleport branches — disabled plays only the buzzer and returns, no
+  attempt, no message. `Scene::ItemMenu#choose_item`
+  (`mruby-rpg2k/mrblib/scene/item_menu.rb`) previously had no such gate at
+  all for this case, relying on `#apply_escape_item`/`#apply_teleport_item`'s
+  own nil-return fallback — a fabricated "It had no effect." message plus a
+  stray Decision-then-Buzzer double beep that RPG_RT never produces for a
+  disabled entry — so `#choose_item` now runs the identical
+  `escape_skill_available?`/`teleport_skill_available?` pre-check before
+  ever playing the Decision sound or dispatching. This is a narrow slice of
+  the broader deferred Item-menu gap just above (ordinary equipment/
+  medicine/switch items are still hidden rather than listed-disabled when
+  unusable — unchanged, still deferred) — resolved here only because it
+  rode along with the Skill-menu fix through the shared `#field_skill?` call,
+  not because the general Item-menu CheckInclude/CheckEnable conflation was
+  addressed. Covered by rewriting the four existing
+  `scripts/rpg2k_logic_check.rb` checks that had asserted the opposite (an
+  unavailable Escape/Teleport skill or item hidden from
+  `#field_skills`/`#field_items` entirely), each confirmed to fail against
+  the pre-fix code, plus new `#escape_skill_available?`/
+  `#teleport_skill_available?` assertions at every state transition proving
+  castability gating still works independently of listing.
 - ✅ Save & Continue — the portable `Marshal` save of the game state
   (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
   menu's Save command; "Continue" reloads it. (One research question remains: a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4721,9 +4721,11 @@ module Game
     # are summoned and dismissed exactly this way (skills 120–125, "ファルを召還"
     # and friends, each flipping the switch its common event watches).
     #
-    # `state` is optional and only read for the Escape / Teleport types below —
-    # every other caller (the host-side fixture checks included) can omit it and
-    # gets the old scope/occasion-only behaviour.
+    # `state` is accepted for callers that have one to pass, but `#field_skill?`
+    # itself no longer reads it -- a known Escape/Teleport skill is always
+    # listed regardless of whether it is currently usable (see
+    # `#field_skill?`'s own comment); a caller checking *usability* wants
+    # `#escape_skill_available?`/`#teleport_skill_available?` directly.
     #
     # A database shrink can leave a learned skill id with no matching row
     # (docs/TODO.md's runtime error catalog) -- `db_skill` degrades that to a
@@ -4763,10 +4765,20 @@ module Game
     def field_skill?(sk, state = nil)
       return false unless sk
       case sk.type
-      when SKILL_TELEPORT
-        teleport_skill_available?(state)
-      when SKILL_ESCAPE
-        escape_skill_available?(state)
+      when SKILL_TELEPORT, SKILL_ESCAPE
+        # A known Escape/Teleport skill is *always* listed on the field
+        # menu, whether or not it is usable right this moment -- confirmed
+        # against RPG_RT's own live source: `Window_Skill::CheckInclude`
+        # (`src/window_skill.cpp`) is `if (!Game_Battle::IsBattleRunning())
+        # return true;` outside battle, with no per-type filter at all.
+        # `#escape_skill_available?`/`#teleport_skill_available?` (access,
+        # a registered target, not flying) are `Algo::IsSkillUsable`'s own
+        # logic, which only backs `Window_Skill::CheckEnable` (greying the
+        # entry / Buzzing on selection, `Scene::SkillMenu#choose_skill`) --
+        # a genuinely separate real-engine check this method used to
+        # conflate with list membership, hiding the skill outright instead
+        # of listing it disabled.
+        true
       when SKILL_SWITCH
         field_occasion?(sk)
       else

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -141,17 +141,45 @@ class RPG2k
           play_system_se(SFX_BUZZER)
           return
         end
-        play_system_se(SFX_DECISION)
         id, = items[@item_index]
         it = @state.party.db_item(id)
+        sk = (it && (it.type == Game::Party::ITEM_SPECIAL ||
+                    (it.use_skill && (1..5).cover?(it.type)))) ?
+               @state.party.db_skill(it.skill_id) : nil
+        # An Escape/Teleport-invoking item is always listed (see
+        # Game::Party#field_skill?, which #field_usable?'s special-item
+        # branch now defers to) but only castable once access and a
+        # registered target are there. Confirmed against RPG_RT's own live
+        # source: `Scene_Item::vUpdate` (`src/scene_item.cpp`) gates its
+        # *entire* per-type dispatch behind `item_window->CheckEnable
+        # (item_id)` before ever reaching the Escape/Teleport branches --
+        # disabled plays only the buzzer and returns, no attempt, no
+        # message, exactly like an unavailable skill in
+        # Scene::SkillMenu#choose_skill. Left to #apply_escape_item /
+        # #apply_teleport_item's own nil-return fallback instead, this would
+        # show a fabricated "It had no effect." message and a stray
+        # Decision-then-Buzzer double beep that RPG_RT never produces for a
+        # disabled entry.
+        if sk && sk.type == Game::Party::SKILL_ESCAPE &&
+           @state.party.respond_to?(:escape_skill_available?) &&
+           !@state.party.escape_skill_available?(@state)
+          play_system_se(SFX_BUZZER)
+          return
+        end
+        if sk && sk.type == Game::Party::SKILL_TELEPORT &&
+           @state.party.respond_to?(:teleport_skill_available?) &&
+           !@state.party.teleport_skill_available?(@state)
+          play_system_se(SFX_BUZZER)
+          return
+        end
+        play_system_se(SFX_DECISION)
         # A switch item has no actor target; an all-ally medicine skips the
         # target prompt; single-target medicines / skill books ask who to use on.
         # A special item follows the *skill* it invokes, since that is what
         # decides the scope — self (2) or all-ally (4) needs no prompt.
         if it && it.type == Game::Party::ITEM_SWITCH
           apply_switch_item(id)
-        elsif it && (it.type == Game::Party::ITEM_SPECIAL ||
-                    (it.use_skill && (1..5).cover?(it.type)))
+        elsif sk
           # A type-9 special item, or an equipment item flagged `use_skill`
           # (schema field 71), both invoke the skill named in `skill_id`: the
           # invoked skill's type/scope decides the dispatch, so a self (2) or
@@ -161,8 +189,7 @@ class RPG2k
           # `#use_equip_skill_item` / `#use_special_escape_item` /
           # `#use_special_teleport_item` backing as it already does for an
           # ordinary targeted cast.
-          sk = @state.party.db_skill(it.skill_id)
-          if sk && sk.type == Game::Party::SKILL_ESCAPE
+          if sk.type == Game::Party::SKILL_ESCAPE
             # Escape has one registered target and no picker -- mirroring
             # Scene::SkillMenu#apply_escape_skill, a successful cast warps
             # straight there with no confirmation message.

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -144,18 +144,28 @@ class RPG2k
         # (`IsSkillLearned && IsSkillUsable`, `src/window_skill.cpp`) before
         # playing any SE or pushing `Scene_ActorTarget`/dispatching a
         # switch skill at all; the `else` (disabled) branch just buzzes and
-        # stays on the list. `#skills` (`Game::Party#field_skills`) already
-        # filters the listing by `#field_skill?` -- the same per-type
-        # availability `Algo::IsSkillUsable` covers on the reference's own
-        # `IsSkillUsable` -- so `Game::Party#can_cast?` (affordability, the
-        # 封印/Silence seal, weapon-Attribute gating) is everything left to
-        # check here, the same predicate `Game_Battler::IsSkillUsable`'s own
-        # pre-`Algo::IsSkillUsable` checks cover. Previously nothing gated
-        # this at all: choosing an unaffordable or sealed skill still played
-        # Decision and opened the full target-confirm screen (or, for a
-        # switch skill, cast it outright), with the failure only ever
-        # surfacing afterward as #apply_skill's "It had no effect." message.
-        if @state.party.respond_to?(:can_cast?) && !@state.party.can_cast?(caster, sid)
+        # stays on the list. `#skills` (`Game::Party#field_skills`) now
+        # lists a known skill unconditionally -- confirmed against
+        # `Window_Skill::CheckInclude`, trivially `true` outside battle with
+        # no per-type filter at all, a fact this comment previously got
+        # backwards (claiming `#field_skill?` already covered per-type
+        # availability the way `IsSkillUsable`/`CheckEnable` actually does)
+        # -- so every one of `IsSkillUsable`'s checks needs covering here:
+        # `Game::Party#can_cast?` (affordability, the 封印/Silence seal,
+        # weapon-Attribute gating -- `Game_Battler::IsSkillUsable`'s own
+        # pre-`Algo::IsSkillUsable` checks) plus, for the two types
+        # `Algo::IsSkillUsable` special-cases, `#escape_skill_available?`/
+        # `#teleport_skill_available?` (access, a registered target, not
+        # flying).
+        unavailable =
+          (@state.party.respond_to?(:can_cast?) && !@state.party.can_cast?(caster, sid)) ||
+          (sk && sk.type == Game::Party::SKILL_ESCAPE &&
+           @state.party.respond_to?(:escape_skill_available?) &&
+           !@state.party.escape_skill_available?(@state)) ||
+          (sk && sk.type == Game::Party::SKILL_TELEPORT &&
+           @state.party.respond_to?(:teleport_skill_available?) &&
+           !@state.party.teleport_skill_available?(@state))
+        if unavailable
           play_system_se(SFX_BUZZER)
           return
         end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6475,49 +6475,67 @@ check 'a switch skill is cast for its switch, and only where its flags allow' do
   ok st.party.cast_switch_skill(hero, 99).nil?
 end
 
-check 'an Escape skill is hidden with no runtime state, then gated on access ' \
-      'and a registered target, and warps there for free -- but not while flying' do
+check 'an Escape skill is always listed on the field menu, even unavailable, ' \
+      'but only warps once access and a registered target are there -- and ' \
+      'never while flying' do
+  # Confirmed against RPG_RT's own live source: `Window_Skill::CheckInclude`
+  # (`src/window_skill.cpp`) is `if (!Game_Battle::IsBattleRunning()) return
+  # true;` outside battle, with no per-type filter -- a known Escape skill
+  # is always listed, whether or not it is castable right now.
+  # `Algo::IsSkillUsable`'s own Type_escape arm (access, a registered
+  # target, not flying) is what `Window_Skill::CheckEnable` (greying the
+  # entry) and #cast_escape_skill (the actual cast) both gate on instead.
   skills = { 6 => fake_skill(name: 'Escape', type: Game::Party::SKILL_ESCAPE,
                              sp_cost: 4) }
   st = skill_party(skills)
   hero = st.party.actor_by_id(1)
   hero.learn_skill(6)
   # No state at all -- the bare #field_skill?(sk) a fixture check would call --
-  # reads exactly like the old "not built" behaviour.
-  eq [], st.party.field_skills(hero), 'unsupported with no state to gate on'
-  ok st.party.unsupported_field_skill?(st.party.db_skill(6))
+  # still lists it: list membership never reads state for this type any more.
+  eq [[6, 4]], st.party.field_skills(hero), 'listed even with no state to gate castability on'
+  ok st.party.unsupported_field_skill?(st.party.db_skill(6)),
+     'castability is still state-dependent, even though listing no longer is'
   ok st.party.cast_escape_skill(hero, 6, nil).nil?
-  # State present, but access off (the RPG2000 default) and no target set.
-  eq [], st.party.field_skills(hero, st)
+  # State present, but access off (the RPG2000 default) and no target set --
+  # still listed, just not castable.
+  eq [[6, 4]], st.party.field_skills(hero, st)
+  ok !st.party.escape_skill_available?(st)
   st.escape_access = true
-  eq [], st.party.field_skills(hero, st), 'access alone is not enough -- no target yet'
+  eq [[6, 4]], st.party.field_skills(hero, st), 'still listed -- access alone is not enough to cast'
+  ok !st.party.escape_skill_available?(st), 'access alone is not enough -- no target yet'
   st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
   eq [[6, 4]], st.party.field_skills(hero, st)
+  ok st.party.escape_skill_available?(st)
   before = hero.mp
   eq({ map_id: 3, x: 4, y: 5, switch_id: nil }, st.party.cast_escape_skill(hero, 6, st))
   eq before - 4, hero.mp, "the warp costs the skill's SP like any other cast"
-  # Flying (boarded the airship) bars it even with access and a target set --
-  # EasyRPG's Algo::IsSkillUsable Type_escape arm reads Game_Player::IsFlying.
+  # Flying (boarded the airship) bars casting even with access and a target
+  # set -- EasyRPG's Algo::IsSkillUsable Type_escape arm reads Game_Player::
+  # IsFlying -- but the skill stays listed, just uncastable (Buzzer on
+  # selection, Scene::SkillMenu#choose_skill).
   st.boarded = :airship
-  eq [], st.party.field_skills(hero, st), 'the airship blocks it'
+  eq [[6, 4]], st.party.field_skills(hero, st), 'still listed -- the airship only blocks casting'
   ok st.party.cast_escape_skill(hero, 6, st).nil?
   st.boarded = nil
   # A skill that is not Escape casts nothing through the Escape path.
   ok st.party.cast_escape_skill(hero, 99, st).nil?
 end
 
-check 'a Teleport skill lists every registered destination and warps to the ' \
-      'one chosen' do
+check 'a Teleport skill is always listed on the field menu, even with no ' \
+      'destinations registered, but only warps once one is chosen and ' \
+      'reachable' do
   skills = { 7 => fake_skill(name: 'Warp', type: Game::Party::SKILL_TELEPORT,
                              sp_cost: 3) }
   st = skill_party(skills)
   hero = st.party.actor_by_id(1)
   hero.learn_skill(7)
-  eq [], st.party.field_skills(hero, st), 'no targets registered yet'
+  eq [[7, 3]], st.party.field_skills(hero, st), 'listed even with no targets registered yet'
+  ok !st.party.teleport_skill_available?(st)
   st.teleport_access = true
   st.teleport_targets[10] = { x: 1, y: 2, switch_id: nil }
   st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
-  eq [[7, 3]], st.party.field_skills(hero, st), 'access plus any target offers it'
+  eq [[7, 3]], st.party.field_skills(hero, st), 'access plus any target still lists it'
+  ok st.party.teleport_skill_available?(st)
   before = hero.mp
   eq({ map_id: 5, x: 8, y: 9, switch_id: nil }, st.party.cast_teleport_skill(hero, 7, st, 5))
   eq before - 3, hero.mp
@@ -6525,9 +6543,10 @@ check 'a Teleport skill lists every registered destination and warps to the ' \
   before = hero.mp
   ok st.party.cast_teleport_skill(hero, 7, st, 999).nil?
   eq before, hero.mp, 'an unknown destination spends no SP'
-  # Riding the airship bars Teleport the same way it bars Escape.
+  # Riding the airship bars casting the same way it bars Escape, without
+  # hiding the entry.
   st.boarded = :airship
-  eq [], st.party.field_skills(hero, st)
+  eq [[7, 3]], st.party.field_skills(hero, st), 'still listed -- the airship only blocks casting'
   ok st.party.cast_teleport_skill(hero, 7, st, 5).nil?
 end
 
@@ -6695,14 +6714,20 @@ check 'class_set is ignored under the default "by Actor" equipment setting' do
      "have excluded both"
 end
 
-check 'a special item invoking an Escape skill is hidden with no runtime ' \
-      'state, then gated on access/target like the skill itself, and warps ' \
-      'for free without spending an SP the item never had' do
-  # #field_usable? used to call #field_skill? with no `state` at all, so an
-  # item wrapping an Escape/Teleport skill always read unusable -- the same
-  # gap #field_skills used to have before it started threading `state`
-  # through, just never closed on the item side. See docs/TODO.md's "Menu
-  # scene" entry.
+check 'a special item invoking an Escape skill is always listed on the ' \
+      'field menu, even unavailable, but only warps once access and a ' \
+      'registered target are there -- and never while flying, for free ' \
+      'without spending an SP the item never had' do
+  # #field_usable?'s special-item branch defers to #field_skill?, which now
+  # always lists a known Escape/Teleport skill regardless of runtime state --
+  # see docs/TODO.md's "Menu scene" entry and Game::Party#field_skill?'s own
+  # doc comment, both confirmed against RPG_RT's own live source:
+  # `Window_Item::CheckInclude` (`src/window_item.cpp`) is a trivial
+  # `item_id > 0` check with no per-skill filter at all, so any held item is
+  # always listed; `#escape_skill_available?` backs only `CheckEnable`
+  # (`Window_Item::CheckEnable` -> `Game_Party::IsItemUsable` ->
+  # `Algo::IsSkillUsable`), gating whether *casting* it actually does
+  # anything, not whether it appears.
   skills = { 6 => fake_skill(name: 'Scroll of Escape',
                              type: Game::Party::SKILL_ESCAPE, sp_cost: 4) }
   items = { 3 => fake_item(type: 9, skill_id: 6, name: 'Scroll') }
@@ -6710,40 +6735,49 @@ check 'a special item invoking an Escape skill is hidden with no runtime ' \
   hero = st.party.actor_by_id(1)
   ok !hero.knows_skill?(6), 'the item is the cost -- the caster need not know it'
   st.party.gain_item(3, 2)
-  ok !st.party.field_usable?(3), 'unsupported with no state to gate on'
-  ok st.party.use_special_escape_item(3, hero, nil).nil?, 'and casts nothing'
+  ok st.party.field_usable?(3), 'listed even with no state to gate on'
+  ok st.party.use_special_escape_item(3, hero, nil).nil?, 'but casts nothing'
   eq 2, st.party.item_count(3), 'nothing consumed'
-  # State present, but access off (the RPG2000 default) and no target set.
-  ok !st.party.field_usable?(3, st)
+  # State present, but access off (the RPG2000 default) and no target set --
+  # still listed, just not castable yet.
+  ok st.party.field_usable?(3, st)
+  ok !st.party.escape_skill_available?(st)
   st.escape_access = true
-  ok !st.party.field_usable?(3, st), 'access alone is not enough -- no target yet'
+  ok st.party.field_usable?(3, st)
+  ok !st.party.escape_skill_available?(st), 'access alone is not enough -- no target yet'
   st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
   ok st.party.field_usable?(3, st)
+  ok st.party.escape_skill_available?(st)
   eq [[3, 2]], st.party.field_items(st)
   before = hero.mp
   eq({ map_id: 3, x: 4, y: 5, switch_id: nil }, st.party.use_special_escape_item(3, hero, st))
   eq before, hero.mp, 'free -- the item pays, not the caster'
   eq 1, st.party.item_count(3), 'one was consumed'
-  # Flying bars it even with access and a target set, same as the skill path.
+  # Flying bars it even with access and a target set, same as the skill path
+  # -- still listed, just not castable.
   st.boarded = :airship
-  ok !st.party.field_usable?(3, st), 'the airship blocks it'
+  ok st.party.field_usable?(3, st), 'still listed while flying'
+  ok !st.party.escape_skill_available?(st), 'the airship blocks it'
   ok st.party.use_special_escape_item(3, hero, st).nil?
   eq 1, st.party.item_count(3), 'and nothing more is consumed by a failed cast'
 end
 
-check 'a special item invoking a Teleport skill offers every registered ' \
-      'destination and warps to the one chosen, for free' do
+check 'a special item invoking a Teleport skill is always listed on the ' \
+      'field menu, even with no destinations registered, and warps to the ' \
+      'one chosen once available, for free' do
   skills = { 7 => fake_skill(name: 'Scroll of Teleport',
                              type: Game::Party::SKILL_TELEPORT, sp_cost: 3) }
   items = { 4 => fake_item(type: 9, skill_id: 7, name: 'Scroll') }
   st = skill_party(skills, items)
   hero = st.party.actor_by_id(1)
   st.party.gain_item(4, 1)
-  ok !st.party.field_usable?(4, st), 'no destinations registered yet'
+  ok st.party.field_usable?(4, st), 'listed even with no destinations registered yet'
+  ok !st.party.teleport_skill_available?(st)
   st.teleport_access = true
   st.teleport_targets[10] = { x: 1, y: 2, switch_id: nil }
   st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
-  ok st.party.field_usable?(4, st), 'access plus any target offers it'
+  ok st.party.field_usable?(4, st)
+  ok st.party.teleport_skill_available?(st), 'access plus any target offers it'
   before = hero.mp
   eq({ map_id: 5, x: 8, y: 9, switch_id: nil }, st.party.use_special_teleport_item(4, hero, st, 5))
   eq before, hero.mp, 'free -- no SP spent for an item cast'


### PR DESCRIPTION
## Summary

- RPG_RT's `Window_Skill::CheckInclude` (`src/window_skill.cpp`) lists every known skill outside battle unconditionally (`if (!Game_Battle::IsBattleRunning()) return true;`), with no per-type filter at all. `Algo::IsSkillUsable`'s Escape/Teleport arms (access flag, a registered target, not flying) back only `CheckEnable` — greying the entry and gating `Scene_Skill::vUpdate`'s Decision handler — not list membership.
- `Game::Party#field_skill?` conflated the two for `SKILL_ESCAPE`/`SKILL_TELEPORT`, routing them through `#escape_skill_available?`/`#teleport_skill_available?` for *inclusion* rather than just castability, so a learned-but-currently-unusable Escape/Teleport skill disappeared from the field Skill menu instead of staying listed and disabled.
- Fixed by making `#field_skill?` always include a known Escape/Teleport skill, and moving the availability check into `Scene::SkillMenu#choose_skill`'s Decision handler (buzz-only, matching `Scene_Skill::vUpdate`'s `CheckEnable` gate).
- Since `Game::Party#field_usable?`'s `ITEM_SPECIAL` branch already defers to `#field_skill?`, this also fixes a special item invoking an unavailable Escape/Teleport skill vanishing from the field Item list. `Scene::ItemMenu#choose_item` gained the matching gate, confirmed against `Scene_Item::vUpdate` (`src/scene_item.cpp`), which gates its entire per-type dispatch behind `item_window->CheckEnable(item_id)` before ever reaching the Escape/Teleport branches — disabled just buzzes, no attempt, no message. Previously this codebase would show a fabricated "It had no effect." message plus a stray Decision-then-Buzzer double beep instead.
- This is a narrow slice of a broader, still-deliberately-deferred Item-menu gap (documented in `docs/TODO.md`): ordinary equipment/medicine/switch items are still hidden rather than listed-disabled when unusable. Only the Escape/Teleport slice is resolved here, as a byproduct of the shared `#field_skill?` call.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1069 checks passed (rewrote the 4 tests that had asserted the old hidden-when-unavailable behavior, plus new `escape_skill_available?`/`teleport_skill_available?` assertions at each state transition)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 807 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures
- [x] Verified the 4 rewritten tests genuinely fail against the pre-fix code via `git stash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_