### PR TITLE
Hide the Order screen's left cursor when the Confirm/Redo prompt opens

### DIFF
--- a/changelog.d/order-confirm-cursor-hidden.fixed.md
+++ b/changelog.d/order-confirm-cursor-hidden.fixed.md
@@ -1,0 +1,6 @@
+- **UI:** the field Order (party reorder) screen's left column now hides its
+  selection cursor entirely once every member has been picked and the
+  Confirm/Redo prompt opens, instead of leaving it frozen on the now-blank
+  final row -- matching RPG_RT, which explicitly clears that column's
+  selection at this one transition. Redo still correctly restores the
+  cursor when picking resumes.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14067,8 +14067,8 @@ not yet verified:
   unless @active` right after clearing the cursor bitmap, so setting a
   window inactive (`#active=`, which calls `#draw_cursor` immediately) blanked
   the highlight outright — reachable in live UI code: `Scene::Menu
-  #enter_actor_selection`/`#open_end_game_confirm` and `Scene::Order
-  #enter_confirm` (`mruby-rpg2k/mrblib/scene/menu.rb`/`order.rb`) all set
+  #enter_actor_selection`/`#open_end_game_confirm` and ~~`Scene::Order
+  #enter_confirm`~~ (`mruby-rpg2k/mrblib/scene/menu.rb`/`order.rb`) all set
   `.active = false` on a list whose `cursor_rect` still points at the
   just-picked row, expecting it to stay highlighted (frozen) the way real
   RPG_RT leaves it, not disappear. `#update`'s own `@cursor_frame` advance
@@ -14079,6 +14079,27 @@ not yet verified:
   further frames of `#update` while inactive never redraw it at all, the
   already-correct half of the gate), confirmed to fail against the pre-fix
   code before the fix.
+  ✅ **Follow-up (2026-08-21): `Scene::Order#enter_confirm` was wrongly
+  grouped in with the "expects to stay frozen" sites above — real RPG_RT
+  hides the left column's cursor entirely at this one specific transition,
+  it does not freeze it.** Confirmed against EasyRPG's actual C++ source:
+  `Scene_Order::UpdateOrder` (`src/scene_order.cpp`), once the last member is
+  picked, calls `window_left->SetIndex(-1)` *before* `SetActive(false)` — an
+  extra, additional mutation beyond what `Scene::Menu
+  #enter_actor_selection`/`#open_end_game_confirm` do, which only ever go
+  inactive. `Window_Selectable::UpdateCursorRect` (`src/
+  window_selectable.cpp`) special-cases a negative index to
+  `SetCursorRect(Rect())`, emptying the highlight outright. So the general
+  "freeze, don't hide" rule the fix above correctly restored for every
+  *other* inactive window is, at this one specific call site, exactly the
+  wrong behavior: `enter_confirm` left the left column's cursor frozen on
+  the now-blank final row instead of hiding it. Fixed by having
+  `enter_confirm` also clear `@left_window.cursor_rect` to an empty `Rect`,
+  mirroring `SetIndex(-1)`'s effect directly (`redo_picks`'s own
+  `refresh_left_cursor` call already correctly restores it when picking
+  resumes, unaffected). Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (the left column's cursor rect is empty the instant the Confirm/Redo
+  prompt opens), confirmed to fail against the pre-fix code before the fix.
 - ✅ **An action pattern's "Enemies" condition (`condition_type` 3,
   `COND_ACTORS`) now ranges over the acting monster's own living
   troop-mates, not the player party's headcount — a straight side-swap,

--- a/mruby-rpg2k/mrblib/scene/order.rb
+++ b/mruby-rpg2k/mrblib/scene/order.rb
@@ -105,10 +105,21 @@ class RPG2k
         refresh_right_window
       end
 
+      # Confirmed against EasyRPG's actual C++ source: `Scene_Order::
+      # UpdateOrder` (`src/scene_order.cpp`), once the last member is picked,
+      # calls `window_left->SetIndex(-1)` before `SetActive(false)` --
+      # distinct from simply going inactive (see `RPG2k::Window#draw_cursor`'s
+      # own "freeze, don't hide" fix, which still applies to every *other*
+      # inactive window whose index is untouched). `Window_Selectable::
+      # UpdateCursorRect` (`src/window_selectable.cpp`) special-cases a
+      # negative index to `SetCursorRect(Rect())`, emptying the highlight
+      # outright -- so real RPG_RT hides the left column's cursor entirely at
+      # this transition rather than freezing it on the now-blank final row.
       def enter_confirm
         @focus = :confirm
         @confirm_index = 0
         @left_window.active = false
+        @left_window.cursor_rect = Rect.new(0, 0, 0, 0)
         @confirm_window.visible = true
         @confirm_window.active = true
         refresh_confirm_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17172,6 +17172,36 @@ check 'Scene::Order: picking every member opens the Confirm/Redo prompt, ' \
   ok scene.parent.pop_called, 'the screen closes on Confirm'
 end
 
+# Confirmed against EasyRPG's actual C++ source: `Scene_Order::UpdateOrder`
+# (`src/scene_order.cpp`), once the last member is picked, calls
+# `window_left->SetIndex(-1)` before `SetActive(false)` -- distinct from
+# simply going inactive. `Window_Selectable::UpdateCursorRect`
+# (`src/window_selectable.cpp`) special-cases a negative index to
+# `SetCursorRect(Rect())`, so real RPG_RT hides the left column's cursor
+# entirely at this transition, rather than freezing it on the now-blank
+# final row the way an ordinary inactive window's cursor otherwise would
+# (see the `RPG2k::Window#draw_cursor` "freeze, don't hide" fix, which still
+# applies to every *other* inactive window whose index is untouched).
+check 'Scene::Order: opening the Confirm/Redo prompt hides the left ' \
+      "column's cursor entirely, rather than freezing it on the blank " \
+      'final row' do
+  scene, state = order_scene
+  RGSS::Input.triggered = [RGSS::Input::C] # pick index 0
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move onto the only unpicked row
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # pick index 1 -- both picked, prompt opens
+  scene.update
+  RGSS::Input.reset
+  eq :confirm, scene.instance_variable_get(:@focus), 'both picked -- prompt opens'
+  left = scene.instance_variable_get(:@left_window)
+  eq 0, left.cursor_rect.width, "the left column's cursor is emptied, not left " \
+     'highlighting the now-blank final row'
+  eq 0, left.cursor_rect.height
+end
+
 check 'Scene::Order: Redo clears every pick and returns to the left column, ' \
       'without touching the party' do
   scene, state = order_scene


### PR DESCRIPTION
## Summary

- RPG_RT explicitly hides the field Order (party reorder) screen's left column cursor once every member has been picked, rather than freezing it on the now-blank final row. Confirmed against EasyRPG's actual C++ source: `Scene_Order::UpdateOrder` (`src/scene_order.cpp`) calls `window_left->SetIndex(-1)` *before* `SetActive(false)` once the last pick lands; `Window_Selectable::UpdateCursorRect` (`src/window_selectable.cpp`) special-cases a negative index to an empty cursor rect (`SetCursorRect(Rect())`).
- This is a narrower exception to the general "an inactive window freezes, doesn't hide, its cursor" rule fixed in PR #1204. That fix's own writeup listed `Scene::Order#enter_confirm` as one of the sites expecting the frozen behavior -- which turns out to be wrong specifically for this one transition: real RPG_RT performs an extra `SetIndex(-1)` here that the other cited sites (`Scene::Menu#enter_actor_selection`/`#open_end_game_confirm`) never do.
- `enter_confirm` (`mruby-rpg2k/mrblib/scene/order.rb`) now also clears `@left_window.cursor_rect` to an empty `Rect`, mirroring `SetIndex(-1)`'s effect directly. `redo_picks`'s own `refresh_left_cursor` call already correctly restores the cursor when picking resumes, unaffected.
- This also corrects the prior `docs/TODO.md` writeup that grouped this site in with the general rule.

## Test plan

- [x] Added a new `scripts/rpg2k_scene_check.rb` check: opening the Confirm/Redo prompt leaves the left column's cursor rect empty (width/height 0), rather than highlighting the blank final row.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `order.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 838 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1097 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_