### PR TITLE
Fix: an enemy action's out-of-range condition type fires, not excluded

### DIFF
--- a/changelog.d/enemy-ai-unknown-condition-fires.fixed.md
+++ b/changelog.d/enemy-ai-unknown-condition-fires.fixed.md
@@ -1,0 +1,4 @@
+- **Battle:** An enemy action-pattern entry with an out-of-range condition
+  type now fires unconditionally instead of being permanently excluded --
+  matching RPG_RT's own `EnemyAi::IsActionValid`, whose `default` case
+  returns eligible, not ineligible.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13365,6 +13365,29 @@ not yet verified:
   own headcount (fires with all three troop-mates alive, stops firing
   once two are killed off, regardless of the untouched one-hero party),
   confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-20): ~~An operand this build does not know stays
+  out of the running rather than firing unchecked~~ — corrected, real
+  RPG_RT does the opposite: an action pattern's out-of-range
+  `condition_type` fires unconditionally, not excluded.** Confirmed
+  directly against RPG_RT's live source: `EnemyAi::IsActionValid`'s own
+  `switch (action.condition_type)` (`src/enemyai.cpp`) ends `default:
+  return true;`, applying identically on RPG2000 and RPG2003 (no version
+  gate anywhere in the function). `Game::Battle#enemy_action_valid?`'s
+  fallthrough `else` branch (`mruby-rpg2k/mrblib/game.rb`) mirrors every
+  one of the eight named condition cases correctly but flipped the
+  fallthrough's own polarity to `false`, with no citation for that specific
+  branch — reasoning by analogy to this same method's own (correctly)
+  conservative `COND_ACTORS`/skill-type fixes just above, rather than
+  independently checking this particular `default` case's real C++ source.
+  A `condition_type` byte past `COND_FATIGUE` (7) — reachable from
+  hand-edited or non-standard-tool-written data, since the schema stores
+  this field as a bare unbounded `:int` — permanently excluded that action
+  from the weighted draw here, where genuine RPG_RT always keeps it
+  eligible. Fixed by flipping the `else` branch to `true`. The existing
+  `scripts/rpg2k_logic_check.rb` check ("an unknown condition type keeps
+  the action out of the running") had itself encoded this same wrong
+  polarity — replaced with a check asserting the action fires, confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ **An HP-increase cannot revive a downed (0 HP) combatant**, checked
   across all three paths that can raise HP. The **field actor** path
   (`Game::Actor#change_hp`, `mruby-rpg2k/mrblib/game.rb`) was already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11216,9 +11216,17 @@ module Game
         f = fatigue
         f >= a.condition_param1 && f <= a.condition_param2
       else
-        # An operand this build does not know stays out of the running rather
-        # than firing unchecked.
-        false
+        # An out-of-range condition_type (past COND_FATIGUE, the highest of
+        # the eight RPG_RT recognises) reads as unconditionally eligible, not
+        # excluded -- confirmed directly against RPG_RT's live source:
+        # `EnemyAi::IsActionValid`'s own `switch (action.condition_type)`
+        # (`src/enemyai.cpp`) ends `default: return true;`, applying
+        # identically on RPG2000 and RPG2003 (no version gate anywhere in
+        # the function). This is the mirror image of the "unset/unknown
+        # stays conservative" shape this method's own COND_ACTORS/skill-type
+        # fixes correctly use elsewhere -- this one specific fallthrough
+        # goes the other way in real RPG_RT.
+        true
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -17885,9 +17885,15 @@ check 'a party-level action reads the average level through the AI env' do
   ok enemy_entry([miss], ai)[:defend].nil?, 'outside it'
 end
 
-check 'an unknown condition type keeps the action out of the running' do
+check 'an out-of-range condition type still fires, matching RPG_RT\'s own ' \
+      'default: return true' do
+  # Confirmed directly against RPG_RT's live source: `EnemyAi::
+  # IsActionValid`'s own `switch (action.condition_type)`
+  # (`src/enemyai.cpp`) ends `default: return true;` -- a condition_type
+  # past the eight it recognises (e.g. a hand-edited or non-standard-tool
+  # database byte) reads as unconditionally eligible, not excluded.
   act = enemy_action(kind: 0, basic: 2, condition_type: 99)
-  ok enemy_entry([act], nil)[:defend].nil?, 'not fired unchecked'
+  eq true, enemy_entry([act], nil)[:defend], 'fires unconditionally, like RPG_RT'
 end
 
 # -- post-action switches ------------------------------------------------------


### PR DESCRIPTION
## Summary
- RPG_RT's `EnemyAi::IsActionValid` (`src/enemyai.cpp`) switches on `condition_type` across its eight known cases and ends with `default: return true;` — an out-of-range byte (reachable from hand-edited or non-standard-tool-written data, since the schema stores this field as a bare unbounded `:int`) reads as unconditionally eligible. Applies identically on RPG2000 and RPG2003 — no version gate anywhere in the function.
- `Game::Battle#enemy_action_valid?` (`mruby-rpg2k/mrblib/game.rb`) mirrored every one of the eight named condition cases correctly but flipped this one fallthrough's own polarity to `false`, with no citation for that specific branch — reasoning by analogy to this same method's own (correctly) conservative `COND_ACTORS`/skill-type fixes, rather than independently checking this particular `default` case's real C++ source.
- Fixed by flipping the `else` branch to `true`.

## Test plan
- [x] The existing `scripts/rpg2k_logic_check.rb` check ("an unknown condition type keeps the action out of the running") had itself encoded this same wrong polarity — replaced with a check asserting the action fires unconditionally.
- [x] Confirmed the corrected check fails against the pre-fix code (`git stash` on `game.rb` only — `expected true, got nil`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 822 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1073 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_