### PR TITLE
Fix: \N[] only substitutes the party leader when a number was parsed

### DIFF
--- a/changelog.d/message-n-bracket-leader-guard.fixed.md
+++ b/changelog.d/message-n-bracket-leader-guard.fixed.md
@@ -1,0 +1,6 @@
+- **Message text:** A bare `\N[]`, or `\N[x]` where `x` is neither a digit
+  nor a `\V[]`/`\v[]` reference, now expands to nothing -- matching RPG_RT's
+  own `Game_Message::ParseParam`, the party-leader substitution for actor id
+  0 only applies when a digit or a resolvable nested `\V[]` was actually
+  read inside the brackets. Previously any unparseable `\N[]` bracket named
+  the party leader instead.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11618,6 +11618,43 @@ not yet verified:
   reproducing RPG_RT's own quirk of leaving a stray `]` behind when
   nested past that limit rather than resolving cleanly), confirmed to
   fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-20): `\N[]`'s id-0-means-party-leader convenience
+  applied unconditionally whenever the parsed value came out 0, including
+  a bracket that parsed nothing at all — `\N[]`, or `\N[x]` where `x` is
+  neither a digit nor a recognised `\V[]`/`\v[]` reference — which real
+  RPG_RT leaves blank, not the leader's name.** Confirmed directly against
+  RPG_RT's live source: `Game_Message::ParseParam` (`src/game_message.cpp`)
+  tracks its own `got_valid_number` flag, set only when a literal digit or
+  a resolvable nested `\V[]`/`\v[]` is actually consumed inside the
+  brackets, and gates the substitution on `upper == 'N' && values.front()
+  == 0 && got_valid_number` — not on the value alone. A bracket that reads
+  nothing leaves the id at 0, which is not a valid 1-based actor id; real
+  RPG_RT's `DefaultCommandInserter` (`src/pending_message.cpp`) then misses
+  on `GetActor(0)`, logs `"Invalid Actor Id 0 in message text"`, and
+  expands to an empty string. `Game::Message.parse_bracket_value`
+  (`mruby-rpg2k/mrblib/game.rb`) — the character-scanning port described
+  just above — never tracked this flag at all, and `Scene::Map#actor_name`
+  applies its own id-0-means-leader shortcut (`id.to_i.zero? ?
+  party_leader : ...`) purely off the numeric value it is handed, so every
+  route into it read the same way: an explicit `\N[0]` and a bare `\N[]`
+  both named the party leader, where only the former should. Fixed by
+  having `parse_bracket_value` return a third element, `got_number`
+  (RPG_RT's own `got_valid_number`, set on the digit branch and the nested-
+  `\V[]` branch alike, mirroring its explicit `got_valid_number = true;` in
+  that branch independent of the recursive call's own result) — the other
+  three callers (`\V[]`/`\C[]`/`\S[]`) simply destructure the first two
+  elements, which Ruby allows without error. `Message.scan`'s `'n', 'N'`
+  case now passes `-1` (a value `#actor_name`'s own zero-check will never
+  match) instead of the raw parsed value whenever `got_number` is false, so
+  an unresolved bracket falls through to its own dangling-id blank-string
+  path instead of ever reaching the leader shortcut; `Scene::Map#actor_name`
+  itself is unchanged. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (an explicit `\N[0]` still substitutes the leader; a bare `\N[]`
+  and a non-digit, non-`\V[]` `\N[x]` both resolve to blank, and the id-0
+  lookup is never even attempted for either; a nested `\V[]` that resolves
+  to variable value 0 still counts as "a number was read" and the
+  substitution applies), confirmed to fail against the pre-fix code before
+  the fix.
 
 **Pictures**
 - ✅ **Move Picture's own per-frame easing now keeps full float precision

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -134,8 +134,24 @@ module Game
             end
           when 'n', 'N'
             if text[i] == '['
-              val, i = parse_bracket_value(text, i, variables)
-              s = (names[val] || '').to_s
+              val, i, got_number = parse_bracket_value(text, i, variables)
+              # `\N[]`'s id-0-means-party-leader convenience
+              # (`Scene::Map#actor_name`) only applies when a digit or a
+              # resolvable nested `\V[]` was actually read inside the
+              # brackets -- confirmed directly against RPG_RT's live
+              # source: `Game_Message::ParseParam` (`src/game_message.cpp`)
+              # guards the substitution on `values.front() == 0 &&
+              # got_valid_number`, not on the value alone. A bracket that
+              # parsed nothing at all (a bare `\N[]`, or `\N[x]` where `x`
+              # is neither a digit nor `\V[]`/`\v[]`) leaves the id at 0,
+              # which is not a valid 1-based actor id -- real RPG_RT's
+              # `DefaultCommandInserter` (`src/pending_message.cpp`) then
+              # misses on `GetActor(0)` and expands to an empty string, not
+              # the leader's name. `-1` here is simply a value #actor_name's
+              # own `id.to_i.zero?` leader check will never match, so an
+              # unresolved bracket falls through to its own dangling-id
+              # blank-string path unchanged.
+              s = (names[got_number ? val : -1] || '').to_s
               cur << s
               count += s.length
             end
@@ -266,16 +282,23 @@ module Game
     #   rather than resetting to 0 -- unlike this method's own predecessor,
     #   which fell through to `String#to_i` and silently dropped everything
     #   from the first non-leading-digit character on.
+    #
+    # Returns a third element, `got_number` -- whether a digit or a
+    # resolvable nested `\V[]` was actually read (RPG_RT's own
+    # `got_valid_number`, `src/game_message.cpp`) -- callers besides `\N[]`
+    # (`\V[]`/`\C[]`/`\S[]`) have no use for it and simply destructure the
+    # first two elements, which Ruby allows without error.
     def self.parse_bracket_value(text, i, variables, depth = 1)
       n = text.length
       # No bracket at all (reachable recursively too -- a malformed nested
       # reference like `\N[\V]`, `\v` with no `[` following): RPG_RT's own
       # ParseParam returns 0 without consuming anything, matching `if (iter
       # == end || *iter != '[') { return { iter, 0 }; }`.
-      return [0, i] unless i < n && text[i] == '['
+      return [0, i, false] unless i < n && text[i] == '['
       i += 1
       value = 0
       stop_parsing = false
+      got_number = false
       while i < n && text[i] != ']'
         if stop_parsing
           i += 1
@@ -285,18 +308,20 @@ module Game
         if ch >= '0' && ch <= '9'
           value = value * 10 + ch.to_i
           i += 1
+          got_number = true
         elsif depth > 0 && ch == '\\' && i + 1 < n && (text[i + 1] == 'V' || text[i + 1] == 'v')
           var_id, i = parse_bracket_value(text, i + 2, variables, depth - 1)
           var_val = variables[var_id].to_i
           m = 10
           m *= 10 while value != 0 && m < var_val
           value = value * m + var_val
+          got_number = true
         else
           stop_parsing = true
         end
       end
       i += 1 if i < n # consume the matching ']'
-      [value, i]
+      [value, i, got_number]
     end
   end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -851,6 +851,42 @@ check 'Message.scan resolves a nested \V[] argument inside \c[]/\s[] too ' \
   eq [{ at: 1, speed: 12 }], s2[:speeds]
 end
 
+check 'Message.scan\'s \N[]-id-0-means-party-leader convenience only applies ' \
+      'when a digit or resolvable \V[] was actually read inside the brackets' do
+  # Confirmed directly against RPG_RT's live source: `Game_Message::
+  # ParseParam` (`src/game_message.cpp`) guards the substitution on
+  # `values.front() == 0 && got_valid_number` -- a bracket that parsed
+  # nothing at all (`\N[]`, or `\N[x]` where `x` is neither a digit nor
+  # `\V[]`/`\v[]`) leaves the id at 0, which real RPG_RT's own
+  # `DefaultCommandInserter` (`src/pending_message.cpp`) then misses on
+  # `GetActor(0)` and expands to an empty string, not the leader's name.
+  vars = Game::Variables.new
+  vars[5] = 0
+  seen = []
+  names = ->(id) { seen << id; id.zero? ? 'Leader' : nil }
+
+  s = Game::Message.scan('\N[0]', vars, names)
+  eq 'Leader', s[:segments].map { |seg| seg[:text] }.join,
+     'an explicit \\N[0] still substitutes the leader'
+
+  seen.clear
+  s2 = Game::Message.scan('\N[]', vars, names)
+  eq '', s2[:segments].map { |seg| seg[:text] }.join,
+     'a bare \\N[] with nothing parsed resolves to blank, not the leader'
+  ok !seen.include?(0), 'the leader lookup (id 0) must never be attempted for an unparsed bracket'
+
+  seen.clear
+  s3 = Game::Message.scan('\N[x]', vars, names)
+  eq '', s3[:segments].map { |seg| seg[:text] }.join,
+     'a non-digit, non-\\V[] bracket body resolves to blank too'
+
+  seen.clear
+  s4 = Game::Message.scan('\N[\V[5]]', vars, names)
+  eq 'Leader', s4[:segments].map { |seg| seg[:text] }.join,
+     'a nested \\V[] that resolves to 0 still counts as "a number was read" -- ' \
+     'leader substitution applies'
+end
+
 check 'Message.scan flags \$ (show gold) and drops it from the text' do
   vars = Object.new
   def vars.[](_i); 0; end


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Message::ParseParam` (`src/game_message.cpp`) tracks a `got_valid_number` flag, set only when a literal digit or a resolvable nested `\V[]`/`\v[]` reference is actually consumed inside the brackets, and gates the actor-id-0-means-party-leader substitution on `upper == 'N' && values.front() == 0 && got_valid_number` — not on the value alone. A bracket that parses nothing at all (a bare `\N[]`, or `\N[x]` where `x` is neither a digit nor a recognized nested reference) leaves the id at 0, which real RPG_RT's `DefaultCommandInserter` (`src/pending_message.cpp`) then misses on `GetActor(0)`, logs `"Invalid Actor Id 0 in message text"`, and expands to an empty string.
- `Game::Message.parse_bracket_value` (`mruby-rpg2k/mrblib/game.rb`) never tracked this flag, and `Scene::Map#actor_name`'s own id-0-means-leader shortcut applies purely off the numeric value it is handed — so an explicit `\N[0]` and a bare `\N[]` both named the party leader, where only the former should.
- Fixed by having `parse_bracket_value` return a third element, `got_number` (set on the digit branch and the nested-`\V[]` branch, mirroring RPG_RT's explicit `got_valid_number = true;` in that branch independent of the recursive call's own result) — the other three callers (`\V[]`/`\C[]`/`\S[]`) simply destructure the first two elements. `Message.scan`'s `'n', 'N'` case now passes `-1` (a value `#actor_name`'s own zero-check will never match) instead of the raw parsed value whenever `got_number` is false, so an unresolved bracket falls through to its existing dangling-id blank-string path instead of ever reaching the leader shortcut.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: an explicit `\N[0]` still substitutes the leader; a bare `\N[]` and a non-digit, non-`\V[]` `\N[x]` both resolve to blank with the id-0 lookup never even attempted; a nested `\V[]` resolving to variable value 0 still counts as "a number was read" and the substitution applies.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 819 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1072 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_