### PR TITLE
Fix: a field skill's SP restoration is blocked on a downed target too

### DIFF
--- a/changelog.d/cast-skill-sp-downed-target.fixed.md
+++ b/changelog.d/cast-skill-sp-downed-target.fixed.md
@@ -1,0 +1,5 @@
+- **Field Skill menu:** a skill with Affect SP on but no Death cure no
+  longer restores SP on a downed (dead, non-revived) party member -- matching
+  RPG_RT's own `Game_Battler::UseSkill`, whose SP-restoration branch carries
+  the identical `!IsDead()` guard its HP sibling already had. Previously a
+  KO'd member's SP could be silently topped up while they stayed downed.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17608,6 +17608,43 @@ above are repeated here)
   max HP rather than overshooting), all four confirmed to fail against the
   pre-fix code (`expected 25, got 1` / `expected 50, got 1` / `expected
   50, got 1` / `expected 100, got 1`) before the fix.
+  ✅ **Follow-up (2026-08-20): a field-cast skill's SP restoration was not
+  blocked on a downed (dead, non-revived) target the way its HP sibling
+  already was.** `Game_Battler::UseSkill`'s own out-of-battle HP/SP
+  branches (`src/game_battler.cpp`, cited above) gate identically: `effect
+  > 0 && skill->affect_hp && !HasFullHp() && !IsDead()` for HP, `effect >
+  0 && skill->affect_sp && !HasFullSp() && !IsDead()` for SP — the same
+  `!IsDead()` guard on both. `Game::Party#cast_skill`
+  (`mruby-rpg2k/mrblib/game.rb`) had `t.change_mp(amount) if sk.affect_sp
+  && amount > 0` with no dead-target guard of its own; the HP branch
+  (`t.change_hp(amount) if sk.affect_hp && amount > 0`, right above it)
+  only came out correct incidentally, via `Actor#change_hp`'s own built-in
+  `return @hp if dead?` early return — `Actor#change_mp` has no such guard
+  at all. Concretely: casting a field skill with Affect SP on but no Death
+  cure (an SP-restoring support skill, say) on a KO'd party member silently
+  topped up their SP while they stayed downed, something real RPG_RT never
+  does. Fixed by adding `&& !t.dead?` to the SP branch — `t.dead?` there
+  already reflects any Death cure the same loop iteration already applied
+  (the cure loop runs first), so a genuine revive skill with Affect SP on
+  still restores SP correctly; only a target still dead at that point is
+  blocked, matching the reference exactly. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check mirroring the existing "a plain heal
+  skill cannot revive a downed ally" one immediately above it in the test
+  file, but for an SP-restoring skill instead, confirmed to fail against
+  the pre-fix code (the downed ally's MP was fully restored) before the
+  fix. **Not fixed here, noticed along the way**: `Game::Party
+  #skill_effective?` (used to grey out a no-op skill in the menu) checks
+  `t.hp < t.max_hp` / `t.mp < t.max_mp` for its Affect HP/SP clauses with
+  no `t.dead?` guard either — a dead target's HP/MP always reads as "less
+  than max," so a non-reviving skill with Affect HP or SP set still shows
+  as selectable against a downed ally even now that casting it is
+  correctly a no-op. Whether real RPG_RT's own field Skill menu greys out
+  a target row by per-target effectiveness at all (`Window_Skill::
+  CheckEnable`, the one greying mechanism independently checked while
+  investigating this, only gates the *skill list* by caster-side
+  learnedness/usability — it has no target-specific "would this help"
+  concept at that layer) was not verified before writing this note, so
+  it's left for a dedicated follow-up rather than guessed at here.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5394,7 +5394,18 @@ module Game
           # plays here).
           t.change_hp(t.max_hp * amount / 100 - 1)
         end
-        t.change_mp(amount) if sk.affect_sp && amount > 0
+        # `!t.dead?` mirrors `Game_Battler::UseSkill`'s own SP branch
+        # (`src/game_battler.cpp`): `effect > 0 && skill->affect_sp &&
+        # !HasFullSp() && !IsDead()`, the exact same `!IsDead()` guard its HP
+        # sibling carries just above. `t.dead?` here already reflects any
+        # Death cure this same loop iteration just applied (`cured.each`,
+        # above), so a genuine revive skill with Affect SP on still restores
+        # SP correctly -- only a target still dead at this point (the skill
+        # did not cure Death) is blocked, matching the reference exactly.
+        # `#change_hp`'s own `return @hp if dead?` guard gives the HP branch
+        # this same protection incidentally; `#change_mp` has no such guard
+        # of its own, so this needed to be explicit here.
+        t.change_mp(amount) if sk.affect_sp && amount > 0 && !t.dead?
         changed ||= t.hp != before_hp || t.mp != before_mp
         affected.push(t) if changed
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7501,6 +7501,28 @@ check 'a plain heal skill cannot revive a downed ally' do
   eq 30, hero.mp                               # nothing spent
 end
 
+check 'an SP-restoring skill cannot touch a downed ally either' do
+  # Confirmed against RPG_RT's own live source: `Game_Battler::UseSkill`
+  # (src/game_battler.cpp) gates SP restoration behind the identical
+  # `!IsDead()` guard its HP sibling carries just above it (`effect > 0 &&
+  # skill->affect_sp && !HasFullSp() && !IsDead()`) -- a non-reviving skill
+  # must leave a downed target's SP untouched exactly like it leaves HP
+  # untouched, the same rule the "plain heal" check just above already
+  # covers for the HP branch.
+  skills = { 10 => fake_skill(name: 'Refresh SP', scope: 3, sp_cost: 5,
+                              power: 20, mrate: 40, sp: true) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.learn_skill(10)
+  ally.change_hp(-9999)                        # KO
+  ally.mp = 0
+  eq [], st.party.cast_skill(hero, 10, ally)   # a plain SP-restore can't touch a KO'd actor
+  eq true, ally.dead?
+  eq 0, ally.mp, 'SP is not restored on a downed, non-revived target'
+  eq 30, hero.mp                               # nothing spent
+end
+
 check 'a reverse skill inflicts its state_effects states' do
   skills = { 8 => fake_skill(name: 'Curse', scope: 3, sp_cost: 3,
                              state_effects: [0, 0, 1], reverse_state: true) }


### PR DESCRIPTION
## Summary
- `Game_Battler::UseSkill` (`src/game_battler.cpp`) gates HP and SP restoration identically: `effect > 0 && skill->affect_hp && !HasFullHp() && !IsDead()` for HP, `effect > 0 && skill->affect_sp && !HasFullSp() && !IsDead()` for SP — the same `!IsDead()` guard on both.
- `Game::Party#cast_skill` (`mruby-rpg2k/mrblib/game.rb`) had `t.change_mp(amount) if sk.affect_sp && amount > 0` with no dead-target guard of its own. The HP branch right above it only came out correct incidentally, via `Actor#change_hp`'s own built-in `return @hp if dead?` early return — `Actor#change_mp` has no such guard at all.
- Casting a field skill with Affect SP on but no Death cure (an SP-restoring support skill, say) on a KO'd party member silently topped up their SP while they stayed downed, something real RPG_RT never does.
- Fixed by adding `&& !t.dead?` to the SP branch — `t.dead?` there already reflects any Death cure the same loop iteration already applied (the cure loop runs first), so a genuine revive skill with Affect SP on still restores SP correctly; only a target still dead at that point is blocked.
- Also documented (but deliberately not fixed, since it needs independent verification of its own) a possible companion gap: `Game::Party#skill_effective?`'s menu-greying logic checks `t.hp < t.max_hp`/`t.mp < t.max_mp` with no `t.dead?` guard either, so a non-reviving skill still shows as selectable against a downed ally. Whether real RPG_RT's own Skill menu even greys out by per-target effectiveness at all wasn't verified before writing this note (`Window_Skill::CheckEnable` only gates the skill list by caster-side usability, no target-specific concept at that layer) — left for a dedicated follow-up.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check mirroring the existing "a plain heal skill cannot revive a downed ally" test, but for an SP-restoring skill.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — the downed ally's MP was fully restored) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1084 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_