### PR TITLE
Fix: direction_toward resolves an exact tie vertically, not horizontally

### DIFF
--- a/changelog.d/direction-toward-tie-vertical.fixed.md
+++ b/changelog.d/direction-toward-tie-vertical.fixed.md
@@ -1,0 +1,10 @@
+- **Move routes / move types:** an event facing or moving toward/away from
+  its target (Move Route Face/Move Toward Hero / Away From Hero, Move Type
+  "Approach Player" / "Away from Player") now resolves an exact horizontal/
+  vertical tie the same way RPG_RT does -- vertically, landing on Down --
+  instead of the horizontal axis. An event already standing on its target's
+  tile now also turns to face Down like real RPG_RT, instead of keeping
+  whatever direction it last faced. Matches `Game_Character::
+  GetDirectionToCharacter`'s strict `>` comparison, which falls to the
+  vertical branch (and its `sy == 0` -> Down default) on any tie including
+  the same-tile case.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -294,6 +294,38 @@ The work below is roughly ordered by the critical path to a walkable game
   blocks, every one enclosing a runtime-directed move (484 away from the hero,
   188 toward it, 133 forward) rather than a literal direction, and 141 enclose
   more than one, so those now clear the tile they hop over.
+  ✅ **Follow-up (2026-08-20): ~~ties (and equal distance) resolve to the
+  horizontal axis~~ — corrected, real RPG_RT resolves a tie vertically, and
+  the same-tile case is not special-cased to "keep the current facing" at
+  all.** `Game::Character#direction_toward` (`mruby-rpg2k/mrblib/game.rb`)
+  — which faces/moves an event toward or away from a target for Move Route
+  Face/Move Toward Hero / Away From Hero and Move Type "Approach Player" /
+  "Away from Player" alike, `#direction_away` deriving from it via
+  `TURN_180` — compared `dx.abs >= dy.abs` (a non-strict `>=`) and returned
+  the character's own current facing outright when `dx == dy == 0`.
+  Confirmed against RPG_RT's own live source: `Game_Character::
+  GetDirectionToCharacter` (`src/game_character.cpp`) compares with a
+  strict `std::abs(sx) > std::abs(sy)`, so an exact tie — a genuine
+  diagonal tie, or the degenerate same-tile case — falls to the *vertical*
+  branch every time, landing on Down since `sy > 0` reads false when
+  `sy == 0`; the reference does not special-case the same-tile case at
+  all, it just evaluates the same two branches and gets the same Down
+  result any other zero-`sy` tie would. Concretely: a chase/patrol event
+  exactly as far horizontally as vertically from its target — a common
+  diagonal-approach case — turned/stepped along the wrong axis (East/West
+  instead of Down), and an event already standing on its target's tile
+  kept facing whichever way it last faced instead of turning to face Down
+  like real RPG_RT does. Fixed by tightening the horizontal comparison to
+  a strict `>` and making the vertical branch unconditional (`dy < 0 ? 8
+  : 2`), reproducing the reference's `sy == 0` → Down fallthrough without
+  a separate same-tile case. `#direction_away` needed no change — it
+  already derives correctly from `#direction_toward` via `TURN_180`
+  regardless of which branch fires. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a 4-and-4 diagonal tie and the
+  same-tile case both land on Down, starting the character faced Up so a
+  same-tile result of Down cannot be mistaken for a coincidental "kept
+  facing" match), confirmed to fail against the pre-fix code (`expected
+  2, got 6`) before the fix.
   **The hop is drawn as one now, too.** The move happened in a single step and
   the sprite went with it, so a jump — the move whose whole point is being
   airborne — was a blink from one tile to another. A jumping event slides across

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6162,18 +6162,24 @@ module Game
     def turn_left;   @direction = TURN_LEFT[@direction]  || @direction; end
     def turn_around; @direction = TURN_180[@direction]   || @direction; end
 
-    # Direction pointing from this character toward (tx, ty). Ties (and equal
-    # distance) resolve to the horizontal axis, matching RPG2000's toward-hero
-    # behaviour; returns the current facing when already on the tile.
+    # Direction pointing from this character toward (tx, ty). ~~Ties (and
+    # equal distance) resolve to the horizontal axis, matching RPG2000's
+    # toward-hero behaviour; returns the current facing when already on the
+    # tile.~~ Corrected against RPG_RT's own live source: `Game_Character::
+    # GetDirectionToCharacter` (`src/game_character.cpp`) compares with a
+    # strict `>` (`std::abs(sx) > std::abs(sy)`), so an exact tie -- and the
+    # degenerate same-tile case (dx == dy == 0), which the reference does not
+    # special-case at all -- falls through to the *vertical* branch, and
+    # lands on Down there since `sy > 0` is false when `sy == 0`. This used
+    # to compare with `>=` and treat the same-tile case as "keep the current
+    # facing," neither of which the reference does.
     def direction_toward(tx, ty)
       dx = tx - @x
       dy = ty - @y
-      if dx.abs >= dy.abs && dx != 0
+      if dx.abs > dy.abs
         dx > 0 ? 6 : 4
-      elsif dy != 0
-        dy > 0 ? 2 : 8
       else
-        @direction
+        dy < 0 ? 8 : 2
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -186,7 +186,25 @@ check 'direction_toward/away point at and away from a target' do
   eq 6, c.direction_toward(9, 6)  # dx dominates -> east
   eq 2, c.direction_toward(5, 9)  # pure vertical -> south
   eq 4, c.direction_away(9, 5)    # away from east -> west
-  eq 2, c.direction_toward(5, 5)  # already there -> keep facing
+end
+
+check 'direction_toward: an exact tie (and the same-tile case) resolves ' \
+      'vertically, landing on Down -- not the horizontal axis and not ' \
+      '"keep the current facing"' do
+  # Confirmed against RPG_RT's own live source: `Game_Character::
+  # GetDirectionToCharacter` (src/game_character.cpp) compares with a
+  # strict `>` (`std::abs(sx) > std::abs(sy)`), so `abs(dx) == abs(dy)`
+  # (a genuine diagonal tie, or the degenerate dx == dy == 0 same-tile
+  # case) falls to the vertical branch, landing on Down since `sy > 0` is
+  # false when `sy == 0`. A prior version of this method compared with
+  # `>=` (tying to the *horizontal* axis instead) and special-cased the
+  # same-tile case to "keep the current facing" -- neither of which the
+  # reference does. Starting the character facing Up (8) rather than Down
+  # (2) rules out a same-tile result of 2 being a coincidental match with
+  # "keep facing" rather than the genuine Down default.
+  c = Game::Character.new(5, 5, 8)
+  eq 2, c.direction_toward(9, 9), 'a 4-and-4 diagonal tie lands on Down, not East'
+  eq 2, c.direction_toward(5, 5), 'the same-tile case also lands on Down'
 end
 
 # -- MoveRoute: movement ------------------------------------------------------


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Character::GetDirectionToCharacter` (`src/game_character.cpp`) compares with a strict `std::abs(sx) > std::abs(sy)`, so an exact tie — including the degenerate same-tile case (`sx == sy == 0`) — falls to the *vertical* branch and lands on Down, since `sy > 0` reads false when `sy == 0`. The reference does not special-case the same-tile case at all; it just evaluates the same two branches and gets Down from any zero-`sy` tie.
- `Game::Character#direction_toward` (`mruby-rpg2k/mrblib/game.rb`) compared with `>=` (tying to the *horizontal* axis instead) and special-cased `dx == dy == 0` to return the character's own current facing — neither of which the reference does. This drives Move Route Face/Move Toward Hero / Away From Hero and Move Type "Approach Player" / "Away from Player" alike (`#direction_away` derives from it via `TURN_180`).
- A chase/patrol event exactly as far horizontally as vertically from its target — a common diagonal-approach case — turned/stepped along the wrong axis (East/West instead of Down), and an event already standing on its target's tile kept whatever direction it last faced instead of turning to face Down.
- Fixed by tightening the horizontal comparison to a strict `>` and making the vertical branch unconditional (`dy < 0 ? 8 : 2`), reproducing the reference's `sy == 0` → Down fallthrough without a separate same-tile case. `#direction_away` needed no change — it already derives correctly via `TURN_180` regardless of which branch fires.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a 4-and-4 diagonal tie and the same-tile case both land on Down, starting the character faced Up so a same-tile result of Down can't be mistaken for a coincidental "kept facing" match.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — `expected 2, got 6`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 823 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1075 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_