### PR TITLE
Reset a state's turn counter when cured, not just its presence

### DIFF
--- a/changelog.d/cure-state-stale-turn-counter.fixed.md
+++ b/changelog.d/cure-state-stale-turn-counter.fixed.md
@@ -1,0 +1,5 @@
+- **Battle:** curing a state now resets its "turns held" counter, so a
+  state cured and then reinflicted later in the same fight no longer
+  inherits a stale duration and auto-releases too early -- matching RPG_RT,
+  whose `State::Add`/`State::Remove` share one literal field for "present"
+  and "turns held," so the two can never drift apart there.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10749,6 +10749,31 @@ not yet verified:
   `#cure_state` call is refused on the same state while the armor stays
   equipped), both confirmed to fail against the pre-fix code before the
   fix.
+  ✅ **Follow-up (2026-08-21): `#cure_state` cleared a state from
+  `Combatant#states` but never cleared the matching entry in this
+  codebase's own separate `#apply_turn_states`-owned `state_turns` hash —
+  so a state cured and then reinflicted later in the *same* battle
+  inherited a stale "turns held" count instead of restarting at zero,
+  making it eligible for its `auto_release_prob` roll far too early
+  (sometimes on the very next tick).** Real RPG_RT cannot have this bug at
+  all: `State::Add`/`State::Remove` (`src/state.cpp`) share one literal
+  field for "state present" and "turns held" — `states[state_id - 1] = 1;`
+  on Add, `st = 0;` on Remove — and `Game_Battler::BattleStateHeal`
+  (`src/game_battler.cpp`) increments that exact same field each turn
+  (`states[i] > lcf::Data::states[i].hold_turn && ...`), so a cure always
+  zeroes the one field a later reinfliction resets to 1; the two states
+  (presence, duration) can never drift apart. This codebase's own other two
+  state-removal sites in the same class — `#apply_turn_states`'s own
+  auto-release branch and `#shake_off_states`'s physical-release branch —
+  already clear `state_turns` correctly; only `#cure_state`, the shared
+  helper behind an attack-skill's cure branch, a recovery-skill/item's cure
+  branch, and an RPG2003 weapon's `reverse_state_effect` heal, was missed.
+  Fixed with `target.state_turns.delete(sid) if target.state_turns` right
+  after the existing `states -= [sid]` line, mirroring `#shake_off_states`'s
+  own idiom exactly. Covered by a new `scripts/rpg2k_logic_check.rb` check
+  (a state held for two turns, cured, reinflicted, then held for one more
+  turn stays afflicted — not auto-released early off the stale counter),
+  confirmed to fail against the pre-fix code before the fix.
   ✅ **Follow-up (2026-08-19): Full Recovery never re-inflicted a
   cursed-armor-forced state the map-side Change Condition exemption above
   had already lifted — every fix in this cluster only ever kept an id

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13304,6 +13304,20 @@ module Game
       return unless target.state?(sid)
       return if combatant_permanent_states(target).include?(sid)
       target.states = (target.states || []) - [sid]
+      # Clear the per-state turn counter too, the same idiom
+      # #shake_off_states already uses for its own release path -- real
+      # RPG_RT's `State::Add`/`State::Remove` (`src/state.cpp`) share one
+      # literal field for "state present" and "turns held"
+      # (`states[state_id - 1] = 1` on Add, `st = 0` on Remove;
+      # `Game_Battler::BattleStateHeal`, `src/game_battler.cpp`, increments
+      # that same field each turn), so a cured-then-reinflicted state can
+      # never inherit a stale duration there. `#apply_turn_states`'s own
+      # `state_turns` hash tracks it separately here and is only ever
+      # incremented, never reset on infliction (`#inflict_state` touches
+      # `states`/`hp` only) -- leaving a stale entry behind would make a
+      # state re-inflicted later in the same fight eligible for its
+      # auto-release roll far too early, sometimes on the very next tick.
+      target.state_turns.delete(sid) if target.state_turns
       target.hp = 1 if sid == Game::States::DEATH_ID
     end
     public :inflict_state, :cure_state, :apply_knockout_reset

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14635,6 +14635,32 @@ check 'battle state at 0% auto_release_prob never wears off on its own' do
   eq true, hero.state?(5)                            # 0% -> stays for the whole fight
 end
 
+check 'battle: curing a state resets its turn-held counter, so a ' \
+      'reinflicted state does not inherit a stale duration' do
+  # RPG_RT's own State::Add/State::Remove (src/state.cpp) share one literal
+  # field for "state present" and "turns held" -- Add sets it to 1, Remove
+  # sets it to 0 -- so a cured-then-reinflicted state can never carry a
+  # stale duration into BattleStateHeal's (src/game_battler.cpp) hold_turn
+  # check. #cure_state used to remove the state from `states` without ever
+  # clearing the matching #apply_turn_states entry in this codebase's own
+  # separate `state_turns` hash, which #inflict_state never resets either.
+  states = { 5 => FakeStateDef.new(0, 0, 0, 0, 0, 2, 100) } # hold_turn 2, 100% release
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [5]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.send(:apply_turn_states, hero) # counter 1, not > 2
+  bat.send(:apply_turn_states, hero) # counter 2, not > 2 (2 is not > 2)
+  ok hero.state?(5), 'still held after two turns -- not yet eligible to auto-release'
+  bat.send(:cure_state, hero, 5)
+  ok !hero.state?(5), 'cured'
+  bat.send(:inflict_state, hero, 5)
+  ok hero.state?(5), 'reinflicted'
+  bat.send(:apply_turn_states, hero) # one turn on the freshly reinflicted state
+  ok hero.state?(5), 'counter restarted at 1, not resumed from the stale 2 -- ' \
+                      'still held, not auto-released a turn early'
+end
+
 # デフォ戦botまとめ: "'party wipe' for game-over purposes is defined as 'every
 # member is both unable to act and does not recover naturally,' not literally
 # 'every member's HP is 0' (why Stone status can wipe a party without zeroing


### PR DESCRIPTION
## Summary

- RPG_RT's `State::Add`/`State::Remove` (`src/state.cpp`) share one literal field for "state present" and "turns held" — `states[state_id - 1] = 1;` on Add, `st = 0;` on Remove — and `Game_Battler::BattleStateHeal` (`src/game_battler.cpp`) increments that exact same field each turn (`states[i] > lcf::Data::states[i].hold_turn && ...`). So a cure always zeroes the one field a later reinfliction resets to 1; the two can never drift apart in real RPG_RT.
- `Game::Battle#cure_state` (`mruby-rpg2k/mrblib/game.rb`) removes the state from `Combatant#states` but never clears the matching entry in this codebase's own separate `#apply_turn_states`-owned `state_turns` hash, and `#inflict_state` never resets it either. So a state cured (by a curative skill/item, or an RPG2003 weapon's `reverse_state_effect` heal) and then reinflicted later in the *same* battle inherits a stale "turns held" count instead of restarting at zero, making it eligible for its `auto_release_prob` roll far too early — sometimes on the very next tick.
- This codebase's own other two state-removal sites in the same class — `#apply_turn_states`'s own auto-release branch and `#shake_off_states`'s physical-release branch — already clear `state_turns` correctly; only `#cure_state` was missed, despite being the shared helper behind three common call sites (an attack-skill's cure branch, a recovery-skill/item's cure branch, and the RPG2003 weapon heal).
- Fixed with `target.state_turns.delete(sid) if target.state_turns` right after the existing `states -= [sid]` line, mirroring `#shake_off_states`'s own idiom exactly.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a state held for two turns (hold_turn 2, not yet eligible), cured, reinflicted, then held for one more turn stays afflicted — not auto-released early off the stale counter.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1092 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 834 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_