### PR TITLE
Resume the command after movement/blocked waits settle same-frame too

### DIFF
--- a/changelog.d/movement-blocked-commands-wait-same-frame-resume.fixed.md
+++ b/changelog.d/movement-blocked-commands-wait-same-frame-resume.fixed.md
@@ -1,0 +1,7 @@
+- **Events:** Proceed With Movement, and a blocked Show/Move/Erase Picture,
+  Transfer Player / Recall to Location, Battle Processing / Enemy
+  Encounter, or "show message"-flagged Change EXP / Change Level command,
+  now resume the very next command the same real frame the forced route
+  finishes or the blocking message window closes, matching RPG_RT --
+  previously each cost one further frame before the following command ran,
+  for both the foreground event and a Parallel Process's own interpreter.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9640,7 +9640,9 @@ not yet verified:
   shape in both dispatchers, but a block-and-retry command's own blocking
   condition is a different mechanism (message/choice window open) than a
   `_state.wait_time` countdown, so it needs its own citation pass before
-  assuming the identical fix applies. Covered by three new
+  assuming the identical fix applies. Closed by the "the same same-frame
+  fix now covers Proceed With Movement and the four block-and-retry
+  commands too" bullet below (2026-08-21). Covered by three new
   `scripts/rpg2k_scene_check.rb` checks with exact frame-count assertions
   (a foreground Tint Screen, a foreground Flash Sprite, and a Parallel
   Process's own Move Picture each resume the command right after them on
@@ -9649,6 +9651,51 @@ not yet verified:
   asserts resumption after exactly one further frame instead of a generous
   multi-frame margin), all confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **The same same-frame fix now covers Proceed With Movement and the four
+  block-and-retry commands too (Show/Move/Erase Picture, Transfer Player /
+  Recall to Location, Battle Processing / Enemy Encounter, and a "show
+  message"-flagged Change EXP / Change Level) — closing the follow-up the
+  bullet above flagged and deliberately left open (2026-08-21).** Confirmed
+  against EasyRPG's actual C++ source that RPG_RT's own `Game_Interpreter::
+  Update` loop falls through into whatever command follows in that same
+  frame for both blocking mechanisms, not just a `_state.wait_time`
+  countdown: `if (_state.wait_movement) { if (Game_Map::IsAnyMovePending())
+  break; _state.wait_movement = false; }` (`src/game_interpreter.cpp`) does
+  not unconditionally `break` either — once every targeted forced route
+  finishes, the loop keeps going. And each of the four blocked commands'
+  own guard — `Game_Interpreter_Map::CommandTeleport`/
+  `CommandRecallToLocation`/`CommandEnemyEncounter` (`src/
+  game_interpreter_map.cpp`, `if (Game_Message::IsMessageActive()) { return
+  false; }`), `Game_Interpreter::CommandShowPicture` (`src/
+  game_interpreter.cpp`, the identical guard gated on `!Player::IsEnglish()
+  && !Player::IsPatchUnlockPics()`), and `CommandChangeExp`/
+  `CommandChangeLevel` (`if (show_msg && !Game_Message::CanShowMessage(
+  true)) { return false; }`) — all `return false` with the command index
+  left untouched while blocked, so RPG_RT's own loop simply re-attempts the
+  identical command on its next iteration, in the same frame the block
+  clears, exactly like any other retried `ExecuteCommand` call; when the
+  retry succeeds, that same loop iteration falls through to whatever comes
+  next exactly as for any other command. This codebase's own
+  `#block_pending_picture_command`/`#block_pending_teleport_command`/
+  `#block_pending_battle_command`/`#block_pending_exp_level_command`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) already rewind `@index` back onto
+  the blocked command for the identical retry effect — only the *dispatch*
+  side (`Scene::Map`) was missing the same-frame follow-through. Fixed by
+  adding the identical `unless @interpreter.waiting? … @interpreter.update;
+  apply_interpreter_requests(...) end` idiom to `:movement`,
+  `:picture_blocked`, `:teleport_blocked`, `:battle_blocked`, and
+  `:exp_level_blocked` in the foreground dispatcher, and by adding all five
+  to `#step_parallel`'s own same-frame-continuation wait-kind list.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks with exact
+  frame-count assertions — Proceed With Movement resumes the command right
+  after it the same frame a single-step forced route finishes (armed with
+  `move_timer` starting at 0, so its very first `#step_forced_movement`
+  call both executes the step and finishes the route, pinning an exact
+  frame count without waiting out a real movement-frequency pace), and a
+  blocked Show Picture (issued from a Parallel Process, mirroring the
+  existing block-and-retry check just above) both retries and runs the
+  command right after it on the very same frame the message window closes
+  — both confirmed to fail against the pre-fix code before the fix.
 - ✅ **An ally's equipped shield/armor/helmet/accessory can now resist a
   status effect from landing at all, instead of only its A-E susceptibility
   rank ever mattering.** Confirmed against EasyRPG's actual C++ source:

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1785,11 +1785,25 @@ class RPG2k
           # mechanism, so :screen/:picture/:sprite_flash get the same
           # same-frame treatment here too -- the identical fix
           # #drive_event's foreground dispatcher just received for those
-          # three wait kinds. Other wait kinds keep their old
-          # one-frame-per-call pacing.
+          # three wait kinds. :movement's own `_state.wait_movement` check
+          # in real RPG_RT's `Update` loop is not an unconditional `break`
+          # either (`src/game_interpreter.cpp`), and each of the four
+          # `_blocked` kinds' underlying command (`CommandShowPicture`/
+          # `CommandMovePicture`/`CommandErasePicture`, `CommandTeleport`/
+          # `CommandRecallToLocation`, `CommandEnemyEncounter`,
+          # `CommandChangeExp`/`CommandChangeLevel`) just `return false`
+          # with the command index untouched while blocked -- RPG_RT's own
+          # loop re-executes that identical command the instant the block
+          # clears, in that same frame, the same as any other retried
+          # command -- so all five join the same-frame list too, matching
+          # #drive_event's foreground dispatcher exactly. Other wait kinds
+          # keep their old one-frame-per-call pacing.
           unless (wait_kind == :wait || wait_kind == :animation ||
                   wait_kind == :screen || wait_kind == :picture ||
-                  wait_kind == :sprite_flash) && !it.waiting?
+                  wait_kind == :sprite_flash || wait_kind == :movement ||
+                  wait_kind == :picture_blocked || wait_kind == :teleport_blocked ||
+                  wait_kind == :battle_blocked || wait_kind == :exp_level_blocked) &&
+                 !it.waiting?
             apply_interpreter_requests(it, p[:event])
             return record_parallel_progress(p)
           end
@@ -4592,7 +4606,20 @@ class RPG2k
             end
             return
           when :teleport then perform_teleport(@interpreter.teleport)
-          when :movement then @interpreter.resume if step_forced_movement
+          when :movement
+            @interpreter.resume if step_forced_movement
+            # Same reasoning as :screen/:picture/:sprite_flash below: RPG_RT's
+            # own `Game_Interpreter::Update` loop does not unconditionally
+            # `break` on `_state.wait_movement` either -- `if
+            # (_state.wait_movement) { if (Game_Map::IsAnyMovePending())
+            # break; _state.wait_movement = false; }` (`src/
+            # game_interpreter.cpp`) -- once every targeted route finishes,
+            # that same `Update` call falls straight through into whatever
+            # command follows, costing no further frame.
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
           when :screen
             @interpreter.resume unless @state.screen.busy?
             # Same "spend this frame's own step budget immediately" idiom as
@@ -4623,28 +4650,65 @@ class RPG2k
             # window or choice list is open (#block_pending_picture_command)
             # -- real RPG_RT retries the identical command every subsequent
             # frame rather than dropping it, see that method's own citation.
+            # The retry itself is not a "wait", though: `CommandShowPicture`/
+            # `CommandMovePicture`/`CommandErasePicture` (`src/
+            # game_interpreter.cpp`) each just `return false` with the
+            # command index untouched while a message window blocks them --
+            # RPG_RT's own `Update` loop keeps looping and re-executes that
+            # same command the instant the block clears, in that same frame,
+            # exactly like every other `ExecuteCommand` retry. Since
+            # `#block_pending_picture_command` already rewinds `@index` back
+            # onto the blocked command, re-invoking `#update` the moment the
+            # block clears reproduces that -- it re-attempts the identical
+            # command this frame, not the next one, matching RPG_RT.
             @interpreter.resume unless message_window_open?
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
           when :teleport_blocked
             # A Transfer Player / Recall to Location command reached while a
             # message window or choice list is open
             # (#block_pending_teleport_command) -- the identical
             # block-and-retry shape as :picture_blocked just above, see that
-            # method's own citation.
+            # method's own citation and :picture_blocked's own same-frame
+            # reasoning (`Game_Interpreter_Map::CommandTeleport`/
+            # `CommandRecallToLocation`, `src/game_interpreter_map.cpp`, the
+            # identical `return false` with the index untouched).
             @interpreter.resume unless message_window_open?
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
           when :battle_blocked
             # A Battle Processing / Enemy Encounter command reached while a
             # message window or choice list is open
             # (#block_pending_battle_command) -- the identical
             # block-and-retry shape as :picture_blocked/:teleport_blocked
-            # above, see that method's own citation.
+            # above, see that method's own citation and :picture_blocked's
+            # own same-frame reasoning (`Game_Interpreter_Map::
+            # CommandEnemyEncounter`, `src/game_interpreter_map.cpp`, the
+            # identical `return false` with the index untouched).
             @interpreter.resume unless message_window_open?
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
           when :exp_level_blocked
             # A "show message"-flagged Change EXP / Change Level command
             # reached while a message window or choice list is open
             # (#block_pending_exp_level_command) -- the identical
             # block-and-retry shape as :picture_blocked/:teleport_blocked/
-            # :battle_blocked above, see that method's own citation.
+            # :battle_blocked above, see that method's own citation and
+            # :picture_blocked's own same-frame reasoning
+            # (`Game_Interpreter::CommandChangeExp`/`CommandChangeLevel`,
+            # `src/game_interpreter.cpp`, the identical `return false` with
+            # the index untouched).
             @interpreter.resume unless message_window_open?
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
           when :return_title then perform_return_to_title
           when :game_over then perform_game_over
           when :name_input then drive_name_input

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3429,6 +3429,7 @@ check 'Show/Move/Erase Picture from an independently-running parallel process ar
   ok st.variables[1] > 0, 'and the command after it then runs too'
 
   # -- Move Picture -----------------------------------------------------------
+
   par2 = page(trigger: 4)
   par2.event_commands = [ECmd.new(ic::MOVE_PICTURE,
                                   [1, 0, 200, 200, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0, 0, 0])]
@@ -3460,6 +3461,36 @@ check 'Show/Move/Erase Picture from an independently-running parallel process ar
   scene3.send(:close_message)
   5.times { scene3.update }
   ok !st3.pictures.key?(1), 'Erase Picture applies once the window closes'
+end
+
+check 'a blocked Show Picture resumes the command right after it the same ' \
+      'real frame the message window closes, not one frame later' do
+  # RPG_RT's own `Game_Interpreter::Update` loop does not treat a blocked
+  # command specially once it succeeds -- `CommandShowPicture` (`src/
+  # game_interpreter.cpp`) just `return true`s like any other command the
+  # instant `Game_Message::IsMessageActive()` reads false, so the *same*
+  # `Update()` call keeps going into whatever follows, costing no further
+  # frame -- the identical reasoning already fixed for :screen/:picture/
+  # :sprite_flash/:movement.
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4)
+  par.event_commands = [
+    ECmd.new(ic::SHOW_PICTURE, [1, 0, 100, 100, 0, 100, 0, 0, 100, 100, 100, 100],
+             string: 'pic'),
+    add_var_cmd(1),
+  ]
+  scene = new_scene({ 1 => event(4, 4, par) })
+  st = scene.instance_variable_get(:@state)
+  scene.send(:open_message, ['hi'], false)
+
+  scene.update # frame 1: the process starts, blocks on the open message
+  ok !st.pictures.key?(1), 'blocked, message window still open'
+  eq 0, st.variables[1]
+
+  scene.send(:close_message)
+  scene.update # frame 2: retries -- must succeed AND run the next command
+  ok st.pictures.key?(1), 'Show Picture retried and applied the same frame the window closed'
+  ok st.variables[1] > 0, 'and the command right after it ran that same frame too'
 end
 
 check 'parallel processes pause during battle' do
@@ -5170,6 +5201,36 @@ check 'Proceed With Movement holds the interpreter until a forced route finishes
   200.times { scene.update } # enough frames for the freq-4 route to finish
   eq 3, c.x, 'the forced event reached the end of its route'
   ok st.switches[1], 'the interpreter resumed and ran the next command'
+end
+
+check 'Proceed With Movement resumes the command right after it the same ' \
+      'real frame the forced route finishes, not one frame later' do
+  # RPG_RT's own `Game_Interpreter::Update` loop does not unconditionally
+  # `break` on `_state.wait_movement` either -- `if (_state.wait_movement) {
+  # if (Game_Map::IsAnyMovePending()) break; _state.wait_movement = false; }`
+  # (`src/game_interpreter.cpp`) -- once every targeted route finishes, that
+  # same `Update` call falls straight through into whatever command follows.
+  # A freshly-armed forced route's own `move_timer` starts at 0
+  # (#force_event_route), so its very first step fires on the first frame
+  # #step_forced_movement is ever consulted -- a single-command route is
+  # therefore already fully done that same frame, letting this test pin an
+  # exact frame count without waiting out a real movement-frequency pace.
+  ic = Game::Interpreter::Cmd
+  cmds = [
+    ECmd.new(ic::MOVE_EVENT, [2, 4, 0, 0, R::MOVE_RIGHT]),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, []),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 2 => event(0, 1, page) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  c = chars(scene)[2]
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  scene.update # frame 1: arms the forced route and the wait
+  eq 0, c.x, 'has not stepped yet'
+  ok !st.switches[1], 'the command after it has not run yet'
+  scene.update # frame 2: the single-step route finishes on this very frame
+  eq 1, c.x, 'the forced event stepped'
+  ok st.switches[1], 'the command after it ran the very same frame the route finished'
 end
 
 check 'Set Move Route targeting a currently-hidden map event freezes Proceed With Movement (yado.tk)' do


### PR DESCRIPTION
## Summary

Extends #1220's same-frame-continuation fix to the five remaining wait kinds
that PR explicitly left as a follow-up: `:movement` (Proceed With Movement)
and the four block-and-retry kinds (`:picture_blocked`, `:teleport_blocked`,
`:battle_blocked`, `:exp_level_blocked`).

RPG_RT's `Game_Interpreter::Update` loop does not unconditionally `break` on
`_state.wait_movement` either:

```cpp
if (_state.wait_movement) {
    if (Game_Map::IsAnyMovePending()) {
        break;
    }
    _state.wait_movement = false;
}
```

Once every targeted forced route finishes, the loop keeps going within that
same frame — the same shape already fixed for `_state.wait_time` in #1220.

And each blocked command's own guard returns `false` with the command index
left untouched while blocked:

- `Game_Interpreter_Map::CommandTeleport`/`CommandRecallToLocation`/
  `CommandEnemyEncounter` (`src/game_interpreter_map.cpp`):
  `if (Game_Message::IsMessageActive()) { return false; }`
- `Game_Interpreter::CommandShowPicture` (`src/game_interpreter.cpp`): the
  identical guard, gated on `!Player::IsEnglish() && !Player::
  IsPatchUnlockPics()`
- `CommandChangeExp`/`CommandChangeLevel`: `if (show_msg && !Game_Message::
  CanShowMessage(true)) { return false; }`

So RPG_RT's own loop just re-attempts the identical command on its next
iteration — in the same frame the block clears — and once it succeeds,
falls through to whatever follows, same as any other command. This
codebase's own `#block_pending_picture_command`/`#block_pending_teleport_
command`/`#block_pending_battle_command`/`#block_pending_exp_level_command`
(`mruby-rpg2k/mrblib/interpreter.rb`) already rewind `@index` back onto the
blocked command for the identical retry effect — only the *dispatch* side
(`Scene::Map`) was missing the same-frame follow-through.

## Changes

- `Scene::Map#update`'s foreground dispatcher: `:movement`,
  `:picture_blocked`, `:teleport_blocked`, `:battle_blocked`, and
  `:exp_level_blocked` now follow a cleared wait with the same `unless
  @interpreter.waiting? … @interpreter.update; apply_interpreter_requests(
  ...) end` idiom already used for `:wait`/`:screen`/`:picture`/
  `:sprite_flash`/`:animation`.
- `Scene::Map#step_parallel`: adds all five to its own
  same-frame-continuation wait-kind list.
- Two new `scripts/rpg2k_scene_check.rb` checks with exact frame-count
  assertions: Proceed With Movement (a single-step forced route's own
  `move_timer` starts at 0, so its very first `#step_forced_movement` call
  both executes the step and finishes the route, pinning an exact frame
  count without waiting out a real movement-frequency pace), and a blocked
  Show Picture issued from a Parallel Process.
- `docs/TODO.md`: closes the follow-up note on the #1220 bullet, plus a new
  bullet for this fix.
- `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] Both new checks confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/scene/map.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 851 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1106 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_