### PR TITLE
Fix: field Status screen shows RPG2003 Front/Back battle-row label

### DIFF
--- a/changelog.d/status-screen-battle-row.fixed.md
+++ b/changelog.d/status-screen-battle-row.fixed.md
@@ -1,0 +1,6 @@
+- **Status screen:** On an RPG2003 database, the field Status screen now
+  shows a right-aligned "Front"/"Back" label for the displayed actor's
+  current battle row, matching RPG_RT's `Window_ActorInfo::DrawInfo` --
+  previously the screen never drew it at all, even though the row itself was
+  already tracked and toggleable from the field menu's own Row command. An
+  RPG2000 database still shows neither label.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14987,6 +14987,33 @@ depends on. Covered by a new `scripts/rpg2k_scene_check.rb` check (a blank
 Class row with the bare fixture actor, matching RPG2000's no-job-table case;
 a classed fixture actor shows its class name), confirmed to fail against the
 pre-fix code.
+✅ **Follow-up (2026-08-20): on an RPG2003 database, the field Status screen
+never showed which battle row (Front/Back) the displayed actor is
+currently in.** Confirmed directly against RPG_RT's live source:
+`Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`) draws
+`"Front"`/`"Back"` right-aligned at the top of the panel, above the
+face/name block, whenever `Feature::HasRow()` holds. `Feature::HasRow`
+(`src/feature.cpp`) is `HasRpg2k3BattleSystem() &&
+!battlecommands.easyrpg_disable_row_feature` — the second half is an
+EasyRPG-only extension flag with no real LCF field, so for a genuine,
+unmodified project this reduces to a plain database-edition check: shown
+on RPG2003, never on RPG2000. `easyrpg_status_scene_back`/`_front` are
+likewise EasyRPG-only Term extensions absent from RPG_RT's own Term
+chunk, so real RPG_RT hardcodes the literal English labels, the same
+situation the Class row fix (above) already found for its own label.
+The underlying row data was already fully modeled here —
+`Game::Actor#battle_row`/`#battle_row=` (`mruby-rpg2k/mrblib/game.rb`),
+persisted to save data, and already toggled live from the field menu's
+own Row command (`Game::Party#toggle_actor_row`) — only the Status
+screen's own `#build_window` (`mruby-rpg2k/mrblib/scene/status_menu.rb`)
+never read it. Fixed by adding `#rpg2003_party?`/`#draw_battle_row`,
+gated on `@state.party.rpg2003?` (this codebase's established
+RPG2003-presentation gate) and drawn after the flat line pass so it can
+sit right-aligned in the header's own row without disturbing the
+existing left-aligned lines. Covered by a new
+`scripts/rpg2k_scene_check.rb` check (an RPG2000 party draws neither
+label; an RPG2003 party shows "Front" by default and "Back" once the
+actor's own row is toggled), confirmed to fail against the pre-fix code.
 ✅ **A dangling battle-animation id no longer draws nothing with no trace** —
 the "battle animation" case from the "invalid hero, skill, item, enemy,
 enemy group, battle animation, terrain, chipset, common event" list above.

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -147,7 +147,33 @@ class RPG2k
         end
         draw_actor_state c, a, STATE_VALUE_X, STATE_ROW * LINE_H,
                          inner_w - STATE_VALUE_X, LINE_H, @skin
+        draw_battle_row(c, a, inner_w) if rpg2003_party?
         @window.contents = c
+      end
+
+      # RPG_RT's own status screen additionally shows which RPG2003 battle
+      # row the displayed actor is currently in -- confirmed against
+      # `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`):
+      # `if (Feature::HasRow()) { ... TextDraw(width, 2, ..., battle_row,
+      # AlignRight); }`, right-aligned at the top of the panel, above the
+      # face/name block. `Feature::HasRow` (`src/feature.cpp`) reduces to
+      # "the database is RPG2003" for a genuine, unmodified project (its
+      # other half is an EasyRPG-only battlecommands flag with no real LCF
+      # field), so this is gated the same way the rest of this codebase
+      # gates RPG2003-only presentation: `@state.party.rpg2003?`.
+      # `easyrpg_status_scene_back/front` are likewise EasyRPG-only Term
+      # extensions absent from RPG_RT's own Term chunk, so real RPG_RT
+      # hardcodes the literal English "Front"/"Back" -- matching this file's
+      # own `"Class: ..."` precedent for the same situation.
+      def rpg2003_party?
+        @state.party.respond_to?(:rpg2003?) && @state.party.rpg2003?
+      end
+
+      def draw_battle_row(bmp, actor, inner_w)
+        back = actor.respond_to?(:battle_row) && actor.battle_row == Game::Battle::ROW_BACK
+        text = back ? 'Back' : 'Front'
+        w = bmp.text_size(text).width
+        bmp.draw_text inner_w - w, 0, w, LINE_H, text
       end
     end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19152,6 +19152,30 @@ check 'the status screen shows the party\'s own Gold' do
   ok texts.include?('0G'), "zero Gold still shows, got: #{texts.inspect}"
 end
 
+# `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`) additionally
+# draws "Front"/"Back" right-aligned at the top of the panel whenever
+# `Feature::HasRow()` (`src/feature.cpp`) holds -- which for a genuine,
+# unmodified project reduces to "the database is RPG2003". An RPG2000
+# database never shows either label.
+check 'the status screen shows the RPG2003 battle row, gated on rpg2003?' do
+  st = menu_state
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
+                         .instance_variable_get(:@window))
+  ok !texts.include?('Front') && !texts.include?('Back'),
+     "an RPG2000 party draws neither row label, got: #{texts.inspect}"
+
+  rpg2003_party = Class.new(MenuStubParty) { def rpg2003?; true; end }.new
+  st2 = Game::State.new(rpg2003_party, 1, 0, 0)
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st2)
+                         .instance_variable_get(:@window))
+  ok texts.include?('Front'), "front row shows by default, got: #{texts.inspect}"
+
+  rpg2003_party.actors.first.battle_row = Game::Battle::ROW_BACK
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st2)
+                         .instance_variable_get(:@window))
+  ok texts.include?('Back'), "back row shows once toggled, got: #{texts.inspect}"
+end
+
 check 'Scene::StatusMenu: the actor cursor wraps around' do
   scene = menu_scene(RPG2k::Scene::StatusMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@actor_index), 'starts on the first actor'


### PR DESCRIPTION
## Summary
- On an RPG2003 database, real RPG_RT's field Status screen (`Window_ActorInfo::DrawInfo`, `src/window_actorinfo.cpp`) draws a right-aligned "Front"/"Back" label showing which battle row the displayed actor is currently in, gated on `Feature::HasRow()` (`src/feature.cpp`) — for a genuine, unmodified project this reduces to a plain database-edition check (RPG2003 only).
- `Scene::StatusMenu` never drew this label at all, even though `Game::Actor#battle_row` is already tracked, persisted to save data, and toggleable live from the field menu's own Row command.
- Fixed by adding `Scene::StatusMenu#draw_battle_row`/`#rpg2003_party?` (`mruby-rpg2k/mrblib/scene/status_menu.rb`), gated on `@state.party.rpg2003?`. `easyrpg_status_scene_back`/`_front` are EasyRPG-only Term extensions with no real RPG_RT counterpart, so the labels are hardcoded literal English, matching this file's existing "Class" label precedent.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: an RPG2000 party draws neither "Front" nor "Back"; an RPG2003 party shows "Front" by default and "Back" once the actor's row is toggled.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `status_menu.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 815 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1070 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_