### PR TITLE
Fix: Fade Out BGM keeps the current-BGM record instead of clearing it

### DIFF
--- a/changelog.d/fadeout-bgm-keeps-current-track.fixed.md
+++ b/changelog.d/fadeout-bgm-keeps-current-track.fixed.md
@@ -1,0 +1,7 @@
+- **Interpreter:** Fade Out BGM no longer forgets which track was playing --
+  matching RPG_RT's own `Game_System::BgmFade`, the current-BGM record
+  survives an ordinary fade untouched. Previously a Memorize BGM taken after
+  a fade memorised silence instead of the faded track, a Save taken right
+  after a fade forgot the track on Continue, and disembarking a vehicle or
+  ending a battle/inn stay shortly after a fade restored silence instead of
+  resuming it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8979,6 +8979,45 @@ not yet verified:
   the bug rather than catching it); its expected value is corrected to the
   pass-through relationship (`param 2000 → 2000ms`), confirmed to fail
   against the pre-fix code (`expected 2000, got 200000`) before the fix.
+  ✅ **Follow-up (2026-08-20): ~~Clears the current-BGM record so a Memorize
+  BGM taken afterwards memorises silence, as RPG_RT does~~ — corrected,
+  real RPG_RT does the opposite: an ordinary Fade Out BGM leaves the
+  current-BGM record untouched, so a Memorize BGM taken afterwards still
+  memorises the track that was fading, not silence.** This method's own
+  doc comment carried that claim with no citation of its own (only the
+  neighbouring millisecond-vs-tenths conversion, quoted above, was actually
+  sourced) — re-reading RPG_RT's live source directly contradicts it.
+  Confirmed: `Game_Interpreter::CommandFadeOutBGM`
+  (`src/game_interpreter.cpp`) calls `Main_Data::game_system->
+  BgmFade(fadeout)` with a single argument; `Game_System::BgmFade`
+  (`src/game_system.h`: `void BgmFade(int duration, bool
+  clear_current_music = false);`, `src/game_system.cpp`) only clears
+  `data.current_music` when its second parameter is explicitly `true` —
+  defaulted `false`, so the event command never passes it. `BgmFade(...,
+  true)` is reserved for unrelated callers (a title/reset path in
+  `player.cpp`), not the ordinary event command. `Game_System::
+  MemorizeBGM` (`src/game_system.h`, inline: `data.stored_music =
+  data.current_music;`) then confirms a Memorize BGM issued after a fade
+  captures whatever `current_music` still holds — the pre-fade track.
+  `Interpreter#do_fadeout_bgm` (`mruby-rpg2k/mrblib/interpreter.rb`)
+  unconditionally set `@state.current_bgm = nil`, with concrete
+  player-visible consequences traced through the whole call chain: `#do_
+  memorize_bgm` stored `nil` instead of the pre-fade track (a later Play
+  Memorized BGM restored silence instead of resuming it); `@current_bgm`
+  is persisted into both the Marshal save and the `.lsd` (`game.rb`: `sys
+  [75] = bgm_chunk(@current_bgm) if @current_bgm`), so a Save taken right
+  after a fade forgot the track entirely instead of resuming it on
+  Continue; and `Scene::Map`'s vehicle/battle/inn BGM-restore snapshots
+  (`@pre_vehicle_bgm`/`@pre_battle_bgm`/`@pre_inn_bgm = @state.current_
+  bgm`) captured `nil` instead of the pre-fade track, so disembarking/
+  ending a battle/leaving an inn shortly after a Fade Out BGM restored
+  silence instead of the track that had been fading. Fixed by removing the
+  `@state.current_bgm = nil` line — `@state.bgm_looped = false` is
+  unrelated and left alone. Covered by rewriting the existing `scripts/
+  rpg2k_logic_check.rb` "Fade Out BGM" check (the current-BGM record must
+  still name the faded track, not `nil`) and a new "Memorize BGM taken
+  after a Fade Out BGM still memorises the faded track" check, both
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A Forced-AI actor's auto-battle skill-ranking cost is no longer
   inflated by a percent-cost formula RPG2000 never applies.**
   `Game::Battle#auto_battle_raw_cost` (`mruby-rpg2k/mrblib/game.rb`) is the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3695,9 +3695,16 @@ module Game
     end
 
     # Fade Out BGM (11520): fade the music to silence over param0
-    # milliseconds, then leave nothing playing. Clears the current-BGM
-    # record so a Memorize BGM taken afterwards memorises silence, as
-    # RPG_RT does. Non-blocking — the event runs on while the music fades.
+    # milliseconds, then leave nothing playing. The current-BGM record
+    # survives the fade untouched -- a Memorize BGM taken afterwards still
+    # memorises the track that was fading, not silence. Confirmed directly
+    # against RPG_RT's live source: `Game_Interpreter::CommandFadeOutBGM`
+    # (`src/game_interpreter.cpp`) calls `Main_Data::game_system->
+    # BgmFade(fadeout)` with a single argument, and `Game_System::BgmFade`
+    # (`src/game_system.h`/`.cpp`) only clears `data.current_music` when its
+    # second parameter, `clear_current_music`, is explicitly `true` --
+    # defaulted to `false`, so the event command never sets it. Non-blocking
+    # — the event runs on while the music fades.
     #
     # param0 is already milliseconds, not tenths of a second: EasyRPG's
     # `CommandFadeOutBGM` (src/game_interpreter.cpp) passes
@@ -3709,7 +3716,6 @@ module Game
     # `RGSS::Audio.bgm_fade` already expects milliseconds too --
     # `Scene::Menu`'s own End Game call passes `bgm_fade(400)` directly.
     def do_fadeout_bgm(cmd)
-      @state.current_bgm = nil
       @state.bgm_looped = false
       RGSS::Audio.bgm_fade(cmd.param(0))
     rescue StandardError => e

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15989,11 +15989,20 @@ check 'Flash Sprite without its wait flag does not pause the interpreter' do
   eq 1, it.take_sprite_flash_requests.size
 end
 
-check 'Fade Out BGM fades the music and forgets the current track' do
+check 'Fade Out BGM fades the music but keeps the current-BGM record intact' do
   # param0 is already milliseconds -- EasyRPG's CommandFadeOutBGM passes it
   # straight through to Game_System::BgmFade with no scaling (confirmed
   # against its "Duration in ms" doc comment and every real call site, all
   # bare millisecond literals).
+  #
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  # CommandFadeOutBGM` (`src/game_interpreter.cpp`) calls `Game_System::
+  # BgmFade(fadeout)` with a single argument, and `Game_System::BgmFade`
+  # (`src/game_system.h`/`.cpp`) only clears `data.current_music` when its
+  # second parameter, `clear_current_music`, is explicitly `true` --
+  # defaulted `false`, so the event command never clears it. A save taken
+  # (or a Memorize BGM issued) right after a Fade Out BGM must still see
+  # the track that was fading, not silence.
   st = new_state
   RGSS::Audio.log = []
   it = Game::Interpreter.new(st)
@@ -16002,8 +16011,25 @@ check 'Fade Out BGM fades the music and forgets the current track' do
     FakeCmd.new(IC::FADEOUT_BGM, [2000]), # 2000 ms
   ])
   it.update
-  eq nil, st.current_bgm, 'nothing is playing after a fade-out'
+  eq 'Town', st.current_bgm[:name],
+     'the current-BGM record still names the track that was fading'
   eq [:bgm_fade, 2000], RGSS::Audio.log.last, 'the parameter is passed straight through as ms'
+end
+
+check 'Memorize BGM taken after a Fade Out BGM still memorises the faded track' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::FADEOUT_BGM, [2000]),
+    FakeCmd.new(IC::MEMORIZE_BGM, []),
+    FakeCmd.new(IC::PLAY_BGM, [0, 100, 100], string: 'fanfare'),
+    FakeCmd.new(IC::PLAY_MEMORIZED_BGM, []),
+  ])
+  it.update
+  eq 'town', st.current_bgm[:name],
+     'the memorized BGM is the pre-fade track, not silence'
 end
 
 check 'Play Movie records the request instead of dropping it' do


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter::CommandFadeOutBGM` (`src/game_interpreter.cpp`) calls `Main_Data::game_system->BgmFade(fadeout)` with a single argument. `Game_System::BgmFade`'s `clear_current_music` parameter (`src/game_system.h`: `void BgmFade(int duration, bool clear_current_music = false);`) defaults to `false`, so an ordinary Fade Out BGM never clears `data.current_music` — only callers that explicitly pass `true` (an unrelated title/reset path in `player.cpp`) do. `Game_System::MemorizeBGM` (`data.stored_music = data.current_music;`) confirms a Memorize BGM issued after a fade captures whatever `current_music` still holds — the pre-fade track.
- `Interpreter#do_fadeout_bgm` (`mruby-rpg2k/mrblib/interpreter.rb`) unconditionally set `@state.current_bgm = nil`, contradicted by the source above — its own doc comment carried that claim with no citation. Traced consequences: `#do_memorize_bgm` stored `nil` instead of the pre-fade track (a later Play Memorized BGM restored silence); `@current_bgm` is persisted into the Marshal save and `.lsd`, so a Save taken right after a fade forgot the track on Continue; and `Scene::Map`'s vehicle/battle/inn BGM-restore snapshots captured `nil` instead of the faded track, so disembarking/ending a battle/leaving an inn shortly after a fade restored silence instead of resuming it.
- Fixed by removing the `@state.current_bgm = nil` line (`@state.bgm_looped = false` is unrelated and left alone) and correcting the misleading doc comment.

## Test plan
- [x] Rewrote the existing `scripts/rpg2k_logic_check.rb` "Fade Out BGM" check: the current-BGM record must still name the faded track, not `nil`.
- [x] New check: a Memorize BGM taken after a Fade Out BGM still memorises the faded track, not silence.
- [x] Confirmed both fail against the pre-fix code (`git stash` on `interpreter.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 817 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1071 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_