### PR TITLE
Keep a preemptive weapon's turn-order jump under Berserk

### DIFF
--- a/changelog.d/preemptive-weapon-berserk-turn-order.fixed.md
+++ b/changelog.d/preemptive-weapon-berserk-turn-order.fixed.md
@@ -1,0 +1,7 @@
+- **Battle:** a `preemptive` (先制攻撃) weapon's turn-order jump to the front
+  of the round no longer drops when its wielder is forced to attack under
+  Berserk -- matching RPG_RT's own `CreateExecutionOrder`, whose `+9999`
+  bonus keys purely on a `Type::Normal` attack plus the weapon flag, with no
+  dependency on whether that attack was forced by Berserk or Confusion.
+  Previously a berserked wielder lost the jump and fell back to plain
+  agility ordering.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18316,13 +18316,35 @@ codebase yet):
   the attack-all spread to `RESTRICTION_ATTACK_ALLY` only (Berserk now always
   hits its single forced target via `#swing` directly, so the now-redundant
   `#attack_side` helper was removed in favour of the existing `#swing_side`),
-  and returning `false` from `#preemptive_boost?` for `RESTRICTION_ATTACK_ENEMY`
-  before the existing `RESTRICTION_ATTACK_ALLY` case. Covered by four new
+  ~~and returning `false` from `#preemptive_boost?` for `RESTRICTION_ATTACK_ENEMY`
+  before the existing `RESTRICTION_ATTACK_ALLY` case~~. Covered by four new
   `scripts/rpg2k_logic_check.rb` checks (Berserk plus attack-all hits one
-  target; a preemptive weapon's jump is dropped under Berserk; Berserk still
+  target; ~~a preemptive weapon's jump is dropped under Berserk~~; Berserk still
   swings a dual-wield weapon twice; a confused, attack-all, dual-wield
   attacker swings twice per target), all four confirmed to fail against the
-  pre-fix code. **Confirmed already correct, no change needed**: hit rate's
+  pre-fix code.
+  ✅ **Follow-up (2026-08-20): that `#preemptive_boost?` change above was
+  itself wrong — RPG_RT does not drop a `preemptive` weapon's turn-order jump
+  under Berserk.** The doc comment introduced alongside it cited only an
+  uncited fan-wiki page (「デフォ戦botまとめ」) for the exclusion, never a real
+  source. Checked against EasyRPG Player's actual C++: `Scene_Battle_Rpg2k::
+  SelectNextActor` (`src/scene_battle_rpg2k.cpp`) builds an identical
+  `Game_BattleAlgorithm::Normal` for a forced `Restriction_attack_ally`
+  (confusion) and `Restriction_attack_enemy` (berserk) alike — the same
+  `switch` only changes which side `GetRandomActiveBattler()` draws the
+  target from — and `CreateExecutionOrder`'s `battle_order += 9999` bonus
+  keys purely on `GetBattleAlgorithm()->GetType() == Type::Normal &&
+  HasPreemptiveAttack()` (`Game_Actor::HasPreemptiveAttack`, `src/
+  game_actor.cpp`, a bare equipped-weapon flag check), with no restriction
+  dependency anywhere in that chain. `Game::Battle#preemptive_boost?`
+  (`mruby-rpg2k/mrblib/game.rb`) now returns `true` for
+  `RESTRICTION_ATTACK_ENEMY` the same as `RESTRICTION_ATTACK_ALLY`, so
+  Berserk keeps the weapon's jump exactly like Confusion does. The
+  `scripts/rpg2k_logic_check.rb` check this same paragraph added ("a
+  preemptive weapon's jump is dropped under Berserk") was rewritten in place
+  to assert the opposite ("berserk keeps a 先制攻撃 weapon's turn-order jump,
+  same as confusion"), confirmed to fail against the pre-fix code before the
+  fix. **Confirmed already correct, no change needed**: hit rate's
   floor/ceiling relative to a skill's configured rate by relative Agility (a
   90%-accuracy skill can't exceed 95% actual hit even against a much slower
   target; an 80% one caps at 90%). `Game::Battle#to_hit`'s existing

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11207,18 +11207,26 @@ module Game
     # Whether `b`'s action this round earns the `preemptive` weapon's
     # turn-order jump: only a basic Attack qualifies (a Skill, Item or Defend
     # with the same weapon equipped keeps its ordinary agility slot, matching
-    # `CreateExecutionOrder`'s own `Type::Normal` guard). A forced
-    # attack-ally restriction (confusion) still counts, since the confused
-    # battler is still swinging a basic Attack under the hood; a forced
+    # `CreateExecutionOrder`'s own `Type::Normal` guard). ~~A forced
+    # attack-ally restriction (confusion) still counts... a forced
     # attack-enemy restriction (berserk) does not -- per the site's own
-    # デフォ戦botまとめ trivia, berserk specifically drops the weapon's
-    # preemptive jump on top of forcing the target. `preemptive` is
-    # actor-only (see Combatant), so an enemy never qualifies either way.
+    # デフォ戦botまとめ trivia~~ -- corrected against RPG_RT's own live
+    # source: `Scene_Battle_Rpg2k::SelectNextActor` (`src/
+    # scene_battle_rpg2k.cpp`) builds an identical `Game_BattleAlgorithm::
+    # Normal` for both `Restriction_attack_ally` (confusion) and
+    # `Restriction_attack_enemy` (berserk) -- the same `switch` just picks
+    # which side `GetRandomActiveBattler()` draws from -- and
+    # `CreateExecutionOrder`'s own `+= 9999` bonus and `Game_Actor::
+    # HasPreemptiveAttack` (`src/game_actor.cpp`) both key purely on
+    # `Type::Normal` plus the equipped weapon's flag, with no restriction
+    # dependency anywhere in the chain. The uncited fan-wiki claim that
+    # berserk specifically drops the bonus does not hold up against the
+    # actual source. `preemptive` is actor-only (see Combatant), so an enemy
+    # never qualifies either way.
     def preemptive_boost?(b)
       return false unless b.preemptive
       r = battler_restriction(b)
-      return false if r == RESTRICTION_ATTACK_ENEMY
-      return true if r == RESTRICTION_ATTACK_ALLY
+      return true if r == RESTRICTION_ATTACK_ALLY || r == RESTRICTION_ATTACK_ENEMY
       b.command.nil? && !b.defending && !b.skip
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15975,7 +15975,12 @@ check '先制攻撃 does not jump the turn order for a Skill, Item or Defend' do
      'Defend keeps the ordinary agility slot, even with the weapon still equipped'
 end
 
-check "battle: berserk drops a 先制攻撃 weapon's turn-order jump" do
+check "battle: berserk keeps a 先制攻撃 weapon's turn-order jump, same as confusion" do
+  # RPG_RT's SelectNextActor builds an identical Type::Normal attack for both
+  # a forced attack-enemy (berserk) and attack-ally (confusion) restriction,
+  # and CreateExecutionOrder's +9999 bonus keys purely on Type::Normal plus
+  # HasPreemptiveAttack -- neither depends on which restriction forced the
+  # attack, so berserk must jump the turn order exactly like confusion does.
   items = { 7 => fake_item(type: 1, atk: 5, preemptive: true) }
   states = { 9 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0) } # attack-enemy (berserk)
   st = geared_party(items)
@@ -15984,8 +15989,8 @@ check "battle: berserk drops a 先制攻撃 weapon's turn-order jump" do
   fast_foe = combatant('FastFoe', 0, 0, 999, 100)          # far faster than the hero
   bat = Game::Battle.new([Game::Battle.from_actor(hero)], [fast_foe], Game::Rng.new(1), states)
   bat.allies[0].states = [9]
-  eq [fast_foe, bat.allies[0]], bat.send(:turn_order),
-     "berserk drops the weapon's jump: agility alone decides again"
+  eq [bat.allies[0], fast_foe], bat.send(:turn_order),
+     "berserk still jumps the weapon's Attack ahead of a far faster foe"
 end
 
 check 'battle: 強力防御 halves damage a second time' do


### PR DESCRIPTION
## Summary

- RPG_RT's `preemptive` (先制攻撃) weapon turn-order jump (`CreateExecutionOrder`'s `+9999` bonus) applies to any `Type::Normal` attack, regardless of whether it was forced by Berserk (`Restriction_attack_enemy`) or Confusion (`Restriction_attack_ally`) — `Scene_Battle_Rpg2k::SelectNextActor` (`src/scene_battle_rpg2k.cpp`) builds an identical `Game_BattleAlgorithm::Normal` for both, and the `+9999` bonus itself plus `Game_Actor::HasPreemptiveAttack` (`src/game_actor.cpp`) key purely on `Type::Normal` + the equipped weapon's flag, with no restriction dependency anywhere in the chain.
- `Game::Battle#preemptive_boost?` (`mruby-rpg2k/mrblib/game.rb`) wrongly excluded the Berserk case, based on an uncited fan-wiki (「デフォ戦botまとめ」) claim baked into its own doc comment from an earlier fix in this repo. It now treats both restrictions the same.
- This also corrects that earlier fix's `docs/TODO.md` writeup, which had asserted the Berserk exclusion as correct without independently verifying it against RPG_RT's actual source.

## Test plan

- [x] Rewrote the existing `scripts/rpg2k_logic_check.rb` check that had encoded the wrong ("berserk drops the jump") behavior to assert the opposite ("berserk keeps a 先制攻撃 weapon's turn-order jump, same as confusion").
- [x] Confirmed the rewritten check fails against the pre-fix code (`git stash` on `game.rb` only, left the test unstashed).
- [x] Confirmed it passes after restoring the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1084 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed.
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures.
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures.

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_