### PR TITLE
Fix: Set Transparent Flag polarity, and the actor ghost flag is translucent not hidden

### DIFF
--- a/changelog.d/player-visibility-transparent-ghost-opacity.fixed.md
+++ b/changelog.d/player-visibility-transparent-ghost-opacity.fixed.md
@@ -1,0 +1,6 @@
+- **Map:** Set Transparent Flag's parameter polarity was fixed to match
+  RPG_RT (0 hides the player, non-zero shows it -- previously backwards).
+  Separately, the leader actor graphic's own "Transparent" flag (Change Actor
+  Graphic / the database Actor checkbox) now makes the player sprite
+  translucent (opacity 159/255), matching RPG_RT's ghost effect, instead of
+  hiding it outright -- the two were previously folded into a single hide.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9521,6 +9521,49 @@ not yet verified:
   round-trip (which explicitly exercised the now-removed field 55) was
   updated to match, and gained its own from-scratch check for the corrected
   `SAVE_MOVABLE` field. `ninja -C build test` still passes.
+  ✅ **Follow-up (2026-08-20): two further, independent bugs in this same
+  feature, found while re-verifying the entry above against RPG_RT's own
+  live source rather than trusting its existing citations at face value.**
+  (1) **Set Transparent Flag's own parameter polarity was backwards.**
+  `Game_Interpreter::CommandPlayerVisibility` (`src/game_interpreter.cpp`,
+  code 11310) is `bool hidden = (com.parameters[0] == 0); player->
+  SetSpriteHidden(hidden);` — param0 *zero* hides the player, non-zero shows
+  it. `Interpreter#do_player_visibility` (`mruby-rpg2k/mrblib/interpreter.rb`)
+  had `@state.player_transparent = cmd.param(0) != 0`, backwards, and its own
+  comment cited "EasyRPG's `SetSpriteHidden(parameters[0] != 0)`" — a
+  paraphrase that does not match the real function at all (it computes
+  `hidden` from `parameters[0] == 0` *before* ever calling `SetSpriteHidden`,
+  which takes the already-resolved boolean, not a raw parameter expression).
+  (2) **A wholly separate RPG_RT mechanism — the leader's own actor graphic
+  "Transparent" flag (Change Actor Graphic's third parameter, or the
+  database Actor's own checkbox) — was folded into the same hide, when real
+  RPG_RT renders it as a *translucent ghost*, not a hide at all.** Confirmed
+  against RPG_RT's own live source: `Game_Actor::SetSprite`
+  (`src/game_actor.cpp`) stores `data.transparency = transparent ? 3 : 0`;
+  `Game_Character::GetOpacity` (`src/game_character.cpp`) is `Clamp((8 -
+  GetTransparency()) * 32 - 1, 0, 255)` — level 3 yields opacity 159/255
+  (~62%); and `Game_Character::IsVisible` (`src/game_character.h`) is
+  `IsActive() && !IsSpriteHidden() && GetOpacity() > 0` — `IsSpriteHidden()`
+  (Set Transparent Flag's own mechanism) and `GetOpacity()` (the ghost flag)
+  are genuinely independent gates, never merged into one. `Scene::Map
+  #player_hidden?` (`mruby-rpg2k/mrblib/scene/map.rb`) computed `@state.
+  player_transparent || (leader && leader.transparent)` as one combined
+  hide-boolean — its own adjacent comment even called the ghost flag
+  "(rarely used)" and "semi-transparent" while the code hid the sprite
+  outright, a direct contradiction between comment and code caught only by
+  fetching the real source rather than trusting the comment's own framing.
+  Fixed by splitting `#player_hidden?` down to `@state.player_transparent`
+  alone, adding a new `#player_translucent?` for the leader-graphic ghost
+  flag, and a new `#apply_player_visibility` that sets both `@player_sprite.
+  visible` (the real hide) and `@player_sprite.opacity` (159 while
+  translucent, 255 otherwise) every frame — replacing the two raw
+  `@player_sprite.visible = !player_hidden?` call sites in `#refresh_player_
+  graphic` and `#render`. `do_player_visibility`'s polarity was flipped to
+  `cmd.param(0) == 0`. Covered by rewriting the existing
+  `scripts/rpg2k_logic_check.rb`/`scripts/rpg2k_scene_check.rb` checks that
+  had encoded the backwards polarity, plus a new scene check asserting the
+  ghost flag sets opacity 159 without ever clearing `visible`, all confirmed
+  to fail against the pre-fix code.
 - ✅ **A hero's, vehicle's or map event's saved facing is now decoded (and
   encoded) correctly — this build used to read/write liblcf's raw wire value
   for the field as if it were already this runtime's own numpad convention,

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3216,11 +3216,13 @@ module Game
     # Set Transparent Flag (Change Player Visibility): toggle whether the party
     # leader's map sprite is hidden. Non-blocking — it only records the flag on
     # the shared game state; the owning scene reads it each frame. The polarity
-    # (param0 non-zero = transparent / hidden) follows EasyRPG's
-    # `SetSpriteHidden(parameters[0] != 0)`; the flag persists through Save /
-    # Continue.
+    # (param0 zero = hidden) follows RPG_RT's own live source: `Game_Interpreter
+    # ::CommandPlayerVisibility` (`src/game_interpreter.cpp`, code 11310) is
+    # `bool hidden = (com.parameters[0] == 0); player->SetSpriteHidden(hidden);`
+    # -- the reverse of an earlier, uncited pass here that had param0 non-zero
+    # meaning hidden instead. The flag persists through Save / Continue.
     def do_player_visibility(cmd)
-      @state.player_transparent = cmd.param(0) != 0
+      @state.player_transparent = cmd.param(0) == 0
     end
 
     # Flash Sprite (11320): pulse a character's sprite with a colour that decays

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3195,21 +3195,52 @@ class RPG2k
       end
 
       # Reload the party leader's CharSet graphic and apply its transparency to
-      # the player sprite, forcing a redraw on the next frame. The transparency
-      # flag hides the sprite outright (the renderer has no partial-opacity path).
+      # the player sprite, forcing a redraw on the next frame.
       def refresh_player_graphic
         @charset = load_charset
         @last_frame = nil
-        @player_sprite.visible = !player_hidden?
+        apply_player_visibility
         @player_bmp.clear unless @charset
       end
 
-      # Whether the party leader's map sprite should be hidden this frame: either
-      # the Set Transparent Flag command hid the player, or the leader's own
-      # actor graphic carries the (rarely used) semi-transparent flag.
+      # Whether the party leader's map sprite is genuinely hidden this frame --
+      # the Set Transparent Flag command (11310), which RPG_RT itself calls
+      # "Change Player Visibility" and implements as a real hide. Confirmed
+      # against RPG_RT's own live source: `Game_Interpreter::
+      # CommandPlayerVisibility` (`src/game_interpreter.cpp`) is `bool hidden =
+      # (com.parameters[0] == 0); player->SetSpriteHidden(hidden);` -- a wholly
+      # separate mechanism from #player_translucent? below (`IsSpriteHidden()`
+      # vs `GetOpacity()`, both independently gating `Game_Character::
+      # IsVisible()`).
       def player_hidden?
+        @state.player_transparent ? true : false
+      end
+
+      # Whether the leader's *actor graphic* carries RPG2000's "Transparent"
+      # ghost flag (the ChangeActorGraphic/database Actor checkbox) -- this
+      # does not hide the sprite, it makes it translucent. Confirmed against
+      # RPG_RT's own live source: `Game_Actor::SetSprite` stores `data.
+      # transparency = transparent ? 3 : 0` (`src/game_actor.cpp`), and
+      # `Game_Character::GetOpacity` (`src/game_character.cpp`) is `Clamp((8 -
+      # GetTransparency()) * 32 - 1, 0, 255)` -- level 3 yields opacity
+      # 159/255 (~62%), not 0. This codebase used to fold this flag into
+      # #player_hidden? and hide the sprite outright instead.
+      def player_translucent?
         leader = @state.party.leader
-        @state.player_transparent || (leader && leader.transparent) ? true : false
+        leader && leader.transparent ? true : false
+      end
+
+      # RPG_RT's own opacity for the "Transparent" ghost flag (see
+      # #player_translucent?'s citation) -- `(8 - 3) * 32 - 1 == 159`.
+      TRANSLUCENT_OPACITY = 159
+
+      # Apply both independent visibility signals to the player sprite: a
+      # real Set Transparent Flag hide, and the leader graphic's own
+      # translucent-ghost opacity, every frame so the hero hides/shows and
+      # fades as events toggle either one.
+      def apply_player_visibility
+        @player_sprite.visible = !player_hidden?
+        @player_sprite.opacity = player_translucent? ? TRANSLUCENT_OPACITY : 255
       end
 
       # -- Change Map Tileset -------------------------------------------------
@@ -8103,9 +8134,9 @@ class RPG2k
           @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
           @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE) -
                              player_jump_offset
-          # Reflect the Set Transparent Flag command (and any leader graphic flag)
-          # every frame so the hero hides/shows as events toggle it.
-          @player_sprite.visible = !player_hidden?
+          # Reflect the Set Transparent Flag command (and the leader graphic's
+          # own translucent-ghost flag) every frame -- see #apply_player_visibility.
+          apply_player_visibility
           RGSS::Profiler.section("map.chars") do
             draw_player_frame
             draw_vehicles cam_x, cam_y, px, py

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8622,19 +8622,24 @@ end
 
 # -- Player Visibility / Return to Title --------------------------------------
 
+# Confirmed against RPG_RT's own live source: `Game_Interpreter::
+# CommandPlayerVisibility` (`src/game_interpreter.cpp`, code 11310) is
+# `bool hidden = (com.parameters[0] == 0); player->SetSpriteHidden(hidden);`
+# -- param0 *zero* hides the player, non-zero shows it, the reverse of an
+# earlier, uncited pass here that had the polarity backwards.
 check 'Set Transparent Flag toggles the player-transparent state, non-blocking' do
   st = party_state
   it = Game::Interpreter.new(st)
-  it.start([FakeCmd.new(IC::PLAYER_VISIBILITY, [1]),
+  it.start([FakeCmd.new(IC::PLAYER_VISIBILITY, [0]),
             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
   it.update
-  eq true, st.player_transparent, 'param0 != 0 hides the player'
+  eq true, st.player_transparent, 'param0 == 0 hides the player'
   ok !it.waiting?, 'Set Transparent Flag must not pause the interpreter'
   eq true, st.switches[1], 'the command after it still ran'
   it2 = Game::Interpreter.new(st)
-  it2.start([FakeCmd.new(IC::PLAYER_VISIBILITY, [0])])
+  it2.start([FakeCmd.new(IC::PLAYER_VISIBILITY, [1])])
   it2.update
-  eq false, st.player_transparent, 'param0 == 0 shows the player again'
+  eq false, st.player_transparent, 'param0 != 0 shows the player again'
 end
 
 check 'player_transparent round-trips through the save' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3541,20 +3541,48 @@ check "Halt All Movement lands an in-progress jump but drops the route's trailin
   ok scene.instance_variable_get(:@player_route).nil?, 'the route itself is cancelled'
 end
 
+# Confirmed against RPG_RT's own live source: `Game_Interpreter::
+# CommandPlayerVisibility` (`src/game_interpreter.cpp`) is `bool hidden =
+# (com.parameters[0] == 0)` -- param0 zero hides.
 check 'Set Transparent Flag hides and shows the player sprite' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
-  auto.event_commands = [ECmd.new(ic::PLAYER_VISIBILITY, [1])] # transparent ON
+  auto.event_commands = [ECmd.new(ic::PLAYER_VISIBILITY, [0])] # hidden
   one_shot_auto(auto, 9011)
   scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
   5.times { scene.update }
   spr = scene.instance_variable_get(:@player_sprite)
-  eq false, spr.visible, 'the player sprite is hidden while transparent'
+  eq false, spr.visible, 'the player sprite is hidden'
   # A second event turns it back off.
   st = scene.instance_variable_get(:@state)
   st.player_transparent = false
   scene.update
-  eq true, spr.visible, 'the player sprite shows again once transparency clears'
+  eq true, spr.visible, 'the player sprite shows again once hidden clears'
+end
+
+# The leader's own actor graphic "Transparent" flag (Change Actor Graphic /
+# the database Actor checkbox) is a wholly separate, ghost-opacity mechanism
+# from Set Transparent Flag's real hide -- confirmed against RPG_RT's own
+# live source: `Game_Actor::SetSprite` stores `data.transparency = 3`
+# (`src/game_actor.cpp`), and `Game_Character::GetOpacity` (`src/
+# game_character.cpp`) is `Clamp((8 - GetTransparency()) * 32 - 1, 0, 255)`
+# -- level 3 yields 159/255, not a hide. This codebase used to fold the two
+# into one hide-only flag.
+check 'the leader actor graphic\'s Transparent flag makes the player sprite ' \
+      'translucent, not hidden' do
+  scene = new_scene({}, player: [5, 5], members: [SlipActor.new])
+  st = scene.instance_variable_get(:@state)
+  spr = scene.instance_variable_get(:@player_sprite)
+  scene.update
+  eq true, spr.visible, 'not hidden'
+  eq 255, spr.opacity, 'fully opaque with the flag off'
+  st.party.leader.transparent = true
+  scene.update
+  eq true, spr.visible, 'the ghost flag never hides the sprite outright'
+  eq 159, spr.opacity, 'ghost-translucent, RPG_RT\'s own (8 - 3) * 32 - 1'
+  st.party.leader.transparent = false
+  scene.update
+  eq 255, spr.opacity, 'and clears back to fully opaque'
 end
 
 check 'Return to Title Screen hands control back to the app' do


### PR DESCRIPTION
## Summary

Two independent bugs in the player-visibility feature, found while re-verifying an existing `docs/TODO.md` entry against RPG_RT's own live source rather than trusting its existing citations at face value.

1. **Set Transparent Flag's own parameter polarity was backwards.** `Game_Interpreter::CommandPlayerVisibility` (`src/game_interpreter.cpp`, code 11310) is `bool hidden = (com.parameters[0] == 0); player->SetSpriteHidden(hidden);` — param0 *zero* hides the player, non-zero shows it. `Interpreter#do_player_visibility` (`mruby-rpg2k/mrblib/interpreter.rb`) had `@state.player_transparent = cmd.param(0) != 0`, backwards, and its own comment cited "EasyRPG's `SetSpriteHidden(parameters[0] != 0)`" — a paraphrase that doesn't match the real function at all (it computes `hidden` from `parameters[0] == 0` *before* ever calling `SetSpriteHidden`, which takes the already-resolved boolean).

2. **A wholly separate RPG_RT mechanism — the leader's own actor graphic "Transparent" flag (Change Actor Graphic's third parameter, or the database Actor's own checkbox) — was folded into the same hide, when real RPG_RT renders it as a translucent ghost, not a hide.** Confirmed against RPG_RT's own live source: `Game_Actor::SetSprite` (`src/game_actor.cpp`) stores `data.transparency = transparent ? 3 : 0`; `Game_Character::GetOpacity` (`src/game_character.cpp`) is `Clamp((8 - GetTransparency()) * 32 - 1, 0, 255)` — level 3 yields opacity 159/255 (~62%); and `Game_Character::IsVisible` (`src/game_character.h`) is `IsActive() && !IsSpriteHidden() && GetOpacity() > 0` — the two gates are genuinely independent, never merged. `Scene::Map#player_hidden?` (`mruby-rpg2k/mrblib/scene/map.rb`) computed one combined hide-boolean from both — its own adjacent comment even called the ghost flag "(rarely used)" and "semi-transparent" while the code hid the sprite outright.

Fixed by splitting `#player_hidden?` down to `@state.player_transparent` alone, adding a new `#player_translucent?` for the leader-graphic ghost flag, and a new `#apply_player_visibility` that sets both `@player_sprite.visible` (the real hide) and `@player_sprite.opacity` (159 while translucent, 255 otherwise) every frame — replacing the two raw `@player_sprite.visible = !player_hidden?` call sites. `do_player_visibility`'s polarity was flipped to `cmd.param(0) == 0`.

## Test plan

- [x] Rewrote the existing `scripts/rpg2k_logic_check.rb`/`scripts/rpg2k_scene_check.rb` checks that had encoded the backwards polarity.
- [x] New `scripts/rpg2k_scene_check.rb` check: the ghost flag sets opacity 159 without ever clearing `visible`.
- [x] Verified via `git stash` on `interpreter.rb`/`map.rb`: all three affected checks fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 810 passed, `rpg2k_logic_check.rb` 1070 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_