### PR TITLE
Float a 0.0s Tint/Flash Screen wait to one frame, matching RPG_RT

### DIFF
--- a/changelog.d/tint-flash-screen-zero-duration-wait.fixed.md
+++ b/changelog.d/tint-flash-screen-zero-duration-wait.fixed.md
@@ -1,0 +1,4 @@
+- **Screen effects:** a Tint Screen or one-shot Flash Screen command with its
+  wait flag set now blocks for one frame even when its own duration is
+  0.0 seconds, matching RPG_RT -- previously a zero-duration transition
+  applied instantly and the wait was skipped outright.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9483,6 +9483,40 @@ not yet verified:
   unscaled — corrected to realistic 0..31 inputs and their now-correctly-
   scaled 0..255 expectations, both confirmed to fail against the pre-fix
   code before the fix.
+- ✅ **A Tint Screen or one-shot Flash Screen command with its wait flag set
+  now blocks the interpreter for one frame even when its own duration is
+  0.0 seconds, instead of skipping the wait entirely (2026-08-21).**
+  Confirmed against EasyRPG's actual C++ source: `Game_Interpreter::
+  CommandTintScreen`/`CommandFlashScreen` (`src/game_interpreter.cpp`,
+  codes 11030/11040 mode 0) both call `SetupWait(tenths)` unconditionally
+  whenever the command's own wait flag is set — never gated on whether
+  `tenths` is nonzero — and `SetupWait` (same file) explicitly special-cases
+  a zero duration: `if (duration == 0) { // 0.0 waits 1 frame; _state.
+  wait_time = 1; }`. `Interpreter#do_tint_screen`/`#do_flash_screen`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) instead armed the wait only when the
+  screen effect was *still animating* (`@state.screen.tinting?`/
+  `flashing?`) — but a 0-duration tint/flash applies instantly
+  (`Game::Screen#tint_to`/`#flash`, `mruby-rpg2k/mrblib/game.rb`, both
+  `frames <= 0` branches), so those predicates were never true for exactly
+  the case RPG_RT still guarantees a 1-frame wait for. A project that sets a
+  Tint/Flash Screen's duration to 0.0s deliberately (an instant colour snap)
+  while leaving "wait" checked — common when a later command's timing is
+  meant to line up with it — silently ran zero frames early. `Game_Interpreter
+  ::CommandShakeScreen`'s own equivalent 0-duration case is genuinely
+  different and untouched by this fix: it calls `ShakeEnd()` instead of
+  `ShakeOnce`/`SetupWait` at all when `tenths <= 0`, so a 0-duration shake
+  was never meant to wait in the first place. Fixed by dropping the
+  `&& @state.screen.tinting?`/`&& @state.screen.flashing?` conjuncts from
+  both methods' wait guard, leaving the wait flag alone decide whether to
+  arm `@wait_kind = :screen` — the existing `:screen` wait dispatcher
+  (`Scene::Map`'s wait-kind handler, `@interpreter.resume unless @state.
+  screen.busy?`) already resolves on the very next frame once nothing is
+  left animating, exactly the same 1-frame floor `#drive_wait` already gives
+  an ordinary `Wait 0.0s` command. Covered by two rewritten
+  `scripts/rpg2k_logic_check.rb` checks (a 0-duration Tint/Flash Screen with
+  its wait flag set now waits exactly one frame before the following command
+  runs, in place of the prior checks that had asserted no wait at all),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An ally's equipped shield/armor/helmet/accessory can now resist a
   status effect from landing at all, instead of only its A-E susceptibility
   rank ever mattering.** Confirmed against EasyRPG's actual C++ source:

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3412,14 +3412,23 @@ module Game
 
     # Tint Screen: transition the shared screen tint to the RPG2000 channels
     # param0..3 (red / green / blue / saturation, each 0..200) over param4 tenths
-    # of a second. When param5 (the wait flag) is set and the transition takes
-    # time, pause until it finishes — the owning scene advances Game::Screen each
-    # frame and resumes us once it settles.
+    # of a second. When param5 (the wait flag) is set, pause until it finishes —
+    # the owning scene advances Game::Screen each frame and resumes us once it
+    # settles. RPG_RT always honours the wait flag, even for a 0.0s transition:
+    # `Game_Interpreter::CommandTintScreen` (`src/game_interpreter.cpp`) calls
+    # `SetupWait(tenths)` unconditionally whenever the wait flag is set, and
+    # `SetupWait` (same file) explicitly floors a 0 duration to one frame ("0.0
+    # waits 1 frame") rather than skipping the wait. A 0.0s tint therefore still
+    # blocks the interpreter for exactly one frame, which the `:screen` wait
+    # dispatcher (`Scene::Map`'s wait-kind handler) already provides for free —
+    # `@state.screen.busy?` is false the instant a 0-duration tint applies, so
+    # the very next frame's dispatch resumes us, the same one-frame floor
+    # `#drive_wait` gives an ordinary `Wait 0.0s` command.
     def do_tint_screen(cmd)
       frames = cmd.param(4) * FRAMES_PER_TENTH
       @state.screen.tint_to(cmd.param(0), cmd.param(1), cmd.param(2),
                             cmd.param(3), frames)
-      return unless cmd.param(5) != 0 && @state.screen.tinting?
+      return unless cmd.param(5) != 0
       @wait_kind = :screen
       @waiting = true
     end
@@ -3428,6 +3437,11 @@ module Game
     # peak strength param3, fading out over param4 tenths of a second. When param5
     # (the wait flag) is set, pause until it fades — the owning scene advances
     # Game::Screen each frame and resumes us once no screen effect is animating.
+    # As with Tint Screen, RPG_RT always honours the wait flag on the one-shot
+    # mode, even for a 0.0s flash: `Game_Interpreter::CommandFlashScreen`
+    # (`src/game_interpreter.cpp`) calls `SetupWait(tenths)` unconditionally
+    # whenever the wait flag is set on the mode-0 path, and `SetupWait` floors a
+    # 0 duration to one frame rather than skipping the wait.
     # RPG2003 extends the command with a param6 mode byte (0 one-shot / 1 begin a
     # repeating strobe / 2 end one), matching EasyRPG's `CommandFlashScreen`
     # (src/game_interpreter.cpp): a command list carrying no 7th parameter (an
@@ -3457,7 +3471,7 @@ module Game
         frames = cmd.param(4) * FRAMES_PER_TENTH
         @state.screen.flash(cmd.param(0) * FLASH_SCALE, cmd.param(1) * FLASH_SCALE,
                             cmd.param(2) * FLASH_SCALE, cmd.param(3) * FLASH_SCALE, frames)
-        return unless cmd.param(5) != 0 && @state.screen.flashing?
+        return unless cmd.param(5) != 0
         @wait_kind = :screen
         @waiting = true
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2335,13 +2335,19 @@ check 'Tint Screen with a wait pauses until the transition settles' do
   eq 0, st.screen.tint[0]
 end
 
-check 'Tint Screen with an instant (zero-duration) transition does not wait' do
+check 'Tint Screen with an instant (zero-duration) transition still waits one frame' do
   st = new_state
   it = Game::Interpreter.new(st)
-  it.start([FakeCmd.new(IC::TINT_SCREEN, [50, 60, 70, 100, 0, 1])]) # dur 0, wait 1
+  it.start([FakeCmd.new(IC::TINT_SCREEN, [50, 60, 70, 100, 0, 1]), # dur 0, wait 1
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
   it.update
-  ok !it.waiting?, 'nothing to wait for when the tint is immediate'
-  eq [50, 60, 70, 100], st.screen.tint
+  eq [50, 60, 70, 100], st.screen.tint, 'the tint itself applies immediately'
+  ok it.waiting?, 'RPG_RT floors a 0.0s wait to one frame instead of skipping it'
+  ok !st.switches[1], 'the following command has not run yet'
+  st.screen.update until !st.screen.busy? # the scene advances it each frame
+  it.resume
+  it.update
+  eq true, st.switches[1], 'resumed the very next frame, since nothing is left animating'
 end
 
 check 'Shake Screen without a wait starts a shake and does not pause' do
@@ -2462,6 +2468,21 @@ check 'Flash Screen with a wait pauses until the flash fades out' do
   it.update
   eq true, st.switches[2], 'resumed once the flash faded'
   eq 0, st.screen.flash_color[3]
+end
+
+check 'Flash Screen with an instant (zero-duration) flash still waits one frame' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::FLASH_SCREEN, [31, 0, 0, 20, 0, 1]), # dur 0, wait 1
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq 0, st.screen.flash_color[3], 'a zero-duration flash settles at no flash immediately'
+  ok it.waiting?, 'RPG_RT floors a 0.0s wait to one frame instead of skipping it'
+  ok !st.switches[1], 'the following command has not run yet'
+  st.screen.update until !st.screen.busy? # the scene advances it each frame
+  it.resume
+  it.update
+  eq true, st.switches[1], 'resumed the very next frame, since nothing is left animating'
 end
 
 check 'RPG2003 Flash Screen mode 1 (Begin) strobes indefinitely and never pauses' do


### PR DESCRIPTION
## Summary

RPG_RT always honours a Tint Screen / one-shot Flash Screen command's wait
flag, even when the command's own duration is 0.0 seconds — it blocks for
exactly one frame rather than skipping the wait outright.

`Game_Interpreter::CommandTintScreen`/`CommandFlashScreen` (mode 0)
(`src/game_interpreter.cpp`) both call `SetupWait(tenths)` unconditionally
whenever the wait flag is set, never gated on `tenths > 0`:

```cpp
screen->TintScreen(r, g, b, s, tenths * DEFAULT_FPS / 10);
if (wait)
    SetupWait(tenths);
```

And `SetupWait` explicitly floors a zero duration instead of skipping the wait:

```cpp
void Game_Interpreter::SetupWait(int duration) {
	if (duration == 0) {
		// 0.0 waits 1 frame
		_state.wait_time = 1;
	} else {
		_state.wait_time = duration * DEFAULT_FPS / 10;
	}
}
```

`Interpreter#do_tint_screen`/`#do_flash_screen`
(`mruby-rpg2k/mrblib/interpreter.rb`) instead armed the wait only when the
screen effect was *still animating* (`@state.screen.tinting?`/`flashing?`)
— but a 0-duration tint/flash applies instantly
(`Game::Screen#tint_to`/`#flash`, both `frames <= 0` branches), so that
predicate was never true for exactly the case RPG_RT still guarantees a
1-frame wait for. A project that sets a Tint/Flash Screen's duration to
0.0s deliberately (an instant colour snap) while leaving "wait" checked —
common when a later command's timing is meant to line up with it — silently
ran zero frames early instead of RPG_RT's one.

(`CommandShakeScreen`'s own 0-duration case is genuinely different and
untouched by this fix: it calls `ShakeEnd()` instead of
`ShakeOnce`/`SetupWait` at all when `tenths <= 0`, so a 0-duration shake was
never meant to wait in the first place.)

## Changes

- `do_tint_screen`/`do_flash_screen`'s mode-0 branch drop the
  `&& @state.screen.tinting?`/`&& @state.screen.flashing?` conjunct from
  their wait guard — the wait flag alone decides whether to wait now.
  Doc comments updated with the citation.
- Existing `scripts/rpg2k_logic_check.rb` check "Tint Screen with an instant
  (zero-duration) transition does not wait" rewritten to assert the correct
  one-frame wait instead.
- New `scripts/rpg2k_logic_check.rb` check for the equivalent Flash Screen
  case (no prior test covered it).
- `docs/TODO.md` bullet and a `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] Both checks confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/interpreter.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 846 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1104 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_