### PR TITLE
Clamp the Change Parameters/Seed modifier to +/-999 on every call

### DIFF
--- a/changelog.d/change-param-mod-clamp.fixed.md
+++ b/changelog.d/change-param-mod-clamp.fixed.md
@@ -1,0 +1,8 @@
+- **Actors:** the Change Parameters event command and Seed items now clamp
+  their running stat modifier to +/-999 on every application, matching
+  RPG_RT's own `SetBaseAtk`/`SetBaseDef`/`SetBaseSpi`/`SetBaseAgi`/
+  `SetBaseMaxHp`/`SetBaseMaxSp`. Previously an unbounded shadow total could
+  accumulate underneath the displayed 1..999/1..9999 clamp, so a deep
+  debuff followed by a partial recovery stayed pinned at the old value
+  until the raw total genuinely climbed all the way back -- real RPG_RT
+  reacts to the very next partial raise instead.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18348,14 +18348,15 @@ codebase yet):
   unbuffed value, and `Party#effective_def` agrees with `Battle#
   effective_def` instead of diverging from it), confirmed to fail against
   the pre-fix code (`expected 2, got 5`) before the fix.
-  **Change Parameters' hidden
-  unclamped total is now tracked.** `Game::Actor#change_param`
+  ~~**Change Parameters' hidden unclamped total is now tracked.**~~
+  (**this framing turned out to be backwards — see the dated Follow-up at
+  the end of this Change Parameters section.**) `Game::Actor#change_param`
   (`mruby-rpg2k/mrblib/game.rb`) clamped and overwrote `@base[type]` on
   every call, permanently discarding how far past the 1..999 (1..9999 for
   max HP/MP) limit the real total had gone — lowering Attack by 2000 off a
   base of 3, then raising it back by 1000, landed at the clamp ceiling
-  (999) instead of staying floored, even though the real total
-  (3 − 2000 + 1000 = −997) is still deep underwater. Fixed with a parallel
+  (999) instead of staying floored ~~, even though the real total
+  (3 − 2000 + 1000 = −997) is still deep underwater~~. Fixed with a parallel
   `@base_raw` shadow that `#change_param` accumulates the signed delta on
   before clamping the result into `@base` — the value `#recompute_stats`
   and every other reader still uses, so nothing outside `#change_param`
@@ -18411,6 +18412,39 @@ codebase yet):
   with no such adjustment round-trips unaffected), confirmed to fail
   against the pre-fix code (the restored actor's stats reverted to the
   level-derived baseline) before the fix.
+  ✅ **Follow-up (2026-08-21): the whole "unclamped shadow total" premise
+  above was backwards — RPG_RT clamps the Change Parameters/Seed modifier
+  itself to +/-999 on every single call, it does not let an unbounded raw
+  total accumulate underneath the display clamp.** Both bullets above were
+  built on an uncited assumption (traced to a code comment attributing it
+  to `yado.tk`/`デフォ戦botまとめ`, never actually checked against real
+  source) that a deep debuff keeps "banking" magnitude indefinitely until a
+  later raise climbs all the way back through it. Checked directly against
+  RPG_RT's own live C++ this time: `Game_Actor::SetBaseAtk`/`SetBaseDef`/
+  `SetBaseSpi`/`SetBaseAgi` (`src/game_actor.cpp`) each clamp the modifier
+  itself — `data.attack_mod` etc, a shadow entirely separate from the level
+  curve — to `+/-MaxStatBaseValue()` (999) via a `ClampStatMod` helper, on
+  every call, *before* `GetBaseAtk` ever adds the curve and equipment and
+  clamps the combined total again to `1..999`; `SetBaseMaxHp`/`SetBaseMaxSp`
+  clamp `data.hp_mod`/`data.sp_mod` the same way via `ClampMaxHpMod`/
+  `ClampMaxSpMod`. So a deep debuff can never bank more magnitude in the
+  modifier than its own +/-999 ceiling, and a partial recovery afterward
+  reflects immediately once the (already-bounded) modifier crosses back
+  over the curve's own threshold — concretely, lowering Attack by 2000 off
+  a base-3 actor and then raising it back by 1000 twice now reads 1, then
+  **4** (curve 3 + a modifier that only ever reached -999, now raised to 1),
+  not 1, then 1 again the way the unclamped-total design left it. Fixed by
+  clamping the *isolated modifier* (`@base_raw[type] - base_stats(@level)
+  [type]`, the same diff `#set_level`'s own `preserve_mod` logic already
+  computes) to `+/-base_param_limit(type)` on every `#change_param` call,
+  before adding it back onto the curve — `@base_raw`'s own "curve + mod"
+  invariant, `#set_level`'s mod-preservation, and `#restore_base`'s
+  save/load round-trip are all otherwise untouched, since this only bounds
+  the modifier at write time rather than changing what `@base_raw` means.
+  The two existing `scripts/rpg2k_logic_check.rb` checks this section's own
+  bullets added were rewritten in place with the corrected values (the
+  save/load check's own reload-then-raise assertion changed from 3 to 4),
+  both confirmed to fail against the pre-fix code before the fix.
   ✅ **"Party wipe" for game-over purposes is now "every
   member is both unable to act and does not recover naturally," not
   literally "every member's HP is 0"** — why Stone status can wipe a party

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2937,18 +2937,42 @@ module Game
     # (max HP/MP 1..9999, the four battle stats 1..999); recomputing re-clamps the
     # current HP/MP so a lowered maximum never leaves a vital over its cap.
     #
-    # yado.tk's `2000/デフォ戦botまとめ`: the displayed/effective stat clamps to
-    # that range, but RPG_RT keeps accumulating the *unclamped* running total
-    # underneath -- lower Attack far past 1 with one call, then raise it back
-    # only part way, and the effective value stays pinned at the old clamp
-    # until the raw total genuinely climbs back past it, rather than reacting
-    # to the partial raise immediately. @base_raw is that shadow total; @base
+    # ~~yado.tk's `2000/デフォ戦botまとめ`: the displayed/effective stat clamps
+    # to that range, but RPG_RT keeps accumulating the *unclamped* running
+    # total underneath -- lower Attack far past 1 with one call, then raise
+    # it back only part way, and the effective value stays pinned at the old
+    # clamp until the raw total genuinely climbs back past it, rather than
+    # reacting to the partial raise immediately.~~ This turned out to be
+    # backwards -- confirmed against RPG_RT's own live source:
+    # `Game_Actor::SetBaseAtk`/`SetBaseDef`/`SetBaseSpi`/`SetBaseAgi`
+    # (`src/game_actor.cpp`) each clamp the *modifier itself* --
+    # `data.attack_mod` etc, a shadow entirely separate from the level curve
+    # -- to `+/-MaxStatBaseValue()` (999) via `ClampStatMod`, on every single
+    # call, before `GetBaseAtk` ever adds the curve and equipment and clamps
+    # the combined total again to `1..999`; `SetBaseMaxHp`/`SetBaseMaxSp`
+    # clamp `data.hp_mod`/`data.sp_mod` the same way via `ClampMaxHpMod`/
+    # `ClampMaxSpMod`. So a deep debuff can never bank more magnitude in the
+    # modifier than its own +/-999 ceiling, and a partial recovery afterward
+    # reflects immediately once the (already-bounded) modifier crosses back
+    # over the curve's own threshold -- it never has to "climb back" through
+    # however deep the original delta was. `@base_raw` (curve + modifier, no
+    # equipment -- see `#set_level`'s own `preserve_mod` diff) is this
+    # codebase's combined shadow; `@base_raw[type] - base_stats(@level)[type]`
+    # is the isolated modifier #set_level already computes this exact way,
+    # clamped here to `+/-base_param_limit(type)` before being added back
+    # onto the curve, matching `ClampStatMod`'s bound (the same ceiling
+    # `#base_param_limit` already uses for the *displayed* clamp, since the
+    # HP/MP edition-cap mismatch documented above this method already covers
+    # why the two ceilings aren't perfectly split by edition here). `@base`
     # (read by #recompute_stats and everything else) stays the clamped,
     # display/effective value throughout.
     def change_param(type, delta)
       return unless type >= 0 && type < STAT_NAMES.size
-      @base_raw[type] += delta
-      @base[type] = Game.clamp(@base_raw[type], 1, base_param_limit(type))
+      limit = base_param_limit(type)
+      curve = base_stats(@level)[type]
+      mod = Game.clamp(@base_raw[type] - curve + delta, -limit, limit)
+      @base_raw[type] = curve + mod
+      @base[type] = Game.clamp(@base_raw[type], 1, limit)
       recompute_stats
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4988,21 +4988,28 @@ check 'An ordinary level change carries a live Change Parameters adjustment ' \
   eq 72, a.atk
 end
 
-check 'Change Parameters tracks an unclamped total under the displayed clamp' do
-  # yado.tk `2000/デフォ戦botまとめ`: the displayed/effective stat clamps to
-  # 1..999 (1..9999 for HP/MP), but RPG_RT keeps accumulating the *real*
-  # total underneath -- a big drop below the floor doesn't "spend" any of a
-  # later raise until the raw total genuinely climbs back past the floor.
+check "Change Parameters clamps the modifier itself to +/-999 on every " \
+      'call, not the displayed total' do
+  # RPG_RT's own Game_Actor::SetBaseAtk (src/game_actor.cpp) clamps
+  # data.attack_mod -- a shadow entirely separate from the level curve --
+  # to +/-MaxStatBaseValue() (999) via ClampStatMod on every single call,
+  # before the curve and equipment are ever added and the combined total
+  # clamped again to 1..999. So a deep debuff can never bank more magnitude
+  # in the modifier than its own +/-999 ceiling, and a partial recovery
+  # afterward reflects immediately once the (already-bounded) modifier
+  # crosses back over the curve's own threshold.
   db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1])
   a = Game::Party.new(db).leader
-  eq 3, a.atk                                     # base atk starts at 3
-  a.change_param(Game::Actor::PARAM_ATK, -2000)    # raw 3 - 2000 = -1997
-  eq 1, a.atk                                      # clamped to the floor
-  a.change_param(Game::Actor::PARAM_ATK, 1000)     # raw -1997 + 1000 = -997
-  eq 1, a.atk                                      # still floored -- raw is still negative
-  a.change_param(Game::Actor::PARAM_ATK, 1000)     # raw -997 + 1000 = 3
-  eq 3, a.atk                                      # raw crossed back above 1: unclamps
-  # An ordinary, never-clamped sequence is untouched by the shadow tracking.
+  eq 3, a.atk                                     # base atk starts at 3, mod 0
+  a.change_param(Game::Actor::PARAM_ATK, -2000)    # mod clamp(0-2000,-999,999) = -999
+  eq 1, a.atk                                      # curve 3 + mod -999 = -996, floored to 1
+  a.change_param(Game::Actor::PARAM_ATK, 1000)     # mod clamp(-999+1000,..) = 1
+  eq 4, a.atk                                      # curve 3 + mod 1 = 4 -- reacts immediately,
+                                                     # not still floored the way an unclamped
+                                                     # running total would leave it
+  a.change_param(Game::Actor::PARAM_ATK, 1000)     # mod clamp(1+1000,-999,999) = 999
+  eq 999, a.atk                                     # curve 3 + mod 999 = 1002, capped at 999
+  # An ordinary, never-clamped sequence is unaffected by the modifier clamp.
   a.change_param(Game::Actor::PARAM_DEF, 5)        # base def 2 -> 7
   eq 7, a.def
   a.change_param(Game::Actor::PARAM_DEF, -3)       # 7 -> 4
@@ -5021,21 +5028,22 @@ check 'Party save round-trips a Change Parameters adjustment across Continue' do
   hero.gain_exp(500) # level up, so Continue's #set_exp also re-derives @base via
                       # #set_level -- the common case, not just the fresh-object one
   hero.change_param(Game::Actor::PARAM_DEF, 5)      # ordinary, never-clamped: 2 -> 7
-  hero.change_param(Game::Actor::PARAM_ATK, -2000)  # floors atk at 1, raw deep negative
-  hero.change_param(Game::Actor::PARAM_ATK, 1000)   # raw still negative -- stays floored
+  hero.change_param(Game::Actor::PARAM_ATK, -2000)  # mod clamps to -999, floors atk at 1
   eq 7, hero.def
   eq 1, hero.atk
   loaded = Game::State.load(db, st.to_h).party.actor_by_id(1)
   eq hero.level, loaded.level      # the level-up itself round-tripped too
   eq 7, loaded.def                 # ordinary adjustment survives Continue
   eq 1, loaded.atk                 # still floored, not reverted to the level-derived base
-  # The floor is still the hidden shadow total (raw -997), not a fresh clamp:
-  # one more +1000 crosses it back above 1 on the reloaded actor exactly as it
-  # does on the live one, rather than needing a second raise the way a
-  # freshly-floored (raw -1997) actor would.
+  # The floor is still the persisted -999 modifier, not a fresh clamp with no
+  # memory of it: a +1000 raise lands at curve 3 + mod 1 = 4 on the reloaded
+  # actor exactly as it does on the live one -- a fresh, never-adjusted actor
+  # given the same +1000 would instead land at curve 3 + mod 999 = 999
+  # (mod clamp(0+1000,-999,999) = 999), proving the saved modifier really did
+  # round-trip rather than resetting to 0.
   loaded.change_param(Game::Actor::PARAM_ATK, 1000)
   hero.change_param(Game::Actor::PARAM_ATK, 1000)
-  eq 3, loaded.atk
+  eq 4, loaded.atk
   eq hero.atk, loaded.atk
 end
 


### PR DESCRIPTION
## Summary

- RPG_RT clamps the Change Parameters/Seed stat modifier itself — separate from the level curve — to `+/-MaxStatBaseValue()` (999) on every call, *before* the combined curve+mod+equipment total is clamped again for display: `Game_Actor::SetBaseAtk`/`SetBaseDef`/`SetBaseSpi`/`SetBaseAgi` (`src/game_actor.cpp`) each compute `data.attack_mod` etc. through a `ClampStatMod` helper; `SetBaseMaxHp`/`SetBaseMaxSp` clamp `data.hp_mod`/`data.sp_mod` the same way via `ClampMaxHpMod`/`ClampMaxSpMod`. So a deep debuff can never bank more magnitude in the modifier than its own ±999 ceiling, and a partial recovery afterward reflects immediately once the (already-bounded) modifier crosses back over the curve's own threshold.
- `Game::Actor#change_param` (`mruby-rpg2k/mrblib/game.rb`) instead let an unbounded shadow total (`@base_raw`) accumulate with no per-call bound — a design this codebase's own doc comment (and a test title) attributed to an uncited `yado.tk`/`デフォ戦botまとめ` claim, never actually checked against real source. Concretely: lowering Attack by 2000 off a base-3 actor and then raising it back by 1000 twice previously read 1, then 1 again (the raw total needing to climb all the way back through -1997 before the display would react); real RPG_RT reads 1, then **4** (the modifier itself only ever reached -999, so raising it by 1000 crosses back over the curve's own threshold immediately).
- Fixed by clamping the *isolated modifier* (`@base_raw[type] - base_stats(@level)[type]`, the same diff `#set_level`'s own `preserve_mod` logic already computes) to `+/-base_param_limit(type)` on every `#change_param` call, before adding it back onto the curve. `@base_raw`'s own "curve + mod" invariant, `#set_level`'s mod-preservation, and `#restore_base`'s save/load round-trip are all otherwise untouched.
- This also corrects two prior `docs/TODO.md` writeups (and their own tests) that had built on the wrong premise.

## Test plan

- [x] Rewrote `scripts/rpg2k_logic_check.rb`'s "Change Parameters tracks an unclamped total under the displayed clamp" and "Party save round-trips a Change Parameters adjustment across Continue" checks in place with the corrected values.
- [x] Confirmed both rewritten checks fail against the pre-fix code (`git stash` on `game.rb` only — `expected 4, got 1`) and pass after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1091 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 834 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_