### PR TITLE
Fix: a use_skill equipment item invoking Escape/Teleport no longer warps for free

### DIFF
--- a/changelog.d/use-skill-item-escape-teleport-no-warp.fixed.md
+++ b/changelog.d/use-skill-item-escape-teleport-no-warp.fixed.md
@@ -1,0 +1,12 @@
+- **Field Item menu:** a weapon/shield/armour/helmet/accessory item flagged
+  `use_skill` (schema field 71) invoking an Escape- or Teleport-type skill no
+  longer warps the party for free -- matching RPG_RT's own
+  `Game_Battler::UseSkill`, which for these two skill types only plays the
+  invoked skill's sound effect, never a warp of any kind, no matter which
+  item kind reached it. Only a genuine type-9 special item still warps
+  straight away; a `use_skill` equipment item now prompts for an ordinary
+  target the same as any other equipment item, and a successful use plays the
+  invoked skill's own success sound instead of Buzzer. Previously, such an
+  item warped the party the instant Escape/Teleport access and a registered
+  destination both existed, something only a type-9 special item is
+  supposed to do.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3638,19 +3638,63 @@ The work below is roughly ordered by the critical path to a walkable game
    see the dedicated ✅ bullet above; this line used to read "with no target
    prompt", which was wrong -- and an Escape/Teleport skill warps straight
    away; a single-ally scope still prompts for a target, which was already
-   correct. The warp path
+   correct. ~~The warp path
    needed `#use_special_escape_item` / `#use_special_teleport_item`'s own type
    guard relaxed from `== ITEM_SPECIAL` to also admit a `use_skill`
    equipment item (the cast is identical -- free, the caster need not know the
    skill -- and the equipment item is **not** consumed, since RPG_RT returns
    early from `ConsumeItemUse` on the five equipment types, the same
-   reusable-tool rule `#use_equip_skill_item` already follows). Covered by a
+   reusable-tool rule `#use_equip_skill_item` already follows).~~ Covered by a
    new `scripts/rpg2k_scene_check.rb` check (a `use_skill` weapon invoking an
    all-ally skill is cast by the leader with no prompt) and two new
    `scripts/rpg2k_logic_check.rb` checks (a `use_skill` equipment item
-   invoking an Escape/Teleport skill warps for free and a plain weapon is
+   invoking an Escape/Teleport skill ~~warps for free~~ and a plain weapon is
    never treated as one), confirmed to fail against the pre-fix code. See
    `changelog.d/menu-use-skill-equipment-item.fixed.md`.
+   - **Follow-up (2026-08-20):** the relaxed type guard above was never
+     verified against real RPG_RT's own live source, only assumed "identical"
+     by analogy to the type-9 special-item cast -- it was not. Confirmed
+     against EasyRPG Player's actual C++, fetched live: `Scene_Item::vUpdate`
+     (`src/scene_item.cpp`) only ever reaches its ReserveTeleport/
+     Scene_Teleport dispatch for `item.type == Type_special && item.skill_id
+     > 0`; a `use_skill`-flagged equipment item invoking the very same
+     Escape/Teleport skill always falls to the generic `else` branch there (a
+     plain `Scene_ActorTarget` push), and `Game_Battler::UseSkill`
+     (`src/game_battler.cpp`) — reached from that generic path through
+     `Game_Party::UseItem`/`Game_Battler::UseItem`'s shared `do_skill` gate —
+     plays only the skill's own `sound_effect` for a `Type_teleport`/
+     `Type_escape` skill and sets `was_used = true`; it never calls
+     `ReserveTeleport` or performs any warp at all. So the relaxed guard let
+     a `use_skill` weapon/shield/armor/helmet/accessory item warp the party
+     for free the instant access and a target both existed — something real
+     RPG_RT never does for such an item, only for a genuine type-9 special
+     one. Fixed by re-narrowing `#use_special_escape_item`/
+     `#use_special_teleport_item`'s guard back to `it.type == ITEM_SPECIAL`
+     only, and `Scene::ItemMenu#choose_item`'s Escape/Teleport dispatch
+     branches (the buzzer-gate checks and the no-prompt warp/teleport-picker
+     calls) to `it.type == ITEM_SPECIAL` as well — a `use_skill` equipment
+     item invoking Escape/Teleport now falls to the same ordinary
+     `#prompt_item_target` single-target picker every other equipment item
+     takes. `Game::Party#use_equip_skill_item` gained its own Escape/
+     Teleport branch (`#cast_skill`'s ordinary HP/SP/state loop has no
+     notion of these two skill types and always found nothing to change,
+     which misreported success as failure and played Buzzer instead of the
+     invoked skill's own success SE) so that once a target is picked and
+     confirmed, `Scene::ItemMenu#apply_item`'s existing empty-vs-non-empty
+     check plays the skill's animation SE rather than buzzing, matching
+     `Scene_ActorTarget::UpdateItem`'s identical `do_skill`-on-success
+     branch. The Switch-type dispatch (`#apply_special_switch_item`/
+     `#use_special_switch_item`) was independently re-verified correct as
+     written for both item kinds and is untouched -- `Game_Battler::
+     UseSkill`'s `Type_switch` branch flips the switch through the identical
+     shared `do_skill` path regardless of which item kind reached it.
+     Covered by rewriting the same two `scripts/rpg2k_logic_check.rb` checks
+     cited just above (which had baked in the wrong "eventually warps"
+     expectation once access/target existed) to instead assert
+     `#use_special_escape_item`/`#use_special_teleport_item` stay `nil`
+     unconditionally for equipment while the ordinary `#use_item` path
+     succeeds without a target/warp of any kind, confirmed to fail against
+     the pre-fix code. See `changelog.d/use-skill-item-escape-teleport-no-warp.fixed.md`.
    ✅ **The battle-scene half of this same fix was still missing its own
    dispatch, so an enemy-scope item skill (Nepheshel's whole thrown-bomb
    line — 火炎玉, 爆裂玉, 氷結玉, 雷撃玉 and the rest — is exactly this

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4419,8 +4419,40 @@ module Game
     # weapon a reusable tool rather than a one-shot. Routing the consumption
     # through #consume_item_use is what gets that right -- this used to spend
     # the weapon on its first use and leave the party without it.
+    #
+    # An Escape/Teleport-type skill can't run through #cast_skill at all --
+    # confirmed against genuine RPG_RT's own live source: `Game_Battler::
+    # UseSkill` (`src/game_battler.cpp`) gives these two types their own
+    # branch, entirely separate from the ordinary HP/SP/state loop
+    # #cast_skill ports (`Algo::IsNormalOrSubskill`'s branch) -- it plays
+    # only `skill->sound_effect` and sets `was_used = true`, never touching
+    # HP/SP/a state, and never returning early/false the way an ordinary
+    # skill with nothing to change on this target would. Since
+    # `Game_Battler::UseItem`'s `do_skill` branch (the equipment-item
+    # counterpart to this method) forwards straight to `UseSkill` and
+    # returns its `was_used`, a use_skill equipment item invoking one of
+    # these two types always succeeds once #item_usable_by? passes --
+    # treated here as `[actor]`, a one-element "changed" list, so the
+    # caller's own empty-vs-non-empty success check (`Scene::ItemMenu#
+    # apply_item`) plays the invoked skill's own animation SE rather than
+    # Buzzer, matching `Scene_ActorTarget::UpdateItem`'s identical
+    # `do_skill`-on-success branch (see `#play_item_use_se`'s own
+    # citation). This used to fall through to #cast_skill unconditionally,
+    # which has no notion of these two types at all and always found
+    # nothing to change -- an empty `affected`, misreported to the caller
+    # as failure and playing Buzzer instead. (A Switch-type skill needs no
+    # equivalent branch here: `Scene::ItemMenu#choose_item` already routes
+    # a use_skill equipment item invoking one to `#apply_special_switch_item`/
+    # `#use_special_switch_item` before this method is ever reached, the
+    # only path that calls #use_item today -- see #use_special_switch_item's
+    # own doc.)
     def use_equip_skill_item(it, id, actor)
       return [] unless actor && item_usable_by?(it, actor.id)
+      sk = db_skill(it.skill_id)
+      if sk && (sk.type == SKILL_ESCAPE || sk.type == SKILL_TELEPORT)
+        consume_item_use(id)
+        return [actor]
+      end
       affected = cast_skill(actor, it.skill_id, actor, true)
       consume_item_use(id) unless affected.empty?
       affected
@@ -4437,11 +4469,22 @@ module Game
     # consumed, mirroring `Scene::SkillMenu#apply_escape_skill`'s own gate.
     def use_special_escape_item(id, actor, state)
       it = db_item(id)
-      # A type-9 special item, or an equipment item flagged `use_skill` (field
-      # 71) invoking an Escape-type skill, both warp free the same way.
-      return nil unless it &&
-                        (it.type == ITEM_SPECIAL ||
-                         (it.use_skill && (1..5).cover?(it.type))) &&
+      # Only a genuine type-9 special item takes this free-warp fast path --
+      # confirmed directly against RPG_RT's live source: `Scene_Item::
+      # vUpdate`'s Escape/Teleport dispatch (`src/scene_item.cpp`) sits
+      # inside an `item.type == Type_special && item.skill_id > 0` gate, so
+      # a `use_skill`-flagged weapon/shield/armor/helmet/accessory (field 71)
+      # never reaches it at all -- it falls to the ordinary
+      # `Scene_ActorTarget` picker instead, which routes through
+      # `Game_Battler::UseItem`/`UseSkill` (`src/game_battler.cpp`); for
+      # `Type_teleport`/`Type_escape` that function only plays the skill's
+      # sound effect (`Main_Data::game_system->SePlay(skill->sound_effect);
+      # was_used = true;`) -- no `ReserveTeleport` call, no warp of any kind.
+      # A prior version of this comment assumed the two item kinds shared
+      # this fast path from `Game_Party::UseItem`'s identical `do_skill`
+      # computation without tracing one level further into what `UseSkill`
+      # itself does for these two skill types specifically.
+      return nil unless it && it.type == ITEM_SPECIAL &&
                         actor && item_usable_by?(it, actor.id)
       target = cast_escape_skill(actor, it.skill_id, state, true)
       return nil unless target
@@ -4454,11 +4497,11 @@ module Game
     # which — see `Scene::SkillMenu`'s teleport list, which this mirrors).
     def use_special_teleport_item(id, actor, state, map_id)
       it = db_item(id)
-      # A type-9 special item, or an equipment item flagged `use_skill` (field
-      # 71) invoking a Teleport-type skill, both warp free the same way.
-      return nil unless it &&
-                        (it.type == ITEM_SPECIAL ||
-                         (it.use_skill && (1..5).cover?(it.type))) &&
+      # Only a genuine type-9 special item takes this free-warp fast path --
+      # see #use_special_escape_item's own citation just above; the same
+      # `Scene_Item::vUpdate`/`Game_Battler::UseSkill` gap applies to
+      # Teleport-type skills identically.
+      return nil unless it && it.type == ITEM_SPECIAL &&
                         actor && item_usable_by?(it, actor.id)
       target = cast_teleport_skill(actor, it.skill_id, state, map_id, true)
       return nil unless target

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -146,7 +146,31 @@ class RPG2k
         sk = (it && (it.type == Game::Party::ITEM_SPECIAL ||
                     (it.use_skill && (1..5).cover?(it.type)))) ?
                @state.party.db_skill(it.skill_id) : nil
-        # An Escape/Teleport-invoking item is always listed (see
+        # Only a genuine type-9 special item warps for an Escape/Teleport
+        # skill (or is buzzer-gated on access/target before it even tries)
+        # -- confirmed against genuine RPG_RT's own live source:
+        # `Scene_Item::vUpdate` (`src/scene_item.cpp`) gates its whole
+        # ReserveTeleport/Scene_Teleport dispatch behind `item.type ==
+        # Type_special`; a `use_skill`-flagged weapon/shield/armor/helmet/
+        # accessory item (schema field 71) invoking the very same skill type
+        # always falls to the generic `else` branch there instead (a plain
+        # `Scene_ActorTarget` push), and `Game_Battler::UseSkill`'s own
+        # Escape/Teleport branch for it plays only the skill's sound effect,
+        # no warp at all (see `#use_special_escape_item`'s own citation).
+        # `#use_equip_skill_item` already mirrors that exact "SE only, no
+        # warp" outcome once a target is confirmed (see its own doc), so
+        # this scene needs no special dispatch for that case beyond the
+        # ordinary `#prompt_item_target` every other targeted item already
+        # takes. This used to route a use_skill equipment item through the
+        # special-item Escape/Teleport branches too, which let it warp the
+        # party for free -- something real RPG_RT never does for such an
+        # item. A Switch-type skill is unaffected either way: `Game_Battler
+        # ::UseSkill`'s Switch branch flips the switch through the same
+        # shared `do_skill` path for both item kinds, which `#apply_special
+        # _switch_item`/`#use_special_switch_item` below already gets right
+        # for both.
+        special = it && it.type == Game::Party::ITEM_SPECIAL
+        # An Escape/Teleport-invoking special item is always listed (see
         # Game::Party#field_skill?, which #field_usable?'s special-item
         # branch now defers to) but only castable once access and a
         # registered target are there. Confirmed against RPG_RT's own live
@@ -160,13 +184,13 @@ class RPG2k
         # show a fabricated "It had no effect." message and a stray
         # Decision-then-Buzzer double beep that RPG_RT never produces for a
         # disabled entry.
-        if sk && sk.type == Game::Party::SKILL_ESCAPE &&
+        if special && sk && sk.type == Game::Party::SKILL_ESCAPE &&
            @state.party.respond_to?(:escape_skill_available?) &&
            !@state.party.escape_skill_available?(@state)
           play_system_se(SFX_BUZZER)
           return
         end
-        if sk && sk.type == Game::Party::SKILL_TELEPORT &&
+        if special && sk && sk.type == Game::Party::SKILL_TELEPORT &&
            @state.party.respond_to?(:teleport_skill_available?) &&
            !@state.party.teleport_skill_available?(@state)
           play_system_se(SFX_BUZZER)
@@ -179,35 +203,35 @@ class RPG2k
         # decides the scope — self (2) or all-ally (4) needs no prompt.
         if it && it.type == Game::Party::ITEM_SWITCH
           apply_switch_item(id)
+        elsif sk && special && sk.type == Game::Party::SKILL_ESCAPE
+          # Escape has one registered target and no picker -- mirroring
+          # Scene::SkillMenu#apply_escape_skill, a successful cast warps
+          # straight there with no confirmation message. Genuine special
+          # items only -- see this method's own doc comment above.
+          apply_escape_item(id)
+        elsif sk && special && sk.type == Game::Party::SKILL_TELEPORT
+          # Teleport opens a third list of every registered destination, the
+          # same as Scene::SkillMenu's own teleport picker. Genuine special
+          # items only -- see this method's own doc comment above.
+          @pending_item = id
+          @mode = :teleport_target
+          @teleport_index = 0
+          build_teleport_window
+          refresh_desc
         elsif sk
-          # A type-9 special item, or an equipment item flagged `use_skill`
-          # (schema field 71), both invoke the skill named in `skill_id`: the
-          # invoked skill's type/scope decides the dispatch, so a self (2) or
-          # all-ally (4) skill needs no target prompt and an Escape/Teleport
-          # skill warps. Mirrors the special-item path exactly (see the
-          # type-9 fixes above); an equipment item simply reaches the same
-          # `#use_equip_skill_item` / `#use_special_escape_item` /
-          # `#use_special_teleport_item` backing as it already does for an
-          # ordinary targeted cast.
-          if sk.type == Game::Party::SKILL_ESCAPE
-            # Escape has one registered target and no picker -- mirroring
-            # Scene::SkillMenu#apply_escape_skill, a successful cast warps
-            # straight there with no confirmation message.
-            apply_escape_item(id)
-          elsif sk && sk.type == Game::Party::SKILL_TELEPORT
-            # Teleport opens a third list of every registered destination, the
-            # same as Scene::SkillMenu's own teleport picker.
-            @pending_item = id
-            @mode = :teleport_target
-            @teleport_index = 0
-            build_teleport_window
-            refresh_desc
-          elsif sk && sk.type == Game::Party::SKILL_SWITCH
+          if sk.type == Game::Party::SKILL_SWITCH
             # A switch skill has no target and no confirmation message either
             # -- mirroring Scene::SkillMenu#apply_switch_skill, a successful
-            # cast closes the whole menu stack at once.
+            # cast closes the whole menu stack at once. Both item kinds take
+            # this branch -- see this method's own doc comment above.
             apply_special_switch_item(id)
-          elsif sk && (sk.scope == 2 || sk.scope == 4)
+          elsif sk.type == Game::Party::SKILL_ESCAPE || sk.type == Game::Party::SKILL_TELEPORT
+            # A use_skill equipment item invoking Escape/Teleport: no warp,
+            # no picker of its own -- the ordinary single-target prompt
+            # below, exactly like ordinary equipment (see this method's own
+            # doc comment above and #use_equip_skill_item's).
+            prompt_item_target(id)
+          elsif sk.scope == 2 || sk.scope == 4
             # Unlike a medicine (whose all-ally scope needs no actor at all --
             # #use_medicine reads the whole party off `@actors`, ignoring the
             # argument), a special item's `actor` argument is the *caster*

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6886,19 +6886,33 @@ check 'a special item invoking a Switch skill flips its switch and warps ' \
 end
 
 check 'a use_skill equipment item invoking an Escape skill is menu-usable purely by ' \
-      "scope, matching real RPG_RT's own use_skill shortcut -- access/target only " \
-      'gate the cast itself, and a plain weapon is never treated as one' do
+      "scope, matching real RPG_RT's own use_skill shortcut, but never warps -- " \
+      'only a genuine special item does that, and a plain weapon is never treated ' \
+      'as either' do
   # Confirmed against EasyRPG's actual C++ source, fetched live:
   # `Game_Party::IsItemUsable` (src/game_party.cpp) checks `item->use_skill`
   # *before* its own `switch (item->type)`, and its own comment flags the
   # result as "RPG_RT BUG: Does not check if skill is usable" -- `skill &&
   # (in_battle || scope == Scope_self/_ally/_party)`, nothing about escape
-  # access or a registered target at all; those only gate the actual warp
-  # (`#cast_escape_skill`'s own `#escape_skill_available?`, unchanged here).
-  # A prior version of this test asserted the opposite -- that #field_usable?
-  # itself withheld the item until access/target existed -- reusing
-  # #field_skill?'s general Escape-type handling without checking this
-  # use_skill-specific branch of IsItemUsable against the real source.
+  # access or a registered target at all. A prior version of this test
+  # asserted the opposite -- that #field_usable? itself withheld the item
+  # until access/target existed -- reusing #field_skill?'s general
+  # Escape-type handling without checking this use_skill-specific branch of
+  # IsItemUsable against the real source.
+  #
+  # #use_special_escape_item now never returns a destination for a use_skill
+  # equipment item, access/target notwithstanding -- confirmed against
+  # `Scene_Item::vUpdate` (`src/scene_item.cpp`), whose whole ReserveTeleport
+  # dispatch is gated on `item.type == Type_special`; an equipment item
+  # invoking the very same Escape skill instead goes through
+  # `Game_Battler::UseSkill`'s "SE only, no warp, always succeeds" branch
+  # (`Game::Party#use_item`/`#use_equip_skill_item` here), regardless of
+  # escape access or a registered target -- neither gates it at all, since
+  # nothing about the actual warp is ever attempted. A prior version of this
+  # test asserted the opposite -- that a use_skill equipment item eventually
+  # warped once access and a target both existed, the exact bug
+  # `#use_special_escape_item`'s own doc comment now cites `Scene_Item::
+  # vUpdate` and `Game_Battler::UseSkill` to correct.
   skills = { 6 => fake_skill(name: 'Blade Escape',
                              type: Game::Party::SKILL_ESCAPE, sp_cost: 4) }
   items = { 3 => fake_item(type: 1, skill_id: 6, use_skill: true, name: 'Escape Blade') }
@@ -6906,27 +6920,37 @@ check 'a use_skill equipment item invoking an Escape skill is menu-usable purely
   hero = st.party.actor_by_id(1)
   st.party.gain_item(3, 2)
   ok st.party.field_usable?(3, st), 'listed by scope alone, before access/target exist at all'
-  ok st.party.use_special_escape_item(3, hero, st).nil?, 'the cast itself still needs access'
+  ok st.party.use_special_escape_item(3, hero, st).nil?, 'never a special-item cast -- no access yet either'
   st.escape_access = true
-  ok st.party.field_usable?(3, st)
-  ok st.party.use_special_escape_item(3, hero, st).nil?, 'access alone is not enough -- no target yet'
   st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
+  ok st.party.field_usable?(3, st)
+  ok st.party.use_special_escape_item(3, hero, st).nil?,
+     'access and a registered target both present now -- still nil, equipment never takes this path'
   before = hero.mp
-  eq({ map_id: 3, x: 4, y: 5, switch_id: nil }, st.party.use_special_escape_item(3, hero, st))
-  eq before, hero.mp, 'free -- the item pays, not the caster'
+  affected = st.party.use_item(3, hero)
+  eq [hero], affected, 'the ordinary item-use path succeeds -- ' \
+                        "Game_Battler::UseSkill's Escape/Teleport branch always sets was_used = true"
+  eq before, hero.mp, 'free -- no SP spent for an item cast'
   eq 2, st.party.item_count(3), 'equipment is not consumed -- a reusable tool, like #use_equip_skill_item'
   # A plain weapon (no use_skill flag) must never be treated as an escape item.
   plain = { 5 => fake_item(type: 1, skill_id: 6, use_skill: false, name: 'Plain Blade') }
   st2 = skill_party(skills, plain)
+  st2.party.gain_item(5, 1)
   st2.escape_access = true
   st2.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
   ok !st2.party.field_usable?(5, st2), 'a plain weapon is not menu-usable even matching the skill'
   ok st2.party.use_special_escape_item(5, st2.party.actor_by_id(1), st2).nil?,
      'and is not cast as an escape item'
+  eq [], st2.party.use_item(5, st2.party.actor_by_id(1)), 'nor through the ordinary item-use path'
 end
 
 check 'a use_skill equipment item invoking a Teleport skill is menu-usable purely by ' \
-      'scope, matching real RPG_RT -- destinations only gate the cast itself' do
+      'scope, matching real RPG_RT, but never warps -- only a genuine special item ' \
+      'does that' do
+  # See the Escape check above for the full citation chain -- identical
+  # reasoning, `Scene_Item::vUpdate`'s Type_special-only ReserveTeleport/
+  # Scene_Teleport gate and `Game_Battler::UseSkill`'s shared "SE only, no
+  # warp, always succeeds" branch apply the same way to Teleport.
   skills = { 7 => fake_skill(name: 'Blade Teleport',
                              type: Game::Party::SKILL_TELEPORT, sp_cost: 3) }
   items = { 4 => fake_item(type: 1, skill_id: 7, use_skill: true, name: 'Warp Blade') }
@@ -6934,13 +6958,17 @@ check 'a use_skill equipment item invoking a Teleport skill is menu-usable purel
   hero = st.party.actor_by_id(1)
   st.party.gain_item(4, 1)
   ok st.party.field_usable?(4, st), 'listed by scope alone, before any destination is registered'
-  ok st.party.use_special_teleport_item(4, hero, st, 5).nil?, 'the cast itself still needs a destination'
+  ok st.party.use_special_teleport_item(4, hero, st, 5).nil?, 'never a special-item cast -- no destination yet either'
   st.teleport_access = true
   st.teleport_targets[10] = { x: 1, y: 2, switch_id: nil }
   st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
   ok st.party.field_usable?(4, st)
+  ok st.party.use_special_teleport_item(4, hero, st, 5).nil?,
+     'destinations registered now -- still nil, equipment never takes this path'
   before = hero.mp
-  eq({ map_id: 5, x: 8, y: 9, switch_id: nil }, st.party.use_special_teleport_item(4, hero, st, 5))
+  affected = st.party.use_item(4, hero)
+  eq [hero], affected, 'the ordinary item-use path succeeds -- ' \
+                        "Game_Battler::UseSkill's Escape/Teleport branch always sets was_used = true"
   eq before, hero.mp, 'free -- no SP spent for an item cast'
   eq 1, st.party.item_count(4), 'equipment is not consumed -- a reusable tool'
 end


### PR DESCRIPTION
## Summary

- RPG_RT only lets a genuine type-9 special item warp the party for an Escape/Teleport skill (`Scene_Item::vUpdate`'s ReserveTeleport/Scene_Teleport dispatch is gated on `item.type == Type_special`). A weapon/shield/armor/helmet/accessory item flagged `use_skill` (schema field 71) invoking the very same skill type instead falls to the ordinary `Scene_ActorTarget` picker, where `Game_Battler::UseSkill` plays only the skill's own sound effect and never warps at all.
- A prior fix (merged earlier this cycle) relaxed `Game::Party#use_special_escape_item`/`#use_special_teleport_item`'s type guard to also admit `use_skill` equipment items, reasoning "the cast is identical" by analogy to the type-9 special-item path — this was never independently verified against real RPG_RT source, and it is not identical: it let such an item warp the party for free.
- `game.rb`: re-narrowed `use_special_escape_item`/`use_special_teleport_item` back to `ITEM_SPECIAL` only. Gave `use_equip_skill_item` its own Escape/Teleport branch so the ordinary item-use path correctly reports success (plays the invoked skill's animation SE) instead of misreporting failure through `cast_skill`, which has no notion of these two skill types and always found nothing to change.
- `scene/item_menu.rb`: `choose_item`'s Escape/Teleport buzzer-gate checks and no-prompt warp/teleport-picker dispatch now only fire for genuine special items; a `use_skill` equipment item falls to the same ordinary `prompt_item_target` single-target picker every other equipment item already takes. Switch-type dispatch is untouched — independently re-verified correct as written for both item kinds.
- `docs/TODO.md`: corrected the stale "the cast is identical" claim with strikethrough + a dated Follow-up citing the exact EasyRPG source confirming the real behavior.

## Test plan

- [x] Rewrote the two existing `scripts/rpg2k_logic_check.rb` checks that had baked in the wrong "eventually warps" expectation once access/target existed; confirmed via `git stash` that they fail against the pre-fix source and pass post-fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 823 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1073 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_