### PR TITLE
Fix: Enter Hero Name refuses a blank confirm instead of resuming with one

### DIFF
--- a/changelog.d/name-input-blank-confirm-refuses.fixed.md
+++ b/changelog.d/name-input-blank-confirm-refuses.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** Confirming the Enter Hero Name widget with nothing typed no
+  longer closes it and resumes the event with a blank name -- matching
+  RPG_RT, it refills the field with the actor's current name and stays open,
+  requiring a second (now non-blank) confirm to actually leave. Applies to
+  both the letters page and the kana grids.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4489,6 +4489,41 @@ The work below is roughly ordered by the critical path to a walkable game
   `.triggered`, still moves both the ASCII and kana grid cursors), both
   confirmed to fail against the pre-fix code (`expected 1, got 0`) before
   the fix.
+  ✅ **Follow-up (2026-08-20): confirming the OK/DONE cell with nothing
+  typed closed the widget and resumed the event with a blank name, instead
+  of refusing the blank confirm the way real RPG_RT does.** Confirmed
+  directly against RPG_RT's live source: `Scene_Name::vUpdate`'s DONE branch
+  (`src/scene_name.cpp`) is `if (name_window->Get().empty()) { name_window
+  ->Set(ToString(actor.GetName())); name_window->Refresh(); } else {
+  actor.SetName(name_window->Get()); Scene::Pop(); }` — a blank confirm
+  resets the field to the actor's *current* name and leaves the screen
+  open; the player must confirm a second time (now non-blank) to actually
+  leave. This check lives in the single shared `vUpdate`, gated only on
+  which cell was picked, so it applies identically to every keyboard page
+  (the kana grids included — RPG2000/2003 share one `Scene_Name`), not just
+  the Latin-alphabet one. This is the *opposite* correction from the
+  already-fixed Change Actor Name (10610) blank-string bug elsewhere in this
+  document (that command's own C++ source has no blank guard at all,
+  unconditional `SetName`) — the two commands needed opposite fixes, and
+  only one of them had been made; `#name_input_cancel`'s Cancel-key branch
+  (the SE-pass bullet above) was already ported correctly from this exact
+  function, only the sibling DONE branch was missed.
+  `Scene::Map#commit_name_input` (`mruby-rpg2k/mrblib/scene/map.rb`), the
+  shared target both `#name_input_confirm`'s `'OK'` cell and
+  `#kana_name_input_confirm`'s `:confirm` cell dispatch to, unconditionally
+  did `close_name_input; interp.resume_name_input(name)` with no blank
+  check. Fixed by checking `@name_ui[:name].empty?` first: if so, look the
+  actor back up (`#roster_actor`, the same helper `#draw_kana_name_input`'s
+  face panel already uses) and refill `@name_ui[:name]` with its current
+  name, redraw (`#draw_kana_name_input`/`#draw_name_input`) and return,
+  skipping the close/resume entirely. `#drive_name_input`'s Latin-page
+  branch built its `@name_ui` hash without an `actor_id:` field at all
+  (only the kana branch had one) — added for parity, since the refill now
+  needs it on both pages. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (one per keyboard page: confirming blank refills the field and
+  keeps the widget open without resuming the event; confirming again with
+  the refilled name then closes it normally), both confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **The same "silent embedded widget" family, found once more: Open Shop
   and Show Inn played zero sound effects at all (2026-08-18).** Verified
   against RPG_RT's actual behavior via EasyRPG Player's own C++ source,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5508,7 +5508,7 @@ class RPG2k
           background = build_field_background(@windowskin)
           if req[:charset] == 2
             @name_ui = { name: req[:seed] || '', sel: 0, win: nil, kana: false,
-                         background: background, interp: it }
+                         actor_id: req[:actor_id], background: background, interp: it }
             draw_name_input
           else
             @name_ui = { name: req[:seed] || '', sel: 0, kana: true,
@@ -5619,9 +5619,27 @@ class RPG2k
         @name_ui[:kana] ? draw_kana_name_input : draw_name_input
       end
 
+      # A blank confirm does not close the widget -- confirmed against
+      # RPG_RT's own live source: `Scene_Name::vUpdate`'s DONE branch
+      # (`src/scene_name.cpp`) is `if (name_window->Get().empty()) {
+      # name_window->Set(ToString(actor.GetName())); name_window->Refresh();
+      # } else { actor.SetName(...); Scene::Pop(); }` -- an empty typed name
+      # resets the field back to the actor's current name and leaves the
+      # screen open, rather than resuming the event with an empty string.
+      # This check lives in the single shared `vUpdate` (gated only on
+      # which cell was picked), so it applies identically to every keyboard
+      # page -- the kana grid's own :confirm cell routes through this same
+      # method.
       def commit_name_input
-        name = @name_ui[:name]
-        interp = @name_ui[:interp]
+        ui = @name_ui
+        if ui[:name].empty?
+          actor = roster_actor(ui[:actor_id])
+          ui[:name] = actor ? actor.name.to_s : ''
+          ui[:kana] ? draw_kana_name_input : draw_name_input
+          return
+        end
+        name = ui[:name]
+        interp = ui[:interp]
         close_name_input
         interp.resume_name_input(name)
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7568,6 +7568,50 @@ check 'Enter Hero Name: typing on the grid and confirming renames the actor' do
   ok st.switches[5], 'the event resumed after entry'
 end
 
+# Confirmed against RPG_RT's own live source: `Scene_Name::vUpdate`'s DONE
+# branch (`src/scene_name.cpp`) is `if (name_window->Get().empty()) {
+# name_window->Set(ToString(actor.GetName())); name_window->Refresh(); }
+# else { actor.SetName(...); Scene::Pop(); }` -- an empty typed name resets
+# the field to the actor's current name and leaves the screen open, rather
+# than resuming the event with a blank name.
+check 'Enter Hero Name: confirming a blank name refills it and stays open, ' \
+      'instead of resuming the event' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::NAME_INPUT, [1, 2, 0], indent: 0), # actor 1, letters, no seed
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  6.times do
+    scene.update
+    break if scene.instance_variable_get(:@name_ui)
+  end
+  ui = scene.instance_variable_get(:@name_ui)
+  eq '', ui[:name], 'starts empty (no seed)'
+
+  # Confirm the OK cell straight away, with nothing typed.
+  ui[:sel] = RPG2k::Scene::Map::NAME_CELLS.length - 1
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok scene.instance_variable_get(:@name_ui), 'the widget stays open on a blank confirm'
+  eq 'Hero', ui[:name], "refilled with the actor's current name"
+  eq 'Hero', st.party.actor_by_id(1).name, 'the actor itself is untouched so far'
+
+  # Confirming again now commits the refilled (non-blank) name.
+  ui[:sel] = RPG2k::Scene::Map::NAME_CELLS.length - 1
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq nil, scene.instance_variable_get(:@name_ui), 'now the widget closes'
+  eq 'Hero', st.party.actor_by_id(1).name
+  3.times { scene.update }
+  ok st.switches[5], 'and the event resumed'
+end
+
 check 'Enter Hero Name plays the RPG_RT system SE on every interaction' do
   # Confirmed against EasyRPG's Scene_Name::vUpdate (src/scene_name.cpp,
   # Cursor on every grid move, Decision unconditionally on every C press
@@ -7828,6 +7872,51 @@ check 'Enter Hero Name: typing a kana and confirming renames the actor' do
   eq nil, scene.instance_variable_get(:@name_ui), 'the widget closed'
   3.times { scene.update }
   ok st.switches[5], 'the event resumed after entry'
+end
+
+# Same DONE/blank-confirm refusal as the letters page (see the earlier check's
+# citation) -- the kana grid's :confirm cell routes through the identical
+# #commit_name_input.
+check 'Enter Hero Name: confirming a blank kana name refills it and stays ' \
+      'open, instead of resuming the event' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::NAME_INPUT, [1, 0, 0], indent: 0), # actor 1, hiragana, no seed
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  6.times do
+    scene.update
+    break if scene.instance_variable_get(:@name_ui)
+  end
+  ui = scene.instance_variable_get(:@name_ui)
+  eq '', ui[:name], 'starts empty (no seed)'
+
+  rows = RPG2k::Scene::Map::NAME_HIRAGANA_ROWS
+  cols = RPG2k::Scene::Map::NAME_KANA_COLS
+  last_row = rows.length - 1
+  ui[:sel] = last_row * cols + (rows[last_row].length - 1)
+
+  # Confirm the :confirm cell straight away, with nothing typed.
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok scene.instance_variable_get(:@name_ui), 'the widget stays open on a blank confirm'
+  eq 'Hero', ui[:name], "refilled with the actor's current name"
+  eq 'Hero', st.party.actor_by_id(1).name, 'the actor itself is untouched so far'
+
+  # Confirming again now commits the refilled (non-blank) name.
+  ui[:sel] = last_row * cols + (rows[last_row].length - 1)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq nil, scene.instance_variable_get(:@name_ui), 'now the widget closes'
+  eq 'Hero', st.party.actor_by_id(1).name
+  3.times { scene.update }
+  ok st.switches[5], 'and the event resumed'
 end
 
 check 'Enter Hero Name: the toggle cell swaps the hiragana/katakana page' do


### PR DESCRIPTION
## Summary

- `Scene_Name::vUpdate`'s DONE branch (`src/scene_name.cpp`) is `if (name_window->Get().empty()) { name_window->Set(ToString(actor.GetName())); name_window->Refresh(); } else { actor.SetName(name_window->Get()); Scene::Pop(); }` — a blank confirm resets the field to the actor's *current* name and leaves the screen open; the player must confirm a second time (now non-blank) to actually leave. This lives in the single shared `vUpdate`, gated only on which cell was picked, so it applies identically to the Latin-alphabet page and both kana grids (RPG2000/2003 share one `Scene_Name`).
- This is the *opposite* correction from the already-fixed Change Actor Name (10610) blank-string bug documented elsewhere in `docs/TODO.md` — that command's own C++ source has no blank guard at all (unconditional `SetName`). The two commands needed opposite fixes, and only one had been made; the Cancel-key branch of the name widget was already ported correctly from this exact function, only the sibling DONE branch was missed.
- `Scene::Map#commit_name_input` (`mruby-rpg2k/mrblib/scene/map.rb`), the shared target both keyboard pages' confirm cell dispatch to, unconditionally did `close_name_input; interp.resume_name_input(name)` with no blank check.
- Fixed by checking `@name_ui[:name].empty?` first: if so, look the actor back up (`#roster_actor`, the same helper the kana panel's face draw already uses) and refill `@name_ui[:name]` with its current name, redraw and return — skipping the close/resume entirely. `#drive_name_input`'s Latin-page branch was missing an `actor_id:` field in its `@name_ui` hash (only the kana branch had one); added for parity since the refill needs it on both pages.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks (one per keyboard page): confirming blank refills the field and keeps the widget open without resuming the event; confirming again with the refilled name then closes it normally.
- [x] Verified via `git stash` on `map.rb` alone: both new checks fail pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 812 passed, `rpg2k_logic_check.rb` 1070 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_