### PR TITLE
Fix: battle-event message window sits at the bottom for RPG2000, top for RPG2003

### DIFF
--- a/changelog.d/battle-event-message-position-by-edition.fixed.md
+++ b/changelog.d/battle-event-message-position-by-edition.fixed.md
@@ -1,0 +1,4 @@
+- **Battle:** A troop battle-event page's Show Message/Show Choices window
+  now sits at the bottom of the screen for an RPG2000 database, matching
+  RPG_RT -- previously it always drew at the top regardless of edition. An
+  RPG2003 database still shows it at the top.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9813,6 +9813,35 @@ not yet verified:
    animation collapses to the single screen-centre target with no enemy
    sprite flashed), both confirmed against the prior single-target-only
    behaviour.
+- ✅ **A troop battle-event page's Show Message/Show Choices window always
+  drew at the top of the screen, when real RPG_RT positions it there only
+  for an RPG2003 database — an RPG2000 database (this project's primary
+  target) shows it at the bottom instead.** Confirmed directly against
+  RPG_RT's live source: `Game_Message::GetRealPosition`
+  (`src/game_message.cpp`) is `if (Game_Battle::IsBattleRunning()) { return
+  Feature::HasRpg2kBattleSystem() ? 2 : 0; }` — position 2 (bottom) for an
+  RPG2000 database, position 0 (top) for RPG2003 — overriding any
+  Message-Options position entirely while a battle is running.
+  `Feature::HasRpg2kBattleSystem` (`src/feature.cpp`) is a pure
+  database-edition check (`Player::IsRPG2k()`), unrelated to `battle_type`/
+  gauge mode, so this is a base RPG2000-vs-RPG2003 difference, not a
+  gauge-battle-only one. `Scene::Battle::BATTLE_EVENT_MSG_Y`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) hardcoded the top position for
+  every edition, justified only by an uncited internal design rationale
+  ("so a page talking mid-round does not fight the action banner for the
+  same row") with no RPG_RT citation at all — the same class's own
+  `RPG2k3::Scene::Battle` (`battle_rpg2k3.rb`) never overrode it either, so
+  both editions inherited the single hardcoded top position. Fixed by
+  making `#battle_text_window` (the message panel's one build site, called
+  only from `#drive_battle_event_message`) pick the position itself off
+  `@state.party.rpg2003?` — `BATTLE_EVENT_MSG_Y` (top) for RPG2003, or
+  flush against the screen's bottom edge (`SCREEN_H - inner_h -
+  Window::BORDER * 2`, computed from the panel's own content height since
+  this codebase's message panel is content-fit rather than RPG_RT's fixed
+  size) for RPG2000. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  (an RPG2000 battle-event message sits flush against the bottom edge; an
+  RPG2003 one sits at `BATTLE_EVENT_MSG_Y`), confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **Weather Effects now clamps an RPG2003-only weather type back to none on
   RPG2000, and clamps strength to at most 2 on every edition — both used to
   be stored verbatim off the raw command bytes with no bound at all.**

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -804,8 +804,18 @@ class RPG2k
         bmp
       end
 
-      # Where a battle-event page's message panel sits — above the action banner,
-      # so a page talking mid-round does not fight it for the same row.
+      # Where a battle-event page's message panel sits when the database is
+      # RPG2003 -- the top of the screen. Confirmed against RPG_RT's own live
+      # source: `Game_Message::GetRealPosition` (`src/game_message.cpp`) is
+      # `if (Game_Battle::IsBattleRunning()) { return Feature::
+      # HasRpg2kBattleSystem() ? 2 : 0; }` -- position 2 (bottom) for an
+      # RPG2000 database, position 0 (top) for RPG2003 -- overriding any
+      # Message-Options position entirely while a battle is running.
+      # `Feature::HasRpg2kBattleSystem` (`src/feature.cpp`) is a pure
+      # database-edition check (`Player::IsRPG2k()`), unrelated to
+      # `battle_type`/gauge mode. See `#battle_text_window`, which picks
+      # between this and the bottom (`BATTLE_PANEL_Y`, content-height
+      # adjusted) by `@state.party.rpg2003?`.
       BATTLE_EVENT_MSG_Y = 8
 
       # The backdrop this encounter fights over. Enemy Encounter's own param2
@@ -2403,8 +2413,7 @@ class RPG2k
       def drive_battle_event_message(it)
         unless @ui[:event_win]
           lines = it.wait_kind == :choice ? it.choice_labels : it.message_lines
-          @ui[:event_win] =
-            battle_text_window(lines || [], BATTLE_EVENT_MSG_Y, 340)
+          @ui[:event_win] = battle_text_window(lines || [], 340)
           return # shown this frame; take the button from the next one
         end
         return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
@@ -3636,14 +3645,14 @@ class RPG2k
         win
       end
 
-      # A text panel of `lines` at vertical position `y` and depth `z`, sized to
-      # fit its content -- used for the battle-event page message window, which
-      # this screen deliberately keeps off the bottom panel's rect (see
-      # `BATTLE_EVENT_MSG_Y`) so a page talking mid-round does not fight the
-      # action banner for the same row.
-      def battle_text_window(lines, y, z)
+      # A text panel of `lines` at depth `z`, sized to fit its content -- used
+      # for the battle-event page message window. Positioned at the top
+      # (`BATTLE_EVENT_MSG_Y`) for an RPG2003 database, or flush against the
+      # bottom edge for RPG2000 -- see that constant's own citation.
+      def battle_text_window(lines, z)
         inner_w = SCREEN_W - 20 - Window::BORDER * 2
         inner_h = [lines.length, 1].max * BATTLE_LINE_H
+        y = @state.party.rpg2003? ? BATTLE_EVENT_MSG_Y : SCREEN_H - inner_h - Window::BORDER * 2
         win = Window.new(10, y, SCREEN_W - 20, inner_h + Window::BORDER * 2)
         win.z = z
         win.windowskin = windowskin

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13815,6 +13815,43 @@ check 'a battle page shows its message in a battle panel and waits for a key' do
      'the panel closed with the message'
 end
 
+# Confirmed against RPG_RT's own live source: `Game_Message::
+# GetRealPosition` (`src/game_message.cpp`) is `if (Game_Battle::
+# IsBattleRunning()) { return Feature::HasRpg2kBattleSystem() ? 2 : 0; }` --
+# position 2 (bottom) for an RPG2000 database, position 0 (top) for
+# RPG2003 -- overriding any Message-Options position outright while a
+# battle is running. `Feature::HasRpg2kBattleSystem` (`src/feature.cpp`) is
+# a pure database-edition check, unrelated to `battle_type`/gauge mode.
+check 'a battle-event page message sits at the bottom for RPG2000, the ' \
+      'top for RPG2003' do
+  ic = Game::Interpreter::Cmd
+  pages2k = { 1 => troop_page([ECmd.new(ic::SHOW_MESSAGE, [], string: 'Hi')]) }
+  scene, _st = battle_scene_with_pages(pages2k)
+  90.times do
+    scene.update
+    ui = battle_ui(scene)
+    break if ui && ui[:event_win]
+  end
+  win2k = battle_ui(scene)[:event_win]
+  ok win2k, 'the message panel is up'
+  eq RPG2k::Scene::Battle::SCREEN_H - win2k.height, win2k.y,
+     'RPG2000 sits flush against the bottom edge'
+
+  pages2k3 = { 1 => troop_page([ECmd.new(ic::SHOW_MESSAGE, [], string: 'Hi')]) }
+  scene3, _st3 = battle_scene_with_pages(
+    pages2k3, rpg2003: true, party: BattleStubParty.new(rpg2003: true),
+    battlecommands: OpenStruct.new(battle_type: 0, placement: 1)
+  )
+  90.times do
+    scene3.update
+    ui = battle_ui(scene3)
+    break if ui && ui[:event_win]
+  end
+  win2k3 = battle_ui(scene3)[:event_win]
+  ok win2k3, 'the message panel is up'
+  eq RPG2k::Scene::Battle::BATTLE_EVENT_MSG_Y, win2k3.y, 'RPG2003 sits at the top'
+end
+
 check 'a hidden troop member is not targetable until it is revealed' do
   scene, _st = battle_scene_with_pages(nil)
   90.times do


### PR DESCRIPTION
## Summary

- `Game_Message::GetRealPosition` (`src/game_message.cpp`) is `if (Game_Battle::IsBattleRunning()) { return Feature::HasRpg2kBattleSystem() ? 2 : 0; }` — position 2 (bottom) for an RPG2000 database, position 0 (top) for RPG2003 — overriding any Message-Options position entirely while a battle is running. `Feature::HasRpg2kBattleSystem` (`src/feature.cpp`) is a pure database-edition check (`Player::IsRPG2k()`), unrelated to `battle_type`/gauge mode, so this is a base RPG2000-vs-RPG2003 difference, not a gauge-battle-only one.
- `Scene::Battle::BATTLE_EVENT_MSG_Y` (`mruby-rpg2k/mrblib/scene/battle.rb`) hardcoded the top position for every edition, justified only by an uncited internal design rationale ("so a page talking mid-round does not fight the action banner for the same row") with no RPG_RT citation at all. `RPG2k3::Scene::Battle` never overrode it either, so both editions inherited the single hardcoded top position.
- Fixed by making `#battle_text_window` (the message panel's one build site) pick the position itself off `@state.party.rpg2003?` — `BATTLE_EVENT_MSG_Y` (top) for RPG2003, or flush against the screen's bottom edge (computed from the panel's own content height, since this codebase's message panel is content-fit rather than RPG_RT's fixed size) for RPG2000.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: an RPG2000 battle-event message sits flush against the bottom edge; an RPG2003 one sits at `BATTLE_EVENT_MSG_Y`.
- [x] Verified via `git stash` on `battle.rb` alone: fails pre-fix.
- [x] Full suite green: `rpg2k_scene_check.rb` 814 passed, `rpg2k_logic_check.rb` 1070 passed, `rpg2k3_battle_row_check.rb` 18 passed, `rpg2k3_battle_gauge_check.rb` 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_