### PR TITLE
Fix: Status screen shows the absolute EXP threshold, not the remainder

### DIFF
--- a/changelog.d/status-screen-exp-threshold.fixed.md
+++ b/changelog.d/status-screen-exp-threshold.fixed.md
@@ -1,0 +1,5 @@
+- **Status screen:** The "Next" EXP figure now shows the absolute EXP
+  threshold for the next level -- matching RPG_RT's own
+  `Window_ActorStatus::DrawStatus`/`GetNextExpString` -- instead of the
+  remaining delta to reach it (e.g. "2000" rather than "766" for an actor
+  1234 EXP into a 2000 threshold).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15230,6 +15230,34 @@ existing left-aligned lines. Covered by a new
 `scripts/rpg2k_scene_check.rb` check (an RPG2000 party draws neither
 label; an RPG2003 party shows "Front" by default and "Back" once the
 actor's own row is toggled), confirmed to fail against the pre-fix code.
+✅ **Follow-up (2026-08-20): the field Status screen's "Next" EXP figure
+showed the remaining delta to the next level, not the absolute threshold
+RPG_RT itself displays.** Confirmed directly against RPG_RT's live
+source: `Window_ActorStatus::DrawStatus` (`src/window_actorstatus.cpp`)
+draws the Exp row via `DrawMinMax(90, 34, -1, -1)` — the `-1, -1`
+sentinel routes both halves through `actor.GetExpString(true)`/
+`GetNextExpString(true)` rather than a literal min/max pair.
+`Game_Actor::GetNextExpString`/`GetNextExp` (`src/game_actor.cpp`)
+stringifies `exp_list[GetLevel()]`, the same absolute cumulative-total
+curve value `CalculateExp` produces — not a subtraction against current
+EXP. `Scene::StatusMenu#build_window`
+(`mruby-rpg2k/mrblib/scene/status_menu.rb`) read `a.exp_to_next`
+(`mruby-rpg2k/mrblib/game.rb`), which subtracts current EXP from the
+threshold and returns the remainder (e.g. exp 1234 against a 2000
+threshold shows "766", where real RPG_RT shows "2000") — the wrong
+accessor for this screen. `Game::Actor#next_level_exp` already computed
+exactly the correct absolute value (a direct port of `CalculateExp`,
+used correctly elsewhere) but was never the one this screen read.
+`#exp_to_next` is used nowhere else in this codebase besides its own
+independent test coverage, so it is left in place unchanged — only the
+Status screen's own accessor choice was wrong. Fixed by swapping
+`a.exp_to_next` for `a.next_level_exp` in `#build_window`, and
+correcting this file's own class comment, which had asserted the old
+(wrong) accessor as fact with no citation of its own. Covered by a new
+`scripts/rpg2k_scene_check.rb` check (`MenuStubActor` gives
+`#next_level_exp`/`#exp_to_next` distinct values, 420 vs 120, so the
+check can tell which one the screen actually reads — it must show 420,
+never 120), confirmed to fail against the pre-fix code.
 ✅ **A dangling battle-animation id no longer draws nothing with no trace** —
 the "battle animation" case from the "invalid hero, skill, item, enemy,
 enemy group, battle animation, terrain, chipset, common event" list above.

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -1,10 +1,13 @@
 class RPG2k
   module Scene
     # The field status screen (main menu -> Status). Shows one party member's full
-    # detail -- name/title, level, EXP and EXP-to-next, HP/MP, the six stats and
-    # the five equipment slots; LEFT/RIGHT cycle the member. Read-only, so there
-    # is no sub-mode. The EXP-to-next figure is Game::Actor#exp_to_next
-    # (host-tested); the rest reads existing accessors.
+    # detail -- name/title, level, EXP and the next level's absolute EXP
+    # threshold, HP/MP, the six stats and the five equipment slots; LEFT/
+    # RIGHT cycle the member. Read-only, so there is no sub-mode. The "Next"
+    # figure is Game::Actor#next_level_exp -- the absolute threshold RPG_RT's
+    # own `Window_ActorStatus::DrawStatus` displays (`GetNextExpString`),
+    # not the remaining-EXP delta `#exp_to_next` computes (host-tested); the
+    # rest reads existing accessors.
     class StatusMenu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
@@ -104,7 +107,21 @@ class RPG2k
         a = @state.party.actors[@actor_index]
         title = a.title.to_s
         header = title.empty? ? a.name.to_s : "#{a.name}  #{title}"
-        nxt = a.exp_to_next
+        # The "Next" figure is the *absolute* EXP threshold for the next
+        # level, not the remaining delta -- confirmed directly against
+        # RPG_RT's live source: `Window_ActorStatus::DrawStatus`
+        # (`src/window_actorstatus.cpp`) draws the Exp row via
+        # `DrawMinMax(90, 34, -1, -1)`, whose `-1, -1` sentinel routes both
+        # halves through `actor.GetExpString(true)`/`GetNextExpString(true)`
+        # rather than the literal `min`/`max` a normal HP/MP-style call
+        # would draw; `Game_Actor::GetNextExpString` (`src/game_actor.cpp`)
+        # stringifies `GetNextExp()`, which is `exp_list[GetLevel()]` --
+        # the same absolute cumulative-total curve value `CalculateExp`
+        # produces, not a subtraction against current EXP. `#next_level_exp`
+        # (`mruby-rpg2k/mrblib/game.rb`) already computes exactly this
+        # absolute value; `#exp_to_next` instead subtracts current EXP from
+        # it, matching neither RPG_RT's own displayed number.
+        nxt = a.next_level_exp
         lines = [
           header,
           # RPG_RT always draws a labelled Class/Profession row on this

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16108,6 +16108,7 @@ class MenuStubActor
     @battle_row = Game::Battle::ROW_FRONT
   end
   def exp_to_next; 120; end
+  def next_level_exp; 420; end
   def add_state(id); @states.push(id) unless @states.include?(id); end
   attr_accessor :can_act_flag
   def can_act?; @can_act_flag.nil? ? true : @can_act_flag; end
@@ -19239,6 +19240,26 @@ check 'the status screen shows a labelled Class row' do
   texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
                          .instance_variable_get(:@window))
   ok texts.include?('Class: Paladin'), "shows the class name, got: #{texts.inspect}"
+end
+
+# Confirmed directly against RPG_RT's live source: `Window_ActorStatus::
+# DrawStatus` (`src/window_actorstatus.cpp`) draws the Exp row via
+# `DrawMinMax(90, 34, -1, -1)`, whose sentinel routes both halves through
+# `GetExpString`/`GetNextExpString` rather than a literal min/max pair;
+# `Game_Actor::GetNextExpString` (`src/game_actor.cpp`) stringifies
+# `GetNextExp()` -- the absolute cumulative-total curve value for the next
+# level, not a subtraction against current EXP. `MenuStubActor` gives
+# `#next_level_exp`/`#exp_to_next` distinct values (420 vs 120) precisely so
+# this check can tell which one the screen actually reads.
+check 'the status screen\'s "Next" EXP figure is the absolute next-level ' \
+      'threshold, not the remaining delta' do
+  st = menu_state
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
+                         .instance_variable_get(:@window))
+  ok texts.include?('Lv 5    EXP 300    Next 420'),
+     "expected the absolute threshold (420), got: #{texts.inspect}"
+  ok !texts.any? { |t| t.include?('Next 120') },
+     "must not show the remaining-EXP delta (120) instead, got: #{texts.inspect}"
 end
 
 check 'the status screen gives the condition a labelled row' do


### PR DESCRIPTION
## Summary
- RPG_RT's `Window_ActorStatus::DrawStatus` (`src/window_actorstatus.cpp`) draws the Exp row via `DrawMinMax(90, 34, -1, -1)` — the `-1, -1` sentinel routes both halves through `actor.GetExpString(true)`/`GetNextExpString(true)` rather than a literal min/max pair. `Game_Actor::GetNextExpString`/`GetNextExp` (`src/game_actor.cpp`) stringifies `exp_list[GetLevel()]`, the same absolute cumulative-total curve value `CalculateExp` produces — not a subtraction against current EXP.
- `Scene::StatusMenu#build_window` (`mruby-rpg2k/mrblib/scene/status_menu.rb`) read `a.exp_to_next` (`mruby-rpg2k/mrblib/game.rb`), which subtracts current EXP from the threshold and returns the remainder (e.g. exp 1234 against a 2000 threshold shows "766", where real RPG_RT shows "2000") — the wrong accessor for this screen. `Game::Actor#next_level_exp` already computed exactly the correct absolute value (a direct port of `CalculateExp`, used correctly elsewhere) but was never the one this screen read.
- `#exp_to_next` is used nowhere else in this codebase besides its own independent test coverage, so it is left in place unchanged — only the Status screen's own accessor choice was wrong. Fixed by swapping `a.exp_to_next` for `a.next_level_exp`, and correcting this file's own class comment, which had asserted the old (wrong) accessor as fact with no citation of its own.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: `MenuStubActor` gives `#next_level_exp`/`#exp_to_next` distinct values (420 vs 120) so the check can tell which one the screen actually reads — it must show 420, never 120.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `status_menu.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 820 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1072 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_