### PR TITLE
Don't zero Simulated Attack's result variable on an invalid target

### DIFF
--- a/changelog.d/simulated-attack-invalid-target-variable.fixed.md
+++ b/changelog.d/simulated-attack-invalid-target-variable.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** a Simulated Attack command naming an invalid actor id (an
+  authoring mistake, or a variable-actor mode's own variable gone stale)
+  no longer zeroes its "store damage" result variable, matching RPG_RT --
+  previously a target-less hit silently cleared whatever value the
+  variable already held.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14300,6 +14300,40 @@ not yet verified:
   identical per-edition ceiling, `MAX_EFFECTIVE_HP_2K`/`_2K3`, so an
   attack this large is lethal either way — the stored variable is the
   only place the real, uncapped number is ever observable.)
+  - **Follow-up (2026-08-21):** Simulated Attack's result variable is now
+    left untouched when its target actor id is invalid, instead of being
+    zeroed — a third correction to this same command, this time to the
+    *variable write's own placement*, not the damage formula. Confirmed
+    directly against RPG_RT's live source: `Game_Interpreter::
+    CommandSimulatedAttack` (`src/game_interpreter.cpp`) writes
+    `Main_Data::game_variables->Set(com.parameters[7], result)` *inside*
+    its own `for (const auto& actor : GetActors(com.parameters[0],
+    com.parameters[1]))` loop — never reached at all when that loop is
+    empty. `GetActors` (same file) returns an empty vector, without ever
+    touching the variable, whenever a fixed actor id names a database row
+    that does not exist, or a variable-actor mode's own variable holds an
+    invalid/stale id (`if (!actor) { Output::Warning(...); return actors;
+    }`, modes 1/2). `Interpreter#do_simulated_attack`
+    (`mruby-rpg2k/mrblib/interpreter.rb`) instead pre-initialized
+    `damage = 0` *before* the target loop and wrote the result variable
+    *after* it, unconditionally on the "store result" flag alone — so an
+    invalid actor id (an authoring mistake, or a variable gone stale after
+    that actor left the party) silently zeroed whatever the variable held
+    before, where real RPG_RT leaves it exactly as it was. `#stat_targets`
+    (same file) already mirrors `GetActors`'s empty-vector behaviour
+    precisely for an invalid fixed/variable actor id (`Actors#[]`,
+    `mruby-rpg2k/mrblib/game.rb`, returns `nil` for a non-positive id or an
+    unbuilt database row, `.compact`-ed away) — only the write's own
+    placement was wrong, not the target-resolution logic. Fixed by moving
+    the variable write inside the `each` loop, gated on a `store_result`
+    flag captured once before the loop, and dropping the pre-loop
+    `damage = 0` entirely — multi-target scope (party-wide) is unaffected,
+    since both the old and new code already overwrote the variable once per
+    actor, so the last actor visited still "wins" identically either way.
+    Covered by a new `scripts/rpg2k_logic_check.rb` check (a stale value
+    already sitting in the result variable survives a Simulated Attack
+    naming a nonexistent actor id, instead of being zeroed), confirmed to
+    fail against the pre-fix code before the fix.
 - ✅ **A troop member still `hidden` at the moment of victory — never
   revealed by its own Show Hidden Monster page, or sent running by that
   page's Force Flee — used to still hand over its EXP, gold and treasure

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2221,6 +2221,18 @@ module Game
     # at 0, then spread by `Algo::VarianceAdjustEffect` and floored at 0 again.
     # The hit can be lethal.
     #
+    # The variable write happens once per resolved target, from inside
+    # RPG_RT's own target-resolution loop -- confirmed against
+    # `Game_Interpreter::CommandSimulatedAttack` (`src/game_interpreter.cpp`):
+    # `Main_Data::game_variables->Set(com.parameters[7], result)` sits inside
+    # the `for (const auto& actor : GetActors(...))` loop, never reached at
+    # all when that loop is empty. `GetActors` (same file) returns an empty
+    # vector without ever touching the variable when a fixed actor ID names a
+    # row the database doesn't have, or a variable-actor mode's variable
+    # holds an invalid/stale ID (`if (!actor) { ...; return actors; }`,
+    # modes 1/2). An empty target list therefore leaves the variable exactly
+    # as it was, not zeroed.
+    #
     # Deliberately **not** clamped to `Game::Battle#damage_cap`. A prior
     # version of this method assumed it should be, by analogy with the
     # normal-attack/skill/self-destruct damage-popup cap ("RPG_RT's damage
@@ -2238,15 +2250,15 @@ module Game
     # `Game_Battler::ChangeHp` directly, neither of which clamps either.
     def do_simulated_attack(cmd)
       atk = cmd.param(2)
-      damage = 0
+      store_result = cmd.param(6) != 0
       stat_targets(cmd).each do |a|
         damage = atk - (a.def * cmd.param(3)) / 400 - (a.int * cmd.param(4)) / 800
         damage = 0 if damage < 0
         damage = simulated_attack_variance(damage, cmd.param(5))
         damage = 0 if damage < 0
         a.change_hp(-damage, true)
+        variables[cmd.param(7)] = damage if store_result
       end
-      variables[cmd.param(7)] = damage if cmd.param(6) != 0
       check_game_over
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -16541,6 +16541,25 @@ check 'Simulated Attack floors the damage at zero' do
   eq 100, st.party.actor_by_id(1).hp
 end
 
+check 'Simulated Attack leaves its result variable untouched when the ' \
+      'target actor id is invalid, instead of zeroing it' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  # CommandSimulatedAttack` (`src/game_interpreter.cpp`) writes the result
+  # variable *inside* its own `for (const auto& actor : GetActors(...))`
+  # loop, never reached at all when that loop is empty -- and `GetActors`
+  # returns an empty vector, without ever touching the variable, when a
+  # fixed actor id names a database row that does not exist (`if (!actor)
+  # { ...; return actors; }`). A stale value already sitting in the
+  # variable must therefore survive, not get zeroed by a target-less hit.
+  st = party_state
+  st.variables[6] = 77 # a stale value the empty-target case must not clear
+  it = Game::Interpreter.new(st)
+  # scope 1 (fixed actor), actor id 99 (no such actor), store-damage flag 1.
+  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 99, 50, 0, 0, 0, 1, 6])])
+  it.update
+  eq 77, st.variables[6], 'no target resolved, so the variable is left exactly as it was'
+end
+
 # A prior version of this codebase clamped Simulated Attack's own damage
 # to Game::Battle::DAMAGE_CAP, by analogy with the normal-attack/skill/
 # self-destruct/slip-damage popup cap -- a plausible-sounding but


### PR DESCRIPTION
## Summary

RPG_RT writes Simulated Attack's "store damage" result variable once per
resolved target, from inside its own target-resolution loop. When the
command's actor selector resolves to no actor at all, the loop body never
runs, so the variable is left completely untouched.

`Game_Interpreter::CommandSimulatedAttack` (`src/game_interpreter.cpp`, code
10500):

```cpp
for (const auto& actor : GetActors(com.parameters[0], com.parameters[1])) {
    int result = atk;
    ...
    if (com.parameters[6] != 0) {
        Main_Data::game_variables->Set(com.parameters[7], result);
        ...
    }
}
```

`GetActors` (same file) returns an empty vector — without ever touching the
variable — whenever a fixed actor id names a database row that doesn't
exist, or a variable-actor mode's own variable holds an invalid/stale id:

```cpp
case 1:
    actor = Main_Data::game_actors->GetActor(id);
    if (!actor) {
        Output::Warning("Invalid actor ID {}", id);
        return actors; // empty
    }
    ...
```

`Interpreter#do_simulated_attack` instead pre-initialized `damage = 0`
*before* the target loop and wrote the result variable *after* it,
unconditionally on the "store result" flag — so an invalid actor id (an
authoring mistake, or a variable gone stale after that actor left the
party) silently zeroed whatever the variable already held, where real
RPG_RT leaves it alone. `#stat_targets` already mirrors `GetActors`'s
empty-vector behaviour precisely for this case — only the write's own
placement was wrong.

## Changes

- `do_simulated_attack` (`mruby-rpg2k/mrblib/interpreter.rb`): moves the
  variable write inside the `each` loop, gated on a `store_result` flag
  captured once before the loop, dropping the pre-loop `damage = 0`
  entirely. Multi-target scope (party-wide) is unaffected — both the old
  and new code already overwrote the variable once per actor, so the last
  actor visited still "wins" identically either way.
- New `scripts/rpg2k_logic_check.rb` check.
- `docs/TODO.md` Follow-up bullet and a `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] New check confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/interpreter.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 852 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1107 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_