### PR TITLE
Fix: Show Battle Animation no-ops for an unresolved target

### DIFF
--- a/changelog.d/battle-animation-unresolved-target-noop.fixed.md
+++ b/changelog.d/battle-animation-unresolved-target-noop.fixed.md
@@ -1,0 +1,9 @@
+- **Show Battle Animation event command:** a target that doesn't resolve --
+  "This Event" fired from a common event's own Parallel Process, or a
+  specific event id the map has no character for -- no longer draws on the
+  player instead. Matches RPG_RT's own `Game_Interpreter_Map::
+  CommandShowBattleAnimation`, which no-ops the entire command (including a
+  "Whole screen" target) whenever the named event can't be resolved. A
+  "wait until it finishes" request on such a target now also falls
+  straight through to the next command the same tick, instead of stalling
+  for the animation's own real duration.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14148,6 +14148,48 @@ not yet verified:
   and the screen flash untouched), the first and third confirmed to fail
   against the pre-fix code before the fix (the second failing on the sprite
   never having drawn at all).
+- ✅ **A map-triggered Show Battle Animation (11210) whose target doesn't
+  resolve — "This Event" from a common event's own Parallel Process, or a
+  specific event id the map has no character for — drew on the player
+  instead of not drawing at all, and a "wait until it finishes" request on
+  one stalled for the animation's own real duration instead of falling
+  straight through the very same tick.** Confirmed against RPG_RT's own
+  live source: `Game_Interpreter_Map::CommandShowBattleAnimation`
+  (`src/game_interpreter_map.cpp`) calls `GetCharacter(evt_id, ...)`
+  unconditionally, before it ever reads the "Whole screen" flag or computes
+  a frame count, and returns outright when that comes back null — so the
+  *entire* command, "Whole screen" target included, no-ops for an
+  unresolved target. `Game_Interpreter::GetCharacter`
+  (`src/game_interpreter.cpp`) is null both for "This Event" (0) when the
+  calling interpreter has no owning map event (`GetThisEventId() == 0`,
+  exactly what a common event's own Parallel Process is) and for a specific
+  event id the map has no character for; `_state.wait_time = frames` is
+  never reached in either case. `Scene::Map#animation_target_pixel`/
+  `#map_animation_flash_target` (`mruby-rpg2k/mrblib/scene/map.rb`) both
+  fell back to the player's own pixel/`:player` for these same two cases —
+  their own doc comments described this as deliberate, but neither was ever
+  checked against `GetCharacter`'s real null-return behavior — and
+  `#begin_map_animation` had no notion of "target didn't resolve" distinct
+  from "target resolved but the animation id/graphic is missing"
+  (`#missing_animation_wait`'s own, unrelated fallback), so a waited-for
+  play on an unresolved target stalled for a real animation's own frame
+  count instead of RPG_RT's immediate fallthrough. Fixed with a new
+  `#animation_target_resolves?(target)` predicate (true for the player and
+  every vehicle slot unconditionally, `!@active_event.nil?` for "This
+  Event," and an `@events` membership check otherwise), consulted by
+  `#start_map_animation` (returns `nil` immediately, before either the
+  global or non-global branch, mirroring the reference's own check-before-
+  `global` ordering) and by `#begin_map_animation` (sets `@anim_wait = 0`
+  directly rather than routing through `#missing_animation_wait`). The two
+  target-decoding helpers' own doc comments, which described the fallback
+  as reachable/deliberate, are corrected in place — both are now only ever
+  called once the target is already known to resolve. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (a common event's "This Event"
+  target, and a specific unknown event id, each resuming within the same
+  one-frame build/step latency every `:animation` wait already has rather
+  than stalling for animation 8's own ~8-frame duration, with
+  `@map_animation` confirmed to stay `nil` — nothing was ever drawn),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **The "1 frame = 1/30s" half of the bullet above is now correct, and
   the "'Wait' frame is internally two consecutive frames" framing turns out
   to have been a misreading — settled against EasyRPG Player's actual C++

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2023,11 +2023,9 @@ module Game
     # Change EXP: add (or, when the operation is "remove", subtract) an amount of
     # experience to the target actors, re-deriving each one's level and base
     # stats from the growth curve. Uses the same scope/operation/operand layout
-    # as Change HP (stat_targets / stat_amount); the show-level-up-message flag is
-    # ignored (no battle/message UI drives it here).
-    # Change EXP: add or remove experience for the target actors, which may cross
-    # one or more level thresholds. param5 is the "show message" flag — when set,
-    # each level an actor gains queues a level-up message (drained by #resume).
+    # as Change HP (stat_targets / stat_amount). May cross one or more level
+    # thresholds; param5 is the "show message" flag — when set, each level an
+    # actor gains queues a level-up message (drained by #resume).
     def do_change_exp(cmd)
       amount = stat_amount(cmd)
       show_msg = cmd.param(5) != 0
@@ -2045,10 +2043,8 @@ module Game
 
     # Change Level: add or subtract levels for the target actors, recomputing
     # their base stats and re-aligning EXP to the new level. Same scope/operation/
-    # operand layout as Change EXP.
-    # Change Level: add or remove levels for the target actors. param5 is the
-    # "show message" flag — when set, each level an actor gains queues a level-up
-    # message (drained by #resume).
+    # operand layout as Change EXP; param5 is the "show message" flag — when set,
+    # each level an actor gains queues a level-up message (drained by #resume).
     def do_change_level(cmd)
       amount = stat_amount(cmd)
       show_msg = cmd.param(5) != 0

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6099,12 +6099,51 @@ class RPG2k
       # build the frame-by-frame player from a raw `battle_animation` request
       # hash, or arm the timed-wait fallback when there is no drawable
       # animation.
+      #
+      # An unresolved map target (see #animation_target_resolves?) waits
+      # exactly 0, not #missing_animation_wait's animation-duration fallback
+      # -- confirmed against RPG_RT's own live source: `Game_Interpreter_Map::
+      # CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) calls
+      # `GetCharacter(evt_id, ...)` unconditionally, before it ever looks at
+      # `global` or computes a frame count, and returns outright when that is
+      # null -- `_state.wait_time = frames` is simply never reached, so a
+      # "wait until finished" request on an unresolved target falls straight
+      # through to the next command the same tick rather than stalling for
+      # the animation's own real duration (or the invalid-animation-id
+      # fallback's timing either).
       def begin_map_animation(req)
+        if req && !req[:battle] && !animation_target_resolves?(req[:target])
+          @map_animation = nil
+          @anim_wait = 0
+          return
+        end
         @map_animation = start_map_animation(req)
         if @map_animation
           fire_animation_flashes(@map_animation) # frame 0 flashes
         else
           @anim_wait = missing_animation_wait(req[:animation])
+        end
+      end
+
+      # Whether Show Battle Animation's map target id names something real to
+      # draw over -- confirmed against RPG_RT's own live source:
+      # `Game_Interpreter::GetCharacter` (`src/game_interpreter.cpp`) returns
+      # null both for "This Event" (0) when the calling interpreter has no
+      # owning map event (a common/parallel event -- `GetThisEventId() == 0`)
+      # and for a specific event id the map has no character for; either way
+      # `CommandShowBattleAnimation` no-ops the *entire* command, including a
+      # "Whole screen" one, since the null check runs before `global` is even
+      # read. The player and every vehicle slot always resolve --
+      # `Game_Character::GetCharacter` constructs those unconditionally,
+      # never returning null for them.
+      def animation_target_resolves?(target)
+        case target
+        when MOVE_TARGET_PLAYER, MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          true
+        when 0, MOVE_TARGET_THIS
+          !@active_event.nil?
+        else
+          @events.any? { |e| e[:id] == target }
         end
       end
 
@@ -6295,6 +6334,7 @@ class RPG2k
       def start_map_animation(req)
         return nil unless req
         return @battle.start_battle_page_animation(req) if req[:battle]
+        return nil unless animation_target_resolves?(req[:target])
         flash_target = map_animation_flash_target(req[:target])
         targets =
           if req[:global]
@@ -6351,14 +6391,13 @@ class RPG2k
 
       # The character a map-triggered flash_scope-1 timing (see
       # #fire_map_target_flash) should pulse: `:player`, a specific `@events`
-      # entry (this event / a named map event id), a `Game::Vehicle::TYPES`
-      # symbol (`:boat`/`:ship`/`:airship`) for a vehicle slot, or nil when
-      # the target id names nothing (a stale/invalid event id no live event
-      # matches). Mirrors #animation_target_pixel's own target-id decoding
-      # exactly, including its "this event" -> player fallback when there is
-      # no active event (a common event Parallel Process's own Show Battle
-      # Animation) and its `Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT]`
-      # idiom for a vehicle slot.
+      # entry (this event / a named map event id), or a `Game::Vehicle::TYPES`
+      # symbol (`:boat`/`:ship`/`:airship`) for a vehicle slot. Only ever
+      # called once #animation_target_resolves?(target) has already passed
+      # (see #start_map_animation), so the "this event, no active event" and
+      # "unknown event id" cases it decodes have both already been ruled
+      # out -- this ~~falls back to `:player`~~ no longer needs a fallback
+      # for either.
       def map_animation_flash_target(target)
         case target
         when MOVE_TARGET_PLAYER then :player
@@ -6460,13 +6499,17 @@ class RPG2k
       end
 
       # The target character's map-pixel position: the player, the running event
-      # ("this event" / 0), a vehicle slot, or a map event by id, defaulting to
-      # the player. yado.tk: a vehicle target reads that vehicle's real,
-      # currently-live x/y off `Game::State` (the same source
-      # `#event_operand`'s Control Variables "character position" vehicle fix
-      # reads) even when the vehicle is not on the map this scene has loaded --
-      # RPG_RT does not check that the two agree before placing the animation,
-      # the same blind-read quirk as the Control Variables fix.
+      # ("this event" / 0), a vehicle slot, or a map event by id. Only ever
+      # called once #animation_target_resolves?(target) has already passed
+      # (see #start_map_animation), so its "this event, no active event" and
+      # "unknown event id" ~~fall back to the player~~ branches are dead --
+      # both cases are already ruled out by then. yado.tk: a vehicle target
+      # reads that vehicle's real, currently-live x/y off `Game::State` (the
+      # same source `#event_operand`'s Control Variables "character
+      # position" vehicle fix reads) even when the vehicle is not on the map
+      # this scene has loaded -- RPG_RT does not check that the two agree
+      # before placing the animation, the same blind-read quirk as the
+      # Control Variables fix.
       def animation_target_pixel(target)
         case target
         when MOVE_TARGET_PLAYER then player_pixel

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9791,6 +9791,61 @@ check "a Common Event Parallel Process's own waited-for Show Battle Animation sh
   ok !st.switches[5], "the process is still held on its own wait that same frame, not resumed already"
 end
 
+# Confirmed against RPG_RT's own live source: `Game_Interpreter_Map::
+# CommandShowBattleAnimation` (src/game_interpreter_map.cpp) calls
+# `GetCharacter(evt_id, ...)` unconditionally, before it ever reads `global`
+# or computes a frame count, and returns outright when that comes back null
+# -- `GetCharacter` (src/game_interpreter.cpp) is null for "This Event" (0)
+# when the calling interpreter has no owning map event, exactly what a
+# common event's own Parallel Process is. `_state.wait_time = frames` is
+# never reached in that case, so a "wait until finished" request falls
+# straight through the same tick rather than drawing on the player (this
+# codebase's own prior fallback) and stalling for the animation's real
+# duration.
+check "a common event Parallel Process's Show Battle Animation targeting " \
+      '"This Event" no-ops instead of falling back to the player, and does ' \
+      'not stall the wait' do
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 0, 1], indent: 0), # animation, This Event, wait
+                              ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  resumed_frame = nil
+  3.times do |i|
+    scene.update
+    resumed_frame ||= i if st.switches[5]
+  end
+  ok resumed_frame && resumed_frame <= 1,
+     'resumes within the same one-frame build/step latency every :animation wait already has, not ' \
+     "stalled for animation 8's own multi-frame missing_animation_wait duration (8 frames)"
+  ok scene.instance_variable_get(:@map_animation).nil?, 'nothing was ever built to draw'
+end
+
+# Same fact for a specific-but-nonexistent event id -- `GetCharacter` is
+# equally null for an id the map has no character for, regardless of
+# whether the target is "This Event" or a stale/invalid one.
+check 'a Show Battle Animation naming an event id the map has no character ' \
+      'for no-ops instead of falling back to the player' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 99, 1], indent: 0), # animation, unknown event 99, wait
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  resumed_frame = nil
+  3.times do |i|
+    scene.update
+    resumed_frame ||= i if st.switches[5]
+  end
+  ok resumed_frame && resumed_frame <= 1,
+     'resumes within the same one-frame build/step latency every :animation wait already has, not ' \
+     'stalled on the animation duration'
+  ok scene.instance_variable_get(:@map_animation).nil?, 'nothing was ever built to draw'
+end
+
 # yado.tk: RPG_RT drops straight into Game Over the instant a wipe-triggering
 # command finds the whole party dead outside battle, regardless of which
 # event noticed it -- a Simulated Attack floor trap on a background Parallel


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter_Map::CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) calls `GetCharacter(evt_id, ...)` unconditionally, before it ever reads the "Whole screen" flag or computes a frame count, and returns outright when that comes back null — so the *entire* command, "Whole screen" target included, no-ops for an unresolved target. `Game_Interpreter::GetCharacter` (`src/game_interpreter.cpp`) is null both for "This Event" (0) when the calling interpreter has no owning map event (`GetThisEventId() == 0`, exactly what a common event's own Parallel Process is) and for a specific event id the map has no character for; `_state.wait_time = frames` is never reached in either case.
- `Scene::Map#animation_target_pixel`/`#map_animation_flash_target` (`mruby-rpg2k/mrblib/scene/map.rb`) both fell back to the player's own pixel/`:player` for these same two cases — their own doc comments described this as deliberate, but neither was ever checked against `GetCharacter`'s real null-return behavior. `#begin_map_animation` also had no notion of "target didn't resolve" distinct from "target resolved but the animation id/graphic is missing" (`#missing_animation_wait`'s own, unrelated fallback), so a waited-for play on an unresolved target stalled for a real animation's own frame count instead of RPG_RT's immediate fallthrough.
- A common/parallel-process event using Show Battle Animation with target "This Event" (a real editor option regardless of event type), or any Show Battle Animation naming a stale/nonexistent event id, played the animation centered on the player's sprite instead of doing nothing — and if "wait until it finishes" was checked, the triggering event visibly stalled for the animation's playtime instead of continuing immediately.
- Fixed with a new `#animation_target_resolves?(target)` predicate (true for the player and every vehicle slot unconditionally, `!@active_event.nil?` for "This Event," and an `@events` membership check otherwise), consulted by `#start_map_animation` (returns `nil` immediately, before either the global or non-global branch, mirroring the reference's own check-before-`global` ordering) and by `#begin_map_animation` (sets `@anim_wait = 0` directly rather than routing through `#missing_animation_wait`). Corrected the two target-decoding helpers' own doc comments, which described the fallback as reachable/deliberate — both are now only ever called once the target is already known to resolve.
- Also cleaned up a stale leftover doc-comment line on `do_change_exp`/`do_change_level` (`interpreter.rb`) noticed along the way — an older sentence claiming the show-level-up-message flag is ignored, directly contradicted by the newer, correct sentence right after it and by the code itself.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` checks: a common event's "This Event" target, and a specific unknown event id, each resume within the same one-frame build/step latency every `:animation` wait already has rather than stalling for animation 8's own ~8-frame duration, with `@map_animation` confirmed to stay `nil` (nothing was ever drawn).
- [x] Confirmed both new checks fail against the pre-fix code (`git stash` on `map.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 827 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1079 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_