### PR TITLE
Scale a Knockout infliction by the target's state rank like any other state

### DIFF
--- a/changelog.d/knockout-state-rank-scaling.fixed.md
+++ b/changelog.d/knockout-state-rank-scaling.fixed.md
@@ -1,0 +1,7 @@
+- **Battle:** an instant-death ("Knockout"/戦闘不能) infliction from a skill
+  or weapon is now scaled by the target's own A-E state resistance rank
+  (and any anti-death equipment) exactly like every other status, matching
+  RPG_RT's own `GetStateProbability`. Previously this codebase exempted
+  Knockout from rank scaling entirely, based on an uncited fan-site claim --
+  so a target with rank-E ("immune") Knockout resistance, or full anti-death
+  gear, could still be instant-killed at the skill's raw occurrence rate.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16366,7 +16366,7 @@ above are repeated here)
   Attribute resistance rank A-E already maps to the Attribute database's own
   per-rank effect-% table too (`Game::Battle#attr_rate`, `a_rate`..`e_rate`
   with a `[300, 200, 100, 50, 0]` fallback — **confirmed already correct**,
-  no change needed). ✅ **Death/Knockout is now exempt from rank scaling and
+  no change needed). ~~✅ **Death/Knockout is now exempt from rank scaling and
   always lands at the skill's own occurrence rate.** RPG2000 has no separate
   instant-death mechanic — an "instant death" spell is just a skill whose
   state-effect list names Knockout (state id 1, `Game::Actor::DEATH_STATE`)
@@ -16380,7 +16380,29 @@ above are repeated here)
   `scripts/rpg2k_logic_check.rb` checks (a rank-E target still catches
   Knockout; the same rank on an ordinary state — the control case — still
   resists it, pinning the exemption to state id 1 specifically), the first
-  confirmed to fail against the pre-fix code before the fix.
+  confirmed to fail against the pre-fix code before the fix.~~
+  ✅ **Follow-up (2026-08-20): that Knockout exemption was itself wrong —
+  RPG_RT scales an instant-death infliction by the target's A-E resistance
+  rank exactly like any other state, never bypassing it.** The fix above
+  relied solely on an uncited yado.tk claim, never checked against real
+  source. Confirmed against EasyRPG Player's actual C++, fetched live:
+  `Game_Actor::GetStateProbability`/`Game_Enemy::GetStateProbability`
+  (`src/game_actor.cpp`/`src/game_enemy.cpp`) have no `state_id ==
+  kDeathID` special case whatsoever, and both of `Game_BattleAlgorithm`'s
+  infliction call sites — the Skill state-effect loop and the weapon
+  `state_set` loop (`src/game_battlealgorithm.cpp`) — call
+  `target->GetStateProbability(state_id)` uniformly for every flagged state
+  id; each only checks `state_id == kDeathID` *after* a successful roll, to
+  track whether the target just died, never to skip the roll itself. Fixed
+  by removing `state_susceptibility`'s `return 100 if sid ==
+  Game::Actor::DEATH_STATE` early return, letting state id 1 fall through
+  the same rank/equipment-scaled path every other state already uses.
+  `scripts/rpg2k_logic_check.rb`'s two checks from the reverted fix were
+  rewritten in place: the rank-E check now expects Knockout to be blocked
+  (matching every other state's own rank-E check), and a new rank-A check
+  confirms Knockout still lands when the target is genuinely susceptible —
+  both confirmed to fail/pass appropriately against the pre-fix code before
+  the fix.
 - ✅ **A state id past the end of a battler's own `state_ranks` array now
   defaults to the correct rank per side — B/80% for an enemy, C/60% for an
   actor — instead of always C/60%.** A routine situation: liblcf/RPG_RT

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13092,15 +13092,22 @@ module Game
     # (only an actor-built Combatant, #from_actor, carries a live `actor`).
     # 100 (unscaled) when the target (a bare fixture) models no ranks at all,
     # so a plain sim keeps landing every status.
-    # The Knockout state (id 1, `Game::Actor::DEATH_STATE`) is exempt from rank
-    # scaling entirely -- a skill's "state change" effect list can name it
-    # directly (RPG2000 has no separate instant-death mechanic), and yado.tk
-    # documents its infliction chance as governed solely by the skill's own
-    # occurrence-rate operand, never reduced by the target's A-E resistance rank.
+    # The Knockout state (id 1, `Game::Actor::DEATH_STATE`) is scaled exactly
+    # like any other state, despite an uncited yado.tk claim this codebase
+    # used to carry (and special-case) that its infliction chance was governed
+    # solely by the skill's own occurrence-rate operand, never reduced by the
+    # target's A-E resistance rank. Confirmed against RPG_RT's actual C++
+    # source: `Game_Actor::GetStateProbability`/`Game_Enemy::
+    # GetStateProbability` (`src/game_actor.cpp`/`src/game_enemy.cpp`) have no
+    # `state_id == kDeathID` special case at all, and both of
+    # `Game_BattleAlgorithm`'s infliction call sites -- the Skill state-effect
+    # loop and the weapon `state_set` loop (`src/game_battlealgorithm.cpp`) --
+    # call `target->GetStateProbability(state_id)` uniformly for every flagged
+    # state id, checking `state_id == kDeathID` only *after* a successful roll
+    # (to track whether the target just died), never to skip the roll itself.
     # An ally's own defensive equipment can scale the A-E result down further
     # still -- see Actor#state_resist_mul.
     def state_susceptibility(target, sid)
-      return 100 if sid == Game::Actor::DEATH_STATE
       ranks = target.state_ranks
       return 100 if ranks.nil? || ranks.empty?
       is_ally = ally?(target)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13973,26 +13973,37 @@ check 'battle: a mid susceptibility (rank C 60%) both lands and resists' do
   ok results.any?(&:empty?), 'and sometimes is resisted'
 end
 
-check 'battle: Knockout (state 1) ignores state_ranks -- rank E still lands' do
-  # RPG2000 has no separate instant-death mechanic; a skill's state-effect list
-  # names Knockout (id 1, Game::Actor::DEATH_STATE) directly, and yado.tk
-  # documents its landing chance as governed solely by the skill's own
-  # occurrence-rate operand -- never scaled down by the target's A-E rank the
-  # way every other state is.
+check 'battle: Knockout (state 1) is scaled by state_ranks like any other ' \
+      'state -- rank E blocks it' do
+  # RPG2000 has no separate instant-death mechanic; a skill's state-effect
+  # list names Knockout (id 1, Game::Actor::DEATH_STATE) directly. RPG_RT's
+  # own Game_Actor::GetStateProbability (src/game_actor.cpp) has no
+  # state_id == kDeathID special case, and Game_BattleAlgorithm's infliction
+  # loops (src/game_battlealgorithm.cpp) call GetStateProbability uniformly
+  # for every flagged state id, Knockout included.
   foe = combatant('Foe', 0, 0, 5, 100)
-  foe.state_ranks = { Game::Actor::DEATH_STATE => 4 } # rank E -> 0% for any other state
+  foe.state_ranks = { Game::Actor::DEATH_STATE => 4 } # rank E -> 0%
   e = poison_cast_state(foe, Game::Actor::DEATH_STATE)
-  eq [Game::Actor::DEATH_STATE], e[:inflicted], 'Knockout lands despite rank-E "immunity"'
-  ok foe.state?(Game::Actor::DEATH_STATE)
+  eq [], e[:inflicted], 'rank-E resistance blocks Knockout the same as any other state'
+  ok !foe.state?(Game::Actor::DEATH_STATE)
 end
 
-check 'battle: an ordinary state at the same rank E is still blocked' do
-  # Control: the same rank on a non-Knockout state id keeps resisting, proving
-  # the exemption above is specific to id 1, not a general susceptibility bypass.
+check 'battle: an ordinary state at the same rank E is also blocked' do
+  # Control: a non-Knockout state id at the same rank resists identically,
+  # confirming Knockout gets no special treatment either way.
   foe = combatant('Foe', 0, 0, 5, 100)
   foe.state_ranks = { 3 => 4 }
   e = poison_cast_state(foe, 3)
   eq [], e[:inflicted]
+end
+
+check 'battle: a susceptible target (state rank A) still catches a sure ' \
+      'Knockout' do
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.state_ranks = { Game::Actor::DEATH_STATE => 0 } # rank A -> 100%
+  e = poison_cast_state(foe, Game::Actor::DEATH_STATE)
+  eq [Game::Actor::DEATH_STATE], e[:inflicted]
+  ok foe.state?(Game::Actor::DEATH_STATE)
 end
 
 # A state the target already carries is not a silent no-op: RPG_RT reports it as


### PR DESCRIPTION
## Summary

- RPG_RT scales an instant-death ("Knockout"/戦闘不能, state id 1) infliction from a skill or weapon by the target's own A-E state resistance rank (and any anti-death equipment) exactly like any other status — `Game_Actor::GetStateProbability`/`Game_Enemy::GetStateProbability` (`src/game_actor.cpp`/`src/game_enemy.cpp`) have no `state_id == kDeathID` special case at all, and both of `Game_BattleAlgorithm`'s infliction call sites — the Skill state-effect loop and the weapon `state_set` loop (`src/game_battlealgorithm.cpp`) — call `target->GetStateProbability(state_id)` uniformly for every flagged state id. Each only checks `state_id == kDeathID` *after* a successful roll, to track whether the target just died, never to skip the roll itself.
- `Game::Battle#state_susceptibility` (`mruby-rpg2k/mrblib/game.rb`) carried an early `return 100 if sid == Game::Actor::DEATH_STATE`, exempting Knockout from rank scaling and equipment resistance entirely — so a target with rank-E ("immune") Knockout resistance, or full anti-death gear, could still be instant-killed at the skill's raw occurrence rate.
- This exemption was itself a prior fix in this repo, based solely on an uncited yado.tk claim, never checked against real EasyRPG/RPG_RT source. Fixed by removing the early return so state id 1 falls through the same rank/equipment-scaled path every other state already uses; corrected the prior `docs/TODO.md` writeup with a strikethrough and dated Follow-up.

## Test plan

- [x] Rewrote `scripts/rpg2k_logic_check.rb`'s two Knockout-exemption checks in place: the rank-E check now expects Knockout to be *blocked* (matching every other state's own rank-E check), and a new rank-A check confirms Knockout still lands when the target is genuinely susceptible.
- [x] Confirmed the rank-E check fails against the pre-fix code (`git stash` on `game.rb` only — `expected [], got [1]`) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1087 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 833 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_