### PR TITLE
Fix: Flash Sprite targeting a vehicle now actually flashes it

### DIFF
--- a/changelog.d/flash-sprite-vehicle-target.fixed.md
+++ b/changelog.d/flash-sprite-vehicle-target.fixed.md
@@ -1,0 +1,7 @@
+- **Flash Sprite event command:** a Boat/Ship/Airship target now actually
+  flashes the vehicle's sprite, instead of silently doing nothing. Matches
+  RPG_RT's own `Game_Character::GetCharacter`, which resolves a vehicle
+  target to the live vehicle object exactly like the player or a map
+  event. A "wait for it to finish" request on a vehicle target now also
+  holds for the flash's real configured duration, instead of releasing on
+  the very next frame the way an unresolved target always did.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14667,6 +14667,43 @@ not yet verified:
   where `:boat` was expected, a `NoMethodError` from the old
   Hash-`[]=`-on-a-Symbol dispatch, and the full-pipeline sprite never being
   flashed at all).
+  ✅ **Follow-up (2026-08-20): ~~a target that cannot be resolved (a vehicle,
+  or an unknown event id) simply flashes nothing~~ — the vehicle half of
+  that claim was never actually true; the Flash Sprite command (11320)
+  itself, not just Show Battle Animation's flash_scope-1 mechanism above,
+  had the identical gap.** `#apply_sprite_flash`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) had no `MOVE_TARGET_BOAT`/`SHIP`/
+  `AIRSHIP` branch at all — a vehicle target fell into the generic `else`,
+  `@events.find` never matches a vehicle (vehicles aren't map events), so
+  the command silently did nothing. Confirmed against RPG_RT's own live
+  source: `Game_Character::GetCharacter` (`src/game_character.cpp`)
+  resolves `CharBoat`/`CharShip`/`CharAirship` (10002-10004) to the live
+  `Game_Vehicle` object exactly like `CharPlayer`/`CharThisEvent`, so
+  `Game_Interpreter_Map::CommandFlashSprite`'s `event->Flash(...)` call
+  reaches a vehicle just as it reaches the player or a map event — nothing
+  in real RPG_RT exempts it, the same fact the bullet above already
+  established for the sibling flash_scope-1 mechanism, just never carried
+  over to this command's own dispatch. An event using Flash Sprite on
+  "Boat"/"Ship"/"Airship" (e.g. flashing the ship red on storm damage)
+  produced no visual effect at all, and a "wait for it to finish" request
+  released on the very next frame regardless of the configured duration,
+  since `#sprite_flashing?` read a `@flash_wait` that was never armed.
+  Fixed by giving `#apply_sprite_flash` a vehicle branch that calls
+  `@vehicle_sprites[type].flash(...)` directly — the same native `Sprite
+  #flash` primitive the flash_scope-1 fix above already uses and
+  `#update_vehicle_flashes` already decays every frame — and having
+  `#update_sprite_flashes` also decay `@flash_wait` when it carries a new
+  `:vehicle` marker (the player/event branches already decay their own
+  `@player_flash`/`[:flash]`, which `@flash_wait` aliases when the target
+  is one of those; the marker keeps a vehicle-origin `@flash_wait` from
+  ever being decayed twice). Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (a vehicle-targeted Flash Sprite
+  pulses and decays the vehicle's own sprite with the correctly-scaled
+  colour; the wait flag holds the interpreter for the real duration rather
+  than releasing the very next update because the target went unresolved
+  — checking still-held partway through the duration, not just
+  "eventually resumes," since the old no-op path resumed just as fast),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A Timer with "valid during battle" checked force-ends the battle**
   the instant it reaches 0:00, regardless of encounter source (default or
   scripted) — an easy accidental trap if the same Timer is reused for a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3485,8 +3485,20 @@ class RPG2k
 
       # Start the character flashes an interpreter queued this step (11320). The
       # hero and map events both keep their flash as a decaying colour the
-      # renderer tones their CharSet frame with; a target that cannot be resolved
-      # (a vehicle, or an unknown event id) simply flashes nothing.
+      # renderer tones their CharSet frame with; a Boat/Ship/Airship target
+      # instead pulses the native RGSS `Sprite#flash` primitive
+      # #fire_map_target_flash already uses for the same vehicle-target case
+      # under Show Battle Animation's flash_scope -- confirmed against RPG_RT's
+      # own live source: `Game_Character::GetCharacter`
+      # (`src/game_character.cpp`) resolves `CharBoat`/`CharShip`/`CharAirship`
+      # (10002-10004) to the live `Game_Vehicle` object exactly like
+      # `CharPlayer`/`CharThisEvent`, so `Game_Interpreter_Map::
+      # CommandFlashSprite`'s `event->Flash(...)` call reaches a vehicle just
+      # as it reaches the player or a map event -- nothing in real RPG_RT
+      # exempts it. ~~a target that cannot be resolved (a vehicle, or an
+      # unknown event id) simply flashes nothing~~ was true only for the
+      # unknown-event-id half; a vehicle target is not actually unresolvable.
+      # An unknown event id is still a silent no-op.
       def apply_sprite_flash_requests(interp, this_event)
         reqs = interp.take_sprite_flash_requests
         return if reqs.nil? || reqs.empty?
@@ -3514,6 +3526,13 @@ class RPG2k
           flash
         when 0, MOVE_TARGET_THIS
           this_event ? (this_event[:flash] = flash) : nil
+        when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          type = Game::Vehicle::TYPES[r[:target] - MOVE_TARGET_BOAT]
+          spr = @vehicle_sprites && @vehicle_sprites[type]
+          return nil unless spr
+          spr.flash(Color.new(flash[:red], flash[:green], flash[:blue], flash[:power]), flash[:frames])
+          flash[:vehicle] = true
+          flash
         else
           ev = @events.find { |e| e[:id] == r[:target] }
           ev ? (ev[:flash] = flash) : nil
@@ -3538,6 +3557,13 @@ class RPG2k
         @last_frame = nil if @player_flash
         @player_flash = tick_flash(@player_flash)
         @events.each { |e| e[:flash] = tick_flash(e[:flash]) if e[:flash] }
+        # A vehicle-target Flash Sprite has no CharSet-tone hash of its own to
+        # decay here (its visuals are the native sprite #update_vehicle_flashes
+        # already drives) -- @flash_wait's `:vehicle` marker is only ever set
+        # by #apply_sprite_flash's own vehicle branch, so this can never
+        # double-decay the identical object the @player_flash/event lines
+        # above already tick.
+        @flash_wait = tick_flash(@flash_wait) if @flash_wait && @flash_wait[:vehicle]
       end
 
       def tick_flash(flash)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12958,6 +12958,49 @@ check 'Flash Sprite on the hero holds a waiting event until it decays' do
   eq 1, st.variables[5], 'the event resumed once the flash finished'
 end
 
+check 'Flash Sprite targeting a vehicle (Boat) pulses the native sprite flash ' \
+      'and decays, instead of silently dropping the target' do
+  # Confirmed against RPG_RT's own live source: `Game_Character::
+  # GetCharacter` (src/game_character.cpp) resolves CharBoat/CharShip/
+  # CharAirship (10002-10004) to the live Game_Vehicle object exactly like
+  # CharPlayer/CharThisEvent, so `Game_Interpreter_Map::
+  # CommandFlashSprite`'s `event->Flash(...)` call reaches a vehicle just
+  # as it reaches the player or a map event -- nothing in real RPG_RT
+  # exempts it, unlike this codebase's prior "vehicle target = unresolved,
+  # flashes nothing" behaviour.
+  cmds = [ECmd.new(IC2::FLASH_SPRITE, [10002, 31, 0, 0, 31, 2, 0])] # boat, r g b power, 2 tenths, wait=0
+  scene = new_scene({}, player: [0, 0])
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  scene.update
+  spr = scene.instance_variable_get(:@vehicle_sprites)[:boat]
+  ok spr.flash_color, 'the boat sprite was flashed'
+  eq [248, 0, 0, 248],
+     [spr.flash_color.red, spr.flash_color.green, spr.flash_color.blue, spr.flash_color.alpha],
+     'the configured colour/power, already scaled to 0..255 the same way the player/event flash is'
+  20.times { scene.update }
+  ok !spr.flash_color, 'the vehicle flash decays away like any other'
+end
+
+check 'Flash Sprite on a vehicle with the wait flag holds the interpreter ' \
+      'until the flash decays, rather than resuming the very next update ' \
+      'because the target went unresolved' do
+  # 1 tenth = 6 frames (Interpreter::FRAMES_PER_TENTH). Before this fix the
+  # vehicle target never resolved, so #sprite_flashing? was false from the
+  # start and the wait released on the very next #update regardless of the
+  # configured duration -- checking still-0 a couple of updates in (well
+  # short of the real 6-frame duration) is what catches that, not just
+  # "it eventually reaches 1" (which the old, broken no-op path did too).
+  cmds = [ECmd.new(IC2::FLASH_SPRITE, [10002, 31, 0, 0, 31, 1, 1]), # boat, r g b power, 1 tenth, wait=1
+          add_var_cmd(5)]
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  3.times { scene.update }
+  eq 0, st.variables[5], 'still held partway through the vehicle flash duration'
+  10.times { scene.update }
+  eq 1, st.variables[5], 'the event resumed once the vehicle flash finished'
+end
+
 check 'Tile Substitution rewrites the map the scene walks on' do
   cmds = [ECmd.new(IC2::TILE_SUBSTITUTION, [0, 0, 41])]
   scene = new_scene(parallel_event(cmds), player: [0, 0])


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Character::GetCharacter` (`src/game_character.cpp`) resolves `CharBoat`/`CharShip`/`CharAirship` (10002-10004) to the live `Game_Vehicle` object exactly like `CharPlayer`/`CharThisEvent`, so `Game_Interpreter_Map::CommandFlashSprite`'s `event->Flash(...)` call reaches a vehicle just as it reaches the player or a map event.
- `Scene::Map#apply_sprite_flash` (`mruby-rpg2k/mrblib/scene/map.rb`) had no vehicle branch at all — a vehicle target fell into the generic `else`, `@events.find` never matches a vehicle (vehicles aren't map events), so the command silently no-op'd. The doc comment above it even asserted this as intended ("a target that cannot be resolved (a vehicle, or an unknown event id) simply flashes nothing"), with no citation — contradicted by this same file's own `fire_map_target_flash`, which already correctly flashes a vehicle for the sibling Show Battle Animation flash_scope-1 mechanism.
- An event using Flash Sprite on "Boat"/"Ship"/"Airship" (e.g. flashing the ship red on storm damage) produced no visual effect at all, and a "wait for it to finish" request released on the very next frame regardless of the configured duration.
- Fixed by giving `#apply_sprite_flash` a vehicle branch that calls `@vehicle_sprites[type].flash(...)` directly — the same native `Sprite#flash` primitive `#fire_map_target_flash` already uses. `#update_sprite_flashes` now also decays `@flash_wait` when it carries a new `:vehicle` marker (the player/event branches already decay their own `@player_flash`/`[:flash]`, which `@flash_wait` aliases for those targets; the marker avoids double-decaying a vehicle-origin `@flash_wait`), so the command's own wait flag correctly holds for the real duration.
- Corrected the now-contradicted doc comment.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` checks: a vehicle-targeted Flash Sprite pulses and decays the vehicle's own sprite with the correctly-scaled colour; the wait flag holds the interpreter for the real duration rather than releasing the very next update (checked partway through the duration, not just "eventually resumes," since the old no-op path resumed just as fast).
- [x] Confirmed both new checks fail against the pre-fix code (`git stash` on `map.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 831 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1080 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_