### PR TITLE
Add: field Status screen shows a labelled Class row

### DIFF
--- a/changelog.d/status-menu-class-row.added.md
+++ b/changelog.d/status-menu-class-row.added.md
@@ -1,0 +1,3 @@
+- **Field menu:** The Status screen now shows a labelled Class/Profession row
+  for the selected party member, matching RPG_RT -- blank for an RPG2000
+  database with no job table, the class name for an RPG2003 actor with one.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14925,6 +14925,39 @@ label" rendering, the identical no-space convention `Scene::Map`'s shop gold
 panel already uses. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
 nonzero Gold figure renders as its own line; Gold still shows at exactly 0),
 confirmed to fail against the pre-fix code.
+✅ **Follow-up (2026-08-20): the field Status screen never drew a Class
+(Profession/Job) row at all, under any circumstances.** Confirmed directly
+against RPG_RT's live source: `Window_ActorInfo::DrawInfo`
+(`src/window_actorinfo.cpp`) always draws a labelled Class row — `TextDraw(0,
+82, ..., "Class"); DrawActorClass(actor, 36, 98);` — between Name and Title,
+with no version gate around it at all (unlike the RPG2003-only Row-formation
+line at the very top of the same function), so it draws for RPG2000-format
+saves too, just blank when no job table/class is set. `Game_Actor::
+GetClassName` (`src/game_actor.cpp`) resolves via `GetClass()`
+unconditionally — `data.class_id`, falling back to the database actor's own
+starting `class_id` when no Change Class event has run yet — with **no**
+gate on whether a live Change Class has ever fired; that gate only governs
+the separate "class settings" (`super_guard`/`lock_equipment`/
+`battler_animation`/etc.) `ChangeClass` itself applies, per its own comment
+already quoted elsewhere in this document. `easyrpg_status_scene_class` has
+no counterpart in RPG_RT's own Term chunk (an EasyRPG-only extension term,
+confirmed against liblcf's generated `terms.h`: `easyrpg_`-prefixed,
+`kDefaultTerm` fallback), so real RPG_RT hardcodes the English label "Class",
+matching this codebase's own `order.rb` precedent for "Confirm"/"Redo".
+`Game::Actor` (`mruby-rpg2k/mrblib/game.rb`) already resolves and holds
+`@class_row` unconditionally at construction (`#set_class_id`, called from
+`#initialize` off the actor's own starting `class_id`, independent of the
+`@class_changed` flag that correctly still gates the *growth-curve* readers)
+but exposed no accessor for it at all. Fixed by adding a new
+`Game::Actor#class_name` reader (`@class_row ? @class_row.name.to_s : ''`,
+deliberately not gated on `@class_changed`) and inserting a
+`"Class: #{a.class_name}"` line into `Scene::StatusMenu#build_window`
+between the Name/Title header and the Level/EXP line — `STATE_ROW` bumped
+from 4 to 5 to track the shifted line index the state-value draw position
+depends on. Covered by a new `scripts/rpg2k_scene_check.rb` check (a blank
+Class row with the bare fixture actor, matching RPG2000's no-job-table case;
+a classed fixture actor shows its class name), confirmed to fail against the
+pre-fix code.
 ✅ **A dangling battle-animation id no longer draws nothing with no trace** —
 the "battle animation" case from the "invalid hero, skill, item, enemy,
 enemy group, battle animation, terrain, chipset, common event" list above.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1477,6 +1477,21 @@ module Game
     # branch on `class_id > 0`).
     attr_reader :class_id
 
+    # The class row's own display name ('' with no class row -- an RPG2000
+    # database, or an unknown/class-less id). Unlike the growth-curve/
+    # battler-animation readers below, this is *not* gated on
+    # `@class_changed`: confirmed against RPG_RT's own live source,
+    # `Game_Actor::GetClassName` (`src/game_actor.cpp`) reads straight
+    # through `GetClass()`, which resolves `data.class_id` (falling back to
+    # the database actor's own starting `class_id` when no Change Class
+    # event has run yet) with no such gate at all -- `@class_changed` only
+    # governs the separate "class settings" (`super_guard`/`lock_equipment`/
+    # `battler_animation`/etc.) `ChangeClass` itself applies, per that
+    # function's own comment already quoted above. `@class_row` is already
+    # populated unconditionally at construction from the actor's starting
+    # class id, so this just reads it straight.
+    def class_name; @class_row ? @class_row.name.to_s : ''; end
+
     def initialize(db, id)
       @db = db
       @id = id

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -11,7 +11,7 @@ class RPG2k
       LINE_H = 16
       # The condition row: which line of the panel it is, its label, and where
       # the state itself starts (clear of the label).
-      STATE_ROW = 4
+      STATE_ROW = 5
       STATE_LABEL = "State".freeze
       STATE_VALUE_X = 48
 
@@ -107,6 +107,18 @@ class RPG2k
         nxt = a.exp_to_next
         lines = [
           header,
+          # RPG_RT always draws a labelled Class/Profession row on this
+          # screen too, between Name and Title -- confirmed against
+          # `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`):
+          # `TextDraw(..., "Class"); DrawActorClass(actor, ...)`, with no
+          # version gate around it (unlike the RPG2003-only Row line just
+          # above it in the same function), so it draws blank rather than
+          # being omitted for an RPG2000 database with no class table.
+          # `easyrpg_status_scene_class` has no counterpart in RPG_RT's own
+          # Term chunk (an EasyRPG-only extension term), so real RPG_RT
+          # hardcodes the English label, matching this codebase's own
+          # `order.rb` precedent for "Confirm"/"Redo".
+          "Class: #{a.respond_to?(:class_name) ? a.class_name : ''}",
           "#{term(:level_short, 'Lv')} #{a.level}    " \
           "#{term(:exp_short, 'EXP')} #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
           "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}    " \

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19063,6 +19063,27 @@ check 'Scene::EquipMenu: a dangling equipped item id logs once, not per rebuild,
   ok out2.empty?, "re-rendering the already-warned id must stay silent, got: #{out2.inspect}"
 end
 
+# Confirmed against RPG_RT's own live source: `Window_ActorInfo::DrawInfo`
+# (`src/window_actorinfo.cpp`) always draws a labelled Class/Profession row
+# (`TextDraw(..., "Class"); DrawActorClass(actor, ...)`), with no version
+# gate around it -- an RPG2000 database with no class table still gets the
+# row, just blank.
+check 'the status screen shows a labelled Class row' do
+  st = menu_state
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
+                         .instance_variable_get(:@window))
+  ok texts.any? { |t| t.start_with?('Class:') },
+     "the row is labelled even with no class (RPG2000), got: #{texts.inspect}"
+  eq 'Class: ', texts.find { |t| t.start_with?('Class:') },
+     'blank value with no class table'
+
+  classed = Class.new(MenuStubActor) { def class_name; 'Paladin'; end }.new
+  st.party.instance_variable_set(:@actors, [classed])
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
+                         .instance_variable_get(:@window))
+  ok texts.include?('Class: Paladin'), "shows the class name, got: #{texts.inspect}"
+end
+
 check 'the status screen gives the condition a labelled row' do
   st = menu_state
   texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)


### PR DESCRIPTION
## Summary

- `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`) always draws a labelled Class row — `TextDraw(0, 82, ..., "Class"); DrawActorClass(actor, 36, 98);` — between Name and Title, with no version gate around it at all (unlike the RPG2003-only Row-formation line at the top of the same function), so it draws for RPG2000-format saves too, just blank when no job table/class is set.
- `Game_Actor::GetClassName` (`src/game_actor.cpp`) resolves via `GetClass()` unconditionally — `data.class_id`, falling back to the database actor's own starting `class_id` when no Change Class event has run yet — with **no** gate on whether a live Change Class has ever fired; that gate only governs the separate "class settings" (`super_guard`/`lock_equipment`/`battler_animation`/etc.) `ChangeClass` itself applies.
- `easyrpg_status_scene_class` has no counterpart in RPG_RT's own Term chunk (an EasyRPG-only extension term, confirmed against liblcf's generated `terms.h`), so real RPG_RT hardcodes the English label "Class", matching this codebase's own `order.rb` precedent for "Confirm"/"Redo".
- `Game::Actor` (`mruby-rpg2k/mrblib/game.rb`) already resolves and holds `@class_row` unconditionally at construction (`#set_class_id`, called off the actor's own starting `class_id`, independent of the `@class_changed` flag that correctly still gates the growth-curve readers) but exposed no accessor for it at all.
- Fixed by adding a new `Game::Actor#class_name` reader (deliberately not gated on `@class_changed`) and inserting a `"Class: #{a.class_name}"` line into `Scene::StatusMenu#build_window` between the Name/Title header and the Level/EXP line — `STATE_ROW` bumped from 4 to 5 to track the shifted line index the state-value draw position depends on.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a blank Class row with the bare fixture actor (matching RPG2000's no-job-table case); a classed fixture actor shows its class name.
- [x] Verified via `git stash` on `game.rb`/`status_menu.rb`: fails pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 813 passed, `rpg2k_logic_check.rb` 1070 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_