### PR TITLE
Exclude a same-layer event from the action-button overlap check

### DIFF
--- a/changelog.d/action-overlap-excludes-same-layer.fixed.md
+++ b/changelog.d/action-overlap-excludes-same-layer.fixed.md
@@ -1,0 +1,7 @@
+- **Events:** a "same as characters" priority-type event co-located with the
+  player (reachable only by a page re-select while the player already
+  stands there, since that priority type otherwise blocks the party from
+  ever stepping onto it) no longer answers the action button by tile
+  overlap -- matching RPG_RT, which excludes that priority type from the
+  overlap check the same way it already excludes it from the adjacent-tile
+  facing check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6652,6 +6652,30 @@ following this paragraph as the original record.
   (trigger 0) by tile overlap, never by facing it from an adjacent tile —
   only "same as characters" answers by facing (yado.tk: 決定キーを押しても
   マップイベントが実行しない, `2k/09_bug/025_ibento_kettei_huka/`).
+  ✅ **Follow-up (2026-08-21): the overlap check itself never excluded a
+  "same as characters" event, when real RPG_RT excludes one there too.**
+  `Scene::Map#try_action_trigger`'s own "under the player" branch
+  (`mruby-rpg2k/mrblib/scene/map.rb`) carried an uncited comment claiming
+  "Overlap answers the button regardless of priority type" — the opposite
+  of what its sibling checks two paragraphs below (the faced-tile check,
+  the counter-reach loop) already correctly restrict to `LAYER_SAME` only,
+  by symmetry with the *below/above*-only rule this very bullet documents.
+  Confirmed against EasyRPG's actual C++ source: `Game_Player::
+  CheckEventTriggerHere` (`src/game_player.cpp`) — the function both the
+  overlap check and the Trigger_touched/collision-here check in
+  `CheckActionEvent` share — explicitly excludes a same-layer event
+  (`ev.GetLayer() != lcf::rpg::EventPage::Layers_same`). A same-layer event
+  ordinarily can never reach this branch at all (it blocks the party from
+  ever standing on it — the very first bullet in this list), so the missing
+  exclusion only mattered for the one way a same-layer event *can* end up
+  co-located with the player anyway: its page re-selects to a blocking,
+  action-triggered same-layer page while the player already happens to
+  occupy that exact tile, with no movement in between (a switch flipped
+  elsewhere). Fixed by adding the same `here[:layer] != LAYER_SAME` guard
+  the sibling checks already carry. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a same-layer action event
+  co-located with the player does not answer the button by overlap),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ Set Move Route **Change Graphic** targeting the hero now actually
   changes the on-screen sprite (it applied to `@player_char` but the
   renderer never read it), and reverts on Transfer Player like real RPG_RT

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2191,12 +2191,27 @@ class RPG2k
         return unless Input.trigger?(Input::C)
         # An action event **under the player** fires too: RPG_RT checks the tile
         # the party is standing on before the one it faces, which is how a
-        # trigger-0 event on a doorway tile answers the action button. Overlap
-        # answers the button regardless of priority type, so this check alone
-        # is how a below/above-characters action event (see below) is ever
-        # reachable at all.
+        # trigger-0 event on a doorway tile answers the action button. ~~Overlap
+        # answers the button regardless of priority type~~ -- corrected against
+        # RPG_RT's own live source: `Game_Player::CheckEventTriggerHere`
+        # (`src/game_player.cpp`), which this overlap check and
+        # `#try_action_trigger`'s own faced-tile check below both port,
+        # excludes a same-layer event explicitly (`ev.GetLayer() !=
+        # lcf::rpg::EventPage::Layers_same`) -- the overlap check is
+        # LAYER_SAME-excluded, the exact opposite of "regardless of priority
+        # type". A below/above-characters action event (typically one whose
+        # graphic is an upper-layer chip, which defaults to LAYER_BELOW) is
+        # what this check is actually for; a LAYER_SAME event blocks the
+        # party from ever standing on it in the first place (see
+        # #char_passable?'s own LAYER_SAME collision), so it can never
+        # legitimately reach this branch at all -- the missing exclusion only
+        # mattered for the one way a same-layer event *can* end up
+        # co-located with the player anyway: its page re-selects to a
+        # blocking, action-triggered LAYER_SAME page while the player already
+        # happens to be standing on that exact tile (e.g. a switch flips
+        # elsewhere, with no movement in between).
         here = event_at(@state.x, @state.y)
-        return start_event(here, true) if actionable?(here)
+        return start_event(here, true) if actionable?(here) && here[:layer] != LAYER_SAME
 
         # The faced tile only answers the button for a LAYER_SAME event: RPG_RT
         # ties this to priority type the same way it ties collision to it

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2097,6 +2097,31 @@ check 'an action event under the player answers the action button' do
   ok st.switches[4], 'the event under the party ran'
 end
 
+# Confirmed against EasyRPG's actual C++ source: `Game_Player::
+# CheckEventTriggerHere` (`src/game_player.cpp`) -- the overlap check
+# `#try_action_trigger`'s own "under the player" branch above ports --
+# explicitly excludes a same-layer event (`ev.GetLayer() != lcf::rpg::
+# EventPage::Layers_same`), the same restriction the faced-tile check a few
+# lines below already carries. A same-layer event ordinarily can never
+# reach this branch at all (it blocks the party from ever standing on it),
+# but a page re-select can still leave one co-located with the player --
+# a switch elsewhere flips a same-layer, action-triggered page active while
+# the player already happens to occupy that exact tile, with no movement
+# in between.
+check 'a same-layer action event under the player does not answer the ' \
+      'action button by overlap' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_SAME)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [2, 2])
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  5.times { scene.update }
+  ok !st.switches[4], 'the same-layer event under the party must not answer the button'
+end
+
 # yado.tk: 決定キーを押してもマップイベントが実行しない (「決定キーを押しても
 # マップイベントが実行しない」バグ・エラーページ) — a below/above-characters
 # action event only answers the button by overlap (see the check above), never


### PR DESCRIPTION
## Summary

- `Game_Player::CheckEventTriggerHere` (`src/game_player.cpp`) -- shared by both the "under the player" overlap check and the `Trigger_touched`/`collision`-here check in `CheckActionEvent` -- explicitly excludes a same-layer event: `ev.GetLayer() != lcf::rpg::EventPage::Layers_same`.
- `Scene::Map#try_action_trigger`'s own overlap branch (`mruby-rpg2k/mrblib/scene/map.rb`) carried no such restriction, and an uncited comment there actively claimed the opposite ("Overlap answers the button regardless of priority type") -- contradicting its own sibling checks two paragraphs below (the faced-tile check, the counter-reach loop), which already correctly restrict to `LAYER_SAME` only, by symmetry with the below/above-only overlap rule this codebase's own `docs/TODO.md` already documents.
- A same-layer event ordinarily can never share the player's tile at all (it blocks the party from ever standing on it), so the missing exclusion only mattered for the one way a same-layer event can end up co-located with the player anyway: its page re-selects to a blocking, action-triggered same-layer page while the player already happens to occupy that exact tile, with no movement in between (a switch flipped elsewhere).
- Fixed by adding the same `here[:layer] != LAYER_SAME` guard the sibling checks already carry.
- This also adds a Follow-up correction to the prior `docs/TODO.md` writeup for the original below/above-only overlap rule.

## Test plan

- [x] Added a new `scripts/rpg2k_scene_check.rb` check: a same-layer action event co-located with the player does not answer the button by overlap.
- [x] Confirmed the new check fails against the pre-fix code (`git stash` on `map.rb` only) and passes after.
- [x] `ruby scripts/rpg2k_scene_check.rb` -- 846 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` -- 1101 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` -- 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` -- 15 checks, 0 failures

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_