### PR TITLE
Fix: Change Items no-ops on a sign-mismatched variable amount

### DIFF
--- a/changelog.d/change-items-sign-guard.fixed.md
+++ b/changelog.d/change-items-sign-guard.fixed.md
@@ -1,0 +1,11 @@
+- **Change Items event command:** a variable-sourced amount whose sign
+  contradicts the chosen operation (a negative value under "Add", or a
+  value that flips positive under "Remove") is now a no-op, instead of
+  silently flipping direction -- matching RPG_RT's own
+  `Game_Interpreter::CommandChangeItems`, which refuses to apply the
+  command at all when the computed sign doesn't match "Add item can't be
+  used to remove an item and remove item can't be used to add one".
+  Previously, an event driving the amount through a variable that could
+  go negative (arithmetic on other variables, a computed stock delta)
+  would gain items on a "Remove" or lose them on an "Add". Change Gold is
+  unaffected -- real RPG_RT applies no such guard there.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1849,6 +1849,33 @@ The work below is roughly ordered by the critical path to a walkable game
   in-battle Show Battle Animation is deliberately *not* gated with them: it
   renders through `@animation_sprite`, a top-level sprite at z 150 (above the
   battlers, below the pictures), not through either map viewport.
+  ✅ **Follow-up (2026-08-20): Change Items (10320) was missing RPG_RT's own
+  guard against a variable-sourced amount whose sign contradicts the chosen
+  operation, letting Add remove items or Remove add them instead of doing
+  nothing.** Confirmed against RPG_RT's own live source:
+  `Game_Interpreter::CommandChangeItems` (`src/game_interpreter.cpp`)
+  computes its signed `value` through the same `OperateValue` a
+  variable-sourced amount can make negative even under "Add" — "Add item
+  can't be used to remove an item and remove item can't be used to add
+  one" — and no-ops the whole command outright when the resulting sign
+  doesn't match: `if (value > 0) return true;` under Remove, `if (value <
+  0) return true;` under Add. `Game_Interpreter::CommandChangeGold`
+  (10310) calls the identical `OperateValue` with no such guard at all, so
+  this asymmetric no-op is Change Items-specific, not a general
+  Change-command rule. `Interpreter#do_change_items`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) applied whatever signed count
+  `#gain_item` was handed with no sign check of its own: an event driving
+  the amount through a variable that can go negative (arithmetic on other
+  variables, a computed stock delta) silently flipped direction — gaining
+  items on a "Remove" or losing them on an "Add" — instead of the command
+  harmlessly doing nothing like real RPG_RT. Fixed by computing the same
+  signed `value` and returning before `#gain_item` when its sign
+  contradicts `cmd.param(0)`'s chosen operation; `#do_change_gold` is
+  untouched, matching `CommandChangeGold`'s own lack of a guard. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check (a variable holding -2
+  under both Add and Remove leaves each item's count untouched),
+  confirmed to fail against the pre-fix code (`expected 5, got 3`) before
+  the fix.
 - ✅ **Change Screen Tone now reaches the battle backdrop too.** The battle
   backdrop (`Scene::Battle`'s `@ui[:back_sprite]`, a top-level sprite at z 5)
   rides none of the toned viewports, so a Tint Screen active during a fight

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1945,10 +1945,23 @@ module Game
       party.gain_gold(cmd.param(0) == 0 ? v : -v)
     end
 
+    # Confirmed against RPG_RT's own live source: `Game_Interpreter::
+    # CommandChangeItems` (`src/game_interpreter.cpp`) computes its signed
+    # `value` through the same `OperateValue` a variable-sourced amount can
+    # make negative even under "Add", then refuses to apply it at all --
+    # "Add item can't be used to remove an item and remove item can't be
+    # used to add one" -- unless the sign still matches the chosen
+    # operation. `Game_Interpreter::CommandChangeGold` calls the identical
+    # `OperateValue` with no such guard, so this asymmetric no-op is
+    # specific to Change Items. Without it, a variable holding a negative
+    # amount silently flips Add into a removal (or Remove into a gain)
+    # instead of doing nothing.
     def do_change_items(cmd)
       item = cmd.param(1) == 0 ? cmd.param(2) : variables[cmd.param(2)]
       amount = cmd.param(3) == 0 ? cmd.param(4) : variables[cmd.param(4)]
-      party.gain_item(item, cmd.param(0) == 0 ? amount : -amount)
+      value = cmd.param(0) == 0 ? amount : -amount
+      return if cmd.param(0) == 0 ? value < 0 : value > 0
+      party.gain_item(item, value)
     end
 
     # Change Party Member (10330): add or remove the actor named by param2 (a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1426,6 +1426,31 @@ check 'interpreter change gold/items updates the party' do
   eq 2, st.party.items[3]
 end
 
+check 'Change Items no-ops when a variable-sourced amount has the wrong ' \
+      'sign for the chosen operation, instead of flipping direction' do
+  # Confirmed against RPG_RT's own live source: `Game_Interpreter::
+  # CommandChangeItems` (src/game_interpreter.cpp) computes its value
+  # through the same `OperateValue` a variable-sourced amount can make
+  # negative even under "Add", then refuses to apply it at all -- "Add
+  # item can't be used to remove an item and remove item can't be used to
+  # add one" -- unless the sign still matches. `CommandChangeGold` has no
+  # such guard, so this is Change Items-specific.
+  st = new_state
+  st.party.gain_item(3, 5)
+  st.party.gain_item(4, 5)
+  st.variables[1] = -2
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CHANGE_ITEMS, [0, 0, 3, 1, 1]),  # Add item 3, amount = var[1] (-2)
+    FakeCmd.new(IC::CHANGE_ITEMS, [1, 0, 4, 1, 1]),  # Remove item 4, amount = var[1] (-2)
+  ])
+  it.update
+  eq 5, st.party.items[3],
+     'Add with a negative operand no-ops rather than removing 2'
+  eq 5, st.party.items[4],
+     'Remove with a negative operand (which flips positive) no-ops rather than adding 2'
+end
+
 check 'interpreter pauses on a message and resumes' do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter::CommandChangeItems` (`src/game_interpreter.cpp`) computes its signed `value` through `OperateValue`, which a variable-sourced amount can make negative even under "Add" — then refuses to apply the command at all when the resulting sign doesn't match the chosen operation: `if (value > 0) return true;` under Remove, `if (value < 0) return true;` under Add ("Add item can't be used to remove an item and remove item can't be used to add one"). `Game_Interpreter::CommandChangeGold` (10310) calls the identical `OperateValue` with no such guard, so this asymmetric no-op is Change Items-specific.
- `Interpreter#do_change_items` (`mruby-rpg2k/mrblib/interpreter.rb`) applied whatever signed count it computed straight to `#gain_item`, with no sign check of its own. An event driving the amount through a variable that can go negative (arithmetic on other variables, a computed stock delta) silently flipped direction — gaining items on a "Remove" or losing them on an "Add" — instead of the command harmlessly doing nothing like real RPG_RT.
- Fixed by computing the same signed value and returning before `#gain_item` when its sign contradicts the chosen operation. `#do_change_gold` is untouched, matching `CommandChangeGold`'s own lack of a guard.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a variable holding -2 under both Add and Remove leaves each item's count untouched.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `interpreter.rb` only — `expected 5, got 3`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 825 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1079 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_