### PR TITLE
Show a battler's per-turn state-affected/recovery reminder before its action

### DIFF
--- a/changelog.d/battle-turn-state-affected-message.fixed.md
+++ b/changelog.d/battle-turn-state-affected-message.fixed.md
@@ -1,0 +1,9 @@
+- **Battle:** a battler still afflicted with a status condition (or one that
+  just wore off on its own) now opens its turn with that state's own
+  reminder line -- "Zero is poisoned!" (or, the turn it clears, its own
+  recovery line) -- before whatever it goes on to do, matching RPG_RT's own
+  per-turn state scan. Previously the `message_affected`/`message_recovery`
+  database fields were only ever read the instant a state first landed or
+  was actively cured by an item/skill; the ordinary per-turn "still
+  poisoned" reminder a player would see every single turn a real RPG_RT
+  game runs never appeared here at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1496,8 +1496,49 @@ The work below is roughly ordered by the critical path to a walkable game
   too — making the report depend on the roll would be the natural guess and it is
   wrong. `roll_inflict` returns the already-carried states beside the landed ones
   and the action banner prints the sentence, one wording for both sides.
-  `message_affected` is deliberately still unread: EasyRPG defines its helper and
-  never calls it from either battle scene, so nothing pins when RPG_RT prints it.
+  ~~`message_affected` is deliberately still unread: EasyRPG defines its helper
+  and never calls it from either battle scene, so nothing pins when RPG_RT
+  prints it.~~
+  ✅ **Follow-up (2026-08-21): that claim is simply wrong against current live
+  EasyRPG source — `message_affected` (and `message_recovery`, reused for the
+  same purpose) is read every single turn.** Confirmed via curl:
+  `Scene_Battle_Rpg2k::ProcessBattleActionBegin` (`src/scene_battle_rpg2k.cpp`)
+  scans every state id 1..N the acting battler either still carries or just had
+  auto-cured this very turn (`BattleStateHeal()`/`ApplyConditions()`, already
+  this codebase's own `#apply_turn_states`), keeps whichever has the highest
+  `priority` (`>=`, walked ascending — a tie goes to the *later*, higher id),
+  and shows that state's own `message_affected` (still held; only if
+  non-blank) or `message_recovery` (just healed; always, even blank) right at
+  the start of the battler's turn, before whatever it goes on to do. This is a
+  **different** scan from `Game_Battler::GetSignificantState`/`State::
+  GetSignificantState` (this codebase's own `States.significant`, used
+  elsewhere for the battle-sprite pose) — confirmed these are two genuinely
+  distinct functions in EasyRPG's own source rather than reasoned by analogy:
+  `GetSignificantState` special-cases Knockout outright and never considers a
+  just-healed state at all, neither of which `ProcessBattleActionBegin`'s own
+  inline loop does. So a per-turn reminder like "Zero is poisoned!" — the
+  single most common way a real database actually uses `message_affected` —
+  never appeared anywhere in this engine, on either an actor's or an
+  enemy's turn, whether or not the state also happened to block acting. Fixed
+  with a new `Combatant#turn_state_message` field (the resolved message text
+  for this turn, or nil), computed by a new `Battle#turn_state_message(b,
+  healed)` at the end of `#apply_turn_states` and a new `Game::States.
+  affected_message` (mirroring the existing `#recovery_message` exactly), then
+  threaded onto the acting battler's first log entry in `#record_action` (so a
+  buffered multi-hit action only opens with it once) and rendered ahead of the
+  action's own lines by `Scene::Battle#battle_action_lines`. Deliberately
+  scoped to the battler's still-be-able-to-act case only — the case where a
+  restriction locks the turn to "do nothing" already produces *zero* log entry
+  or banner of any kind today (`step`/`step_action` both silently `next` past
+  it), a separate, larger pre-existing gap this fix does not attempt, since
+  making that turn visible at all is its own conceptual change or turn/banner
+  plumbing, not a `message_affected` wiring fix. Covered by four new
+  `scripts/rpg2k_logic_check.rb` checks (a still-held state's own
+  `message_affected`; a blank `message_affected` shows nothing at all; a
+  just-healed state's `message_recovery` instead; the higher-priority of two
+  simultaneously-held states wins), all four confirmed to fail against the
+  pre-fix code (three via a wrong/missing message, one already vacuously true)
+  before the fix.
   **A condition drains the party on the map now, too** — RPG2000's field poison,
   the last of the 状態 row's simulation fields with a game behind it.
   `hp_change_map_steps` / `hp_change_map_val` (and the matching SP pair) say how

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9298,6 +9298,14 @@ module Game
       message(battler_name, field(id, table, :message_recovery))
     end
 
+    # ... and the per-turn reminder a battler still carrying (or just having
+    # shaken off) a state gets at the very start of its own turn, before its
+    # action -- distinct from #inflict_message, which fires only the instant
+    # a state first lands. One wording for both sides, like recovery.
+    def self.affected_message(id, table, battler_name)
+      message(battler_name, field(id, table, :message_affected))
+    end
+
     # ... and for one the target **already** carried when something tried to
     # inflict it again ("はすでに毒に冒されている！"). One wording for both sides,
     # like the recovery line. RPG_RT treats this as a result worth announcing
@@ -9686,7 +9694,20 @@ module Game
                             # the battle-page `command_actor` condition. nil
                             # until an actor picks a command (an enemy, or an
                             # auto-battling ally, never records one).
-                            :last_battle_action) do
+                            :last_battle_action,
+                            # The per-turn state reminder line this battler's
+                            # turn should open with, as of the most recent
+                            # #apply_turn_states call -- the message text
+                            # itself (already resolved against this
+                            # battler's name), or nil when nothing qualifies.
+                            # EasyRPG's `Scene_Battle_Rpg2k::
+                            # ProcessBattleActionBegin` (`src/
+                            # scene_battle_rpg2k.cpp`) computes this fresh
+                            # every turn from whichever single highest-
+                            # `priority` state (ties to the higher id) the
+                            # battler either still carries or just had
+                            # auto-cured -- not accumulated across turns.
+                            :turn_state_message) do
       def dead?; hp <= 0; end
 
       # The HP/MP ceiling a status panel should show for this combatant: the
@@ -10246,10 +10267,16 @@ module Game
     # all-target skill returns an array — every entry is logged now (the effects
     # all landed at once) but surfaced one per #step so the screen animates them
     # in turn. nil (no living target) passes straight through.
+    #
+    # The acting battler's own #apply_turn_states-computed per-turn state
+    # reminder (see Combatant#turn_state_message) rides on the *first* entry
+    # only, matching RPG_RT showing it once at the very start of the turn,
+    # not once per buffered hit.
     def record_action(result)
       return nil if result.nil?
       entries = result.is_a?(Array) ? result : [result]
       return nil if entries.empty?
+      entries.first[:state_message] = @acting.turn_state_message if @acting
       entries.each { |e| @log << e }
       @pending.concat(entries[1..-1])
       entries.first
@@ -11141,6 +11168,7 @@ module Game
     def apply_turn_states(b)
       can_act = true
       b.state_turns ||= {}
+      healed = []
       (b.states || []).dup.each do |id|
         d = state_def(id)
         next unless d
@@ -11148,6 +11176,7 @@ module Game
         if recovers_from_state?(b, id, d)
           b.states = b.states - [id]
           b.state_turns.delete(id)
+          healed << id
           next
         end
         # Not clamped to #damage_cap: confirmed against EasyRPG's own live
@@ -11170,7 +11199,41 @@ module Game
         end
         can_act = false if state_field(d, :restriction) == RESTRICTION_DO_NOTHING
       end
+      b.turn_state_message = turn_state_message(b, healed)
       can_act
+    end
+
+    # `b`'s per-turn state reminder line, freshly computed for this call --
+    # EasyRPG's `Scene_Battle_Rpg2k::ProcessBattleActionBegin`'s own inline
+    # scan (`src/scene_battle_rpg2k.cpp`), not `States.significant`/EasyRPG's
+    # own separate `State::GetSignificantState` (which special-cases
+    # Knockout and never considers a just-healed state) -- confirmed these
+    # are two genuinely different functions in EasyRPG's own source, not two
+    # names for the same algorithm. Walks every id either just healed this
+    # turn or still held afterward in ascending order, keeping whichever has
+    # the highest `priority` (`>=`, so a tie goes to the later, higher id).
+    # A healed state's line always shows, even blank; a still-held one only
+    # shows if its own `message_affected` is non-blank -- matching RPG_RT's
+    # own asymmetric rule exactly, not guessed at.
+    def turn_state_message(b, healed)
+      best_id = nil
+      best_healed = false
+      best_priority = -1
+      (healed | (b.states || [])).sort.each do |id|
+        d = state_def(id)
+        next unless d
+        priority = state_field(d, :priority)
+        next if priority < best_priority
+        best_id = id
+        best_healed = healed.include?(id)
+        best_priority = priority
+      end
+      return nil unless best_id
+      if best_healed
+        States.recovery_message(best_id, @states, b.name) || ''
+      else
+        States.affected_message(best_id, @states, b.name)
+      end
     end
 
     # One state's per-turn slip applied to a single stat (`cur` against `max`):

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2915,8 +2915,18 @@ class RPG2k
       # Everything the action announces: what it did, then the conditions it
       # changed. `log_round` traces all of it and `show_battle_action` banners
       # all of it, so the console and the screen never disagree.
+      # The per-turn state reminder line (Combatant#turn_state_message, via
+      # `entry[:state_message]`) opens the banner, ahead of the action's own
+      # lines -- RPG_RT shows it right at the start of the battler's turn,
+      # before whatever it goes on to do (`Scene_Battle_Rpg2k::
+      # ProcessBattleActionBegin`, `src/scene_battle_rpg2k.cpp`). A blank
+      # reminder (a healed state with no configured `message_recovery`,
+      # which RPG_RT still flashes for but has no text to show) is dropped
+      # rather than rendered as an empty line.
       def battle_action_lines(entry)
-        battle_action_body(entry) + battle_state_lines(entry)
+        lines = battle_action_body(entry) + battle_state_lines(entry)
+        msg = entry[:state_message]
+        msg && !msg.empty? ? [msg] + lines : lines
       end
 
       # The result window's text: the outcome, and on a win the EXP / gold gained

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3693,7 +3693,16 @@ FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           # also persists onto the map. Appended last, same
                           # reason again -- nil reads as 0/battle-only via
                           # #state_field, the schema's own default.
-                          :type)
+                          :type,
+                          # ... and `message_affected`: the per-turn reminder
+                          # (Game::Battle#turn_state_message) a battler still
+                          # carrying this state opens its turn with, distinct
+                          # from message_actor/message_enemy (which fire only
+                          # the instant it lands). Appended last, same reason
+                          # again -- nil reads as "no reminder configured" via
+                          # States.field, matching the schema's own blank
+                          # default.
+                          :message_affected)
 # A state row carrying only the fields a check names, with the rest at the
 # database defaults — notably reduce_hit_ratio 100, which is "does not blind".
 def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
@@ -3708,7 +3717,7 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                hp_change_type: Game::States::CHANGE_TYPE_LOSE,
                sp_change_type: Game::States::CHANGE_TYPE_LOSE,
                avoid_attacks: false, reflect_magic: false, cursed: false,
-               type: 0)
+               type: 0, affected_msg: nil)
   FakeStateDef.new(restriction, hp_val, hp_max, sp_val, sp_max, hold_turn,
                    auto_release, release_by_attack, reduce_hit_ratio,
                    restrict_skill, restrict_skill_level,
@@ -3718,7 +3727,7 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                    affect_type, affect_attack, affect_defense,
                    affect_spirit, affect_agility,
                    hp_change_type, sp_change_type, avoid_attacks, reflect_magic,
-                   cursed, type)
+                   cursed, type, affected_msg)
 end
 # An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
@@ -14520,6 +14529,77 @@ check 'battle: a "do nothing" state (restriction 1) skips the turn' do
   bat.command_attack(hero, slime)                    # even commanded, it cannot act
   bat.run_round
   eq 100, slime.hp                                   # the asleep hero never struck
+end
+
+# Confirmed against EasyRPG's actual C++ source: Scene_Battle_Rpg2k::
+# ProcessBattleActionBegin (src/scene_battle_rpg2k.cpp) scans every state id
+# the battler either still carries or just had auto-cured this turn (not
+# Game_Battler::GetSignificantState/State::GetSignificantState -- confirmed
+# these are two genuinely distinct functions in EasyRPG's own source, the
+# latter special-casing Knockout and never considering a just-healed state),
+# keeping whichever has the highest `priority` (ties to the higher id), and
+# shows that state's own message_affected (still held) or message_recovery
+# (just healed) at the very start of the battler's turn, before its action.
+# This codebase's own docs/TODO.md had claimed the opposite -- that
+# message_affected is "deliberately still unread" because "EasyRPG ...
+# never calls it from either battle scene" -- which is simply wrong against
+# current live EasyRPG source.
+check 'battle: a still-afflicted state opens the battler\'s turn with its own ' \
+      'message_affected line' do
+  states = { 3 => fake_state(priority: 50, affected_msg: 'は毒に苦しんでいる！') } # poison, no restriction
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [3]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.begin_round
+  entry = bat.step_action
+  eq 'Heroは毒に苦しんでいる！', entry[:state_message],
+     "the still-held state's own message_affected, prefixed with the battler's name"
+end
+
+check 'battle: a state with no configured message_affected opens the turn ' \
+      'with no reminder line at all' do
+  states = { 3 => fake_state(priority: 50) } # affected_msg left blank
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [3]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.begin_round
+  entry = bat.step_action
+  eq nil, entry[:state_message],
+     'RPG_RT only shows the still-held case when message_affected is non-blank'
+end
+
+check 'battle: a state that auto-cures this turn opens the turn with its own ' \
+      'message_recovery instead of message_affected' do
+  # hold_turn 0, auto_release 100 -- guaranteed to clear on this very turn
+  # (#recovers_from_state? needs state_turns[id] > hold_turn, already true
+  # after this turn's own +1, and rolls under the 100% chance).
+  states = { 3 => fake_state(priority: 50, hold_turn: 0, auto_release: 100,
+                             affected_msg: 'は毒に苦しんでいる！',
+                             recovery_msg: 'の毒が治った！') }
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [3]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.begin_round
+  entry = bat.step_action
+  eq 'Heroの毒が治った！', entry[:state_message],
+     'a just-healed state shows its own message_recovery, not message_affected'
+end
+
+check 'battle: the higher-priority of two simultaneously-held states opens ' \
+      "the turn, a tie going to the higher id" do
+  states = { 3 => fake_state(priority: 10, affected_msg: 'は毒に苦しんでいる！'),
+             4 => fake_state(priority: 50, affected_msg: 'は暗闇に閉ざされている！') }
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [3, 4]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.begin_round
+  entry = bat.step_action
+  eq 'Heroは暗闇に閉ざされている！', entry[:state_message],
+     "state 4's higher priority (50 > 10) wins outright, no tie involved"
 end
 
 # デフォ戦bot: "once afflicted with a 'cannot act' state, curing it before your


### PR DESCRIPTION
## Summary

- RPG_RT scans every state a battler either still carries or just had auto-cured at the very start of each of its turns, and shows the highest-`priority` one's `message_affected` (still held, only if non-blank) or `message_recovery` (just healed, always) right before its action -- confirmed against EasyRPG's actual C++ source: `Scene_Battle_Rpg2k::ProcessBattleActionBegin` (`src/scene_battle_rpg2k.cpp`). This is a genuinely distinct scan from `Game_Battler::GetSignificantState`/`State::GetSignificantState` (already ported here as `States.significant`, used for the battle-sprite pose) -- that function special-cases Knockout and never considers a just-healed state, neither of which `ProcessBattleActionBegin`'s own inline loop does.
- `message_affected` was never read anywhere in `game.rb`. This project's own `docs/TODO.md` had claimed the opposite -- "EasyRPG defines its helper and never calls it from either battle scene" -- which is simply wrong against current live EasyRPG source.
- Added `Combatant#turn_state_message` (the resolved message text for this turn, or nil), computed by a new `Battle#turn_state_message(b, healed)` at the end of `#apply_turn_states`, and a new `Game::States.affected_message` mirroring the existing `#recovery_message` exactly. Threaded onto the acting battler's first log entry in `#record_action` (so a buffered multi-hit action only opens with it once) and rendered ahead of the action's own lines by `Scene::Battle#battle_action_lines`.
- Deliberately scoped to the battler's still-able-to-act case: a "do nothing" restricted turn (asleep/paralysed) produces zero log entry or banner of any kind today (`step`/`step_action` both silently skip past it) -- a separate, larger pre-existing gap this fix does not attempt, since making that turn visible at all is its own conceptual change to the turn/banner plumbing.

## Test plan

- [x] Added 4 new `scripts/rpg2k_logic_check.rb` checks: a still-held state's own `message_affected`; a blank `message_affected` shows no reminder at all; a just-healed state's `message_recovery` instead; the higher-priority of two simultaneously-held states wins.
- [x] Confirmed 3 of the 4 fail against the pre-fix code (`git stash` on `game.rb`/`battle.rb` only -- wrong/missing message) and all pass after (the 4th, a blank message showing nothing, was already vacuously true both ways).
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1097 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 837 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_