### PR TITLE
Fix scrambled small-kana order and vu/star glyphs in the name-input grid

### DIFF
--- a/changelog.d/name-input-kana-grid-table.fixed.md
+++ b/changelog.d/name-input-kana-grid-table.fixed.md
@@ -1,0 +1,6 @@
+- **UI:** the Enter Hero Name kana grid's ま/マ row now types the correct
+  small kana (small-tsu, small-ya, small-yu, small-yo, small-wa, in that
+  order) instead of a scrambled order with a stray duplicate cell, and the
+  hiragana page's own "vu" cell now types katakana ヴ (matching RPG_RT)
+  instead of hiragana ゔ. The や/ヤ row's final cell is now the white star
+  (☆) RPG_RT actually uses, not a black star.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5088,6 +5088,31 @@ The work below is roughly ordered by the critical path to a walkable game
   keeps the widget open without resuming the event; confirming again with
   the refilled name then closes it normally), both confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-21): the kana grid's own character table had three
+  cells scrambled or outright wrong, typed from memory rather than ported
+  from real data.** Confirmed against EasyRPG's actual C++ source:
+  `Window_Keyboard::layouts[]` (`src/window_keyboard.cpp`), the real RPG_RT
+  keyboard table. `NAME_HIRAGANA_ROWS`/`NAME_KATAKANA_ROWS`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) had the ま/マ row's small-kana columns
+  as ゃゅょっー — small-tsu (っ) had drifted three columns right of its real
+  position (column 5, right after the base も/モ row), and the final column
+  was a stray duplicate of the ー already one row below, rather than
+  small-wa (ゎ/ヮ). `NAME_KANA_LAST_HIRAGANA`'s own "vu" cell used hiragana
+  ゔ, where the reference table uses katakana ヴ on *both* the hiragana and
+  katakana pages (hiragana has no canonical vu glyph of its own here) — the
+  katakana constant already had this right, only the hiragana one was
+  wrong. The や/ヤ row's final cell was also the black star ★ (U+2605)
+  where the reference uses the white star ☆ (U+2606). None of these three
+  constants carried a source citation, unlike almost everything else in
+  this file. This is inert game data, not a control-flow method, so it sits
+  in no other fix's call chain and has no sibling call site to have caught
+  it — `NAME_CHARS`/`NAME_CELLS`, the separate Latin-alphabet page, was
+  already correct and untouched. Fixed by correcting the three data
+  literals to match the cited table exactly. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (the ま row matches the reference
+  table cell-for-cell; typing the corrected small-tsu and small-wa cells
+  produces the right characters; the hiragana page's own "vu" cell is
+  katakana ヴ), confirmed to fail against the pre-fix code before the fix.
 - ✅ **The same "silent embedded widget" family, found once more: Open Shop
   and Show Inn played zero sound effects at all (2026-08-18).** Verified
   against RPG_RT's actual behavior via EasyRPG Player's own C++ source,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5634,7 +5634,17 @@ class RPG2k
       # long-vowel mark, then a symbol row, and a final row of six kana plus
       # the page-toggle and confirm cells (each drawn two columns wide, so the
       # last row fills the same 10 columns as the rows above it).
-      NAME_KANA_LAST_HIRAGANA = (%w[ら り る れ ろ ゔ] + %i[toggle confirm]).freeze
+      # Confirmed against EasyRPG's actual C++ source: `Window_Keyboard::
+      # layouts[]` (`src/window_keyboard.cpp`), the real RPG_RT keyboard
+      # table -- the ま/マ row's small kana column order is っゃゅょゎ, not
+      # ゃゅょっー (small-tsu had drifted three columns right, and the last
+      # column was a stray duplicate of the ー already on the row below,
+      # rather than small-wa ゎ/ヮ); the last row's "vu" cell is katakana
+      # ヴ on *both* the hiragana and katakana pages in the reference table
+      # (hiragana has no glyph of its own there), not hiragana ゔ on the
+      # hiragana page; and the や/ヤ row's final cell is the white star ☆
+      # (U+2606), not the black star ★ (U+2605).
+      NAME_KANA_LAST_HIRAGANA = (%w[ら り る れ ろ ヴ] + %i[toggle confirm]).freeze
       NAME_KANA_LAST_KATAKANA = (%w[ラ リ ル レ ロ ヴ] + %i[toggle confirm]).freeze
       NAME_HIRAGANA_ROWS = [
         %w[あ い う え お が ぎ ぐ げ ご],
@@ -5643,8 +5653,8 @@ class RPG2k
         %w[た ち つ て と ば び ぶ べ ぼ],
         %w[な に ぬ ね の ぱ ぴ ぷ ぺ ぽ],
         %w[は ひ ふ へ ほ ぁ ぃ ぅ ぇ ぉ],
-        %w[ま み む め も ゃ ゅ ょ っ ー],
-        %w[や ゆ よ わ ん ー 〜 ・ ＝ ★],
+        %w[ま み む め も っ ゃ ゅ ょ ゎ],
+        %w[や ゆ よ わ ん ー 〜 ・ ＝ ☆],
         NAME_KANA_LAST_HIRAGANA
       ].freeze
       NAME_KATAKANA_ROWS = [
@@ -5654,8 +5664,8 @@ class RPG2k
         %w[タ チ ツ テ ト バ ビ ブ ベ ボ],
         %w[ナ ニ ヌ ネ ノ パ ピ プ ペ ポ],
         %w[ハ ヒ フ ヘ ホ ァ ィ ゥ ェ ォ],
-        %w[マ ミ ム メ モ ャ ュ ョ ッ ー],
-        %w[ヤ ユ ヨ ワ ン ー 〜 ・ ＝ ★],
+        %w[マ ミ ム メ モ ッ ャ ュ ョ ヮ],
+        %w[ヤ ユ ヨ ワ ン ー 〜 ・ ＝ ☆],
         NAME_KANA_LAST_KATAKANA
       ].freeze
       NAME_KANA_COLS = 10

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8121,6 +8121,51 @@ check 'Enter Hero Name: confirming a blank kana name refills it and stays ' \
   ok st.switches[5], 'and the event resumed'
 end
 
+# Confirmed against EasyRPG's actual C++ source: `Window_Keyboard::
+# layouts[]` (`src/window_keyboard.cpp`), the real RPG_RT keyboard table --
+# the ま row's small-kana columns are っゃゅょゎ (small-tsu, then small-ya/
+# yu/yo, then small-wa), and the last row's "vu" cell is katakana ヴ even
+# on the hiragana page (hiragana has no glyph of its own there in the
+# reference table).
+check 'Enter Hero Name: the ま row and "vu" cell match RPG_RT\'s own keyboard ' \
+      'table, not a scrambled small-kana order' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::NAME_INPUT, [1, 0, 0], indent: 0)]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  6.times do
+    scene.update
+    break if scene.instance_variable_get(:@name_ui)
+  end
+  ui = scene.instance_variable_get(:@name_ui)
+  ok ui, 'the name-entry widget opened'
+
+  rows = RPG2k::Scene::Map::NAME_HIRAGANA_ROWS
+  cols = RPG2k::Scene::Map::NAME_KANA_COLS
+  ma_row = rows.index { |r| r[0] == 'ま' }
+  ok ma_row, 'the ま row exists'
+  eq %w[ま み む め も っ ゃ ゅ ょ ゎ], rows[ma_row],
+     'small-tsu, then small-ya/yu/yo, then small-wa -- not ゃゅょっー'
+
+  ui[:sel] = ma_row * cols + 5 # っ
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'っ', ui[:name], 'column 5 types small-tsu'
+
+  ui[:sel] = ma_row * cols + 9 # ゎ
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq 'っゎ', ui[:name], 'column 9 types small-wa, not a duplicate ー'
+
+  last_row = rows.length - 1
+  eq 'ヴ', rows[last_row][5],
+     'the hiragana page\'s own "vu" cell is katakana ヴ, not hiragana ゔ'
+end
+
 check 'Enter Hero Name: the toggle cell swaps the hiragana/katakana page' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- Confirmed against EasyRPG's actual C++ source: `Window_Keyboard::layouts[]` (`src/window_keyboard.cpp`), RPG_RT's real keyboard table.
- `NAME_HIRAGANA_ROWS`/`NAME_KATAKANA_ROWS` (`mruby-rpg2k/mrblib/scene/map.rb`) had the ま/マ row's small-kana columns as ゃゅょっー -- small-tsu (っ) had drifted three columns right of its real position (column 5, right after the base も/モ row), and the final column was a stray duplicate of the ー already one row below, rather than small-wa (ゎ/ヮ).
- `NAME_KANA_LAST_HIRAGANA`'s own "vu" cell used hiragana ゔ, where the reference table uses katakana ヴ on *both* the hiragana and katakana pages (hiragana has no canonical vu glyph of its own in this table) -- the katakana constant already had this right, only the hiragana one was wrong.
- The や/ヤ row's final cell was also the black star ★ (U+2605) where the reference uses the white star ☆ (U+2606).
- None of these three data literals carried a source citation, unlike almost everything else in this file -- they were evidently typed from memory. This is inert game data, not a control-flow method, so it sits in no other fix's call chain and has no sibling call site (`NAME_CHARS`/`NAME_CELLS`, the separate Latin-alphabet page, was already correct).
- Fixed by correcting the three data literals to match the cited table exactly -- pure array-literal correction, no control-flow change.

## Test plan

- [x] Added a new `scripts/rpg2k_scene_check.rb` check: the ま row matches the reference table cell-for-cell, typing the corrected small-tsu and small-wa cells produces the right characters, and the hiragana page's own "vu" cell is katakana ヴ.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `map.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 840 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1101 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_