### PR TITLE
Stop a fully-restricted enemy troop from ending the battle in victory

### DIFF
--- a/changelog.d/enemy-restriction-victory.fixed.md
+++ b/changelog.d/enemy-restriction-victory.fixed.md
@@ -1,0 +1,8 @@
+- **Battle:** a fully-restricted enemy troop (e.g. every enemy locked into a
+  Stone-style "do nothing" status with 0% self-cure) no longer ends the
+  fight in an instant, damage-free victory -- matching RPG_RT's own
+  `Game_Battle::CheckWin`, which only checks whether every enemy is
+  dead or hidden, unlike the party's own defeat check, which does widen to
+  "permanently unable to act." A live-but-restricted enemy troop now has to
+  actually be reduced to 0 HP (or hidden/removed) like real RPG_RT, instead
+  of ending the fight for free.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13692,9 +13692,12 @@ not yet verified:
   site's own text; found by comparing `Game::Troop` against EasyRPG Player's
   actual C++ source while triaging the drop-related bullets nearby.
   `Game::Battle#incapacitated?` (`mruby-rpg2k/mrblib/game.rb`) already treats
-  `out_of_play?` (dead **or** hidden) as "out of the fight" for win/loss
-  purposes, so `alive?(@enemies)` — and with it victory — can go true the
-  instant every *visible* member is down, with no requirement that a
+  `out_of_play?` (dead **or** hidden) as "out of the fight," and the enemy
+  side's own win test (`#enemy_active?` as of a later 2026-08-20 follow-up
+  elsewhere in this document — `alive?(@enemies)` at the time this was
+  written) shares that same `out_of_play?` dead-or-hidden equivalence, so
+  victory can go true the instant every *visible* member is down, with no
+  requirement that a
   still-hidden one (never revealed, or fled) ever took a hit at all. `Game::
   Troop#total_exp`/`#total_gold`/`#drops` summed/rolled every member
   unconditionally, with no such check. Verified against real RPG_RT's own
@@ -18342,15 +18345,43 @@ codebase yet):
   own (Sleep, Paralysis with a nonzero `auto_release_prob`) does not count
   towards a wipe, matching "does not recover naturally": the fight keeps
   running, the same roll `#recovers_from_state?` would eventually use to
-  stand that battler back up. Applies symmetrically to both sides (an
+  stand that battler back up. ~~Applies symmetrically to both sides (an
   all-Stoned enemy troop ends the fight in victory too), since nothing in
   the source material suggests the rule is ally-only and `#alive?` was
-  already shared by both `@allies`/`@enemies` call sites. Covered by three
+  already shared by both `@allies`/`@enemies` call sites.~~ Covered by three
   new `scripts/rpg2k_logic_check.rb` checks (a fully-Stoned party is a loss
   with no HP ever moving, confirmed to fail against the pre-fix code before
   the fix; a party-wide do-nothing state with a nonzero `auto_release_prob`
   does *not* end the fight; one incapacitated ally among others is not a
-  wipe). ✅ **Berserk/Confusion override target selection but still
+  wipe).
+  ✅ **Follow-up (2026-08-20): that "applies symmetrically to both sides"
+  claim was wrong — the source material does say the rule is ally-only,
+  it just hadn't been checked.** `Game::Battle#finished?`
+  (`mruby-rpg2k/mrblib/game.rb`) reused `#alive?`/`#incapacitated?` for
+  *both* `@allies` and `@enemies`, so a skill/state that locked an entire
+  enemy troop into a restriction-based "do nothing" status (e.g. a
+  full-troop Stone with 0% self-cure) ended the fight in an instant,
+  damage-free victory. Checked against RPG_RT's own live source:
+  `Game_Battle::CheckWin`/`CheckLose` (`src/game_battle.cpp`) use two
+  genuinely different predicates, not one shared one — `CheckWin` is
+  `!game_enemyparty->IsAnyActive()`, which bottoms out in
+  `Game_Battler::Exists()` (`src/game_battler.h`, `!IsHidden() && !IsDead()
+  && IsInParty()`) with no restriction/recovery check anywhere in that
+  chain, while only `CheckLose` calls `CanActOrRecoverable()` (the source
+  `#incapacitated?` already correctly ports). The ally-side widening exists
+  specifically to avoid a stall where the player can never submit another
+  command; the enemy side carries no such risk (the player can always keep
+  attacking a restricted-but-alive enemy), so RPG_RT's own win check never
+  needed it. Fixed by giving the enemy side its own `#enemy_active?(side)`
+  (`side.any? { |b| !b.out_of_play? }` — dead/hidden only, no restriction
+  check) and using it for the enemy half of `#finished?` in place of
+  `#alive?`; the ally half, and both `#result` call sites (already
+  `@allies`-only), are untouched and still match `CheckLose` exactly.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (a fully-Stoned
+  enemy troop, still at full HP, does not end the fight — the fight only
+  ends once they're actually reduced to 0 HP), confirmed to fail against
+  the pre-fix code before the fix.
+  ✅ **Berserk/Confusion override target selection but still
   honour "hits twice"/"ignores evasion," while Berserk additionally
   collapses an "attack all" weapon down to a single target and disables
   "always acts first."** `Game::Battle#strike`'s forced-restriction branch

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8856,10 +8856,10 @@ module Game
     # its own basic Autodestruct -- see `Game::Battle#enemy_autodestruct`)
     # contributes none of the three, even though a fight can end in victory
     # while such a member is technically still at full HP:
-    # `Game::Battle#incapacitated?` (`mruby-rpg2k/mrblib/game.rb`) already
+    # `Game::Battle#enemy_active?` (`mruby-rpg2k/mrblib/game.rb`) already
     # treats hidden the same as dead for win/loss purposes (`out_of_play?`),
-    # so `alive?(@enemies)` goes false -- and victory fires -- the instant
-    # every *visible* member is down, with no requirement that a still-hidden
+    # so `enemy_active?(@enemies)` goes false -- and victory fires -- the
+    # instant every *visible* member is down, with no requirement that a still-hidden
     # one ever engaged at all. Matches EasyRPG's actual C++ source:
     # `Game_EnemyParty::GetExp`/`GetMoney`/`GenerateDrops` (`src/
     # game_enemyparty.cpp`) each loop `if (enemy.IsDead())` before
@@ -9921,8 +9921,20 @@ module Game
     STATE_PERSISTS_ON_MAP = 1
 
     # True once one side has been wiped out, or the party has fled — the battle
-    # is decided.
-    def finished?; @escaped || !alive?(@allies) || !alive?(@enemies); end
+    # is decided. The two sides use genuinely different tests, not a shared
+    # symmetric one: RPG_RT's own `Game_Battle::CheckWin`/`CheckLose`
+    # (`src/game_battle.cpp`) are `!game_enemyparty->IsAnyActive()` for the
+    # enemy side against `CanActOrRecoverable()` (`incapacitated?`'s own
+    # source) per party member for the ally side -- `IsAnyActive` bottoms
+    # out in `Game_Battler::Exists()` (`src/game_battler.h`, `!IsHidden() &&
+    # !IsDead() && IsInParty()`), a bare dead-or-hidden test with no
+    # restriction/recovery check at all. The ally-side widening to "locked
+    # into a permanent do-nothing state" exists purely to avoid a stall
+    # where the player can never submit another command; the enemy side has
+    # no such risk (the player can always keep attacking a
+    # restricted-but-alive enemy), so a fully-Stoned enemy troop must still
+    # be finished off with real damage, not treated as an instant win.
+    def finished?; @escaped || !alive?(@allies) || !enemy_active?(@enemies); end
 
     # Whether the party successfully escaped this fight.
     def escaped?; @escaped; end
@@ -11094,16 +11106,25 @@ module Game
       @rng.random(100) < prob
     end
 
-    # Whether `b` counts as out of the fight for win/loss purposes: dead or
+    # Whether `b` counts as out of the fight *for the ally side's own
+    # win/loss test only* (#alive?/#finished?'s `@allies` half): dead or
     # hidden (#out_of_play?), or locked into a "do nothing" restriction by a
-    # state with zero chance of ever shaking itself off. デフォ戦botまとめ:
-    # "party wipe" for game-over purposes means every member is both unable
-    # to act *and* does not recover naturally, not literally "every member's
-    # HP is 0" -- why a fully-Stoned party loses instantly even though nobody
-    # was ever damaged. A do-nothing state that *can* still clear itself
+    # state with zero chance of ever shaking itself off. Ported from
+    # RPG_RT's own `Game_Battler::CanActOrRecoverable`/`Game_Battle::
+    # CheckLose` (`src/game_battler.cpp`/`src/game_battle.cpp`): "party
+    # wipe" for game-over purposes means every member is both unable to act
+    # *and* does not recover naturally, not literally "every member's HP is
+    # 0" -- why a fully-Stoned party loses instantly even though nobody was
+    # ever damaged. A do-nothing state that *can* still clear itself
     # (Sleep, Paralysis with a nonzero auto_release_prob) does not count: the
     # fight keeps running, the same way #recovers_from_state? would
-    # eventually stand that battler back up on its own.
+    # eventually stand that battler back up on its own. This widening exists
+    # purely to avoid a stall where the player can never submit another
+    # command -- RPG_RT's `Game_Battle::CheckWin` (the enemy side's own
+    # test, see #enemy_active?) has no equivalent, and must not reuse this
+    # method: the player can always keep attacking a
+    # restricted-but-alive enemy, so a fully-Stoned enemy troop stays in the
+    # fight until it is actually reduced to 0 HP or removed.
     def incapacitated?(b)
       return true if b.out_of_play?
       (b.states || []).any? do |id|
@@ -11114,6 +11135,14 @@ module Game
     end
 
     def alive?(side); side.any? { |b| !incapacitated?(b) }; end
+
+    # Whether the enemy side still has anyone in the fight -- RPG_RT's own
+    # `Game_Battle::CheckWin` (see #finished?'s citation) only tests
+    # dead-or-hidden (`Exists()`), never a restriction/recovery state, so a
+    # live-but-permanently-restricted enemy troop (e.g. fully Stoned) does
+    # not end the battle on its own; unlike #alive?, this does not fold in
+    # #incapacitated?'s do-nothing-restriction check.
+    def enemy_active?(side); side.any? { |b| !b.out_of_play? }; end
 
     def refill_queue
       @rounds += 1

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14588,6 +14588,24 @@ check 'battle: one incapacitated ally among others is not a party wipe' do
   ok !bat.finished?, 'a still-able ally keeps the party in the fight'
 end
 
+# RPG_RT's own Game_Battle::CheckWin/CheckLose (src/game_battle.cpp) are two
+# genuinely different tests, not one shared symmetric one: CheckWin is a bare
+# dead-or-hidden check (!IsAnyActive(), bottoming out in Exists()), with no
+# restriction/recovery concept at all -- only CheckLose widens to
+# CanActOrRecoverable(). A fully-Stoned enemy troop, unlike a fully-Stoned
+# party, does not end the fight on its own: the player can always keep
+# attacking a restricted-but-alive enemy, so real RPG_RT keeps the battle
+# running until the enemies are actually reduced to 0 HP or hidden/removed.
+check 'battle: a fully-Stoned enemy troop, still at full HP, does not end the fight' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) } # do-nothing, 0% auto-release
+  hero = combatant('Hero', 40, 0, 20, 100)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  slime.states = [8]
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  ok !bat.finished?, 'a live-but-restricted enemy troop keeps the fight going'
+  eq 100, slime.hp, 'and nobody has actually been reduced to 0 HP'
+end
+
 # yado.tk's "unrecoverable input-blocking state lock" case, next to the
 # empty/all-KO'd-party fix: EasyRPG's Scene_Battle_Rpg2k::SelectNextActor
 # skips the Fight/Skill/Defend/Item prompt entirely for a "do nothing"


### PR DESCRIPTION
## Summary

- RPG_RT's own win/loss checks are two genuinely different tests, not one shared symmetric one — `Game_Battle::CheckWin`/`CheckLose` (`src/game_battle.cpp`): `CheckWin` is `!game_enemyparty->IsAnyActive()`, bottoming out in `Game_Battler::Exists()` (`src/game_battler.h`, `!IsHidden() && !IsDead() && IsInParty()`) with no restriction/recovery check at all, while only `CheckLose` widens to `CanActOrRecoverable()` (`src/game_battler.cpp`) — false only for a state with `restriction == Restriction_do_nothing && auto_release_prob == 0`.
- The ally-side widening exists purely to avoid a stall where the player can never submit another command; the enemy side has no such risk (the player can always keep attacking a restricted-but-alive enemy), so RPG_RT's own win check never needed it.
- `Game::Battle#finished?` (`mruby-rpg2k/mrblib/game.rb`) reused `#alive?`/`#incapacitated?` — which correctly ports `CanActOrRecoverable` — for **both** `@allies` and `@enemies`. A skill/state that locked an entire enemy troop into a restriction-based "do nothing" status (e.g. a full-troop Stone with 0% self-cure) ended the fight in an instant, damage-free victory, instead of requiring the enemies to actually be reduced to 0 HP.
- Fixed by adding `#enemy_active?(side)` (`side.any? { |b| !b.out_of_play? }` — dead/hidden only, no restriction check) and using it for the enemy half of `#finished?`. The ally half, and both `#result` call sites (already `@allies`-only), are untouched and still match `CheckLose` exactly.
- This also corrects a prior `docs/TODO.md` claim (from the original `#incapacitated?`/party-wipe fix's own writeup) asserting the rule "applies symmetrically to both sides ... an all-Stoned enemy troop ends the fight in victory too" — this was never independently checked and turned out to be wrong.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a fully-Stoned enemy troop, still at full HP, does not end the fight.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1086 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_