### PR TITLE
Fix: confirming an Order reorder refreshes the leader's map sprite

### DIFF
--- a/changelog.d/order-refreshes-leader-sprite.fixed.md
+++ b/changelog.d/order-refreshes-leader-sprite.fixed.md
@@ -1,0 +1,6 @@
+- **Order screen:** Confirming a party reorder now refreshes the leader's
+  on-map sprite immediately -- matching RPG_RT's own `Scene_Order::Confirm`,
+  which resets the map sprite via `Game_Party::AddActor`/`RemoveActor` as
+  part of applying the new order. Previously, promoting a member whose
+  CharSet graphic differs from the previous leader's left the hero visibly
+  wearing the old leader's sprite until some unrelated event refreshed it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3509,6 +3509,40 @@ The work below is roughly ordered by the critical path to a walkable game
   time or leaves the screen with none picked; Confirm applies the picked
   order to the party and closes; Redo clears every pick without touching the
   party)
+  ✅ **Follow-up (2026-08-20): confirming an Order reorder never refreshed the
+  party leader's on-map sprite, so promoting a member whose CharSet graphic
+  differs from the previous leader's left the hero walking around wearing
+  the old leader's sprite until some unrelated trigger (a map transfer, or
+  a Change Party Member / Change Actor Sprite event) happened to refresh
+  it.** Confirmed directly against RPG_RT's live source:
+  `Scene_Order::Confirm` (`src/scene_order.cpp`) removes then re-adds every
+  member through `Game_Party::RemoveActor`/`AddActor` (`src/game_party.cpp`),
+  and *each* of those calls unconditionally calls `Main_Data::
+  game_player->ResetGraphic()` as a side effect; `Game_Player::
+  ResetGraphic()` (`src/game_player.cpp`) re-reads slot 0's (the new
+  leader's) CharSet name/index/transparency onto the map sprite. The
+  `#reorder` fix above deliberately applies the remove/re-add dance's *net
+  array effect* directly rather than replaying it command-by-command — a
+  correct optimization for the party order itself, but one that silently
+  dropped this specific side effect along with the replay, since nothing
+  else in this codebase's Order path ever calls the sprite refresh.
+  `Scene::Map#apply_graphic_change` already polls an identical flag
+  (`Interpreter#take_actor_graphic_changed`) for the interpreter-driven
+  Change Actor Graphic command, but Order is driven entirely by
+  `Scene::Order`, a pushed screen with no interpreter command of its own to
+  carry it. Fixed by adding `Game::Party#leader_graphic_dirty`/
+  `#take_leader_graphic_dirty` (the identical one-shot-read idiom,
+  mirroring `Interpreter#take_actor_graphic_changed`), set unconditionally
+  by `#reorder` the same way RPG_RT's own `ResetGraphic()` call is
+  unconditional, and polled by `Scene::Map#update` as the very first thing
+  once the scene is on top again — the same "catch up on whatever the
+  pushed screen did" timing `@state.pending_teleport`'s own poll,
+  immediately below it, already uses for a different pushed-screen side
+  effect. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+  two-member party's map sprite starts on the leader's own CharSet, then
+  refreshes to the newly-promoted member's CharSet once `#reorder` runs and
+  the scene updates), confirmed to fail against the pre-fix code before
+  the fix.
   ✅ **Wait (RPG2003 `menu_commands` id 8, the ATB toggle) is implemented.** Of
   the three ids `RPG2K3_COMMAND_IDS` used to skip wholesale (Row, Order,
   Wait), the toggle turned out to live on the **save system**, not the Battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3482,6 +3482,7 @@ module Game
       @item_usage = {}
       @gold = 0
       @revision = 0
+      @leader_graphic_dirty = false
     end
 
     # Serialise the mutable party state (see State#to_h). Beyond HP/MP this keeps
@@ -3602,9 +3603,30 @@ module Game
     # but the leader can be -- `#leader` is simply `@actors.first` -- which is
     # why this bumps @revision the same as #promote_to_leader above, the
     # existing precedent for a leader change with no membership change.
+    #
+    # `Game_Party::AddActor`/`RemoveActor` (`src/game_party.cpp`) -- the pair
+    # `Confirm()` calls once per member during the remove/re-add dance -- each
+    # unconditionally call `Main_Data::game_player->ResetGraphic()` as a side
+    # effect, and `Game_Player::ResetGraphic()` (`src/game_player.cpp`) re-reads
+    # slot 0's (the new leader's) CharSet name/index/transparency onto the map
+    # sprite. Skipping the replay (above) also skipped this side effect, so
+    # `@leader_graphic_dirty` reproduces it directly: set unconditionally here,
+    # the same way real RPG_RT's own call is unconditional, not only when the
+    # leader actually changed.
     def reorder(new_order)
       @actors = new_order.map { |i| @actors[i] }
       @revision += 1
+      @leader_graphic_dirty = true
+    end
+
+    # One-shot read of #reorder's own leader-graphic side effect -- the
+    # `Interpreter#take_actor_graphic_changed` idiom (`mruby-rpg2k/mrblib/
+    # interpreter.rb`), applied here since a reorder is driven entirely by
+    # Scene::Order rather than an interpreter command.
+    def take_leader_graphic_dirty
+      v = @leader_graphic_dirty
+      @leader_graphic_dirty = false
+      v
     end
 
     # RPG2003's field-menu **Row** command (`RPG2K3_COMMAND_IDS` id 6,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -388,6 +388,17 @@ class RPG2k
       end
 
       def update
+        # RPG2003's Order screen (party reorder) is driven entirely by
+        # Scene::Order, with no interpreter command of its own to carry the
+        # leader-graphic-refresh flag #apply_graphic_change already polls for
+        # Change Actor Graphic -- so it is polled here instead, the very
+        # first thing once this scene is on top again, the same "catch up on
+        # whatever the pushed screen did" timing #state.pending_teleport
+        # (just below) already uses for a different pushed-screen side
+        # effect. See Game::Party#reorder's own citation of RPG_RT's
+        # `Game_Party::AddActor`/`RemoveActor`/`Game_Player::ResetGraphic`.
+        refresh_player_graphic if @state.party.respond_to?(:take_leader_graphic_dirty) &&
+                                   @state.party.take_leader_graphic_dirty
         # An Escape / Teleport field skill queues its destination here rather
         # than jumping directly -- it is cast from the skill menu, a scene with
         # none of this one's map-load machinery, and this scene does not even

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16833,6 +16833,32 @@ check 'Scene::Order: holding Down auto-repeats both the left-column pick ' \
      'a held (repeated, not triggered) Down still flips the prompt cursor to Redo'
 end
 
+# Confirmed directly against RPG_RT's live source: `Scene_Order::Confirm`
+# (`src/scene_order.cpp`) removes then re-adds every member through
+# `Game_Party::RemoveActor`/`AddActor` (`src/game_party.cpp`), and each of
+# those calls `Main_Data::game_player->ResetGraphic()` (`src/game_player.cpp`)
+# as a side effect -- re-reading slot 0's (the new leader's) CharSet name
+# onto the map sprite. `Game::Party#reorder` applies the net effect of the
+# remove/re-add dance directly rather than replaying it, so this side effect
+# needs its own explicit wiring (`#take_leader_graphic_dirty`, polled by
+# Scene::Map#update the same way Change Actor Graphic's own flag already is).
+check 'Scene::Map refreshes the leader\'s map sprite once a reorder promotes ' \
+      'a different member to the front' do
+  hero = SlipActor.new
+  hero.instance_variable_set(:@charset_name, 'Hero')
+  ally = SlipActor.new
+  ally.instance_variable_set(:@charset_name, 'Ally')
+  scene = new_scene({}, members: [hero, ally])
+  st = scene.instance_variable_get(:@state)
+  eq 'CharSet/Hero', scene.instance_variable_get(:@charset).load_name,
+     'starts on the leader\'s own charset'
+
+  st.party.reorder([1, 0]) # promote Ally to the front
+  scene.update
+  eq 'CharSet/Ally', scene.instance_variable_get(:@charset).load_name,
+     'the map sprite refreshes to the newly-promoted leader\'s charset'
+end
+
 # -- Scene::SaveLoad: the save/load file-select screen -------------------------
 #
 # Scene::Menu's Save command and Scene::Title's Continue entry both used to


### PR DESCRIPTION
## Summary
- RPG_RT's `Scene_Order::Confirm` (`src/scene_order.cpp`) removes then re-adds every member through `Game_Party::RemoveActor`/`AddActor` (`src/game_party.cpp`), and each of those calls unconditionally calls `Main_Data::game_player->ResetGraphic()` as a side effect; `Game_Player::ResetGraphic()` (`src/game_player.cpp`) re-reads slot 0's (the new leader's) CharSet name/index/transparency onto the map sprite.
- `Game::Party#reorder` (`mruby-rpg2k/mrblib/game.rb`) deliberately applies the remove/re-add dance's net array effect directly rather than replaying it — a correct optimization for the party order itself, but one that silently dropped this side effect too, since nothing else in this codebase's Order path ever called the sprite refresh. Promoting a member whose CharSet graphic differs from the previous leader's left the hero walking around wearing the old leader's sprite until some unrelated trigger happened to refresh it.
- Fixed by adding `Game::Party#leader_graphic_dirty`/`#take_leader_graphic_dirty` (mirroring `Interpreter#take_actor_graphic_changed`'s existing one-shot-read idiom), set unconditionally by `#reorder` the same way RPG_RT's own `ResetGraphic()` call is unconditional, and polled by `Scene::Map#update` as the very first thing once the scene is on top again — the same "catch up on whatever the pushed screen did" timing `@state.pending_teleport`'s own poll, immediately below it, already uses for a different pushed-screen side effect.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a two-member party's map sprite starts on the leader's own CharSet, then refreshes to the newly-promoted member's CharSet once `#reorder` runs and the scene updates.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb`/`map.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 823 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1073 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_