### PR TITLE
Show state-adjusted stats on the Status/Equip screens

### DIFF
--- a/changelog.d/status-equip-stat-state-adjustment.fixed.md
+++ b/changelog.d/status-equip-stat-state-adjustment.fixed.md
@@ -1,0 +1,8 @@
+- **Status/Equip screens:** an actor's ATK/DEF/Int(Spirit)/AGI on the field
+  Status screen, and both the current and previewed value on the Equip
+  screen, now reflect any currently-active halve/double state -- matching
+  RPG_RT's own `GetAtk`/`GetDef`/`GetSpi`/`GetAgi`. Previously these two
+  screens showed the raw base stat, ignoring a state that persisted onto
+  the map. The Equip screen's preview also no longer shows a raw, unclamped
+  negative total when a heavy two-handed weapon swap forces off other
+  equipment.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16900,10 +16900,61 @@ above are repeated here)
   checks (the candidate list draws no glyph at all; the stats window shows
   the correct per-stat preview for a better/worse/unchanged candidate and
   reverts once the list is left; a 両手持ち candidate previews Atk rising and
-  Def falling *at once*, the exact case a single summed verdict could only
-  ever show one side of; the preview colour comes from the loaded
-  windowskin's own swatch cells, not a hardcoded RGB value), all four
-  confirmed to fail against the pre-fix code before the fix.
+  ~~Def falling *at once*, the exact case a single summed verdict could only
+  ever show one side of~~ (that check's own expected Def value was itself
+  wrong — see the dated Follow-up a few bullets below); the preview colour
+  comes from the loaded windowskin's own swatch cells, not a hardcoded RGB
+  value), all four confirmed to fail against the pre-fix code before the fix.
+- ✅ **The field Status screen and Equip screen showed an actor's ATK/DEF/
+  Int(Spirit)/AGI as the raw base stat, ignoring any currently-active
+  halve/double state (2026-08-21).** Confirmed against RPG_RT's own live
+  source: `Window_ParamStatus::Refresh` (`src/window_paramstatus.cpp`)
+  draws `actor.GetAtk()`/`GetDef()`/`GetSpi()`/`GetAgi()` directly (not a
+  "base" variant), and `Game_Battler::GetAtk` et al. (`src/game_battler.cpp`)
+  run the base value through `AdjustParam`, which halves/doubles it against
+  whatever states the actor currently carries (`GetInflictedStates()`, not
+  battle-scoped — whatever is on the actor, in battle or on the field).
+  `Window_EquipStatus::DrawParameter` (`src/window_equipstatus.cpp`) draws
+  the Equip screen's "current" column the same way, and `Scene_Equip::
+  UpdateStatusWindow` (`src/scene_equip.cpp`) finishes its "new" preview
+  column with `actor.CalcValueAfterAtkStates(atk)` — both columns are
+  state-adjusted in the reference. This codebase had already built the
+  correct machinery for exactly this — `Game::Party#effective_atk`/
+  `#effective_def`/`#effective_int`/`#effective_agi`, ported for skill power
+  formulas with the identical "not a battle-only variant" reasoning cited
+  above — but `status_menu.rb`/`equip_menu.rb` read `Game::Actor#atk`/`#def`/
+  `#int`/`#agi` directly and never called them. Fixed by routing both
+  screens' current-value display through the existing `effective_*`
+  methods. Covered by two new `scripts/rpg2k_scene_check.rb` checks (the
+  status screen shows a halved Atk under an active state, not the raw base;
+  the equip screen's current-value column does too), confirmed to fail
+  against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-21): the Equip screen's preview column had two
+  further gaps in the same method, one of them predating this state-
+  adjustment fix — a negative preview total was shown raw and unclamped,
+  and the preview never applied a state's halve/double at all.** Confirmed
+  against RPG_RT's own live source: `Scene_Equip::UpdateStatusWindow`
+  rebuilds the new *base* total (each stat's own `GetBaseAtk(..., equip:
+  false)` plus every equipped item's own point field, the candidate
+  swapped in), clamps it to `actor.MaxStatBaseValue()` (999, floor 1) via
+  `Utils::Clamp`, and only *then* calls `CalcValueAfterAtkStates` — state
+  adjustment is the last step, applied to an already-floored value, not
+  folded additively into the raw item-swap delta and left unclamped. This
+  codebase's own `#draw_stat_row` computed `value + delta` with no clamp of
+  any kind — a 両手持ち weapon swap that forces off a hefty shield could
+  (and, per the check just above, did) preview a genuine negative Def —
+  and never reapplied `stat_mode`/`adjust_stat` to the preview at all.
+  Fixed by clamping the new base to `1..Game::Actor::MAX_EFFECTIVE_STAT`
+  before applying the same `stat_mode`/`adjust_stat` pair the current-value
+  fix above already wired in; `Window_EquipStatus::GetNewParameterColor`
+  compares the two *displayed* (state-adjusted) values, not the raw item
+  delta's sign, so the preview's up/down colouring was corrected to match
+  (the two agree away from a clamp boundary or an active state, which is
+  every case the existing colour check already covered, so it needed no
+  changes). The existing 両手持ち preview check's own expected Def value
+  (`-13`) was corrected to the clamped `1`, and a new check confirms both
+  the current and previewed value halve together under an active state,
+  both confirmed to fail against the pre-fix code before the fix.
 - ✅ **A State's own configured display-color field is a pointer into the
   same shared message-colour palette every `\c[n]` code draws from —
   confirmed already correct, no code change needed.** There is only one

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -254,16 +254,17 @@ class RPG2k
         @stats_window.contents = c
       end
 
-      # RPG2000 term / equip-bonus field / actor-accessor triples for the four
-      # battle stats, in the order EasyRPG's own `Window_EquipStatus::
-      # DrawParameter` (`src/window_equipstatus.cpp`) draws them (Atk/Def/
-      # Spirit/Agility -- this codebase's own `term(:mind, ...)`/`#int` name
-      # RPG2000's "Spirit" stat "Int" instead, matching status_menu.rb).
+      # RPG2000 term / equip-bonus field / actor-accessor / effective-stat
+      # method / state-flag quintuples for the four battle stats, in the
+      # order EasyRPG's own `Window_EquipStatus::DrawParameter`
+      # (`src/window_equipstatus.cpp`) draws them (Atk/Def/Spirit/Agility --
+      # this codebase's own `term(:mind, ...)`/`#int` name RPG2000's
+      # "Spirit" stat "Int" instead, matching status_menu.rb).
       STAT_DEFS = [
-        [:attack, 'Atk', :atk_points1, :atk],
-        [:defense, 'Def', :def_points1, :def],
-        [:mind, 'Int', :spi_points1, :int],
-        [:agility, 'Agi', :agi_points1, :agi]
+        [:attack, 'Atk', :atk_points1, :atk, :effective_atk, :affect_attack],
+        [:defense, 'Def', :def_points1, :def, :effective_def, :affect_defense],
+        [:mind, 'Int', :spi_points1, :int, :effective_int, :affect_spirit],
+        [:agility, 'Agi', :agi_points1, :agi, :effective_agi, :affect_agility]
       ].freeze
 
       # Four independent stat rows -- one "label value" per row while
@@ -280,23 +281,56 @@ class RPG2k
       def draw_stat_row(c, a)
         previewing = @mode == :items
         cand_id = previewing ? candidates[@cand_index].first : nil
-        STAT_DEFS.each_with_index do |(term_key, label, field, accessor), i|
+        STAT_DEFS.each_with_index do |(term_key, label, field, accessor,
+                                        effective_method, stat_flag), i|
           y = LINE_H * (1 + i)
           x = 0
-          value = a.send(accessor)
+          # State-adjusted (halve/double), not the raw base+equip total --
+          # confirmed against RPG_RT's own live source: `Window_EquipStatus::
+          # DrawParameter` (`src/window_equipstatus.cpp`) draws
+          # `actor.GetAtk()` et al., which run the base value through
+          # `Game_Battler::AdjustParam` (`src/game_battler.cpp`) against
+          # whatever states the actor currently carries. `Game::Party
+          # #effective_atk`/`#effective_def`/`#effective_int`/`#effective_agi`
+          # already port this (built for skill formulas); this screen never
+          # called them.
+          value = @state.party.send(effective_method, a)
           text = "#{term(term_key, label)} #{value}"
           c.font.color = Color.new(255, 255, 255, 255)
           w = c.text_size(text).width
           c.draw_text x, y, w, LINE_H, text
           x += w
           if previewing
+            # The preview recomputes the new *base* total (this stat's own
+            # raw base+equip accessor plus the candidate's raw point delta,
+            # matching `#effective_atk` et al.'s own base+equip reading)
+            # and only then reapplies the state halve/double, exactly
+            # mirroring `Scene_Equip::UpdateStatusWindow` (`src/
+            # scene_equip.cpp`): it rebuilds `atk`/`def`/`spi`/`agi` from
+            # `GetBaseAtk(..., equip: false)` plus each equipped item's own
+            # point field, clamps, then calls
+            # `actor.CalcValueAfterAtkStates(atk)` -- the state adjustment
+            # is the last step, not folded additively into the raw delta.
             delta = stat_field_delta(cand_id, field)
+            # Clamped to 1..999 (`Game::Actor::MAX_EFFECTIVE_STAT`, matching
+            # `scene_equip.cpp`'s own `actor.MaxStatBaseValue()`) *before*
+            # the state adjustment -- the reference's `Utils::Clamp(atk, 1,
+            # limit)` runs ahead of `CalcValueAfterAtkStates`, not after.
+            new_base = Game.clamp(a.send(accessor) + delta, 1,
+                                   Game::Actor::MAX_EFFECTIVE_STAT)
+            new_value = @state.party.adjust_stat(
+              new_base, @state.party.stat_mode(a, stat_flag)
+            )
             arrow_w = c.text_size('>').width
             draw_system_text c, x, y, arrow_w, LINE_H, '>', @skin, 1
             x += arrow_w
-            new_text = (value + delta).to_s
+            new_text = new_value.to_s
             new_w = c.text_size(new_text).width
-            color_idx = delta.zero? ? 0 : (delta.positive? ? 2 : 3)
+            # `Window_EquipStatus::GetNewParameterColor` (same file) compares
+            # the two *displayed* (state-adjusted) values, not the raw item
+            # delta's sign -- the two usually agree, but only this matches
+            # the reference at a clamp boundary or under a halving state.
+            color_idx = new_value == value ? 0 : (new_value > value ? 2 : 3)
             draw_system_text c, x, y, new_w, LINE_H, new_text, @skin, color_idx
           end
         end

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -140,8 +140,22 @@ class RPG2k
           "#{term(:exp_short, 'EXP')} #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
           "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}    " \
           "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}",
-          "#{term(:attack, 'Atk')} #{a.atk}   #{term(:defense, 'Def')} #{a.def}   " \
-          "#{term(:mind, 'Int')} #{a.int}   #{term(:agility, 'Agi')} #{a.agi}",
+          # ATK/DEF/Int(Spirit)/AGI, state-adjusted -- confirmed against
+          # RPG_RT's own live source: `Window_ParamStatus::Refresh`
+          # (`src/window_paramstatus.cpp`) draws `actor.GetAtk()`/`GetDef()`/
+          # `GetSpi()`/`GetAgi()` directly, and `Game_Battler::GetAtk` et al.
+          # (`src/game_battler.cpp`) run the base value through `AdjustParam`,
+          # which halves/doubles it against whatever states the actor
+          # currently carries (`GetInflictedStates()`, not battle-scoped) --
+          # so a halving/doubling state that persists onto the map shows its
+          # effect here too, not just in battle math. `Game::Party
+          # #effective_atk`/`#effective_def`/`#effective_int`/`#effective_agi`
+          # already port this (built for skill formulas, see their own
+          # citation) but were never wired into this screen.
+          "#{term(:attack, 'Atk')} #{@state.party.effective_atk(a)}   " \
+          "#{term(:defense, 'Def')} #{@state.party.effective_def(a)}   " \
+          "#{term(:mind, 'Int')} #{@state.party.effective_int(a)}   " \
+          "#{term(:agility, 'Agi')} #{@state.party.effective_agi(a)}",
           # The condition gets a labelled row of its own, as on RPG_RT's status
           # screen (its Window_ActorInfo draws the label then the state). Only
           # the label goes through the flat pass below; the state itself is drawn

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16536,13 +16536,47 @@ class MenuStubActor
 
 class MenuStubParty
   attr_reader :actors, :gold, :revision
-  attr_accessor :leader
+  attr_accessor :leader, :situation
   def initialize
     @actors = [MenuStubActor.new]; @gold = 0; @leader = nil; @revision = 0
+    @situation = nil # a state-definition table, for the one check below
+                      # that exercises a stat-affecting (halve/double) state
   end
   def field_items(_state = nil); []; end
   def field_skills(_actor, _state = nil); []; end
   def reorder(new_order); @actors = new_order.map { |i| @actors[i] }; end
+  # Mirrors Game::Party#stat_mode/#adjust_stat/#effective_atk (etc, see
+  # game.rb) -- Scene::StatusMenu/Scene::EquipMenu now read an actor's
+  # state-adjusted battle stat through the real party object rather than
+  # its bare accessor. @situation nil (the default here, matching every
+  # existing check's own state-free actors) always reads :normal, so this
+  # is a no-op for every check except the one that sets it.
+  def stat_mode(b, stat_flag)
+    return :normal unless @situation
+    half = false; dbl = false
+    (b.states || []).each do |sid|
+      d = @situation[sid]
+      next unless d && d.respond_to?(stat_flag) && d.send(stat_flag)
+      case d.respond_to?(:affect_type) ? d.affect_type : 2
+      when 0 then half = true
+      when 1 then dbl = true
+      end
+    end
+    return :double if dbl && !half
+    return :half if half && !dbl
+    :normal
+  end
+  def adjust_stat(value, mode)
+    case mode
+    when :double then value * 2
+    when :half then [value / 2, 1].max
+    else value
+    end
+  end
+  def effective_atk(b); adjust_stat(b.atk, stat_mode(b, :affect_attack)); end
+  def effective_def(b); adjust_stat(b.def, stat_mode(b, :affect_defense)); end
+  def effective_int(b); adjust_stat(b.int, stat_mode(b, :affect_spirit)); end
+  def effective_agi(b); adjust_stat(b.agi, stat_mode(b, :affect_agility)); end
   # Mirrors Game::Party#toggle_actor_row's own guard (see rpg2k_logic_check.rb
   # for that method's own coverage) -- this scene-check only needs to prove
   # Scene::Menu's `:row` dispatch actually reaches it, not re-prove the guard.
@@ -19511,6 +19545,41 @@ check 'Scene::EquipMenu: the stats window previews each battle stat ' \
   eq false, texts.include?('>'), 'back on the slot list, the preview arrow is gone entirely'
 end
 
+# Confirmed against RPG_RT's own live source: `Window_EquipStatus::
+# DrawParameter` (`src/window_equipstatus.cpp`) draws `actor.GetAtk()` (the
+# state-adjusted value), and `Scene_Equip::UpdateStatusWindow` (`src/
+# scene_equip.cpp`) computes its own "new" preview by rebuilding the raw
+# base+equip total first, clamping to `MaxStatBaseValue()` (999), and only
+# then calling `actor.CalcValueAfterAtkStates` -- the state adjustment is
+# the last step in both the current and the preview column, not skipped or
+# folded additively into the raw item-swap delta.
+check 'Scene::EquipMenu: both the current and previewed stat are halved by ' \
+      'an active state' do
+  state = Game::State.new(EquipCompareParty.new, 1, 0, 0)
+  actor = state.party.actors.first
+  actor.equipment[0] = 1 # weapon slot: Worn (atk 10); actor's own Atk stub is 20
+  actor.add_state(5)
+  state.party.situation = { 5 => OpenStruct.new(affect_type: 0, affect_attack: true) }
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  texts = window_texts(scene.instance_variable_get(:@stats_window))
+  # Each stat is its own draw call here (unlike the combined status-screen
+  # line above); the Atk row is whichever one ends in " 10", not the term
+  # text (a real database's own, not this fixture's fallback labels).
+  ok texts.any? { |t| t.match?(/\b10\z/) },
+     "expected the halved current Atk (10), got: #{texts.inspect}"
+  ok !texts.any? { |t| t.match?(/\b20\z/) },
+     "the raw base Atk (20) should not still appear: #{texts.inspect}"
+
+  scene.instance_variable_set(:@mode, :items)
+  scene.send(:build_cand_window)
+  scene.instance_variable_set(:@cand_index, 1) # Better (id 2, atk 15)
+  scene.send(:refresh_cand_cursor)
+  texts = window_texts(scene.instance_variable_get(:@stats_window))
+  # base+equip: 20 + (15 - 10) = 25, then halved: 12 (25 / 2 truncated)
+  ok texts.include?('12'),
+     "expected the halved preview (12), not a linear 10 + 5, got: #{texts.inspect}"
+end
+
 # The same per-stat preview, but through the 両手持ち forced-unequip case a
 # single summed verdict used to collapse into one arrow: Atk rises (+40 the
 # claymore, -20 the old sword) while Def falls at the same time (-25 the
@@ -19563,9 +19632,15 @@ check 'Scene::EquipMenu: a 両手持ち candidate previews Atk rising and Def ' 
   texts = window_texts(scene.instance_variable_get(:@stats_window))
   ok texts.include?('40'),
      'Atk rises: stub actor\'s own 20 + delta (claymore 40 - sword 20 = 20) = 40'
-  ok texts.include?('-13'),
-     'Def falls in the same preview: stub actor\'s own 12 + delta (0 - forced-off ' \
-     "shield's 25 = -25) = -13"
+  # Def falls in the same preview: stub actor's own 12 + delta (0 -
+  # forced-off shield's 25 = -25) = -13 -- but RPG_RT clamps the new base
+  # total to 1..999 (`Utils::Clamp(atk, 1, limit)`, `src/scene_equip.cpp`)
+  # *before* ever displaying it, the same clamp #draw_stat_row now applies,
+  # so a negative preview floors to 1, not the raw negative sum.
+  ok texts.include?('1'),
+     'Def falls to the floor in the same preview: -13 clamped to 1'
+  ok !texts.include?('-13'),
+     'the raw, unclamped negative total should not be shown at all'
 end
 
 # EasyRPG's `Window_EquipStatus::DrawParameter` (`src/window_equipstatus.cpp`)
@@ -19675,6 +19750,32 @@ check 'the status screen shows a labelled Class row' do
   texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
                          .instance_variable_get(:@window))
   ok texts.include?('Class: Paladin'), "shows the class name, got: #{texts.inspect}"
+end
+
+# Confirmed against RPG_RT's own live source: `Window_ParamStatus::Refresh`
+# (`src/window_paramstatus.cpp`) draws `actor.GetAtk()`/`GetDef()`/
+# `GetSpi()`/`GetAgi()`, and `Game_Battler::GetAtk` et al. (`src/
+# game_battler.cpp`) run the base value through `AdjustParam`, which halves
+# or doubles it against whatever states the actor currently carries -- a
+# state that persists onto the map affects this screen too, not just battle
+# math.
+check 'the status screen shows a battle stat halved by an active state, ' \
+      'not the raw base value' do
+  st = menu_state
+  hero = st.party.actors.first
+  eq 20, hero.atk # MenuStubActor's own base stub value
+  hero.add_state(5)
+  st.party.situation = { 5 => OpenStruct.new(affect_type: 0, affect_attack: true) }
+  texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
+                         .instance_variable_get(:@window))
+  # Def/Int/Agi (12/9/14) are unaffected -- only Atk (base 20) halves to 10;
+  # matched by number rather than term text since the term table (a real
+  # database's own, unlike this fixture's bare fallback labels) is not what
+  # this check is about.
+  stat_line = texts.find { |t| t.include?('12') && t.include?('9') && t.include?('14') }
+  ok stat_line, "expected the stat row somewhere, got: #{texts.inspect}"
+  ok stat_line.match?(/\b10\b/), "expected the halved Atk (10), not the raw base (20): #{stat_line.inspect}"
+  ok !stat_line.match?(/\b20\b/), "the raw base Atk (20) should not still appear: #{stat_line.inspect}"
 end
 
 # Confirmed directly against RPG_RT's live source: `Window_ActorStatus::


### PR DESCRIPTION
## Summary

- RPG_RT's `Window_ParamStatus::Refresh` (`src/window_paramstatus.cpp`) draws `actor.GetAtk()`/`GetDef()`/`GetSpi()`/`GetAgi()` directly, and `Game_Battler::GetAtk` et al. (`src/game_battler.cpp`) run the base value through `AdjustParam`, which halves/doubles it against whatever states the actor currently carries (`GetInflictedStates()`, not battle-scoped — whatever is on the actor, in battle or on the field). `Window_EquipStatus::DrawParameter` (`src/window_equipstatus.cpp`) draws the Equip screen's "current" column the same way, and `Scene_Equip::UpdateStatusWindow` (`src/scene_equip.cpp`) finishes its "new" preview column with `actor.CalcValueAfterAtkStates(atk)`.
- `mruby-rpg2k/mrblib/scene/status_menu.rb` and `equip_menu.rb` read `Game::Actor#atk`/`#def`/`#int`/`#agi` directly, bypassing the existing `Game::Party#effective_atk`/`#effective_def`/`#effective_int`/`#effective_agi` — already built for skill power formulas with the identical "not a battle-only variant" reasoning. Fixed by routing both screens' current-value display through them.
- Along the way, found and fixed two further gaps in the Equip screen's preview column, in the same method: the reference clamps the new *base* total to `MaxStatBaseValue()` (999, floor 1) **before** applying the state adjustment, not after folding a raw delta in unclamped — so a heavy 両手持ち weapon swap forcing off other equipment could preview a genuine negative stat, and the preview never applied a state's halve/double at all. Fixed both, and corrected the pre-existing `scripts/rpg2k_scene_check.rb` check whose own expected Def value (`-13`) had baked in the unclamped bug.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` checks: the status screen shows a halved Atk under an active state, not the raw base; the equip screen's current *and* previewed value both halve together under an active state.
- [x] Corrected the pre-existing 両手持ち preview check's expected Def value (`-13` → the clamped `1`).
- [x] Confirmed all three fail against the pre-fix code (`git stash` on `status_menu.rb`/`equip_menu.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 836 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1092 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_