### PR TITLE
Fix: Move Type "Random" is a relative turn roll, not a fresh cardinal

### DIFF
--- a/changelog.d/move-type-random-relative-turn.fixed.md
+++ b/changelog.d/move-type-random-relative-turn.fixed.md
@@ -1,0 +1,10 @@
+- **Move Type "Random":** a Random-moving event now rolls a *relative* turn
+  off its own current facing -- matching RPG_RT's own
+  `Game_Event::MoveTypeRandom`, which continues straight most of the time
+  (30%), turns 90° left (20%) or right (20%), turns 180° (10%), or skips the
+  move attempt entirely for that tick (20%) -- instead of restarting in a
+  fresh, independent absolute cardinal direction every single step.
+  Previously, a "Random"-moving NPC spun between the four cardinal
+  directions with no continuity between steps; real RPG_RT's Random movers
+  read as noticeably more purposeful, tending to wander mostly straight
+  with occasional turns.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -428,6 +428,40 @@ The work below is roughly ordered by the critical path to a walkable game
   model, not a one-line fix) and a genuinely separate discrepancy from the
   blocked-move-facing gap just closed above — left for its own future
   investigation.
+  ✅ **Follow-up (2026-08-20): closed the Random-move gap just above —
+  ~~`random` picks a cardinal~~, a fresh independent uniform cardinal every
+  single step, where real RPG_RT rolls a relative turn off the event's own
+  current facing and sometimes skips the move attempt entirely.** Re-confirmed
+  against RPG_RT's own live source: `Game_Event::MoveTypeRandom`
+  (`src/game_event.cpp`) draws `Rand::GetRandomNumber(0, 9)`: 0-2 (30%) keep
+  going straight with no turn, 3-4 (20%) `Turn90DegreeLeft()`, 5-6 (20%)
+  `Turn90DegreeRight()`, 7 (10%) `Turn180Degree()`, and 8-9 (20%)
+  `SetStopCount(Rand::GetRandomNumber(0, GetMaxStopCount())); return;` —
+  skipping the movement decision *before* `Move()` is ever called, so there is
+  no move attempt that tick at all, not even one in the already-current
+  facing. `Turn90DegreeLeft`/`Turn90DegreeRight`/`Turn180Degree`
+  (`src/game_character.cpp`) are themselves plain `SetDirection` remaps with
+  no passability check of their own — `GetDirection90DegreeLeft(dir)` is
+  `(dir + 3) % 4`, `GetDirection90DegreeRight` is `(dir + 1) % 4`,
+  `GetDirection180Degree` is `(dir + 2) % 4` (`src/game_character.h`, against
+  that file's `Up = 0, Right, Down, Left` enum) — confirmed to match this
+  codebase's existing `Character::TURN_LEFT`/`TURN_RIGHT`/`TURN_180` hashes
+  (`mruby-rpg2k/mrblib/game.rb`) direction-for-direction, so no new rotation
+  table was needed. Fixed by replacing `Game::MoveType.next_direction`'s
+  `RANDOM` case (`Character::CARDINALS[world.random(4)]`) with a new
+  `MoveType.random_direction` porting the same ten-way roll, reusing
+  `TURN_LEFT`/`TURN_RIGHT`/`TURN_180` for the three turning branches and
+  returning `nil` for the skip draw — already `#step_event`'s own sentinel
+  for "no autonomous movement this frame" (`move_autonomous(e, dir, ...) if
+  dir`, `mruby-rpg2k/mrblib/scene/map.rb`), so no caller-side change was
+  needed: `nil` never collides with a real numpad direction (2/4/6/8 are all
+  truthy). Covered by a new `scripts/rpg2k_logic_check.rb` check exercising
+  all five draw outcomes (straight, left, right, 180, skip) off a fixed
+  starting facing, confirmed to fail against the pre-fix code (`expected 6,
+  got 2` — the old implementation's `world.random(4)` call consumed the
+  queued roll but the RANDOM case never even looked at a `random(10)` draw,
+  landing on the FakeWorld's fallback-0 cardinal, `CARDINALS[0] == 2`,
+  instead of the still-facing-right `6` the fix produces) before the fix.
   ✅ **Follow-up (2026-08-20): a move route's effect-only sub-commands
   (Switch On/Off, Speed/Frequency Up/Down, Change Graphic, Play Sound,
   Through Mode, Stop/Start Animation, Transparency Up/Down) each paid a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6660,12 +6660,16 @@ module Game
   end
 
   # Autonomous (non-custom) event movement: given a page's `move_type`, pick the
-  # direction the character should try to step next. `random` picks a cardinal;
+  # direction the character should try to step next. ~~`random` picks a
+  # cardinal~~ -- corrected against RPG_RT's own live source: `random` rolls a
+  # *relative* turn off the event's own current facing instead, and sometimes
+  # skips the move attempt entirely -- see #random_direction's own citation;
   # `vertical`/`horizontal` keep bouncing along one axis, reversing when the way
   # ahead is blocked; `toward`/`away` chase or flee the hero, but only most of
   # the time and only in sight -- see #toward_away_direction's own citation.
-  # Returns a numpad direction, or nil for "no autonomous movement" (stationary)
-  # and for the custom-route type (which is driven by a MoveRoute instead).
+  # Returns a numpad direction, or nil for "no autonomous movement" (stationary,
+  # the custom-route type -- driven by a MoveRoute instead -- and a `random`
+  # draw that skips this decision's move attempt entirely).
   module MoveType
     STATIONARY = 0
     RANDOM     = 1
@@ -6677,13 +6681,46 @@ module Game
 
     def self.next_direction(type, character, world)
       case type
-      when RANDOM     then Character::CARDINALS[world.random(4)]
+      when RANDOM     then random_direction(character, world)
       when VERTICAL   then bounce(character, world, [8, 2])
       when HORIZONTAL then bounce(character, world, [4, 6])
       when TOWARD then toward_away_direction(character, world, true)
       when AWAY   then toward_away_direction(character, world, false)
       else nil
       end
+    end
+
+    # Random movement is a *relative* roll off the event's own current facing,
+    # not a uniform pick among the four absolute cardinals -- confirmed against
+    # RPG_RT's own live source: `Game_Event::MoveTypeRandom` (`src/
+    # game_event.cpp`) draws `Rand::GetRandomNumber(0, 9)`: 0-2 (30%) keep
+    # going straight with no turn at all, 3-4 (20%) turn 90 degrees left, 5-6
+    # (20%) turn 90 degrees right, 7 (10%) turn 180 degrees, and 8-9 (20%)
+    # skip the movement decision entirely -- `SetStopCount(Rand::
+    # GetRandomNumber(0, GetMaxStopCount())); return;` fires *before* `Move()`
+    # is ever called, so there is no move attempt this tick at all, not even
+    # one in the direction the character already faces.
+    # `Turn90DegreeLeft`/`Turn90DegreeRight`/`Turn180Degree` (`src/
+    # game_character.cpp`) are themselves plain `SetDirection` remaps with no
+    # passability check of their own (`GetDirection90DegreeLeft(dir)` is
+    # `(dir + 3) % 4`, `GetDirection90DegreeRight` is `(dir + 1) % 4`,
+    # `GetDirection180Degree` is `(dir + 2) % 4`, against that file's `Up = 0,
+    # Right, Down, Left` enum) -- exactly this codebase's own
+    # `Character::TURN_LEFT`/`TURN_RIGHT`/`TURN_180` hashes, confirmed to
+    # match direction-for-direction (both rotate Up -> Left -> Down -> Right
+    # -> Up for a left turn and the reverse for a right turn). Returns nil for
+    # the skip draw -- already `#step_event`'s own sentinel for "no
+    # autonomous movement this frame" (see STATIONARY/CUSTOM above), so no
+    # caller-side change was needed to keep it distinct from a real
+    # direction: nil never collides with a numpad direction (2/4/6/8 are all
+    # truthy).
+    def self.random_direction(character, world)
+      draw = world.random(10)
+      return character.direction if draw < 3
+      return Character::TURN_LEFT[character.direction]  || character.direction if draw < 5
+      return Character::TURN_RIGHT[character.direction] || character.direction if draw < 7
+      return Character::TURN_180[character.direction]   || character.direction if draw == 7
+      nil
     end
 
     # Approach/Away from Player is not the deterministic beeline it looks

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -741,6 +741,40 @@ check 'MoveType stationary and custom yield no autonomous direction' do
   eq nil, Game::MoveType.next_direction(Game::MoveType::CUSTOM, c, w)
 end
 
+check 'MoveType random is a relative roll off the event\'s own current ' \
+      'facing, not a uniform pick among the four absolute cardinals -- ' \
+      'confirmed against RPG_RT\'s own live source: Game_Event::' \
+      'MoveTypeRandom (src/game_event.cpp) draws Rand::GetRandomNumber(0, ' \
+      '9): 0-2 keep going straight, 3-4 turn left, 5-6 turn right, 7 turns ' \
+      '180, and 8-9 skip the move attempt entirely -- returning before ' \
+      'Move() is ever called' do
+  # Facing right (6): TURN_LEFT[6] == 8 (up), TURN_RIGHT[6] == 2 (down),
+  # TURN_180[6] == 4 (left).
+  c = Game::Character.new(0, 0, 6)
+
+  # draw 0-2: continue straight, no turn -- still the current facing.
+  eq 6, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [0]))
+  eq 6, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [2]))
+
+  # draw 3-4: turn 90 degrees left and attempt that new direction.
+  eq 8, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [3]))
+  eq 8, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [4]))
+
+  # draw 5-6: turn 90 degrees right and attempt that new direction.
+  eq 2, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [5]))
+  eq 2, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [6]))
+
+  # draw 7: turn 180 degrees and attempt that new direction.
+  eq 4, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [7]))
+
+  # draw 8-9: skip this decision entirely -- nil, not a move in the
+  # character's current direction and not any other real direction value,
+  # so #step_event's `move_autonomous(...) if dir` never even calls
+  # #move_autonomous this tick, exactly like RPG_RT never calling Move().
+  eq nil, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [8]))
+  eq nil, Game::MoveType.next_direction(Game::MoveType::RANDOM, c, FakeWorld.new(rolls: [9]))
+end
+
 check 'MoveType vertical bounces off a blocked tile' do
   c = Game::Character.new(2, 2, 8) # heading up
   # Up (2,1) is blocked, so it should reverse to down.


### PR DESCRIPTION
## Summary
- `Game::MoveType.next_direction`'s `RANDOM` case picked a uniform random cardinal (`Character::CARDINALS[world.random(4)]`) every single decision, independent of the event's previous facing. Real RPG_RT's `Game_Event::MoveTypeRandom` (`src/game_event.cpp`) is not that: it draws `Rand::GetRandomNumber(0, 9)` and rolls a *relative* turn off the event's own current facing — 0-2 (30%) continue straight with no turn at all, 3-4 (20%) turn 90° left, 5-6 (20%) turn 90° right, 7 (10%) turn 180°, and 8-9 (20%) skip the movement decision entirely (`SetStopCount(...); return;`, which fires *before* `Move()` is ever called, so there is no move attempt that tick at all — not even a step in the already-current facing).
- `Turn90DegreeLeft`/`Turn90DegreeRight`/`Turn180Degree` (`src/game_character.cpp`) are themselves plain `SetDirection` remaps with no passability check of their own — `GetDirection90DegreeLeft(dir)` is `(dir + 3) % 4`, `GetDirection90DegreeRight` is `(dir + 1) % 4`, `GetDirection180Degree` is `(dir + 2) % 4` against that file's `Up = 0, Right, Down, Left` enum (`src/game_character.h`). Confirmed these match this codebase's existing `Character::TURN_LEFT`/`TURN_RIGHT`/`TURN_180` hashes direction-for-direction, so the fix reuses them as-is rather than adding a new rotation table.
- Concretely: a "Random"-moving NPC previously spun between the four absolute cardinals with no continuity between steps, restarting fresh every decision. Real RPG_RT's Random movers read as noticeably more purposeful — mostly continuing straight, with occasional 90/180° turns and occasional idle pauses where no move is attempted at all.
- Fixed by replacing the `RANDOM` case with a new `MoveType.random_direction` that ports the same ten-way roll. The skip-decision draw (8-9) returns `nil`, which was already `Scene::Map#step_event`'s own sentinel for "no autonomous movement this frame" (`move_autonomous(e, dir, ...) if dir`) — `nil` never collides with a real numpad direction (2/4/6/8 are all truthy), so no caller-side change was needed.
- This was independently surfaced (but deliberately left unfixed to keep that change narrow) by the prior "blocked autonomous move no longer turns to face the obstacle" fix in this same area — see `docs/TODO.md`'s paragraph beginning "Also surfaced, deliberately left out of this fix to keep it narrow" for the original note.
- Corrected the `MoveType`/`next_direction` doc comment, which described `random` as picking a cardinal with no qualification.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check exercising all five draw outcomes (straight, left, right, 180, skip) off a fixed starting facing.
- [x] Confirmed the new check fails against the pre-fix code (checked out `game.rb` from the prior commit, test file untouched — `expected 6, got 2`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1081 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_