### PR TITLE
Fix: Tile Substitution chains by current value, matching RPG_RT

### DIFF
--- a/changelog.d/tile-substitution-chains-by-current-value.fixed.md
+++ b/changelog.d/tile-substitution-chains-by-current-value.fixed.md
@@ -1,0 +1,7 @@
+- **Map:** Tile Substitution (Replace Chipset Tiles) now chains the way
+  RPG_RT does -- a later substitution whose source tile matches an earlier
+  substitution's target retargets the earlier one too, instead of being
+  applied independently. Substituting a tile back to its own original id no
+  longer undoes a prior substitution (matching RPG_RT, this never actually
+  worked that way -- reverting requires substituting from the tile's current,
+  already-rewritten id).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10602,6 +10602,43 @@ not yet verified:
   (a substitution snapshotted mid-play restores onto a freshly-built
   `Game::Map`, contrasted with the existing "leaving and returning drops it"
   check just above), all confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-20): a second Tile Substitution independently
+  replaced (rather than chained with) an earlier one, and "substituting a
+  tile back to its own original id" was modelled as reverting a prior
+  substitution — both backwards from real RPG_RT, per an earlier, uncited
+  claim on `Game::Map#substitute_tile`'s own doc comment.** Confirmed
+  directly against RPG_RT's live source: `Game_Map::DoSubstitute`
+  (`src/game_map.cpp`) operates on a *persistent* 144-entry table
+  (`map_info.lower_tiles`/`upper_tiles`, identity-initialized via
+  `std::iota` once per map load) and scans it by **current value**, not
+  original index, on every call: `for (i) if (tiles[i] == old_id) tiles[i]
+  = new_id;`. This means a later substitution whose `old_id` matches an
+  earlier `new_id` retargets the earlier entry too (chaining) rather than
+  replacing it independently, and `old_id == new_id` only resets whichever
+  slots *currently* hold that value back to it — a slot already remapped
+  away from `old_id` is untouched, so "substitute a tile back to its
+  original id" does nothing once a prior substitution has already moved it
+  elsewhere; reverting requires substituting *from* the tile's current
+  (already-rewritten) id instead. `Game::Map#substitute_tile`
+  (`mruby-rpg2k/mrblib/game.rb`) kept a flat `{original_id => new_id}` hash
+  applied once against each tile's pristine id on every read, with its own
+  comment explicitly claiming "a second substitution of the same tile
+  replaces (not chains with) the first" and "substituting a tile back to
+  itself drops the rewrite" — both uncited and, per the fetched source,
+  simply wrong. The adjacent Save/Continue round-trip code (`Game::State.
+  tile_replacement_bytes`/`.tile_replacement_hash`, part of the fix above)
+  already correctly modelled the real 144-slot identity array for
+  serialization; the bug was confined to this one live-mutation method,
+  which was never updated to match. Fixed by rewriting `#substitute_tile` to
+  scan the sparse `{original_id => current_id}` hash by current value
+  (rebuilding it: every entry whose value equals `old_id` retargets to
+  `new_id`; `old_id`'s own slot, if still implicitly identity, gets the same
+  treatment; any entry that ends up mapping back to its own key is dropped,
+  keeping the sparse "deviates from identity" invariant `#tile` and
+  `#substitution_snapshot` already rely on) — no other call site needed to
+  change. Covered by rewriting the existing `scripts/rpg2k_logic_check.rb`
+  check that had asserted the old (backwards) semantics, confirmed to fail
+  against the pre-fix code (`expected 7, got 4`).
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5719,12 +5719,23 @@ module Game
       @chipset_id = unit.chipset_id
       @lower = unit.lower_layer || []
       @upper = unit.upper_layer || []
-      # Tile Substitution (11750) rewrites, per layer: { old_id => new_id }. Kept
-      # as a lookup applied on read rather than as an edit of the layer arrays,
-      # the way RPG_RT does it — the map data stays pristine, a second
-      # substitution of the same tile replaces (not chains with) the first, and
-      # passability follows the substituted tile because every reader goes
-      # through #lower / #upper. Cleared with the map, so leaving resets it.
+      # Tile Substitution (11750) rewrites, per layer: a sparse { original_id =>
+      # current_id } deviation from identity. Kept as a lookup applied on read
+      # rather than as an edit of the layer arrays -- the map data stays
+      # pristine, and passability follows the substituted tile because every
+      # reader goes through #lower / #upper. Cleared with the map, so leaving
+      # resets it. Confirmed against RPG_RT's own live source: `Game_Map::
+      # SubstituteDown`/`SubstituteUp` (`src/game_map.cpp`) operate on a
+      # persistent 144-entry table, `map_info.lower_tiles`/`upper_tiles`,
+      # identity-initialized (`std::iota`) once per map load and mutated
+      # in place every call via `DoSubstitute`, which scans by *current*
+      # value, not original index: `for (i) if (tiles[i] == old_id) tiles[i]
+      # = new_id;`. A second substitution therefore **chains** through the
+      # first whenever its `old_id` matches the first's `new_id`, rather than
+      # independently replacing it -- and "substituting a tile back to
+      # itself" is not how a prior substitution is undone (see
+      # #substitute_tile's own doc comment for the full correction; an
+      # earlier, uncited pass here got both of these backwards).
       @substitutions = [{}, {}]
     end
 
@@ -5735,16 +5746,28 @@ module Game
     def lower(x, y); tile(@lower, 0, x, y); end
     def upper(x, y); tile(@upper, 1, x, y); end
 
-    # Tile Substitution: from now on draw (and treat) every `old_id` tile on
-    # `layer` (0 lower, 1 upper) as `new_id`. Substituting a tile back to itself
-    # drops the rewrite.
+    # Tile Substitution: from now on draw (and treat) as `new_id` every tile on
+    # `layer` (0 lower, 1 upper) that *currently* renders as `old_id` -- not
+    # just tiles whose original chipset id is `old_id`. Confirmed against
+    # RPG_RT's own live source (`Game_Map::DoSubstitute`, `src/game_map.cpp`,
+    # see the constructor's fuller citation): it scans the persistent
+    # substitution table by current value every call, so a later
+    # substitution chains through an earlier one whenever its `old_id`
+    # matches the earlier `new_id` -- e.g. substituting 5->8 then 8->12
+    # leaves *both* original tiles 5 and 8 rendering as 12, not tile 5 stuck
+    # at 8. `old_id == new_id` is not a special "undo" case either: it only
+    # resets whichever tiles currently render as `old_id` back to `old_id`
+    # (a no-op for most of them) -- reverting a specific earlier
+    # substitution means substituting *from* its current (already-rewritten)
+    # id, not its original one.
     def substitute_tile(layer, old_id, new_id)
-      table = @substitutions[layer == 0 ? 0 : 1]
-      if old_id == new_id
-        table.delete(old_id)
-      else
-        table[old_id] = new_id
-      end
+      idx = layer == 0 ? 0 : 1
+      rebuilt = {}
+      @substitutions[idx].each { |k, v| rebuilt[k] = v == old_id ? new_id : v }
+      rebuilt[old_id] = new_id unless rebuilt.key?(old_id)
+      table = {}
+      rebuilt.each { |k, v| table[k] = v unless k == v }
+      @substitutions[idx] = table
       @revision += 1
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -16032,15 +16032,35 @@ check 'Tile Substitution rewrites a tile on the map and flags a redraw' do
   eq false, it.take_tiles_changed, 'the flag is one-shot'
 end
 
-check 'Game::Map substitutions are per layer and undone by an identity swap' do
+# Confirmed against RPG_RT's own live source: `Game_Map::DoSubstitute`
+# (`src/game_map.cpp`) scans its persistent substitution table by *current*
+# value every call (`for (i) if (tiles[i] == old_id) tiles[i] = new_id;`),
+# not by each tile's original chipset id -- so a later substitution chains
+# through an earlier one whenever its `old_id` matches the earlier `new_id`,
+# and "substituting a tile back to its original id" does not undo a prior
+# substitution once the tile's current value has moved on. An earlier,
+# uncited pass here modelled both of these the opposite way.
+check 'Game::Map substitutions are per layer and chain by current value, ' \
+      'not by original id' do
   m = fake_map_2x2([1, 1, 1, 1], [1, 1, 1, 1])
-  m.substitute_tile(1, 1, 4) # upper only
+  m.substitute_tile(1, 1, 4) # upper: every tile originally 1 now shows 4
   eq 1, m.lower(0, 0)
   eq 4, m.upper(0, 0)
   ok m.substituted?
-  m.substitute_tile(1, 1, 1) # back to itself: drop the rewrite
-  eq 1, m.upper(0, 0)
-  ok !m.substituted?
+
+  # Chaining: retargets the earlier substitution rather than replacing it.
+  m.substitute_tile(1, 4, 7)
+  eq 7, m.upper(0, 0), 'chained through the first substitution (1 -> 4 -> 7)'
+
+  # "Back to its original id" is not how a substitution is undone: the
+  # tile's slot currently holds 7, not 1, so re-substituting old_id 1 (its
+  # original chipset id) touches nothing.
+  m.substitute_tile(1, 1, 1)
+  eq 7, m.upper(0, 0), 'substituting the original id again has no effect once chained away'
+
+  # Reverting means substituting FROM the tile's *current* id.
+  m.substitute_tile(1, 7, 1)
+  eq 1, m.upper(0, 0), 'substituting from the current id reverts the visible tile'
 end
 
 check 'Open Save Menu and Open Main Menu pause on their own wait kinds' do


### PR DESCRIPTION
## Summary

- `Game_Map::DoSubstitute` (`src/game_map.cpp`) operates on a *persistent* 144-entry table (`map_info.lower_tiles`/`upper_tiles`, identity-initialized via `std::iota` once per map load) and scans it by **current value**, not original tile index, on every call: `for (i) if (tiles[i] == old_id) tiles[i] = new_id;`. This means a later substitution whose `old_id` matches an earlier `new_id` retargets the earlier entry too (chaining) rather than replacing it independently, and `old_id == new_id` only resets whichever slots *currently* hold that value — a slot already remapped away from `old_id` is untouched, so "substitute a tile back to its original id" does not undo a prior substitution once it has already moved elsewhere; reverting requires substituting *from* the tile's current (already-rewritten) id instead.
- `Game::Map#substitute_tile` (`mruby-rpg2k/mrblib/game.rb`) kept a flat `{original_id => new_id}` hash applied once against each tile's pristine id on every read, with its own comment explicitly (and, per the fetched source, wrongly) claiming "a second substitution of the same tile replaces (not chains with) the first" and "substituting a tile back to itself drops the rewrite" — both uncited. The adjacent Save/Continue round-trip code already correctly modelled the real 144-slot identity array for serialization; the bug was confined to this one live-mutation method, which was never updated to match.
- Fixed by rewriting `#substitute_tile` to scan the sparse `{original_id => current_id}` hash by current value (rebuild it: every entry whose value equals `old_id` retargets to `new_id`; `old_id`'s own slot, if still implicitly identity, gets the same treatment; any entry that ends up mapping back to its own key is dropped, keeping the sparse "deviates from identity" invariant `#tile`/`#substitution_snapshot` already rely on). No other call site needed to change.

## Test plan

- [x] Rewrote the existing `scripts/rpg2k_logic_check.rb` check that had asserted the old (backwards) semantics — now covers chaining, "back to original id has no effect once chained away," and "revert by substituting from the current id."
- [x] Verified via `git stash` on `game.rb` alone: fails pre-fix (`expected 7, got 4`).
- [x] Full suite green: `rpg2k_logic_check.rb` 1070 passed, `rpg2k_scene_check.rb` 810 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_