### PR TITLE
Fix: move route effect-only sub-commands no longer pay a pacing delay

### DIFF
--- a/changelog.d/move-route-effect-commands-free.fixed.md
+++ b/changelog.d/move-route-effect-commands-free.fixed.md
@@ -1,0 +1,9 @@
+- **Move routes:** an effect-only sub-command (Switch On/Off, Speed/
+  Frequency Up/Down, Change Graphic, Play Sound, Through Mode, Stop/Start
+  Animation, Transparency Up/Down) no longer spends a full pacing delay of
+  its own -- matching RPG_RT's own `Game_Character::UpdateMoveRoute`, which
+  runs any number of these in the same frame and only pauses for an actual
+  Move/Turn/Wait/Jump sub-command. Previously, a route mixing effect
+  commands with moves (a common "reskin then step" authoring pattern)
+  crawled through the effect commands at the route's own pacing speed
+  instead of applying them instantly before the next real move.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -326,6 +326,42 @@ The work below is roughly ordered by the critical path to a walkable game
   same-tile result of Down cannot be mistaken for a coincidental "kept
   facing" match), confirmed to fail against the pre-fix code (`expected
   2, got 6`) before the fix.
+  ✅ **Follow-up (2026-08-20): a move route's effect-only sub-commands
+  (Switch On/Off, Speed/Frequency Up/Down, Change Graphic, Play Sound,
+  Through Mode, Stop/Start Animation, Transparency Up/Down) each paid a
+  full pacing delay, where real RPG_RT runs any number of them for free
+  within the same frame.** Confirmed against RPG_RT's own live source:
+  `Game_Character::UpdateMoveRoute` (`src/game_character.cpp`) loops
+  `while (true)` over a route's commands each frame, calling
+  `SetMaxStopCountFor{Step,Turn,Wait}` — the only thing that actually
+  stalls the loop for the rest of that frame — solely for a Move/Turn/
+  Wait/Jump sub-command; every other sub-command falls straight through
+  to the next command within the same iteration, guarded only against a
+  same-frame infinite loop on a repeating route made entirely of effect
+  commands (`current_index == start_index`). `#step_event`,
+  `#step_player_route`, `#step_vehicle_route` and `#step_forced_event`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) each called `Game::MoveRoute#step`
+  exactly once per pacing-timer expiry regardless of what kind of
+  sub-command it ran, so a route mixing effect commands with moves — a
+  common "reskin then step" authoring pattern (Switch ON, Change Graphic,
+  then Move) — crawled through the effect commands at `#EVENT_MOVE_DELAY`'s
+  own pace (up to 96 frames per sub-command at the slowest frequency)
+  instead of running them in the same frame as genuine RPG_RT. Fixed with
+  a shared `#run_route_step(route, character, world)` helper that loops
+  `route.step` while the returned status is `:effect` (not `:moved`/
+  `:blocked`/`:turned`/`:waited`/`:done`), bounded by `route.index`
+  wrapping back to where the burst started — mirroring the reference's own
+  `current_index == start_index` guard — used in place of the bare
+  `route.step` call at all four sites. The existing "reset the pacing
+  timer to a full delay, once, before dispatch" logic in each of those
+  methods needed no change: it already fires once per real frame, and now
+  that one dispatch can run an unbounded burst of effect commands before
+  the one blocking command that actually earns the delay, the timer
+  correctly charges one delay per burst rather than one per sub-command.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a forced player
+  route of two Switch ON commands followed by a Move runs both switches
+  and starts the move on the very same frame, at the slowest frequency),
+  confirmed to fail against the pre-fix code before the fix.
   **The hop is drawn as one now, too.** The move happened in a single step and
   the sprite went with it, so a jump — the move whose whole point is being
   airborne — was a blink from one tile to another. A jumping event slides across

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2774,6 +2774,35 @@ class RPG2k
         @events.each { |e| step_event(e, allow_trigger: allow_trigger) }
       end
 
+      # Run `route`'s sub-commands until one actually costs a frame of pacing
+      # delay (a Move/Turn/Wait/Jump, `Game::MoveRoute#step`'s own :moved/
+      # :blocked/:turned/:waited statuses) or the route finishes -- an
+      # effect-only sub-command (Switch On/Off, Speed/Frequency Up/Down,
+      # Change Graphic, Play Sound, Through Mode, Stop/Start Animation,
+      # Transparency Up/Down) runs free in the same frame as whatever
+      # follows it, never spending a pacing tick of its own. Confirmed
+      # against RPG_RT's own live source: `Game_Character::UpdateMoveRoute`
+      # (`src/game_character.cpp`) only calls `SetMaxStopCountFor{Step,Turn,
+      # Wait}` for those four command kinds; every other sub-command falls
+      # straight through to the next command within the same `while (true)`
+      # frame, guarded only against an infinite same-frame loop on a
+      # repeating route made entirely of effect commands
+      # (`current_index == start_index`, mirrored here via `route.index`
+      # wrapping back to where this burst started). Every #step call site
+      # below used to charge one full pacing delay per sub-command
+      # regardless of kind, so a route mixing effect commands with moves
+      # (a common "reskin then step" authoring pattern) crawled at
+      # #EVENT_MOVE_DELAY's pace through commands RPG_RT spends no time on
+      # at all.
+      def run_route_step(route, character, world)
+        start = route.index
+        status = route.step(character, world)
+        while status == :effect && !route.done? && route.index != start
+          status = route.step(character, world)
+        end
+        status
+      end
+
       def step_event(e, allow_trigger: true)
         # Cleared unconditionally, before any early return, so a crossing
         # recognised on some earlier frame (see #move_autonomous /
@@ -2797,7 +2826,7 @@ class RPG2k
         oy = ch.y
         status = nil
         if forced
-          status = forced.step(ch, @world) unless forced.done?
+          status = run_route_step(forced, ch, @world) unless forced.done?
           if forced.done? # revert to page movement
             e[:forced_route] = nil
             # The page's own Move Frequency reasserts itself once the forced
@@ -2807,7 +2836,7 @@ class RPG2k
             ch.move_frequency = page_move_frequency(e[:page])
           end
         elsif e[:route]
-          status = e[:route].step(ch, @world) unless e[:route].done?
+          status = run_route_step(e[:route], ch, @world) unless e[:route].done?
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
           move_autonomous(e, dir, allow_trigger: allow_trigger) if dir
@@ -3948,7 +3977,7 @@ class RPG2k
         @vehicle_route_timers[type] -= 1
         return if @vehicle_route_timers[type] > 0
         @vehicle_route_timers[type] = EVENT_MOVE_DELAY[ch.move_frequency] || 40
-        route.step(ch, @vehicle_worlds[type]) unless route.done?
+        run_route_step(route, ch, @vehicle_worlds[type]) unless route.done?
         v = @state.vehicle(type)
         v.x = ch.x
         v.y = ch.y
@@ -4016,7 +4045,7 @@ class RPG2k
         # already does for #try_move (the input-driven path, see
         # @state.boarded? above).
         world = @state.boarded? ? @vehicle_worlds[@state.boarded] : @world
-        @player_route.step(@player_char, world) unless @player_route.done?
+        run_route_step(@player_route, @player_char, world) unless @player_route.done?
         # Mirror Through Mode out to the standing flag every step (not just when
         # the route ends), so a Halt All Movement mid-route sees whatever the
         # route had set so far rather than the mirror's now-discarded state.
@@ -4115,7 +4144,7 @@ class RPG2k
         e[:move_timer] = EVENT_MOVE_DELAY[e[:forced_freq] || ch.move_frequency] || 40
         ox = ch.x
         oy = ch.y
-        e[:forced_route].step(ch, @world) unless e[:forced_route].done?
+        run_route_step(e[:forced_route], ch, @world) unless e[:forced_route].done?
         e[:forced_route] = nil if e[:forced_route].done?
         # A jump that lands where it started still needs the render slide, so
         # the hop is visible; an ordinary step only when the tile changed.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8434,6 +8434,36 @@ check "a boarded hero's own Set Move Route respects the ridden vehicle's " \
      "can't -- ended at (#{st.x}, #{st.y})"
 end
 
+check 'a move route runs consecutive effect-only sub-commands in the same ' \
+      'frame as the Move that follows them, only the Move itself spending ' \
+      "the route's own pacing delay" do
+  # Confirmed against RPG_RT's own live source: `Game_Character::
+  # UpdateMoveRoute` (src/game_character.cpp) only calls
+  # `SetMaxStopCountFor{Step,Turn,Wait}` for a Move/Turn/Wait/Jump
+  # sub-command; every other sub-command (Switch On/Off, Speed/Frequency
+  # Up/Down, Change Graphic, Play Sound, Through Mode, Stop/Start
+  # Animation, Transparency Up/Down -- Game::MoveRoute#step's own :effect
+  # status) falls straight through to the next command within the same
+  # frame, with no pacing delay of its own at all. This used to charge one
+  # full #EVENT_MOVE_DELAY tick per sub-command regardless of kind, so a
+  # route mixing effect commands with moves (a common "reskin then step"
+  # authoring pattern) crawled through the effect commands at the route's
+  # own pace instead of running them for free.
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  route = Game::MoveRoute.new(
+    [Game::MoveCommand.new(R::SWITCH_ON, '', 1),
+     Game::MoveCommand.new(R::SWITCH_ON, '', 2),
+     Game::MoveCommand.new(R::MOVE_RIGHT)],
+    repeat: false, skippable: true)
+  scene.send(:start_player_route, route, 1) # freq 1, slowest: 96 frames/step
+  scene.update
+  ok st.switches[1] && st.switches[2],
+     'both Switch ON sub-commands ran on the same frame as the Move that follows them'
+  ok scene.instance_variable_get(:@moving),
+     "the Move itself started that same frame too, spending the route's only pacing delay"
+end
+
 check 'a Move Route request targeting a currently-ridden vehicle is ignored' do
   scene = new_scene({}, player: [0, 0], boat_pass: true)
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Character::UpdateMoveRoute` (`src/game_character.cpp`) loops `while (true)` over a route's commands each frame, calling `SetMaxStopCountFor{Step,Turn,Wait}` — the only thing that actually stalls the loop for the rest of that frame — solely for a Move/Turn/Wait/Jump sub-command. Every other sub-command (Switch On/Off, Speed/Frequency Up/Down, Change Graphic, Play Sound, Through Mode, Stop/Start Animation, Transparency Up/Down) falls straight through to the next command within the same frame, guarded only against a same-frame infinite loop on a repeating route made entirely of effect commands (`current_index == start_index`).
- `#step_event`, `#step_player_route`, `#step_vehicle_route` and `#step_forced_event` (`mruby-rpg2k/mrblib/scene/map.rb`) each called `Game::MoveRoute#step` exactly once per pacing-timer expiry regardless of what kind of sub-command it ran, so a route mixing effect commands with moves — a common "reskin then step" authoring pattern (Switch ON, Change Graphic, then Move) — crawled through the effect commands at `#EVENT_MOVE_DELAY`'s own pace (up to 96 frames per sub-command at the slowest frequency) instead of running them in the same frame as genuine RPG_RT.
- Fixed with a shared `#run_route_step(route, character, world)` helper that loops `route.step` while the returned status is `:effect`, bounded by `route.index` wrapping back to where the burst started — mirroring the reference's own `current_index == start_index` guard — used in place of the bare `route.step` call at all four sites. The existing "reset the pacing timer once before dispatch" logic needed no change: it already fires once per real frame, and now that one dispatch can run an unbounded burst of effect commands before the blocking command that actually earns the delay, the timer correctly charges one delay per burst rather than one per sub-command.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a forced player route of two Switch ON commands followed by a Move runs both switches and starts the move on the very same frame, at the slowest frequency (1).
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `scene/map.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 825 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1078 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_