### PR TITLE
Stop Through Mode from letting the airship land on an event's tile

### DIFF
--- a/changelog.d/airship-landing-through-mode.fixed.md
+++ b/changelog.d/airship-landing-through-mode.fixed.md
@@ -1,16 +1,4 @@
-- **An airship can no longer land on a tile a map event occupies**, unless
-  that event's own move route has Through Mode on. `Scene::Map
-  #airship_landable?` gated its blocker check on the hero's own priority-type
-  occupancy test (`blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]`),
-  so a below/above-characters event — which airborne flight already ignores
-  entirely, since `#vehicle_passable?`'s airship branch never reads
-  `@event_tiles` — was also silently landable on, the same way the walking
-  hero correctly overlaps it. RPG_RT's landing rule is the vehicle-specific
-  one already fixed for a boarded boat/ship: any layer blocks, priority-type/
-  `overlap_forbidden` gating is ignored entirely, and only the blocking
-  event's own Through Mode lets it through. The blocker check is now
-  `blocker && !blocker[:char].through`, matching `#vehicle_passable?`'s
-  boat/ship branch exactly; flying itself, and the terrain's own
-  `airship_land` flag, are untouched. Covered by a new
-  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix
-  code before the fix.
+- **Vehicles:** an event with Through Mode on no longer lets the airship
+  land on its tile -- matching RPG_RT's own `CanLandAirship`, which blocks
+  a landing on any active event's tile unconditionally and never reads
+  Through Mode at all, unlike a boat/ship's own movement collision.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15481,13 +15481,36 @@ not yet verified:
   (`blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]`), the exact
   same reused-hero-rule mistake the boat/ship fix above already corrected for
   sailing: a below-characters event was silently landable on instead of
-  refusing the landing. The blocker check is now `blocker &&
+  refusing the landing. ~~The blocker check is now `blocker &&
   !blocker[:char].through`, textually identical to `#vehicle_passable?`'s
-  boat/ship branch; the terrain's own `airship_land` flag and flight itself
-  are untouched. Covered by a new `scripts/rpg2k_scene_check.rb` check (an
-  airship boarded directly over a below-characters event cannot land there
-  despite `airship_land: true`; turning that event's own Through Mode on lets
-  it land), confirmed to fail against the pre-fix code before the fix.
+  boat/ship branch~~ (**that Through-Mode exemption was itself wrong — see
+  the dated Follow-up below**); the terrain's own `airship_land` flag and
+  flight itself are untouched. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (an airship boarded directly over a below-characters event cannot
+  land there despite `airship_land: true`; ~~turning that event's own
+  Through Mode on lets it land~~), confirmed to fail against the pre-fix
+  code before the fix.
+  ✅ **Follow-up (2026-08-21): the Through-Mode exemption the fix above
+  copied from `#vehicle_passable?`'s boat/ship rule was itself wrong for
+  airship landing — RPG_RT never reads Through Mode when deciding whether
+  an event blocks a landing at all.** Confirmed against RPG_RT's own live
+  source: `Game_Map::CanLandAirship` (`src/game_map.cpp`) is a standalone
+  loop over every event — `if (ev.IsInPosition(x, y) && ev.IsActive() &&
+  ev.GetActivePage() != nullptr) return false;` — entirely separate from
+  `WouldCollide`/`CheckOrMakeWayEx`, the function `#vehicle_passable?`'s
+  own boat/ship rule legitimately reads `GetThrough()` from.
+  `CanLandAirship` never calls into that machinery and never reads Through
+  Mode anywhere: an event with Through Mode ON still blocks a landing,
+  unlike a boat/ship's own movement collision — landing is the airship
+  occupying the ground tile outright, not a "pass through" move. Fixed by
+  dropping the Through-Mode filter from `Scene::Map#airship_landable?`
+  entirely (`blockers_at(x, y).any?`, unconditional — `blockers_at` already
+  only ever indexes an event with a currently active page, the same
+  `IsActive() && GetActivePage() != nullptr` test `CanLandAirship` itself
+  uses). The existing `scripts/rpg2k_scene_check.rb` check above was
+  rewritten in place to assert the opposite of its own final assertion
+  (Through Mode no longer lets the airship land), confirmed to fail against
+  the pre-fix code before the fix.
 
 **Save / Load persistence — consolidated master list**
 Runtime state that does **not** survive a map re-visit (leave and return,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2387,15 +2387,24 @@ class RPG2k
       # ignores events entirely (#vehicle_passable?'s airship branch never
       # reads @event_tiles, so the airship can cruise directly over a
       # below-characters event a walking hero would just as happily overlap),
-      # so this is the one place events reach it at all — and, once they do,
-      # this follows the same vehicle-specific rule #vehicle_passable? already
-      # uses for a boat/ship (`!blocker[:char].through`): any layer blocks,
-      # priority-type/overlap_forbidden gating is ignored entirely, and only
-      # the blocking event's own Through Mode lets it through. A tile with no
-      # terrain data (a bare fixture) is landable.
+      # so this is the one place events reach it at all. Confirmed against
+      # RPG_RT's own live source: `Game_Map::CanLandAirship`
+      # (`src/game_map.cpp`) is a standalone loop -- `if (ev.IsInPosition(x,
+      # y) && ev.IsActive() && ev.GetActivePage() != nullptr) return false;`
+      # -- entirely separate from `WouldCollide`/`CheckOrMakeWayEx` (the
+      # function `#vehicle_passable?`'s own boat/ship rule legitimately
+      # reads `GetThrough()` from). `CanLandAirship` never reads Through
+      # Mode at all: any event with a currently-active page blocks a
+      # landing, Through Mode or not -- unlike a boat/ship's own movement
+      # collision, an airship landing is not itself a "pass through" move,
+      # it is occupying the ground tile outright. `blockers_at` already only
+      # ever indexes an event with a currently active page (the same
+      # `IsActive() && GetActivePage() != nullptr` test), so any blocker it
+      # returns here blocks unconditionally. A tile with no terrain data (a
+      # bare fixture) is landable.
       def airship_landable?(x, y)
         return false unless @map.in_bounds?(x, y)
-        return false if blockers_at(x, y).any? { |b| !b[:char].through }
+        return false if blockers_at(x, y).any?
         # A Boat/Ship parked on the ground blocks a landing too, matching
         # `Game_Map::CanLandAirship`'s own `for (auto vid: { Boat, Ship })`
         # loop (`src/game_map.cpp`) -- see `#vehicle_blocks?`.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8848,15 +8848,20 @@ check 'the airship crosses a tile in half the frames walking on foot takes' do
      "the airship's slide is exactly half the length of the on-foot one"
 end
 
-check 'the airship cannot land on a tile a map event occupies unless it has Through Mode on' do
+check 'the airship cannot land on a tile a map event occupies, Through ' \
+      'Mode or not' do
   # yado.tk: an airship can never land on a tile a map event occupies,
   # regardless of terrain. Flying itself ignores events entirely
   # (#vehicle_passable?'s airship branch never reads @event_tiles), so the
   # airship can cruise -- and be boarded -- directly over a below-characters
   # event a walking hero would just as happily overlap; landing there must
-  # still refuse it, the same vehicle-specific "any layer, only the blocking
-  # event's own Through Mode lets it through" rule already confirmed for a
-  # boarded boat/ship (see the boat/below-characters-event check above).
+  # still refuse it. Confirmed against RPG_RT's own live source:
+  # `Game_Map::CanLandAirship` (`src/game_map.cpp`) is a standalone loop
+  # over every event's `IsInPosition`/`IsActive`/`GetActivePage`, entirely
+  # separate from `WouldCollide`/`CheckOrMakeWayEx` (the function
+  # #vehicle_passable?'s own boat/ship rule reads Through Mode from) -- it
+  # never reads Through Mode at all, so an event with Through Mode ON still
+  # blocks a landing, unlike a boat/ship's own movement collision.
   blocker = event(0, 0, page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_BELOW))
   scene = new_scene({ 1 => blocker }, player: [0, 0], airship_land: true)
   st = scene.instance_variable_get(:@state)
@@ -8876,13 +8881,13 @@ check 'the airship cannot land on a tile a map event occupies unless it has Thro
   RGSS::Input.triggered = []
   eq :airship, st.boarded, 'a below-characters event on the tile still blocked landing'
 
-  # Turn the blocking event's own Through Mode on and try again: now it lands.
+  # Turn the blocking event's own Through Mode on and try again: still
+  # blocked -- CanLandAirship never reads Through Mode at all.
   chars(scene)[1].through = true
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.triggered = []
-  ok !st.boarded?, 'Through Mode on the blocking event let the airship land'
-  eq [0, 0], [st.x, st.y], 'the party stands where the airship touched down'
+  eq :airship, st.boarded, 'Through Mode on the blocking event does not let the airship land'
 end
 
 check 'an unridden boat/ship blocks the hero on foot, but an unridden airship does not' do


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_Map::CanLandAirship` (`src/game_map.cpp`) is a standalone loop over every event — `if (ev.IsInPosition(x, y) && ev.IsActive() && ev.GetActivePage() != nullptr) return false;` — entirely separate from `WouldCollide`/`CheckOrMakeWayEx`, the function `Scene::Map#vehicle_passable?`'s own boat/ship rule legitimately reads Through Mode (`GetThrough()`) from. `CanLandAirship` never calls into that machinery and never reads Through Mode anywhere: an event with Through Mode ON still blocks a landing — landing is the airship occupying the ground tile outright, not a "pass through" move like a boat/ship's own movement collision.
- `Scene::Map#airship_landable?` (`mruby-rpg2k/mrblib/scene/map.rb`) had copied the boat/ship Through-Mode exemption by analogy in an earlier fix (`blockers_at(x, y).any? { |b| !b[:char].through }`), so an event with Through Mode ON was incorrectly excluded from blocking a landing.
- Fixed by dropping the Through-Mode filter entirely (`blockers_at(x, y).any?`, unconditional) — `blockers_at` already only ever indexes an event with a currently active page, the same `IsActive() && GetActivePage() != nullptr` test `CanLandAirship` itself uses.
- This also corrects the prior `docs/TODO.md` writeup and its own test, which had asserted the Through-Mode exemption as correct without checking it against `CanLandAirship`'s actual source (it was verified against the *boat/ship* rule instead, and copied over by analogy).

## Test plan

- [x] Rewrote `scripts/rpg2k_scene_check.rb`'s existing check ("the airship cannot land on a tile a map event occupies unless it has Through Mode on") in place to assert the opposite of its own final assertion — Through Mode no longer lets the airship land.
- [x] Confirmed the rewritten check fails against the pre-fix code (`git stash` on `map.rb` only — `expected :airship, got nil`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 834 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1092 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_