### PR TITLE
Fix: a blocked Show/Move/Erase Picture command retries instead of dropping

### DIFF
--- a/changelog.d/picture-commands-block-retry.fixed.md
+++ b/changelog.d/picture-commands-block-retry.fixed.md
@@ -1,0 +1,6 @@
+- **Interpreter:** A Show/Move/Erase Picture command reached while a message
+  window or choice list is open no longer gets silently dropped forever --
+  matching RPG_RT's own `Game_Interpreter::CommandShowPicture` et al., it now
+  blocks the interpreter on that exact command (and any command after it in
+  the same list) and retries every subsequent frame, taking effect once the
+  message closes.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11753,10 +11753,11 @@ not yet verified:
   a new `scripts/rpg2k_scene_check.rb` check ("a Teleport/Escape field skill
   warp does not clear shown pictures"), confirmed to fail against the
   pre-fix code before the fix.
-- ✅ **Picture commands (Show/Move/Erase) are now fully suppressed while any
-  message window or choice list is open**, anywhere, including inside an
-  already-running parallel process — an unconditional engine limitation with
-  no workaround. This was a real, reachable gap: `Game::Interpreter#
+- ✅ **~~Picture commands (Show/Move/Erase) are now fully suppressed while any
+  message window or choice list is open~~, anywhere, including inside an
+  already-running parallel process — ~~an unconditional engine limitation with
+  no workaround~~ (corrected below, 2026-08-20: RPG_RT blocks and retries the
+  exact same command, it does not drop it).** This was a real, reachable gap: `Game::Interpreter#
   do_show_picture`/`#do_move_picture`/`#do_erase_picture` called straight
   into `Game::State#show_picture`/`#move_picture`/`#erase_picture` with no
   gating at all, and the sibling "parallel processes were paused too
@@ -11770,20 +11771,66 @@ not yet verified:
   existing `map_info` hook — the same `@map_info.respond_to?(:x) &&
   @map_info.x` pattern `#event_operand`/`#screen_operand` already use for
   `#event_position`/`#character_screen_position` — so a headless interpreter
-  (no `map_info`, or a battle page) is unaffected. All three picture
+  (no `map_info`, or a battle page) is unaffected. ~~All three picture
   commands now return immediately when it answers true; a suppressed Move
   Picture's wait flag is not honoured either (nothing moved, so there is
-  nothing to wait for), matching "no workaround". Covered by four new
+  nothing to wait for), matching "no workaround".~~ Covered by four new
   `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against the
   pre-fix code: a direct interpreter poke while its own message window is
   open, the same poke against an open choice list, and a full scene
   simulation proving a parallel process's Show/Move/Erase Picture attempts
-  are dropped while a message window (opened via `#open_message`, sidestepping
+  ~~are dropped~~ while a message window (opened via `#open_message`, sidestepping
   the `#step_parallels`-before-`#start_autostart` ordering that would
   otherwise let the parallel process's first lap land before the window is
-  actually open) is up and take effect on the very next lap once it closes —
-  while confirming the same process's non-picture commands (`Control
-  Variables`) keep advancing throughout, so the sibling fix stays intact.
+  actually open) is up and take effect ~~on the very next lap~~ once it closes —
+  ~~while confirming the same process's non-picture commands (`Control
+  Variables`) keep advancing throughout, so the sibling fix stays intact.~~
+  ✅ **Follow-up (2026-08-20): the suppression above was too strong — real
+  RPG_RT blocks a Show/Move/Erase Picture command in place and retries the
+  identical command every subsequent frame, it does not drop it.**
+  Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  CommandShowPicture`/`CommandMovePicture`/`CommandErasePicture`
+  (`src/game_interpreter.cpp`, codes 11110/11120/11130) each open with the
+  identical guard `if (!Player::IsEnglish() && !Player::IsPatchUnlockPics()
+  && Game_Message::IsMessageActive()) { return false; }` — and returning
+  `false` is EasyRPG's own block-and-retry idiom, not "discard": the main
+  dispatch loop (`Game_Interpreter::Update`) only advances
+  `frame->current_command` when the handler returns `true` (`if
+  (!ExecuteCommand()) { break; }` ... `if (index_before_exec ==
+  frame->current_command) { frame->current_command++; }`), so a `false`
+  return re-attempts the identical command on the very next `Update()` call
+  instead of skipping past it — and once the message clears, the same
+  command actually executes and takes effect, including its own wait flag
+  (Move Picture's) once it finally runs. The previous fix's own
+  justification cited only fan-wiki pages ("an unconditional engine
+  limitation with no workaround"), never the real C++ source — re-reading
+  the actual fetched EasyRPG source shows the wiki's "suppressed"/"blocked"
+  wording was taken literally as "permanently dropped" when the real
+  mechanism is "blocked, then retried, then applied." Concretely, this also
+  means the *whole* interpreter blocks at that exact command, not merely
+  that one command in isolation: a command right after a blocked picture
+  command in the same list must not run either until the picture command
+  itself finally succeeds — the prior fix's own test had this backwards,
+  asserting a parallel process's other commands "keep advancing regardless"
+  past its own blocked picture command (masked by parallel processes
+  auto-restarting their command list once finished, `Scene::Map#step_parallels`'s
+  `it.start(p[:commands]) # loop the process`, which coincidentally re-tried
+  a single-command page's own Show Picture from scratch every lap and made
+  the old drop-based code look like it retried). Fixed by adding
+  `Game::Interpreter#block_pending_picture_command`, called from all three
+  handlers in place of the old bare `return if picture_commands_suppressed?`:
+  it rewinds `@index` back onto the same command (already advanced past it
+  by `#update` before `#execute` runs) and suspends on a new
+  `:picture_blocked` wait, mirroring this codebase's own established
+  `:screen`/`:picture`/`:sprite_flash` block-and-retry waits just gated on a
+  different condition. `Scene::Map#drive_event`'s foreground dispatch and
+  `#drive_parallel_wait` both gained a matching `:picture_blocked` case
+  (`resume unless message_window_open?`). Covered by rewriting the existing
+  suite's own wrong assertion (a blocked Show Picture's own trailing
+  `Control Variables` command must read `0` while blocked, not keep
+  incrementing every lap) and confirming it now applies (and the trailing
+  command runs) once the message closes, confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **Not applicable: re-issuing Show Picture every tick being expensive
   enough to cause real frame drops (vs. cheap repeated Move Picture) is a
   real-RPG_RT-specific performance characteristic, not a state/behaviour

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3481,17 +3481,45 @@ module Game
       end
     end
 
-    # Whether Show/Move/Erase Picture must no-op this call: per yado.tk, real
-    # RPG_RT fully suppresses all three picture commands while any message
-    # window or choice list is open, anywhere in the scene — including a
-    # picture command reached by an already-running parallel process while a
-    # *different* interpreter's message window sits on screen (parallel
-    # processes keep advancing during a message window, see
-    # Scene::Map#parallels_paused?; this is the narrower rule layered on top
-    # of that). Without a map_info hook (a headless interpreter, or a battle
-    # page) there is no message window to suppress against.
+    # Whether Show/Move/Erase Picture must block this call: real RPG_RT
+    # blocks all three picture commands while any message window or choice
+    # list is open, anywhere in the scene — including a picture command
+    # reached by an already-running parallel process while a *different*
+    # interpreter's message window sits on screen (parallel processes keep
+    # advancing during a message window, see Scene::Map#parallels_paused?;
+    # this is the narrower rule layered on top of that). Without a map_info
+    # hook (a headless interpreter, or a battle page) there is no message
+    # window to block against.
     def picture_commands_suppressed?
       @map_info.respond_to?(:message_window_open?) && @map_info.message_window_open?
+    end
+
+    # Real RPG_RT does not permanently discard a Show/Move/Erase Picture
+    # command reached while a message window or choice list is open — it
+    # blocks the interpreter on that exact command and retries it every
+    # subsequent frame, so the very same command still takes effect once the
+    # message clears. Confirmed directly against RPG_RT's live source:
+    # `Game_Interpreter::CommandShowPicture`/`CommandMovePicture`/
+    # `CommandErasePicture` (`src/game_interpreter.cpp`, codes 11110/11120/
+    # 11130) each open with the identical guard `if (!Player::IsEnglish() &&
+    # !Player::IsPatchUnlockPics() && Game_Message::IsMessageActive()) {
+    # return false; }` — and the main dispatch loop (`Game_Interpreter::
+    # Update`) only advances `frame->current_command` when the handler
+    # returns `true` (`if (!ExecuteCommand()) { break; }` ... `if
+    # (index_before_exec == frame->current_command) { frame->current_command
+    # ++; }`), so a `false` return re-attempts the identical command on the
+    # next `Update()` rather than dropping it. Rewinds `@index` back onto
+    # this same command (#update already advanced past it before calling
+    # #execute) and suspends on a new :picture_blocked wait so Scene::Map can
+    # retry it once the message window closes — the same block-and-retry
+    # shape this codebase's own :screen/:picture/:sprite_flash waits already
+    # use, just gated on a different condition.
+    def block_pending_picture_command
+      return false unless picture_commands_suppressed?
+      @index -= 1
+      @wait_kind = :picture_blocked
+      @waiting = true
+      true
     end
 
     # Show Picture (11110): display picture param0 from the string file name at
@@ -3504,7 +3532,7 @@ module Game
     def do_show_picture(cmd)
       id = cmd.param(0)
       return if id <= 0
-      return if picture_commands_suppressed?
+      return if block_pending_picture_command
       @state.show_picture(id,
                           name: picture_name(cmd),
                           x: picture_coord(cmd, 2), y: picture_coord(cmd, 3),
@@ -3522,7 +3550,7 @@ module Game
     # and resumes us once none is moving. Same parameter layout as Show Picture,
     # plus the trailing duration/wait pair (EasyRPG's CommandMovePicture).
     def do_move_picture(cmd)
-      return if picture_commands_suppressed?
+      return if block_pending_picture_command
       id = cmd.param(0)
       frames = cmd.param(14) * FRAMES_PER_TENTH
       @state.move_picture(id, picture_coord(cmd, 2), picture_coord(cmd, 3),
@@ -3537,7 +3565,7 @@ module Game
 
     # Erase Picture (11130): remove picture param0 from the screen.
     def do_erase_picture(cmd)
-      return if picture_commands_suppressed?
+      return if block_pending_picture_command
       @state.erase_picture(cmd.param(0))
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1999,6 +1999,12 @@ class RPG2k
           # Move Picture's own wait flag, the parallel-process equivalent of
           # the :screen case just above.
           it.resume unless @state.pictures_moving?
+        elsif it.wait_kind == :picture_blocked
+          # A Show/Move/Erase Picture command issued from a Parallel Process
+          # while a message window or choice list is open -- the parallel-
+          # process equivalent of #drive_event's own :picture_blocked case
+          # just above, see #block_pending_picture_command for the citation.
+          it.resume unless message_window_open?
         elsif it.wait_kind == :sprite_flash
           # Flash Sprite's own wait flag, the parallel-process equivalent of
           # the :screen/:picture cases just above.
@@ -4426,6 +4432,12 @@ class RPG2k
           when :movement then @interpreter.resume if step_forced_movement
           when :screen then @interpreter.resume unless @state.screen.busy?
           when :picture then @interpreter.resume unless @state.pictures_moving?
+          when :picture_blocked
+            # A Show/Move/Erase Picture command reached while a message
+            # window or choice list is open (#block_pending_picture_command)
+            # -- real RPG_RT retries the identical command every subsequent
+            # frame rather than dropping it, see that method's own citation.
+            @interpreter.resume unless message_window_open?
           when :return_title then perform_return_to_title
           when :game_over then perform_game_over
           when :name_input then drive_name_input

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3234,7 +3234,7 @@ check 'Show Picture is suppressed while a choice list is open (yado.tk)' do
 end
 
 check 'Show/Move/Erase Picture from an independently-running parallel process are ' \
-      'suppressed while a message window is open, and apply once it closes (yado.tk)' do
+      'blocked (not dropped) while a message window is open, and retry once it closes' do
   ic = Game::Interpreter::Cmd
 
   # Each sub-case opens the message window directly (via the same #open_message
@@ -3242,10 +3242,21 @@ check 'Show/Move/Erase Picture from an independently-running parallel process ar
   # against the parallel process's very first frame -- #step_parallels already
   # runs before #start_autostart each frame (see Scene::Map#update), so a
   # naturally-triggered message would not be open yet for the parallel
-  # process's first lap, and these commands are non-blocking no-ops once
-  # applied, not something a later suppression could retract.
+  # process's first lap.
 
   # -- Show Picture ---------------------------------------------------------
+  # RPG_RT's own dispatch loop (`Game_Interpreter::Update`,
+  # `if (!ExecuteCommand()) { break; }`) breaks the *whole* per-frame command
+  # loop for this exact interpreter when a picture command's own guard
+  # returns false -- not just that one command -- so `add_var_cmd(1)` right
+  # after the blocked Show Picture must not run either, until the message
+  # closes and the picture command itself finally succeeds
+  # (#block_pending_picture_command). This is narrower than, and does not
+  # contradict, the sibling "a message box is not a pause condition for
+  # parallel processes" rule the check just above already covers -- that
+  # rule is about *other, independent* parallel processes continuing
+  # elsewhere, not about this interpreter's own commands past a command it
+  # is itself blocked on.
   par = page(trigger: 4)
   par.event_commands = [
     ECmd.new(ic::SHOW_PICTURE, [1, 0, 100, 100, 0, 100, 0, 0, 100, 100, 100, 100],
@@ -3259,13 +3270,14 @@ check 'Show/Move/Erase Picture from an independently-running parallel process ar
   10.times { scene.update }
   ok !st.pictures.key?(1),
      'Show Picture from a still-running parallel process must not apply while a message window is open'
-  ok st.variables[1] > 0,
-     'the parallel process keeps advancing its non-picture commands regardless -- the sibling ' \
-     '"parallel processes were paused too broadly" fix must stay intact'
+  eq 0, st.variables[1],
+     'the command right after the blocked Show Picture must not run either -- the whole ' \
+     'interpreter is blocked on this exact command, not merely skipping it'
 
   scene.send(:close_message)
   5.times { scene.update }
-  ok st.pictures.key?(1), 'Show Picture applies once the window closes'
+  ok st.pictures.key?(1), 'Show Picture retries and applies once the window closes'
+  ok st.variables[1] > 0, 'and the command after it then runs too'
 
   # -- Move Picture -----------------------------------------------------------
   par2 = page(trigger: 4)


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter::CommandShowPicture`/`CommandMovePicture`/`CommandErasePicture` (`src/game_interpreter.cpp`, codes 11110/11120/11130) all return `false` when a message window or choice list is open. That's EasyRPG's own block-and-retry idiom, not "discard": the main dispatch loop (`Game_Interpreter::Update`) only advances `frame->current_command` when the handler returns `true`, so a `false` return re-attempts the *identical* command on the next `Update()` call rather than skipping past it — once the message clears, the same command actually executes.
- This codebase's `picture_commands_suppressed?` guard (`mruby-rpg2k/mrblib/interpreter.rb`) permanently discarded the command instead — a real correction of a prior fix in this repo (documented in `docs/TODO.md`, corrected with strikethrough + a dated Follow-up) that was justified only by fan-wiki wording ("suppressed"/"blocked"), never checked against the actual C++ source before now.
- Also corrected: real RPG_RT's `break` on a blocked command stops that *whole* interpreter's per-frame command loop, not just the one picture command — so a command right after a blocked picture command in the same list must not run either, until the picture command itself finally succeeds. The existing test suite had this backwards (see Test plan).
- Fixed by adding `Game::Interpreter#block_pending_picture_command` (rewinds `@index` back onto the same command, suspends on a new `:picture_blocked` wait), used by all three handlers in place of the old bare `return if picture_commands_suppressed?`. Added matching `:picture_blocked` dispatch to `Scene::Map#drive_event`'s foreground switch and `#drive_parallel_wait`, mirroring this codebase's own existing `:screen`/`:picture`/`:sprite_flash` block-and-retry waits.

## Test plan
- [x] Corrected the existing `scripts/rpg2k_scene_check.rb` check's own wrong assertion: a `Control Variables` command right after a blocked Show Picture must read `0` while blocked (not keep incrementing every lap, which the old code's parallel-process auto-loop masked), and both the picture and the trailing command apply once the message closes.
- [x] Confirmed the corrected check fails against the pre-fix code (`git stash` on `interpreter.rb`/`map.rb` only — `expected 0, got 10`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 815 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1070 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_