### PR TITLE
Fix: field menu grays out a disabled command's label

### DIFF
--- a/changelog.d/menu-disabled-command-swatch.fixed.md
+++ b/changelog.d/menu-disabled-command-swatch.fixed.md
@@ -1,0 +1,6 @@
+- **Field menu:** A command the menu will refuse (Save with saving turned
+  off, Item/Skill/Equip with an empty party) now grays out, reading the
+  windowskin's own disabled-text swatch -- matching RPG_RT's own
+  `Window_Command::DrawItem`. Previously every row drew in the same plain
+  white regardless of whether it was actually usable, even though selecting
+  a disabled command already correctly refused with just a buzzer.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4296,6 +4296,36 @@ The work below is roughly ordered by the critical path to a walkable game
   @state.save_access`, no `else`. This buzzer, and the rest of the field
   menu's system SE playback, is now modelled too -- see the ✅ bullet just
   below.
+  ✅ **Follow-up (2026-08-20): the field menu never grayed out a disabled
+  command's label at all -- only the buzzer-and-refuse *behaviour* above
+  was fixed, not the visual cue RPG_RT shows before the player even
+  tries.** Confirmed directly against RPG_RT's live source: `Scene_Menu::
+  CreateCommandWindow` (`src/scene_menu.cpp`, the "Disable items" loop)
+  disables Save on `!GetAllowSave()`, Order on `GetActors().size() <= 1`,
+  and every other command (Item/Skill/Equipment/Status/Row) on
+  `GetActors().empty()` -- Wait/Quit/Settings/Debug are never disabled.
+  `Window_Command::SetItemEnabled`/`DrawItem` (`src/window_command.cpp`)
+  then draws a disabled row through `Font::ColorDisabled` (swatch index 3,
+  `src/font.h`), the same windowskin-blended path every row uses, not a
+  hardcoded flat gray -- the identical convention already ported for
+  `Scene::Title`'s Continue and `Scene::SaveLoad`'s file rows (both
+  documented elsewhere in this file), just never carried over to the field
+  menu's own command list. `Scene::Menu#build_windows`/
+  `#redraw_command_labels` (`mruby-rpg2k/mrblib/scene/menu.rb`) drew every
+  row through a bare `cc.draw_text` in plain white, with no check of
+  `@state.save_access` or the party's size/emptiness at all -- `#select_
+  command`'s own per-key gates (quoted just above) already implement the
+  buzzer, but nothing told the player which rows were live before they
+  tried. Fixed by adding `#command_disabled?(key)` (the same three RPG_RT
+  rules, reusing the exact conditions `#select_command` already checks) and
+  a shared `#draw_command_labels(cc)` helper, called from both label-drawing
+  sites, that switches between the default and disabled `draw_system_text`
+  swatch per row exactly like `Scene::Title`'s own fix. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (a disabled Save blends from swatch
+  index 3, restoring save access clears it; an empty party disables exactly
+  the three party-dependent RPG2000 commands, Item/Skill/Equip, leaving
+  Save/End Game alone), both confirmed to fail against the pre-fix code
+  before the fix.
   ✅ **End Game now opens a Yes/No confirmation instead of quitting the game
   outright on the first press.** This engine's `Scene::Menu#select_command`
   played the Decision SE and called `@parent.return_to_title` directly --

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -285,10 +285,7 @@ class RPG2k
         @command.z = 400
         @command.windowskin = @skin
         cc = Bitmap.new(cw - Window::BORDER * 2, @commands.size * LINE_H)
-        cc.font.color = Color.new(255, 255, 255, 255)
-        @commands.each_with_index do |(_key, label), i|
-          cc.draw_text 0, i * LINE_H + 2, cc.width, LINE_H, label
-        end
+        draw_command_labels(cc)
         @command.contents = cc
         refresh_cursor
 
@@ -360,11 +357,52 @@ class RPG2k
       def redraw_command_labels
         cc = @command.contents
         cc.clear
-        cc.font.color = Color.new(255, 255, 255, 255)
-        @commands.each_with_index do |(_key, label), i|
-          cc.draw_text 0, i * LINE_H + 2, cc.width, LINE_H, label
-        end
+        draw_command_labels(cc)
         refresh_cursor
+      end
+
+      # Whether command `key`'s row should read the windowskin's own
+      # *disabled* swatch instead of its default text colour -- confirmed
+      # directly against RPG_RT's live source: `Scene_Menu::
+      # CreateCommandWindow` (`src/scene_menu.cpp`) disables Save on
+      # `!GetAllowSave()`, Order on `GetActors().size() <= 1`, and every
+      # other command (Item/Skill/Equipment/Status/Row) on
+      # `GetActors().empty()` -- Wait/Quit/Settings/Debug are never
+      # disabled. The exact same three gates `#select_command` above
+      # already enforces as buzzer-and-refuse *behaviour*; this is only the
+      # missing visual cue RPG_RT shows before the player even tries.
+      def command_disabled?(key)
+        case key
+        when :save then !@state.save_access
+        when :order then @state.party.actors.size <= 1
+        when :item, :skill, :equip, :status, :row then @state.party.actors.empty?
+        else false
+        end
+      end
+
+      # Draw every command row into `cc`, in the windowskin's own default
+      # text colour or its *disabled* swatch (system-colour index 3) per
+      # `#command_disabled?` -- confirmed against RPG_RT's live source:
+      # `Window_Command::SetItemEnabled`/`DrawItem` (`src/window_command.cpp`)
+      # always draws a disabled row through `Font::ColorDisabled` (swatch
+      # index 3, `src/font.h`), the same windowskin-blended path every
+      # enabled row uses, not a hardcoded flat gray -- a custom windowskin
+      # whose disabled swatch is tinted shows that tint on real RPG_RT, the
+      # same rule already ported for `Scene::Title`'s Continue and
+      # `Scene::SaveLoad`'s file rows. `draw_system_text`'s own no-windowskin
+      # fallback (plain `draw_text` in the current font colour) still
+      # supplies the flat gray when there is no skin to sample.
+      def draw_command_labels(cc)
+        @commands.each_with_index do |(key, label), i|
+          y = i * LINE_H + 2
+          if command_disabled?(key)
+            cc.font.color = Color.new(128, 128, 128, 255)
+            draw_system_text cc, 0, y, cc.width, LINE_H, label, @skin, 3
+          else
+            cc.font.color = Color.new(255, 255, 255, 255)
+            draw_system_text cc, 0, y, cc.width, LINE_H, label, @skin
+          end
+        end
       end
 
       # Height of one party-status row (see #build_windows's own `y = i *

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16804,6 +16804,48 @@ check 'Scene::Menu: Save access forbidden refuses the selection silently, no mes
   ok scene.instance_variable_get(:@message).nil?, 'no message shown at all'
 end
 
+check 'Scene::Menu: a disabled command reads the windowskin\'s own disabled ' \
+      'swatch, not the default text colour' do
+  # Confirmed directly against RPG_RT's live source: `Scene_Menu::
+  # CreateCommandWindow` (`src/scene_menu.cpp`) disables Save on
+  # `!GetAllowSave()` and every other non-Order command on
+  # `GetActors().empty()`; `Window_Command::SetItemEnabled`/`DrawItem`
+  # (`src/window_command.cpp`) then draws a disabled row through
+  # `Font::ColorDisabled` (swatch index 3, `src/font.h`), the same
+  # windowskin-blended path every row uses -- the same convention already
+  # ported for Scene::Title's Continue and Scene::SaveLoad's file rows.
+  db = fake_db
+  db.system.system_graphic = 'Skin1' # non-empty -> a real windowskin loads
+  st = wrap_menu_state
+  st.save_access = false
+  scene = menu_scene(RPG2k::Scene::Menu, st, db)
+  bc = scene.instance_variable_get(:@command).contents.blend_calls || []
+  # colour 3 -> swatch cell (3%10*16, 3/10*16+48) = (48, 48), the same
+  # geometry Scene::Title's own disabled-Continue check pins.
+  ok bc.any? { |call| call[6] == 48 && call[7] == 48 },
+     'the disabled Save label blends from swatch index 3 (48, 48)'
+
+  st.save_access = true
+  scene2 = menu_scene(RPG2k::Scene::Menu, st, db)
+  bc2 = scene2.instance_variable_get(:@command).contents.blend_calls || []
+  ok !bc2.any? { |call| call[6] == 48 && call[7] == 48 },
+     'once save access is restored, no row blends from the disabled swatch'
+end
+
+check 'Scene::Menu: an empty party disables Item/Skill/Equip too, not just Save' do
+  db = fake_db
+  db.system.system_graphic = 'Skin1'
+  st = wrap_menu_state
+  st.party.instance_variable_set(:@actors, [])
+  scene = menu_scene(RPG2k::Scene::Menu, st, db)
+  bc = scene.instance_variable_get(:@command).contents.blend_calls || []
+  disabled_rows = bc.count { |call| call[6] == 48 && call[7] == 48 }
+  # RPG2000's fixed five commands: Item/Skill/Equip disable on an empty
+  # party; Save (gated on save_access, untouched here) and End Game (Quit,
+  # never disabled) do not.
+  eq 3, disabled_rows, "expected 3 disabled rows (Item/Skill/Equip), got #{disabled_rows}"
+end
+
 def save_load_scene(mode, state = nil, db = fake_db, parent: nil)
   parent ||= fake_parent(db)
   [RPG2k::Scene::SaveLoad.new(parent, state, mode), parent]


### PR DESCRIPTION
## Summary
- RPG_RT's `Scene_Menu::CreateCommandWindow` (`src/scene_menu.cpp`, the "Disable items" loop) disables Save on `!GetAllowSave()`, Order on `GetActors().size() <= 1`, and every other command (Item/Skill/Equipment/Status/Row) on `GetActors().empty()` — Wait/Quit/Settings/Debug are never disabled. `Window_Command::SetItemEnabled`/`DrawItem` (`src/window_command.cpp`) then draws a disabled row through `Font::ColorDisabled` (swatch index 3, `src/font.h`), the same windowskin-blended path every row uses, not a hardcoded flat gray — the identical convention already ported for `Scene::Title`'s Continue and `Scene::SaveLoad`'s file rows, just never carried over to the field menu's own command list.
- `Scene::Menu#build_windows`/`#redraw_command_labels` (`mruby-rpg2k/mrblib/scene/menu.rb`) drew every row through a bare `cc.draw_text` in plain white, with no check of `@state.save_access` or the party's size/emptiness at all — `#select_command`'s own per-key gates already implement the buzzer-and-refuse behavior, but nothing told the player which rows were live before they tried.
- Fixed by adding `#command_disabled?(key)` (the same three rules `#select_command` already checks) and a shared `#draw_command_labels(cc)` helper, called from both label-drawing sites, switching between the default and disabled `draw_system_text` swatch per row exactly like `Scene::Title`'s own fix.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` checks: a disabled Save blends from the windowskin's swatch index 3, restoring save access clears it; an empty party disables exactly the three party-dependent RPG2000 commands (Item/Skill/Equip), leaving Save/End Game alone.
- [x] Confirmed both fail against the pre-fix code (`git stash` on `menu.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 819 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1071 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_