### PR TITLE
Float a 0.0s Flash Sprite wait to one frame, matching RPG_RT

### DIFF
--- a/changelog.d/flash-sprite-zero-duration-wait.fixed.md
+++ b/changelog.d/flash-sprite-zero-duration-wait.fixed.md
@@ -1,0 +1,4 @@
+- **Events:** a Flash Sprite command with its wait flag set now blocks the
+  event even when its own duration is 0.0 seconds, matching RPG_RT --
+  previously a zero-duration flash applied instantly and the wait was
+  skipped outright.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9517,6 +9517,22 @@ not yet verified:
   its wait flag set now waits exactly one frame before the following command
   runs, in place of the prior checks that had asserted no wait at all),
   confirmed to fail against the pre-fix code before the fix.
+  - **Follow-up (2026-08-21):** ~~the `:screen` wait dispatcher already
+    resolves on the very next frame once nothing is left animating~~ —
+    `resume` alone only clears the wait flag; unlike `:wait`'s own dispatch
+    branch (which explicitly follows a cleared wait with its own
+    `@interpreter.update` call the same frame, "RPG_RT resumes a Wait the
+    instant its timer elapses and keeps spending that same frame's step
+    budget", per that branch's own citation), `:screen`'s branch has no such
+    follow-up call, so the *following* command does not actually run until a
+    further frame's dispatch reaches the newly-un-waiting interpreter. The
+    wait itself still floors to the correct minimum this fix set out to
+    guarantee (never fewer than one frame), which is what the checks above
+    actually verify — but the write-up's own "waits exactly one frame before
+    the following command runs" overstated the dispatcher's precision. This
+    gap is pre-existing (shared by every duration of Tint/Flash Screen, Move
+    Picture, and Flash Sprite alike, not introduced by any of these fixes)
+    and left as a follow-up candidate rather than folded in here.
 - ✅ **Move Picture's wait flag has the identical 0.0s-still-waits-one-frame
   gap the Tint/Flash Screen fix above just closed — a 0-duration picture move
   with its wait flag set skipped the wait outright, instead of blocking the
@@ -9543,6 +9559,36 @@ not yet verified:
   a new `scripts/rpg2k_logic_check.rb` check (a 0-duration Move Picture with
   its wait flag set now waits exactly one frame before the following command
   runs), confirmed to fail against the pre-fix code before the fix.
+  - **Follow-up (2026-08-21):** the identical correction applies here as the
+    one just added to the Tint/Flash Screen bullet above — `:picture`'s
+    dispatch branch has the same "resume clears the wait, but does not also
+    spend that same frame executing the next command" gap `:wait`'s own
+    branch avoids, so ~~waits exactly one frame before the following command
+    runs~~ overstates the dispatcher's actual precision; the checks still
+    correctly verify the wait itself never floors to zero, which is this
+    fix's real scope.
+- ✅ **Flash Sprite has the identical 0.0s-still-waits-one-frame gap already
+  fixed twice this session for Tint/Flash Screen and Move Picture — a
+  0-duration sprite flash with its wait flag set skipped the wait outright,
+  instead of blocking the interpreter for one frame like RPG_RT
+  (2026-08-21).** Confirmed against EasyRPG's actual C++ source:
+  `Game_Interpreter_Map::CommandFlashSprite` (`src/game_interpreter_map.cpp`,
+  code 11320) calls `SetupWait(tenths)` unconditionally whenever the wait
+  flag (`com.parameters[6] > 0`) is set — never gated on the flash's own
+  duration — and `SetupWait` (`src/game_interpreter.cpp`) floors a zero
+  duration to one frame rather than skipping the wait, exactly as already
+  cited for the two prior fixes. `Interpreter#do_flash_sprite`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) instead armed the wait only when
+  `cmd.param(6) != 0 && frames > 0` — a 0-duration flash therefore never
+  paused at all, unlike RPG_RT's guaranteed one-frame block. Fixed by
+  dropping the `&& frames > 0` conjunct — the wait flag alone now decides —
+  since `Scene::Map#apply_sprite_flash` already returns `nil` (no flash
+  attached) for a 0-duration request, so `#sprite_flashing?` reads false the
+  instant the `:sprite_flash` dispatcher checks it. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (interpreter-level: the wait arms) and
+  a new `scripts/rpg2k_scene_check.rb` check (full-scene: the following
+  command is genuinely held back, not run the very same update), both
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An ally's equipped shield/armor/helmet/accessory can now resist a
   status effect from landing at all, instead of only its A-E susceptibility
   rank ever mattering.** Confirmed against EasyRPG's actual C++ source:

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3259,6 +3259,21 @@ module Game
     # the duration in tenths of a second and param6 the wait flag. Queued for the
     # owning scene (which owns the sprites); with the wait flag set the event also
     # pauses on a :sprite_flash wait until the scene reports the flash finished.
+    # RPG_RT always honours the wait flag, even for a 0.0s flash: `Game_Interpreter
+    # _Map::CommandFlashSprite` (`src/game_interpreter_map.cpp`) calls
+    # `SetupWait(tenths)` unconditionally whenever the wait flag is set, and
+    # `SetupWait` floors a 0 duration to one frame rather than skipping the
+    # wait -- the same rule already fixed for Tint/Flash Screen and Move
+    # Picture. `Scene::Map#apply_sprite_flash` already returns nil (no flash
+    # attached) for a 0-duration request, so `#sprite_flashing?` is false the
+    # instant it applies, and the `:sprite_flash` wait dispatcher's own
+    # `resume unless sprite_flashing?` clears the wait as soon as it is
+    # checked -- still pausing the event at least one frame, matching the
+    # floor, even if this dispatcher (unlike `:wait`'s own documented "resume
+    # and keep spending this frame's budget" idiom) does not yet resume and
+    # continue in that identical frame; that gap is pre-existing and shared
+    # by every duration of Tint/Flash Screen, Move Picture and Flash Sprite
+    # alike, not something this fix changes.
     FLASH_CHANNEL_SCALE = 8
 
     def do_flash_sprite(cmd)
@@ -3271,7 +3286,7 @@ module Game
         power: cmd.param(4) * FLASH_CHANNEL_SCALE,
         frames: frames
       )
-      return unless cmd.param(6) != 0 && frames > 0
+      return unless cmd.param(6) != 0
       @wait_kind = :sprite_flash
       @waiting = true
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -16649,6 +16649,19 @@ check 'Flash Sprite without its wait flag does not pause the interpreter' do
   eq 1, it.take_sprite_flash_requests.size
 end
 
+check 'Flash Sprite with an instant (zero-duration) flash still waits one frame' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # target the hero, colour 31/0/16, power 31, 0 tenths (instant), wait flag set
+  it.start([FakeCmd.new(IC::FLASH_SPRITE, [10001, 31, 0, 16, 31, 0, 1])])
+  it.update
+  reqs = it.take_sprite_flash_requests
+  eq 1, reqs.size
+  eq 0, reqs[0][:frames], 'the flash itself is instant'
+  ok it.waiting?, 'RPG_RT floors a 0.0s wait to one frame instead of skipping it'
+  eq :sprite_flash, it.wait_kind
+end
+
 check 'Fade Out BGM fades the music but keeps the current-BGM record intact' do
   # param0 is already milliseconds -- EasyRPG's CommandFadeOutBGM passes it
   # straight through to Game_System::BgmFade with no scaling (confirmed

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13182,6 +13182,22 @@ check 'Flash Sprite on the hero holds a waiting event until it decays' do
   eq 1, st.variables[5], 'the event resumed once the flash finished'
 end
 
+check 'Flash Sprite on the hero with an instant (zero-duration) flash still ' \
+      'holds the event, instead of never pausing at all' do
+  # 0 tenths (instant) with the wait flag set, then a variable bump that must
+  # not run the same frame -- RPG_RT still floors a 0.0s wait to one frame.
+  cmds = [ECmd.new(IC2::FLASH_SPRITE, [10001, 31, 0, 0, 31, 0, 1]),
+          add_var_cmd(5)]
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  scene.update
+  ok !scene.instance_variable_get(:@player_flash), 'nothing left to flash, it was instant'
+  eq 0, st.variables[5], 'the event is still held right after the flash is queued'
+  3.times { scene.update }
+  eq 1, st.variables[5], 'the event resumed once the (already-finished) flash was reported clear'
+end
+
 check 'Flash Sprite targeting a vehicle (Boat) pulses the native sprite flash ' \
       'and decays, instead of silently dropping the target' do
   # Confirmed against RPG_RT's own live source: `Game_Character::


### PR DESCRIPTION
## Summary

Same bug shape as #1217 (Tint/Flash Screen) and #1218 (Move Picture), found
in a third command handler: RPG_RT always honours Flash Sprite's wait flag,
even when the command's own duration is 0.0 seconds — it blocks for exactly
one frame rather than skipping the wait outright.

`Game_Interpreter_Map::CommandFlashSprite` (`src/game_interpreter_map.cpp`,
code 11320) calls `SetupWait(tenths)` unconditionally whenever the wait flag
is set, never gated on the flash's own duration:

```cpp
int tenths = com.parameters[5];
bool wait = com.parameters[6] > 0;
...
if (event != NULL) {
    event->Flash(r, g, b, p, tenths * DEFAULT_FPS / 10);
    if (wait) {
        SetupWait(tenths);
    }
}
```

`Interpreter#do_flash_sprite` (`mruby-rpg2k/mrblib/interpreter.rb`) instead
gated the wait on **both** the wait flag **and** `frames > 0`:

```ruby
return unless cmd.param(6) != 0 && frames > 0
```

so a 0-duration Flash Sprite with the wait flag set never paused at all.

## Changes

- `do_flash_sprite` drops the `&& frames > 0` conjunct — the wait flag alone
  decides now. Doc comment updated with the citation.
- New `scripts/rpg2k_logic_check.rb` check (interpreter-level: the wait
  arms) and a new `scripts/rpg2k_scene_check.rb` check (full-scene: the
  following command is genuinely held back).
- `docs/TODO.md` bullet plus a small correction to the #1217/#1218
  write-ups: the `:screen`/`:picture` wait dispatchers only clear the wait
  flag on resume — unlike `:wait`'s own branch, they don't also spend that
  same frame executing the next command — so those write-ups' "waits
  exactly one frame before the following command runs" overstated the
  dispatcher's actual precision. The wait itself still correctly floors to
  a minimum of one frame, which is what all three fixes' checks verify;
  fixing the extra dispatch-frame gap itself is left as a follow-up.
- `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] Both new checks confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/interpreter.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 847 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1106 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_