### PR TITLE
Drop the Game Over screen's arming delay before Decision

### DIFF
--- a/changelog.d/game-over-arming-delay.fixed.md
+++ b/changelog.d/game-over-arming-delay.fixed.md
@@ -1,0 +1,7 @@
+- **Game Over screen:** a fresh Decision press now dismisses it immediately,
+  matching RPG_RT's own `Scene_Gameover::vUpdate` (a bare trigger check with
+  no arming/pending state at all). Previously the screen required a frame
+  with neither Decision nor Cancel held before it would respond, so a
+  player merely still holding Cancel -- which does nothing on this screen
+  -- when it appeared had their next Decision press silently ignored until
+  they let go.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1976,17 +1976,42 @@ The work below is roughly ordered by the critical path to a walkable game
   { Scene::ReturnToTitleScene(); }` — the entire file contains no reference
   to `Input::CANCEL` anywhere. Pressing Cancel on the real screen does
   nothing at all; only Decision returns to the title. Fixed by dropping the
-  `Input::B` half of the dismiss check (the pre-arming debounce, which
+  `Input::B` half of the dismiss check (~~the pre-arming debounce, which
   watches both keys purely to swallow whatever key was still held from the
   battle result that led here, was left alone — delaying arming by a frame
-  is harmless, unlike actually dismissing on the wrong key). An existing
-  check ("a game with no game-over picture still reaches the screen") had
-  been asserting the buggy behavior itself, dismissing with `Input::B` —
-  switched to `Input::C` to keep testing what it was meant to test (a
-  missing picture does not block dismissal) rather than the bug. Covered by
-  a new `scripts/rpg2k_scene_check.rb` check confirming Cancel is inert and
-  Decision still works right after, confirmed to fail against the pre-fix
-  code before the fix.
+  is harmless, unlike actually dismissing on the wrong key~~ -- **this
+  "harmless" framing turned out to be wrong too; see the dated Follow-up
+  below**). An existing check ("a game with no game-over picture still
+  reaches the screen") had been asserting the buggy behavior itself,
+  dismissing with `Input::B` — switched to `Input::C` to keep testing what
+  it was meant to test (a missing picture does not block dismissal) rather
+  than the bug. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  confirming Cancel is inert and Decision still works right after,
+  confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-21): the pre-arming debounce left alone above was
+  not harmless — it had no counterpart in real RPG_RT at all, and could
+  silently swallow a genuine fresh Decision press.** `Scene_Gameover::
+  vUpdate` (`src/scene_gameover.cpp`, cited above) is a bare
+  `if (Input::IsTriggered(Input::DECISION)) { ReturnToTitleScene(); }` —
+  no arming/pending state of any kind. The debounce's own justification
+  ("stops the button that closed the battle result from skipping the
+  screen in the same frame") does not hold up against this codebase's own
+  call chain either: `RPG2k#show_game_over` swaps `@scenes` without ever
+  calling `.update` on the new scene itself, so `Scene::GameOver`'s first
+  real `#update` always lands on the *next* `#main_loop` iteration, by
+  which point that iteration's own `Input.update` has already cleared the
+  old trigger (`@triggered` resets at the top of every `Input.update` call,
+  set again only by a genuine new key-down event) — the scenario the
+  debounce defended against cannot occur through the actual engine loop.
+  Meanwhile the debounce gated on `Input.press?` (held state, not a fresh
+  trigger) for *both* Decision and Cancel, so a player merely still
+  *holding* Cancel — which does nothing on this screen — when it appeared
+  had a fresh Decision press silently ignored until they let go, something
+  real RPG_RT never does. Fixed by removing `@armed` entirely, making
+  `#update` a literal one-line port of `vUpdate`. The existing "held key"
+  check was rewritten to assert the corrected behavior (the very first
+  `#update` call already honours a fresh Decision trigger, no delay),
+  confirmed to fail against the pre-fix code before the fix.
   **The battle backdrop is chosen from the game's own data now** rather than
   always being the flat void. RPG2000 keeps it on the map-tree node, not the map:
   `Game::Backdrop.name_for` reads the node's `backdrop_type`, a tri-state the

--- a/mruby-rpg2k/mrblib/scene/game_over.rb
+++ b/mruby-rpg2k/mrblib/scene/game_over.rb
@@ -31,21 +31,29 @@ class RPG2k
         bmp = gameover_bitmap
         @picture.bitmap = bmp if bmp
         play_gameover_bgm
-        # RPG_RT ignores whatever key ended the fight; requiring a *fresh* press
-        # stops the button that closed the battle result from skipping the
-        # screen in the same frame.
-        @armed = false
       end
 
+      # A literal port of EasyRPG's `Scene_Gameover::vUpdate`
+      # (src/scene_gameover.cpp): `if (Input::IsTriggered(Input::DECISION))
+      # { Scene::ReturnToTitleScene(); }` -- the whole method, no Cancel
+      # anywhere in the file (unlike the message/choice/menu windows this
+      # screen otherwise resembles, Cancel does not also dismiss it) and no
+      # arming/pending state of any kind. An earlier version here required a
+      # key-released frame before arming, on the theory that the key which
+      # dismissed the battle-defeat result could otherwise skip this screen
+      # in the same frame -- but `RPG2k#show_game_over` swaps `@scenes`
+      # without ever calling `.update` on the new scene itself, so this
+      # screen's first real `#update` always lands on the *next*
+      # `#main_loop` iteration, by which point that iteration's own
+      # `Input.update` has already cleared the old trigger (`@triggered` is
+      # reset at the top of every `Input.update` call, and only a genuine
+      # new key-down event sets it again) -- the scenario the arming gate
+      # defended against cannot occur through this engine's actual update
+      # loop, and the gate itself introduced a real divergence: a player
+      # merely still *holding* Cancel (which does nothing here) when this
+      # screen appears had a fresh Decision press silently ignored until
+      # they let go, something real RPG_RT never does.
       def update
-        unless @armed
-          @armed = true unless Input.press?(Input::C) || Input.press?(Input::B)
-          return
-        end
-        # EasyRPG's `Scene_Gameover::vUpdate` (src/scene_gameover.cpp) checks
-        # only `Input::IsTriggered(Input::DECISION)` -- no Cancel anywhere in
-        # the file. Unlike the message/choice/menu windows this screen
-        # otherwise resembles, Cancel does not also dismiss it.
         return unless Input.trigger?(Input::C)
         parent.return_to_title
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7519,19 +7519,26 @@ check 'a game-over battle defeat hands its Game::State to the Game Over screen' 
   eq st, parent.game_over_state, 'carrying the very Game::State the battle ran on'
 end
 
-check 'a button still held from the battle does not skip the Game Over screen' do
+check "Game Over's very first #update already honours a Decision trigger " \
+      '-- there is no arming delay' do
+  # EasyRPG's Scene_Gameover::vUpdate (src/scene_gameover.cpp) is a bare
+  # `if (Input::IsTriggered(Input::DECISION)) { ReturnToTitleScene(); }` --
+  # no arming/pending state of any kind. An earlier version here required a
+  # key-released frame first, on the theory that the key which dismissed
+  # the battle-defeat result could otherwise skip this screen in the same
+  # frame -- but `RPG2k#show_game_over` swaps `@scenes` without ever
+  # calling `.update` on the new scene itself, so this screen's first real
+  # `#update` always lands on the *next* `#main_loop` iteration, by which
+  # point that iteration's own `Input.update` has already cleared the old
+  # trigger. That scenario can never reach this screen's very first
+  # `#update` call through the real engine loop, so a fresh Decision
+  # trigger dismisses it immediately, exactly like the reference.
   parent = fake_parent(fake_db)
   Input.reset
-  # The key that dismissed the defeat message is still down as the scene opens.
-  Input.triggered = [Input::C]
   scene = RPG2k::Scene::GameOver.new(parent)
-  scene.update
-  ok !parent.returned_to_title, 'the held key is ignored'
-  Input.reset
-  scene.update                       # released: the screen arms
   Input.triggered = [Input::C]
-  scene.update                       # pressed afresh
-  ok parent.returned_to_title, 'a fresh press dismisses it'
+  scene.update
+  ok parent.returned_to_title, 'the very first update already honours it'
   Input.reset
 end
 
@@ -7545,12 +7552,10 @@ check 'the Cancel button does not dismiss the Game Over screen -- only Decision 
   parent = fake_parent(fake_db)
   Input.reset
   scene = RPG2k::Scene::GameOver.new(parent)
-  scene.update # arm: no key held yet
   Input.triggered = [Input::B]
   scene.update
   ok !parent.returned_to_title, 'Cancel is not a dismiss trigger for this screen'
   Input.reset
-  scene.update
   Input.triggered = [Input::C]
   scene.update
   ok parent.returned_to_title, 'Decision still dismisses it, right after'


### PR DESCRIPTION
## Summary

- RPG_RT's `Scene_Gameover::vUpdate` (`src/scene_gameover.cpp`) is a bare `if (Input::IsTriggered(Input::DECISION)) { Scene::ReturnToTitleScene(); }` — the whole method, no arming/pending state of any kind.
- `Scene::GameOver#update` (`mruby-rpg2k/mrblib/scene/game_over.rb`) required a frame with neither Decision nor Cancel *held* (`Input.press?`) before it would even look at a fresh trigger, on the theory that the key which dismissed the preceding battle-defeat result could otherwise skip this screen in the same frame.
- That theory doesn't hold up against this codebase's own call chain: `RPG2k#show_game_over` swaps `@scenes` without ever calling `.update` on the new scene itself, so `Scene::GameOver`'s first real `#update` always lands on the *next* `#main_loop` iteration — by which point that iteration's own `Input.update` has already cleared the old trigger (`@triggered` resets at the top of every `Input.update` call, set again only by a genuine new key-down event). The scenario the arming delay defended against cannot occur through the actual engine loop.
- Worse, the gate used *held* state (`Input.press?`) for both Decision and Cancel, so a player merely still holding Cancel — which does nothing on this screen, per the existing "Cancel does not dismiss" fix — when the screen appeared had their next fresh Decision press silently ignored until they let go, something real RPG_RT never does.
- Fixed by removing the `@armed` gate entirely, making `#update` a literal one-line port of `vUpdate`.

## Test plan

- [x] Rewrote `scripts/rpg2k_scene_check.rb`'s "a button still held from the battle does not skip the Game Over screen" check to assert the corrected behavior: the very first `#update` call already honours a fresh Decision trigger, no delay.
- [x] Confirmed the rewritten check (and the existing Cancel-inert check, updated to drop its own now-unneeded pre-arming `scene.update` call) fail against the pre-fix code (`git stash` on `game_over.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 834 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1092 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_