### PR TITLE
Fix: Move Forward continues a diagonal move diagonally

### DIFF
--- a/changelog.d/move-forward-diagonal-continuation.fixed.md
+++ b/changelog.d/move-forward-diagonal-continuation.fixed.md
@@ -1,0 +1,8 @@
+- **Move routes:** a Move Forward sub-command following a diagonal move
+  (Move Upper-Right/Upper-Left/Lower-Right/Lower-Left) now continues
+  diagonally, matching RPG_RT's own `Game_Character::UpdateMoveRoute` --
+  its `GetDirection()` is an 8-way value that a diagonal move simply
+  leaves set, so Move Forward reuses the same diagonal. Previously it
+  collapsed to the diagonal's vertical component only, so a route like
+  "Move Upper-Right, Move Forward" veered off the diagonal path onto a
+  straight vertical line instead of continuing the diagonal dash.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11523,6 +11523,42 @@ not yet verified:
   while its visible `direction` stays Left, and a follow-up Move Forward
   walks Down rather than the stale pre-jump direction), confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-20): Move Forward after a diagonal move collapsed
+  to one cardinal axis instead of continuing diagonally.** Confirmed
+  against RPG_RT's own live source: `Game_Character::Direction`
+  (`src/game_character.h`) is an 8-way enum (Up/Right/Down/Left/UpRight/
+  DownRight/DownLeft/UpLeft), and `UpdateMoveRoute`'s diagonal case
+  (`SetDirection(cmd)`, `src/game_character.cpp`) sets it to the literal
+  diagonal value; `move_forward` does nothing but `break` before
+  `Move(GetDirection())` reuses whatever `GetDirection()` still holds — so
+  a route "Move Upper-Right, Move Forward" moves diagonally *twice* (2
+  tiles right, 2 tiles up), never diagonally-then-straight. `#move_diagonal`
+  (`mruby-rpg2k/mrblib/game.rb`) stored only the *vertical* component into
+  `#last_move_direction`, collapsing this codebase's own 8-way state to
+  4-way — a following Move Forward continued along one axis only and
+  silently veered off the diagonal path real RPG_RT walks, compounding
+  further on a longer or repeating diagonal route. Fixed by storing the
+  full `[horizontal, vertical]` pair in `#last_move_direction` for a
+  diagonal move, and having `Game::MoveRoute#execute`'s `MOVE_FORWARD`
+  case dispatch to a new shared `#do_diagonal_dir(character, world,
+  horizontal, vertical)` (factored out of `#do_diagonal`, which now just
+  looks up its pair and delegates) when the stored direction is a pair,
+  instead of always calling the cardinal-only `#do_move`. `#move`/`#jump`
+  are unchanged — a cardinal move still stores a plain numpad int, and
+  `Jump`'s own dominant-axis facing is inherently cardinal in the real
+  engine too (see the jump bullet just above). Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (Move Upper-Right then Move Forward
+  advances both axes a second time, landing at `[4, 0]` from a `[2, 2]`
+  start rather than `[3, 0]`), confirmed to fail against the pre-fix code
+  (`expected [4, 0], got [3, 0]`) before the fix. **Still open**: the
+  identical bug in the Begin Jump/End Jump path — `MoveRoute#jump_move_
+  direction`'s `else dir` branch (`mruby-rpg2k/mrblib/game.rb`) never
+  updates the running `dir` for a diagonal move command inside a jump
+  block, so a later Move Forward *inside the same block* would continue
+  along the pre-diagonal direction instead of the diagonal just walked —
+  the same root cause (this codebase's direction state could only hold a
+  single cardinal), just not exercised by this fix, which only touched the
+  non-jump path.
 - A move-route "Change Graphic" sub-command (hero, event, or vehicle) is
   **not persistent** — it reverts to the base graphic on save-load or map
   transfer, unlike the dedicated Change Graphic event commands. ✅ **All three

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6040,6 +6040,11 @@ module Game
     # movement) and a blocked #do_move (turns to face an obstruction but
     # never steps) leave it alone. yado.tk: a move-route "One Step Forward"
     # continues in *this* direction, not the sprite's #direction.
+    #
+    # A plain numpad int (2/4/6/8) after #move/#jump, or a `[horizontal,
+    # vertical]` pair after #move_diagonal -- see #move_diagonal's own
+    # citation for why a diagonal step's full 8-way direction has to survive
+    # here, not just one cardinal component.
     attr_reader :last_move_direction
 
     # Placing a character outright -- Change Event Location, a page refresh
@@ -6179,9 +6184,22 @@ module Game
     end
 
     # Move one tile diagonally, combining a horizontal and a vertical direction.
+    #
+    # #last_move_direction is set to the `[horizontal, vertical]` pair itself,
+    # not just one component -- confirmed against RPG_RT's own live source:
+    # `Game_Character::Direction` (`src/game_character.h`) is an 8-way enum
+    # (Up/Right/Down/Left/UpRight/DownRight/DownLeft/UpLeft), and
+    # `UpdateMoveRoute`'s diagonal case (`SetDirection(cmd)`,
+    # `src/game_character.cpp`) sets it to the literal diagonal value, which
+    # `GetDirection()` still holds the next time a Move Forward sub-command
+    # reads it -- a two-command route "Move Upper-Right, Move Forward" moves
+    # diagonally *twice*, not diagonally-then-straight-up. Storing only
+    # `vertical` here (this method's own prior behaviour) collapsed that
+    # 8-way state to 4-way, so a following Move Forward continued along one
+    # axis only and silently veered off the diagonal path real RPG_RT walks.
     def move_diagonal(horizontal, vertical)
       face(diagonal_facing(horizontal, vertical))
-      @last_move_direction = vertical
+      @last_move_direction = [horizontal, vertical]
       hx, = DIR_DELTA[horizontal] || [0, 0]
       _, vy = DIR_DELTA[vertical] || [0, 0]
       @x += hx
@@ -6396,8 +6414,15 @@ module Game
         # yado.tk: continues in the direction actually last walked/jumped,
         # not the sprite's displayed facing -- the two can diverge under a
         # Direction Fix lock or an explicit Face command (see
-        # Character#last_move_direction).
-        do_move(character, world, character.last_move_direction)
+        # Character#last_move_direction). A diagonal last move continues
+        # diagonally (see #last_move_direction's own citation) rather than
+        # collapsing to one cardinal axis.
+        last = character.last_move_direction
+        if last.is_a?(Array)
+          do_diagonal_dir(character, world, last[0], last[1])
+        else
+          do_move(character, world, last)
+        end
       # A Face Direction sub-command always turns the sprite, even right after
       # a Direction Fix ON earlier in the same route (yado.tk) -- #face!, not
       # the lock-respecting #face movement uses.
@@ -6592,6 +6617,19 @@ module Game
 
     def do_diagonal(character, world, id)
       horizontal, vertical = DIAGONAL[id]
+      do_diagonal_dir(character, world, horizontal, vertical)
+    end
+
+    # The shared body of a diagonal step, whether it comes from an explicit
+    # Move Upper-Right/etc. sub-command (#do_diagonal, which looks up its
+    # `horizontal`/`vertical` pair from the move id) or from Move Forward
+    # continuing a diagonal #last_move_direction (see #execute's own
+    # MOVE_FORWARD case) -- RPG_RT's own `UpdateMoveRoute`
+    # (src/game_character.cpp) has no such split at all: `Move(GetDirection())`
+    # is the one call site for every move sub-command, cardinal or diagonal
+    # alike, since `GetDirection()` is an 8-way enum that a diagonal move
+    # simply leaves set.
+    def do_diagonal_dir(character, world, horizontal, vertical)
       prev_dir = character.direction
       character.face(character.diagonal_facing(horizontal, vertical))
       passable = character.through ||

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -516,6 +516,25 @@ check 'diagonal move needs both cardinals and faces vertical' do
   eq 2, c3.direction, 'reverted to Down, not left turned toward the wall (8)'
 end
 
+check 'Move Forward continues a diagonal last move diagonally, not along ' \
+      'one collapsed cardinal axis' do
+  # Confirmed against RPG_RT's own live source: `Game_Character::
+  # Direction` (src/game_character.h) is an 8-way enum (Up/Right/Down/Left/
+  # UpRight/DownRight/DownLeft/UpLeft); `UpdateMoveRoute`'s diagonal case
+  # (`SetDirection(cmd)`, src/game_character.cpp) sets it to the literal
+  # diagonal value, and `move_forward` does nothing but `break` before
+  # `Move(GetDirection())` reuses whatever `GetDirection()` still holds --
+  # so a route "Move Upper-Right, Move Forward" moves diagonally *twice*
+  # (2 tiles right, 2 tiles up), not diagonally then straight up.
+  route = R.new([mc(R::MOVE_UPRIGHT), mc(R::MOVE_FORWARD)])
+  c = Game::Character.new(2, 2)
+  eq :moved, route.step(c, FakeWorld.new)
+  eq [3, 1], [c.x, c.y]
+  eq :moved, route.step(c, FakeWorld.new)
+  eq [4, 0], [c.x, c.y], 'continues diagonally -- both axes advance again, ' \
+     'not just the vertical one'
+end
+
 # Confirmed against RPG_RT's own live source: `Game_Character::UpdateFacing`
 # (`src/game_character.cpp`) only reverses the prior facing when it matches
 # *neither* of the diagonal's two cardinal components -- it never


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Character::Direction` (`src/game_character.h`) is an 8-way enum (Up/Right/Down/Left/UpRight/DownRight/DownLeft/UpLeft). `UpdateMoveRoute`'s diagonal case (`SetDirection(cmd)`, `src/game_character.cpp`) sets it to the literal diagonal value, and `move_forward` does nothing but `break` before `Move(GetDirection())` reuses whatever `GetDirection()` still holds — so a move route "Move Upper-Right, Move Forward" moves diagonally *twice* (2 tiles right, 2 tiles up), never diagonally-then-straight.
- `Character#move_diagonal` (`mruby-rpg2k/mrblib/game.rb`) stored only the *vertical* component into `#last_move_direction`, collapsing this codebase's own 8-way state to 4-way — a following Move Forward continued along one axis only and silently veered off the diagonal path real RPG_RT walks, compounding further on a longer or repeating diagonal route (a common way to author a diagonal dash).
- Fixed by storing the full `[horizontal, vertical]` pair in `#last_move_direction` for a diagonal move, and having `Game::MoveRoute#execute`'s `MOVE_FORWARD` case dispatch to a new shared `#do_diagonal_dir(character, world, horizontal, vertical)` (factored out of `#do_diagonal`, which now just looks up its pair and delegates) when the stored direction is a pair, instead of always calling the cardinal-only `#do_move`. `#move`/`#jump` are unchanged — a cardinal move still stores a plain numpad int, and `Jump`'s own dominant-axis facing is inherently cardinal in the real engine too.
- **Still open** (documented in `docs/TODO.md`, not fixed here to keep this change small): the identical bug exists in the Begin Jump/End Jump path — `MoveRoute#jump_move_direction`'s `else dir` branch never updates the running direction for a diagonal move command inside a jump block, so a later Move Forward *inside the same block* would continue along the pre-diagonal direction instead. Same root cause, separate call site, left for a follow-up.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: Move Upper-Right then Move Forward advances both axes a second time, landing at `[4, 0]` from a `[2, 2]` start rather than `[3, 0]`.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — `expected [4, 0], got [3, 0]`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 827 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1080 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_