### PR TITLE
Block a waiting Key Input Processing command on an open message window

### DIFF
--- a/changelog.d/key-input-proc-message-window-block.fixed.md
+++ b/changelog.d/key-input-proc-message-window-block.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** a waiting Key Input Processing command now blocks and retries
+  while a message window or choice list is open, matching RPG_RT -- most
+  visibly, a Parallel Process's own waiting Key Input Processing no longer
+  resolves a keypress while a different event's message window still sits
+  on screen.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9696,6 +9696,43 @@ not yet verified:
   existing block-and-retry check just above) both retries and runs the
   command right after it on the very same frame the message window closes
   — both confirmed to fail against the pre-fix code before the fix.
+- ✅ **A waiting Key Input Processing command now blocks-and-retries while a
+  message window or choice list is open too, the fifth instance of the
+  block-and-retry shape already ported for Show/Move/Erase Picture,
+  Transfer Player / Recall to Location, Battle Processing / Enemy Encounter
+  and a "show message"-flagged Change EXP / Change Level (2026-08-21).**
+  Confirmed against EasyRPG's actual C++ source: `Game_Interpreter::
+  CommandKeyInputProc` (`src/game_interpreter.cpp`, code 11610) resets the
+  target variable to 0 every retried frame first (`if (wait) {
+  Main_Data::game_variables->Set(var_id, 0); ... }`), *then* checks `if
+  (wait && Game_Message::IsMessageActive()) { return false; }` —
+  unconditionally, not gated behind any edition/patch check, the same base
+  RPG2000 behaviour already confirmed for Teleport/Recall to Location/Enemy
+  Encounter. A no-wait proc (param1 clear) never calls `IsMessageActive` at
+  all and always samples immediately, matching Change EXP/Level's own
+  `show_msg`-gated shape. `Interpreter#do_key_input`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) armed the wait unconditionally, with
+  no equivalent guard at all — most concretely reachable through a Parallel
+  Process: a still-running Common Event's own waiting Key Input Processing
+  command could resolve the instant an accepted key is pressed while a
+  *different* interpreter's message window sat open on screen, instead of
+  waiting for it to close first, exactly the bug class already fixed for
+  the other four commands. Fixed by adding `#block_pending_key_input_command`
+  (identical shape to `#block_pending_picture_command` et al., gated on the
+  command's own `wait` flag the same way `#block_pending_exp_level_command`
+  gates on `show_msg`) and calling it from `do_key_input` right after the
+  variable reset — matching `CommandKeyInputProc`'s own reset-then-check
+  order exactly, so the reset still happens on every retried frame — and by
+  adding a `:key_input_blocked` case to both `Scene::Map` dispatchers
+  (foreground and Parallel Process), including the same-frame
+  continuation the four sibling `_blocked` kinds already carry. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check (issued from a Parallel
+  Process, since a foreground autostart never even reaches this code
+  path — it simply refuses to begin at all while a message window is
+  already open, unlike a Parallel Process which keeps advancing during one;
+  a key held down throughout is proven not to resolve a proc that never
+  armed, then resolves once the window closes), confirmed to fail against
+  the pre-fix code before the fix.
 - ✅ **An ally's equipped shield/armor/helmet/accessory can now resist a
   status effect from landing at all, instead of only its A-E susceptibility
   rank ever mattering.** Confirmed against EasyRPG's actual C++ source:

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1321,7 +1321,13 @@ module Game
     #                     further-extended param list (out of scope, see
     #                     below). param7/param8 are a separate "timed input"
     #                     countdown-variable feature, still unmodelled.
-    # The interpreter only records the request and suspends on a :key_input
+    # A waiting proc (param1 set) first blocks-and-retries while a message
+    # window or choice list is open anywhere in the scene, the same as
+    # Show/Move/Erase Picture, Teleport/Recall to Location, Battle
+    # Processing/Enemy Encounter and a "show message"-flagged Change EXP/
+    # Level (#block_pending_key_input_command, see its own citation) -- a
+    # no-wait proc is never gated by this at all. Once past that, the
+    # interpreter only records the request and suspends on a :key_input
     # wait; the owning scene samples real input (triggered edges when waiting,
     # held state otherwise) and calls resume_key_input with the resulting code.
     # Numbers/Operators decoded into `accepted` are sampled by
@@ -1335,6 +1341,12 @@ module Game
     def do_key_input(cmd)
       var_id = cmd.param(0)
       wait = cmd.param(1) != 0
+      # RPG_RT clears the variable every retried frame while a waiting proc
+      # is pending, before it even checks whether a message window blocks it
+      # (`CommandKeyInputProc`'s own citation above) -- reset first, then
+      # check the block, so the reset still happens on every retry.
+      variables[var_id] = 0 if wait && var_id && var_id > 0
+      return if block_pending_key_input_command(wait)
       size = cmd.parameters.size
       accepted = { decision: cmd.param(3) != 0, cancel: cmd.param(4) != 0,
                    shift: false, down: false, left: false, right: false,
@@ -1364,9 +1376,6 @@ module Game
       end
       @input_variable = var_id
       @key_input_request = { wait: wait, accepted: accepted }
-      # RPG_RT clears the variable while a waiting proc is pending; a no-wait proc
-      # overwrites it below via the scene's immediate resume.
-      variables[var_id] = 0 if wait && var_id && var_id > 0
       @wait_kind = :key_input
       @waiting = true
     end
@@ -3644,6 +3653,31 @@ module Game
       return false unless show_msg && message_window_blocks_command?
       @index -= 1
       @wait_kind = :exp_level_blocked
+      @waiting = true
+      true
+    end
+
+    # A waiting Key Input Processing command block-and-retries the same way
+    # too, but only in its own wait mode -- confirmed directly against
+    # RPG_RT's live source: `Game_Interpreter::CommandKeyInputProc`
+    # (`src/game_interpreter.cpp`, code 11610) resets the target variable to
+    # 0 every retried frame first (`if (wait) { Main_Data::game_variables->
+    # Set(var_id, 0); ... }`), *then* checks `if (wait &&
+    # Game_Message::IsMessageActive()) { return false; }` -- unconditionally,
+    # not gated behind any edition/patch check, the same base RPG2000
+    # behaviour as Teleport/Recall to Location/Enemy Encounter. A no-wait
+    # proc (param1 clear) never calls `IsMessageActive` at all and always
+    # samples immediately, matching every other block-and-retry command's own
+    # flag-gated shape (Change EXP/Level's `show_msg`). Without this guard, a
+    # still-running parallel process's own Key Input Processing could resolve
+    # the instant an accepted key is pressed while a different event's
+    # message window still sits on screen, instead of waiting for it to
+    # close first -- the same bug class already fixed for the other four
+    # commands.
+    def block_pending_key_input_command(wait)
+      return false unless wait && message_window_blocks_command?
+      @index -= 1
+      @wait_kind = :key_input_blocked
       @waiting = true
       true
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1796,13 +1796,17 @@ class RPG2k
           # loop re-executes that identical command the instant the block
           # clears, in that same frame, the same as any other retried
           # command -- so all five join the same-frame list too, matching
-          # #drive_event's foreground dispatcher exactly. Other wait kinds
-          # keep their old one-frame-per-call pacing.
+          # #drive_event's foreground dispatcher exactly. A waiting Key
+          # Input Processing command's own block (`CommandKeyInputProc`,
+          # `src/game_interpreter.cpp`) has the identical `return false`
+          # shape, so it joins the list too. Other wait kinds keep their
+          # old one-frame-per-call pacing.
           unless (wait_kind == :wait || wait_kind == :animation ||
                   wait_kind == :screen || wait_kind == :picture ||
                   wait_kind == :sprite_flash || wait_kind == :movement ||
                   wait_kind == :picture_blocked || wait_kind == :teleport_blocked ||
-                  wait_kind == :battle_blocked || wait_kind == :exp_level_blocked) &&
+                  wait_kind == :battle_blocked || wait_kind == :exp_level_blocked ||
+                  wait_kind == :key_input_blocked) &&
                  !it.waiting?
             apply_interpreter_requests(it, p[:event])
             return record_parallel_progress(p)
@@ -2063,6 +2067,13 @@ class RPG2k
           # list is open -- the parallel-process equivalent of #drive_event's
           # own :exp_level_blocked case, see
           # Interpreter#block_pending_exp_level_command for the citation.
+          it.resume unless message_window_open?
+        elsif it.wait_kind == :key_input_blocked
+          # A waiting Key Input Processing command issued from a Parallel
+          # Process while a message window or choice list is open -- the
+          # parallel-process equivalent of #drive_event's own
+          # :key_input_blocked case, see
+          # Interpreter#block_pending_key_input_command for the citation.
           it.resume unless message_window_open?
         elsif it.wait_kind == :sprite_flash
           # Flash Sprite's own wait flag, the parallel-process equivalent of
@@ -4702,6 +4713,20 @@ class RPG2k
             # :battle_blocked above, see that method's own citation and
             # :picture_blocked's own same-frame reasoning
             # (`Game_Interpreter::CommandChangeExp`/`CommandChangeLevel`,
+            # `src/game_interpreter.cpp`, the identical `return false` with
+            # the index untouched).
+            @interpreter.resume unless message_window_open?
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
+          when :key_input_blocked
+            # A waiting Key Input Processing command reached while a message
+            # window or choice list is open (#block_pending_key_input_command)
+            # -- the identical block-and-retry shape as :picture_blocked/
+            # :teleport_blocked/:battle_blocked/:exp_level_blocked above, see
+            # that method's own citation and :picture_blocked's own
+            # same-frame reasoning (`Game_Interpreter::CommandKeyInputProc`,
             # `src/game_interpreter.cpp`, the identical `return false` with
             # the index untouched).
             @interpreter.resume unless message_window_open?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3234,6 +3234,49 @@ check 'Key Input Proc waits for a key, stores its code, then continues' do
   ok st.switches[5], 'the event continued after the key press'
 end
 
+check 'a waiting Key Input Proc issued from a Parallel Process is blocked ' \
+      '(not armed) while a message window is open, and retries once it closes' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  # CommandKeyInputProc` (`src/game_interpreter.cpp`, code 11610) resets the
+  # target variable to 0 every retried frame, *then* checks `if (wait &&
+  # Game_Message::IsMessageActive()) { return false; }` -- unconditionally,
+  # the same block-and-retry shape already ported for Show/Move/Erase
+  # Picture, Teleport/Recall to Location, Battle Processing/Enemy Encounter
+  # and a "show message"-flagged Change EXP/Level. A key held down while
+  # blocked must not resolve the proc the instant it becomes armed. Issued
+  # from a Parallel Process (not the foreground) since an autostart event
+  # does not even begin while a message window is already open -- it simply
+  # waits to start until the window closes, never actually reaching this
+  # command mid-block; a Parallel Process, unlike an autostart, keeps
+  # advancing and reaching new commands while a *different* interpreter's
+  # message window sits open (see Scene::Map#parallels_paused?), which is
+  # the scenario this fix actually guards against.
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4)
+  par.event_commands = [
+    ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 1, 1, 1, 1]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
+  ]
+  scene = new_scene({ 1 => event(4, 4, par) })
+  st = scene.instance_variable_get(:@state)
+  scene.send(:open_message, ['hi'], false)
+  # Held throughout, including while blocked -- Down, not Decision, since
+  # Decision is also this message window's own "advance/close" key and
+  # would close the very window this check means to hold open.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+
+  5.times { scene.update }
+  eq 0, st.variables[1], 'blocked -- the held key must not resolve a proc that never armed'
+  ok !st.switches[5], 'the command after it has not run either'
+
+  scene.send(:close_message)
+  scene.update # retries the same frame the window closes -- now actually arms
+  scene.update # samples the still-held key and resolves
+  eq 1, st.variables[1], 'Down stored code 1, once the window closed'
+  scene.update # the following command runs once the proc has resumed
+  ok st.switches[5], 'the event continued after the key press'
+end
+
 check 'Key Input Proc ignores keys it was not told to accept' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

RPG_RT's Key Input Processing command, when its wait flag is set, blocks and
retries every frame while a message window or choice list is open — the same
block-and-retry shape already ported in this codebase for Show/Move/Erase
Picture, Transfer Player / Recall to Location, Battle Processing / Enemy
Encounter, and a "show message"-flagged Change EXP / Change Level. Key Input
Processing never got the same treatment.

`Game_Interpreter::CommandKeyInputProc` (`src/game_interpreter.cpp`, code
11610):

```cpp
if (wait) {
    // While waiting the variable is reset to 0 each frame.
    Main_Data::game_variables->Set(var_id, 0);
    ...
}

if (wait && Game_Message::IsMessageActive()) {
    return false;
}
```

Unconditional — not gated behind any edition/patch check, the same base
RPG2000 behaviour already confirmed for the sibling commands. A no-wait proc
never calls `IsMessageActive` at all, matching Change EXP/Level's own
`show_msg`-gated shape.

`Interpreter#do_key_input` armed the wait unconditionally with no equivalent
guard at all. Most concretely reachable through a Parallel Process: a
still-running Common Event's own waiting Key Input Processing command could
resolve the instant an accepted key is pressed while a *different*
interpreter's message window sat open on screen, instead of waiting for it
to close first — exactly the bug class already fixed for the other four
commands.

## Changes

- `mruby-rpg2k/mrblib/interpreter.rb`: new `#block_pending_key_input_command`
  (identical shape to the four existing `block_pending_*_command` methods),
  called from `do_key_input` right after the variable reset — matching
  `CommandKeyInputProc`'s own reset-then-check order exactly, so the reset
  still happens on every retried frame.
- `mruby-rpg2k/mrblib/scene/map.rb`: a new `:key_input_blocked` case in both
  wait dispatchers (foreground and Parallel Process), including the
  same-frame continuation the four sibling `_blocked` kinds already carry
  (#1221).
- New `scripts/rpg2k_scene_check.rb` check, issued from a Parallel Process
  (a foreground autostart never even reaches this code path — it simply
  refuses to begin at all while a message window is already open, unlike a
  Parallel Process, which keeps advancing during one).

## Test plan

- [x] New check confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/interpreter.rb
      mruby-rpg2k/mrblib/scene/map.rb`, then pass after `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 852 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1106 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_