### PR TITLE
Keep the shop command cursor where the player left it, not always Buy

### DIFF
--- a/changelog.d/shop-command-cursor-persists.fixed.md
+++ b/changelog.d/shop-command-cursor-persists.fixed.md
@@ -1,0 +1,5 @@
+- **UI:** the field shop screen's Buy/Sell/Leave command cursor now stays
+  where the player left it after cancelling out of the Buy or Sell item
+  list, instead of always snapping back to "Buy" -- matching RPG_RT, whose
+  command-menu cursor position persists across a trip into either list and
+  back.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1367,6 +1367,29 @@ The work below is roughly ordered by the critical path to a walkable game
   confirmation; the gold panel hides on the command menu and the sell list
   and shows on the quantity counter), both confirmed to fail against the
   pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-21): cancelling out of the Buy or Sell list back to
+  the command menu always snapped the command cursor onto Buy, instead of
+  leaving it wherever the player had it.** Confirmed against EasyRPG's
+  actual C++ source: `Window_Shop` (`src/window_shop.cpp`) sets `index = 1`
+  (the Buy row) exactly once, in its constructor; neither `Refresh()` nor
+  `SetMode()` (called by `Scene_Shop::UpdateBuySelection`/
+  `UpdateSellSelection`'s own Cancel branch, `src/scene_shop.cpp`, to return
+  to `BuySellLeave2`) ever touches `index` again — so cancelling out of the
+  Sell list, say, returns to the command menu with Sell still highlighted,
+  not Buy. `#shop_switch` (`mruby-rpg2k/mrblib/scene/map.rb`) is the one
+  method used both to *enter* Buy/Sell from the command menu (where a fresh
+  `index: 0` is correct) and to *return* to the command menu from a list
+  (where it wrongly applied the same reset) — this codebase's single shared
+  `@shop[:index]` field, reused across all four shop screens, has no
+  equivalent to `Window_Shop`'s own persistent per-widget cursor. Fixed with
+  a new `@shop[:cmd_index]` field that `#shop_switch` saves the command
+  menu's cursor into on the way out and restores on the way back, while
+  every other screen (Buy, Sell, the quantity counter) still always starts
+  fresh at row 0. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  (moving the command cursor onto Sell, entering the sell list, then
+  cancelling back out leaves the cursor on Sell, not reset to Buy),
+  confirmed to fail against the pre-fix code (`expected 1, got 0`) before
+  the fix.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4980,8 +4980,9 @@ class RPG2k
         has_menu = req[:allow_buy] && req[:allow_sell]
         screen = has_menu ? :command : (req[:allow_buy] ? :buy : :sell)
         @shop = { model: model, has_menu: has_menu, screen: screen, index: 0,
-                  window: nil, gold: build_shop_gold_window, status: nil,
-                  terms: shop_terms(req[:type]), browsed: false, interp: it }
+                  cmd_index: 0, window: nil, gold: build_shop_gold_window,
+                  status: nil, terms: shop_terms(req[:type]), browsed: false,
+                  interp: it }
         draw_shop
       end
 
@@ -5355,8 +5356,22 @@ class RPG2k
         # shopkeeper's line on returning to the command menu switches from a
         # first-time greeting to "anything else?" for the rest of it.
         @shop[:browsed] = true if screen == :buy || screen == :sell
+        # The command menu's own cursor position persists across a trip into
+        # Buy/Sell and back, rather than always snapping to the first row --
+        # confirmed against EasyRPG's actual C++ source: `Window_Shop`
+        # (`src/window_shop.cpp`) sets `index = 1` (the Buy row) exactly once,
+        # in its constructor; neither `Refresh()` nor `SetMode()` (called by
+        # `Scene_Shop::UpdateBuySelection`/`UpdateSellSelection`'s own Cancel
+        # branch, `src/scene_shop.cpp`, to return to `BuySellLeave2`) ever
+        # touches `index` again. So cancelling out of the Sell list, say,
+        # returns to the command menu with Sell still highlighted, not Buy.
+        # Saved/restored here rather than in a fresh field per screen, since
+        # only the command menu has a cursor position worth remembering
+        # across a screen change -- Buy/Sell/the quantity counter always
+        # start a fresh browse at their own first row.
+        @shop[:cmd_index] = @shop[:index] if @shop[:screen] == :command
         @shop[:screen] = screen
-        @shop[:index] = 0
+        @shop[:index] = screen == :command ? (@shop[:cmd_index] || 0) : 0
         draw_shop
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14444,6 +14444,50 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
      'having browsed once, the shopkeeper asks "anything else?" rather than greeting again'
 end
 
+# Confirmed against EasyRPG's actual C++ source: `Window_Shop`
+# (`src/window_shop.cpp`) sets `index = 1` (the Buy row) exactly once, in
+# its constructor; neither `Refresh()` nor `SetMode()` (called by
+# `Scene_Shop::UpdateBuySelection`/`UpdateSellSelection`'s own Cancel
+# branch, `src/scene_shop.cpp`, to return to `BuySellLeave2`) ever touches
+# `index` again. So the command menu's own cursor persists across a trip
+# into Buy or Sell and back, rather than always snapping back to the first
+# row (Buy).
+check 'Open Shop scene: the command cursor stays on Sell after cancelling ' \
+      'out of the sell list, not snapping back to Buy' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0)]
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the command menu opens (mode 0: buy+sell)
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  eq 0, shop[:index], 'starts on the first row (Buy)'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move onto Sell
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq 1, shop[:index], 'now on the second row (Sell)'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # enter the sell list
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :sell, shop[:screen]
+
+  RGSS::Input.triggered = [RGSS::Input::B] # cancel back to the command menu
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  eq 1, shop[:index],
+     'the cursor is still on Sell, not reset to Buy (row 0)'
+end
+
 check 'Open Shop scene: buying shows the shop_purchased confirmation, then returns ' \
       'to the buy list' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

- RPG_RT's shop command cursor persists across a trip into Buy or Sell and back, rather than always snapping to the first row (Buy). Confirmed against EasyRPG's actual C++ source: `Window_Shop` (`src/window_shop.cpp`) sets `index = 1` (the Buy row) exactly once, in its constructor; neither `Refresh()` nor `SetMode()` (called by `Scene_Shop::UpdateBuySelection`/`UpdateSellSelection`'s own Cancel branch, `src/scene_shop.cpp`, to return to `BuySellLeave2`) ever touches `index` again -- so cancelling out of the Sell list, say, returns to the command menu with Sell still highlighted, not Buy.
- `Scene::Map#shop_switch` (`mruby-rpg2k/mrblib/scene/map.rb`) is the one method used both to *enter* Buy/Sell from the command menu (where a fresh `index: 0` is correct) and to *return* to the command menu from a list (where it wrongly applied the same reset) -- this codebase's single shared `@shop[:index]` field, reused across all four shop screens, has no equivalent to `Window_Shop`'s own persistent per-widget cursor.
- Fixed with a new `@shop[:cmd_index]` field that `#shop_switch` saves the command menu's cursor into on the way out and restores on the way back in, while every other screen (Buy, Sell, the quantity counter) still always starts fresh at row 0.
- This also adds a Follow-up correction to the prior `docs/TODO.md` writeup for the shop screen.

## Test plan

- [x] Added a new `scripts/rpg2k_scene_check.rb` check: moving the command cursor onto Sell, entering the sell list, then cancelling back out leaves the cursor on Sell, not reset to Buy.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `map.rb` only -- `expected 1, got 0`) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 839 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1101 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_