### PR TITLE
Make Move Forward follow an explicit Face/Turn, not the stale walked direction

### DIFF
--- a/changelog.d/move-forward-after-face-turn.fixed.md
+++ b/changelog.d/move-forward-after-face-turn.fixed.md
@@ -1,0 +1,6 @@
+- **Move routes:** a "Move Forward" sub-command right after an explicit
+  Face/Turn sub-command now continues in the newly faced direction, not the
+  direction last physically walked before the turn -- matching RPG_RT,
+  whose `UpdateMoveRoute` uses one single shared direction field for both a
+  Face/Turn command and a following Move Forward, with no lock exemption
+  either way.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11658,7 +11658,7 @@ not yet verified:
   unchanged. Covered by a new `scripts/rpg2k_logic_check.rb` check (Direction
   Fix ON, then a Move Right that keeps the facing frozen, then a Face Up that
   turns north despite the still-active lock), confirmed to fail against the
-  pre-fix code (asserting direction 8, getting 2) before the fix. ✅ **The
+  pre-fix code (asserting direction 8, getting 2) before the fix. ~~✅ **The
   related, separate "One Step Forward" question this fix scoped out is now
   fixed too**: a move-route "One Step Forward" is documented to continue in
   the *last direction actually moved* rather than the displayed facing, which
@@ -11676,7 +11676,9 @@ not yet verified:
   is no axis to be dominant when nothing moved. Covered by a new
   `scripts/rpg2k_logic_check.rb` check (Direction Fix ON, a locked Move
   Right, an explicit Face Up, then One Step Forward continues east, not
-  north), confirmed to fail against the pre-fix code before the fix. ✅ **The
+  north), confirmed to fail against the pre-fix code before the fix.~~ (this
+  whole "actually moved, not displayed facing" framing was backwards — see
+  the dated Follow-up a few bullets below.) ✅ **The
   "Animation Type" half of the original claim is now fixed too, verified
   against EasyRPG Player's actual C++ source rather than guessed at.** A
   page's own fixed-direction Animation Type (Fixed/Fixed-Continuous/Fixed-
@@ -11832,6 +11834,36 @@ not yet verified:
   the same root cause (this codebase's direction state could only hold a
   single cardinal), just not exercised by this fix, which only touched the
   non-jump path.
+  ✅ **Follow-up (2026-08-21): Move Forward after an explicit Face/Turn
+  sub-command continued in the direction last *physically walked* instead
+  of the newly faced direction — the opposite of what the original fix in
+  this cluster claimed, and the mirror image of the diagonal bug fixed
+  directly above (which correctly traced the same `UpdateMoveRoute` source
+  but never applied that reading to Face/Turn).** RPG_RT does not have a
+  "last actually walked" concept distinct from "currently faced" at all:
+  `Game_Character::UpdateMoveRoute`'s Face/Turn branch (`src/
+  game_character.cpp`) ends every one of Face Up/Right/Down/Left,
+  `Turn90DegreeRight`/`Turn90DegreeLeft`/`Turn180Degree`/`TurnRandom`/
+  `TurnTowardCharacter`/`TurnAwayFromCharacter` in a `SetDirection(...)`
+  call — the *exact same* `direction` field the Move-command branch's
+  `Move(GetDirection())` reads for a later Move Forward, with no lock check
+  anywhere in the Face/Turn branch. So `Turn Right` immediately followed by
+  `Move Forward` walks in the *turned* direction in real RPG_RT, lock or no
+  lock — never the stale pre-turn direction. `Character#face!`
+  (`mruby-rpg2k/mrblib/game.rb`) and `#turn_right`/`#turn_left`/
+  `#turn_around` wrote only `@direction`, deliberately leaving
+  `@last_move_direction` untouched per the original (uncited yado.tk-
+  sourced) doc comment quoted above — so `MOVE_FORWARD` kept reading the
+  direction from before the Face/Turn command ran. Fixed by having all four
+  methods also assign `@last_move_direction`, mirroring `#move`/`#jump`/
+  `#move_diagonal`'s existing assignment; `#face` (the lock-respecting
+  variant `#move` itself uses) is untouched, matching `UpdateFacing()`'s
+  own separate lock-respecting path in the reference. Covered by rewriting
+  the existing `scripts/rpg2k_logic_check.rb` check for this exact
+  Direction-Fix-then-Face-Up-then-Move-Forward sequence in place — it now
+  asserts continuing north (the newly faced direction) instead of east (the
+  old, wrong "last walked" assertion) — confirmed to fail against the
+  pre-fix code before the fix.
 - A move-route "Change Graphic" sub-command (hero, event, or vehicle) is
   **not persistent** — it reverts to the base graphic on save-load or map
   transfer, unlike the dedicated Change Graphic event commands. ✅ **All three

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6106,20 +6106,30 @@ module Game
     attr_accessor :fixed_facing
     attr_reader :graphic_name, :graphic_index, :x, :y
 
-    # The direction actually walked/jumped by the last successful move,
-    # distinct from #direction (the displayed sprite facing): a Direction
-    # Fix lock or an explicit Face command can turn the sprite without the
-    # character having moved a step in that direction, and the reverse --
-    # a locked move steps somewhere the sprite never turns to face. Only
-    # #move / #jump / #move_diagonal update this; #face!/#turn_* (no
-    # movement) and a blocked #do_move (turns to face an obstruction but
-    # never steps) leave it alone. yado.tk: a move-route "One Step Forward"
-    # continues in *this* direction, not the sprite's #direction.
+    # What a following move-route "Move Forward" sub-command walks in --
+    # NOT simply "the direction actually walked/jumped by the last
+    # successful move" the way an uncited yado.tk claim this comment used to
+    # repeat had it. RPG_RT's own `Game_Character::UpdateMoveRoute`
+    # (`src/game_character.cpp`) uses a single shared `direction` field for
+    # both purposes: a Face/Turn sub-command's branch (`SetDirection(...)`
+    # for Face Up/Right/Down/Left, or `Turn90DegreeRight`/`Turn90DegreeLeft`/
+    # `Turn180Degree`/`TurnRandom`/`TurnTowardCharacter`/
+    # `TurnAwayFromCharacter`, each itself a `SetDirection` call) writes the
+    # exact same `direction` a later Move-command branch's `Move(GetDirection
+    # ())` reads for Move Forward -- so `Turn Right` immediately followed by
+    # `Move Forward` walks in the *turned* direction in real RPG_RT, not
+    # whichever direction the character was last physically stepped in
+    # before the route began. #face!/#turn_right/#turn_left/#turn_around
+    # (the move-route Face/Turn sub-commands) update this field for exactly
+    # that reason; #move/#jump/#move_diagonal (actual steps) update it too,
+    # since RPG_RT's shared field is written by both. A blocked #do_move
+    # (turns to face an obstruction but never steps) still leaves it alone,
+    # matching #face's own lock-respecting, no-step nature.
     #
-    # A plain numpad int (2/4/6/8) after #move/#jump, or a `[horizontal,
-    # vertical]` pair after #move_diagonal -- see #move_diagonal's own
-    # citation for why a diagonal step's full 8-way direction has to survive
-    # here, not just one cardinal component.
+    # A plain numpad int (2/4/6/8) after #move/#jump/#face!/#turn_*, or a
+    # `[horizontal, vertical]` pair after #move_diagonal -- see
+    # #move_diagonal's own citation for why a diagonal step's full 8-way
+    # direction has to survive here, not just one cardinal component.
     attr_reader :last_move_direction
 
     # Placing a character outright -- Change Event Location, a page refresh
@@ -6188,7 +6198,9 @@ module Game
     # one of the fixed kinds -- RPG_RT still turns a "statue" NPC's sprite on
     # an explicit Face command even though it never turns while it walks.
     def face!(dir)
-      @direction = dir unless dir.nil?
+      return if dir.nil?
+      @direction = dir
+      @last_move_direction = dir
     end
 
     # Whether the move just made was a jump (a Begin Jump / End Jump block)
@@ -6282,9 +6294,20 @@ module Game
       @jumped = false
     end
 
-    def turn_right;  @direction = TURN_RIGHT[@direction] || @direction; end
-    def turn_left;   @direction = TURN_LEFT[@direction]  || @direction; end
-    def turn_around; @direction = TURN_180[@direction]   || @direction; end
+    def turn_right
+      @direction = TURN_RIGHT[@direction] || @direction
+      @last_move_direction = @direction
+    end
+
+    def turn_left
+      @direction = TURN_LEFT[@direction] || @direction
+      @last_move_direction = @direction
+    end
+
+    def turn_around
+      @direction = TURN_180[@direction] || @direction
+      @last_move_direction = @direction
+    end
 
     # Direction pointing from this character toward (tx, ty). ~~Ties (and
     # equal distance) resolve to the horizontal axis, matching RPG2000's
@@ -6486,12 +6509,13 @@ module Game
       when MOVE_AWAY_HERO
         do_move(character, world, away_hero(character, world))
       when MOVE_FORWARD
-        # yado.tk: continues in the direction actually last walked/jumped,
-        # not the sprite's displayed facing -- the two can diverge under a
-        # Direction Fix lock or an explicit Face command (see
-        # Character#last_move_direction). A diagonal last move continues
-        # diagonally (see #last_move_direction's own citation) rather than
-        # collapsing to one cardinal axis.
+        # #last_move_direction is what RPG_RT's own shared `direction` field
+        # holds at this point -- the immediately preceding Face/Turn
+        # sub-command in this same route wins over whatever the character
+        # last physically stepped in, since #face!/#turn_* update it too
+        # (see #last_move_direction's own citation). A diagonal last
+        # direction continues diagonally rather than collapsing to one
+        # cardinal axis.
         last = character.last_move_direction
         if last.is_a?(Array)
           do_diagonal_dir(character, world, last[0], last[1])

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -609,13 +609,22 @@ check 'a Face Direction sub-command overrides an earlier Direction Fix ON in the
   eq 8, c.direction
 end
 
-check 'move forward after a Direction-Fix move continues in the last direction actually moved' do
-  # yado.tk: "One Step Forward" is documented to continue in the direction
-  # last *walked*, not the sprite's displayed facing -- the follow-up this
-  # codebase scoped out of the Face Direction fix above, since #direction
-  # alone cannot tell the two apart once a locked move and an explicit Face
-  # command have diverged. Character#last_move_direction (added for this)
-  # is what Move Forward now reads instead of #direction.
+check 'move forward after an explicit Face command continues in the newly ' \
+      'faced direction, even under an active Direction-Fix lock' do
+  # Confirmed against RPG_RT's own live source rather than an uncited
+  # yado.tk claim this check used to repeat (the opposite of this):
+  # `Game_Character::UpdateMoveRoute` (src/game_character.cpp) uses one
+  # single shared `direction` field for both purposes -- its Face/Turn
+  # branch's `SetDirection(...)` (Face Up/Right/Down/Left, or
+  # Turn90DegreeRight/Left/Turn180Degree/TurnRandom/TurnTowardCharacter/
+  # TurnAwayFromCharacter, each itself a SetDirection call) writes the
+  # exact same `direction` a later Move-command branch's
+  # `Move(GetDirection())` reads for Move Forward -- with no lock check
+  # anywhere in the Face/Turn branch. So "Face Up" immediately followed by
+  # "Move Forward" walks north in real RPG_RT, not east (the direction last
+  # physically walked before the Face command), lock or no lock.
+  # Character#last_move_direction is what Move Forward reads; #face!
+  # (Face/Turn sub-commands) now updates it exactly like #move does.
   route = R.new([mc(R::LOCK_FACING), mc(R::MOVE_RIGHT), mc(R::FACE_UP),
                  mc(R::MOVE_FORWARD)], repeat: false)
   c = Game::Character.new(5, 5, 2) # facing south
@@ -624,12 +633,12 @@ check 'move forward after a Direction-Fix move continues in the last direction a
   route.step(c, w) # Move Right: last-moved direction east, facing stays south
   eq [6, 5], [c.x, c.y]
   eq 6, c.last_move_direction
-  route.step(c, w) # Face Up: turns the sprite north; last-moved direction untouched
+  route.step(c, w) # Face Up: turns the sprite north, and last_move_direction with it
   eq 8, c.direction
-  eq 6, c.last_move_direction
-  route.step(c, w) # One Step Forward: continues east (last walked), not north (facing)
-  eq [7, 5], [c.x, c.y]
-  eq 8, c.direction # the lock is still on, so the step itself doesn't re-face south
+  eq 8, c.last_move_direction
+  route.step(c, w) # One Step Forward: continues north (newly faced), not east
+  eq [6, 4], [c.x, c.y]
+  eq 8, c.direction
 end
 
 check 'a fixed-direction Animation Type suppresses movement-driven facing, but ' \


### PR DESCRIPTION
## Summary

- RPG_RT's `Game_Character::UpdateMoveRoute` (`src/game_character.cpp`) uses one single shared `direction` field for both purposes: every Face/Turn sub-command (Face Up/Right/Down/Left, or `Turn90DegreeRight`/`Turn90DegreeLeft`/`Turn180Degree`/`TurnRandom`/`TurnTowardCharacter`/`TurnAwayFromCharacter`) ends in a `SetDirection(...)` call — the exact same field the Move-command branch's `Move(GetDirection())` reads for a later Move Forward, with no lock check anywhere in the Face/Turn branch. So `Turn Right` immediately followed by `Move Forward` walks in the *turned* direction in real RPG_RT, lock or no lock — never the stale pre-turn direction.
- `Character#face!` and `#turn_right`/`#turn_left`/`#turn_around` (`mruby-rpg2k/mrblib/game.rb`) wrote only `@direction`, deliberately leaving `@last_move_direction` (the field `MOVE_FORWARD` actually reads) untouched — per this codebase's own doc comment, which cited an uncited yado.tk claim asserting the opposite of what the reference source actually does. So `MOVE_FORWARD` kept reading whatever direction was in effect *before* the Face/Turn command ran.
- Fixed by having all four methods also assign `@last_move_direction`, mirroring `#move`/`#jump`/`#move_diagonal`'s existing assignment. `#face` (the lock-respecting variant `#move` itself uses for movement-driven facing) is untouched, matching `UpdateFacing()`'s own separate lock-respecting path in the reference.
- This also corrects the prior `docs/TODO.md` writeup for the original "One Step Forward" fix in this area, which had asserted the wrong design, and updates its own doc comments accordingly.

## Test plan

- [x] Rewrote `scripts/rpg2k_logic_check.rb`'s existing check for the exact Direction-Fix-then-Face-Up-then-Move-Forward sequence to assert continuing north (the newly faced direction) instead of east (the old, wrong "last walked" assertion).
- [x] Confirmed the rewritten check fails against the pre-fix code (`git stash` on `game.rb` only — `expected 8, got 6`) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1092 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 834 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_