### PR TITLE
Halve an offensive skill's HP damage against a defending target

### DIFF
--- a/changelog.d/skill-hp-defend-halving.fixed.md
+++ b/changelog.d/skill-hp-defend-halving.fixed.md
@@ -1,0 +1,7 @@
+- **Battle:** an offensive Skill's HP damage is now halved (quartered under
+  強力防御) against a defending target, matching RPG_RT's own
+  `AdjustDamageForDefend` -- previously only a basic Attack and self-destruct
+  got this treatment, so any attack skill (elemental spells, physical
+  skills, drain skills) dealt full, un-halved damage to a guarding target. A
+  skill's SP effect and its ATK/DEF/SPI/AGI stat-mod effects are unaffected,
+  matching RPG_RT's own behavior there.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8636,6 +8636,29 @@ not yet verified:
   base-damage-1 hit lands for 0, both with and without 強力防御's second
   halving; the identical pair for `#enemy_autodestruct`), all confirmed to
   fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-20): `AdjustDamageForDefend` was also missing
+  entirely from an offensive Skill's HP damage, only ever applied to a plain
+  Attack and to self-destruct.** `Game::Battle#apply_skill_hit`
+  (`mruby-rpg2k/mrblib/game.rb`) computed an enemy-scope skill's `hp_dmg`
+  through attribute multiplier, critical, variance and the damage cap, then
+  applied it to the target's HP completely unadjusted by whether that target
+  was defending — Defend's halving existed only in
+  `#deal_attack_with_current_weapon` and `#enemy_autodestruct`, never here.
+  Confirmed against EasyRPG Player's actual source, fetched live:
+  `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`)
+  computes `hp_effect` as `IsPositive() ? effect :
+  Algo::AdjustDamageForDefend(effect, *target)` — every enemy-scope skill's
+  HP branch gets the same treatment a basic Attack's `Normal::vExecute`
+  already does, not just Attack. The same function's SP branch and its
+  ATK/DEF/SPI/AGI stat-mod branches (lines 1074-1136) read the raw `effect`
+  with no such adjustment, so only the HP branch needed the fix — SP drain
+  and stat-mod skills are correct as they stood. Fixed by inserting the same
+  `hp_dmg /= 2; hp_dmg /= 2 if target.strong_defence` halving
+  `#deal_attack_with_current_weapon` already uses, applied to `hp_dmg` right
+  after it is set and before the 吸収 (absorb) clamp. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a dual HP+SP drain skill against a
+  defending target: the HP hit is halved, the SP hit is not), confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ **Simulated Attack's damage spread now uses RPG_RT's real variance
   formula, not a coarser stand-in this method's own comment misattributed to
   EasyRPG's source.** `Interpreter#do_simulated_attack` modelled its damage

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12761,6 +12761,20 @@ module Game
         hp_dmg = 0
         if hits && hp != 0
           hp_dmg = dmg
+          # An offensive skill's HP effect is halved (quartered under 強力防御)
+          # against a defending target, the same `AdjustDamageForDefend` a
+          # basic attack already gets (`#deal_attack_with_current_weapon`
+          # above) — EasyRPG's `Skill::vExecute` (`src/game_battlealgorithm.
+          # cpp`) computes `hp_effect` as `IsPositive() ? effect :
+          # Algo::AdjustDamageForDefend(effect, *target)`, i.e. every
+          # enemy-scoped skill's HP branch, not just a plain Attack. The SP
+          # effect and the ATK/DEF/SPI/AGI stat-mod branches read the same
+          # raw `effect` with no such adjustment (`Skill::vExecute` lines
+          # 1074-1136), so only `hp_dmg` gets this treatment here.
+          if target.defending && hp_dmg > 0
+            hp_dmg /= 2
+            hp_dmg /= 2 if target.strong_defence
+          end
           if cmd[:absorb] && hp_dmg > 0
             hp_dmg = target.hp if hp_dmg > target.hp
             absorbed = hp_dmg

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -12900,6 +12900,35 @@ check 'an enemy-scope attack skill with both affect_hp and affect_sp deals ' \
   eq 18, foe.mp, '50 - 32'
 end
 
+check 'an offensive skill halves its HP effect against a defending target, ' \
+      'but leaves the SP effect untouched' do
+  # EasyRPG's Skill::vExecute: `hp_effect = IsPositive() ? effect :
+  # Algo::AdjustDamageForDefend(effect, *target)` -- an enemy-scope skill's HP
+  # branch gets the same defend-halving a plain Attack already gets, but the
+  # SP branch (and the ATK/DEF/SPI/AGI stat-mod branches) read the raw
+  # `effect` with no such adjustment.
+  skills = { 7 => fake_skill(name: 'Drain Fire', scope: 0, sp_cost: 6, power: 20,
+                             mrate: 40, hp: true, sp: true) }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # spi 12 -> effect 32
+  foe = combatant_mp('Foe', 0, 0, 5, 100, 50)
+  foe.defending = true
+  cmd = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  eq(-32, cmd[:hp], 'hp still carries the full, un-halved effect at this stage')
+  eq(-32, cmd[:mp], 'mp carries the identical effect, not a separate roll')
+
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+  bat.command_skill(caster, foe, name: 'Drain Fire', cost: cmd[:cost], hp: cmd[:hp],
+                    mp: cmd[:mp], attack: cmd[:attack], chance: cmd[:chance],
+                    variance: cmd[:variance])
+  bat.begin_round
+  e = bat.step_action
+  eq 16, e[:damage], 'defending halves the HP effect: 32 -> 16'
+  eq 32, e[:sp_damage], 'the SP effect is not halved by defending'
+  eq 84, foe.hp, '100 - 16'
+  eq 18, foe.mp, '50 - 32'
+end
+
 check 'an enemy-scope attack skill with affect_sp but not affect_hp deals ' \
       'only SP damage' do
   skills = { 7 => fake_skill(name: 'SP Drain', scope: 0, sp_cost: 6, power: 20,


### PR DESCRIPTION
## Summary

- RPG_RT halves (quarters under 強力防御) an offensive Skill's HP damage against a defending target — `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`) computes `hp_effect` as `IsPositive() ? effect : Algo::AdjustDamageForDefend(effect, *target)`, applying the same `AdjustDamageForDefend` (`src/algo.cpp`) a plain Attack already gets to every enemy-scope skill's HP branch too.
- `Game::Battle#apply_skill_hit` (`mruby-rpg2k/mrblib/game.rb`) only ever applied this halving in `#deal_attack_with_current_weapon` (basic attack) and `#enemy_autodestruct` (self-destruct) — an offensive skill's `hp_dmg` was applied to the target's HP completely unadjusted by whether the target was defending. Any attack skill (elemental spells, physical skills, drain skills) dealt full, un-halved damage to a guarding target.
- The skill's SP effect and its ATK/DEF/SPI/AGI stat-mod effects read the same raw, un-adjusted `effect` in `Skill::vExecute` (lines 1074-1136 of `game_battlealgorithm.cpp`) — no `AdjustDamageForDefend` call there — so only the HP branch needed the fix; SP drain and stat-mod skills are correct as they stood.
- Fixed by inserting the same `hp_dmg /= 2; hp_dmg /= 2 if target.strong_defence` halving already used at the basic-attack/self-destruct call sites, applied to `hp_dmg` right after it's set and before the 吸収 (absorb) clamp.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a dual HP+SP drain skill against a defending target halves the HP hit but leaves the SP hit untouched.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — `expected 16, got 32`) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1085 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_