### PR TITLE
Fix: Change Equipment ignores dual-wield redirection rules

### DIFF
--- a/changelog.d/change-equipment-dual-wield-redirect.fixed.md
+++ b/changelog.d/change-equipment-dual-wield-redirect.fixed.md
@@ -1,0 +1,12 @@
+- **Change Equipment event command:** now respects a 二刀流 (dual-wield)
+  actor's second weapon slot, matching RPG_RT's own
+  `Game_Interpreter::CommandChangeEquipment`. Handing such an actor a
+  shield is a complete no-op (nothing equipped, nothing consumed from the
+  bag), and handing them a second weapon fills their empty off-hand
+  weapon slot instead of overwriting the first -- unless that slot is
+  already occupied or the standing weapon is two-handed, in which case it
+  falls through to the ordinary weapon-slot overwrite, same as before.
+  Previously this command equipped purely by the item's database type,
+  so a scripted "learn dual-wield, here is your second blade" event
+  overwrote the first weapon, and handing such an actor a shield silently
+  jammed it into their off-hand weapon slot.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6841,6 +6841,34 @@ Everything below is unverified against the codebase.
   in param4 (0) must remove the armour and leave the weapon on, the
   opposite of what the pre-fix code did — all three confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-20): the equip branch never gave a 二刀流
+  (`double_hand?`) actor the dual-wield redirect the equip menu already
+  gets structurally from `#equip_candidates`.** Confirmed directly against
+  RPG_RT's live source: `Game_Interpreter::CommandChangeEquipment`
+  (`src/game_interpreter.cpp`) special-cases `HasTwoWeapons()` *before* its
+  own `ChangeEquipment` call — a shield-type item is a complete no-op
+  (`continue`, nothing equipped, nothing consumed); a weapon-type item
+  equips into the *shield* slot instead when the weapon slot already holds
+  a non-two-handed weapon and the shield slot is empty, otherwise it falls
+  through to the ordinary weapon-slot overwrite.
+  `Game::Party#equip_item_from_bag` (`mruby-rpg2k/mrblib/game.rb`) equipped
+  purely by the item's own database type regardless of `#double_hand?`, so
+  a scripted "learn 二刀流, here is your second blade" event overwrote the
+  actor's first weapon instead of filling the empty second slot, and
+  handing such an actor a shield silently jammed it into their off-hand
+  weapon slot instead of the harmless no-op real RPG_RT makes it. Fixed by
+  mirroring the three-way branch inside `#equip_item_from_bag` itself,
+  reusing `Actor#two_handed?`/`#equipment` rather than re-deriving the
+  two-handed check. `Actor#equip_item`'s own doc comment, which described
+  the event command as always equipping "by type, since that command names
+  no slot," was corrected — it now sometimes passes an explicit shield-slot
+  the same way the equip menu does. Covered by three new
+  `scripts/rpg2k_logic_check.rb` checks (a shield is a complete no-op and
+  is never even consumed from the bag; a second weapon fills the empty
+  shield slot instead of overwriting the first; the redirect does not fire
+  once the shield slot is already occupied or the standing weapon is
+  two-handed), all three confirmed to fail against the pre-fix code before
+  the fix.
 - ✅ **Call Event** — every checkable engine-behavior sub-claim is confirmed
   correct: it doesn't move the target event, ignores its appearance
   conditions, can't cross maps, continues the *caller* right after itself

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1888,7 +1888,10 @@ module Game
     # (1) as the candidate list `Party#equip_candidates` offered it for. A
     # non-equippable item, an unknown id, or a database without an item table
     # is ignored. Drives the Change Equipment event command's equip operation
-    # (always by type, since that command names no slot).
+    # too -- ~~always by type, since that command names no slot~~: since the
+    # dual-wield redirect below, `Party#equip_item_from_bag` also passes an
+    # explicit shield-slot for a 二刀流 actor's second weapon, the same way
+    # the equip menu does.
     def equip_item(item_id, slot = nil)
       return if item_id.nil? || item_id == 0 || !@db.respond_to?(:item)
       it = @db.item[item_id]
@@ -4711,10 +4714,38 @@ module Game
     # or unknown item id is a no-op, matching EasyRPG's own type-switch
     # default. Callers apply any actor_set restriction themselves (per target,
     # same as #equip_candidate_for? would) before calling this.
+    #
+    # A 二刀流 (double_hand) actor gets the same dual-wield redirect
+    # `Scene::EquipMenu` gets structurally from #equip_candidates, since this
+    # command bypasses the candidate list entirely -- confirmed against
+    # RPG_RT's own live source: `Game_Interpreter::CommandChangeEquipment`
+    # (`src/game_interpreter.cpp`) special-cases `HasTwoWeapons()` before its
+    # own `ChangeEquipment` call: a shield-type item is a complete no-op
+    # (`continue`, nothing equipped, nothing consumed); a weapon-type item
+    # equips into the *shield* slot instead when the weapon slot already
+    # holds a (non-two-handed) weapon, the shield slot is empty, and the new
+    # weapon is not two-handed either -- otherwise it falls through to the
+    # ordinary weapon-slot overwrite. Previously this method equipped purely
+    # by item type regardless of `double_hand?`, so a scripted "learn 二刀流,
+    # here is your second blade" event overwrote the first weapon instead of
+    # filling the empty second slot, and handing such an actor a shield
+    # silently jammed it into their off-hand weapon slot instead of being
+    # the no-op real RPG_RT makes it.
     def equip_item_from_bag(actor, item_id)
       return false unless actor
       slot = equip_slot_for(item_id)
       return false if slot.nil?
+      if actor.double_hand?
+        return false if slot == Actor::SHIELD_SLOT
+        if slot == Actor::WEAPON_SLOT
+          weapon = actor.equipment[Actor::WEAPON_SLOT]
+          shield = actor.equipment[Actor::SHIELD_SLOT]
+          if weapon && weapon != 0 && (shield.nil? || shield == 0) &&
+             !actor.two_handed?(weapon) && !actor.two_handed?(item_id)
+            slot = Actor::SHIELD_SLOT
+          end
+        end
+      end
       swap_equipment_through_bag(actor, item_id, slot)
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -19347,6 +19347,69 @@ check 'a two-handed second weapon still empties the shield-turned-weapon hand\'s
   eq 0, hero.equipment[0], 'the two-handed claymore still claims the other hand'
 end
 
+# The Change Equipment event command (#equip_item_from_bag) bypasses
+# #equip_candidates/#equip_candidate_for? entirely -- it names no slot at
+# all, unlike the equip menu -- so it needs its own dual-wield handling.
+# Confirmed against RPG_RT's own live source: `Game_Interpreter::
+# CommandChangeEquipment` (src/game_interpreter.cpp) special-cases
+# `HasTwoWeapons()` before its own `ChangeEquipment` call: a shield-type
+# item is a complete no-op, and a weapon-type item redirects into the
+# shield slot when the weapon slot already holds a non-two-handed weapon
+# and the shield slot is empty, otherwise it falls through to the ordinary
+# weapon-slot overwrite. A prior version of #equip_item_from_bag equipped
+# purely by item type regardless of #double_hand?, so a Change Equipment
+# command handing a 二刀流 actor a second weapon overwrote the first
+# instead of filling the empty second slot, and handing one a shield
+# silently jammed it into the off-hand weapon slot instead of doing
+# nothing.
+check 'Change Equipment on a 二刀流 actor: a shield is a complete no-op' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(3, 1) # shield
+  ok !st.party.equip_item_from_bag(hero, 3), 'no-op, matching HasTwoWeapons()\'s continue'
+  eq 0, hero.equipment[Game::Actor::SHIELD_SLOT], 'nothing was equipped'
+  eq 1, st.party.item_count(3), 'and the shield was never even consumed from the bag'
+end
+
+check 'Change Equipment on a 二刀流 actor: a second weapon fills the empty ' \
+      'shield slot instead of overwriting the first' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1) # sword
+  st.party.gain_item(2, 1) # dagger
+  ok st.party.equip_item_from_bag(hero, 1), 'first weapon: the ordinary weapon slot'
+  eq [1, 0], hero.equipment[0, 2]
+  ok st.party.equip_item_from_bag(hero, 2), 'second weapon: redirected into the shield slot'
+  eq [1, 2], hero.equipment[0, 2], 'both weapons on, neither overwriting the other'
+end
+
+check 'Change Equipment on a 二刀流 actor: the redirect does not fire once ' \
+      'the shield slot is already occupied, or the standing weapon is ' \
+      'two-handed' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 2) # two swords
+  st.party.gain_item(4, 1) # claymore (two-handed)
+  ok st.party.equip_item_from_bag(hero, 1), 'first sword: the ordinary weapon slot'
+  ok st.party.equip_item_from_bag(hero, 1), 'second sword: redirected into the now-empty shield slot'
+  eq [1, 1], hero.equipment[0, 2]
+  ok st.party.equip_item_from_bag(hero, 4), 'a third weapon overwrites the weapon slot -- the shield slot is full'
+  # The claymore is two-handed, so #equip_item's own pre-existing
+  # two-handed-clearing rule (unrelated to this fix) also empties the
+  # shield slot it now claims as its second hand.
+  eq [4, 0], hero.equipment[0, 2]
+
+  st2 = double_hand_party
+  hero2 = st2.party.actor_by_id(1)
+  st2.party.gain_item(4, 1) # claymore, two-handed
+  st2.party.gain_item(1, 1) # sword
+  ok st2.party.equip_item_from_bag(hero2, 4), 'the claymore, into the weapon slot'
+  eq [4, 0], hero2.equipment[0, 2]
+  ok st2.party.equip_item_from_bag(hero2, 1),
+     'a second weapon overwrites the two-handed claymore instead of redirecting'
+  eq [1, 0], hero2.equipment[0, 2]
+end
+
 # -- 装備固定 actors (equipment_fixed) -----------------------------------------
 # An actor (or RPG2003 class) trait meaning the field cannot change their
 # equipment at all. EasyRPG gates this at the equip *scene* -- confirming a


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter::CommandChangeEquipment` (`src/game_interpreter.cpp`) special-cases `HasTwoWeapons()` *before* its own `ChangeEquipment` call: a shield-type item is a complete no-op (`continue`, nothing equipped, nothing consumed); a weapon-type item equips into the *shield* slot instead when the weapon slot already holds a non-two-handed weapon and the shield slot is empty, otherwise it falls through to the ordinary weapon-slot overwrite.
- `Game::Party#equip_item_from_bag` (`mruby-rpg2k/mrblib/game.rb`), which drives the Change Equipment event command, equipped purely by the item's own database type regardless of `#double_hand?` — no dual-wield awareness at all. The field Equip menu is unaffected: it sidesteps the issue structurally via `#equip_candidates`, which already retargets a dual-wielder's shield slot to list weapons instead.
- Concretely: a scripted "learn 二刀流, here is your second blade" event overwrote the actor's first weapon instead of filling the empty second slot, and handing such an actor a shield silently jammed it into their off-hand weapon slot instead of the harmless no-op real RPG_RT makes it.
- Fixed by mirroring the three-way branch inside `#equip_item_from_bag` itself, reusing `Actor#two_handed?`/`#equipment` rather than re-deriving the two-handed check. `Actor#equip_item`'s own doc comment, which described the event command as always equipping "by type, since that command names no slot," was corrected — it now sometimes passes an explicit shield-slot the same way the equip menu does.

## Test plan
- [x] Three new `scripts/rpg2k_logic_check.rb` checks: a shield is a complete no-op and is never even consumed from the bag; a second weapon fills the empty shield slot instead of overwriting the first; the redirect does not fire once the shield slot is already occupied or the standing weapon is two-handed.
- [x] Confirmed all three new checks fail against the pre-fix code (`git stash` on `game.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 824 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1078 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_