### PR TITLE
Decode terrain footstep as a real Sound struct, not a bare filename

### DIFF
--- a/changelog.d/terrain-footstep-sound-struct.fixed.md
+++ b/changelog.d/terrain-footstep-sound-struct.fixed.md
@@ -1,0 +1,6 @@
+- **Audio:** an RPG2003 terrain's footstep sound effect now plays with its
+  own configured volume and pitch, and correctly plays nothing when set to
+  "(OFF)" -- the database field was declared as a bare filename instead of
+  the full sound (filename + volume + pitch + balance) RPG_RT actually
+  stores there, so a project's real per-terrain volume/pitch was silently
+  dropped and an explicit "(OFF)" footstep still attempted playback.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16263,8 +16263,9 @@ once per the two call sites that both read the same landed-on tile in a
 single step, and not again on further re-queries of the same tile) while
 terrain damage/bush depth both fall back to their harmless defaults.
 ✅ **Terrain's `footstep` and `on_damage_se` fields (chunk 16 elements 15/16)
-are wired up** — parsed by `mruby-lcf/mrblib/schema.rb` since the terrain
-chunk was first decoded (ADR 0034) but never read by the runtime;
+are wired up** — ~~parsed by `mruby-lcf/mrblib/schema.rb` since the terrain
+chunk was first decoded (ADR 0034)~~ (see the Follow-up below — `footstep`
+was parsed as the wrong *type*, not just left unread) but never read by the runtime;
 `scripts/rpg2k_field_audit.rb`'s `NOT_OURS` table used to list `footstep` as
 out of scope for exactly that reason. Checked against a real
 `Game_Player::Move` (EasyRPG source, not guessed): the footstep SE is
@@ -16282,6 +16283,38 @@ now passed to both rather than queried twice. Covered by three new
 firing once per tile walked; an RPG2000 fixture never playing one even when
 the field is set; and an RPG2003 fixture with `on_damage_se` set staying
 silent on a harmless tile while playing on every tile of a damaging one.
+✅ **Follow-up (2026-08-21): `footstep` (chunk 16 element 0x0F) was declared
+as a bare `:string` in the schema — real RPG_RT's field is a full `Sound`
+struct (filename + volume + tempo + balance), the same shape every other
+Sound-typed database field already uses.** Confirmed against liblcf's own
+source, fetched live: `generator/csv/fields.csv` —
+`Terrain,footstep,f,Sound,0x0F,...` — and `src/generated/lcf/rpg/
+terrain.h` — `Sound footstep;`. `Game_Player::BeginMove`
+(`src/game_player.cpp`) plays it with `Main_Data::game_system->
+SePlay(terrain->footstep)`, the identical `Game_System::SePlay(const
+lcf::rpg::Sound&, bool)` (`src/game_system.cpp`) every other system/
+animation SE call site reads — the same method already fixed twice this
+session for its blank-vs-"(OFF)" distinction (`#db_system_se`/
+`#play_animation_se`). Mistyping the field as `:string` meant
+`#play_terrain_footstep_se` read raw undecoded sub-chunk bytes instead of
+the real filename for any project that actually configured a footstep SE
+(the fixture-only checks above happened to never exercise a real decoded
+row, so the mistyped field went unnoticed), silently dropped the SE's own
+volume/pitch even when the filename decoded to something plausible by
+accident, and had no "(OFF)" check at all — every *other* Sound-typed field
+in this schema (`SE`, reused by `cursor_se`/`decision_se`/.../`battle_se`
+and the skill/item/animation `se` fields alike) was already declared
+correctly; `footstep` was the one sibling left mistyped, evidently added ad
+hoc for the original ADR 0034 fix without reusing the established `SE`
+convention. Fixed by retyping the schema field to
+`{ type: :Array1D, elements: SE }` and updating
+`#play_terrain_footstep_se` to read `.file`/`.volume`/`.pitch` off the
+decoded `Sound` struct, with the same blank-or-"(OFF)" no-op guard every
+other Sound-typed call site in this codebase already follows. Covered by
+two new `scripts/rpg2k_scene_check.rb` checks (a footstep plays with its
+own configured volume/pitch, not the schema defaults; a footstep explicitly
+set to "(OFF)" plays nothing), confirmed to fail against the pre-fix code
+before the fix.
 ✅ **Riding the airship now skips terrain damage and the footstep SE
 entirely (2026-08-18).** `#note_party_step` looked up and applied the
 stepped-on tile's terrain regardless of what the party was riding.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -340,7 +340,14 @@ module LCF
             7 => { name: :airship_pass, type: :bool, default: true },
             9 => { name: :airship_land, type: :bool, default: true },
             11 => { name: :bush_depth, type: :int, default: 0 },
-            15 => { name: :footstep, type: :string, default: '' },
+            # RPG2003 field 0x0F is a full `Sound` struct (filename + volume +
+            # tempo + balance, liblcf's own `generator/csv/fields.csv`:
+            # `Terrain,footstep,f,Sound,0x0F,...`), not a bare filename --
+            # the same shape every other Sound-typed database field here
+            # already uses (see `SE` above). Confirmed against EasyRPG's
+            # actual C++ source: `src/generated/lcf/rpg/terrain.h` declares
+            # `Sound footstep;`.
+            15 => { name: :footstep, type: :Array1D, elements: SE },
             16 => { name: :on_damage_se, type: :bool, default: false },
             17 => { name: :background_type, type: :int, default: 0 },
             21 => { name: :background_a_name, type: :string, default: '' },

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8092,13 +8092,22 @@ class RPG2k
       # damaged someone (EasyRPG's `!terrain->on_damage_se || red_flash`),
       # turning it from an ambient step sound into the terrain's own damage-tick
       # SE instead of playing on every ordinary step onto that terrain.
+      # Confirmed against EasyRPG's actual C++ source: `Game_Player::
+      # BeginMove` (`src/game_player.cpp`) calls `Main_Data::game_system->
+      # SePlay(terrain->footstep)` -- a full `Sound` (filename + volume +
+      # tempo + balance), read by `Game_System::SePlay(const lcf::rpg::
+      # Sound&, bool)` (`src/game_system.cpp`), which treats a blank name
+      # *or* the literal "(OFF)" sentinel as silent no-ops, the same
+      # convention every other Sound-typed field in this codebase already
+      # follows (see `#db_system_se`/`#play_animation_se`).
       def play_terrain_footstep_se(row, damaged)
         return unless @db.respond_to?(:rpg2003?) && @db.rpg2003?
         return unless row && row.respond_to?(:footstep) && row.respond_to?(:on_damage_se)
         return if row.on_damage_se && !damaged
-        name = row.footstep
-        return if name.nil? || name.empty?
-        RGSS::Audio.se_play(name)
+        se = row.footstep
+        name = se && se.respond_to?(:file) ? se.file : nil
+        return if name.nil? || name.empty? || name == '(OFF)'
+        RGSS::Audio.se_play(name, se.volume, se.pitch)
       rescue StandardError => e
         $stderr.puts "[RPG2k] Terrain: footstep SE playback failed: #{e.message}"
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -597,10 +597,20 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
     # Every tile of the synthetic map is chip 0, which the fake chipset tags as
     # terrain 42 — so this one row decides whether walking hurts, and (for the
     # airship checks) whether it may fly over / land on any tile.
+    #
+    # `footstep` is a real `Sound` (filename + volume + pitch + balance, see
+    # #play_terrain_footstep_se's own citation), not a bare filename -- a
+    # plain String here is a convenience shorthand for "that filename, at the
+    # Sound schema's own default volume/pitch", auto-wrapped so every
+    # existing `footstep: 'Step1'` caller keeps working unchanged; a caller
+    # that needs a specific volume/pitch or the "(OFF)" sentinel passes an
+    # already Sound-shaped object (`respond_to?(:file)`) directly instead.
     terrain: { 42 => OpenStruct.new(damage: terrain_damage, bush_depth: bush_depth,
                                     airship_land: airship_land, airship_pass: airship_pass,
                                     boat_pass: boat_pass, ship_pass: ship_pass,
-                                    footstep: footstep, on_damage_se: on_damage_se) },
+                                    footstep: footstep.respond_to?(:file) ? footstep :
+                                      OpenStruct.new(file: footstep, volume: 100, pitch: 100),
+                                    on_damage_se: on_damage_se) },
     common_event: common,
     # Database actor rows carry the *original* names, which a \N[n] must not
     # use once the actor has been renamed in play (see the \N[n] check).
@@ -20292,6 +20302,33 @@ check 'RPG2003 terrain footstep plays every ordinary step onto that tile' do
   scene = new_scene({}, player: [0, 0], members: [hero], rpg2003: true, footstep: 'Step1')
   walk(scene, 3)
   eq 3, RGSS::Audio.se_calls.count { |c| c[0] == 'Step1' }, 'one footstep per tile walked'
+end
+
+# Confirmed against EasyRPG's actual C++ source: liblcf's own
+# `generator/csv/fields.csv` (`Terrain,footstep,f,Sound,0x0F,...`) and
+# `src/generated/lcf/rpg/terrain.h` (`Sound footstep;`) -- the field is a
+# full Sound struct (filename + volume + tempo + balance), not a bare
+# filename, the same shape `Game_System::SePlay(const lcf::rpg::Sound&,
+# bool)` (`src/game_system.cpp`) already reads for every other Sound-typed
+# database field.
+check 'RPG2003 terrain footstep plays with its own configured volume/pitch, ' \
+      'not the schema defaults' do
+  RGSS::Audio.reset_se
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero], rpg2003: true,
+                     footstep: OpenStruct.new(file: 'Step2', volume: 80, pitch: 120))
+  walk(scene, 1)
+  eq ['Step2', 80, 120], RGSS::Audio.se_calls.find { |c| c[0] == 'Step2' }
+end
+
+check 'a terrain footstep explicitly set to "(OFF)" plays nothing, matching ' \
+      'every other Sound-typed field\'s own "(OFF)" convention' do
+  RGSS::Audio.reset_se
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero], rpg2003: true,
+                     footstep: OpenStruct.new(file: '(OFF)', volume: 100, pitch: 100))
+  walk(scene, 3)
+  eq [], RGSS::Audio.se_calls, 'a "(OFF)" footstep never plays'
 end
 
 check 'RPG2000 never plays a terrain footstep, even when one is set' do


### PR DESCRIPTION
## Summary

- Confirmed against liblcf's own source, fetched live: `generator/csv/fields.csv` -- `Terrain,footstep,f,Sound,0x0F,...` -- and `src/generated/lcf/rpg/terrain.h` -- `Sound footstep;`. RPG2003's terrain footstep field (chunk 16, sub-field 0x0F) is a full `Sound` struct (filename + volume + tempo + balance), the same shape every other Sound-typed database field in this schema already uses (`SE`, reused by `cursor_se`/`decision_se`/.../`battle_se` and the skill/item/animation `se` fields alike).
- `mruby-lcf/mrblib/schema.rb` declared `footstep` as a bare `:string`, evidently added ad hoc for ADR 0034's original footstep fix without reusing the established `SE` convention -- the one sibling among every Sound-typed field left mistyped.
- `Game_Player::BeginMove` (`src/game_player.cpp`) plays it via `Main_Data::game_system->SePlay(terrain->footstep)`, the identical `Game_System::SePlay(const lcf::rpg::Sound&, bool)` (`src/game_system.cpp`) every other system/animation SE call site reads -- the same method already fixed twice this session (`#db_system_se`/`#play_animation_se`, PR #1213) for its blank-vs-"(OFF)" distinction.
- Mistyping the field as `:string` meant `Scene::Map#play_terrain_footstep_se` read raw undecoded sub-chunk bytes instead of the real filename for any project that actually configured a footstep SE, silently dropped the SE's own volume/pitch, and had no "(OFF)" check at all.
- Fixed by retyping the schema field to `{ type: :Array1D, elements: SE }` and updating `#play_terrain_footstep_se` to read `.file`/`.volume`/`.pitch` off the decoded `Sound` struct, with the same blank-or-"(OFF)" no-op guard every other Sound-typed call site in this codebase already follows.
- This also adds a Follow-up correction to the prior `docs/TODO.md` writeup for the original footstep fix.

## Test plan

- [x] Added two new `scripts/rpg2k_scene_check.rb` checks: a footstep plays with its own configured volume/pitch (not the schema defaults); a footstep explicitly set to `"(OFF)"` plays nothing.
- [x] Updated the scene-check fixture helper (`fake_db`'s terrain-row builder) to auto-wrap a plain-string `footstep:` shorthand into a Sound-shaped object, so every existing `footstep: 'Step1'`-style test keeps working unchanged.
- [x] Confirmed the two new checks fail against the pre-fix code (`git stash` on `schema.rb`/`map.rb` only) and pass after.
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 845 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1101 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures
- [x] `ruby scripts/lcf_schema_coverage.rb` -- confirms the retyped field still decodes cleanly against the real test-bed database chunk data

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_