### PR TITLE
Share one variance roll across a heal skill's HP/SP/stat-mod fields

### DIFF
--- a/changelog.d/heal-skill-shared-variance-roll.fixed.md
+++ b/changelog.d/heal-skill-shared-variance-roll.fixed.md
@@ -1,0 +1,11 @@
+- **Battle:** a recovery skill (or an ATK/DEF/SPI/AGI-modifying buff) that
+  affects more than one of HP, SP, and a stat modifier at once now spreads
+  all of them by the *same* randomized amount, instead of rolling each one
+  independently -- matching RPG_RT, which computes one variance-adjusted
+  effect per cast and reuses it raw for every affected field. Previously a
+  Cure spell restoring both HP and SP (or a buff healing HP while also
+  raising a stat) could land two or three different randomized amounts on
+  the same cast, and consumed extra random draws that desynced every
+  subsequent seeded roll in the fight. Also fixed: the ATK/DEF/SPI/AGI
+  modifier never received the skill's elemental attribute scaling at all,
+  and the SP amount was never capped the way HP and the stat modifier were.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3755,10 +3755,12 @@ The work below is roughly ordered by the critical path to a walkable game
   the attack branch rather than inventing a new mechanism:
   `battle_skill_command`'s `else` (heal) branch now reports `variance:
   skill_variance(sk)` alongside its `hp`/`mp`, and `apply_skill_hit` spreads
-  `hp` and `mp` independently through the same `#varied` helper the attack
+  ~~`hp` and `mp` independently through the same `#varied` helper the attack
   branch already calls (each rolls its own random offset, since HP and SP are
   two separate effect values sharing one base rather than one number applied
-  twice), gated on the fight having variance enabled at all. Both the party's
+  twice)~~ (see the Follow-up below — that parenthetical is wrong; RPG_RT
+  applies one shared roll, not one per field), gated on the fight having
+  variance enabled at all. Both the party's
   own healers and an enemy's ally-scoped heal (行動パターン, see the Event
   command interpreter entry) go through the identical `battle_skill_command`
   call, so the fix reaches both sides symmetrically with no separate enemy-AI
@@ -3775,6 +3777,42 @@ The work below is roughly ordered by the critical path to a walkable game
   recovery` check's expectations (both now include the `variance` key),
   confirmed to fail against the pre-fix code (a constant heal across every
   seeded cast; a missing `variance` key) before the fix.
+  ✅ **Follow-up (2026-08-21): HP and SP do not roll independently — RPG_RT
+  spreads both (and any ATK/DEF/SPI/AGI modifier the same cast applies) with
+  one single shared roll, off one shared effect magnitude.** The fix above
+  introduced its own uncited claim in the same breath as fixing the original
+  gap: "each rolls its own random offset, since HP and SP are two separate
+  effect values sharing one base rather than one number applied twice."
+  Confirmed against EasyRPG's actual C++ source: `Algo::CalcSkillEffect`
+  (`src/algo.cpp`) computes one `effect` local — the attribute multiplier and
+  `VarianceAdjustEffect` are each applied exactly once — and
+  `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`)
+  reads that identical raw number into every one of its
+  `affect_hp`/`affect_sp`/`affect_attack`/`affect_defense`/`affect_spirit`/
+  `affect_agility` branches, each still gated by its own fresh
+  `Rand::PercentChance(to_hit)` roll (that part of the original fix — the
+  independent *accuracy* gate per field — was already correct and is
+  unaffected). So a Cure spell restoring both HP and SP could land two
+  different randomized amounts (and burn two RNG draws instead of one,
+  desyncing every seeded roll afterward) where real RPG_RT always lands the
+  identical amount off a single draw. Separately, `stat_amount` (the ATK/
+  DEF/SPI/AGI modifier) never even received the attribute multiplier at all
+  in the recovery branch, only `hp`/`mp` did — another gap from the same
+  root cause (three fields computed independently instead of one shared
+  effect split three ways at the end) — and `mp` was never clamped to
+  `#recover_cap` the way `hp`/`stat_amount` were, matching EasyRPG's own
+  single `Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue())` right
+  after `CalcSkillEffect` returns, before any affect_* branch reads it.
+  `Game::Battle#apply_skill_hit`'s recovery branch now computes one shared
+  `effect` (attribute-multiplied, variance-spread, and capped exactly once)
+  and assigns it identically to whichever of `hp`/`mp`/`stat_amount` is
+  active, mirroring the attack branch's own established `dmg = hp != 0 ? hp
+  : (mp != 0 ? mp : cmd[:stat_effect])` idiom. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a heal restoring both HP and SP with
+  a seeded two-value RNG sequence lands the *same* amount on both, proving
+  only the first value was ever drawn — a second, independent roll would
+  have produced a different SP amount), confirmed to fail against the
+  pre-fix code (`expected 35, got 45`) before the fix.
   ✅ **A special item (type 9) invoking an Escape/Teleport skill is castable
   from the field Item menu now.** `#field_usable?` used to call
   `#field_skill?(db_skill(it.skill_id))` with no `Game::State` at all, so its

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13062,40 +13062,40 @@ module Game
           absorbed_hp: absorbed, sp_damage: sp_dmg,
           target_mp: target.mp }
       else
-        # Spread the recovery by the skill's own variance when the fight rolls
-        # it, the same way the attack branch above does: EasyRPG's
-        # `Algo::VarianceAdjustEffect` is one function applied to whichever
-        # signed effect `CalcSkillEffect` produced, not a damage-only step, so
-        # a Cure spell's heal wobbles exactly like a Fire spell's damage does.
-        # HP and SP roll independently (`#varied` draws its own random offset
-        # each call) since a skill can restore both from the same base effect
-        # and RPG_RT does not correlate the two rolls. An item's fixed effect
-        # never carries a `variance` (items have no such field), so this is a
-        # no-op there; a 0 (or absent) `hp`/`mp` clears #varied's own `base >
-        # 0` guard, so a skill that only restores one of the two leaves the
-        # other alone.
-        # The ATK/DEF/SPI/AGI modifier delta rides the identical variance roll
-        # as HP/SP (see the comment above), off `cmd[:stat_effect]` rather
-        # than `hp` itself: a buff-only skill (affect_hp clear) leaves `hp` at
-        # 0 throughout, but the modifier still applies off the skill's own
-        # base effect.
-        stat_amount = cmd[:stat_effect] || 0
-        # Elemental scaling applies to a recovery's own effect exactly the way
-        # it applies to an attack's (see #battle_skill_command's ally branch
-        # comment above) -- EasyRPG's `CalcSkillEffect` order is attribute
-        # multiplier first, then variance last, for either sign of effect.
-        hp = apply_attr_multiplier(hp, cmd[:attributes], target)
-        mp = apply_attr_multiplier(mp, cmd[:attributes], target)
-        if @variance && cmd[:variance] && cmd[:variance] > 0
-          hp = varied(hp, cmd[:variance])
-          mp = varied(mp, cmd[:variance])
-          stat_amount = varied(stat_amount, cmd[:variance])
-        end
+        # The skill's one shared, un-gated effect magnitude -- the exact same
+        # idiom the attack branch's own `dmg` local above uses (`hp != 0 ?
+        # hp : (mp != 0 ? mp : cmd[:stat_effect])`), since `#battle_skill_command`'s
+        # ally branch already builds `hp`/`mp`/`stat_effect` from the
+        # identical `base`. EasyRPG's `Skill::vExecute` (`src/
+        # game_battlealgorithm.cpp`) computes one `effect` local --
+        # `Algo::CalcSkillEffect` applies the attribute multiplier and then
+        # `VarianceAdjustEffect` exactly once each -- and reads that same raw
+        # number into every one of its `affect_hp`/`affect_sp`/`affect_attack`/
+        # `affect_defense`/`affect_spirit`/`affect_agility` branches, each
+        # still gated by its own fresh `Rand::PercentChance(to_hit)` roll (see
+        # `#skill_effect_hits?`'s own per-field calls below -- that part was
+        # already correct). Previously `hp`/`mp`/`stat_amount` each ran
+        # `#apply_attr_multiplier`/`#varied` independently, so a Cure spell
+        # restoring both HP and SP could land two different randomized
+        # amounts (and burn two RNG draws) where real RPG_RT always lands the
+        # identical one off a single draw -- `stat_amount` never even got the
+        # attribute multiplier at all, only hp/mp did.
+        effect = hp != 0 ? hp : (mp != 0 ? mp : (cmd[:stat_effect] || 0))
+        effect = apply_attr_multiplier(effect, cmd[:attributes], target)
+        effect = varied(effect, cmd[:variance]) if @variance && cmd[:variance] && cmd[:variance] > 0
+        # Same hard cap as `MaxDamageValue()`'s single clamp on EasyRPG's one
+        # shared `effect` (`Utils::Clamp(effect, -MaxDamageValue(),
+        # MaxDamageValue())`, right after `CalcSkillEffect` returns, before
+        # any affect_* branch reads it) -- applied once here for the same
+        # reason, rather than separately per field afterward (which
+        # previously left `mp` uncapped entirely).
+        rcap = recover_cap
+        effect = rcap if effect > rcap
+        hp = effect if hp != 0
+        mp = effect if mp != 0
+        stat_amount = effect
         before_hp = target.hp
         before_mp = target.mp || 0
-        rcap = recover_cap
-        hp = rcap if hp > rcap
-        stat_amount = rcap if stat_amount > rcap
         # Each affected field rolls its own, independent accuracy check --
         # EasyRPG calls `Rand::PercentChance(to_hit)` fresh inside each of
         # `affect_hp`/`affect_sp`'s own `if`, not once for the whole skill

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13646,6 +13646,33 @@ check 'battle: a heal skill restoring both HP and SP rolls each independently' d
   eq 10, hero.mp
 end
 
+# Confirmed against EasyRPG's actual C++ source: `Algo::CalcSkillEffect`
+# (src/algo.cpp) computes one `effect` local -- attribute multiplier, then
+# `VarianceAdjustEffect`, each applied exactly once -- and `Skill::vExecute`
+# (src/game_battlealgorithm.cpp) reads that identical raw number into every
+# `affect_hp`/`affect_sp`/`affect_attack`/etc. branch it takes, each still
+# gated by its own independent `Rand::PercentChance(to_hit)` roll (the
+# check above, unaffected by this one). The *magnitude* itself is never
+# rolled twice, unlike the accuracy gate.
+check "battle: a heal skill restoring both HP and SP shares one variance " \
+      "roll, not an independent one per field" do
+  hero = combatant_mp('Hero', 0, 0, 20, 100, 100)
+  hero.hp = 50
+  hero.mp = 50
+  cmd = { variance: 5 }
+  # A single shared roll (SequenceRng value 5) must land 35 on the base-40
+  # spread; a second, independent draw (value 15) would instead land 45 --
+  # so HP and SP landing the *same* amount proves only one roll happened.
+  bat = Game::Battle.new([hero], [combatant('Foe', 0, 0, 5, 100)],
+                         SequenceRng.new([5, 15]), nil, true)
+  e = bat.send(:apply_skill_hit, hero, hero, 40, 40, cmd)
+  eq 35, e[:recover_hp], 'the shared roll (SequenceRng value 5)'
+  eq 35, e[:recover_mp], 'SP restored the identical amount as HP, not a second, ' \
+     'independent roll (value 15, which would give 45)'
+  eq 85, hero.hp
+  eq 85, hero.mp
+end
+
 # RPG_RT's `Game_BattleAlgorithm::Skill::vExecute` (src/game_battlealgorithm.cpp)
 # gates every state a skill would cure behind its own `Rand::PercentChance(
 # to_hit_states)` roll -- the same fresh-per-field idiom `#skill_effect_hits?`


### PR DESCRIPTION
## Summary

- RPG_RT computes one variance-adjusted effect per skill cast and reuses it raw for every affected field. Confirmed against EasyRPG's actual C++ source: `Algo::CalcSkillEffect` (`src/algo.cpp`) applies the attribute multiplier and `VarianceAdjustEffect` exactly once each, producing a single `effect` local; `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`) then reads that identical raw number into every one of its `affect_hp`/`affect_sp`/`affect_attack`/`affect_defense`/`affect_spirit`/`affect_agility` branches -- each still gated by its own independent `Rand::PercentChance(to_hit)` accuracy roll (that per-field independence is real and was already correctly ported; only the *magnitude* is shared, not the hit/miss roll).
- `Game::Battle#apply_skill_hit`'s recovery branch (`mruby-rpg2k/mrblib/game.rb`) previously ran `hp`/`mp`/`stat_amount` each through `#apply_attr_multiplier`/`#varied` independently -- so a Cure spell restoring both HP and SP could land two different randomized amounts on the same cast, and consumed an extra RNG draw that desynced every subsequent seeded roll in the fight. The stat modifier (`stat_amount`) also never received the attribute multiplier at all, and `mp` was never capped to `#recover_cap` the way `hp`/`stat_amount` were -- matching EasyRPG's own single `Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue())` applied once, before any affect_* branch reads it.
- This traces back to an uncited claim introduced in the very PR that first wired up recovery-branch variance: "HP and SP are two separate effect values sharing one base rather than one number applied twice."
- Fixed by computing one shared `effect` (attribute-scaled, variance-spread, and capped exactly once) and assigning it identically to whichever of `hp`/`mp`/`stat_amount` is active, mirroring the attack branch's own established `dmg = hp != 0 ? hp : (mp != 0 ? mp : cmd[:stat_effect])` idiom just above it in the same method.
- This also corrects the prior `docs/TODO.md` writeup that introduced the wrong claim.

## Test plan

- [x] Added a new `scripts/rpg2k_logic_check.rb` check: a heal restoring both HP and SP with a seeded two-value RNG sequence lands the *same* amount on both, proving only the first value was ever drawn (a second, independent roll would have produced a different SP amount).
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `game.rb` only -- `expected 35, got 45`) and passes after.
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1098 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 838 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_