### PR TITLE
Fix field revive+heal over-healing by 1 HP

### DIFF
--- a/changelog.d/field-revive-heal-overhealed.fixed.md
+++ b/changelog.d/field-revive-heal-overhealed.fixed.md
@@ -1,0 +1,6 @@
+- **Field menu:** a medicine or skill that both revives a downed party
+  member and restores HP in the same use no longer over-heals by 1 HP --
+  matching RPG_RT's own `Game_Battler::UseItem`/`UseSkill`, which add
+  `recovery - 1` on top of the revive's 1 HP floor, not the full recovery
+  amount. Previously a revival item/skill landed the target 1 HP higher
+  than real RPG_RT would.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17668,6 +17668,33 @@ above are repeated here)
   learnedness/usability — it has no target-specific "would this help"
   concept at that layer) was not verified before writing this note, so
   it's left for a dedicated follow-up rather than guessed at here.
+  ✅ **Follow-up (2026-08-20): a combined revive-plus-HP-recovery use, from
+  both `#use_medicine` and `#cast_skill`'s primary Affect-HP branch,
+  over-healed by exactly 1 HP.** `#remove_state` already floors a revived
+  target to 1 HP the instant Death comes off, and RPG_RT's own
+  `Game_Battler::UseItem`/`UseSkill` (`src/game_battler.cpp`, cited above)
+  both then add `hp_change - revived`/`effect - revived` on top of that
+  floor, not the full recovery amount — `revived` is `1` exactly when this
+  particular use just cured Death, `0` otherwise, so an ordinary heal on an
+  already-standing ally is unaffected. `#cast_skill`'s own sibling
+  "Affect HP off" branch (documented in the bullet just above this one)
+  already applies this `- revived` treatment correctly
+  (`t.change_hp(t.max_hp * amount / 100 - 1)`) — it was only ever missing
+  from the primary `if sk.affect_hp && amount > 0` branch right above it,
+  an internal inconsistency within the same method, and `#use_medicine` had
+  no `revived` tracking of any kind. Fixed by threading a `was_dead`/
+  `revived` pair through `#use_medicine` mirroring `#cast_skill`'s existing
+  pattern, and subtracting 1 from the applied HP change in both methods
+  whenever `revived` is true. Two existing `scripts/rpg2k_logic_check.rb`
+  checks had baked in the over-healed value and needed correcting: "a
+  revive skill cures the death state, then its HP recovery lands" (expected
+  33 for a revival skill's effect of 32, corrected to 32) and "the same
+  item revives an ally who is down, HP and all" (expected 26 for a 25%-of-
+  100 revive item, corrected to 25) — both confirmed to fail against the
+  pre-fix code with the corrected values before the fix. A third, unrelated
+  comment above (on `Battle command_item actually revives a downed ally`)
+  had asserted the field-menu paths "were already correct" — also wrong,
+  corrected in place.
   ✅ **An Enable Combo (1007) armed for one fight stayed armed on the actor
   forever, multiplying hits in every later battle too, instead of
   clearing once that fight ended (2026-08-19).** `Game::Actor

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4564,6 +4564,7 @@ module Game
         # usable on, even under an all-party scope.
         next if ko_only_blocked?(it, t) || !item_usable_by?(it, t.id)
         changed = false
+        was_dead = t.dead?
         # Cure first: a revive item (curing 戦闘不能) stands the actor back up so
         # the HP recovery below lands instead of being blocked as a no-op.
         cured.each do |s|
@@ -4572,10 +4573,19 @@ module Game
             changed = true
           end
         end
+        # Whether curing Death just revived `t` -- #remove_state's own
+        # bare-revival fallback already floors it to 1 HP the instant Death
+        # comes off, matching EasyRPG's `RemoveState`. `Game_Battler::
+        # UseItem` (`src/game_battler.cpp`) then adds `hp_change - revived`,
+        # not the full `hp_change`, on top of that floor
+        # (`ChangeHp(hp_change - revived, false)`), so a combined revive+HP
+        # item must not add its full recovery on top of the 1 HP the cure
+        # already granted.
+        revived = was_dead && !t.dead?
         hp, mp = item_recovery(it, t)
         before_hp = t.hp
         before_mp = t.mp
-        t.change_hp(hp) if hp > 0
+        t.change_hp(revived ? hp - 1 : hp) if hp > 0
         t.change_mp(mp) if mp > 0
         changed ||= t.hp != before_hp || t.mp != before_mp
         affected.push(t) if changed
@@ -5380,7 +5390,13 @@ module Game
         before_hp = t.hp
         before_mp = t.mp
         if sk.affect_hp && amount > 0
-          t.change_hp(amount)
+          # Same `- revived` treatment as the Affect-HP-off branch just
+          # below: a combined revive+HP skill must not add its full amount
+          # on top of the 1 HP the Death cure above already granted --
+          # `Game_Battler::UseSkill` (`src/game_battler.cpp`) applies
+          # `ChangeHp(effect - revived, false)` here too, not just in its
+          # `cure_hp_percentage` sibling branch.
+          t.change_hp(revived ? amount - 1 : amount)
         elsif revived && amount > 0 && t.max_hp
           # A revival skill with Affect HP off heals a percentage of max HP
           # instead of leaving `t` on the bare revival floor of 1 --

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7439,9 +7439,14 @@ check 'a cure skill removes only its state_effects states (usable at full HP)' d
   eq 26, hero.mp                               # 30 - 4, consumed
 end
 
-check 'a revive skill cures the death state, then its HP recovery lands' do
+check 'a revive skill cures the death state, then its HP recovery lands, ' \
+      'one short of the raw effect' do
   # Cures state 1 (戦闘不能) and heals. States apply first: the cure revives the
-  # ally to 1 HP, then the recovery lands. effect = power 20 + mrate 40*int12/40 = 32.
+  # ally to 1 HP, then the recovery lands -- but one HP short of the raw
+  # effect, since RPG_RT's own `Game_Battler::UseSkill`
+  # (`src/game_battler.cpp`) applies `ChangeHp(effect - revived, false)` on
+  # top of the cure's own floor-to-1, not the full `effect`. effect = power
+  # 20 + mrate 40*int12/40 = 32, landing at 1 + (32 - 1) = 32.
   skills = { 6 => fake_skill(name: 'Life', scope: 3, sp_cost: 6,
                              power: 20, mrate: 40, hp: true, state_effects: [1]) }
   st = skill_party(skills)
@@ -7452,7 +7457,7 @@ check 'a revive skill cures the death state, then its HP recovery lands' do
   eq true, ally.dead?
   eq [ally], st.party.cast_skill(hero, 6, ally)
   eq false, ally.dead?
-  eq 33, ally.hp                               # revived to 1, then +32
+  eq 32, ally.hp                               # revived to 1, then +31 (32 - 1)
 end
 
 check 'a revival skill with Affect HP off heals a percentage of max HP, ' \
@@ -14165,8 +14170,11 @@ end
 # already-selectable downed ally (see #battle_ally_targets, which already
 # lets one be picked) silently fizzled at resolution: no SP/item spent, no
 # state cured, no HP restored, and the ally stayed dead -- the in-battle
-# path never actually revived anyone, unlike the field-menu
-# #use_medicine/#cast_skill, which were already correct.
+# path never actually revived anyone. ~~unlike the field-menu
+# #use_medicine/#cast_skill, which were already correct~~ -- that claim was
+# itself wrong: both field-menu methods over-healed a combined revive+HP
+# use by 1 (see the dedicated fix and its own citation in docs/TODO.md,
+# 2026-08-20).
 check 'Battle command_item actually revives a downed ally (RPG_RT: an ' \
       "item's target is always valid)" do
   user   = combatant('User', 0, 0, 20, 100)
@@ -19107,8 +19115,11 @@ check 'the same item revives an ally who is down, HP and all' do
   eq [hero], st.party.use_item(4, hero)
   ok !hero.dead?, 'back on their feet'
   # Standing up puts them on 1 HP first (the existing revive path), and the
-  # item's 25% of 100 lands on top of that.
-  eq 26, hero.hp, 'with the 25% the item restores'
+  # item's 25% of 100 lands on top of that -- but one HP short of the raw
+  # 25, since RPG_RT's `Game_Battler::UseItem` (`src/game_battler.cpp`)
+  # applies `ChangeHp(hp_change - revived, false)` on top of the cure's own
+  # floor-to-1, not the full `hp_change`.
+  eq 25, hero.hp, 'with the 25% the item restores, one short of the raw 25'
   eq 0, st.party.item_count(4), 'and it was spent'
 end
 


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_Battler::UseItem`/`UseSkill` (`src/game_battler.cpp`) both stand a revived target up on the usual 1 HP floor, then add `hp_change - revived`/`effect - revived` on top of it — not the full recovery amount — where `revived` is `1` exactly when this same use just cured Death. So a combined revive+HP-recovery medicine/skill lands the target at `1 + (recovery - 1) == recovery`, not `recovery + 1`.
- `Game::Party#use_medicine` (`mruby-rpg2k/mrblib/game.rb`) tracked no `revived` state at all — `t.change_hp(hp) if hp > 0` always added the full amount.
- `Game::Party#cast_skill`'s primary `if sk.affect_hp && amount > 0` branch had the same gap — an internal inconsistency, since its own sibling `elsif revived && amount > 0 && t.max_hp` branch (the "Affect HP off" percentage-heal case) already applies the `- revived` treatment correctly and even cites the exact same EasyRPG lines.
- Fixed by threading a `was_dead`/`revived` pair through `#use_medicine` mirroring `#cast_skill`'s existing pattern, and subtracting 1 from the applied HP change in both methods whenever `revived` is true.
- This also corrects two existing tests that had baked in the over-healed (+1) value, and a comment elsewhere in the test suite that had wrongly asserted the field-menu paths "were already correct."

## Test plan

- [x] Corrected `scripts/rpg2k_logic_check.rb`'s "a revive skill cures the death state, then its HP recovery lands" check (33 → 32 for a revival skill with effect 32) and "the same item revives an ally who is down, HP and all" check (26 → 25 for a 25%-of-100 revive item).
- [x] Confirmed both corrected checks fail against the pre-fix code (`git stash` on `game.rb` only — `expected 32, got 33` / `expected 25, got 26`) and pass after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1085 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_