### PR TITLE
Fix: show-message Change EXP/Level blocks while a message window is open

### DIFF
--- a/changelog.d/change-exp-level-message-block.fixed.md
+++ b/changelog.d/change-exp-level-message-block.fixed.md
@@ -1,0 +1,10 @@
+- **Change EXP / Change Level event commands:** a command with its own "show
+  message" flag set is now blocked (not applied) while a message window or
+  choice list is open, and retries once it closes -- matching RPG_RT's own
+  `Game_Interpreter::CommandChangeExp`/`CommandChangeLevel`, which guard the
+  entire command (the actor's EXP/level and re-derived base stats included,
+  not just the level-up message) behind the flag. Previously, a
+  still-running Parallel Process (Message Options' "continue events") could
+  apply the stat change and queue its level-up message a frame early, while
+  a different event's message window still sat on screen. A command with
+  the flag off is unaffected -- it never blocks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12323,6 +12323,40 @@ not yet verified:
   same list, must not run while a message window opened elsewhere is on
   screen; the battle opens once the window closes), confirmed to fail
   against the pre-fix code before the fix.
+- ✅ **A show-message Change EXP / Change Level is now blocked (not applied)
+  while a message window or choice list is open, and retries once it
+  closes — the same block-and-retry shape as the three fixes above, on a
+  fourth and fifth command, but conditional on the command's own "show
+  message" flag rather than unconditional.** Confirmed directly against
+  RPG_RT's live source: `Game_Interpreter::CommandChangeExp`/
+  `CommandChangeLevel` (`src/game_interpreter.cpp`, codes 10410/10420) both
+  open with `bool show_msg = com.parameters[5]; if (show_msg &&
+  !Game_Message::CanShowMessage(true)) { return false; }` — guarding the
+  *entire* command, the actor's EXP/level and re-derived base stats
+  included, not just the level-up message, and only when the flag is set;
+  `CommandChangeGold`/`CommandChangeParameters` (10310/10430) share no such
+  guard, so this is Change EXP/Level-specific, not a general "Change"
+  command rule. `Interpreter#do_change_exp`/`#do_change_level`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) had no such gate at all: a
+  still-running parallel process (Message Options' "continue events" flag)
+  could apply the stat change and queue its level-up message a frame early,
+  while a different event's message window still sat on screen — the
+  identical class of gap the three fixes above closed, just never ported to
+  these two. Fixed by adding `#block_pending_exp_level_command(show_msg)`,
+  the same shape as `#block_pending_picture_command`/
+  `#block_pending_teleport_command`/`#block_pending_battle_command`
+  (reusing the same `#message_window_blocks_command?` check) but taking the
+  flag as an argument, called from the very top of both methods before
+  `stat_amount`/`stat_targets` run. `Scene::Map#drive_event`'s foreground
+  dispatch and `#drive_parallel_wait` both gained a matching
+  `:exp_level_blocked` case (`resume unless message_window_open?`),
+  alongside the existing `:picture_blocked`/`:teleport_blocked`/
+  `:battle_blocked` ones. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (a common event's Parallel Process's own show-message Change Level,
+  and the command right after it in the same list, must not run while a
+  message window opened elsewhere is on screen; the level applies and its
+  own level-up message opens once the window closes), confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **Not applicable: re-issuing Show Picture every tick being expensive
   enough to cause real frame drops (vs. cheap repeated Move Picture) is a
   real-RPG_RT-specific performance characteristic, not a state/behaviour

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2027,8 +2027,9 @@ module Game
     # thresholds; param5 is the "show message" flag — when set, each level an
     # actor gains queues a level-up message (drained by #resume).
     def do_change_exp(cmd)
-      amount = stat_amount(cmd)
       show_msg = cmd.param(5) != 0
+      return if block_pending_exp_level_command(show_msg)
+      amount = stat_amount(cmd)
       stat_targets(cmd).each do |a|
         before = a.level
         before_skills = show_msg && a.respond_to?(:skills) ? a.skills.dup : []
@@ -2046,8 +2047,9 @@ module Game
     # operand layout as Change EXP; param5 is the "show message" flag — when set,
     # each level an actor gains queues a level-up message (drained by #resume).
     def do_change_level(cmd)
-      amount = stat_amount(cmd)
       show_msg = cmd.param(5) != 0
+      return if block_pending_exp_level_command(show_msg)
+      amount = stat_amount(cmd)
       stat_targets(cmd).each do |a|
         before = a.level
         before_skills = show_msg && a.respond_to?(:skills) ? a.skills.dup : []
@@ -3578,6 +3580,29 @@ module Game
       return false unless message_window_blocks_command?
       @index -= 1
       @wait_kind = :battle_blocked
+      @waiting = true
+      true
+    end
+
+    # Change EXP (10410) / Change Level (10420) block-and-retry the same way,
+    # but only when their own "show message" flag is set -- confirmed
+    # directly against RPG_RT's live source: `Game_Interpreter::
+    # CommandChangeExp`/`CommandChangeLevel` (`src/game_interpreter.cpp`)
+    # both open with `bool show_msg = com.parameters[5]; if (show_msg &&
+    # !Game_Message::CanShowMessage(true)) { return false; }`, guarding the
+    # *entire* command -- the actor's EXP/level and re-derived base stats
+    # included, not just the level-up message -- behind the flag. With
+    # `show_msg` clear neither command ever calls `CanShowMessage` at all,
+    # unlike Show/Move/Erase Picture, Teleport/Recall to Location and Battle
+    # Processing/Enemy Encounter, which block unconditionally regardless of
+    # any flag. Without this, a still-running parallel process (Message
+    # Options' "continue events" flag) could apply a Change EXP/Level's
+    # stat change and level-up message a frame early, while a different
+    # event's message window still sits on screen.
+    def block_pending_exp_level_command(show_msg)
+      return false unless show_msg && message_window_blocks_command?
+      @index -= 1
+      @wait_kind = :exp_level_blocked
       @waiting = true
       true
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2033,6 +2033,13 @@ class RPG2k
           # :battle_blocked case, see #block_pending_battle_command for the
           # citation.
           it.resume unless message_window_open?
+        elsif it.wait_kind == :exp_level_blocked
+          # A "show message"-flagged Change EXP / Change Level command
+          # issued from a Parallel Process while a message window or choice
+          # list is open -- the parallel-process equivalent of #drive_event's
+          # own :exp_level_blocked case, see
+          # Interpreter#block_pending_exp_level_command for the citation.
+          it.resume unless message_window_open?
         elsif it.wait_kind == :sprite_flash
           # Flash Sprite's own wait flag, the parallel-process equivalent of
           # the :screen/:picture cases just above.
@@ -4549,6 +4556,13 @@ class RPG2k
             # (#block_pending_battle_command) -- the identical
             # block-and-retry shape as :picture_blocked/:teleport_blocked
             # above, see that method's own citation.
+            @interpreter.resume unless message_window_open?
+          when :exp_level_blocked
+            # A "show message"-flagged Change EXP / Change Level command
+            # reached while a message window or choice list is open
+            # (#block_pending_exp_level_command) -- the identical
+            # block-and-retry shape as :picture_blocked/:teleport_blocked/
+            # :battle_blocked above, see that method's own citation.
             @interpreter.resume unless message_window_open?
           when :return_title then perform_return_to_title
           when :game_over then perform_game_over

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8238,6 +8238,53 @@ check 'Change Level show-message: the scene shows a message per level, then resu
   ok st.switches[5], 'the event resumes once both level-up messages are dismissed'
 end
 
+check "a common event's Parallel Process's own show-message Change Level " \
+      'command is blocked (not applied) while a message window is open, and ' \
+      'retries once it closes' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  # CommandChangeExp`/`CommandChangeLevel` (`src/game_interpreter.cpp`) both
+  # open with `bool show_msg = com.parameters[5]; if (show_msg &&
+  # !Game_Message::CanShowMessage(true)) { return false; }`, guarding the
+  # entire command -- the actor's level itself, not just the level-up
+  # message -- behind the flag, the same block-and-retry shape already
+  # ported for Show/Move/Erase Picture and Transfer Player (see
+  # #block_pending_exp_level_command). Unlike those three, this guard is
+  # conditional on the "show message" flag actually being set -- a Change
+  # Level/EXP command with the flag off never blocks at all. A Parallel
+  # Process (unlike a fresh Auto-Start event, which never even begins while
+  # a message window is open -- #event_busy?) keeps advancing during a
+  # message window by design (Message Options' "continue events"), so it is
+  # the case that actually reaches an already-running command mid-list.
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [add_var_cmd(3),
+                              ECmd.new(ic::CHANGE_LEVEL, [1, 1, 0, 0, 1, 1], indent: 0),
+                              add_var_cmd(4)])
+  scene = new_scene({}, common: { 7 => ce })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, LevelStubParty.new)
+  scene.send(:open_message, ['hi'], false)
+
+  10.times { scene.update }
+  eq 1, st.variables[3], "marker A still runs on the process's first pass"
+  eq 1, st.party.actor_by_id(1).level, 'the level must not change while a message window is open'
+  eq 0, st.variables[4], 'the command right after the blocked Change Level must not run either'
+
+  scene.send(:close_message)
+  # The retried Change Level itself queues its own level-up message once it
+  # finally applies (show_msg is set) -- dismiss it (a C press) the same way
+  # the foreground "Change Level show-message" check above does, so the
+  # process can reach marker B.
+  40.times do
+    RGSS::Input.triggered = [RGSS::Input::C]
+    scene.update
+    RGSS::Input.triggered = []
+    break if st.variables[4] == 1
+  end
+  eq 2, st.party.actor_by_id(1).level, 'the Change Level retries and applies once the window closes'
+  eq 1, st.variables[4], 'and the command after it then runs too'
+end
+
 check 'boarding a boat and disembarking onto the shore' do
   scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Interpreter::CommandChangeExp`/`CommandChangeLevel` (`src/game_interpreter.cpp`, codes 10410/10420) both open with `bool show_msg = com.parameters[5]; if (show_msg && !Game_Message::CanShowMessage(true)) { return false; }` — guarding the *entire* command, the actor's EXP/level and re-derived base stats included, not just the level-up message, and only when the flag is set. `CommandChangeGold`/`CommandChangeParameters` (10310/10430) share no such guard, so this is Change EXP/Level-specific.
- `Interpreter#do_change_exp`/`#do_change_level` (`mruby-rpg2k/mrblib/interpreter.rb`) had no such gate at all: a still-running parallel process (Message Options' "continue events" flag) could apply the stat change and queue its level-up message a frame early, while a different event's message window still sat on screen — the identical class of gap already closed for Show/Move/Erase Picture, Transfer Player/Recall to Location, and Battle Processing/Enemy Encounter, just never ported to these two.
- Fixed by adding `#block_pending_exp_level_command(show_msg)`, the same shape as the existing `#block_pending_picture_command`/`#block_pending_teleport_command`/`#block_pending_battle_command` (reusing `#message_window_blocks_command?`) but taking the flag as an argument, called from the top of both methods before `stat_amount`/`stat_targets` run. `Scene::Map#drive_event`'s foreground dispatch and `#drive_parallel_wait` both gained a matching `:exp_level_blocked` case.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: a common event's Parallel Process's own show-message Change Level, and the command right after it in the same list, must not run while a message window opened elsewhere is on screen; the level applies and its own level-up message opens once the window closes.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `interpreter.rb`/`map.rb` only — `expected 1, got 2`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 832 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1080 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_