### PR TITLE
Fix: the selection cursor now blinks between its two windowskin blocks

### DIFF
--- a/changelog.d/window-cursor-blink.fixed.md
+++ b/changelog.d/window-cursor-blink.fixed.md
@@ -1,0 +1,6 @@
+- **UI:** The selection-cursor highlight in every window now blinks between
+  the windowskin's two cursor art blocks while the window is active --
+  matching RPG_RT's own `Window::Update`/`Window::Draw`. Previously it drew
+  from a single, permanently-static source rect; a windowskin whose two
+  cursor blocks differ (the bundled test skin's happen to match) would show
+  a static highlight instead of blinking.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13315,6 +13315,34 @@ not yet verified:
   flag on still fires normally), confirmed to fail against the pre-fix
   code before the fix (the Teleport-type skill actually cast, computing a
   stray zero-damage "hit").
+- ✅ **Every window's selection cursor now blinks between the windowskin's
+  two cursor blocks, matching RPG_RT — it used to draw from a single,
+  permanently-static source rect.** Confirmed directly against RPG_RT's
+  live source: `Window::Update` (`src/window.cpp`) advances `cursor_frame`
+  by 1 every frame the window is active, wrapping at 21; `Window::Draw`
+  blits the cursor highlight from the windowskin's `cursor1` block (source
+  x 64) while `cursor_frame <= 10`, or `cursor2` (source x 96) otherwise —
+  base engine behaviour, no RPG2003/`Feature::Has*` gate anywhere in either
+  function. `RPG2k::Window` (`mruby-rpg2k/mrblib/main.rb`) already ported
+  the two source-x offsets as `Game::WindowCursor::FRAME1_X`/`FRAME2_X`
+  (`mruby-rpg2k/mrblib/game.rb`) — `FRAME2_X` even carried a doc comment
+  correctly describing the real blink — but `FRAME2_X` was dead code,
+  `grep`-confirmed unreferenced anywhere: `#update` never advanced a
+  cursor-frame counter at all, and `#draw_cursor_skin` always read
+  `FRAME1_X`. The gap was invisible against the one bundled test
+  windowskin, whose two 32×32 cursor blocks happen to draw identically —
+  `#update`'s own stale comment cited exactly this coincidence as though it
+  were a reason the blink did not need porting, rather than a fixture
+  artifact masking the bug. Fixed by adding a `@cursor_frame` counter,
+  advanced by `#update` while the window is active (wrapping at 21,
+  mirroring `Window::Update` exactly) and redrawn only at the two actual
+  transitions (frame 0 and frame 11) rather than every frame, and having
+  `#draw_cursor_skin` pick `FRAME1_X`/`FRAME2_X` by `@cursor_frame <= 10`.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check driving a real
+  `RPG2k::Window` through 21+ frames and asserting the cursor bitmap's own
+  `#blt` calls source from x 64 initially, x 96 once `cursor_frame` crosses
+  11, and x 64 again once it wraps back to 0, confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **An action pattern's "Enemies" condition (`condition_type` 3,
   `COND_ACTORS`) now ranges over the acting monster's own living
   troop-mates, not the player party's headcount — a straight side-swap,

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -59,6 +59,7 @@ class RPG2k
       @contents = nil
       @windowskin = nil
       @cursor_rect = Rect.new(0, 0, 0, 0)
+      @cursor_frame = 0
       @active = true
       @visible = true
       @pause = false
@@ -229,12 +230,26 @@ class RPG2k
     end
 
     # Present so the game loop can drive per-frame behaviour: advances the
-    # open/close animation while one is running, and the pause-arrow blink
-    # while `pause` is set. The cursor highlight itself is drawn steadily
-    # (RPG_RT alternates two cursor frames, but Nepheshel's own skin draws
-    # both identically -- see Game::WindowCursor), so nothing else needs a
-    # per-frame tick yet.
+    # open/close animation while one is running, the selection-cursor blink
+    # while the window is active, and the pause-arrow blink while `pause` is
+    # set. Confirmed directly against RPG_RT's live source: `Window::Update`
+    # (`src/window.cpp`) advances `cursor_frame` by 1 every frame the window
+    # is active, wrapping at 21, and `Window::Draw` blits from the
+    # windowskin's `cursor1` block while `cursor_frame <= 10` or `cursor2`
+    # otherwise -- Game::WindowCursor::FRAME1_X/FRAME2_X already hold both
+    # source-rect x-offsets (64/96), but only FRAME1_X was ever read here,
+    # so the highlight never blinked at all -- invisible against the one
+    # bundled test windowskin that happens to draw both blocks identically,
+    # but wrong against any windowskin whose two blocks actually differ.
     def update
+      if @active
+        @cursor_frame += 1
+        @cursor_frame = 0 if @cursor_frame > 20
+        # Only the two actual transitions (steady -> alternate frame, and
+        # back) need a redraw -- matches RPG_RT's own draw-time branch,
+        # which reads the same source rect for every frame in between.
+        draw_cursor if @cursor_frame == 0 || @cursor_frame == 11
+      end
       if @anim_frames_left > 0
         @anim_frames_left -= 1
         if @anim_frames_left <= 0
@@ -443,7 +458,7 @@ class RPG2k
     # are clipped to half the height each.
     def draw_cursor_skin(x, y, w, h)
       c = Game::WindowCursor::CORNER
-      sx = Game::WindowCursor::FRAME1_X
+      sx = @cursor_frame <= 10 ? Game::WindowCursor::FRAME1_X : Game::WindowCursor::FRAME2_X
       sy = Game::WindowCursor::FRAME_Y
       sz = Game::WindowCursor::SIZE
       sk = @windowskin

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -885,6 +885,33 @@ end
 
 # -- checks -------------------------------------------------------------------
 
+check 'RPG2k::Window blinks its selection cursor between the windowskin\'s ' \
+      'two cursor blocks (source x 64/96), matching RPG_RT' do
+  # Confirmed directly against RPG_RT's live source: `Window::Update`
+  # (`src/window.cpp`) advances `cursor_frame` by 1 every frame the window
+  # is active, wrapping at 21, and `Window::Draw` blits from the
+  # windowskin's `cursor1` block (source x 64, Game::WindowCursor::FRAME1_X)
+  # while `cursor_frame <= 10`, or `cursor2` (source x 96, FRAME2_X)
+  # otherwise -- FRAME2_X already existed in this codebase but was never
+  # read anywhere, so the highlight never blinked at all.
+  win = RPG2k::Window.new(0, 0, 64, 64)
+  win.windowskin = Bitmap.new('System/Skin1', true)
+  win.cursor_rect = Rect.new(0, 0, 16, 16)
+  bmp = win.instance_variable_get(:@cursor_bmp)
+
+  10.times { win.update } # frames 1..10: still the steady half, no crossing yet
+  bmp.clear_blt_calls
+  win.update # frame 11: crosses into the alternate half
+  ok bmp.blt_calls && !bmp.blt_calls.empty?, 'the cursor redraws at the transition'
+  eq 96, bmp.blt_calls.first[3].x, 'now sourced from the alternate cursor block (96)'
+
+  9.times { win.update } # frames 12..20: still the alternate half
+  bmp.clear_blt_calls
+  win.update # frame 21 wraps to 0: back to the steady half
+  ok bmp.blt_calls && !bmp.blt_calls.empty?, 'the cursor redraws at the wrap'
+  eq 64, bmp.blt_calls.first[3].x, 'wraps back to the steady cursor block (64)'
+end
+
 check 'Scene::Map builds and ticks with no events without raising' do
   scene = new_scene({})
   30.times { scene.update }


### PR DESCRIPTION
## Summary
- RPG_RT's `Window::Update` (`src/window.cpp`) advances `cursor_frame` by 1 every frame the window is active, wrapping at 21; `Window::Draw` blits the cursor highlight from the windowskin's `cursor1` block (source x 64) while `cursor_frame <= 10`, or `cursor2` (source x 96) otherwise. Base engine behavior, no RPG2003/`Feature::Has*` gate anywhere.
- `RPG2k::Window` (`mruby-rpg2k/mrblib/main.rb`) already had both source-x offsets ported as `Game::WindowCursor::FRAME1_X`/`FRAME2_X` — `FRAME2_X` even carried a doc comment correctly describing the real blink — but it was dead code: `#update` never advanced a cursor-frame counter at all, and `#draw_cursor_skin` always read `FRAME1_X`. The gap was invisible against the one bundled test windowskin, whose two 32×32 cursor blocks happen to draw identically; any windowskin whose two blocks actually differ would show a static highlight instead of blinking.
- Fixed by adding a `@cursor_frame` counter, advanced by `#update` while the window is active (wrapping at 21, mirroring `Window::Update` exactly) and redrawn only at the two actual transitions (frame 0 and frame 11) rather than every frame, and having `#draw_cursor_skin` pick `FRAME1_X`/`FRAME2_X` by `@cursor_frame <= 10`.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: drives a real `RPG2k::Window` through 21+ frames and asserts the cursor bitmap's own `#blt` calls source from x 64 initially, x 96 once `cursor_frame` crosses 11, and x 64 again once it wraps back to 0.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `main.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 822 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1073 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_