### PR TITLE
Fix: shop Sell list keeps a price-0 (key) item listed, not hidden

### DIFF
--- a/changelog.d/shop-sell-list-includes-price-zero.fixed.md
+++ b/changelog.d/shop-sell-list-includes-price-zero.fixed.md
@@ -1,0 +1,4 @@
+- **Shop:** A price-0 (key) item the party holds now stays on the shop's
+  Sell list, matching RPG_RT -- selecting it still just buzzes and refuses
+  the sale. Previously such an item was dropped from the list outright
+  instead of being shown disabled.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15055,9 +15055,39 @@ above are repeated here)
   `scripts/rpg2k_logic_check.rb` checks predating this entry — `'Shop sell
   refuses unowned, price-0 (key), or in a buy-only shop'`, `'Shop max_buy of
   a free item is limited only by the cap'` (its own comment: "a price-0
-  good does not divide by zero") and `'Shop sellable_items lists only held,
-  priced goods in id order'` — none of them vacuous; each asserts a concrete
-  gold/item-count/list outcome.
+  good does not divide by zero") ~~and `'Shop sellable_items lists only
+  held, priced goods in id order'`~~ (that third check encoded a real bug —
+  see the follow-up right below) — none of them vacuous; each asserts a
+  concrete gold/item-count/list outcome.
+  ✅ **Follow-up (2026-08-20): the transaction-refusal rule above was
+  correct, but this pass never checked whether a price-0 item should still
+  *appear* on the sell list at all — it should, and this codebase hid it
+  outright instead.** Confirmed directly against RPG_RT's live source:
+  `Window_ShopSell` (`src/window_shopsell.cpp`) inherits `Window_Item::
+  CheckInclude`/`Refresh` (`src/window_item.cpp`) completely
+  unchanged — a plain `item_id > 0` filter over every item `Game_Party::
+  GetItems` returns, no price check anywhere in it — and only overrides
+  `CheckEnable` (`return item->price > 0;`), which gates the drawn color
+  and, in `Scene_Shop::UpdateSellSelection` (`src/scene_shop.cpp`), Decision
+  (`if (item && item->price > 0) { ...SFX_Decision...; SetMode(SellHowMany);
+  } else { ...SFX_Buzzer... }`). A price-0 (key) item the party holds is
+  listed in real RPG_RT's Sell screen — the same CheckInclude/CheckEnable
+  split already found and fixed for the field Skill/Item menus above — just
+  refuses the sale with a Buzzer if selected. `Game::Shop#sellable_items`
+  used `.select { |id| sellable?(id) }`, dropping the item from the list
+  outright rather than only from the *sellable* set `#max_sell` (correctly)
+  already gates `Scene::Map#open_shop_quantity`'s Decision handler on — that
+  handler's existing Buzzer-on-refusal path needed no change at all, since
+  it already fires whenever `#max_sell` returns 0, which a price-0 item
+  already did. Fixed by dropping the `#sellable?` filter from
+  `#sellable_items` entirely (`@party.items.keys.sort`, since a bag never
+  holds a zero-count entry — `#gain_item` erases it outright the moment a
+  count reaches zero, the same way EasyRPG's own `Game_Party::AddItem`
+  does). Covered by rewriting the stale `scripts/rpg2k_logic_check.rb` check
+  above and a new `scripts/rpg2k_scene_check.rb` check (a price-0 "Deed" is
+  drawn on the sell screen; moving the cursor onto it and pressing Decision
+  plays only the Buzzer SE and stays on the sell list), both confirmed to
+  fail against the pre-fix code.
 - ✅ State resistance rank A-E only gates **susceptibility** — the actual
   proc chance is entirely the *skill's own* occurrence-rate field (0%
   occurrence never applies regardless of rank) — **confirmed already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8046,9 +8046,22 @@ module Game
     # non-zero price (RPG2000 marks price-0 / key items as unsellable).
     def sellable?(id); price(id) > 0 && @party.item_count(id) > 0; end
 
-    # The party's sellable items, id-ordered, for the sell list.
+    # Every item the party holds, id-ordered, for the sell list -- list
+    # membership and sellability are two different questions, confirmed
+    # against RPG_RT's own live source: `Window_ShopSell` (`src/window_
+    # shopsell.cpp`) inherits `Window_Item::CheckInclude`/`Refresh`
+    # (`src/window_item.cpp`) completely unchanged (a plain `item_id > 0`
+    # filter over every item `Game_Party::GetItems` returns, no price check
+    # anywhere in it) and only overrides `CheckEnable` (`item->price > 0`) --
+    # which gates the drawn color and, in `Scene_Shop::UpdateSellSelection`
+    # (`src/scene_shop.cpp`), Decision (`item && item->price > 0`, Buzzer
+    # otherwise). A price-0 (key) item a player holds still shows up in the
+    # Sell list in real RPG_RT, just refuses the sale -- this method used to
+    # drop it from the list outright instead, via the same `#sellable?` this
+    # class's own #max_sell already, correctly, uses for the "can it
+    # actually be sold" question that #open_shop_quantity gates Decision on.
     def sellable_items
-      @party.items.keys.select { |id| sellable?(id) }.sort
+      @party.items.keys.sort
     end
 
     # The RPG2000 per-item stack cap: a party holds at most 99 of anything.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9965,12 +9965,22 @@ check 'a zero or negative quantity is not a transaction' do
   ok !shop.did_transaction
 end
 
-check 'Shop sellable_items lists only held, priced goods in id order' do
+# Confirmed against RPG_RT's own live source: `Window_ShopSell`
+# (`src/window_shopsell.cpp`) inherits `Window_Item::CheckInclude`/
+# `Refresh` (`src/window_item.cpp`) unchanged -- a plain `item_id > 0`
+# filter with no price check at all -- and only overrides `CheckEnable`
+# (`item->price > 0`), which `Scene_Shop::UpdateSellSelection`
+# (`src/scene_shop.cpp`) reads to Buzz instead of opening the quantity
+# counter. A price-0 (key) item the party holds is listed, just refused.
+check 'Shop sellable_items lists every held item, id order -- a price-0 ' \
+      '(key) item stays listed even though it cannot actually be sold' do
   st, shop = shop_setup(0, { 3 => 100, 5 => 40, 8 => 0 })
-  st.party.gain_item(8, 1) # price 0 -> not sellable
+  st.party.gain_item(8, 1) # price 0 -- listed, but #sellable?/#max_sell refuse it
   st.party.gain_item(5, 2)
   st.party.gain_item(3, 1)
-  eq [3, 5], shop.sellable_items
+  eq [3, 5, 8], shop.sellable_items
+  ok !shop.sellable?(8), 'still not actually sellable'
+  eq 0, shop.max_sell(8), 'and the quantity counter refuses to open for it'
 end
 
 check 'Open Shop parses the mode and goods and suspends on :shop' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -509,7 +509,10 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                                      hp_change_type: 1) },
     # A tiny item table the Open Shop window prices its goods from.
     item: { 3 => OpenStruct.new(name: 'Potion', price: 100),
-            5 => OpenStruct.new(name: 'Herb', price: 40) },
+            5 => OpenStruct.new(name: 'Herb', price: 40),
+            # Price 0 -- RPG2000's own way of marking a key item unsellable,
+            # for the Shop sell-list "listed but refused" check below.
+            8 => OpenStruct.new(name: 'Deed', price: 0) },
     # An enemy and a troop of two, for the placeholder Enemy Encounter victory.
     # Enemy 3 (Bat) carries the "airborne" flag (field 28, `levitate`) for the
     # RPG2003 flying-offset checks; its own troop (group 2) is a lone member
@@ -13843,6 +13846,48 @@ check 'Open Shop scene: selling shows the shop_sold confirmation, then returns '
   scene.update
   shop = scene.instance_variable_get(:@shop)
   eq :sell, shop[:screen], 'and returns to the sell list, same as EasyRPG\'s Sold -> Sell'
+end
+
+# Confirmed against RPG_RT's own live source: `Window_ShopSell`
+# (`src/window_shopsell.cpp`) inherits `Window_Item::CheckInclude`/
+# `Refresh` (`src/window_item.cpp`) unchanged -- a plain `item_id > 0`
+# filter, no price check -- and only overrides `CheckEnable` (`item->price
+# > 0`), which `Scene_Shop::UpdateSellSelection` (`src/scene_shop.cpp`)
+# reads to Buzz instead of opening the quantity counter. A price-0 (key)
+# item the party holds stays on screen in real RPG_RT, just refuses the sale.
+check 'Open Shop scene: a price-0 (key) item stays listed on the sell ' \
+      'screen, but selecting it just buzzes' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [2, 0, 0, 0, 3], indent: 0)] # sell-only
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(fake_db), state)
+  party = ShopStubParty.new(0)
+  party.gain_item(3, 1)
+  party.gain_item(8, 1) # price 0 -- key item
+  state.instance_variable_set(:@party, party)
+  3.times { scene.update } # the shop opens straight to the sell list (sell-only)
+
+  shop = scene.instance_variable_get(:@shop)
+  eq [3, 8], shop[:model].sellable_items, 'the key item stays on the list'
+  texts = window_texts(shop[:window])
+  ok texts.any? { |t| t.include?('Deed') }, 'and is actually drawn'
+
+  # Move the cursor onto it (row 1, the second/last row) and try to select it.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  eq 1, scene.instance_variable_get(:@shop)[:index], 'cursor moved onto the key item'
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  shop = scene.instance_variable_get(:@shop)
+  eq :sell, shop[:screen], 'refused -- still on the sell list, not the quantity counter'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Buzzer1' }, 'a Buzzer SE, not Decision'
 end
 
 check 'Open Shop scene: the status panel shows the highlighted item\'s possessed ' \


### PR DESCRIPTION
## Summary

- `Window_ShopSell` (`src/window_shopsell.cpp`) inherits `Window_Item::CheckInclude`/`Refresh` (`src/window_item.cpp`) completely unchanged — a plain `item_id > 0` filter over every item `Game_Party::GetItems` returns, no price check anywhere in it — and only overrides `CheckEnable` (`return item->price > 0;`), which gates the drawn color and, in `Scene_Shop::UpdateSellSelection` (`src/scene_shop.cpp`), Decision (`if (item && item->price > 0) { ...SFX_Decision...; SetMode(SellHowMany); } else { ...SFX_Buzzer... }`). A price-0 (key) item the party holds is listed in real RPG_RT's Sell screen — the same `CheckInclude`/`CheckEnable` split already found and fixed for the field Skill/Item menus in earlier PRs — just refuses the sale with a Buzzer if selected.
- `Game::Shop#sellable_items` (`mruby-rpg2k/mrblib/game.rb`) used `.select { |id| sellable?(id) }`, dropping the item from the list outright rather than only from the *sellable* set `#max_sell` already (correctly) gates `Scene::Map#open_shop_quantity`'s Decision handler on. That handler's existing Buzzer-on-refusal path needed no change at all — it already fires whenever `#max_sell` returns 0, which a price-0 item already did.
- Fixed by dropping the `#sellable?` filter from `#sellable_items` entirely (`@party.items.keys.sort`, since a bag never holds a zero-count entry — `#gain_item` erases it outright the moment a count reaches zero).
- Also corrects a stale `docs/TODO.md` entry that had marked the *transaction-refusal* rule "confirmed already correct" but never checked whether the item should still *appear* on the list at all (marked with strikethrough, with a dated follow-up explaining the gap).

## Test plan

- [x] Rewrote the stale `scripts/rpg2k_logic_check.rb` check that had encoded the old (wrong) hidden-when-unsellable expectation.
- [x] New `scripts/rpg2k_scene_check.rb` check: a price-0 "Deed" is drawn on the sell screen; moving the cursor onto it and pressing Decision plays only the Buzzer SE and stays on the sell list.
- [x] Verified via `git stash` on `game.rb` alone: both new/rewritten checks fail pre-fix.
- [x] Full suite green: `rpg2k_logic_check.rb` 1070 passed, `rpg2k_scene_check.rb` 809 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_