### PR TITLE
Fix: diagonal Move Route step preserves the facing axis, not always vertical

### DIFF
--- a/changelog.d/diagonal-move-preserves-facing-axis.fixed.md
+++ b/changelog.d/diagonal-move-preserves-facing-axis.fixed.md
@@ -1,0 +1,5 @@
+- **Movement:** A diagonal Move Route step (Up-Right/Down-Right/Down-Left/
+  Up-Left) now keeps whichever axis the character was already facing,
+  matching RPG_RT -- a character facing Left that steps Up-Right now ends up
+  facing Right, not Up. Previously every diagonal step unconditionally faced
+  the diagonal's vertical component, discarding a horizontal facing outright.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10918,6 +10918,43 @@ not yet verified:
   keeps its drawn facing south through the Move Right step, then turns north
   once the Face Up step runs), all three confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **A diagonal Move Route step (Up-Right/Down-Right/Down-Left/Up-Left)
+  always turned the sprite to face that diagonal's *vertical* component,
+  discarding a horizontal facing outright, instead of keeping whichever axis
+  the character was already facing (2026-08-20).** Confirmed directly
+  against RPG_RT's live source: `Game_Character::UpdateFacing`
+  (`src/game_character.cpp`) computes the diagonal's two cardinal
+  components (`f1` vertical, `f2` horizontal) and only reverses the prior
+  facing (`SetFacing((facing + 2) % 4)`) when it matches *neither* of
+  them — otherwise the facing is left completely untouched. Since a
+  180-degree flip of a facing on neither component always lands exactly on
+  the component sharing its own axis, this is equivalent to "keep the
+  vertical component if already facing vertically, keep the horizontal
+  component if already facing horizontally," never an unconditional
+  vertical snap. Concretely: a character facing Left, given an Up-Right
+  step, ends up facing **Right** in real RPG_RT (the horizontal axis it was
+  already on, flipped to align with the diagonal), not Up.
+  `Character#move_diagonal`/`MoveRoute#do_diagonal`
+  (`mruby-rpg2k/mrblib/game.rb`) both hardcoded `face(vertical)`, backed by
+  an uncited comment ("RPG2000 keeps a cardinal facing on diagonals, so we
+  face the vertical part") that turned out to be simply wrong — every
+  existing test exercising this only ever started a character facing Down
+  (itself on the vertical axis), the one starting facing for which "always
+  face vertical" and "preserve the current axis" happen to agree, so the
+  gap was never exercised. Fixed by adding
+  `Character#diagonal_facing(horizontal, vertical)` (returns `vertical` when
+  the current `@direction` is already on the vertical axis, `horizontal`
+  otherwise) and routing both call sites through it instead of the
+  hardcoded component; `#do_diagonal`'s pre-passability-check turn (see the
+  "skippable revert" fix above) and `#move_diagonal`'s own post-move turn
+  both go through the same helper, matching `Move`'s single
+  `SetDirection`/`UpdateFacing` pair in the real source. `#last_move_direction`
+  (what Move Forward reads) is unchanged — this fix is about the *visible*
+  facing only, the same distinction the "One Step Forward" fix above already
+  established. Covered by a new `scripts/rpg2k_logic_check.rb` check (facing
+  Right before an Up-Right step stays Right; facing Left reverses onto
+  Right, not Up; facing Up stays Up), confirmed to fail against the pre-fix
+  code (`expected 6, got 8`) before the fix.
 - Jump needs paired Begin/End; movement commands between them sum into a
   net displacement vector (opposite-axis moves cancel); only the *landing*
   tile's passability is tested, tiles crossed are ignored; speed/direction

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5998,10 +5998,30 @@ module Game
       @jumped = true
     end
 
+    # The facing a diagonal move settles on: whichever of the diagonal's two
+    # cardinal components (`horizontal`/`vertical`) shares the axis the
+    # character is *already* facing, unchanged if it was already on that
+    # axis -- confirmed against RPG_RT's own live source:
+    # `Game_Character::UpdateFacing` (`src/game_character.cpp`) only
+    # reverses the prior facing (`SetFacing((facing + 2) % 4)`) when it
+    # matches *neither* of the diagonal's two cardinal components, otherwise
+    # leaving it untouched. Since a 180-degree flip of a facing that is on
+    # neither component always lands exactly on the component sharing its
+    # own axis (Up flips to Down's opposite-axis partner... concretely: Down
+    # flips to Up, Left flips to Right), the net effect is simply "keep the
+    # vertical component if already facing vertically, keep the horizontal
+    # component if already facing horizontally" -- RPG_RT never
+    # unconditionally snaps to the diagonal's vertical part the way this
+    # method's own prior, uncited comment ("RPG2000 keeps a cardinal facing
+    # on diagonals, so we face the vertical part") claimed. A character
+    # facing Left that steps Up-Right ends up facing Right, not Up.
+    def diagonal_facing(horizontal, vertical)
+      [8, 2].include?(@direction) ? vertical : horizontal
+    end
+
     # Move one tile diagonally, combining a horizontal and a vertical direction.
-    # RPG2000 keeps a cardinal facing on diagonals, so we face the vertical part.
     def move_diagonal(horizontal, vertical)
-      face(vertical)
+      face(diagonal_facing(horizontal, vertical))
       @last_move_direction = vertical
       hx, = DIR_DELTA[horizontal] || [0, 0]
       _, vy = DIR_DELTA[vertical] || [0, 0]
@@ -6408,7 +6428,7 @@ module Game
     def do_diagonal(character, world, id)
       horizontal, vertical = DIAGONAL[id]
       prev_dir = character.direction
-      character.face(vertical)
+      character.face(character.diagonal_facing(horizontal, vertical))
       passable = character.through ||
                  (world.passable?(character, horizontal) &&
                   world.passable?(character, vertical))

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -498,6 +498,41 @@ check 'diagonal move needs both cardinals and faces vertical' do
   eq 2, c3.direction, 'reverted to Down, not left turned toward the wall (8)'
 end
 
+# Confirmed against RPG_RT's own live source: `Game_Character::UpdateFacing`
+# (`src/game_character.cpp`) only reverses the prior facing when it matches
+# *neither* of the diagonal's two cardinal components -- it never
+# unconditionally snaps to the diagonal's vertical part the way the check
+# above's default-Down starting facing alone could not tell apart from the
+# correct axis-preserving rule (Down is on the vertical axis either way, so
+# both rules agree there). Starting on the *horizontal* axis instead is what
+# actually distinguishes them.
+check 'a diagonal move keeps the axis already faced, not always the ' \
+      'vertical component' do
+  # Facing Right (horizontal axis) before an Up-Right step: RPG_RT keeps the
+  # horizontal axis, landing on Right (the diagonal's own horizontal part),
+  # not Up.
+  route = R.new([mc(R::MOVE_UPRIGHT)])
+  c = Game::Character.new(2, 2, 6) # starts facing Right
+  eq :moved, route.step(c, FakeWorld.new)
+  eq 6, c.direction, 'stayed on the horizontal axis it was already facing'
+
+  # Facing Left (horizontal axis, but the *wrong* horizontal component) before
+  # the same Up-Right step: neither of Up-Right's components (Up, Right)
+  # matches Left, so RPG_RT reverses it -- landing on Right, not Up.
+  route2 = R.new([mc(R::MOVE_UPRIGHT)])
+  c2 = Game::Character.new(2, 2, 4) # starts facing Left
+  eq :moved, route2.step(c2, FakeWorld.new)
+  eq 6, c2.direction, 'reversed onto the diagonal\'s own horizontal component'
+
+  # Facing Up (vertical axis, already one of the two components): stays Up,
+  # matching the default-Down check above's "vertical" case but now proven
+  # by an axis-preservation rule rather than a hardcoded one.
+  route3 = R.new([mc(R::MOVE_UPRIGHT)])
+  c3 = Game::Character.new(2, 2, 8) # starts facing Up
+  eq :moved, route3.step(c3, FakeWorld.new)
+  eq 8, c3.direction, 'stayed on the vertical axis it was already facing'
+end
+
 check 'move forward steps in the current facing' do
   route = R.new([mc(R::MOVE_FORWARD)])
   c = Game::Character.new(4, 4, 4) # facing west


### PR DESCRIPTION
## Summary

- `Game_Character::UpdateFacing` (`src/game_character.cpp`) computes a diagonal move's two cardinal components (vertical `f1`, horizontal `f2`) and only reverses the prior facing (`SetFacing((facing + 2) % 4)`) when it matches *neither* of them — otherwise the facing is left completely untouched. Since a 180-degree flip of a facing on neither component always lands exactly on the component sharing its own axis, this is equivalent to "keep the vertical component if already facing vertically, keep the horizontal component if already facing horizontally" — never an unconditional vertical snap. Concretely: a character facing Left, given an Up-Right Move Route step, ends up facing **Right** in real RPG_RT (the horizontal axis it was already on, flipped to align), not Up.
- `Character#move_diagonal`/`MoveRoute#do_diagonal` (`mruby-rpg2k/mrblib/game.rb`) both hardcoded `face(vertical)`, backed by an uncited comment ("RPG2000 keeps a cardinal facing on diagonals, so we face the vertical part") that turned out to be simply wrong. Every existing test exercising this only ever started a character facing Down (itself on the vertical axis) — the one starting facing for which "always face vertical" and "preserve the current axis" happen to agree — so the gap was never caught.
- Fixed by adding `Character#diagonal_facing(horizontal, vertical)` (returns `vertical` when the current `@direction` is already on the vertical axis, `horizontal` otherwise) and routing both call sites through it instead of the hardcoded component. `#last_move_direction` (what Move Forward reads) is unchanged — this fix is about the *visible* facing only.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: facing Right before an Up-Right step stays Right; facing Left reverses onto Right, not Up; facing Up stays Up.
- [x] Verified via `git stash` on `game.rb` alone: fails pre-fix (`expected 6, got 8`).
- [x] Full suite green: `rpg2k_logic_check.rb` 1070 passed, `rpg2k_scene_check.rb` 808 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_