### PR TITLE
Fix: battle state slip damage is not clamped to the damage-popup cap

### DIFF
--- a/changelog.d/battle-state-slip-damage-uncapped.fixed.md
+++ b/changelog.d/battle-state-slip-damage-uncapped.fixed.md
@@ -1,0 +1,8 @@
+- **Battle:** a state's per-turn HP slip damage (poison, and any custom
+  status with a percent-of-max HP drain) is no longer clamped to the
+  damage-popup cap (999 on RPG2000, 9999 on RPG2003) -- matching RPG_RT's
+  own `Game_Battler::ApplyConditions`, which applies the full computed
+  slip every turn with no clamp at all (only floored at 1 HP, never
+  lethal on its own). Previously, a heavy percent-of-max drain on a
+  high-max-HP battler ticked for less damage than genuine RPG_RT once the
+  computed amount exceeded the edition's popup ceiling.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1325,6 +1325,31 @@ The work below is roughly ordered by the critical path to a walkable game
   a 100%-of-max-HP battle poison tick now floors at 1 HP and leaves the
   battler alive across two full rounds instead of knocking it out, confirmed
   to fail against the pre-fix code (`expected 1, got 0`) before the fix.
+  ✅ **Follow-up (2026-08-20): a large enough per-turn HP slip was silently
+  clamped to the damage-popup cap (999 on RPG2000, 9999 on RPG2003) —
+  RPG_RT applies the full computed slip, uncapped.** `apply_turn_states`'s
+  HP branch carried `hp = cap if hp > cap` ahead of the `slip_stat` call,
+  on an uncited inline comment claiming "the popup hard-cap applies to
+  slip damage too." Confirmed against EasyRPG Player's actual C++, fetched
+  live: `Game_Battler::ApplyConditions` (`src/game_battler.cpp`) computes
+  each state's `src_hp` and hands it straight to `ChangeHp(src_hp, /*
+  lethal = */ false)` — no `Utils::Clamp` anywhere in that path.
+  `Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue())`, the actual
+  popup cap, exists at exactly three call sites in the whole codebase, all
+  inside `game_battlealgorithm.cpp`'s Normal/Skill/SelfDestruct algorithms
+  (the same three cited by "Simulated Attack does not hard-cap damage the
+  way a real battle-popup action does" elsewhere in this file) —
+  `ApplyConditions` is not one of them, and the adjacent SP slip branch two
+  lines below was never capped to begin with, which should have been a
+  hint the HP cap was never real. Concretely: a state whose `hp_change_val
+  + max_hp * hp_change_max / 100` exceeds the edition's popup ceiling (a
+  heavy percent-of-max drain on a high-max-HP battler) ticked for less
+  than genuine RPG_RT every turn, understating cumulative slip damage.
+  Fixed by dropping the clamp entirely; the non-lethal floor-at-1 rule
+  above is unaffected. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (a 50%-of-max poison tick on a 10,000-max-HP battler drains the
+  full 5,000, not 999), confirmed to fail against the pre-fix code
+  (`expected 5000, got 9001`) before the fix.
   **The ground drains it too** — RPG2000's 地形ダメージ, the 地形 row's `damage`
   field (ADR 0034). Stepping onto a tile whose terrain carries one takes that
   much HP off every member who is not already down and is not wearing gear

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10859,9 +10859,19 @@ module Game
           b.state_turns.delete(id)
           next
         end
+        # Not clamped to #damage_cap: confirmed against EasyRPG's own live
+        # source (`Game_Battler::ApplyConditions`, `src/game_battler.cpp`) --
+        # its `ChangeHp(src_hp, /* lethal = */ false)` call carries the
+        # computed slip straight through with no `Utils::Clamp` at all. The
+        # popup hard-cap (`MaxDamageValue()`) exists at exactly three call
+        # sites in EasyRPG, all in `src/game_battlealgorithm.cpp`'s
+        # Normal/Skill/SelfDestruct algorithms (see #do_simulated_attack's
+        # own citation of this) -- `ApplyConditions` is not one of them. A
+        # prior version of this method capped the HP slip here anyway, on an
+        # uncited assumption that the popup limit "applies to slip damage
+        # too"; it does not, and the SP slip two lines down was never capped
+        # to begin with, which should have been a hint.
         hp = state_field(d, :hp_change_val) + b.max_hp * state_field(d, :hp_change_max) / 100
-        cap = damage_cap
-        hp = cap if hp > cap # the popup hard-cap applies to slip damage too
         b.hp = slip_stat(b.hp, b.max_hp, hp, state_field(d, :hp_change_type), 1) if hp > 0
         if b.max_mp && b.mp
           sp = state_field(d, :sp_change_val) + b.max_mp * state_field(d, :sp_change_max) / 100

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14175,6 +14175,29 @@ check 'battle poison (percent of max) floors at 1 HP -- slip damage alone cannot
   ok !hero.dead?
 end
 
+check 'battle poison slip damage is not clamped to the damage-popup cap' do
+  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # `Game_Battler::ApplyConditions` (src/game_battler.cpp) computes each
+  # afflicted state's `src_hp` and hands it straight to `ChangeHp(src_hp,
+  # /* lethal = */ false)` -- no `Utils::Clamp(..., -MaxDamageValue(),
+  # MaxDamageValue())` anywhere in that path. The popup hard-cap exists at
+  # exactly three call sites in the whole codebase, all inside
+  # `game_battlealgorithm.cpp`'s Normal/Skill/SelfDestruct algorithms (see
+  # "Simulated Attack does not hard-cap damage..." below for the same
+  # citation) -- `ApplyConditions` is not one of them. A prior version of
+  # this codebase clamped the HP slip here to Game::Battle#damage_cap
+  # anyway, on an uncited assumption that the popup limit "applies to slip
+  # damage too"; it does not.
+  states = { 2 => FakeStateDef.new(0, 0, 50, 0, 0) } # 50% of max HP / turn
+  hero = combatant('Tank', 0, 0, 20, 10_000)         # max HP 10000, acts first
+  hero.states = [2]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.begin_round
+  bat.step_action
+  eq 5_000, hero.hp, 'the full, uncapped 5000 HP slip -- not clamped to 999/9999'
+end
+
 check 'battle: a GAIN-type state heals per turn instead of draining, clamped to max' do
   # hp_change_type/sp_change_type == Game::States::CHANGE_TYPE_GAIN (a
   # "regen"-style state) adds instead of subtracts, clamped to max_hp/max_mp


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Battler::ApplyConditions` (`src/game_battler.cpp`) computes each afflicted state's HP slip and applies it straight to `ChangeHp(src_hp, /* lethal = */ false)` — no clamp at all, only floored at 1 HP (never lethal on its own). The popup hard-cap (`Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue())`) exists at exactly three call sites in the whole codebase, all inside `game_battlealgorithm.cpp`'s Normal/Skill/SelfDestruct algorithms — `ApplyConditions` is not one of them.
- `Game::Battle#apply_turn_states` (`mruby-rpg2k/mrblib/game.rb`) clamped the computed HP slip to `#damage_cap` (999 on RPG2000, 9999 on RPG2003) ahead of applying it, on an uncited inline comment claiming "the popup hard-cap applies to slip damage too" — it does not, and the adjacent SP slip branch two lines below was never capped either, which should have been a hint.
- A state whose `hp_change_val + max_hp * hp_change_max / 100` exceeds the edition's popup ceiling (a heavy percent-of-max drain on a high-max-HP battler) ticked for less damage than genuine RPG_RT every turn.
- Fixed by dropping the clamp entirely; the non-lethal floor-at-1 rule (`slip_stat`'s `floor` parameter) is unaffected.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a 50%-of-max-HP poison tick on a 10,000-max-HP battler drains the full 5,000 HP, not clamped to 999.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — `expected 5000, got 9001`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 823 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1074 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_