### PR TITLE
Fix: Battle Processing/Enemy Encounter blocks on an open message window

### DIFF
--- a/changelog.d/battle-blocks-on-message.fixed.md
+++ b/changelog.d/battle-blocks-on-message.fixed.md
@@ -1,0 +1,7 @@
+- **Interpreter:** A Battle Processing / Enemy Encounter command reached
+  while a message window or choice list is open, anywhere in the scene, is
+  now blocked and retried every subsequent frame instead of opening the
+  fight immediately -- matching RPG_RT's own `Game_Interpreter_Map::
+  CommandEnemyEncounter`. A still-running parallel process could previously
+  cut straight to the battle screen over the top of another event's open
+  message window.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11864,6 +11864,36 @@ not yet verified:
   pre-fix code before the fix — the old code's own auto-loop-on-finish
   masking (documented in the Follow-up just above) made the failure show up
   as the process's own marker command re-running four times over, not zero.
+- ✅ **Battle Processing / Enemy Encounter is now blocked (not run) while a
+  message window or choice list is open, anywhere in the scene, and retries
+  once it closes — the same block-and-retry shape as the Show/Move/Erase
+  Picture and Transfer Player/Recall to Location fixes just above, on a
+  third command.** Confirmed directly against RPG_RT's live source:
+  `Game_Interpreter_Map::CommandEnemyEncounter`
+  (`src/game_interpreter_map.cpp`, code 10710) opens with `if
+  (Game_Message::IsMessageActive()) { return false; }`, unconditionally —
+  not gated behind `IsRPG2k3Commands()` or `main_flag`, so this is base
+  RPG2000 behaviour and applies the same way to a scripted Enemy Encounter
+  command as to any other. This codebase's `Game::Interpreter#
+  do_enemy_encounter` (`mruby-rpg2k/mrblib/interpreter.rb`) had no such
+  gate at all: a still-running parallel process (Message Options' "continue
+  events" flag) could cut straight to the battle screen over an on-screen
+  message window instead of waiting for it to close first — the identical
+  class of gap the two fixes just above closed, just never ported to this
+  command. Fixed by adding `#block_pending_battle_command`, the same shape
+  as `#block_pending_picture_command`/`#block_pending_teleport_command`
+  (reusing the same `#message_window_blocks_command?` check), called from
+  the very top of `#do_enemy_encounter` — matching real RPG_RT's own guard
+  placement, before any of the command's other parameter reads or its
+  `@state.battle_count` increment. `Scene::Map#drive_event`'s foreground
+  dispatch and `#drive_parallel_wait` both gained a matching
+  `:battle_blocked` case (`resume unless message_window_open?`), alongside
+  the existing `:picture_blocked`/`:teleport_blocked` ones. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (a common event's Parallel
+  Process's own Battle Processing, and the command right after it in the
+  same list, must not run while a message window opened elsewhere is on
+  screen; the battle opens once the window closes), confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **Not applicable: re-issuing Show Picture every tick being expensive
   enough to cause real frame drops (vs. cheap repeated Move Picture) is a
   real-RPG_RT-specific performance characteristic, not a state/behaviour

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1463,6 +1463,7 @@ module Game
     # Threaded onto `@battle_request` as `:background`/`:terrain_id`, read
     # back by `Scene::Battle#encounter_backdrop`.
     def do_enemy_encounter(cmd)
+      return if block_pending_battle_command
       escape_mode = cmd.param(3)
       troop_id = cmd.param(0) == 0 ? cmd.param(1) : variables[cmd.param(1)]
       @battle_indent = cmd.indent
@@ -3544,6 +3545,30 @@ module Game
       return false unless message_window_blocks_command?
       @index -= 1
       @wait_kind = :teleport_blocked
+      @waiting = true
+      true
+    end
+
+    # Real RPG_RT does not open a battle from a Battle Processing / Enemy
+    # Encounter command while a message window or choice list is open
+    # either — the identical block-and-retry shape
+    # #block_pending_picture_command/#block_pending_teleport_command already
+    # port, on a third command. Confirmed directly against RPG_RT's live
+    # source: `Game_Interpreter_Map::CommandEnemyEncounter`
+    # (`src/game_interpreter_map.cpp`, code 10710) opens with `if
+    # (Game_Message::IsMessageActive()) { return false; }`, unconditionally
+    # — not gated behind `IsRPG2k3Commands()` or `main_flag`, so this is
+    # base RPG2000 behaviour, not an RPG2003-only rule, and applies the same
+    # way to a scripted Enemy Encounter command as to any other. Without
+    # this guard, a still-running parallel process (Message Options'
+    # "continue events" flag lets one keep advancing past another event's
+    # open Show Text, see Scene::Map#parallels_paused?) could cut straight
+    # to the battle screen over an on-screen message window instead of
+    # waiting for it to close first.
+    def block_pending_battle_command
+      return false unless message_window_blocks_command?
+      @index -= 1
+      @wait_kind = :battle_blocked
       @waiting = true
       true
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2015,6 +2015,13 @@ class RPG2k
           # raises it in the first place); this and the interpreter-side fix
           # land together.
           it.resume unless message_window_open?
+        elsif it.wait_kind == :battle_blocked
+          # A Battle Processing / Enemy Encounter command issued from a
+          # Parallel Process while a message window or choice list is open --
+          # the parallel-process equivalent of #drive_event's own
+          # :battle_blocked case, see #block_pending_battle_command for the
+          # citation.
+          it.resume unless message_window_open?
         elsif it.wait_kind == :sprite_flash
           # Flash Sprite's own wait flag, the parallel-process equivalent of
           # the :screen/:picture cases just above.
@@ -4454,6 +4461,13 @@ class RPG2k
             # (#block_pending_teleport_command) -- the identical
             # block-and-retry shape as :picture_blocked just above, see that
             # method's own citation.
+            @interpreter.resume unless message_window_open?
+          when :battle_blocked
+            # A Battle Processing / Enemy Encounter command reached while a
+            # message window or choice list is open
+            # (#block_pending_battle_command) -- the identical
+            # block-and-retry shape as :picture_blocked/:teleport_blocked
+            # above, see that method's own citation.
             @interpreter.resume unless message_window_open?
           when :return_title then perform_return_to_title
           when :game_over then perform_game_over

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7521,6 +7521,39 @@ check "a Common Event Parallel Process's own Battle Processing now actually open
   ok !st.switches[2], 'the Escape handler was skipped'
 end
 
+check "a Common Event Parallel Process's own Battle Processing is blocked " \
+      '(not run) while a message window is open, and retries once it closes' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter_Map::
+  # CommandEnemyEncounter` (`src/game_interpreter_map.cpp`, code 10710) opens
+  # with `if (Game_Message::IsMessageActive()) { return false; }`,
+  # unconditionally -- the identical block-and-retry shape already ported for
+  # Show/Move/Erase Picture and Transfer Player/Recall to Location, see
+  # #block_pending_battle_command. A command right after the blocked Enemy
+  # Encounter in the same list must not run either, until the Enemy
+  # Encounter itself finally succeeds -- the whole interpreter blocks at
+  # that exact command.
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: Game::CommonEvent::PARALLEL, need_flag: false,
+                      switch_id: nil,
+                      event: [add_var_cmd(3),
+                              ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 0, 0], indent: 0),
+                              add_var_cmd(4)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.send(:open_message, ['hi'], false)
+
+  10.times { scene.update }
+  eq 1, st.variables[3], "marker A still runs on the process's first pass"
+  eq nil, battle_ui(scene), 'the battle must not open while a message window is open'
+  eq 0, st.variables[4],
+     'the command right after the blocked Enemy Encounter must not run either'
+
+  scene.send(:close_message)
+  5.times { scene.update }
+  ok battle_ui(scene), 'the battle opens once the window closes'
+end
+
 # A battle a Parallel Process opened owns the single @battle_ui slot exactly
 # the way one the foreground opened does -- ordinary player movement/menu
 # access must freeze for its whole duration regardless of which interpreter


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter_Map::CommandEnemyEncounter` (`src/game_interpreter_map.cpp`, code 10710) opens with an unconditional `if (Game_Message::IsMessageActive()) { return false; }` guard — the same block-and-retry idiom already ported in the previous two PRs for Show/Move/Erase Picture and Transfer Player/Recall to Location, just never carried over to this command. Not gated behind `IsRPG2k3Commands()` or `main_flag`, so this is base RPG2000 behavior.
- `Game::Interpreter#do_enemy_encounter` (`mruby-rpg2k/mrblib/interpreter.rb`) had no such gate: a still-running parallel process (Message Options' "continue events" flag lets one keep advancing past another event's open Show Text) could cut straight to the battle screen over the top of an on-screen message window instead of waiting for it to close first.
- Fixed by adding `#block_pending_battle_command`, the same shape as `#block_pending_picture_command`/`#block_pending_teleport_command` (reusing the existing `#message_window_blocks_command?` check), called from the very top of `#do_enemy_encounter` — matching real RPG_RT's own guard placement, before any of the command's other parameter reads or its `@state.battle_count` increment. `Scene::Map#drive_event`'s foreground dispatch and `#drive_parallel_wait` both gained a matching `:battle_blocked` case.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a common event's Parallel Process's own Battle Processing, and the command right after it in the same list, must not run while a message window opened elsewhere is on screen; the battle opens once the window closes.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `interpreter.rb`/`map.rb` only — the battle opened immediately even with the message window up) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 817 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1070 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_