### PR TITLE
Fix: a blocked autonomous move no longer turns to face the obstacle

### DIFF
--- a/changelog.d/move-autonomous-blocked-facing.fixed.md
+++ b/changelog.d/move-autonomous-blocked-facing.fixed.md
@@ -1,0 +1,10 @@
+- **Autonomous event movement:** a blocked move (Random/Vertical-cycle/
+  Horizontal-cycle/Approach/Away Player alike) no longer turns the event to
+  face the obstruction on every single failed attempt -- matching RPG_RT's
+  own `Game_Character::Move`/`Game_Event::MoveType*` pair, which reverts
+  that facing change back on the overwhelming majority of blocked
+  attempts, only letting it settle once genuinely stuck for a sustained
+  stretch. Previously, an NPC repeatedly drawing a blocked direction near a
+  wall or another blocking event visibly snapped its sprite to face
+  whatever direction it just failed to enter, reading as a twitchy,
+  spinning NPC instead of holding its last successful facing steady.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -370,6 +370,64 @@ The work below is roughly ordered by the critical path to a walkable game
   masking exactly this gap) exercising all three in-sight draw outcomes
   plus the off-screen case, confirmed to fail against the pre-fix code
   (`expected 6, got 2`) before the fix.
+  ✅ **Follow-up (2026-08-20): closed the "still open" gap directly above —
+  a blocked autonomous move (Random/Vertical/Horizontal-cycle/Toward/Away
+  alike) turned the event to face the obstruction on every single failed
+  attempt, where real RPG_RT reverts that facing back on the overwhelming
+  majority of them.** `Game_Character::Move` (`src/game_character.cpp`)
+  does turn to face the drawn direction immediately, before ever checking
+  passability (`SetDirection(dir); UpdateFacing();` precede the `MakeWay`
+  calls) — but every autonomous-move caller in `src/game_event.cpp`
+  (`MoveTypeRandom`/`MoveTypeCycle`/`MoveTypeTowardsOrAwayPlayer`, all
+  sharing the identical shape) immediately reverts that on a blocked move:
+  `if (IsStopping()) { if (IsWaitingForegroundExecution() ||
+  (GetStopCount() >= GetMaxStopCount() + 60)) { SetStopCount(0); } else {
+  SetDirection(prev_dir); if (!IsFacingLocked()) { SetFacing(prev_dir); }
+  } }`. A movement decision only comes up once every `GetMaxStopCount()`
+  frames to begin with (64 at the default frequency 3, `1 << (9-freq)`),
+  and the extra threshold is `+ 60` *more* frames on top of that, so the
+  sprite's visible facing does not change on the overwhelmingly common
+  blocked attempt — only once genuinely stuck for a sustained stretch does
+  RPG_RT finally let it settle facing the obstruction.
+  `Scene::Map#move_autonomous`'s own doc comment asserted "any other
+  obstacle just turns the event to face it" with no citation at all — the
+  exact kind of uncited claim this project keeps finding wrong. Concretely:
+  an NPC with Random/Cycle/Approach/Away movement repeatedly drawing a
+  blocked direction (a common case near a wall or another blocking event)
+  visibly snapped its sprite to face whatever direction it just failed to
+  enter on every retry, reading as a twitchy, spinning NPC — real RPG_RT's
+  sprite holds its last successful facing steady through nearly all such
+  retries. Fixed by dropping the unconditional `ch.face(dir)` from the
+  blocked (non-player) branch entirely, leaving facing unchanged on a
+  blocked attempt; reproducing the exact "eventually settles facing the
+  obstacle after a sustained stretch" half (the `GetStopCount() >=
+  GetMaxStopCount() + 60` threshold) would need a per-event blocked-streak
+  counter and is left as a further follow-up, since the visible-twitching
+  bug this fixes is the overwhelmingly common case. The player-touch branch
+  (walking into the hero) is untouched — starting a foreground event is
+  exactly `IsWaitingForegroundExecution()`, one of the two revert-exemption
+  conditions above, so unconditionally turning to face the player there was
+  already correct by a different path, not a coincidence. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (an event boxed in on all four sides
+  by stationary blocking events, so every Random draw is blocked, never
+  turns from its starting facing across 60 frames), confirmed to fail
+  against the pre-fix code (`expected 2, got 6`) before the fix.
+  **Also surfaced, deliberately left out of this fix to keep it narrow**: a
+  deeper discrepancy in RPG_RT's actual Random-move algorithm itself.
+  `Game_Event::MoveTypeRandom` is not a uniform pick among the four
+  absolute cardinal directions the way `Game::MoveType.next_direction`'s
+  `RANDOM` case (`Character::CARDINALS[world.random(4)]`) implements it —
+  it is a *relative* roll off the event's own current facing (`Rand::
+  GetRandomNumber(0, 9)`: 0-2 keep going straight, 3-4 turn 90° left, 5-6
+  turn 90° right, 7 turn 180°, 8-9 skip the attempt and idle for a random
+  span), then attempts to move in whatever direction results. A
+  "Random"-moving NPC in real RPG_RT therefore tends to continue mostly
+  straight with occasional turns, not restart in a fresh independent
+  cardinal every single step the way this codebase's port does. This is a
+  substantially larger algorithmic change (a full port of the relative-turn
+  model, not a one-line fix) and a genuinely separate discrepancy from the
+  blocked-move-facing gap just closed above — left for its own future
+  investigation.
   ✅ **Follow-up (2026-08-20): a move route's effect-only sub-commands
   (Switch On/Off, Speed/Frequency Up/Down, Change Graphic, Play Sound,
   Through Mode, Stop/Start Animation, Transparency Up/Down) each paid a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2923,13 +2923,31 @@ class RPG2k
       end
 
       # Move an autonomous event one step in `dir`. Walking into the player fires
-      # an event-touch (trigger 2) event instead of moving; any other obstacle
-      # just turns the event to face it. `allow_trigger: false` (the "keep
-      # moving during an open message" pass, see #step_events) still turns the
-      # event to face the player but never starts one -- there is only one
-      # foreground @interpreter, already mid-message, and RPG2000 never shows
-      # two message windows at once, so a second event's commands have nowhere
-      # safe to run until the first message closes.
+      # an event-touch (trigger 2) event instead of moving. ~~Any other
+      # obstacle just turns the event to face it~~ -- corrected against
+      # RPG_RT's own live source: `Game_Character::Move` (`src/
+      # game_character.cpp`) does turn to face `dir` immediately, before ever
+      # checking passability (`SetDirection(dir); UpdateFacing();` precede
+      # the `MakeWay` calls) -- but every autonomous-movement caller in `src/
+      # game_event.cpp` (`MoveTypeRandom`/`MoveTypeCycle`/
+      # `MoveTypeTowardsOrAwayPlayer`, all sharing the identical shape)
+      # immediately reverts that on a blocked move: `if (IsStopping()) { if
+      # (IsWaitingForegroundExecution() || (GetStopCount() >=
+      # GetMaxStopCount() + 60)) { SetStopCount(0); } else {
+      # SetDirection(prev_dir); if (!IsFacingLocked()) {
+      # SetFacing(prev_dir); } } }`. Since a movement decision only comes up
+      # once every `GetMaxStopCount()` frames (64 at the default frequency 3)
+      # and the extra threshold is `+ 60` *more* frames on top of that, the
+      # sprite's visible facing does not change on the overwhelmingly common
+      # blocked attempt -- only once genuinely stuck for a sustained stretch
+      # does RPG_RT finally let it settle facing the obstruction, which this
+      # method does not attempt to reproduce (a bounded blocked-streak
+      # counter would need its own follow-up). `allow_trigger: false` (the
+      # "keep moving during an open message" pass, see #step_events) still
+      # turns the event to face the player but never starts one -- there is
+      # only one foreground @interpreter, already mid-message, and RPG2000
+      # never shows two message windows at once, so a second event's
+      # commands have nowhere safe to run until the first message closes.
       def move_autonomous(e, dir, allow_trigger: true)
         ch = e[:char]
         nx, ny = Game::Character.step_tile(ch.x, ch.y, dir)
@@ -2959,8 +2977,6 @@ class RPG2k
                              e[:trigger] == TRIGGER_EVENT_TOUCH && e[:commands]
         elsif @world.passable?(ch, dir)
           ch.move(dir)
-        else
-          ch.face(dir)
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1367,6 +1367,32 @@ check 'a random-mover roams but stays in bounds and off the player tile' do
   ok moved, 'a random mover should have moved at least once in 300 frames'
 end
 
+check 'a blocked autonomous move does not turn the event to face the ' \
+      'obstacle -- RPG_RT reverts that facing back on nearly every failed ' \
+      'attempt' do
+  # Confirmed against RPG_RT's own live source: `Game_Character::Move`
+  # (src/game_character.cpp) does turn to face the drawn direction before
+  # ever checking passability, but every autonomous-move caller in
+  # src/game_event.cpp (MoveTypeRandom/MoveTypeCycle/
+  # MoveTypeTowardsOrAwayPlayer) immediately reverts that turn on a blocked
+  # move unless genuinely stuck for a sustained stretch (GetMaxStopCount() +
+  # 60 frames) -- boxing an event in on all four sides means every draw is
+  # blocked, so its facing should never visibly change from whatever it
+  # started at.
+  mover     = event(2, 2, page(x_move_type: Game::MoveType::RANDOM, direction: 2))
+  wall_up    = event(2, 1, page)
+  wall_down  = event(2, 3, page)
+  wall_left  = event(1, 2, page)
+  wall_right = event(3, 2, page)
+  scene = new_scene({ 1 => mover, 2 => wall_up, 3 => wall_down,
+                       4 => wall_left, 5 => wall_right }, player: [0, 0])
+  c = chars(scene)[1]
+  60.times { scene.update }
+  eq [2, 2], [c.x, c.y], 'boxed in on all four sides -- never actually moves'
+  eq 2, c.direction, 'blocked every attempt -- facing never turns to the ' \
+                      'randomly drawn (always-blocked) direction'
+end
+
 check 'two events do not stack on the same tile' do
   # Two events collide whenever their layers match exactly (see the LAYER_*
   # comment in map.rb) -- #page's own default (LAYER_BELOW for both) already


### PR DESCRIPTION
## Summary
- `Game_Character::Move` (`src/game_character.cpp`) turns to face the drawn direction immediately, before ever checking passability (`SetDirection(dir); UpdateFacing();` precede the `MakeWay` calls) — but every autonomous-move caller in `src/game_event.cpp` (`MoveTypeRandom`/`MoveTypeCycle`/`MoveTypeTowardsOrAwayPlayer`, all sharing the identical shape) immediately reverts that on a blocked move: `if (IsStopping()) { if (IsWaitingForegroundExecution() || (GetStopCount() >= GetMaxStopCount() + 60)) { SetStopCount(0); } else { SetDirection(prev_dir); if (!IsFacingLocked()) { SetFacing(prev_dir); } } }`. A movement decision only comes up once every `GetMaxStopCount()` frames to begin with (64 at the default frequency 3), and the extra threshold is `+ 60` *more* frames on top of that, so the sprite's visible facing does not change on the overwhelmingly common blocked attempt.
- `Scene::Map#move_autonomous` (`mruby-rpg2k/mrblib/scene/map.rb`) called `ch.face(dir)` unconditionally on every blocked attempt, for every autonomous move type — its own doc comment asserted "any other obstacle just turns the event to face it" with no citation.
- An NPC with Random/Cycle/Approach/Away movement repeatedly drawing a blocked direction (a common case near a wall or another blocking event) visibly snapped its sprite to face whatever direction it just failed to enter on every retry, reading as a twitchy, spinning NPC — real RPG_RT's sprite holds its last successful facing steady through nearly all such retries.
- Fixed by dropping the unconditional `ch.face(dir)` from the blocked (non-player) branch entirely. Reproducing the exact "eventually settles facing the obstacle after a sustained stretch" half would need a per-event blocked-streak counter and is left as a further follow-up (documented in `docs/TODO.md`), since the visible-twitching bug this fixes is the overwhelmingly common case.
- The player-touch branch (walking into the hero) is untouched — starting a foreground event is exactly `IsWaitingForegroundExecution()`, one of the two revert-exemption conditions above, so unconditionally turning to face the player there was already correct by a different path, not a coincidence.
- Also documented (but deliberately did not fix, to keep this change narrow) a separate, deeper discrepancy surfaced along the way: `Game_Event::MoveTypeRandom` is a relative roll off the event's own current facing, not a uniform pick among the four absolute cardinals the way `Game::MoveType::RANDOM` implements it — left for its own future investigation.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check: an event boxed in on all four sides by stationary blocking events, so every Random draw is blocked, never turns from its starting facing across 60 frames.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `map.rb` only — `expected 2, got 6`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1080 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_