### PR TITLE
Fix: a \./\| message pause can no longer be skipped by a button press

### DIFF
--- a/changelog.d/message-timed-pause-no-skip.fixed.md
+++ b/changelog.d/message-timed-pause-no-skip.fixed.md
@@ -1,0 +1,5 @@
+- **Message text:** A `\.` (quarter-second) or `\|` (full-second) pause can
+  no longer be cut short by pressing Decision or Cancel -- matching RPG_RT's
+  own `Window_Message::Update`, these are frame countdowns unaffected by
+  input; only `\!` waits for a button. Test Play's own Shift fast-forward
+  still speeds through them as before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8561,6 +8561,32 @@ not yet verified:
   new `scripts/rpg2k_scene_check.rb` check pinning a `\s[20]\.` pause to
   exactly 20 frames (16 + 4, the maximum stretch), confirmed to fail against
   the pre-fix code before the fix (`expected 20, got 16`).
+  ✅ **Follow-up (2026-08-20): an ordinary Decision/Cancel press let the
+  player cut a `\.`/`\|` pause short — real RPG_RT never lets a button skip
+  either one, only Test Play's own Shift fast-forward may.** Confirmed
+  directly against RPG_RT's live source: `Window_Message::Update`
+  (`src/window_message.cpp`) decrements `wait_count` (the counter `\.`/`\|`
+  set via `SetWaitForNonPrintable`) and returns unconditionally while it is
+  still positive, entirely before the separate `GetPause()`/`WaitForInput()`
+  branch — the one that checks `Input::IsTriggered(DECISION/CANCEL)` — even
+  runs; `case '.'`/`case '|'` (the same file) only ever call
+  `SetWaitForNonPrintable`, never `SetPause(true)`, unlike `case '!'`, which
+  calls both. `Scene::Map#drive_message_pause`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) merged the ordinary confirm press and
+  Test Play's own Shift fast-forward into one `pressed` flag and released a
+  `:full`/`:quarter` pause on either, letting a plain Decision/Cancel tap
+  blow straight through a timed hold the way it correctly does for a `\!`
+  pause — a discrepancy this file's own class comment ("a button skips the
+  wait") had asserted as fact with no citation of its own. Fixed by
+  threading the Test-Play-Shift component through as its own parameter
+  (`shift_forward`), separate from the merged `pressed`/`fast_forward`
+  flag: `:key` (`\!`) pauses are unchanged, still released by either;
+  `:full`/`:quarter` (`\.`/`\|`) pauses now release only on `shift_forward`
+  reaching zero on their own frame countdown, mirroring `SetWaitForNonPrintable`'s
+  own `if (!instant_speed)` guard around `SetWait`. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a Decision press held throughout a
+  `\.` pause must not shorten it below its real 16 frames), confirmed to
+  fail against the pre-fix code before the fix (`expected 16, got 1`).
 - ✅ **A blocked Move Route step on a *skippable* ("Ignore If Can't Move")
   route no longer leaves the character visibly turned toward the
   obstruction — the failed turn now reverts entirely before the route

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7484,7 +7484,8 @@ class RPG2k
         # speeds up one paragraph's reveal, it does not blow through
         # paragraph after paragraph on its own. Gated on RPG2k#test_play the
         # same way #debug_through? is, so a released game never sees it.
-        fast_forward = confirm || (@parent.test_play && Input.press?(Input::SHIFT))
+        shift_forward = @parent.test_play && Input.press?(Input::SHIFT)
+        fast_forward = confirm || shift_forward
         unless reveal.done?
           pause = reveal.pending_pause
           # A `:page` pause (synthetic, at a page boundary) means the current
@@ -7505,7 +7506,7 @@ class RPG2k
           # `\.` / `\|` holds, which clear on their own.
           @message[:window].pause = pause ? pause[:kind] == :key : false
           if pause
-            drive_message_pause(reveal, pause, fast_forward)
+            drive_message_pause(reveal, pause, fast_forward, shift_forward)
           elsif fast_forward
             reveal.reveal_all
           else
@@ -7532,11 +7533,23 @@ class RPG2k
       end
 
       # Hold the reveal at a pacing code: `\!` waits for a button, `\.` / `\|`
-      # count down a fixed number of frames (a button skips the wait). A `\.`
-      # pause's own length depends on the `\s[n]` typing speed in effect at
-      # that point in the text (see #speed_at and MSG_PAUSE_QUARTER's own
-      # comment); `\|` never varies.
-      def drive_message_pause(reveal, pause, pressed)
+      # count down a fixed number of frames that an ordinary Decision/Cancel
+      # press cannot cut short -- confirmed directly against RPG_RT's live
+      # source: `Window_Message::Update` (`src/window_message.cpp`)
+      # decrements `wait_count` (the counter `\.`/`\|` set via
+      # `SetWaitForNonPrintable`) and returns unconditionally while it is
+      # still positive, entirely before the separate `GetPause()`/
+      # `WaitForInput()` branch that checks `Input::IsTriggered(DECISION/
+      # CANCEL)` even runs -- and `case '.'`/`case '|'` (the same file) only
+      # ever call `SetWaitForNonPrintable`, never `SetPause(true)`, unlike
+      # `case '!'`, which calls both. A `\.` pause's own length depends on
+      # the `\s[n]` typing speed in effect at that point in the text (see
+      # #speed_at and MSG_PAUSE_QUARTER's own comment); `\|` never varies.
+      # `shift_forward` alone (Test Play's own fast-forward, see
+      # #drive_text_message) still cuts a `\.`/`\|` wait short, mirroring
+      # `SetWaitForNonPrintable`'s own `if (!instant_speed)` guard around
+      # `SetWait` -- an ordinary player confirm press must not.
+      def drive_message_pause(reveal, pause, pressed, shift_forward)
         if pause[:kind] == :key
           reveal.release_pause if pressed
           return
@@ -7548,7 +7561,7 @@ class RPG2k
                                        MSG_PAUSE_QUARTER + Game.clamp(speed - 16, 0, 4)
                                      end
         @message[:pause_frames] -= 1
-        if pressed || @message[:pause_frames] <= 0
+        if shift_forward || @message[:pause_frames] <= 0
           @message[:pause_frames] = nil
           reveal.release_pause
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4287,6 +4287,44 @@ check 'a \\. pause holds the reveal for RPG_RT\'s real 16 frames, not the docume
   eq 16, held, 'RPG_RT holds a \\. pause for 16 frames, not the documented 15'
 end
 
+check 'an ordinary Decision press held throughout a \\. pause does not cut it ' \
+      'short -- only Test Play\'s own Shift fast-forward may' do
+  # Confirmed directly against RPG_RT's live source: `Window_Message::
+  # Update` (`src/window_message.cpp`) decrements `wait_count` (the counter
+  # `\.`/`\|` set via `SetWaitForNonPrintable`) and returns unconditionally
+  # while it is still positive -- entirely before the separate
+  # `GetPause()`/`WaitForInput()` branch that checks
+  # `Input::IsTriggered(DECISION/CANCEL)` even runs. `case '.'` (the same
+  # file) only ever calls `SetWaitForNonPrintable`, never `SetPause(true)`,
+  # unlike `case '!'`, which calls both -- so a `\.`/`\|` hold cannot be
+  # shortened by an ordinary button press the way a `\!` pause can.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'a\\.b')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  frames = 0
+  until reveal.pending_pause
+    scene.update
+    frames += 1
+    break if frames > 20
+  end
+  ok reveal.pending_pause, 'the \\. pause is reached'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # held throughout the pause
+  held = 0
+  until reveal.pending_pause.nil?
+    scene.update
+    held += 1
+    break if held > 30
+  end
+  RGSS::Input.reset
+  eq 16, held, 'a held Decision press must not shorten the \\. pause below its real 16 frames'
+end
+
 check 'a \\. pause at typing speed 20 holds for 20 frames, not a flat 16' do
   # EasyRPG's own comment calls this "a bug(??)": `SetWaitForNonPrintable(16
   # + Utils::Clamp(speed - 16, 0, 4))`, where `speed` is whatever `\s[n]`


### PR DESCRIPTION
## Summary
- RPG_RT's `Window_Message::Update` (`src/window_message.cpp`) decrements `wait_count` (the counter `\.`/`\|` set via `SetWaitForNonPrintable`) and returns unconditionally while it is still positive — entirely before the separate `GetPause()`/`WaitForInput()` branch, the one that checks `Input::IsTriggered(DECISION/CANCEL)`, even runs. `case '.'`/`case '|'` (the same file) only ever call `SetWaitForNonPrintable`, never `SetPause(true)`, unlike `case '!'`, which calls both.
- `Scene::Map#drive_message_pause` (`mruby-rpg2k/mrblib/scene/map.rb`) merged the ordinary confirm press and Test Play's own Shift fast-forward into one `pressed` flag and released a `:full`/`:quarter` pause on either — letting a plain Decision/Cancel tap blow straight through a timed `\.`/`\|` hold the way it correctly does for a `\!` pause. This file's own class comment ("a button skips the wait") had asserted this as fact with no citation of its own.
- Fixed by threading the Test-Play-Shift component through as its own parameter (`shift_forward`), separate from the merged `pressed`/`fast_forward` flag: `:key` (`\!`) pauses are unchanged, still released by either; `:full`/`:quarter` (`\.`/`\|`) pauses now release only on `shift_forward` or reaching zero on their own frame countdown, mirroring `SetWaitForNonPrintable`'s own `if (!instant_speed)` guard around `SetWait`.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a Decision press held throughout a `\.` pause must not shorten it below its real 16 frames.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `map.rb` only — `expected 16, got 1`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 821 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1072 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_