### PR TITLE
Fix: Move Type Approach/Away from Player is noisy and sight-gated

### DIFF
--- a/changelog.d/move-type-toward-away-noise.fixed.md
+++ b/changelog.d/move-type-toward-away-noise.fixed.md
@@ -1,0 +1,7 @@
+- **Move Type "Approach Player" / "Away from Player":** a chase/flee event no
+  longer homes in on the player with perfect precision on every step --
+  matching RPG_RT's own `Game_Event::MoveTypeTowardsOrAwayPlayer`, which only
+  computes the real toward/away direction 8 times out of 10 while the event
+  is actually on screen (otherwise it keeps its current facing or picks a
+  random cardinal), and picks a fully random cardinal unconditionally, with
+  no attempt to track the player at all, once off screen.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -326,6 +326,50 @@ The work below is roughly ordered by the critical path to a walkable game
   same-tile result of Down cannot be mistaken for a coincidental "kept
   facing" match), confirmed to fail against the pre-fix code (`expected
   2, got 6`) before the fix.
+  ✅ **Follow-up (2026-08-20): Move Type "Approach Player"/"Away from
+  Player" was a deterministic beeline — every step, in sight or not,
+  computed the exact geometric direction toward/away the hero — where real
+  RPG_RT only tracks the player 8 times out of 10 while actually on
+  screen, and makes no attempt to track at all once off screen.** Confirmed
+  against RPG_RT's own live source: `Game_Event::
+  MoveTypeTowardsOrAwayPlayer` (`src/game_event.cpp`) computes `sx =
+  GetScreenX(); sy = GetScreenY()` and gates on `in_sight` (the view plus a
+  two-tile margin, `TILE_SIZE * 2`) before ever consulting
+  `GetDirectionToCharacter`/`GetDirectionAwayCharacter` (this codebase's
+  own, now-correct `#direction_toward`/`#direction_away`): off screen it
+  always picks `Rand::GetRandomNumber(0, 3)`, a fully random cardinal, with
+  no positional awareness of the hero at all; in sight it rolls
+  `Rand::GetRandomNumber(0, 9)` — 0 keeps the event's current facing, 1 is
+  a random cardinal, and only 2-9 (80% of the time) computes the real
+  direction. `Game::MoveType.next_direction`'s `TOWARD`/`AWAY` cases
+  (`mruby-rpg2k/mrblib/game.rb`) called `#direction_toward`/`#direction_away`
+  unconditionally every single step, with no randomness and no on-screen
+  check at all. Concretely: a chase/flee event in this codebase homed in on
+  the player with laser precision on every move tick, on screen or off,
+  where real RPG_RT looks noticeably more erratic in view (occasional
+  detours, occasional pauses in the current direction) and wanders
+  aimlessly rather than tracking once off screen — directly visible in any
+  guard/monster-chase or escort-flee sequence, a common authored pattern.
+  Fixed with a new `Game::MoveType.toward_away_direction` implementing the
+  same three-way roll, and a new `Scene::Map#char_in_sight?`/
+  `MapWorld#in_sight?` reusing `#character_screen_position`'s own cited
+  screen-pixel math. `VehicleWorld` needs no counterpart — Approach/Away
+  is not a valid Move Type for a vehicle's own Set Move Route. **Still
+  open**: RPG_RT's blocked-move handling for *every* autonomous move type
+  (Random/Cycle/Toward/Away alike) reverts `SetDirection(prev_dir)` when a
+  move fails and the stop-count threshold hasn't been exceeded (the
+  `IsStopping()` block right after `Move(dir)` in the same function) —
+  this codebase's `#move_autonomous` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  just turns to face the obstruction unconditionally on a blocked move
+  instead. That is a related but separate, larger piece of RPG_RT's
+  stop-count state machine shared across all four move types, not just
+  Toward/Away, left for a follow-up investigation of its own. Covered by a
+  rewritten `scripts/rpg2k_logic_check.rb` check (the existing one had
+  itself encoded the old unconditional-geometric-direction behaviour, with
+  no queued `random` roll ever landing on anything but the fallback 0 —
+  masking exactly this gap) exercising all three in-sight draw outcomes
+  plus the off-screen case, confirmed to fail against the pre-fix code
+  (`expected 6, got 2`) before the fix.
   ✅ **Follow-up (2026-08-20): a move route's effect-only sub-commands
   (Switch On/Off, Speed/Frequency Up/Down, Change Graphic, Play Sound,
   Through Mode, Stop/Start Animation, Transparency Up/Down) each paid a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6662,9 +6662,10 @@ module Game
   # Autonomous (non-custom) event movement: given a page's `move_type`, pick the
   # direction the character should try to step next. `random` picks a cardinal;
   # `vertical`/`horizontal` keep bouncing along one axis, reversing when the way
-  # ahead is blocked; `toward`/`away` chase or flee the hero. Returns a numpad
-  # direction, or nil for "no autonomous movement" (stationary) and for the
-  # custom-route type (which is driven by a MoveRoute instead).
+  # ahead is blocked; `toward`/`away` chase or flee the hero, but only most of
+  # the time and only in sight -- see #toward_away_direction's own citation.
+  # Returns a numpad direction, or nil for "no autonomous movement" (stationary)
+  # and for the custom-route type (which is driven by a MoveRoute instead).
   module MoveType
     STATIONARY = 0
     RANDOM     = 1
@@ -6679,14 +6680,35 @@ module Game
       when RANDOM     then Character::CARDINALS[world.random(4)]
       when VERTICAL   then bounce(character, world, [8, 2])
       when HORIZONTAL then bounce(character, world, [4, 6])
-      when TOWARD
-        hx, hy = world.hero_position
-        character.direction_toward(hx, hy)
-      when AWAY
-        hx, hy = world.hero_position
-        character.direction_away(hx, hy)
+      when TOWARD then toward_away_direction(character, world, true)
+      when AWAY   then toward_away_direction(character, world, false)
       else nil
       end
+    end
+
+    # Approach/Away from Player is not the deterministic beeline it looks
+    # like from the command's name -- confirmed against RPG_RT's own live
+    # source: `Game_Event::MoveTypeTowardsOrAwayPlayer` (`src/game_event.cpp`)
+    # only computes the real toward/away direction 8 times out of 10 while
+    # the event is actually on screen (`Rand::GetRandomNumber(0, 9)`: 0 keeps
+    # the current facing, 1 picks a fully random cardinal, 2-9 the real
+    # direction) -- and picks a fully random cardinal unconditionally,
+    # every time, while off screen (`sx`/`sy` outside the view plus a
+    # two-tile margin, `TILE_SIZE * 2`), making no attempt to track the
+    # player at all until back in view. `GetDirectionToCharacter`/
+    # `GetDirectionAwayCharacter` are #direction_toward/#direction_away,
+    # already correct; it is this surrounding stochastic/visibility gate
+    # that was missing entirely -- every step unconditionally computed the
+    # exact geometric direction, in sight or not, which reads as a
+    # noticeably more precise (and, off screen, omniscient) chase/flee than
+    # real RPG_RT's.
+    def self.toward_away_direction(character, world, towards)
+      return Character::CARDINALS[world.random(4)] unless world.in_sight?(character)
+      draw = world.random(10)
+      return character.direction if draw == 0
+      return Character::CARDINALS[world.random(4)] if draw == 1
+      hx, hy = world.hero_position
+      towards ? character.direction_toward(hx, hy) : character.direction_away(hx, hy)
     end
 
     # Continue along the current axis direction, reversing to the other end of

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -300,6 +300,16 @@ class RPG2k
         [s.x, s.y]
       end
 
+      # Whether `character` is on screen (plus a two-tile margin) -- gates
+      # Move Type Approach/Away from Player's own randomness, see
+      # Scene::Map#char_in_sight?'s own citation. Only ever asked of a map
+      # event/the hero, never a vehicle -- Approach/Away is not a valid
+      # Move Type for a vehicle's own Set Move Route, so VehicleWorld below
+      # needs no counterpart.
+      def in_sight?(character)
+        @scene.char_in_sight?(character)
+      end
+
       def set_switch(id, on)
         @scene.state.switches[id] = on
       end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8312,6 +8312,27 @@ class RPG2k
         { x: pixel[0] - cam_x + TILE / 2, y: pixel[1] - cam_y + TILE }
       end
 
+      # Whether `character` is on screen, plus a two-tile margin -- confirmed
+      # against RPG_RT's own live source: `Game_Event::
+      # MoveTypeTowardsOrAwayPlayer` (`src/game_event.cpp`) computes `sx =
+      # GetScreenX(); sy = GetScreenY()` (the same screen-pixel math
+      # #character_screen_position's own citation already ports) and tests
+      # `sx >= -offset && sx <= Player::screen_width + offset && sy >=
+      # -offset && sy <= Player::screen_height + offset`, `offset ==
+      # TILE_SIZE * 2`. Used to gate Move Type Approach/Away from Player's
+      # own randomness (see Game::MoveType.next_direction) -- an off-screen
+      # chaser gets no special treatment there at all, not even a degraded
+      # one, so this uses the character's plain tile position rather than
+      # #event_pixel's mid-slide interpolation (a fresh autonomous-move
+      # decision is only ever made between slides, never mid-step).
+      def char_in_sight?(character)
+        cam_x, cam_y = camera_position
+        sx = character.x * TILE - cam_x + TILE / 2
+        sy = character.y * TILE - cam_y + TILE
+        offset = TILE * 2
+        sx >= -offset && sx <= SCREEN_W + offset && sy >= -offset && sy <= SCREEN_H + offset
+      end
+
       # Current position of vehicle `type` in map pixels: the party's own
       # interpolated pixel position while it's the one being ridden
       # (#player_pixel, so it reads in lockstep with the hero mid-step),
@@ -8323,7 +8344,7 @@ class RPG2k
         return nil unless v.placed? && v.map_id == @state.map_id
         @state.boarded == type ? player_pixel : [v.x * TILE, v.y * TILE]
       end
-      public :camera_position, :character_screen_position
+      public :camera_position, :character_screen_position, :char_in_sight?
 
       # The rest of the "services Scene::Battle calls back into" (see the
       # readers next to #dispose): BGM, backdrop, animation-player and

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -98,14 +98,15 @@ end
 # A grid world implementing the MoveRoute/MoveType `world` protocol. Passability
 # is a set of blocked [x, y] tiles; everything else is walkable.
 class FakeWorld
-  attr_accessor :hero, :switches, :sounds, :rolls
+  attr_accessor :hero, :switches, :sounds, :rolls, :in_sight
 
-  def initialize(blocked: [], hero: [0, 0], rolls: [])
+  def initialize(blocked: [], hero: [0, 0], rolls: [], in_sight: true)
     @blocked = blocked
     @hero = hero
     @switches = {}
     @sounds = []
     @rolls = rolls # queued values for random(n); falls back to 0
+    @in_sight = in_sight
   end
 
   def passable?(character, dir)
@@ -120,6 +121,7 @@ class FakeWorld
   def set_switch(id, on); @switches[id] = on; end
   def play_sound(*a); @sounds << a; end
   def random(_n); @rolls.empty? ? 0 : @rolls.shift; end
+  def in_sight?(_character); @in_sight; end
 end
 
 # Build an LCF::MoveCommand-alike without loading the native parser.
@@ -748,11 +750,33 @@ check 'MoveType vertical bounces off a blocked tile' do
   eq 8, Game::MoveType.next_direction(Game::MoveType::VERTICAL, c, FakeWorld.new)
 end
 
-check 'MoveType toward/away chase and flee the hero' do
-  c = Game::Character.new(0, 0)
-  w = FakeWorld.new(hero: [0, 5])
+check 'MoveType toward/away chase and flee the hero, gated on sight and a ' \
+      '1-in-10 roll -- confirmed against RPG_RT\'s own live source: ' \
+      'Game_Event::MoveTypeTowardsOrAwayPlayer (src/game_event.cpp) only ' \
+      'computes the real direction on a draw of 2-9 out of a 0-9 roll ' \
+      '(0 keeps the current facing, 1 is a random cardinal), and only while ' \
+      'on screen -- picking a random cardinal unconditionally off screen' do
+  c = Game::Character.new(0, 0, 6) # facing right
+  # In sight, draw 2 (>= 2): the real geometric direction.
+  w = FakeWorld.new(hero: [0, 5], rolls: [2])
   eq 2, Game::MoveType.next_direction(Game::MoveType::TOWARD, c, w)
+  w = FakeWorld.new(hero: [0, 5], rolls: [2])
   eq 8, Game::MoveType.next_direction(Game::MoveType::AWAY, c, w)
+
+  # In sight, draw 0: keeps the character's own current facing, not the
+  # geometric direction toward/away the hero.
+  w = FakeWorld.new(hero: [0, 5], rolls: [0])
+  eq 6, Game::MoveType.next_direction(Game::MoveType::TOWARD, c, w)
+
+  # In sight, draw 1: a fully random cardinal (the queued random(4) draw),
+  # not the geometric direction either.
+  w = FakeWorld.new(hero: [0, 5], rolls: [1, 3])
+  eq 8, Game::MoveType.next_direction(Game::MoveType::TOWARD, c, w) # CARDINALS[3] == 8
+
+  # Off screen: always a random cardinal, no attempt to track the hero at
+  # all, regardless of what random(10) would have drawn.
+  w = FakeWorld.new(hero: [0, 5], in_sight: false, rolls: [1])
+  eq 4, Game::MoveType.next_direction(Game::MoveType::TOWARD, c, w) # CARDINALS[1] == 4
 end
 
 # -- Rng ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- RPG_RT's `Game_Event::MoveTypeTowardsOrAwayPlayer` (`src/game_event.cpp`) computes `sx = GetScreenX(); sy = GetScreenY()` and gates on whether the event is in sight (the view plus a two-tile margin, `TILE_SIZE * 2`) before ever consulting `GetDirectionToCharacter`/`GetDirectionAwayCharacter`: off screen it always picks `Rand::GetRandomNumber(0, 3)`, a fully random cardinal, with no positional awareness of the hero at all; in sight it rolls `Rand::GetRandomNumber(0, 9)` — 0 keeps the event's current facing, 1 is a random cardinal, and only 2-9 (80% of the time) computes the real geometric direction.
- `Game::MoveType.next_direction`'s `TOWARD`/`AWAY` cases (`mruby-rpg2k/mrblib/game.rb`) called `#direction_toward`/`#direction_away` unconditionally every single step, with no randomness and no on-screen check at all.
- Concretely: a chase/flee event in this codebase homed in on the player with laser precision on every move tick, on screen or off, where real RPG_RT looks noticeably more erratic in view (occasional detours, occasional pauses in the current direction) and wanders aimlessly rather than tracking once off screen — directly visible in any guard/monster-chase or escort-flee sequence, a common authored pattern.
- Fixed with a new `Game::MoveType.toward_away_direction` implementing the same three-way roll, and a new `Scene::Map#char_in_sight?`/`MapWorld#in_sight?` reusing `#character_screen_position`'s own cited screen-pixel math. `VehicleWorld` needs no counterpart — Approach/Away is not a valid Move Type for a vehicle's own Set Move Route.
- **Still open** (documented in `docs/TODO.md`, not fixed here to keep this change small): RPG_RT's blocked-move handling for *every* autonomous move type (Random/Cycle/Toward/Away alike) reverts the direction when a move fails and the stop-count threshold hasn't been exceeded — this codebase's `#move_autonomous` just turns to face the obstruction unconditionally instead. A related but separate, larger piece of RPG_RT's stop-count state machine, left for a follow-up.

## Test plan
- [x] Rewrote the existing `scripts/rpg2k_logic_check.rb` check, which had itself encoded the old unconditional-geometric-direction behaviour (no queued `random` roll ever landing on anything but the fallback 0, masking exactly this gap), to exercise all three in-sight draw outcomes plus the off-screen case.
- [x] Confirmed the rewritten check fails against the pre-fix code (`git stash` on `game.rb`/`scene/map.rb`/`scene/base.rb` only — `expected 6, got 2`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 832 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1080 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_