### PR TITLE
Fix MV Scene_Boot hang: measureText was font-agnostic, breaking Graphics.isFontLoaded

### DIFF
--- a/changelog.d/mv-measuretext-gamefont-agnostic.fixed.md
+++ b/changelog.d/mv-measuretext-gamefont-agnostic.fixed.md
@@ -1,0 +1,10 @@
+- Fixed `Graphics.isFontLoaded('GameFont')` hanging RPG Maker MV's `Scene_Boot`
+  forever on projects whose corescript uses the classic canvas-`measureText`
+  font-ready check: our `measureText` backed every font shorthand with the
+  loaded game font regardless of the requested family, so the check's two
+  comparison widths (`'GameFont, sans-serif'` vs plain `'sans-serif'`) were
+  always identical and never diverged. `measureText`/`fillText`/`strokeText`
+  now only use the real font metrics when the shorthand actually names
+  "GameFont", falling back to the same rough per-character estimate used when
+  no game font is loaded otherwise. Found against a real, downloaded MV
+  release that had been packed into a single Enigma Virtual Box executable.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17713,6 +17713,29 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     `[MV-AUDIO] op=.. dispatched=.. asset=..` — so the audio path is finally
     exercised end to end (the downloaded beds ship no audio). Audible output
     still wants a device / a native listen; CI only checks dispatch + resolve.
+  - ✅ **`measureText` was font-agnostic, so `Graphics.isFontLoaded('GameFont')`
+    could hang `Scene_Boot` forever on a real MV release.** Found against a
+    real, downloaded RPG Maker MV game (an Enigma Virtual Box-packed
+    single-file distributable, unpacked with `evbunpack` to reach its `www/`
+    project): it never got past `Scene_Boot`, throwing `Error: Failed to load
+    GameFont` after its own 20s timeout. Root cause: MV's classic font-ready
+    check measures `'40px GameFont, sans-serif'` against `'40px sans-serif'`
+    and waits for the two widths to diverge, but our `measureText`
+    (`mruby-mvjs/src/mvcanvas.cxx`) backed every font shorthand with the same
+    loaded game font regardless of the requested family, so the two measured
+    widths were always identical and the check never passed — a project whose
+    bundled corescript takes this path (rather than the newer FontFaceSet
+    path our `document.fonts` stand-in already covers, see that shim's own
+    comment) could never boot. Fixed by having `measureText`/`fillText`/
+    `strokeText` parse whether the font shorthand actually names "GameFont"
+    and route anything else through the same rough per-character estimate
+    already used when no game font is loaded at all, guaranteed to differ
+    from the real metrics. `data/Lunatic-Core` and `data/mv-sample` both use a
+    corescript build that takes the FontFaceSet path already, which is why
+    this stayed hidden until a different real release exercised the older
+    one. Covered by `mruby-mvjs/test/canvas_test.rb` (asserts the exact
+    fallback value for a non-"GameFont" shorthand, independent of whether a
+    real font happens to be loaded in the test environment).
 - 🚧 **M6 — MZ.** A WebGL-subset backend on LVGL so PIXI v5 / RPG Maker MZ runs
   on the same foundation (`js/rmmz_*.js`).
   - ✅ M6.1 foundation: an `MZ` class (`mruby-mvjs/mrblib/mz.rb`) detects an MZ

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -290,10 +290,23 @@ uint32_t utf8_next(const unsigned char* s, size_t n, size_t& i) {
   return cp;
 }
 
-// Total advance width of `text` at `pixel` em size, in pixels.
-double font_text_width(const std::string& text, double pixel) {
+// Total advance width of `text` at `pixel` em size, in pixels. `use_game_font`
+// is false for a CSS font shorthand that doesn't name "GameFont" (MV's own
+// custom-font family, always loaded via Graphics.loadFont as literally
+// "GameFont") -- stb_truetype only ever backs that one font, so a generic
+// family like plain "sans-serif" gets the same rough per-character estimate
+// as an unloaded font, deliberately different from the real metrics below.
+// This is what makes Graphics.isFontLoaded's classic detection trick work:
+// it measures '40px GameFont, sans-serif' against '40px sans-serif' and
+// waits for the two widths to diverge -- with a single font-agnostic
+// measurement (the pre-existing behavior) they never would, hanging
+// Scene_Boot until its own 20s timeout on any project whose corescript
+// doesn't take the newer FontFaceSet-based path (see the document.fonts
+// stand-in's own comment, above).
+double font_text_width(const std::string& text, double pixel,
+                        bool use_game_font = true) {
   GameFont& f = game_font();
-  if (!f.ok)
+  if (!use_game_font || !f.ok)
     return static_cast<double>(text.size()) * pixel * 0.5;
   const float scale =
       stbtt_ScaleForMappingEmToPixels(&f.info, static_cast<float>(pixel));
@@ -592,16 +605,20 @@ JSValue js_draw_image(JSContext* ctx,
   return JS_UNDEFINED;
 }
 
-// __mv_fontMeasure(pixelSize, text) -> advance width in pixels. Backs
-// CanvasRenderingContext2D.measureText, which MV's Bitmap.measureTextWidth uses
-// to align (centre/right) and lay out text, so it must reflect the real font.
+// __mv_fontMeasure(pixelSize, text, hasGameFont) -> advance width in pixels.
+// Backs CanvasRenderingContext2D.measureText, which MV's Bitmap.measureTextWidth
+// uses to align (centre/right) and lay out text, so it must reflect the real
+// font -- except when the caller's own font shorthand doesn't name "GameFont"
+// at all (see font_text_width's own comment), where a different, rougher
+// estimate is deliberate.
 JSValue js_measure_text(JSContext* ctx,
                         JSValueConst,
                         int argc,
                         JSValueConst* argv) {
   const double pixel = ad(ctx, argc, argv, 0, 10);
   const char* text = argc > 1 ? JS_ToCString(ctx, argv[1]) : nullptr;
-  const double w = text ? font_text_width(text, pixel) : 0.0;
+  const bool has_game_font = argc > 2 ? ai(ctx, argc, argv, 2) != 0 : true;
+  const double w = text ? font_text_width(text, pixel, has_game_font) : 0.0;
   if (text)
     JS_FreeCString(ctx, text);
   return JS_NewFloat64(ctx, w);
@@ -1334,6 +1351,12 @@ const char* kCanvasPreamble = R"MVJS(
     var m = /([\d.]+)px/.exec(s || '');
     return m ? parseFloat(m[1]) : 10;
   }
+  // Whether a CSS font shorthand names "GameFont", MV's own custom-font
+  // family (always loaded as literally that name -- see font_text_width's
+  // own comment in mvcanvas.cxx for why this distinction matters).
+  function fontHasGameFont(s) {
+    return /GameFont/.test(s || '');
+  }
   // Map a canvas textBaseline to the native code (0 alphabetic, 1 top,
   // 2 middle, 3 bottom); ideographic/hanging fall back to the nearest.
   function baselineCode(b) {
@@ -1343,7 +1366,8 @@ const char* kCanvasPreamble = R"MVJS(
     return 0;
   }
   Ctx.prototype.measureText = function (t) {
-    return { width: g.__mv_fontMeasure(fontPx(this.font), t == null ? '' : String(t)) };
+    return { width: g.__mv_fontMeasure(fontPx(this.font), t == null ? '' : String(t),
+                                       fontHasGameFont(this.font) ? 1 : 0) };
   };
   // Shared layout for fill/strokeText: resolve colour, size and the horizontal
   // alignment offset, then hand off to the native rasteriser with the current
@@ -1355,11 +1379,12 @@ const char* kCanvasPreamble = R"MVJS(
     var a = Math.round(col[3] * self.globalAlpha);
     if (a <= 0) return;
     var size = fontPx(self.font);
+    var hasGameFont = fontHasGameFont(self.font) ? 1 : 0;
     var ax = x;
     if (self.textAlign === 'center') {
-      ax -= g.__mv_fontMeasure(size, text) / 2;
+      ax -= g.__mv_fontMeasure(size, text, hasGameFont) / 2;
     } else if (self.textAlign === 'right' || self.textAlign === 'end') {
-      ax -= g.__mv_fontMeasure(size, text);
+      ax -= g.__mv_fontMeasure(size, text, hasGameFont);
     }
     var m = self._m;
     g.__mv_canvasDrawText(self.__h, ax, y, text, col[0], col[1], col[2], a,

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -303,8 +303,9 @@ uint32_t utf8_next(const unsigned char* s, size_t n, size_t& i) {
 // Scene_Boot until its own 20s timeout on any project whose corescript
 // doesn't take the newer FontFaceSet-based path (see the document.fonts
 // stand-in's own comment, above).
-double font_text_width(const std::string& text, double pixel,
-                        bool use_game_font = true) {
+double font_text_width(const std::string& text,
+                       double pixel,
+                       bool use_game_font = true) {
   GameFont& f = game_font();
   if (!use_game_font || !f.ok)
     return static_cast<double>(text.size()) * pixel * 0.5;
@@ -606,11 +607,11 @@ JSValue js_draw_image(JSContext* ctx,
 }
 
 // __mv_fontMeasure(pixelSize, text, hasGameFont) -> advance width in pixels.
-// Backs CanvasRenderingContext2D.measureText, which MV's Bitmap.measureTextWidth
-// uses to align (centre/right) and lay out text, so it must reflect the real
-// font -- except when the caller's own font shorthand doesn't name "GameFont"
-// at all (see font_text_width's own comment), where a different, rougher
-// estimate is deliberate.
+// Backs CanvasRenderingContext2D.measureText, which MV's
+// Bitmap.measureTextWidth uses to align (centre/right) and lay out text, so it
+// must reflect the real font -- except when the caller's own font shorthand
+// doesn't name "GameFont" at all (see font_text_width's own comment), where a
+// different, rougher estimate is deliberate.
 JSValue js_measure_text(JSContext* ctx,
                         JSValueConst,
                         int argc,

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -422,6 +422,34 @@ assert 'MV canvas text API is wired (fillText/strokeText/measureText)' do
   )
 end
 
+assert 'MV canvas measureText: a font shorthand without "GameFont" always uses '\
+      'the rough per-character estimate' do
+  # Regression: a bare font-agnostic measureText (the pre-fix behavior) can't
+  # tell '28px GameFont, sans-serif' from '28px sans-serif' apart, so
+  # Graphics.isFontLoaded('GameFont') -- which measures exactly that pair and
+  # waits for the widths to diverge -- never sees them differ and hangs
+  # Scene_Boot on any MV project whose corescript uses that classic detection
+  # (rather than the newer FontFaceSet path our document.fonts stand-in
+  # already covers). A real game (extracted from an Enigma Virtual Box-packed
+  # RPG Maker MV release) hit exactly this: stuck at Scene_Boot until its own
+  # 20s timeout, `Error: Failed to load GameFont`.
+  #
+  # Fixed by having measureText route a font shorthand that doesn't name
+  # "GameFont" through the same rough text.length*pixel*0.5 estimate used when
+  # no game font is loaded at all, guaranteeing it differs from the real
+  # metrics measured against an actual loaded font -- asserted here by its
+  # exact value, so this holds whether or not this test environment happens to
+  # have a real font loaded.
+  assert_equal 100.0, MV::JS.eval(
+    "var c=document.createElement('canvas').getContext('2d'); " \
+    "c.font='40px sans-serif'; c.measureText('abcde').width"
+  )
+  assert_equal 40.0, MV::JS.eval(
+    "var c=document.createElement('canvas').getContext('2d'); " \
+    "c.font='40px serif'; c.measureText('ab').width"
+  )
+end
+
 assert 'MV canvas gradientFillRect interpolates colours across the rect' do
   # A horizontal red -> blue gradient over a 4px-wide rect (as MV's
   # Bitmap.gradientFillRect drives for gauges). The left edge should be


### PR DESCRIPTION
## Summary

- MV's classic font-ready check (`Scene_Boot.isGameFontLoaded`, via `Graphics.isFontLoaded`) measures `'40px GameFont, sans-serif'` against `'40px sans-serif'` and waits for the two widths to diverge. Our `measureText` (`mruby-mvjs/src/mvcanvas.cxx`) backed every font shorthand with the same loaded game font regardless of the requested family, so those two measurements were always identical and the check never passed — `Scene_Boot` would hang until its own 20s timeout and throw `Error: Failed to load GameFont`, on any project whose corescript takes this path rather than the newer FontFaceSet path our `document.fonts` stand-in already covers.
- Found against a real, downloaded RPG Maker MV release (an Enigma Virtual Box-packed single-file distributable, unpacked with `evbunpack` to reach its `www/` project) that never got past `Scene_Boot`.
- Fixed by having `measureText`/`fillText`/`strokeText` parse whether the font shorthand actually names `"GameFont"` and route anything else through the same rough per-character estimate already used when no game font is loaded at all — guaranteed to differ from the real metrics.
- `data/Lunatic-Core` and `data/mv-sample` both happen to use a corescript build that takes the FontFaceSet path already, which is why this stayed hidden until a different real release exercised the older one.

## Test plan

- [x] Verified against the real game: it now reaches `Scene_Boot → Scene_Title → New Game → Scene_Map` (previously stuck at `Scene_Boot` forever)
- [x] `rake test` (mrbtest): 1842 OK, 0 KO, 0 Crash — includes a new regression test in `mruby-mvjs/test/canvas_test.rb` that asserts the exact fallback value for a non-`"GameFont"` shorthand, independent of whether a real font happens to be loaded in the test environment
- [x] Full rebuild + existing MV smoke probes (move/battle/menu/save/audio/message) against `Lunatic-Core` and `mz-sample`: all still green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_