### PR TITLE
Fix: battle-page Show Battle Animation no-ops for an out-of-range target

### DIFF
--- a/changelog.d/battle-page-animation-unresolved-target-noop.fixed.md
+++ b/changelog.d/battle-page-animation-unresolved-target-noop.fixed.md
@@ -1,0 +1,7 @@
+- **Show Battle Animation (battle-event page form):** an out-of-range Ally
+  or Enemy target index no longer draws a spurious screen-centre animation.
+  Matches RPG_RT's own `Game_Interpreter_Battle::CommandShowBattleAnimation`,
+  which no-ops the entire command whenever the named party/troop slot
+  doesn't exist. A "wait until it finishes" request on such a target now
+  also falls straight through to the next command the same tick, instead
+  of stalling for the animation's own real duration.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14226,6 +14226,43 @@ not yet verified:
   than stalling for animation 8's own ~8-frame duration, with
   `@map_animation` confirmed to stay `nil` — nothing was ever drawn),
   confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-20): the battle-*page* form of this same command
+  (13260) had the identical gap for an out-of-range Ally/Enemy target
+  index — it drew a spurious screen-centre animation instead of no-op'ing,
+  and stalled a "wait for completion" request instead of falling through
+  the same tick.** Confirmed against RPG_RT's own live source:
+  `Game_Interpreter_Battle::CommandShowBattleAnimation`
+  (`src/game_interpreter_battle.cpp`) leaves `battler_target` null — and so
+  never calls `ShowBattleAnimation`, `frames` staying 0 — for an Ally index
+  (1-based, `target -= 1` first) outside `0...Game_Party::GetBattlerCount()`
+  (`GetActors().size()`, dead members included, no `Exists()`/`IsDead()`
+  check anywhere in this function), or an Enemy index outside
+  `0...Game_EnemyParty::GetBattlerCount()`. `Scene::Battle
+  #start_battle_page_animation`'s own `elsif req[:allies]` branch
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) never looked at the target index at
+  all, always drawing at screen centre; its `else` (Enemy) branch relied on
+  `#battle_animation_pixel`'s `sprites[i]` returning `nil` for an
+  out-of-range `i`, which falls into that same method's own "no sprite"
+  fallback -- also screen centre. Neither branch ever no-op'd, and
+  `Scene::Map#begin_map_animation`'s `req[:battle]` case had no notion of
+  "target didn't resolve" (the exact gap the map-target fix just above this
+  one already closed for 11210) so a waited-for battle-page play on an
+  out-of-range index stalled for the animation's own real duration too. A
+  per-slot battle-event page reused across encounters with different
+  party/troop sizes (e.g. an "Ally 4" animation on a 3-member party) flashed
+  a spurious animation and, if waited on, visibly stalled the page. Fixed
+  with a new `Scene::Battle#battle_page_target_resolves?(req)`
+  (`target - 1` bounds-checked against `@state.party.actors.size` for Ally,
+  `req[:target]` bounds-checked against `@ui[:foes].size` for Enemy),
+  consulted by `#start_battle_page_animation` (no-op) and by
+  `Scene::Map#begin_map_animation` (sets `@anim_wait = 0` directly, the same
+  treatment the map-target case already gets, dispatched through
+  `@battle.battle_page_target_resolves?(req)` when `req[:battle]`). Covered
+  by two new `scripts/rpg2k_scene_check.rb` checks (an out-of-range Ally
+  index and an out-of-range Enemy index each run the page straight through
+  with the animation sprite confirmed to never draw and `@map_animation`
+  confirmed to stay `nil`), confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **The "1 frame = 1/30s" half of the bullet above is now correct, and
   the "'Wait' frame is internally two consecutive frames" framing turns out
   to have been a misreading — settled against EasyRPG Player's actual C++

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2258,7 +2258,37 @@ class RPG2k
       # when the ally flag is clear, or a single screen-centre animation (the
       # same ally-side fallback above) when it is set, since RPG2000's
       # front-view battle draws no ally sprite to point at.
+      # A single-target request (`req[:target] >= 0`) no-ops when the index
+      # names no actual party/troop slot -- confirmed against RPG_RT's own
+      # live source: `Game_Interpreter_Battle::CommandShowBattleAnimation`
+      # (`src/game_interpreter_battle.cpp`) leaves `battler_target` null (and
+      # so never calls `ShowBattleAnimation` at all) for an Ally index
+      # (1-based, `target -= 1` first) outside `0...GetBattlerCount()`, or an
+      # Enemy index outside `0...GetBattlerCount()` -- both plain party/troop
+      # array bounds checks, dead members included, RPG_RT never consults
+      # `Exists()`/`IsDead()` here. `#start_battle_page_animation` used to
+      # draw an out-of-range Ally target at screen-centre regardless
+      # (`elsif req[:allies]` never even looked at the index) and an
+      # out-of-range Enemy target through `#battle_animation_pixel`'s own
+      # "no sprite" fallback, which is also screen-centre -- neither path
+      # ever no-op'd. A per-slot battle-event page reused across encounters
+      # with different party/troop sizes (e.g. an "Ally 4" animation on a
+      # 3-member party) flashed a spurious screen-centre animation, and
+      # stalled the page for the animation's own duration on a "wait for
+      # completion" request, where real RPG_RT plays nothing and falls
+      # through the same tick.
+      def battle_page_target_resolves?(req)
+        return true unless req[:target] && req[:target] >= 0
+        if req[:allies]
+          idx = req[:target] - 1
+          idx >= 0 && idx < @state.party.actors.size
+        else
+          req[:target] < (@ui[:foes] || []).size
+        end
+      end
+
       def start_battle_page_animation(req)
+        return nil unless battle_page_target_resolves?(req)
         targets =
           if req[:target] && req[:target] < 0
             whole_side_anim_targets(req[:allies])

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6110,9 +6110,16 @@ class RPG2k
       # "wait until finished" request on an unresolved target falls straight
       # through to the next command the same tick rather than stalling for
       # the animation's own real duration (or the invalid-animation-id
-      # fallback's timing either).
+      # fallback's timing either). A battle-page request (`req[:battle]`)
+      # gets the identical treatment for an out-of-range Ally/Enemy index --
+      # see `Scene::Battle#battle_page_target_resolves?`'s own citation of
+      # `Game_Interpreter_Battle::CommandShowBattleAnimation`'s matching null
+      # `battler_target` check.
       def begin_map_animation(req)
-        if req && !req[:battle] && !animation_target_resolves?(req[:target])
+        unresolved =
+          req && (req[:battle] ? @battle && !@battle.battle_page_target_resolves?(req)
+                                : !animation_target_resolves?(req[:target]))
+        if unresolved
           @map_animation = nil
           @anim_wait = 0
           return

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13928,6 +13928,59 @@ check "a battle page's Show Battle Animation actually holds the page, not resumi
   ok st.switches[21], 'the page ran on once the animation actually finished'
 end
 
+# Confirmed against RPG_RT's own live source: `Game_Interpreter_Battle::
+# CommandShowBattleAnimation` (src/game_interpreter_battle.cpp) leaves
+# `battler_target` null -- and so never calls `ShowBattleAnimation` at all --
+# for an Ally index (1-based, `target -= 1` first) outside
+# `0...GetBattlerCount()`, or an Enemy index outside `0...GetBattlerCount()`.
+# `#start_battle_page_animation` used to draw an out-of-range Ally target at
+# screen-centre regardless (its own `elsif req[:allies]` branch never looked
+# at the index at all) and an out-of-range Enemy target through
+# `#battle_animation_pixel`'s "no sprite" fallback, which is also
+# screen-centre -- neither path ever no-op'd, and a "wait for completion"
+# request stalled for the animation's own real duration instead of RPG_RT's
+# immediate fallthrough.
+check "a battle page's Show Battle Animation no-ops for an out-of-range Ally " \
+      'index instead of flashing screen-centre' do
+  ic = Game::Interpreter::Cmd
+  # BattleStubParty defaults to a single actor (index 0); Ally target 2
+  # (1-based -> index 1) names no such member.
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [8, 2, 1, 1], indent: 0), # anim 8, ally #2 (out of range), wait, allies=1
+                             ECmd.new(ic::CONTROL_SWITCHES, [0, 23, 23, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages)
+  spr_shown = false
+  150.times do
+    scene.update
+    anim_spr = scene.instance_variable_get(:@animation_sprite)
+    spr_shown ||= anim_spr && anim_spr.visible
+    break if st.switches[23]
+  end
+  ok st.switches[23], 'the page ran straight through instead of stalling on the animation duration'
+  ok !spr_shown, 'nothing was ever drawn'
+  ok scene.instance_variable_get(:@map_animation).nil?, 'nothing was ever built to draw'
+end
+
+check "a battle page's Show Battle Animation no-ops for an out-of-range " \
+      'Enemy index instead of flashing screen-centre' do
+  ic = Game::Interpreter::Cmd
+  # The default troop has at least two members (see the "draws over the
+  # targeted troop member's own sprite position" check below, which
+  # addresses member 1); member 99 names no such slot.
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [8, 99, 1], indent: 0), # anim 8, enemy #99 (out of range), wait
+                             ECmd.new(ic::CONTROL_SWITCHES, [0, 24, 24, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages)
+  spr_shown = false
+  150.times do
+    scene.update
+    anim_spr = scene.instance_variable_get(:@animation_sprite)
+    spr_shown ||= anim_spr && anim_spr.visible
+    break if st.switches[24]
+  end
+  ok st.switches[24], 'the page ran straight through instead of stalling on the animation duration'
+  ok !spr_shown, 'nothing was ever drawn'
+  ok scene.instance_variable_get(:@map_animation).nil?, 'nothing was ever built to draw'
+end
+
 check "a battle page's Show Battle Animation draws over the targeted troop member's own sprite position" do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [8, 1, 1], indent: 0), # anim 8, member 1, wait


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter_Battle::CommandShowBattleAnimation` (`src/game_interpreter_battle.cpp`) leaves `battler_target` null — and so never calls `ShowBattleAnimation`, `frames` staying 0 — for an Ally index (1-based, `target -= 1` first) outside `0...Game_Party::GetBattlerCount()` (`GetActors().size()`, dead members included, no `Exists()`/`IsDead()` check anywhere in this function), or an Enemy index outside `0...Game_EnemyParty::GetBattlerCount()`.
- `Scene::Battle#start_battle_page_animation` (`mruby-rpg2k/mrblib/scene/battle.rb`) never bounds-checked the index: its `elsif req[:allies]` branch never even looked at the target index, always drawing at screen centre; its `else` (Enemy) branch relied on `#battle_animation_pixel`'s `sprites[i]` returning `nil` for an out-of-range `i`, which falls into that same method's own "no sprite" fallback — also screen centre. Neither branch ever no-op'd. `Scene::Map#begin_map_animation`'s `req[:battle]` case also had no notion of "target didn't resolve" (the same gap the prior map-target fix already closed for 11210), so a waited-for battle-page play on an out-of-range index stalled for the animation's own real duration too.
- A per-slot battle-event page reused across encounters with different party/troop sizes (e.g. an "Ally 4" animation on a 3-member party) flashed a spurious screen-centre animation, and if "wait until it finishes" was set, visibly stalled the page.
- Fixed with a new `Scene::Battle#battle_page_target_resolves?(req)` (`target - 1` bounds-checked against `@state.party.actors.size` for Ally, `req[:target]` bounds-checked against `@ui[:foes].size` for Enemy), consulted by `#start_battle_page_animation` (no-op) and by `Scene::Map#begin_map_animation` (sets `@anim_wait = 0` directly, dispatched through `@battle.battle_page_target_resolves?(req)` when `req[:battle]`) — the same treatment the map-target case already gets.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` checks: an out-of-range Ally index and an out-of-range Enemy index each run the page straight through, with the animation sprite confirmed to never draw and `@map_animation` confirmed to stay `nil`.
- [x] Confirmed both new checks fail against the pre-fix code (`git stash` on `battle.rb`/`map.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 829 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1080 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_