### PR TITLE
Fix: a non-revive medicine no longer affects a downed party member

### DIFF
--- a/changelog.d/use-medicine-downed-target-abort.fixed.md
+++ b/changelog.d/use-medicine-downed-target-abort.fixed.md
@@ -1,0 +1,9 @@
+- **Field Item menu:** an ordinary medicine that does not cure Death (an
+  Antidote-style item that cures some other state, or a plain HP/MP potion)
+  now does nothing at all when used on a downed party member -- no state
+  cure, no HP change, no MP change -- matching RPG_RT's own
+  `Game_Battler::UseItem`, which aborts the whole call immediately for a
+  dead target unless the item cures Death. Previously such an item could
+  silently cure an unrelated status condition or restore MP on a KO'd
+  member and still be consumed, instead of the Buzzer/kept-item no-op real
+  RPG_RT gives.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6290,6 +6290,32 @@ The work below is roughly ordered by the critical path to a walkable game
   Skill Book/Seed used on a downed actor teaches nothing, changes no stat,
   and consumes nothing), both confirmed to fail against the pre-fix code
   (`expected false, got true`).
+  ✅ **Follow-up (2026-08-20): ~~an ordinary non-`ko_only` medicine on a dead
+  actor is also refused, per `Game_Battler::UseItem`'s own `IsDead()`
+  branch, already correctly ported~~ -- corrected, it was not: `#use_medicine`
+  had no `IsDead()`-style guard of its own at all.** The claim above,
+  asserted with no independent check of `#use_medicine`'s own code, was
+  wrong on inspection: `Game_Battler::UseItem` (`src/game_battler.cpp`)
+  checks `IsDead()` *before* anything else and returns `false` immediately
+  -- no state-cure loop, no HP change, no SP change run at all -- unless
+  `item->state_set[0]` (state id 1, Death) is flagged; `#use_medicine`
+  (`mruby-rpg2k/mrblib/game.rb`) only ever gated a *living* target from a
+  `ko_only` item (`#ko_only_blocked?`), never a *dead* target from an
+  ordinary one. `#change_hp` already happens to no-op for a dead actor on
+  its own (`return @hp if dead?`), which is what hid this for the HP half
+  alone and let the earlier claim read as plausible without being checked
+  -- but the cure loop and `#change_mp` (which has no such guard) do not:
+  giving a KO'd party member an Antidote-style item that cures some other
+  state but not Death silently cured it anyway, and any medicine restoring
+  MP topped it up too, both consuming the item and playing the success cue
+  instead of RPG_RT's Buzzer/kept-item no-op. Fixed by adding `next if
+  t.dead? && !cured.include?(Game::Actor::DEATH_STATE)` to `#use_medicine`'s
+  per-target loop, ahead of the existing `#ko_only_blocked?` check, mirroring
+  `IsDead()`'s own precedence in the reference. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a medicine curing Poison but not
+  Death, used on a target carrying both, leaves the Poison, HP, MP and item
+  count all untouched), confirmed to fail against the pre-fix code
+  (Poison cured, MP restored, item spent) before the fix.
 - ✅ **A battle switch item now actually flips its switch.** A switch item
   (type 10) was already listed in the battle Item command
   (`Game::Party#battle_usable?` / `#battle_items` both include `ITEM_SWITCH`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4543,6 +4543,20 @@ module Game
       cured = item_cured_states(it)
       affected = []
       targets.each do |t|
+        # A downed target blocks the item outright unless it's a revive (one
+        # that cures 戦闘不能) -- confirmed against RPG_RT's own live source:
+        # `Game_Battler::UseItem` (`src/game_battler.cpp`) checks `IsDead()`
+        # *before* anything else and returns `false` immediately -- no state
+        # cure, no HP change, no SP change at all -- unless `item->state_set
+        # [0]` (state id 1, Death) is flagged. Without this, an ordinary
+        # medicine with no Death cure (an Antidote that only cures Poison, or
+        # a plain HP/MP potion) used on a KO'd member with some other
+        # affliction silently cured it and/or topped up MP and consumed the
+        # item -- `#change_hp` already happens to no-op for a dead actor on
+        # its own (`return @hp if dead?`), which is what hid this for the HP
+        # half alone, but the cure loop and `#change_mp` below have no such
+        # guard of their own.
+        next if t.dead? && !cured.include?(Game::Actor::DEATH_STATE)
         # A 蘇生専用 item passes over anyone still standing without touching
         # them -- not even the HP restore -- which is what keeps an all-party
         # revive from topping up the members who never fell. An actor_set

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -19066,6 +19066,32 @@ check 'an ordinary medicine is unaffected by the rule' do
   eq 90, hero.hp
 end
 
+check 'a medicine that does not cure Death does nothing at all to a downed ' \
+      'target -- not even curing an unrelated state or restoring MP, and ' \
+      'the item is not spent' do
+  # Confirmed against RPG_RT's own live source: `Game_Battler::UseItem`
+  # (src/game_battler.cpp) checks `IsDead()` before anything else and
+  # returns `false` immediately -- no state-cure loop, no HP change, no SP
+  # change run at all -- unless `item->state_set[0]` (state id 1, Death) is
+  # flagged. An Antidote-style item that cures some other state (Poison,
+  # state id 2 here) but not Death must leave a KO'd target's Poison
+  # untouched too, not just skip the HP/MP halves independently.
+  items = { 6 => fake_item(type: 6, rhp: 50, rsp: 20, state_set: [nil, true]) }
+  st = item_party(items)
+  st.party.gain_item(6, 1)
+  hero = st.party.actor_by_id(1)
+  hero.add_state(Game::Actor::DEATH_STATE)
+  hero.add_state(2) # Poison, alongside Death
+  hero.mp = 0
+  ok hero.dead?
+  eq [], st.party.use_item(6, hero)
+  ok hero.dead?, 'still down -- the item does not cure Death'
+  ok hero.state?(2), 'Poison is not cured either -- the whole call aborts, ' \
+                      'not just the HP/MP halves'
+  eq 0, hero.mp, 'MP is untouched'
+  eq 1, st.party.item_count(6), 'nothing is spent'
+end
+
 # An all-party revive passes over the members who never fell rather than topping
 # them up, which is the case the "not even the HP" reading decides.
 check 'an all-party revive skips the members still standing' do


### PR DESCRIPTION
## Summary
- `Game_Battler::UseItem` (`src/game_battler.cpp`) checks `IsDead()` before anything else and returns `false` immediately — no state-cure loop, no HP change, no SP change at all — unless `item->state_set[0]` (state id 1, Death) is flagged.
- `Game::Party#use_medicine` (`mruby-rpg2k/mrblib/game.rb`) only ever gated a *living* target from a `ko_only` item (`#ko_only_blocked?`), never a *dead* target from an ordinary one. `#change_hp` already no-ops for a dead actor on its own (`return @hp if dead?`), which hid this for the HP half alone, but the cure loop and `#change_mp` (no such guard) do not.
- An Antidote-style item that cures some other state but not Death used on a KO'd member silently cured it anyway, and any medicine restoring MP topped it up too — both consuming the item and playing the success cue instead of RPG_RT's Buzzer/kept-item no-op.
- Fixed by adding `next if t.dead? && !cured.include?(Game::Actor::DEATH_STATE)` to `#use_medicine`'s per-target loop, ahead of the existing `#ko_only_blocked?` check, mirroring `IsDead()`'s own precedence in the reference.
- Corrects a prior `docs/TODO.md` claim (from an earlier Skill Book/Seed fix's own writeup) asserting the reverse case was "already correctly ported" — it was not; that claim was never independently checked against `#use_medicine`'s own code, only inferred from `#change_hp`'s coincidental no-op.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check: a medicine curing Poison but not Death, used on a target carrying both, leaves the Poison, HP, MP and item count all untouched.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — Poison cured, MP restored, item spent) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1083 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_