### PR TITLE
Recognize the literal "(OFF)" audio sentinel, not just a blank filename

### DIFF
--- a/changelog.d/audio-off-literal-string.fixed.md
+++ b/changelog.d/audio-off-literal-string.fixed.md
@@ -1,0 +1,10 @@
+- **Audio:** Play BGM/Play SE now recognize the editor's "(OFF)" choice
+  correctly -- it's the literal text "(OFF)", not a blank filename.
+  Play BGM set to "(OFF)" (or left blank) now always stops the current
+  track, matching RPG_RT; previously only a blank field did anything, and an
+  explicit "(OFF)" selection silently tried (and failed) to play a file
+  literally named "(OFF)". Play SE set to "(OFF)" now correctly stops every
+  playing sound effect, while a genuinely blank Play SE field is now a true
+  no-op (previously a blank field itself stopped every sound effect, which
+  real RPG_RT does not do). The same "(OFF)" vs. blank distinction was fixed
+  for vehicle/pre-battle/pre-inn BGM restoration on the map.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13383,18 +13383,58 @@ not yet verified:
   #play_audio` (`mruby-rpg2k/mrblib/interpreter.rb`) returned immediately on
   a blank filename for both Play BGM and Play SE alike, which is correct for
   a blank Play BGM (nothing establishes RPG_RT treats that as anything but a
-  no-op) but wrong for Play SE: the editor's "(OFF)" choice is encoded the
-  same way, as an empty filename, and since SE is truly polyphonic (no
-  single "current" track the way BGM has one), a blank Play SE genuinely
-  halts every in-flight sound effect rather than leaving one alone. The
-  blank-name branch now calls `RGSS::Audio.se_stop` (already defined as an
-  `Audio` module wrapper in `mruby-rgss`, previously unused from this
-  codebase) when the command is a Play SE; Play BGM's own blank-name case is
-  untouched. Covered by two new `scripts/rpg2k_logic_check.rb` checks (a
-  blank-name Play SE reaches the stop-all backend call and plays nothing; an
-  ordinary named Play SE still plays normally, not a stop-all), confirmed to
-  fail against the pre-fix code before the fix. SE never loops natively
-  (unverified, separate claim).
+  no-op) but wrong for Play SE: ~~the editor's "(OFF)" choice is encoded the
+  same way, as an empty filename~~ (see the Follow-up below — that's an
+  uncited, wrong assumption; "(OFF)" is its own literal string, distinct
+  from blank), and since SE is truly polyphonic (no single "current" track
+  the way BGM has one), a blank Play SE genuinely halts every in-flight
+  sound effect rather than leaving one alone. The blank-name branch now
+  calls `RGSS::Audio.se_stop` (already defined as an `Audio` module wrapper
+  in `mruby-rgss`, previously unused from this codebase) when the command is
+  a Play SE; Play BGM's own blank-name case is untouched. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a blank-name Play SE reaches the
+  stop-all backend call and plays nothing; an ordinary named Play SE still
+  plays normally, not a stop-all), confirmed to fail against the pre-fix
+  code before the fix. SE never loops natively (unverified, separate claim).
+  ✅ **Follow-up (2026-08-21): the editor's "(OFF)" choice is not encoded as
+  a blank filename at all — it is the literal 5-character string "(OFF)",
+  liblcf's own schema default for both the Music and Sound structs — and
+  RPG_RT treats a genuinely blank name and a literal "(OFF)" name
+  differently for Play SE (identically for Play BGM).** Confirmed against
+  EasyRPG's actual C++ source: `Game_System::SePlay` (`src/game_system.cpp`)
+  — `if (se.name.empty()) { return; } else if (se.name == "(OFF)") { if
+  (stop_sounds) Audio().SE_Stop(); return; }` — a genuinely blank name is a
+  silent no-op with **no** stop call, while only the literal "(OFF)" stops
+  every playing SE (gated on `stop_sounds`, which `Game_Interpreter::
+  CommandPlaySound`, `src/game_interpreter.cpp`, always passes `true` for the
+  Play SE event command itself). So the fix above actually had it backwards
+  for a genuinely blank Play SE name (a real no-op in RPG_RT) — it stopped
+  everything — while a Play SE explicitly set to "(OFF)" in the editor never
+  hit the stop branch at all, since its `cmd.string` is the non-empty text
+  `"(OFF)"`: it fell through to `RGSS::Audio.se_play("(OFF)", ...)`, which
+  fails to find a file by that name and silently does nothing (caught by the
+  method's own `rescue`), rather than stopping playback. Separately, `Game_
+  System::BgmPlay` (same file) treats blank and "(OFF)" identically —
+  `if (!bgm.name.empty() && bgm.name != "(OFF)") { ...play... } else {
+  BgmStop(); }` — so Play BGM's own blank-name case (left "untouched" above,
+  on the same reasoning that a blank Play BGM's behavior was unestablished)
+  was also wrong: real RPG_RT always stops the current track on a blank *or*
+  "(OFF)" Play BGM, and an explicit "(OFF)" selection (not just a blank
+  field) never stopped anything here either. `#play_audio` now checks the
+  literal `name == '(OFF)'` string alongside blank for both kinds, correctly
+  reproducing `BgmStop`'s always-stop rule for BGM and `SePlay`'s
+  no-op-vs-stop split for SE. The identical gap existed in `Scene::Map
+  #play_bgm_or_stop` (`mruby-rpg2k/mrblib/scene/map.rb`) too — its own doc
+  comment already correctly cited "(OFF) means play nothing" from `BgmPlay`,
+  but the condition itself only ever checked for a blank name, so a
+  vehicle/pre-battle/pre-inn BGM explicitly set to "(OFF)" fell through to
+  `#play_bgm` and tried to play a file literally named "(OFF)" — fixed the
+  same way. Covered by four new `scripts/rpg2k_logic_check.rb` checks (a
+  genuinely blank Play SE name is now a true no-op — no stop call at all; the
+  literal "(OFF)" Play SE name stops every SE; the literal "(OFF)" Play BGM
+  name stops the current track instead of trying to play it; a blank Play
+  BGM name still also stops it), confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **Not applicable/deliberately not reproduced: "SE files must be WAVE;
   BGM accepts MIDI/WAVE/MP3" is an old Windows API limitation of the
   original executable, not a rule this reimplementation restricts to.**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3907,16 +3907,31 @@ module Game
 
     def play_audio(kind, cmd)
       name = cmd.string
-      if name.nil? || name.empty?
-        # Selecting "(OFF)" for the SE field (an empty string, same encoding
-        # as any other blank filename) is not a no-op like a blank BGM field
-        # is: real RPG_RT stops every currently-playing sound effect at once
-        # (SE is truly polyphonic, unlike the single-channel BGM slot, so
-        # there is no single "current" track for an empty name to leave
-        # alone the way Play BGM does — yado.tk). Play BGM's own blank-name
-        # case stays an untouched no-op; nothing here establishes RPG_RT
-        # treats a blank Play BGM the same way, so that stays unaddressed.
-        RGSS::Audio.se_stop if kind == :se
+      blank = name.nil? || name.empty?
+      # Corrected against EasyRPG's actual C++ source (this method's own
+      # prior comment here had assumed selecting the editor's "(OFF)" choice
+      # is encoded as a blank string, an uncited claim — it is instead the
+      # literal 5-character text "(OFF)", liblcf's own schema default for
+      # both the Music and Sound structs). `Game_System::BgmPlay`
+      # (`src/game_system.cpp`): `if (!bgm.name.empty() && bgm.name !=
+      # "(OFF)") { ...play... } else { BgmStop(); }` — blank *and* "(OFF)"
+      # both stop the current track unconditionally. `Game_System::SePlay`
+      # (same file) instead treats the two differently: `if (se.name.empty())
+      # { return; } else if (se.name == "(OFF)") { if (stop_sounds)
+      # Audio().SE_Stop(); return; }` — a genuinely blank name is a silent
+      # no-op, while only the literal "(OFF)" stops every playing SE (gated
+      # on `stop_sounds`, always true for the Play SE event command itself —
+      # `Game_Interpreter::CommandPlaySound`, `src/game_interpreter.cpp`).
+      if kind == :bgm
+        if blank || name == '(OFF)'
+          RGSS::Audio.bgm_stop
+          @state.current_bgm = nil
+          return
+        end
+      elsif blank
+        return
+      elsif name == '(OFF)'
+        RGSS::Audio.se_stop
         return
       end
       if kind == :bgm

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2460,7 +2460,15 @@ class RPG2k
       # back into a map that itself had no BGM used to leave the vehicle's own
       # track still playing, neither of which real RPG_RT does.
       def play_bgm_or_stop(music)
-        if music && music[:name] && !music[:name].to_s.empty?
+        # The doc comment above already cites "(OFF) means play nothing" from
+        # `BgmPlay`'s own source, but this condition itself only ever checked
+        # for a blank name -- never the literal "(OFF)" text `BgmPlay`
+        # actually compares against (liblcf's own Music-struct schema
+        # default). A vehicle/pre-battle/pre-inn BGM explicitly set to
+        # "(OFF)" in the editor fell through to `#play_bgm` and tried to
+        # play a file literally named "(OFF)" instead of stopping.
+        name = music && music[:name] ? music[:name].to_s : ''
+        if !name.empty? && name != '(OFF)'
           play_bgm(music)
         else
           RGSS::Audio.bgm_stop

--- a/scripts/rpg2k_command_soak.rb
+++ b/scripts/rpg2k_command_soak.rb
@@ -43,6 +43,7 @@ module RGSS
       def bgm_fade(*); end
       def bgm_stop(*); end
       def se_play(*); end
+      def se_stop(*); end
       def me_play(*); end
     end
   end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -25,6 +25,7 @@ module RGSS
       def bgm_volume(*a); (@log ||= []) << [:bgm_volume, *a]; end
       def bgm_pan(*a); (@log ||= []) << [:bgm_pan, *a]; end
       def bgm_fade(*a); (@log ||= []) << [:bgm_fade, *a]; end
+      def bgm_stop(*a); (@log ||= []) << [:bgm_stop, *a]; end
       def se_play(*a);  (@log ||= []) << [:se, *a];  end
       def se_stop(*a);  (@log ||= []) << [:se_stop, *a]; end
     end
@@ -3389,13 +3390,30 @@ check 'Play BGM re-applies pan on a same-file re-trigger, not just a fresh start
   eq [20, 80], pans, 'pan is re-applied on the same-file branch too'
 end
 
-# -- Play SE "(OFF)" ----------------------------------------------------------
+# -- Play SE/BGM "(OFF)" ------------------------------------------------------
+# Confirmed against EasyRPG's actual C++ source: the editor's "(OFF)" choice
+# is encoded as the literal 5-character string "(OFF)" (liblcf's own schema
+# default for both the Music and Sound structs), not as a blank filename --
+# an uncited assumption this project's own prior fix had made. `Game_System::
+# SePlay` (src/game_system.cpp) treats the two differently: a genuinely blank
+# name is a silent no-op (`if (se.name.empty()) { return; }`), while only the
+# literal "(OFF)" stops every playing SE (`else if (se.name == "(OFF)") {
+# if (stop_sounds) Audio().SE_Stop(); return; }`).
 
-check 'Play SE with a blank name (the editor\'s "(OFF)" choice) stops every SE' do
+check 'Play SE with a genuinely blank name is a silent no-op, not a stop-all' do
   RGSS::Audio.log = []
   st = new_state
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::PLAY_SE, [80, 100], string: '')])
+  it.update
+  eq [], RGSS::Audio.log, 'a blank name neither plays nor stops anything'
+end
+
+check 'Play SE with the literal "(OFF)" name stops every SE' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::PLAY_SE, [80, 100], string: '(OFF)')])
   it.update
   eq [[:se_stop]], RGSS::Audio.log, 'the SE-stop-all backend call ran, and no SE played'
 end
@@ -3407,6 +3425,36 @@ check 'Play SE with a real file name plays it, not a stop-all' do
   it.start([FakeCmd.new(IC::PLAY_SE, [80, 100], string: 'cursor')])
   it.update
   eq [[:se, 'cursor', 80, 100]], RGSS::Audio.log
+end
+
+check 'Play BGM with the literal "(OFF)" name stops the current track' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: '(OFF)'),
+  ])
+  it.update
+  eq [[:bgm, 'town', 80, 100], [:bgm_pan, 50], [:bgm_stop]], RGSS::Audio.log,
+     'the second Play BGM stops the track just started, rather than trying ' \
+     'to play a file literally named "(OFF)"'
+  eq nil, it.instance_variable_get(:@state).current_bgm,
+     'the tracked current BGM is cleared too, matching BgmStop\'s own ' \
+     'current_music.name = "(OFF)"'
+end
+
+check 'Play BGM with a blank name also stops the current track' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: ''),
+  ])
+  it.update
+  eq [[:bgm, 'town', 80, 100], [:bgm_pan, 50], [:bgm_stop]], RGSS::Audio.log,
+     'BgmPlay treats a blank name exactly like "(OFF)" -- both stop'
 end
 
 # -- actor HP / MP commands ---------------------------------------------------


### PR DESCRIPTION
## Summary

- RPG_RT's editor encodes the "(OFF)" choice as the literal 5-character string `"(OFF)"` -- liblcf's own schema default for both the Music and Sound structs -- not as a blank filename, an uncited assumption a prior fix in this project (see `docs/TODO.md`) had made.
- Confirmed against EasyRPG's actual C++ source: `Game_System::SePlay` (`src/game_system.cpp`) treats the two differently -- `if (se.name.empty()) { return; } else if (se.name == "(OFF)") { if (stop_sounds) Audio().SE_Stop(); return; }` -- a genuinely blank name is a silent no-op with **no** stop call, while only the literal `"(OFF)"` stops every playing SE (gated on `stop_sounds`, which `Game_Interpreter::CommandPlaySound` always passes `true` for the Play SE event command). `Game_System::BgmPlay` (same file) instead treats blank and `"(OFF)"` identically -- `if (!bgm.name.empty() && bgm.name != "(OFF)") { ...play... } else { BgmStop(); }`.
- `Game::Interpreter#play_audio` (`mruby-rpg2k/mrblib/interpreter.rb`) previously stopped every SE on a genuinely blank name (wrong -- real RPG_RT does nothing there) and never recognized an explicit `"(OFF)"` Play SE selection at all -- it fell through and tried (and failed) to play a file literally named `"(OFF)"`. Play BGM's blank-name case was left an untouched no-op entirely, and an explicit `"(OFF)"` BGM selection was never stopped either.
- The identical gap existed in `Scene::Map#play_bgm_or_stop` (`mruby-rpg2k/mrblib/scene/map.rb`) -- its own doc comment already correctly cited `BgmPlay`'s "(OFF) means play nothing" rule, but the condition itself only ever checked for a blank name, so a vehicle/pre-battle/pre-inn BGM explicitly set to `"(OFF)"` in the editor fell through and tried to play a file literally named `"(OFF)"`. Fixed the same way.
- This also corrects the prior `docs/TODO.md` writeup that introduced the wrong "(OFF) = blank" assumption.

## Test plan

- [x] Rewrote the existing Play SE "(OFF)" check to assert a genuinely blank name is a true no-op, added a new check for the literal `"(OFF)"` name stopping every SE, and two new Play BGM checks (literal `"(OFF)"` and blank both stop the current track).
- [x] Added the missing `RGSS::Audio.bgm_stop` fake backend method to the test harness (previously undefined, since nothing exercised it before).
- [x] Confirmed all four new/rewritten checks fail against the pre-fix code (`git stash` on `interpreter.rb`/`map.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1101 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 838 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_