### PR TITLE
Gate two-weapon per-swing hit/attribute/state/crit split to RPG2003 only

### DIFF
--- a/changelog.d/dual-wield-per-weapon-swing-rpg2003-only.fixed.md
+++ b/changelog.d/dual-wield-per-weapon-swing-rpg2003-only.fixed.md
@@ -1,0 +1,11 @@
+- **Battle:** an RPG2000 two-weapon (二刀流) actor's basic-Attack swings now
+  both roll the merged (max hit rate / union of elemental attributes and
+  weapon states / higher crit bonus) values across both equipped weapons,
+  instead of each swing rolling its own weapon's data in isolation --
+  matching RPG_RT's `Style_Combined`, which only splits swings by weapon
+  under RPG2003's `Style_MultiHit`. Previously a low-hit or unlucky-element
+  second weapon's swing was strictly worse than it should have been (or a
+  strong first weapon's swing carried its bonus into a swing it shouldn't
+  have), even on a genuine RPG2000 project. RPG2003 two-weapon actors are
+  unaffected -- their swings still correctly resolve to one specific
+  weapon's own data.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9022,6 +9022,37 @@ not yet verified:
   own weapon's state, never both), and an actual three-swing basic Attack
   landing all three hits rather than being capped at two — all three
   confirmed to fail against the pre-fix code before the fix.
+  ~~`#swing_weapon_data` applied this per-swing split unconditionally, to
+  every two-weapon actor regardless of RPG2000/2003.~~
+  ✅ **Follow-up (2026-08-21): that per-swing split is RPG2003-only.**
+  Confirmed against EasyRPG's actual C++ source:
+  `Game_BattleAlgorithm::Normal::GetDefaultStyle`
+  (`src/game_battlealgorithm.cpp`) — `return
+  Feature::HasRpg2k3BattleSystem() ? Style_MultiHit : Style_Combined;` — and
+  `Normal::Init`, which only ever sets `weapon_style` (the field `GetWeapon`
+  reads to resolve one specific slot) `if (... style == Style_MultiHit)`;
+  left at its default `-1` under `Style_Combined`, `GetWeapon` always
+  returns `WeaponAll`, so `Game_Actor::GetHitChance`'s own
+  `ForEachEquipment` folds in *both* equipped weapons for *every* swing
+  (`hit = std::max(hit, item.hit)`) — the plain merged max, never a specific
+  weapon's own roll. `Feature::HasRpg2k3BattleSystem()` (`src/feature.cpp`)
+  is `!HasRpg2kBattleSystem()`, itself `true` whenever `Player::IsRPG2k()` —
+  a genuine RPG2000/2003 edition gate, not an incidental detail. So a
+  genuine RPG2000 two-weapon actor (this project's actual default; every
+  fixture above that exercised `#swing_weapon_data` happened to also set
+  `double_hand: true` without ever passing `rpg2003: true`) had *every*
+  swing read one specific weapon's own data instead of the merged max/union
+  `#attack_hit_rate`/`#weapon_attributes`/`#weapon_states`/
+  `#weapon_crit_bonus` already correctly compute for it — the exact
+  inverted-scope bug this bullet's own fix introduced. Fixed by gating
+  `swing_weapon_data` behind `rpg2003?`, returning `nil` (falling back to
+  the ordinary merged Combatant fields, already correct for any actor
+  regardless of weapon count) otherwise. The two existing checks above were
+  updated to pass `rpg2003: true` (they only ever verified the 2003-specific
+  mechanic), and a new check confirms an RPG2000 two-weapon actor's swings
+  both roll the *merged* 100%-hit max rather than one weapon's own
+  guaranteed-miss 10%, confirmed to fail against the pre-fix code before the
+  fix.
 - ✅ **A terrain row's negative `damage` field now heals the party each step
   instead of doing nothing, and bypasses 地形ダメージ無効 gear entirely while
   doing it.** RPG2000/2003 terrain rows carry one plain signed `damage`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2426,17 +2426,19 @@ module Game
 
     # Which weapon governs swing index `i` (0-based) of a two-weapon actor's
     # basic Attack -- EasyRPG's `Normal::GetWeapon`/`weapon_style`
-    # (`src/game_battlealgorithm.cpp`): the primary (weapon-slot) weapon's
-    # own hit count worth of swings, then the secondary (shield-slot)
-    # weapon's, each contributing *its own* hit rate / elemental attributes /
-    # weapon states / crit bonus rather than the merged max/union
-    # `#attack_hit_rate`/`#weapon_attributes`/`#weapon_states`/
-    # `#weapon_crit_bonus` compute across every equipped weapon-type item
-    # (correct for the ordinary single-weapon case, wrong once a second,
-    # *different* weapon governs a later swing). `Battle#deal_attack` reads
-    # this per swing; nil when fewer than two weapons are equipped, so it
-    # falls back to the ordinary merged Combatant fields.
+    # (`src/game_battlealgorithm.cpp`): `Init` only sets `weapon_style`
+    # (and so only lets `GetWeapon` return a specific slot) when
+    # `style == Style_MultiHit`, and `GetDefaultStyle` picks that style only
+    # under `Feature::HasRpg2k3BattleSystem()` -- RPG2000 (and an RPG2003
+    # game running the legacy 2k battle system) instead uses
+    # `Style_Combined`, where `weapon_style` stays `-1` and `GetWeapon`
+    # always returns `WeaponAll`, so *every* swing reads the merged max/union
+    # `GetHitChance`/etc. across both weapons, never one weapon's own data.
+    # So this per-swing split only applies to RPG2003; nil for a non-2003
+    # actor falls back to the ordinary merged Combatant fields, which is
+    # correct there regardless of how many weapons are equipped.
     def swing_weapon_data(i)
+      return nil unless rpg2003?
       weapons = equipped_weapons
       return nil unless weapons.size >= 2
       w1, w2 = weapons[0, 2]

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -19572,26 +19572,32 @@ check 'a 二刀流 actor with one dual_attack weapon sums 2 + 1, not just 2' do
   eq 3, hero.strike_count, "the dual_attack sword's 2 swings plus the dagger's 1"
 end
 
-check "battle: a two-weapon actor's swings each roll their own weapon's to-hit, " \
-      'not a merged max' do
+check "battle: an RPG2003 two-weapon actor's swings each roll their own " \
+      "weapon's to-hit, not a merged max" do
   # Confirmed against EasyRPG's actual C++ source: Game_BattleAlgorithm::
-  # Normal::GetWeapon (src/game_battlealgorithm.cpp) resolves each swing to
-  # exactly one weapon (the primary weapon's own hit count worth of swings,
-  # then the secondary's), and Game_Actor::GetHitChance's own
+  # Normal::GetDefaultStyle (src/game_battlealgorithm.cpp) only picks
+  # Style_MultiHit -- the style whose Init sets weapon_style and so lets
+  # GetWeapon resolve a specific slot instead of WeaponAll -- when
+  # Feature::HasRpg2k3BattleSystem() (src/feature.cpp: !HasRpg2kBattleSystem,
+  # true whenever the game isn't Player::IsRPG2k()). Under that style, each
+  # swing resolves to exactly one weapon (the primary weapon's own hit count
+  # worth of swings, then the secondary's), and Game_Actor::GetHitChance's own
   # ForEachEquipment (src/game_actor.cpp) excludes the *other* weapon's slot
   # entirely -- never a merge/max across both. hit 100 always lands (its own
   # agi term collapses to zero regardless of either side's Agility); a low
   # hit rate against a much nimbler target clamps to a guaranteed miss (the
   # agi term, `100 - (100-base)*(src+tgt)/(2*src)`, goes negative and clamps
   # to 0). Before this fix, both swings read #attack_hit_rate's merged max
-  # (100, from whichever weapon has it) -- the low-hit weapon's swing would
-  # always land too, identically to the other weapon's.
+  # (100, from whichever weapon has it) regardless of RPG2000/2003 -- the
+  # low-hit weapon's swing would always land too, identically to the other
+  # weapon's, even on a non-2003 database (Style_Combined's actual rule --
+  # see the RPG2000 check just below).
   items = { 1 => fake_item(type: 1, atk: 10, hit: 100), # always lands
             2 => fake_item(type: 1, atk: 10, hit: 10) } # clamps to a guaranteed miss below
   row = FakePlayerRow.new('Hero', '', 0, 5,
                           { max_hp: 100, max_mp: 30, atk: 10, def: 0, agi: 10 })
   row.double_hand = true
-  db = FakeActorDB.new({ 1 => row }, [1], items)
+  db = FakeActorDB.new({ 1 => row }, [1], items, rpg2003: true)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   actor = st.party.actor_by_id(1)
   st.party.gain_item(1, 1)
@@ -19607,19 +19613,20 @@ check "battle: a two-weapon actor's swings each roll their own weapon's to-hit, 
                             'clamped to 0 against a much nimbler target'
 end
 
-check "battle: a two-weapon actor's swings each carry their own weapon's " \
-      'elemental attribute and state, not a union of both' do
-  # Same GetWeapon/ForEachEquipment exclusion as the to-hit check above, but
-  # for Attribute::ApplyAttributeNormalAttackMultiplier and the weapon-state
-  # block of Normal::vExecute (both also gated on that swing's own resolved
-  # weapon, per EasyRPG's src/attribute.cpp and src/game_battlealgorithm.cpp).
-  # Both weapons hit 100 so accuracy never interferes; element 1 is immune
-  # (rank 4 -> 0%) and element 2 is normal (rank 2 -> 100%) on the target.
-  # The weapon states are 3 and 4, deliberately not 1: state id 1 is always
-  # Knockout (Game::States::DEATH_ID) in every real database, so inflicting
-  # it -- as this test briefly did by accident, before #inflict_state
-  # correctly started zeroing HP on landing it -- would fell the target on
-  # the very first swing and never reach the second at all.
+check "battle: an RPG2003 two-weapon actor's swings each carry their own " \
+      "weapon's elemental attribute and state, not a union of both" do
+  # Same Style_MultiHit/GetWeapon/ForEachEquipment exclusion as the to-hit
+  # check above, but for Attribute::ApplyAttributeNormalAttackMultiplier and
+  # the weapon-state block of Normal::vExecute (both also gated on that
+  # swing's own resolved weapon, per EasyRPG's src/attribute.cpp and
+  # src/game_battlealgorithm.cpp). Both weapons hit 100 so accuracy never
+  # interferes; element 1 is immune (rank 4 -> 0%) and element 2 is normal
+  # (rank 2 -> 100%) on the target. The weapon states are 3 and 4,
+  # deliberately not 1: state id 1 is always Knockout (Game::States::
+  # DEATH_ID) in every real database, so inflicting it -- as this test
+  # briefly did by accident, before #inflict_state correctly started zeroing
+  # HP on landing it -- would fell the target on the very first swing and
+  # never reach the second at all.
   items = { 1 => fake_item(type: 1, atk: 40, hit: 100, attribute_set: [true, false],
                            state_set: [0, 0, 1, 0], state_chance: 100),  # element 1, state 3
             2 => fake_item(type: 1, atk: 40, hit: 100, attribute_set: [false, true],
@@ -19627,7 +19634,7 @@ check "battle: a two-weapon actor's swings each carry their own weapon's " \
   row = FakePlayerRow.new('Hero', '', 0, 5,
                           { max_hp: 100, max_mp: 30, atk: 10, def: 0, agi: 10 })
   row.double_hand = true
-  db = FakeActorDB.new({ 1 => row }, [1], items)
+  db = FakeActorDB.new({ 1 => row }, [1], items, rpg2003: true)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   actor = st.party.actor_by_id(1)
   st.party.gain_item(1, 1)
@@ -19645,6 +19652,43 @@ check "battle: a two-weapon actor's swings each carry their own weapon's " \
   ok first[:damage] < second[:damage], "swing 2's own element (2) is unscaled, unlike swing 1's"
   eq [3], first[:inflicted], "swing 1 only rolls its own weapon's state (3)"
   eq [4], second[:inflicted], "swing 2 only rolls its own weapon's state (4), not both"
+end
+
+check "battle: an RPG2000 two-weapon actor's swings both roll the merged " \
+      "max to-hit, never one weapon's own low roll" do
+  # Confirmed against EasyRPG's actual C++ source: Game_BattleAlgorithm::
+  # Normal::GetDefaultStyle (src/game_battlealgorithm.cpp) picks
+  # Style_Combined -- not Style_MultiHit -- whenever
+  # !Feature::HasRpg2k3BattleSystem() (a non-2003 database), and Init only
+  # ever sets weapon_style under Style_MultiHit; left at its initial -1,
+  # GetWeapon always returns WeaponAll, so Game_Actor::GetHitChance's
+  # ForEachEquipment (src/game_actor.cpp) folds in *both* equipped weapons'
+  # hit fields for *every* swing (`hit = std::max(hit, item.hit)`), never one
+  # specific slot's own roll. Same fixture as the RPG2003 check above (a
+  # hit-100 and a hit-10 weapon against a much nimbler target -- the low hit
+  # rate's own agi term would clamp to a guaranteed miss if it were rolled on
+  # its own), but with no `rpg2003: true` -- so both swings must land, using
+  # the merged 100 the same way #attack_hit_rate already reports for the
+  # actor as a whole.
+  items = { 1 => fake_item(type: 1, atk: 10, hit: 100), # the merged max
+            2 => fake_item(type: 1, atk: 10, hit: 10) } # would clamp to a guaranteed miss alone
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 0, agi: 10 })
+  row.double_hand = true
+  db = FakeActorDB.new({ 1 => row }, [1], items) # rpg2003: false, the default
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  actor = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(actor, 1, Game::Actor::WEAPON_SLOT)
+  ok st.party.equip_from_bag(actor, 2, Game::Actor::SHIELD_SLOT)
+  hero = Game::Battle.from_actor(actor)
+  foe = combatant('Foe', 0, 0, 20, 999) # much nimbler than the hero's agi 10
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), {}, false, false, true)
+  first, second = bat.send(:swing, hero, foe)
+  ok !first[:missed], 'swing 1 rolls the merged 100, and lands'
+  ok !second[:missed], "swing 2 also rolls the merged 100, not the dagger's own 10 -- " \
+                        'RPG2000 never splits by weapon'
 end
 
 check 'battle: #swing actually lands three attacks when strike_count is three, ' \


### PR DESCRIPTION
## Summary

- RPG_RT only resolves a dual-wielding (二刀流) actor's basic-Attack swings to one specific weapon's own hit rate / elemental attributes / weapon states / crit bonus under RPG2003's `Style_MultiHit`. A genuine RPG2000 database uses `Style_Combined` instead, where every swing reads the merged max/union across both equipped weapons -- confirmed against EasyRPG's actual C++ source: `Game_BattleAlgorithm::Normal::GetDefaultStyle` (`src/game_battlealgorithm.cpp`) -- `return Feature::HasRpg2k3BattleSystem() ? Style_MultiHit : Style_Combined;` -- and `Normal::Init`, which only ever sets `weapon_style` (the field `GetWeapon` reads to resolve one specific slot) under `Style_MultiHit`; left at its default `-1` under `Style_Combined`, `GetWeapon` always returns `WeaponAll`, so `Game_Actor::GetHitChance`'s own `ForEachEquipment` folds in *both* equipped weapons for every swing.
- `Actor#swing_weapon_data` (`mruby-rpg2k/mrblib/game.rb`) applied this per-weapon split unconditionally to any actor with two equipped weapons, with no RPG2000/2003 gate at all -- so a genuine RPG2000 two-weapon actor had every swing incorrectly read one specific weapon's own data instead of the already-correct merged `#attack_hit_rate`/`#weapon_attributes`/`#weapon_states`/`#weapon_crit_bonus`.
- Fixed by gating `swing_weapon_data` behind `rpg2003?`; a non-2003 actor now falls back to `nil` (the ordinary merged Combatant fields), matching `Style_Combined`.
- This also corrects the prior `docs/TODO.md` writeup for the original per-swing split fix, whose own regression checks all happened to dual-wield without ever setting `rpg2003: true` -- meaning the split's actual scope had never been tested at all.

## Test plan

- [x] Updated the two existing `scripts/rpg2k_logic_check.rb` per-swing checks to pass `rpg2003: true` (they only ever verified the genuine 2003-specific mechanic).
- [x] Added a new check: an RPG2000 (default) two-weapon actor's swings both roll the merged max hit rate rather than one weapon's own guaranteed-miss roll.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only -- `swing 2 also rolls the merged 100 ... ` assertion fails) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1093 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 837 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_