### PR TITLE
Exempt affect_attr_defence skills from the weapon-attribute gate

### DIFF
--- a/changelog.d/attr-defence-skill-weapon-gate.fixed.md
+++ b/changelog.d/attr-defence-skill-weapon-gate.fixed.md
@@ -1,0 +1,7 @@
+- **Skills:** an attribute-resistance-shift ("raise X resistance") buff skill
+  no longer requires a matching weapon equipped just because its named
+  attribute happens to be weapon-type -- matching RPG_RT's own
+  `Game_Actor::IsSkillUsable`, which exempts this skill type from the
+  weapon-equip check entirely. Previously such a skill was incorrectly
+  greyed out on the field menu, in battle, and for auto-battle whenever the
+  caster had no matching weapon equipped.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14243,7 +14243,28 @@ not yet verified:
   of "a weapon carrying **that** attribute", not confirmed against a
   multi-attribute skill since neither test bed ships one. Covered by a new
   `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the pre-fix
-  code. **Weapon-type × magic-type attribute stacking is built now too** — a
+  code.
+  ✅ **Follow-up (2026-08-21): that weapon-equip gate wrongly applied to an
+  `affect_attr_defence` (resistance-shift buff) skill too, blocking a
+  perfectly castable "raise Fire resistance"-style skill whenever its named
+  attribute happened to be weapon-type and the caster had no matching weapon
+  equipped.** Confirmed against RPG_RT's own live source: `Game_Actor::
+  IsSkillUsable` (`src/game_actor.cpp`) wraps its *entire* weapon-equip loop
+  in `if (!skill->affect_attr_defence) { ... }` — the exemption sits at
+  exactly this one `Game_Actor` level; neither `Algo::IsSkillUsable` nor
+  `Game_Battler::IsSkillUsable` (`src/algo.cpp`/`src/game_battler.cpp`) has
+  any weapon-attribute check at all. The original bullet above (and its
+  yado.tk source) never mentioned this exemption, so `#weapon_attribute_
+  ready?` never checked it either. Fixed with a single early `return true if
+  sk.respond_to?(:affect_attr_defence) && sk.affect_attr_defence` ahead of
+  the existing weapon-id check — the same one-choke-point `#can_cast?` call
+  site fixes all three live callers (`#can_cast?`, `Game::Battle
+  #skill_ready?`/auto-battle, and `Scene::Battle#confirm_battle_skill`) at
+  once. Covered by a new `scripts/rpg2k_logic_check.rb` check (a defence-
+  shift skill naming a weapon-type attribute is castable with no weapon
+  equipped at all, unlike an ordinary weapon-type-attribute attack skill),
+  confirmed to fail against the pre-fix code before the fix.
+  **Weapon-type × magic-type attribute stacking is built now too** — a
   separate question from equip gating, in the damage formula rather than
   usability. EasyRPG's `Attribute::ApplyAttributeMultiplier` keeps the
   *strongest* rate within each type (physical/weapon and magical/magic

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5112,9 +5112,19 @@ module Game
     # (dual-wield) between them -- there is no test-bed skill with two to
     # confirm that against, so it is the direct reading of "a weapon carrying
     # that same attribute" applied per attribute rather than a guess at
-    # something looser.
+    # something looser. An `affect_attr_defence` skill (a resistance-shift
+    # buff, see `#apply_attr_shift`) is exempt from this whole check,
+    # regardless of which attribute it names -- confirmed against RPG_RT's
+    # own live source: `Game_Actor::IsSkillUsable` (`src/game_actor.cpp`)
+    # wraps its entire weapon-equip loop in `if (!skill->affect_attr_defence)
+    # { ... }`, and neither `Algo::IsSkillUsable` nor `Game_Battler::
+    # IsSkillUsable` (`src/algo.cpp`/`src/game_battler.cpp`) has any such
+    # check at all -- it exists only at this one `Game_Actor` level, guarded
+    # by that flag. yado.tk's own text (cited above) never mentions the
+    # exemption.
     def weapon_attribute_ready?(caster, sk)
       return true unless sk
+      return true if sk.respond_to?(:affect_attr_defence) && sk.affect_attr_defence
       ids = skill_attributes(sk).select { |aid| attribute_weapon_type?(aid) }
       return true if ids.empty?
       equipped = caster.respond_to?(:weapon_attributes) ? caster.weapon_attributes : []

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7272,6 +7272,29 @@ check "can_cast?: a weapon-type Attribute skill needs a weapon carrying it equip
   eq true, st.party.can_cast?(hero, 8)
 end
 
+check "can_cast?: an affect_attr_defence skill is exempt from the weapon " \
+      'check even when it names a weapon-type Attribute' do
+  # RPG_RT's Game_Actor::IsSkillUsable (src/game_actor.cpp) wraps its whole
+  # weapon-equip loop in `if (!skill->affect_attr_defence) { ... }` -- a
+  # resistance-shift buff skill never needs a matching weapon equipped,
+  # regardless of which attribute it names.
+  props = { 1 => AttrTypeRow.new(0) } # weapon-type
+  skills = {
+    9 => fake_skill(name: 'Fire Ward', scope: 3, sp_cost: 1,
+                    attribute_effects: [true], affect_attr_defence: true),
+  }
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  st = Game::State.new(
+    Game::Party.new(FakeActorDB.new(players, [1], {}, skills, {}, nil, props)), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(9)
+  hero.equip([]) # no weapon at all
+  eq true, st.party.can_cast?(hero, 9),
+     'a defence-shift skill needs no matching weapon, unlike an ordinary ' \
+     'weapon-type Attribute skill'
+end
+
 # 封印 / Silence: EasyRPG's Game_Battler::IsSkillUsable (src/game_battler.cpp)
 # checks restrict_skill/restrict_magic unconditionally, in or out of a fight
 # -- Window_Skill::CheckEnable is one shared window class for the field and


### PR DESCRIPTION
## Summary

- RPG_RT exempts an attribute-resistance-shift ("raise X resistance") buff skill from the weapon-equip requirement entirely, regardless of which attribute it names — `Game_Actor::IsSkillUsable` (`src/game_actor.cpp`) wraps its whole weapon-equip loop in `if (!skill->affect_attr_defence) { ... }`. Neither `Algo::IsSkillUsable` nor `Game_Battler::IsSkillUsable` (`src/algo.cpp`/`src/game_battler.cpp`) has any weapon-attribute check at all — it exists only at this one `Game_Actor` level, guarded by that flag.
- `Game::Party#weapon_attribute_ready?` (`mruby-rpg2k/mrblib/game.rb`) never checked `sk.affect_attr_defence` before applying the weapon-equip gate — so a self/ally-scope defence-shift skill whose named attribute happens to be database-flagged weapon-type was incorrectly blocked (greyed out on the field menu, in battle, and for auto-battle) unless the caster happened to have a matching weapon equipped, something real RPG_RT never requires for this skill type.
- This method is the single choke point every live caller funnels through (`#can_cast?`, `Game::Battle#skill_ready?`/auto-battle, and `Scene::Battle#confirm_battle_skill`), so one fix covers all three.
- Fixed with a single early `return true if sk.respond_to?(:affect_attr_defence) && sk.affect_attr_defence` ahead of the existing weapon-id check.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a defence-shift skill naming a weapon-type attribute is castable with no weapon equipped at all, unlike an ordinary weapon-type-attribute attack skill (the existing adjacent check).
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only — `expected true, got false`) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1091 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 834 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_