### PR TITLE
Fix: enemy AI never picks an Escape/Teleport or off-occasion Switch skill

### DIFF
--- a/changelog.d/enemy-ai-skill-battle-usable.fixed.md
+++ b/changelog.d/enemy-ai-skill-battle-usable.fixed.md
@@ -1,0 +1,5 @@
+- **Battle:** An enemy's action pattern no longer casts an Escape/Teleport-
+  type skill, or a Switch-type skill whose battle-occasion flag is off --
+  matching RPG_RT's own `EnemyAi::IsActionValid`/`Algo::IsSkillUsable`, such
+  an action is excluded from the weighted draw entirely, the same as it is
+  for a field/battle actor cast.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13278,6 +13278,43 @@ not yet verified:
   ineffective rating-60 skill's own rating even though the skill itself
   never fires), all three confirmed to fail against the pre-fix code
   before the fix.
+  ✅ **Follow-up (2026-08-20): a skill action naming an Escape/Teleport-type
+  skill, or a Switch-type skill whose battle-occasion flag is off, was
+  still fully eligible for the weighted draw — the same `enemy_action_
+  valid?`/`enemy_skill_ready?` gap `#skill_helps_troop?` (above) closed for
+  a *different* no-op class, left open for this one.** Confirmed directly
+  against RPG_RT's live source: `EnemyAi::IsActionValid`
+  (`src/enemyai.cpp`) rejects a `Kind_skill` action outright — before its
+  weight is even computed, not merely zeroed out afterward — when
+  `!source.IsSkillUsable(action.skill_id)`; `Game_Battler::IsSkillUsable`
+  (`src/game_battler.cpp`) reaches `Algo::IsSkillUsable` (`src/algo.cpp`),
+  which in battle is unconditionally `false` for a `Type_escape` or
+  `Type_teleport` skill, and for a `Type_switch` skill returns exactly
+  `skill.occasion_battle`. `Game::Battle#enemy_skill_ready?`
+  (`mruby-rpg2k/mrblib/game.rb`) checked only skill existence, the silence
+  seal, and SP affordability — never the skill's own type or occasion flag
+  — so an enemy's action pattern naming such a skill (a designer mistake,
+  or a skill later repurposed as Escape/Teleport/an off-occasion Switch
+  after the pattern was authored) could actually fire: casting Escape/
+  Teleport would compute a stray HP/MP effect from a row RPG_RT never lets
+  an enemy read this way, and an off-occasion Switch would still flip its
+  switch. Traced the whole downstream chain to rule out a later catch:
+  `Game::Party#skill_helps_troop?`/`#battle_skill_command` both have no
+  type gate of their own — they trust the caller to have already screened
+  the action. This is base RPG2000 behaviour (skill types Escape/Teleport/
+  Switch and `occasion_battle` are core RPG2000 fields, not an RPG2003/
+  Maniac-only feature). Fixed by adding `Game::EnemyAi#skill_battle_
+  usable?(sk)`, forwarding to `Game::Party#battle_skill?` — the party
+  class's own already-correct type/occasion gate, already used for the
+  ordinary field/battle actor cast path — and calling it from
+  `#enemy_skill_ready?` right after resolving the skill row, ahead of the
+  seal/cost checks. Covered by a new `scripts/rpg2k_logic_check.rb` check
+  (an Escape-type and a Teleport-type skill in an enemy's pattern never
+  fire, falling back to a plain attack instead; an off-occasion Switch
+  skill never fires either; the identical Switch skill with its occasion
+  flag on still fires normally), confirmed to fail against the pre-fix
+  code before the fix (the Teleport-type skill actually cast, computing a
+  stray zero-damage "hit").
 - ✅ **An action pattern's "Enemies" condition (`condition_type` 3,
   `COND_ACTORS`) now ranges over the acting monster's own living
   troop-mates, not the player party's headcount — a straight side-swap,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8733,6 +8733,24 @@ module Game
       party.skill_helps_troop?(sk, caster, troop)
     end
 
+    # Whether `sk` is even a legal in-battle action to name in an enemy's own
+    # action pattern -- reuses Game::Party's own #battle_skill? so an enemy's
+    # AI is gated the exact same way a field/battle actor cast is. Confirmed
+    # directly against RPG_RT's live source: `EnemyAi::IsActionValid`
+    # (`src/enemyai.cpp`) rejects a `Kind_skill` action outright when
+    # `!source.IsSkillUsable(action.skill_id)` -- before the action's own
+    # weight is ever computed -- and `Algo::IsSkillUsable` (`src/algo.cpp`),
+    # which `Game_Battler::IsSkillUsable` (`src/game_battler.cpp`) reaches in
+    # battle, is unconditionally false for an Escape/Teleport-type skill and
+    # gated on the skill's own `occasion_battle` flag for a Switch-type one.
+    # Defaults to "usable" without a party to ask, matching every other
+    # tolerant accessor here.
+    def skill_battle_usable?(sk)
+      party = @state && @state.respond_to?(:party) ? @state.party : nil
+      return true unless party && party.respond_to?(:battle_skill?)
+      party.battle_skill?(sk)
+    end
+
     # Whether `caster` (a live Game::Actor, not a battle Combatant snapshot —
     # #choose_auto_battle_command reaches through a Combatant's own `#actor`
     # to get one) can actually cast skill `sid` right now: reuses
@@ -11211,13 +11229,17 @@ module Game
       pct >= a.condition_param1 && pct <= a.condition_param2
     end
 
-    # Whether `b` can actually cast the skill action `a`: the skill exists and it
-    # can pay the SP. An enemy that cannot afford its spell falls through to its
-    # other actions, the way RPG_RT skips an unusable one.
+    # Whether `b` can actually cast the skill action `a`: the skill exists, is
+    # a legal in-battle action at all (not Escape/Teleport, and not a Switch
+    # skill whose battle-occasion flag is off -- see #skill_battle_usable?),
+    # and it can pay the SP. An enemy that cannot afford its spell -- or whose
+    # pattern names an illegal action entirely -- falls through to its other
+    # actions, the way RPG_RT never lets either kind enter the weighted draw.
     def enemy_skill_ready?(b, a)
       return false unless @ai
       sk = @ai.skill(a.skill_id)
       return false unless sk
+      return false unless @ai.skill_battle_usable?(sk)
       return false if skill_sealed?(b, sk) # silenced: this entry cannot fire
       cmd = @ai.skill_command(sk, b, nil)
       return false unless cmd

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -17909,12 +17909,14 @@ end
 class FakeAiSkill
   attr_accessor :name, :type, :scope, :sp_type, :sp_cost, :sp_percent, :power,
                 :physical_rate, :magical_rate, :hit, :variance, :state_effects,
-                :attribute_effects, :affect_hp, :affect_sp
+                :attribute_effects, :affect_hp, :affect_sp, :occasion_battle,
+                :switch_id
 
   def initialize(h = {})
     @name = 'Spell'; @type = 0; @scope = 0; @sp_type = 0; @sp_cost = 0
     @power = 0; @physical_rate = 0; @magical_rate = 0; @hit = 100
     @variance = 0; @affect_hp = true; @affect_sp = false
+    @occasion_battle = true
     h.each { |k, v| send("#{k}=", v) }
   end
 end
@@ -17939,6 +17941,41 @@ check 'an enemy casts an attack skill from its pattern' do
   e = enemy_entry([enemy_action(kind: 1, skill_id: 1)], ai, foe: foe)
   eq 'Fire', e[:skill], 'the skill is named on the log'
   ok e[:damage] > 0, 'and it hurt'
+end
+
+# Confirmed directly against RPG_RT's live source: `EnemyAi::IsActionValid`
+# (`src/enemyai.cpp`) rejects a `Kind_skill` action outright when
+# `!source.IsSkillUsable(action.skill_id)` -- before the action's own weight
+# is ever computed, not merely zeroed out afterward. `Algo::IsSkillUsable`
+# (`src/algo.cpp`), which `Game_Battler::IsSkillUsable`
+# (`src/game_battler.cpp`) reaches in battle, is unconditionally false for a
+# Teleport- or Escape-type skill, and gated on the skill's own
+# `occasion_battle` flag for a Switch-type one -- an enemy's own action
+# pattern is bound by the exact same rules a field/battle actor cast is.
+check "an enemy's action pattern never fires a Teleport/Escape-type skill, " \
+      'and only fires a Switch-type one when its battle-occasion flag is set' do
+  teleport = skill_ai(1 => FakeAiSkill.new(name: 'Warp', type: Game::Party::SKILL_TELEPORT))
+  foe = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  e = enemy_entry([enemy_action(kind: 1, skill_id: 1)], teleport, foe: foe)
+  ok e[:skill].nil?, "a Teleport-type skill must never be cast, got: #{e.inspect}"
+  ok e[:damage] > 0, 'falls back to a plain attack instead'
+
+  escape = skill_ai(1 => FakeAiSkill.new(name: 'Flee', type: Game::Party::SKILL_ESCAPE))
+  foe2 = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  e2 = enemy_entry([enemy_action(kind: 1, skill_id: 1)], escape, foe: foe2)
+  ok e2[:skill].nil?, "an Escape-type skill must never be cast, got: #{e2.inspect}"
+
+  off_switch = skill_ai(1 => FakeAiSkill.new(name: 'Alarm', type: Game::Party::SKILL_SWITCH,
+                                             occasion_battle: false, switch_id: 4))
+  foe3 = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  e3 = enemy_entry([enemy_action(kind: 1, skill_id: 1)], off_switch, foe: foe3)
+  ok e3[:skill].nil?, "a Switch-type skill with occasion_battle off must not fire, got: #{e3.inspect}"
+
+  on_switch = skill_ai(1 => FakeAiSkill.new(name: 'Alarm', type: Game::Party::SKILL_SWITCH,
+                                            occasion_battle: true, switch_id: 4))
+  foe4 = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  e4 = enemy_entry([enemy_action(kind: 1, skill_id: 1)], on_switch, foe: foe4)
+  eq 'Alarm', e4[:source], 'a Switch-type skill with occasion_battle on still fires'
 end
 
 check "an enemy's attack skill inflicts its states — enemy-cast infliction" do


### PR DESCRIPTION
## Summary
- RPG_RT's `EnemyAi::IsActionValid` (`src/enemyai.cpp`) rejects a `Kind_skill` action outright — before its weight is even computed, not merely zeroed out afterward — when `!source.IsSkillUsable(action.skill_id)`. `Game_Battler::IsSkillUsable` (`src/game_battler.cpp`) reaches `Algo::IsSkillUsable` (`src/algo.cpp`), which in battle is unconditionally `false` for an Escape- or Teleport-type skill, and for a Switch-type skill returns exactly `skill.occasion_battle`.
- `Game::Battle#enemy_skill_ready?` (`mruby-rpg2k/mrblib/game.rb`) checked only skill existence, the silence seal, and SP affordability — never the skill's own type or occasion flag — so an enemy's action pattern naming such a skill (a designer mistake, or a skill later repurposed after the pattern was authored) could actually fire: Escape/Teleport would compute a stray HP/MP effect from a row RPG_RT never lets an enemy read this way, and an off-occasion Switch would still flip its switch.
- Fixed by adding `Game::EnemyAi#skill_battle_usable?(sk)`, forwarding to `Game::Party#battle_skill?` — the party class's own already-correct type/occasion gate, already used for the ordinary field/battle actor cast path — and calling it from `#enemy_skill_ready?` right after resolving the skill row, ahead of the seal/cost checks.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: an Escape-type and a Teleport-type skill in an enemy's pattern never fire, falling back to a plain attack instead; an off-occasion Switch skill never fires either; the identical Switch skill with its occasion flag on still fires normally.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — the Teleport-type skill actually got cast, computing a stray zero-damage "hit") and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 821 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1073 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_