### PR TITLE
Fix: Transfer Player/Recall to Location blocks on an open message window

### DIFF
--- a/changelog.d/teleport-blocks-on-message.fixed.md
+++ b/changelog.d/teleport-blocks-on-message.fixed.md
@@ -1,0 +1,7 @@
+- **Interpreter:** A Transfer Player / Recall to Location command reached
+  while a message window or choice list is open, anywhere in the scene, is
+  now blocked and retried every subsequent frame instead of warping the map
+  immediately -- matching RPG_RT's own `Game_Interpreter_Map::
+  CommandTeleport`/`CommandRecallToLocation`. A still-running parallel
+  process could previously warp the map out from under an on-screen message
+  window from another event.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11831,6 +11831,39 @@ not yet verified:
   incrementing every lap) and confirming it now applies (and the trailing
   command runs) once the message closes, confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **Transfer Player / Recall to Location is now blocked (not run) while a
+  message window or choice list is open, anywhere in the scene, and retries
+  once it closes — the same block-and-retry shape as the Show/Move/Erase
+  Picture fix just above, on a different pair of commands.** Confirmed
+  directly against RPG_RT's live source: `Game_Interpreter_Map::
+  CommandTeleport`/`CommandRecallToLocation` (`src/game_interpreter_map.cpp`,
+  codes 10810/10830) both open with `if (Game_Message::IsMessageActive()) {
+  return false; }`, unconditionally — not gated behind `IsRPG2k3Commands()`,
+  so this is base RPG2000 behaviour, not an RPG2003-only rule. This
+  codebase's `Game::Interpreter#do_teleport`/`#do_recall_location`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) had no such gate at all: a still-running
+  parallel process (Message Options' "continue events" flag lets one keep
+  advancing past another event's open Show Text, see
+  `Scene::Map#parallels_paused?`) could warp the map out from under an
+  on-screen message window instead of waiting for it to close first — the
+  identical class of gap the Show/Move/Erase Picture fix just above closed
+  for those three commands, just never ported to these two. Fixed by
+  renaming the picture fix's own `#picture_commands_suppressed?` to the more
+  general `#message_window_blocks_command?` (its logic is unchanged, and it
+  was already generic — only its name was picture-specific) and adding a new
+  `#block_pending_teleport_command`, the same shape as
+  `#block_pending_picture_command`: rewinds `@index` back onto the same
+  command and suspends on a new `:teleport_blocked` wait.
+  `Scene::Map#drive_event`'s foreground dispatch and `#drive_parallel_wait`
+  both gained a matching `:teleport_blocked` case (`resume unless
+  message_window_open?`), alongside the existing `:picture_blocked` ones.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a common event's
+  Parallel Process's own Transfer Player, and the command right after it in
+  the same list, must not run while a message window opened elsewhere is on
+  screen; both apply once the window closes), confirmed to fail against the
+  pre-fix code before the fix — the old code's own auto-loop-on-finish
+  masking (documented in the Follow-up just above) made the failure show up
+  as the process's own marker command re-running four times over, not zero.
 - ✅ **Not applicable: re-issuing Show Picture every tick being expensive
   enough to cause real frame drops (vs. cheap repeated Move Picture) is a
   real-RPG_RT-specific performance characteristic, not a state/behaviour

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3033,6 +3033,7 @@ module Game
     # here, so converting unconditionally is the same as EasyRPG's
     # `IsRPG2k3Commands` guard for the games that can emit it.
     def do_teleport(cmd)
+      return if block_pending_teleport_command
       @teleport = [cmd.param(0), cmd.param(1), cmd.param(2),
                    teleport_facing(cmd.param(3))]
       @wait_kind = :teleport
@@ -3061,6 +3062,7 @@ module Game
     # the owning scene loads the map and moves the player; the current facing is
     # kept (direction 0).
     def do_recall_location(cmd)
+      return if block_pending_teleport_command
       @teleport = [variables[cmd.param(0)], variables[cmd.param(1)],
                    variables[cmd.param(2)], 0]
       @wait_kind = :teleport
@@ -3481,16 +3483,18 @@ module Game
       end
     end
 
-    # Whether Show/Move/Erase Picture must block this call: real RPG_RT
-    # blocks all three picture commands while any message window or choice
-    # list is open, anywhere in the scene — including a picture command
-    # reached by an already-running parallel process while a *different*
-    # interpreter's message window sits on screen (parallel processes keep
-    # advancing during a message window, see Scene::Map#parallels_paused?;
-    # this is the narrower rule layered on top of that). Without a map_info
-    # hook (a headless interpreter, or a battle page) there is no message
-    # window to block against.
-    def picture_commands_suppressed?
+    # Whether a message-gated command (Show/Move/Erase Picture, Teleport,
+    # Recall to Location — see #block_pending_picture_command /
+    # #block_pending_teleport_command) must block this call: real RPG_RT
+    # blocks each of these while any message window or choice list is open,
+    # anywhere in the scene — including a command reached by an
+    # already-running parallel process while a *different* interpreter's
+    # message window sits on screen (parallel processes keep advancing
+    # during a message window, see Scene::Map#parallels_paused?; this is the
+    # narrower rule layered on top of that). Without a map_info hook (a
+    # headless interpreter, or a battle page) there is no message window to
+    # block against.
+    def message_window_blocks_command?
       @map_info.respond_to?(:message_window_open?) && @map_info.message_window_open?
     end
 
@@ -3515,9 +3519,31 @@ module Game
     # shape this codebase's own :screen/:picture/:sprite_flash waits already
     # use, just gated on a different condition.
     def block_pending_picture_command
-      return false unless picture_commands_suppressed?
+      return false unless message_window_blocks_command?
       @index -= 1
       @wait_kind = :picture_blocked
+      @waiting = true
+      true
+    end
+
+    # Real RPG_RT does not run a Transfer Player / Recall to Location command
+    # while a message window or choice list is open either — the identical
+    # block-and-retry shape #block_pending_picture_command already ports, on
+    # a different pair of commands. Confirmed directly against RPG_RT's live
+    # source: `Game_Interpreter_Map::CommandTeleport`/
+    # `CommandRecallToLocation` (`src/game_interpreter_map.cpp`, codes
+    # 10810/10830) both open with `if (Game_Message::IsMessageActive()) {
+    # return false; }`, unconditionally — not gated behind
+    # `IsRPG2k3Commands()`, so this is base RPG2000 behaviour, not an
+    # RPG2003-only rule. Without this guard, a still-running parallel
+    # process (Message Options' "continue events" flag lets one keep
+    # advancing past another event's open Show Text, see
+    # Scene::Map#parallels_paused?) could warp the map out from under an
+    # on-screen message window instead of waiting for it to close first.
+    def block_pending_teleport_command
+      return false unless message_window_blocks_command?
+      @index -= 1
+      @wait_kind = :teleport_blocked
       @waiting = true
       true
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2005,6 +2005,16 @@ class RPG2k
           # process equivalent of #drive_event's own :picture_blocked case
           # just above, see #block_pending_picture_command for the citation.
           it.resume unless message_window_open?
+        elsif it.wait_kind == :teleport_blocked
+          # A Transfer Player / Recall to Location command issued from a
+          # Parallel Process while a message window or choice list is open --
+          # the parallel-process equivalent of #drive_event's own
+          # :teleport_blocked case, see #block_pending_teleport_command for
+          # the citation. Before this branch existed a blocked teleport
+          # simply never reached :teleport_blocked at all (the guard is what
+          # raises it in the first place); this and the interpreter-side fix
+          # land together.
+          it.resume unless message_window_open?
         elsif it.wait_kind == :sprite_flash
           # Flash Sprite's own wait flag, the parallel-process equivalent of
           # the :screen/:picture cases just above.
@@ -4437,6 +4447,13 @@ class RPG2k
             # window or choice list is open (#block_pending_picture_command)
             # -- real RPG_RT retries the identical command every subsequent
             # frame rather than dropping it, see that method's own citation.
+            @interpreter.resume unless message_window_open?
+          when :teleport_blocked
+            # A Transfer Player / Recall to Location command reached while a
+            # message window or choice list is open
+            # (#block_pending_teleport_command) -- the identical
+            # block-and-retry shape as :picture_blocked just above, see that
+            # method's own citation.
             @interpreter.resume unless message_window_open?
           when :return_title then perform_return_to_title
           when :game_over then perform_game_over

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2450,6 +2450,39 @@ check "a common event's Parallel Process's own Transfer Player command " \
      'and reached marker B on the new map'
 end
 
+check "a common event's Parallel Process's own Transfer Player command is " \
+      'blocked (not dropped) while a message window is open, and retries once ' \
+      'it closes' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter_Map::
+  # CommandTeleport`/`CommandRecallToLocation` (`src/game_interpreter_map.cpp`,
+  # codes 10810/10830) both open with `if (Game_Message::IsMessageActive()) {
+  # return false; }`, unconditionally -- the identical block-and-retry shape
+  # already ported for Show/Move/Erase Picture (see
+  # #block_pending_picture_command). A command right after the blocked
+  # Transfer Player in the same list must not run either, until the Transfer
+  # Player itself finally succeeds -- the whole interpreter blocks at that
+  # exact command, matching the picture-command fix's own citation of
+  # `Game_Interpreter::Update`'s `if (!ExecuteCommand()) { break; }`.
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [add_var_cmd(3), ECmd.new(ic::TELEPORT, [2, 0, 0, 0]),
+                              add_var_cmd(4)])
+  scene = new_scene({}, common: { 7 => ce })
+  st = scene.instance_variable_get(:@state)
+  scene.send(:open_message, ['hi'], false)
+
+  10.times { scene.update }
+  eq 1, st.variables[3], "marker A still runs on the process's first pass"
+  eq 1, st.map_id, 'the Transfer Player must not apply while a message window is open'
+  eq 0, st.variables[4],
+     'the command right after the blocked Transfer Player must not run either'
+
+  scene.send(:close_message)
+  5.times { scene.update }
+  eq 2, st.map_id, 'the Transfer Player retries and applies once the window closes'
+  eq 1, st.variables[4], 'and the command after it then runs too'
+end
+
 check "an unrelated event's page change does not restart another event's " \
       'own Parallel Process' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter_Map::CommandTeleport`/`CommandRecallToLocation` (`src/game_interpreter_map.cpp`, codes 10810/10830) both return `false` unconditionally when `Game_Message::IsMessageActive()` — the identical block-and-retry idiom already ported for Show/Move/Erase Picture in the previous PR, just never carried over to these two commands. The guard is not gated behind `IsRPG2k3Commands()`, so this is base RPG2000 behavior, not RPG2003-specific.
- `Game::Interpreter#do_teleport`/`#do_recall_location` (`mruby-rpg2k/mrblib/interpreter.rb`) had no such gate at all: a still-running parallel process (Message Options' "continue events" flag lets one keep advancing past another event's open Show Text) could warp the map out from under an on-screen message window instead of waiting for it to close first.
- Fixed by renaming the picture fix's own `#picture_commands_suppressed?` to the more general `#message_window_blocks_command?` (logic unchanged, it was already generic — only the name was picture-specific) and adding `#block_pending_teleport_command`, mirroring `#block_pending_picture_command`: rewinds `@index` back onto the same command and suspends on a new `:teleport_blocked` wait. `Scene::Map#drive_event`'s foreground dispatch and `#drive_parallel_wait` both gained a matching `:teleport_blocked` case.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a common event's Parallel Process's own Transfer Player, and the command right after it in the same list, must not run while a message window opened elsewhere is on screen; both apply once the window closes.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `interpreter.rb`/`map.rb` only) and passes after — the old code's auto-loop-on-finish behavior made the failure show up as the marker command re-running four times instead of staying at zero.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 816 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1070 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_