### PR TITLE
Fix: RPG2003 gauge battle defaults to Active ATB mode, not Wait

### DIFF
--- a/changelog.d/rpg2k3-atb-mode-default-active.fixed.md
+++ b/changelog.d/rpg2k3-atb-mode-default-active.fixed.md
@@ -1,0 +1,6 @@
+- **Battle (RPG2003 gauge system):** A fresh gauge-battle game now correctly
+  defaults to Active ATB mode, matching RPG_RT -- the command menu no longer
+  freezes every combatant's gauge by default. The Wait command's field-menu
+  label was also fixed to match (previously showed "Wait On" while active and
+  "Wait Off" while waiting, the reverse of RPG_RT). The two `SaveSystem.atb_mode`
+  raw values (0/1) had been swapped from what real RPG_RT actually stores.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3514,26 +3514,59 @@ The work below is roughly ordered by the critical path to a walkable game
   Wait), the toggle turned out to live on the **save system**, not the Battle
   Commands table: liblcf's `fields.csv` has no `wait` entry on
   `BattleCommands`, and RPG_RT stores the wait/active choice as
-  `SaveSystem.atb_mode` (LSD chunk 140, default 0 = wait, 1 = active,
-  RPG2003-only). The schema now decodes it, `Game::State` carries it
-  (`attr_accessor :atb_mode`, written to the save only when non-zero so an
-  RPG2000 save never gains the 2003-only chunk), and `Scene::Menu`'s Wait row
-  flips it — ported from EasyRPG's own `Scene_Menu` Wait branch: the label
-  shows the *current* mode (`wait_on` / `wait_off`, `Terms` fields 121/122),
-  confirming plays the Decision SE and relabels the row. In the battle scene
-  (ADR 0054) wait mode freezes the gauges while a command menu is open;
-  active mode keeps them filling and a ready non-controllable combatant's
-  action **interrupts** the menu — `active_atb?` / `atb_accumulating?` /
-  `drive_battle_command`'s interrupt gate mirror EasyRPG's
-  `IsAtbAccumulating` and `ProcessSceneActionCommand` (`GetAtbMode() ==
-  active && IsBattleActionPending()`, with SelectActor/AutoBattle always
-  accumulating). Covered by new `scripts/rpg2k_scene_check.rb` checks (wait
-  mode freezes an enemy's gauge behind the menu; active mode keeps it filling
-  and a ready enemy's action interrupts and returns to the menu; a ready
-  enemy waits in wait mode; the menu Wait row toggles and relabels) and a
-  `scripts/rpg2k_save_load_check.rb` round-trip (`atb_mode` 1 survives).
-  Row alone remains genuinely blocked on the unmodelled RPG2003 battle
-  system.
+  `SaveSystem.atb_mode` (LSD chunk 140, ~~default 0 = wait, 1 = active~~
+  **default 0 = active, 1 = wait — this pass had the two raw values swapped;
+  see the dated follow-up right below**, RPG2003-only). The schema now
+  decodes it, `Game::State` carries it (`attr_accessor :atb_mode`, written to
+  the save only when non-zero so an RPG2000 save never gains the 2003-only
+  chunk), and `Scene::Menu`'s Wait row flips it — ported from EasyRPG's own
+  `Scene_Menu` Wait branch: the label shows the *current* mode (`wait_on` /
+  `wait_off`, `Terms` fields 121/122), confirming plays the Decision SE and
+  relabels the row. In the battle scene (ADR 0054) wait mode freezes the
+  gauges while a command menu is open; active mode keeps them filling and a
+  ready non-controllable combatant's action **interrupts** the menu —
+  `active_atb?` / `atb_accumulating?` / `drive_battle_command`'s interrupt
+  gate mirror EasyRPG's `IsAtbAccumulating` and `ProcessSceneActionCommand`
+  (`GetAtbMode() == active && IsBattleActionPending()`, with
+  SelectActor/AutoBattle always accumulating). Covered by new
+  `scripts/rpg2k_scene_check.rb` checks (wait mode freezes an enemy's gauge
+  behind the menu; active mode keeps it filling and a ready enemy's action
+  interrupts and returns to the menu; a ready enemy waits in wait mode; the
+  menu Wait row toggles and relabels) and a `scripts/rpg2k_save_load_check.rb`
+  round-trip (`atb_mode` 1 survives). Row alone remains genuinely blocked on
+  the unmodelled RPG2003 battle system.
+  ✅ **Follow-up (2026-08-20): the two raw `atb_mode` values were swapped from
+  what real RPG_RT actually stores, so a fresh RPG2003 gauge-battle game
+  opened with its command menu *freezing* the gauges by default, when real
+  RPG_RT's default *keeps them filling*.** Confirmed directly against
+  liblcf's own generated save-format header
+  (`src/generated/lcf/rpg/savesystem.h`): `enum AtbMode { AtbMode_atb_active
+  = 0, AtbMode_atb_wait = 1 };`, with field default `int32_t atb_mode = 0;` —
+  i.e. the *default* raw value is **active**, not wait. EasyRPG's own
+  `Scene_Battle_Rpg2k3::IsAtbAccumulating` (`src/scene_battle_rpg2k3.cpp`)
+  confirms the direction directly: `const bool active_atb =
+  GetAtbMode() == AtbMode_atb_active;`. This codebase's own
+  `RPG2k3::Scene::Battle#active_atb?` (`mruby-rpg2k/mrblib/scene/
+  battle_rpg2k3.rb`) had it backwards — `@state.atb_mode == 1` — treating
+  the *wait* raw value as active; `Scene::Menu#wait_label`
+  (`mruby-rpg2k/mrblib/scene/menu.rb`) had a matching but independent bug,
+  correctly comparing `atb_mode == 1` (which genuinely is wait) but then
+  returning the `wait_off` term for that branch instead of `wait_on` —
+  both symptoms of the same single misunderstanding ("0 = wait by default"),
+  each caught only by tracing back to the un-cited claim rather than by
+  analogy from one to the other. `Game::Interpreter#do_toggle_atb_mode`'s
+  actual flip logic (`atb_mode == 1 ? 0 : 1`) and the LSD chunk 140
+  read/write in `Game::State#to_lsd`/`.from_lsd` are direction-agnostic and
+  needed no change — only the two places that gave the raw values *meaning*
+  were wrong. Fixed by flipping `#active_atb?`'s comparison
+  (`@state.atb_mode != 1`) and swapping `#wait_label`'s two term branches;
+  every doc comment asserting the backwards convention (`game.rb`'s
+  `atb_mode` accessor, `interpreter.rb`'s `do_toggle_atb_mode`,
+  `battle_rpg2k3.rb`'s class comment) was corrected alongside. Covered by
+  rewriting the five existing `scripts/rpg2k_scene_check.rb` checks that had
+  encoded the swapped convention (a fresh state's default now asserted
+  active rather than wait, and every explicit `atb_mode =`/expected label
+  updated to match), all five confirmed to fail against the pre-fix code.
   ✅ **A weapon/shield/armour/helmet/accessory item flagged `use_skill`
   (schema field 71) is now usable directly from the field and battle Item
   menus too, invoking its `skill_id` skill without being equipped.** The

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13194,11 +13194,14 @@ module Game
     # changes.
     attr_accessor :system_graphic, :font_id
     # RPG2003's active-time wait/active toggle (`SaveSystem.atb_mode`, LSD
-    # SAVE_SYSTEM chunk 140): 0 = wait (a gauge battle's command menu pauses
-    # the fight), 1 = active (gauges keep filling while a menu is open and a
-    # ready non-controllable combatant's action interrupts it). The field
-    # menu's Wait command (id 8) flips it and the gauge battle scene reads it;
-    # default 0 (wait), matching liblcf. RPG2000 saves never carry the chunk.
+    # SAVE_SYSTEM chunk 140): 0 = active (gauges keep filling while a menu is
+    # open and a ready non-controllable combatant's action interrupts it),
+    # 1 = wait (a gauge battle's command menu pauses the fight) -- confirmed
+    # against liblcf's own generated `AtbMode` enum (`AtbMode_atb_active =
+    # 0, AtbMode_atb_wait = 1`), the opposite of an earlier, uncited pass
+    # here. The field menu's Wait command (id 8) flips it and the gauge
+    # battle scene reads it; default 0 (active), matching liblcf. RPG2000
+    # saves never carry the chunk.
     attr_accessor :atb_mode
     # Last known-good resume position of each running Common Event Parallel
     # Process, id => a command-list index (see Game::Interpreter

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3307,7 +3307,7 @@ module Game
     end
 
     # Toggle ATB Mode (5003): flip the save-system wait/active toggle
-    # (`SaveSystem.atb_mode`, LSD chunk 140) between wait (0) and active (1) —
+    # (`SaveSystem.atb_mode`, LSD chunk 140) between active (0) and wait (1) —
     # the same field the field menu's Wait command (id 8) flips, so a gauge
     # battle's command menu starts freezing / keeping the gauges running
     # accordingly (RPG2k3::Scene::Battle#atb_accumulating? reads it live).

--- a/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
+++ b/mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb
@@ -14,11 +14,13 @@ module RPG2k3
     # controllable party member whose gauge is full opens the command menu;
     # everyone else acts automatically the instant their gauge fires, enemy AI
     # included. How long that command menu lets the fight run is the RPG2003
-    # Wait/active toggle (`SaveSystem.atb_mode`, LSD chunk 140): in wait mode
-    # (the default) the gauges freeze while the menu is open, in active mode
-    # they keep filling and a ready non-controllable combatant's action
-    # interrupts the menu (#atb_accumulating? / #drive_battle_command's
-    # override).
+    # Wait/active toggle (`SaveSystem.atb_mode`, LSD chunk 140): in active mode
+    # (the default) the gauges keep filling while the menu is open and a ready
+    # non-controllable combatant's action interrupts it, in wait mode they
+    # freeze (#atb_accumulating? / #drive_battle_command's override) --
+    # confirmed against liblcf's own generated `AtbMode` enum
+    # (`AtbMode_atb_active = 0, AtbMode_atb_wait = 1`), the opposite of an
+    # earlier, uncited pass here that had the two raw values swapped.
     #
     # The traditional (0) and alternative (1) presentations run the inherited
     # turn-based machine unchanged -- every override below is gated on
@@ -33,10 +35,12 @@ module RPG2k3
 
       # Whether this fight runs in RPG2003's active-during-menu (Wait-off)
       # presentation -- the save-system `atb_mode` toggle (LSD chunk 140),
-      # flipped by the field menu's Wait command (id 8). Wait mode (the
-      # default) freezes the gauges while a command menu is open.
+      # flipped by the field menu's Wait command (id 8). Active mode (the
+      # default, raw 0 -- liblcf's `AtbMode_atb_active`) keeps the gauges
+      # filling while a command menu is open; wait mode (raw 1,
+      # `AtbMode_atb_wait`) freezes them.
       def active_atb?
-        gauge_battle? && @state.atb_mode == 1
+        gauge_battle? && @state.atb_mode != 1
       end
 
       # Whether the active-time gauges advance this frame -- EasyRPG's

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -271,10 +271,12 @@ class RPG2k
       end
 
       # The Wait command row's label: `wait_on` while the fight is set to
-      # pause on its command menu (wait mode), `wait_off` once it is active.
-      # Defaults match the terms' own RPG2003 defaults ("Wait: On" / "Wait: Off").
+      # pause on its command menu (wait mode, raw `atb_mode` 1), `wait_off`
+      # once it is active (raw 0, the default) -- confirmed against
+      # EasyRPG's own `Scene_Menu` Wait row (`src/scene_menu.cpp`):
+      # `GetAtbMode() == AtbMode_atb_wait ? wait_on : wait_off`.
       def wait_label
-        @state.atb_mode == 1 ? term(:wait_off, 'Wait Off') : term(:wait_on, 'Wait On')
+        @state.atb_mode == 1 ? term(:wait_on, 'Wait On') : term(:wait_off, 'Wait Off')
       end
 
       def build_windows

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -238,10 +238,10 @@ def check_game(dir)
   state.teleport_access = true
   state.escape_access = true
   state.save_count = 7
-  # Wait-off (active) ATB: the save-system toggle (LSD chunk 140, ADR 0054's
-  # follow-up). Set it non-default so the round-trip proves it is written and
-  # read back; the default (0, wait mode) is pinned by the scene check's
-  # fresh-state assertion ("a fresh state starts in wait mode").
+  # Wait ATB: the save-system toggle (LSD chunk 140, ADR 0054's follow-up).
+  # Set it non-default so the round-trip proves it is written and read back;
+  # the default (0, active mode) is pinned by the scene check's fresh-state
+  # assertion ("a fresh state starts in active mode").
   state.atb_mode = 1
   if state.party.leader
     state.party.leader.set_charset('HeroAlt', 5)
@@ -319,7 +319,7 @@ def check_game(dir)
   eq true, round.teleport_access, 'to_lsd: teleport_access'
   eq true, round.escape_access, 'to_lsd: escape_access'
   eq 7, round.save_count, 'to_lsd: save_count'
-  eq 1, round.atb_mode, 'to_lsd: the wait-off atb_mode survives the round-trip'
+  eq 1, round.atb_mode, 'to_lsd: the wait atb_mode survives the round-trip'
   if round.party.leader
     eq 'HeroAlt', round.party.leader.charset_name, 'to_lsd: leader sprite override'
     eq 5, round.party.leader.charset_index, 'to_lsd: leader sprite index'

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15113,41 +15113,41 @@ end
 # ADR 0054's follow-up: the gauge fight's Wait/active presentation. The toggle
 # is the save-system `atb_mode` field (LSD chunk 140), flipped by the field
 # menu's Wait command -- *not* a Battle Commands database field, correcting
-# the ADR's own premise. In wait mode (default) the gauges freeze while any
-# command menu is open; in active mode they keep filling and a ready
-# non-controllable combatant's action interrupts the menu (EasyRPG's
+# the ADR's own premise. In active mode (raw 0, the default) the gauges keep
+# filling while any command menu is open and a ready non-controllable
+# combatant's action interrupts the menu (EasyRPG's
 # `ProcessSceneActionCommand`'s `GetAtbMode() == active && IsBattleActionPending()`
-# gate). These checks drive both through the 2003 scene.
+# gate); in wait mode (raw 1) they freeze -- confirmed against liblcf's own
+# generated `AtbMode` enum (`AtbMode_atb_active = 0, AtbMode_atb_wait = 1`),
+# the opposite of an earlier, uncited pass here that had the two raw values
+# swapped (docs/TODO.md's "Wait" entry has the same correction). These checks
+# drive both through the 2003 scene.
 
-check 'wait mode: the command menu freezes every gauge, enemy gauges included' do
+check 'active mode: the command menu keeps every gauge filling, enemy ' \
+      'gauges included -- and is also the default' do
   scene, st = battle_scene_with_pages({}, rpg2003: true,
                                       battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
-  st.atb_mode = 0 # wait mode -- also the default
+  eq 0, st.atb_mode, 'active mode is the default, no explicit set needed'
   ui = battle_until_phase(scene, :command, 250)
   ok ui, 'the battle opened to the ready actor\'s menu'
   hero = ui[:allies][0]
   eq true, hero.gauge_full?, 'the commanded actor\'s gauge is held full'
   enemy = ui[:battle].enemy(0)
-  # Park the enemy mid-fill so the freeze is measurable: under wait mode its
-  # gauge must not move while the menu stays up.
   enemy.gauge = Game::Battle::GAUGE_MAX / 2
   20.times { scene.update }
-  eq Game::Battle::GAUGE_MAX / 2, enemy.gauge,
-     'wait mode: the enemy\'s gauge does not fill while the command menu is open'
+  ok enemy.gauge > Game::Battle::GAUGE_MAX / 2,
+     'active mode: the enemy\'s gauge keeps filling while the command menu is open'
 end
 
-check 'active mode: the command menu keeps the gauges filling, and a ready ' \
-      'enemy\'s action interrupts it' do
+check 'active mode: a ready enemy\'s action interrupts the open command menu' do
   scene, st = battle_scene_with_pages({}, rpg2003: true,
                                       battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
-  st.atb_mode = 1 # Wait-off (active)
+  st.atb_mode = 0 # active (explicit, mirroring the default check above)
   ui = battle_until_phase(scene, :command, 250)
   ok ui, 'the battle opened to the ready actor\'s menu'
   enemy = ui[:battle].enemy(0)
   enemy.gauge = Game::Battle::GAUGE_MAX / 2
   20.times { scene.update }
-  ok enemy.gauge > Game::Battle::GAUGE_MAX / 2,
-     'active mode: the enemy\'s gauge keeps filling while the command menu is open'
   ui = battle_ui(scene)
   eq :command, ui[:phase], 'the menu is still up (no interrupt yet -- the enemy is not ready)'
   # Make the enemy ready: in active mode its full gauge fires *now*, mid-menu.
@@ -15168,13 +15168,21 @@ check 'active mode: the command menu keeps the gauges filling, and a ready ' \
   eq :command, ui[:phase], 'after the interrupt resolves, the ready actor\'s menu returns'
 end
 
-check 'wait mode: a ready enemy waits behind the command menu, no interrupt' do
+check 'wait mode: the command menu freezes every gauge, and a ready enemy ' \
+      'waits behind it with no interrupt' do
   scene, st = battle_scene_with_pages({}, rpg2003: true,
                                       battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
-  st.atb_mode = 0 # wait mode
+  st.atb_mode = 1 # wait mode
   ui = battle_until_phase(scene, :command, 250)
   ok ui, 'the battle opened to the ready actor\'s menu'
   enemy = ui[:battle].enemy(0)
+  # Park the enemy mid-fill so the freeze is measurable: under wait mode its
+  # gauge must not move while the menu stays up.
+  enemy.gauge = Game::Battle::GAUGE_MAX / 2
+  20.times { scene.update }
+  eq Game::Battle::GAUGE_MAX / 2, enemy.gauge,
+     'wait mode: the enemy\'s gauge does not fill while the command menu is open'
+
   enemy.gauge = Game::Battle::GAUGE_MAX
   scene.update
   ui = battle_ui(scene)
@@ -15183,24 +15191,24 @@ check 'wait mode: a ready enemy waits behind the command menu, no interrupt' do
      'and its gauge is left full, waiting for the menu to close'
 end
 
-check 'a battle-page Toggle ATB Mode (5003) flips the live fight to active' do
+check 'a battle-page Toggle ATB Mode (5003) flips the live fight to wait' do
   ic = Game::Interpreter::Cmd
   # A TURN-gated page runs at the first turn boundary; its 5003 flips the
   # same save-system `atb_mode` the field menu Wait command flips, live.
   pages = { 1 => troop_page([ECmd.new(ic::TOGGLE_ATB_MODE, [])]) }
   scene, st = battle_scene_with_pages(pages, rpg2003: true,
                                       battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
-  eq 0, st.atb_mode, 'the fight begins in wait mode'
+  eq 0, st.atb_mode, 'the fight begins in active mode'
   ui = battle_until_phase(scene, :command, 250)
   ok ui, 'the gauge battle opened to the ready actor\'s menu'
-  eq 1, st.atb_mode, 'the 5003 page flipped the fight to active'
-  # And the flip is live: the enemy gauge now fills behind the menu, the
-  # active-mode behaviour pinned by the checks above.
+  eq 1, st.atb_mode, 'the 5003 page flipped the fight to wait'
+  # And the flip is live: the enemy gauge no longer fills behind the menu,
+  # the wait-mode behaviour pinned by the checks above.
   enemy = ui[:battle].enemy(0)
   enemy.gauge = Game::Battle::GAUGE_MAX / 2
   20.times { scene.update }
-  ok enemy.gauge > Game::Battle::GAUGE_MAX / 2,
-     'and the flipped-to-active fight keeps the gauges filling behind the menu'
+  eq Game::Battle::GAUGE_MAX / 2, enemy.gauge,
+     'and the flipped-to-wait fight freezes the gauges behind the menu'
 end
 
 check 'an RPG2003 battle_type 0 (traditional) fight still runs the round machine, never the gauge idle loop' do
@@ -16254,27 +16262,32 @@ check 'Scene::Menu: an RPG2003 database drives the command list from ' \
      'Status (id 5), Row (id 6), Order (id 7) and Wait (id 8) are all offered'
 end
 
+# Confirmed against liblcf's own generated `AtbMode` enum (`AtbMode_atb_active
+# = 0, AtbMode_atb_wait = 1`) and EasyRPG's `Scene_Menu` Wait row
+# (`src/scene_menu.cpp`): `GetAtbMode() == AtbMode_atb_wait ? wait_on :
+# wait_off` -- raw 0 (the default) is active mode and labels `wait_off`, raw
+# 1 is wait mode and labels `wait_on`.
 check 'Scene::Menu: the Wait command shows the current atb_mode, and toggling ' \
       'it flips the field and relabels the row' do
   db = fake_db(rpg2003: true, menu_commands: [1, 8])
   st = wrap_menu_state
-  eq 0, st.atb_mode, 'a fresh state starts in wait mode'
+  eq 0, st.atb_mode, 'a fresh state starts in active mode'
   scene = menu_scene(RPG2k::Scene::Menu, st, db)
   cmds = scene.instance_variable_get(:@commands)
   eq :wait, cmds[1].first, 'the Wait command (id 8) is offered'
-  eq ['Wait On'], [cmds[1][1]], 'wait mode labels the row with wait_on'
+  eq ['Wait Off'], [cmds[1][1]], 'active mode labels the row with wait_off'
   scene.instance_variable_set(:@index, 1)
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.reset
-  eq 1, st.atb_mode, 'confirming Wait flips atb_mode to active'
+  eq 1, st.atb_mode, 'confirming Wait flips atb_mode to wait'
   cmds = scene.instance_variable_get(:@commands)
-  eq ['Wait Off'], [cmds[1][1]], 'the row relabels to wait_off after the flip'
+  eq ['Wait On'], [cmds[1][1]], 'the row relabels to wait_on after the flip'
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.reset
-  eq 0, st.atb_mode, 'confirming again flips back to wait'
-  eq ['Wait On'], [cmds[1][1]], 'and the row relabels back to wait_on'
+  eq 0, st.atb_mode, 'confirming again flips back to active'
+  eq ['Wait Off'], [cmds[1][1]], 'and the row relabels back to wait_off'
 end
 
 check 'Scene::Menu: RPG2003 System.menu_commands can reorder and omit commands' do


### PR DESCRIPTION
## Summary

- liblcf's own generated save-format header (`src/generated/lcf/rpg/savesystem.h`) defines `enum AtbMode { AtbMode_atb_active = 0, AtbMode_atb_wait = 1 };`, with field default `int32_t atb_mode = 0;` — i.e. the *default* raw value is **active**, not wait. EasyRPG's `Scene_Battle_Rpg2k3::IsAtbAccumulating` (`src/scene_battle_rpg2k3.cpp`) confirms the direction directly: `const bool active_atb = GetAtbMode() == AtbMode_atb_active;`.
- `RPG2k3::Scene::Battle#active_atb?` (`mruby-rpg2k/mrblib/scene/battle_rpg2k3.rb`) had it backwards — `@state.atb_mode == 1` — treating the *wait* raw value as active. Since a fresh game/save always starts at the field's default of `0`, every new RPG2003 gauge-battle game opened with its command menu **freezing** every gauge, when real RPG_RT's default **keeps them filling**.
- `Scene::Menu#wait_label` (`mruby-rpg2k/mrblib/scene/menu.rb`) had a matching but independent bug: it correctly compared `atb_mode == 1` (which genuinely is wait), but then returned the `wait_off` term for that branch instead of `wait_on` — both symptoms of the same single misunderstanding ("0 = wait by default"), not one bug causing the other.
- `Game::Interpreter#do_toggle_atb_mode`'s actual flip logic (`atb_mode == 1 ? 0 : 1`) and the LSD chunk 140 read/write in `Game::State#to_lsd`/`.from_lsd` are direction-agnostic and needed no change — only the two places that gave the raw values *meaning* were wrong.
- Fixed by flipping `#active_atb?`'s comparison (`@state.atb_mode != 1`) and swapping `#wait_label`'s two term branches. Every doc comment asserting the backwards convention (`game.rb`'s `atb_mode` accessor, `interpreter.rb`'s `do_toggle_atb_mode`, `battle_rpg2k3.rb`'s class comment) was corrected alongside, and a stale `docs/TODO.md` "Wait" entry that stated the swapped convention as settled fact is marked with strikethrough and a dated follow-up.

## Test plan

- [x] Rewrote the five existing `scripts/rpg2k_scene_check.rb` checks that had encoded the swapped convention (a fresh state's default now asserted active rather than wait, every explicit `atb_mode =`/expected label updated to match).
- [x] Verified via `git stash` on the four source files: all five rewritten/new checks fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 809 passed, `rpg2k_logic_check.rb` 1070 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_