### PR TITLE
Float a 0.0s Move Picture wait to one frame, matching RPG_RT

### DIFF
--- a/changelog.d/move-picture-zero-duration-wait.fixed.md
+++ b/changelog.d/move-picture-zero-duration-wait.fixed.md
@@ -1,0 +1,4 @@
+- **Pictures:** a Move Picture command with its wait flag set now blocks for
+  one frame even when its own duration is 0.0 seconds, matching RPG_RT --
+  previously a zero-duration move applied instantly and the wait was
+  skipped outright.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9517,6 +9517,32 @@ not yet verified:
   its wait flag set now waits exactly one frame before the following command
   runs, in place of the prior checks that had asserted no wait at all),
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **Move Picture's wait flag has the identical 0.0s-still-waits-one-frame
+  gap the Tint/Flash Screen fix above just closed — a 0-duration picture move
+  with its wait flag set skipped the wait outright, instead of blocking the
+  interpreter for one frame like RPG_RT (2026-08-21).** Confirmed against
+  EasyRPG's actual C++ source: `Game_Interpreter::CommandMovePicture`
+  (`src/game_interpreter.cpp`, code 11120) calls `SetupWait(params.duration)`
+  unconditionally whenever `options.wait` is set — never gated on whether
+  the move actually left anything still interpolating — and `SetupWait`
+  (same file) floors a zero duration to one frame rather than skipping the
+  wait, exactly as already cited for Tint/Flash Screen. `Interpreter#
+  do_move_picture` (`mruby-rpg2k/mrblib/interpreter.rb`) instead armed the
+  wait only when `@state.pictures[id].moving?` was still true after the
+  move applied — but a 0-duration move snaps to its target instantly
+  (`Picture#move_to`/`#finish_move`, `mruby-rpg2k/mrblib/game.rb`), so that
+  predicate was never true for exactly the case RPG_RT still guarantees a
+  1-frame wait for. This is the same bug shape as the Tint/Flash Screen fix
+  above, simply not caught in that pass since it lives in a different
+  command handler. Fixed by dropping the `@state.pictures[id] &&
+  @state.pictures[id].moving?` conjunct from `do_move_picture`'s wait guard
+  — the wait flag alone now decides — since the existing `:picture` wait
+  dispatcher (`Scene::Map`'s wait-kind handler, `@interpreter.resume unless
+  @state.pictures_moving?`) already resolves on the very next frame once
+  nothing is left moving, giving the same 1-frame floor for free. Covered by
+  a new `scripts/rpg2k_logic_check.rb` check (a 0-duration Move Picture with
+  its wait flag set now waits exactly one frame before the following command
+  runs), confirmed to fail against the pre-fix code before the fix.
 - ✅ **An ally's equipped shield/armor/helmet/accessory can now resist a
   status effect from landing at all, instead of only its A-E susceptibility
   rank ever mattering.** Confirmed against EasyRPG's actual C++ source:

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3659,7 +3659,18 @@ module Game
     # tone over param14 tenths of a second. When the wait flag (param15) is set,
     # pause until the move finishes — the scene advances the pictures each frame
     # and resumes us once none is moving. Same parameter layout as Show Picture,
-    # plus the trailing duration/wait pair (EasyRPG's CommandMovePicture).
+    # plus the trailing duration/wait pair (EasyRPG's CommandMovePicture). RPG_RT
+    # always honours the wait flag, even for a 0.0s move: `Game_Interpreter::
+    # CommandMovePicture` (`src/game_interpreter.cpp`) calls
+    # `SetupWait(params.duration)` unconditionally whenever `options.wait` is
+    # set, and `SetupWait` explicitly floors a 0 duration to one frame ("0.0
+    # waits 1 frame") rather than skipping the wait -- the same rule already
+    # fixed for Tint/Flash Screen. A 0.0s move therefore still blocks the
+    # interpreter for exactly one frame, which the `:picture` wait dispatcher
+    # (`Scene::Map`'s wait-kind handler, `@state.pictures_moving?`) already
+    # provides for free -- a 0-duration move snaps to its target instantly
+    # (`Picture#move_to`/`#finish_move`), so the very next frame's dispatch
+    # resumes us.
     def do_move_picture(cmd)
       return if block_pending_picture_command
       id = cmd.param(0)
@@ -3668,8 +3679,7 @@ module Game
                           cmd.param(5), trans_to_opacity(cmd.param(6)),
                           cmd.param(8), cmd.param(9), cmd.param(10),
                           cmd.param(11), frames)
-      return unless cmd.param(15) != 0 && @state.pictures[id] &&
-                    @state.pictures[id].moving?
+      return unless cmd.param(15) != 0
       @wait_kind = :picture
       @waiting = true
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8949,6 +8949,30 @@ check 'Move Picture eases the picture and its wait flag pauses the interpreter' 
   eq true, st.switches[1], 'the command after the waited move ran'
 end
 
+check 'Move Picture with an instant (zero-duration) move still waits one frame' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::SHOW_PICTURE,
+               [1, 0, 0, 0, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0], string: 'p'),
+    # Move to (60,0) over 0 tenths (instant) with the wait flag set, then a
+    # switch we can watch to prove the interpreter still paused one frame.
+    FakeCmd.new(IC::MOVE_PICTURE,
+               [1, 0, 60, 0, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0, 0, 1]),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])
+  ])
+  it.update # Show
+  it.update # Move -> snaps instantly but still waits
+  eq 60, st.pictures[1].x, 'the move itself applies immediately'
+  ok !st.pictures[1].moving?, 'nothing left to interpolate'
+  ok it.waiting?, 'RPG_RT floors a 0.0s wait to one frame instead of skipping it'
+  ok !st.switches[1], 'the following command has not run yet'
+  st.update_pictures # the scene advances pictures each frame
+  it.resume
+  it.update
+  eq true, st.switches[1], 'resumed the very next frame, since nothing is left moving'
+end
+
 check 'Erase Picture removes the picture' do
   st = new_state
   # Show alone first, to confirm it is present before erasing.


### PR DESCRIPTION
## Summary

Same bug shape as #1217 (Tint/Flash Screen), found in a different command
handler: RPG_RT always honours Move Picture's wait flag, even when the
command's own duration is 0.0 seconds — it blocks for exactly one frame
rather than skipping the wait outright.

`Game_Interpreter::CommandMovePicture` (`src/game_interpreter.cpp`, code
11120) calls `SetupWait(params.duration)` unconditionally whenever
`options.wait` is set, never gated on whether the move actually left
anything still interpolating:

```cpp
Main_Data::game_pictures->Move(pic_id, params);
...
if (options.wait)
    SetupWait(params.duration);
```

And `SetupWait` (same file, already cited in #1217) explicitly floors a
zero duration instead of skipping the wait:

```cpp
void Game_Interpreter::SetupWait(int duration) {
	if (duration == 0) {
		// 0.0 waits 1 frame
		_state.wait_time = 1;
	} else {
		_state.wait_time = duration * DEFAULT_FPS / 10;
	}
}
```

`Interpreter#do_move_picture` (`mruby-rpg2k/mrblib/interpreter.rb`) instead
armed the wait only when `@state.pictures[id].moving?` was still true after
the move applied — but a 0-duration move snaps to its target instantly
(`Picture#move_to`/`#finish_move`, `mruby-rpg2k/mrblib/game.rb`), so that
predicate was never true for exactly the case RPG_RT still guarantees a
1-frame wait for.

## Changes

- `do_move_picture` drops the `@state.pictures[id] &&
  @state.pictures[id].moving?` conjunct from its wait guard — the wait flag
  alone decides now. Doc comment updated with the citation.
- New `scripts/rpg2k_logic_check.rb` check for the 0-duration Move Picture
  case (no prior test covered it).
- `docs/TODO.md` bullet and a `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] New check confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/interpreter.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 846 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1105 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_