### PR TITLE
Fix: board_vehicle applies the wrong boarding trigger per vehicle type

### DIFF
--- a/changelog.d/vehicle-board-trigger-per-type.fixed.md
+++ b/changelog.d/vehicle-board-trigger-per-type.fixed.md
@@ -1,0 +1,10 @@
+- **Vehicles:** boarding now uses the correct trigger per vehicle type,
+  matching RPG_RT's own `Game_Player::GetOnVehicle` -- the Airship boards
+  only by standing on its own tile, and a Boat/Ship boards only by facing
+  it from an adjacent tile (the shore). Previously, a single generic check
+  applied both triggers to every vehicle type: a placed, grounded Airship
+  could be boarded merely by facing it from next to its tile (real RPG_RT
+  does nothing there), and a Boat/Ship could symmetrically have been
+  boarded by standing on its own tile rather than facing it from the
+  shore. The Enter/Exit Vehicle event command shares this fix, since it
+  drives the identical boarding path the action button uses.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -556,6 +556,41 @@ The work below is roughly ordered by the critical path to a walkable game
   once the ship is moved aside; an airship cannot land on a parked boat's
   tile but lands normally once it moves away), both confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-20): the asymmetric boarding rule the paragraph
+  above (and the earlier `#vehicle_blocks?` paragraph) cited as background —
+  ~~`#board_vehicle`'s own asymmetric boarding rule — a boat/ship only
+  boards by facing it from an adjacent tile, an airship only by already
+  standing on it~~ — described `#board_vehicle`'s own doc comment
+  accurately, but not what the code beneath that comment actually did.**
+  Confirmed directly against RPG_RT's live source: `Game_Player::
+  GetOnVehicle` (`src/game_player.cpp`) checks the Airship only against the
+  player's own tile (`GetX()`/`GetY()`), in an `if` whose `else` branch is
+  the *only* place the faced tile (`front_x`/`front_y`) is computed at
+  all — the Airship is never considered there, and Ship/Boat (checked in
+  that order) are never considered against the player's own tile.
+  `#board_vehicle` (`mruby-rpg2k/mrblib/scene/map.rb`) instead ran one
+  generic loop over every vehicle type applying *both* the "standing on
+  it" and "facing it" checks to *every* type — so a placed, grounded
+  Airship could be boarded merely by facing it from an adjacent tile
+  (real RPG_RT does nothing there; the button falls through to whatever
+  ordinary event sits on that tile instead), and a Boat/Ship could
+  symmetrically have been boarded by standing on its own tile rather than
+  facing it from the shore — the opposite of the rule the comment above
+  already stated correctly. `Game_Interpreter_Map::
+  CommandEnterExitVehicle` (code 10840) reaches the identical
+  `GetOnOffVehicle`/`GetOnVehicle` path, so the Enter/Exit Vehicle event
+  command carried the same bug. Fixed by splitting `#board_vehicle` into a
+  standing-only Airship check and a facing-only Ship/Boat loop (Ship
+  before Boat, matching the reference's own check order), rather than one
+  generic per-type loop. Two existing `scripts/rpg2k_scene_check.rb`
+  checks had themselves relied on the bug (a boat "boarded in place" by
+  standing on its own tile, both directly and via the Enter/Exit Vehicle
+  command) — rewritten to board by facing instead, matching what real
+  RPG_RT actually allows. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (facing a placed airship from an
+  adjacent tile does not board it; standing on a placed boat does not
+  board it either), confirmed to fail against the pre-fix code before the
+  fix.
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2296,20 +2296,35 @@ class RPG2k
       # Board a vehicle placed on the current map at the party's tile (airship) or
       # the tile it faces (boat / ship, boarded from the shore). Steps onto the
       # vehicle's tile and returns whether a vehicle was boarded.
+      #
+      # Each vehicle type has exactly one trigger, never both -- confirmed
+      # against RPG_RT's own live source: `Game_Player::GetOnVehicle`
+      # (`src/game_player.cpp`) checks the airship only against the player's
+      # own tile (`GetX()`/`GetY()`), in an `if` whose `else` branch is the
+      # only place `front_x`/`front_y` (the faced tile) are computed at all --
+      # the airship is never considered there, and Ship/Boat (checked in that
+      # order) are never considered against the player's own tile. This used
+      # to run one generic per-type loop applying *both* checks to *every*
+      # type, which let the airship be boarded merely by facing it from an
+      # adjacent tile (real RPG_RT does nothing there -- the action falls
+      # through to whatever ordinary event sits on that tile instead) and,
+      # symmetrically, would have let a boat/ship be boarded by standing on
+      # its tile rather than facing it from the shore.
       def board_vehicle
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
-        Game::Vehicle::TYPES.each do |type|
+        airship = @state.vehicle(:airship)
+        if airship.placed? && airship.map_id == @state.map_id &&
+           airship.x == @state.x && airship.y == @state.y
+          board_as(:airship)
+          return true
+        end
+        [:ship, :boat].each do |type|
           v = @state.vehicle(type)
-          next unless v.placed? && v.map_id == @state.map_id
-          if v.x == @state.x && v.y == @state.y
-            board_as(type)
-            return true
-          elsif v.x == fx && v.y == fy
-            @state.x = fx
-            @state.y = fy
-            board_as(type)
-            return true
-          end
+          next unless v.placed? && v.map_id == @state.map_id && v.x == fx && v.y == fy
+          @state.x = fx
+          @state.y = fy
+          board_as(type)
+          return true
         end
         false
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8262,6 +8262,41 @@ check 'boarding a boat and disembarking onto the shore' do
   eq [0, 1], [boat.x, boat.y], 'the boat stayed where the party left it'
 end
 
+check 'each vehicle type has exactly one boarding trigger: the airship only ' \
+      'by standing on it, a boat/ship only by facing it' do
+  # Confirmed against RPG_RT's own live source: `Game_Player::GetOnVehicle`
+  # (src/game_player.cpp) checks the Airship only against the player's own
+  # tile (`GetX()`/`GetY()`), in an `if` whose `else` branch is the only
+  # place the faced tile is computed at all -- the Airship is never
+  # considered there, and Ship/Boat are never considered against the
+  # player's own tile. A prior version of `#board_vehicle` ran one generic
+  # per-type loop applying *both* checks to *every* type, which let the
+  # Airship be boarded merely by facing it from an adjacent tile (real
+  # RPG_RT does nothing there) and would have let a Boat/Ship be boarded by
+  # standing on its tile rather than facing it from the shore.
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face down, toward (0, 1)
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 1 # placed on the tile the party faces, not the tile it stands on
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'facing a placed airship from an adjacent tile does not board it'
+  eq [0, 0], [st.x, st.y], 'the party never stepped toward it either'
+
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 0 # right under the party -- standing on it, not facing it
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'standing on a placed boat does not board it'
+end
+
 check 'a boarded boat cannot overlap a below-characters event unless it has Through Mode on' do
   # yado.tk: a below-characters, passable-graphic event lets the *walking*
   # hero overlap it fine (LAYER_BELOW is not LAYER_SAME, see the priority-type
@@ -8380,13 +8415,13 @@ check "a boarded hero's own Set Move Route respects the ridden vehicle's " \
   # way ordinary sailing is" above -- but every tile is still ordinarily
   # walkable on foot, so the pre-fix bug (checking on-foot passability while
   # boarded) would have let this route sail through anyway.
-  scene = new_scene({}, player: [0, 1])
+  scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)
   boat = st.vehicle(:boat)
   boat.map_id = st.map_id
   boat.x = 0
   boat.y = 1
-  RGSS::Input.triggered = [RGSS::Input::C] # board the boat in place (same tile)
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat by facing it (down, the default)
   scene.update
   RGSS::Input.triggered = []
   eq :boat, st.boarded, 'boarded the boat'
@@ -8822,36 +8857,41 @@ end
 # `#vehicle_passable?` and `#airship_landable?`.
 check 'a moving boat collides with a different parked ship, and with a ' \
       'grounded airship' do
+  # A Boat/Ship boards only by facing it from an adjacent tile, never by
+  # standing on it -- see "board_vehicle applies the wrong boarding trigger"
+  # above -- so the party starts one tile above the boat, facing down (2, the
+  # default), and steps onto it via the ordinary facing-tile board.
   scene = new_scene({}, player: [0, 0], boat_pass: true)
   st = scene.instance_variable_get(:@state)
   boat = st.vehicle(:boat)
   boat.map_id = st.map_id
   boat.x = 0
-  boat.y = 0 # under the party; board in place
+  boat.y = 1
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.triggered = []
-  eq :boat, st.boarded, 'boarded the boat in place'
+  eq :boat, st.boarded, 'boarded the boat by facing it from the shore'
+  eq [0, 1], [st.x, st.y], 'and stepped onto its tile'
 
   ship = st.vehicle(:ship)
   ship.map_id = st.map_id
   ship.x = 1
-  ship.y = 0
+  ship.y = 1
   RGSS::Input.dir_value = 6 # hold right, straight into the parked ship
   10.times { scene.update }
   RGSS::Input.dir_value = 0
-  eq [0, 0], [st.x, st.y], 'a different parked vehicle (the ship) blocks the boat'
+  eq [0, 1], [st.x, st.y], 'a different parked vehicle (the ship) blocks the boat'
 
   # Move the ship out of the way and put a grounded airship there instead.
   ship.map_id = 0
   air = st.vehicle(:airship)
   air.map_id = st.map_id
   air.x = 1
-  air.y = 0
+  air.y = 1
   RGSS::Input.dir_value = 6
   10.times { scene.update }
   RGSS::Input.dir_value = 0
-  eq [0, 0], [st.x, st.y], 'a grounded airship blocks the boat too'
+  eq [0, 1], [st.x, st.y], 'a grounded airship blocks the boat too'
 end
 
 check 'the airship cannot land on a parked boat/ship\'s tile' do
@@ -12882,14 +12922,21 @@ check 'Tile Substitution survives a Save/Continue on the same map, unlike an ord
   eq 41, fresh.lower(3, 3), 'Continue restores the substitution onto the fresh map'
 end
 
-check 'Enter/Exit Vehicle boards the vehicle the party stands on' do
+check 'Enter/Exit Vehicle boards the vehicle the party faces' do
+  # `Game_Interpreter_Map::CommandEnterExitVehicle` (code 10840,
+  # src/game_interpreter_map.cpp) just calls `Game_Player::GetOnOffVehicle`
+  # -- the identical function the action button drives -- so a Boat/Ship
+  # boards only by facing it from an adjacent tile, never by standing on it
+  # (see "board_vehicle applies the wrong boarding trigger" above); only the
+  # Airship boards by standing on its own tile.
   cmds = [ECmd.new(IC2::ENTER_EXIT_VEHICLE, [])]
   scene = new_scene(parallel_event(cmds), player: [0, 0])
   st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face down, toward (0, 1)
   boat = st.vehicle(:boat)
   boat.map_id = st.map_id
-  boat.x = st.x
-  boat.y = st.y
+  boat.x = 0
+  boat.y = 1
   scene.update
   eq :boat, st.boarded
   scene.update # the command runs again next loop and steps back off


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Player::GetOnVehicle` (`src/game_player.cpp`) checks the Airship only against the player's own tile (`GetX()`/`GetY()`), in an `if` whose `else` branch is the only place the faced tile (`front_x`/`front_y`) is computed at all — the Airship is never considered there, and Ship/Boat (checked in that order) are never considered against the player's own tile. Each vehicle type has exactly one trigger, never both.
- `Scene::Map#board_vehicle` (`mruby-rpg2k/mrblib/scene/map.rb`) ran one generic per-type loop applying *both* the "standing on it" and "facing it" checks to *every* vehicle type — its own doc comment already described the intended per-type split correctly, but the code beneath it didn't implement it.
- Concretely: facing a placed, grounded airship from an adjacent tile and pressing the action button boarded it immediately (real RPG_RT does nothing there — the button falls through to whatever ordinary event sits on that tile). Symmetrically, standing directly on a placed boat/ship's tile would also board it, when real RPG_RT only allows boarding a boat/ship by facing it from the shore.
- Fixed by splitting `#board_vehicle` into a standing-only Airship check and a facing-only Ship/Boat loop (Ship checked before Boat, matching the reference's own check order). `Game_Interpreter_Map::CommandEnterExitVehicle` (code 10840) reaches the identical `GetOnOffVehicle`/`GetOnVehicle` path, so this fixes the Enter/Exit Vehicle event command too.
- Two existing `scripts/rpg2k_scene_check.rb` checks had themselves relied on the bug (boarding a boat "in place" by standing on its own tile, both directly and via Enter/Exit Vehicle) — rewritten to board by facing instead, matching what real RPG_RT actually allows.
- `docs/TODO.md`: corrected a stale parenthetical elsewhere that cited the (never-actually-implemented) asymmetric rule as settled background, with strikethrough + a dated Follow-up.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: facing a placed airship from an adjacent tile does not board it; standing on a placed boat does not board it either.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `map.rb` only) and passes after.
- [x] Rewrote the two existing checks that relied on the bug (boat "boarded in place"), confirmed they now pass against the corrected boarding rule.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 824 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1075 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_