### PR TITLE
Fix: Vertical/Horizontal-cycle default direction reversed off-axis

### DIFF
--- a/changelog.d/move-type-cycle-off-axis-default.fixed.md
+++ b/changelog.d/move-type-cycle-off-axis-default.fixed.md
@@ -1,0 +1,6 @@
+- **Move Type Vertical/Horizontal-cycle:** an event caught facing off its
+  own cycle axis (e.g. a Vertical-cycle event whose page facing is Left or
+  Right) now takes its first autonomous step in the correct default
+  direction -- matching RPG_RT's own `Game_Event::MoveTypeCycle`, whose
+  default is Down for Vertical-cycle and Right for Horizontal-cycle.
+  Previously it stepped the opposite way (Up / Left) instead.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -462,6 +462,44 @@ The work below is roughly ordered by the critical path to a walkable game
   queued roll but the RANDOM case never even looked at a `random(10)` draw,
   landing on the FakeWorld's fallback-0 cardinal, `CARDINALS[0] == 2`,
   instead of the still-facing-right `6` the fix produces) before the fix.
+  ✅ **Follow-up (2026-08-20): `Game::MoveType.bounce`'s Vertical/Horizontal-
+  cycle default direction was reversed for an event caught facing off its
+  own cycle axis.** Confirmed against RPG_RT's own live source:
+  `Game_Event::MoveTypeCycle` (`src/game_event.cpp`) only continues in
+  `ReverseDir(default_dir)` when the event is already facing exactly that;
+  every other current facing — on-axis (facing `default_dir` itself) or not
+  (facing perpendicular to the cycle axis, a legal independent page field a
+  Vertical/Horizontal-cycle event can start with, or get knocked into by a
+  Change Event Location or forced Face command while staying on the same
+  page) — moves `default_dir` instead. `MoveTypeCycleUpDown`/
+  `MoveTypeCycleLeftRight` pass `Down`/`Right` as that default
+  (`src/game_character.h`'s `Up = 0, Right, Down, Left` enum), so the true
+  RPG_RT default is Down for Vertical, Right for Horizontal — not Up/Left.
+  `Game::MoveType.next_direction`'s `VERTICAL`/`HORIZONTAL` cases
+  (`mruby-rpg2k/mrblib/game.rb`) called `#bounce(character, world, [8, 2])`/
+  `[4, 6])`, whose own fallback for "not currently facing either pair
+  member" is `pair[0]` — `8` (Up) and `4` (Left) respectively, the reverse
+  of RPG_RT's actual default. Concretely: a Vertical-cycle event whose page
+  facing is Left or Right (or a Horizontal-cycle event facing Up or Down)
+  took its very first autonomous step in the wrong direction — Up instead
+  of Down, or Left instead of Right — a deterministic, player-visible
+  reversal on any such off-axis-starting-facing event, not a rare edge
+  case. Fixed by swapping the pair argument order at both call sites
+  (`[2, 8]`/`[6, 4]`) — `#bounce`'s own body needed no change, since its
+  reversal branch (`cur == pair[0] ? pair[1] : pair[0]`) is already
+  order-symmetric; only the off-axis fallback needed the correct default
+  first. Covered by a new `scripts/rpg2k_logic_check.rb` check (a
+  Vertical-cycle event facing Left defaults to Down, a Horizontal-cycle
+  event facing Down defaults to Right), confirmed to fail against the
+  pre-fix code (`expected 2, got 8`) before the fix. Left deliberately
+  untouched: `#bounce`'s own immediate on-block reversal (checking
+  passability once and flipping straight to the opposite pair member) does
+  not reproduce `MoveTypeCycle`'s actual staged timing — a fresh block
+  keeps the current direction and only reverses once stuck for `stop_count
+  >= max_stop_count + 20` frames, itself layered under the same
+  blocked-move-facing-revert threshold (`+ 60` frames) already flagged as
+  a further follow-up above — a separate, deeper timing discrepancy from
+  the plain default-direction bug this fix closes.
   ✅ **Follow-up (2026-08-20): a move route's effect-only sub-commands
   (Switch On/Off, Speed/Frequency Up/Down, Change Graphic, Play Sound,
   Through Mode, Stop/Start Animation, Transparency Up/Down) each paid a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6682,8 +6682,8 @@ module Game
     def self.next_direction(type, character, world)
       case type
       when RANDOM     then random_direction(character, world)
-      when VERTICAL   then bounce(character, world, [8, 2])
-      when HORIZONTAL then bounce(character, world, [4, 6])
+      when VERTICAL   then bounce(character, world, [2, 8])
+      when HORIZONTAL then bounce(character, world, [6, 4])
       when TOWARD then toward_away_direction(character, world, true)
       when AWAY   then toward_away_direction(character, world, false)
       else nil
@@ -6749,7 +6749,20 @@ module Game
     end
 
     # Continue along the current axis direction, reversing to the other end of
-    # `pair` when the way ahead is blocked.
+    # `pair` when the way ahead is blocked. `pair[0]` is also the default when
+    # the event is not currently facing either end of the axis at all (an
+    # independent page field, so a Vertical/Horizontal-cycle event can start
+    # -- or be knocked, by a Change Event Location or forced Face command --
+    # facing perpendicular to its own cycle axis) -- confirmed against
+    # RPG_RT's own live source: `Game_Event::MoveTypeCycle` (`src/
+    # game_event.cpp`) only continues in `ReverseDir(default_dir)` when
+    # already facing exactly that; every other current facing, on-axis or
+    # not, moves `default_dir` instead. `MoveTypeCycleUpDown`/
+    # `MoveTypeCycleLeftRight` pass `Down`/`Right` as that default (`src/
+    # game_character.h`'s `Up = 0, Right, Down, Left` enum), so `pair[0]`
+    # here is `2`/`6`, not `8`/`4` -- a Vertical/Horizontal event caught
+    # facing off-axis took its first step Up/Left instead of RPG_RT's own
+    # Down/Right until this was corrected.
     def self.bounce(character, world, pair)
       cur = pair.include?(character.direction) ? character.direction : pair[0]
       return cur if world.passable?(character, cur)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -784,6 +784,25 @@ check 'MoveType vertical bounces off a blocked tile' do
   eq 8, Game::MoveType.next_direction(Game::MoveType::VERTICAL, c, FakeWorld.new)
 end
 
+check 'MoveType vertical/horizontal-cycle defaults to Down/Right (not Up/' \
+      'Left) when the event is caught facing off its own cycle axis -- ' \
+      'confirmed against RPG_RT\'s own live source: Game_Event::' \
+      'MoveTypeCycle (src/game_event.cpp) only continues in ReverseDir(' \
+      'default_dir) when already facing exactly that; any other current ' \
+      'facing (on-axis or not) moves default_dir instead, and ' \
+      'MoveTypeCycleUpDown/MoveTypeCycleLeftRight pass Down/Right as that ' \
+      'default' do
+  # Vertical-cycle event facing sideways (Left/6): neither pair member, so
+  # it must fall to the RPG_RT default (Down), not the old code's Up.
+  c = Game::Character.new(2, 2, 4)
+  eq 2, Game::MoveType.next_direction(Game::MoveType::VERTICAL, c, FakeWorld.new)
+
+  # Horizontal-cycle event facing vertically (Down/2): neither pair member,
+  # so it must fall to the RPG_RT default (Right), not the old code's Left.
+  c2 = Game::Character.new(2, 2, 2)
+  eq 6, Game::MoveType.next_direction(Game::MoveType::HORIZONTAL, c2, FakeWorld.new)
+end
+
 check 'MoveType toward/away chase and flee the hero, gated on sight and a ' \
       '1-in-10 roll -- confirmed against RPG_RT\'s own live source: ' \
       'Game_Event::MoveTypeTowardsOrAwayPlayer (src/game_event.cpp) only ' \


### PR DESCRIPTION
## Summary
- `Game_Event::MoveTypeCycle` (`src/game_event.cpp`) only continues in `ReverseDir(default_dir)` when the event is already facing exactly that; every other current facing — on-axis (facing `default_dir` itself) or not (facing perpendicular to the cycle axis, a legal independent page field) — moves `default_dir` instead. `MoveTypeCycleUpDown`/`MoveTypeCycleLeftRight` pass `Down`/`Right` as that default (`src/game_character.h`'s `Up = 0, Right, Down, Left` enum), so the true RPG_RT default is Down for Vertical, Right for Horizontal.
- `Game::MoveType.next_direction`'s `VERTICAL`/`HORIZONTAL` cases (`mruby-rpg2k/mrblib/game.rb`) called `#bounce(character, world, [8, 2])`/`[4, 6])`, whose own fallback for "not currently facing either pair member" is `pair[0]` — `8` (Up) and `4` (Left) respectively, the reverse of RPG_RT's actual default.
- Concretely: a Vertical-cycle event whose page facing is Left or Right (or a Horizontal-cycle event facing Up or Down) took its very first autonomous step in the wrong direction — Up instead of Down, or Left instead of Right — a deterministic, player-visible reversal on any such off-axis-starting-facing event, not a rare edge case.
- Fixed by swapping the pair argument order at both call sites (`[2, 8]`/`[6, 4]`) — `#bounce`'s own body needed no change, since its reversal branch (`cur == pair[0] ? pair[1] : pair[0]`) is already order-symmetric; only the off-axis fallback needed the correct default first.
- Left deliberately untouched (documented in `docs/TODO.md`): `#bounce`'s own immediate on-block reversal does not reproduce `MoveTypeCycle`'s actual staged timing (a fresh block keeps the current direction, only reversing once stuck for `stop_count >= max_stop_count + 20` frames) — a separate, deeper timing discrepancy from the plain default-direction bug this fix closes.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a Vertical-cycle event facing Left defaults to Down, a Horizontal-cycle event facing Down defaults to Right.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — `expected 2, got 8`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1082 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_