### PR TITLE
Fix: Equip screen stats panel drops HP/MP, one row per battle stat

### DIFF
--- a/changelog.d/equip-stats-no-hp-mp-per-row.fixed.md
+++ b/changelog.d/equip-stats-no-hp-mp-per-row.fixed.md
@@ -1,0 +1,5 @@
+- **Field menu:** The Equip screen's stats panel no longer shows the actor's
+  HP/MP -- real RPG_RT's equivalent window never has, drawing only the name
+  and the four battle stats (Attack/Defense/Spirit/Agility). Those four stats
+  now each get their own row, matching RPG_RT, instead of being packed onto
+  one shared line. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2896,8 +2896,12 @@ The work below is roughly ordered by the critical path to a walkable game
   CreateCommandWindow`'s `Player::IsRPG2k()` branch hardcodes exactly **five**
   commands — Item, Skill, Equip, Save, End Game, **no Status entry at all** —
   regardless of database content, since RPG2000's party list already shows
-  name/level/HP/MP and Equip already shows the full stat block, leaving
-  nothing for a separate Status screen to add. RPG2003 instead builds the list
+  name/level/HP/MP ~~and Equip already shows the full stat block~~ (Equip's
+  own stat panel is narrower than that phrasing implies — see the
+  `Window_EquipStatus` fix a few entries below: name plus the four battle
+  stats only, no HP/MP field at all), leaving nothing a separate Status
+  screen would need to add beyond what the party list and Equip screen
+  already show between them. RPG2003 instead builds the list
   from the System database's own customizable field (chunk 22 field 27,
   `menu_commands`, `mruby-lcf/mrblib/schema.rb` — parsed by the schema and
   never read anywhere in `mruby-rpg2k` before this), matching EasyRPG's
@@ -2998,6 +3002,37 @@ The work below is roughly ordered by the critical path to a walkable game
   pre-fix code (recording the `nil` actor `#use_special_item` was called
   with) before the fix. **Switch skills** (type 3) flip their switch: that is
   how a Nepheshel player summons and dismisses a companion.
+- ✅ **The field Equip screen's stats panel drew the actor's HP/MP, which
+  real RPG_RT's equivalent window never shows at all, and packed the four
+  battle stats onto one shared line instead of RPG_RT's one-row-each layout
+  (2026-08-20).** Confirmed directly against RPG_RT's live source:
+  `Window_EquipStatus::Refresh` (`src/window_equipstatus.cpp`) draws exactly
+  `DrawActorName` once, then loops the four battle stats (Attack/Defense/
+  Spirit/Agility) via `DrawParameter(0, y_offset + ((12 + 4) * i), i)` — a
+  name row followed by four independent stat rows, no HP/MP field anywhere
+  in the function or the class. `Scene_Equip::Start` (`src/scene_equip.cpp`)
+  confirms `equipstatus_window` is the *only* status window this screen
+  builds (alongside the plain equip-slot list), so there is no second window
+  showing HP/MP either — the figure is simply absent from this screen in
+  real RPG_RT, not shown elsewhere on it. `Scene::EquipMenu#build_stats_window`
+  (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) drew an `"HP h/max  MP m/max"`
+  line with no such source behind it, and `#draw_stat_row` laid all four
+  stats out horizontally on one line, `STAT_GAP`-separated — even though the
+  adjacent doc comment on that very method already paraphrased
+  `DrawParameter` as "one row per stat" without the code actually doing that.
+  Fixed by dropping the HP/MP line entirely and rewriting `#draw_stat_row` to
+  place each stat (and, while browsing candidates, its own arrow/new-value
+  preview) on its own row below the name line; `#build_stats_window`'s window
+  height and `#build_slot_window`'s `y` offset (previously a hardcoded
+  `LINE_H * 3`) now both derive from `STAT_DEFS.size` so the slot list stays
+  correctly positioned below the taller panel. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (no HP/MP figures or term labels
+  anywhere in the stats window; exactly four stat-row draw calls, each on
+  its own `LINE_H`-spaced row), confirmed to fail against the pre-fix code.
+  This also corrects the "Menu scene" entry above, which cited "Equip
+  already shows the full stat block" as the reason RPG2000 has no separate
+  Status command — true that nothing further is needed there, but Equip's
+  own panel is narrower than "full stat block" suggested.
 - ✅ **A self- or all-ally-scope field skill/item never actually showed the
   mandatory second target-confirm screen real RPG_RT always pushes, applying
   on the very first Decision press instead — correcting every "applies at

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -242,7 +242,7 @@ class RPG2k
       def build_stats_window
         @stats_window.dispose if @stats_window
         inner_w = SCREEN_W - Window::BORDER * 2
-        h = LINE_H * 3
+        h = LINE_H * (1 + STAT_DEFS.size)
         @stats_window = Window.new(0, DESC_H, SCREEN_W, h + Window::BORDER * 2)
         @stats_window.z = 400
         @stats_window.windowskin = @skin
@@ -250,9 +250,6 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         a = actor
         c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}  #{term(:level_short, 'Lv')} #{a.level}"
-        c.draw_text 0, LINE_H, inner_w, LINE_H,
-                    "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
-                    "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
         draw_stat_row(c, a)
         @stats_window.contents = c
       end
@@ -269,24 +266,23 @@ class RPG2k
         [:agility, 'Agi', :agi_points1, :agi]
       ].freeze
 
-      # Gap, in pixels, between one stat's block and the next on the combat
-      # stat line.
-      STAT_GAP = 8
-
-      # The combat-stat line: four independent "label value" blocks while
-      # browsing the slot list, or, while browsing candidates, four
-      # independent "label value > new_value" comparisons -- confirmed
-      # against EasyRPG's actual `Window_EquipStatus::DrawParameter`, which
-      # draws one row per stat, each an old value, an arrow, and a new value
-      # coloured by `GetNewParameterColor` (0 unchanged / 2 up / 3 down),
-      # never a single combined verdict for the whole item (see
-      # #build_cand_window's own history for the summed-arrow this replaced).
+      # Four independent stat rows -- one "label value" per row while
+      # browsing the slot list, or, while browsing candidates, "label value
+      # > new_value" comparisons -- confirmed against EasyRPG's actual
+      # `Window_EquipStatus::Refresh`/`DrawParameter`
+      # (`src/window_equipstatus.cpp`), which draws the actor name once,
+      # then loops the four stats at `y_offset + ((12 + 4) * i)` -- a
+      # genuinely separate row per stat, each an old value, an arrow, and a
+      # new value coloured by `GetNewParameterColor` (0 unchanged / 2 up / 3
+      # down), never a single combined verdict for the whole item (see
+      # #build_cand_window's own history for the summed-arrow this
+      # replaced) and never sharing a row with any other stat.
       def draw_stat_row(c, a)
-        y = LINE_H * 2
-        x = 0
         previewing = @mode == :items
         cand_id = previewing ? candidates[@cand_index].first : nil
-        STAT_DEFS.each do |term_key, label, field, accessor|
+        STAT_DEFS.each_with_index do |(term_key, label, field, accessor), i|
+          y = LINE_H * (1 + i)
+          x = 0
           value = a.send(accessor)
           text = "#{term(term_key, label)} #{value}"
           c.font.color = Color.new(255, 255, 255, 255)
@@ -302,9 +298,7 @@ class RPG2k
             new_w = c.text_size(new_text).width
             color_idx = delta.zero? ? 0 : (delta.positive? ? 2 : 3)
             draw_system_text c, x, y, new_w, LINE_H, new_text, @skin, color_idx
-            x += new_w
           end
-          x += STAT_GAP
         end
       end
 
@@ -312,7 +306,7 @@ class RPG2k
         @slot_window.dispose if @slot_window
         inner_w = SCREEN_W - Window::BORDER * 2
         h = @slots.size * LINE_H
-        y = DESC_H + LINE_H * 3 + Window::BORDER * 2
+        y = DESC_H + LINE_H * (1 + STAT_DEFS.size) + Window::BORDER * 2
         @slot_window = Window.new(0, y, SCREEN_W, h + Window::BORDER * 2)
         @slot_window.z = 400
         @slot_window.windowskin = @skin

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18673,6 +18673,40 @@ check 'Scene::EquipMenu: the candidate list draws only a name and count, no comp
      'no arrow glyph anywhere in the candidate list'
 end
 
+# Confirmed against EasyRPG's actual C++ source, fetched live:
+# `Window_EquipStatus::Refresh` (`src/window_equipstatus.cpp`) draws the
+# actor name once (`DrawActorName`) and then loops exactly the four battle
+# stats (`DrawParameter`, type 0-3: Attack/Defense/Spirit/Agility) at
+# `y_offset + ((12 + 4) * i)` -- a genuinely separate row per stat, with no
+# HP/MP field anywhere in the window at all. `Scene_Equip::Start`
+# (`src/scene_equip.cpp`) confirms this is the *only* status window on the
+# screen (alongside the plain slot list) -- there is no second window
+# showing HP/MP either. docs/TODO.md's own "Menu scene" entry used to claim
+# "Equip already shows the full stat block", which this source disproves.
+check 'Scene::EquipMenu: the stats window shows no HP/MP, and each battle ' \
+      'stat is drawn on its own row' do
+  state = Game::State.new(MenuStubParty.new, 1, 0, 0)
+  actor = state.party.actors.first
+  eq 80, actor.hp
+  eq 120, actor.display_max_hp
+  eq 10, actor.mp
+  eq 30, actor.display_max_mp
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  win = scene.instance_variable_get(:@stats_window)
+  texts = window_texts(win)
+  ok !texts.any? { |t| t.include?('80') || t.include?('120') },
+     'no HP figures anywhere in the stats window'
+  ok !texts.any? { |t| t.include?('10/30') }, 'no MP figures anywhere in the stats window'
+  ok !texts.any? { |t| t.include?('HP') || t.include?('MP') },
+     'no HP/MP term labels either'
+  # Row 0 (y 0) is the name/level line; the four stats follow it, name
+  # window's own calls excluded by requiring y > 0.
+  rows = win.contents.draw_calls.select { |a| a[1].positive? }
+  eq 4, rows.size, 'exactly one draw call per battle stat, name row excluded'
+  eq [1, 2, 3, 4].map { |i| RPG2k::Scene::EquipMenu::LINE_H * i }, rows.map { |a| a[1] },
+     'each stat on its own row below the name row, one RPG2k::Scene::EquipMenu::LINE_H apart'
+end
+
 # Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
 # UpdateStatusWindow` (`src/scene_equip.cpp`) recomputes each of the four
 # battle stats independently and hands them to `Window_EquipStatus::


### PR DESCRIPTION
## Summary

- `Window_EquipStatus::Refresh` (`src/window_equipstatus.cpp`) draws the actor name once, then loops exactly the four battle stats (Attack/Defense/Spirit/Agility) via `DrawParameter(0, y_offset + ((12 + 4) * i), i)` — a name row followed by four independent stat rows. No HP/MP field exists anywhere in the window's source. `Scene_Equip::Start` (`src/scene_equip.cpp`) confirms `equipstatus_window` is the only status window this screen builds, alongside the plain equip-slot list — so there's no second window showing HP/MP either; the figure is simply absent from real RPG_RT's Equip screen.
- `Scene::EquipMenu#build_stats_window` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) drew an extra `"HP h/max  MP m/max"` line with no such source behind it, and `#draw_stat_row` packed all four battle stats onto one shared horizontal line — even though the method's own adjacent doc comment already (incorrectly) described the real window as drawing "one row per stat".
- Fixed by dropping the HP/MP line entirely and rewriting `#draw_stat_row` to place each stat (and its arrow/new-value preview while browsing candidates) on its own row below the name line. `#build_stats_window`'s window height and `#build_slot_window`'s `y` offset (previously a hardcoded `LINE_H * 3`) now both derive from `STAT_DEFS.size` so the slot list stays correctly positioned below the taller panel.
- Also corrects a stale claim in `docs/TODO.md`'s "Menu scene" entry, which cited "Equip already shows the full stat block" as the reason RPG2000 has no separate Status command — true that nothing further is needed there, but Equip's own panel is narrower than "full stat block" suggested (marked with strikethrough).

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: no HP/MP figures or term labels anywhere in the stats window; exactly four stat-row draw calls, each on its own `LINE_H`-spaced row.
- [x] Verified via `git stash` on `equip_menu.rb` alone: fails pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 808 passed, `rpg2k_logic_check.rb` 1069 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_