### PR TITLE
Freeze, don't hide, an inactive window's selection cursor

### DIFF
--- a/changelog.d/inactive-window-cursor-freeze.fixed.md
+++ b/changelog.d/inactive-window-cursor-freeze.fixed.md
@@ -1,0 +1,7 @@
+- **UI:** an inactive window's selection cursor now stays visible, frozen
+  on whichever frame it was on, instead of vanishing entirely -- matching
+  RPG_RT's own `Window::Draw`, which never checks whether a window is
+  active when drawing its cursor highlight (only `Window::Update` gates
+  whether the highlight keeps blinking). Previously switching a list
+  inactive -- e.g. after picking an actor from the main menu -- blanked its
+  highlighted row instead of leaving it visibly selected.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13982,6 +13982,31 @@ not yet verified:
   `#blt` calls source from x 64 initially, x 96 once `cursor_frame` crosses
   11, and x 64 again once it wraps back to 0, confirmed to fail against the
   pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-21): an inactive window hid its selection cursor
+  entirely instead of freezing it — `#draw_cursor` carried a second,
+  uncited `active` check the reference does not have.** Confirmed against
+  RPG_RT's own live source: `Window::Draw`'s cursor block (`src/
+  window.cpp`) reads only `cursor_rect`/`animation_frames`/`cursor_frame`,
+  with no `active` check anywhere; `active` only gates whether `Window::
+  Update` keeps *advancing* `cursor_frame` at all (`if (active) {
+  cursor_frame += 1; ... }`) — an inactive window's highlight simply
+  freezes on whatever frame it last stopped at, it does not vanish.
+  `RPG2k::Window#draw_cursor` (`mruby-rpg2k/mrblib/main.rb`) had `return
+  unless @active` right after clearing the cursor bitmap, so setting a
+  window inactive (`#active=`, which calls `#draw_cursor` immediately) blanked
+  the highlight outright — reachable in live UI code: `Scene::Menu
+  #enter_actor_selection`/`#open_end_game_confirm` and `Scene::Order
+  #enter_confirm` (`mruby-rpg2k/mrblib/scene/menu.rb`/`order.rb`) all set
+  `.active = false` on a list whose `cursor_rect` still points at the
+  just-picked row, expecting it to stay highlighted (frozen) the way real
+  RPG_RT leaves it, not disappear. `#update`'s own `@cursor_frame` advance
+  already correctly gated on `@active` — only `#draw_cursor`'s extra check
+  was wrong. Fixed by deleting that one line. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a window's cursor is still drawn
+  the instant it goes inactive, frozen on whichever frame it was on; 20+
+  further frames of `#update` while inactive never redraw it at all, the
+  already-correct half of the gate), confirmed to fail against the pre-fix
+  code before the fix.
 - ✅ **An action pattern's "Enemies" condition (`condition_type` 3,
   `COND_ACTORS`) now ranges over the acting monster's own living
   troop-mates, not the player party's headcount — a straight side-swap,

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -436,9 +436,18 @@ class RPG2k
     # rather than as a flat bar; Game::WindowCursor holds the geometry measured
     # off a genuine RPG_RT frame. Without a windowskin there is nothing to blit,
     # so the old solid bar stays as the fallback.
+    #
+    # An inactive window still draws its cursor -- confirmed against RPG_RT's
+    # own live source: `Window::Draw`'s cursor block (`src/window.cpp`) reads
+    # only `cursor_rect`/`animation_frames`/`cursor_frame`, with no `active`
+    # check anywhere; `active` only gates whether `Window::Update` keeps
+    # *advancing* `cursor_frame` (and so blinking) at all -- an inactive
+    # window's highlight simply freezes on whichever frame it last stopped at
+    # instead of vanishing. `#update`'s own `@cursor_frame` advance already
+    # ports that `active` gate correctly; this method used to add a second,
+    # uncited one of its own that hid the highlight outright.
     def draw_cursor
       @cursor_bmp.clear
-      return unless @active
       r = @cursor_rect
       return if r.width <= 0 || r.height <= 0
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -912,6 +912,34 @@ check 'RPG2k::Window blinks its selection cursor between the windowskin\'s ' \
   eq 64, bmp.blt_calls.first[3].x, 'wraps back to the steady cursor block (64)'
 end
 
+check "RPG2k::Window keeps its selection cursor visible, frozen, once " \
+      'inactive -- it does not hide it' do
+  # Confirmed against RPG_RT's own live source: `Window::Draw`'s cursor
+  # block (`src/window.cpp`) reads only `cursor_rect`/`cursor_frame`, with
+  # no `active` check anywhere -- `active` only gates whether
+  # `Window::Update` keeps *advancing* (blinking) `cursor_frame` at all.
+  win = RPG2k::Window.new(0, 0, 64, 64)
+  win.windowskin = Bitmap.new('System/Skin1', true)
+  win.cursor_rect = Rect.new(0, 0, 16, 16)
+  bmp = win.instance_variable_get(:@cursor_bmp)
+  ok bmp.blt_calls && !bmp.blt_calls.empty?, 'sanity: drawn while active'
+
+  bmp.clear_blt_calls
+  win.active = false
+  ok bmp.blt_calls && !bmp.blt_calls.empty?,
+     'still drawn the instant it goes inactive, not hidden'
+  eq 64, bmp.blt_calls.first[3].x,
+     'frozen on whatever frame it stopped at (still the steady block here)'
+
+  # 20+ frames of #update while inactive never advance/blink it (the
+  # already-correct half of this gate) -- and, per the fix, never hide it
+  # either: the frozen bitmap from the moment it went inactive stays put.
+  bmp.clear_blt_calls
+  25.times { win.update }
+  ok bmp.blt_calls.nil? || bmp.blt_calls.empty?,
+     'an inactive window never redraws its cursor from #update at all'
+end
+
 check 'Scene::Map builds and ticks with no events without raising' do
   scene = new_scene({})
   30.times { scene.update }


### PR DESCRIPTION
## Summary

- RPG_RT's `Window::Draw` cursor block (`src/window.cpp`) reads only `cursor_rect`/`animation_frames`/`cursor_frame`, with no `active` check anywhere. `active` only gates whether `Window::Update` keeps *advancing* `cursor_frame` at all (`if (active) { cursor_frame += 1; ... }`) — an inactive window's highlight simply freezes on whatever frame it last stopped at; it does not vanish.
- `RPG2k::Window#draw_cursor` (`mruby-rpg2k/mrblib/main.rb`) carried a second, uncited `return unless @active` right after clearing the cursor bitmap — so setting a window inactive (`#active=`, which calls `#draw_cursor` immediately) blanked the highlight outright.
- This is reachable in live UI code, not just theoretical: `Scene::Menu#enter_actor_selection`/`#open_end_game_confirm` and `Scene::Order#enter_confirm` all set `.active = false` on a list whose `cursor_rect` still points at the just-picked row, expecting it to stay visibly highlighted (frozen) the way real RPG_RT leaves it, not disappear.
- `#update`'s own `@cursor_frame` advance was already correctly gated on `@active` — only `#draw_cursor`'s extra check was wrong. Fixed by deleting that one line.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a window's cursor is still drawn the instant it goes inactive, frozen on whichever frame it was on; 20+ further frames of `#update` while inactive never redraw it at all (the already-correct half of the gate).
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `main.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 837 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1092 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_