### PR TITLE
Gate Change Class's level-up message on skill mode, not the skill diff

### DIFF
--- a/changelog.d/change-class-levelup-message-skill-mode-gate.fixed.md
+++ b/changelog.d/change-class-levelup-message-skill-mode-gate.fixed.md
@@ -1,0 +1,4 @@
+- **Events:** Change Class's level-up message now shows whenever its skill
+  mode is Reset or Add, matching RPG_RT -- previously a Reset/Add class
+  swap that happened to teach nothing new (the actor already knew every
+  skill the new class's learn table offers) stayed silent instead.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2587,11 +2587,11 @@ The work below is roughly ordered by the critical path to a walkable game
   named a single skill the change taught. Fixed the same way as Change
   Level/Change EXP: snapshot each target's skill list right before
   `#change_class` runs and append one `skill_learned_message` line per
-  post-change skill absent from that snapshot onto the level-up page. The
+  post-change skill absent from that snapshot onto the level-up page. ~~The
   show-message trigger itself is now more precise too — it fires on an
   actual skill diff being non-empty rather than guessing from the skill mode
   alone, so a RESET/ADD class swap that happens to teach nothing new stays
-  quiet, same as a level that didn't move. Covered by two new
+  quiet, same as a level that didn't move.~~ Covered by two new
   `scripts/rpg2k_logic_check.rb` checks (a class swap whose learn table
   teaches two skills across levels 1 and 3 names both on the level-up page;
   a skill taught early via an explicit Change Skills stays quiet, naming
@@ -2601,6 +2601,27 @@ The work below is roughly ordered by the critical path to a walkable game
   still announces each skill on its own level's page; a skill taught early
   via Change Skills still stays quiet once the level that would have taught
   it is reached.)
+  - **Follow-up (2026-08-21):** the "more precise" trigger above was itself
+    wrong — RPG_RT does *not* base the level-up line on the actual skill
+    diff at all. Confirmed against RPG_RT's own live source: `Game_Actor::
+    ChangeClass` (`src/game_actor.cpp`) gates its `PushLine(GetLevelUpMessage
+    (...))` on `new_level > 1 && (new_level > prev_level || new_skill !=
+    eSkillNoChange)` — a skill-*mode* check, one of several known-quirky,
+    deliberately-preserved RPG_RT behaviours EasyRPG's own comments flag in
+    this exact function, never a check of whatever `LearnLevelSkills`
+    (called only for Reset/Add) actually taught. So ~~a RESET/ADD class
+    swap that happens to teach nothing new stays quiet~~ is backwards: real
+    RPG_RT still shows the line whenever the skill mode is Reset or Add,
+    regardless of whether that mode actually taught anything. Fixed by
+    reverting the outer gate from the actual skill-diff check back to a
+    skill-mode check (`skill_mode != Game::Actor::CLASS_SKILL_NO_CHANGE`),
+    while leaving the per-skill diff (used to name which skills to list
+    under the level-up line) untouched — that half was already correct.
+    Covered by a new `scripts/rpg2k_logic_check.rb` check (a RESET class
+    swap that teaches nothing new, because the actor already knows every
+    skill the new class's learn table offers, still shows the bare
+    level-up line with no skill named underneath it), confirmed to fail
+    against the pre-fix code before the fix.
   ✅ **A learned skill's own position in the actor's skill list is now
   kept in ascending id order, not learn order (2026-08-18).**
   `Actor#learn_skill` (`mruby-rpg2k/mrblib/game.rb`) simply `push`ed the new

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2345,17 +2345,22 @@ module Game
         next unless a.change_class(class_id, level_1 ? 1 : a.level,
                                    skill_mode, param_mode)
         # Unlike Change Level (which announces every level crossed) RPG_RT shows
-        # a single line here, and shows it whenever the class change taught new
-        # skills even if the level itself did not move (EasyRPG's ChangeClass,
-        # which calls the identical LearnLevelSkills(1, new_level, pm) Change
-        # Level/Change EXP use -- see queue_level_up_messages's own comment).
-        # The actual skill diff (rather than a skill-mode guess) also decides
-        # whether there is anything to announce at all: a RESET/ADD class swap
-        # that happens to teach nothing the actor didn't already know stays
-        # quiet, matching a level that didn't move.
+        # a single line here, and shows it whenever the level exceeds 1 and
+        # either the level actually rose or the skill mode was Reset/Add --
+        # regardless of whether that mode actually taught anything the actor
+        # didn't already know. Confirmed against RPG_RT's own live source:
+        # `Game_Actor::ChangeClass` (`src/game_actor.cpp`) gates its
+        # `PushLine(GetLevelUpMessage(...))` on `new_level > 1 && (new_level >
+        # prev_level || new_skill != eSkillNoChange)` -- a mode check, never a
+        # check of whatever `LearnLevelSkills` (called only for Reset/Add)
+        # actually taught. One of several known-quirky, deliberately-preserved
+        # RPG_RT behaviours EasyRPG's own comments flag in this function. A
+        # RESET/ADD class swap that happens to teach nothing new (e.g.
+        # swapping between two classes whose level 1..N learn tables the actor
+        # has already fully absorbed) still shows the line.
         next unless show_msg
         new_skills = a.respond_to?(:skills) ? a.skills - before_skills : []
-        next unless a.level > 1 && (a.level > before || !new_skills.empty?)
+        next unless a.level > 1 && (a.level > before || skill_mode != Game::Actor::CLASS_SKILL_NO_CHANGE)
         lines = [level_up_message(a, a.level)]
         new_skills.each do |sid|
           sk = party.db_skill(sid)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5463,6 +5463,42 @@ check 'Change Class stays quiet about a skill the actor already knew going in' d
      'skill 21 was already known, so only the newly-learned skill 22 is named'
 end
 
+check 'Change Class still announces the level even when its Reset/Add skill ' \
+      'mode happens to teach nothing new' do
+  # Confirmed directly against RPG_RT's live source: `Game_Actor::
+  # ChangeClass` (`src/game_actor.cpp`) gates its level-up line on
+  # `new_level > 1 && (new_level > prev_level || new_skill !=
+  # eSkillNoChange)` -- a skill-*mode* check, never a check of whatever
+  # `LearnLevelSkills` (called only for Reset/Add) actually taught. A
+  # Reset/Add class swap that happens to teach nothing new (the actor
+  # already knows every skill the new class's learn table offers) still
+  # shows the line -- only skill_mode NO_CHANGE (or a level that never
+  # exceeds 1) stays quiet.
+  st = Game::State.new(Game::Party.new(class_db_named_skills), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  # Teach both of class 1's learn-table skills (21 at level 1, 22 at level
+  # 3) up front, so a RESET class change at the same level 3 teaches nothing
+  # new at all.
+  it0 = Game::Interpreter.new(st)
+  it0.start([FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 0, 0, 21]),
+             FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 0, 0, 22])])
+  it0.update
+  eq [10, 21, 22], a.skills.sort
+
+  it = Game::Interpreter.new(st)
+  # class 1, keep level 3 (level1 flag off), skills reset, params no-change,
+  # show message on.
+  it.start([FakeCmd.new(IC::CHANGE_CLASS,
+                        [1, 1, 1, 0, Game::Actor::CLASS_SKILL_RESET,
+                         Game::Actor::CLASS_PARAM_NO_CHANGE, 1])])
+  it.update
+  eq :message, it.wait_kind, 'RPG_RT still announces the level, taught nothing new or not'
+  eq ['Hero is now level 3!'], it.message_lines, 'no newly-learned skill to name'
+  it.resume
+  it.update
+  ok !it.waiting?
+end
+
 check 'Change Battle Commands adds, removes and clears the command list' do
   st = class_state
   a = st.party.actor_by_id(1)


### PR DESCRIPTION
## Summary

RPG_RT's Change Class command shows its level-up message whenever the
resulting level is above 1 and either the level actually rose or the skill
mode was Reset/Add — regardless of whether that mode actually taught the
actor anything new.

`Game_Actor::ChangeClass` (`src/game_actor.cpp`):

```cpp
SetLevel(new_level);
if (pm && new_level > 1 && (new_level > prev_level || new_skill != eSkillNoChange)) {
    pm->PushLine(ActorMessage::GetLevelUpMessage(*this, new_level));
}
```

This is one of several known-quirky, deliberately-preserved RPG_RT
behaviors EasyRPG's own comments flag in this function — a skill-*mode*
check, never a check of whatever `LearnLevelSkills` (called only for
Reset/Add) actually taught.

A prior fix in this codebase (documented in `docs/TODO.md`) replaced an
earlier skill-mode check with an actual skill-diff check, reasoning it
would be "more precise" — but that reasoning was never verified against
RPG_RT's own source, and turns out backwards: a RESET/ADD class swap that
happens to teach nothing new (e.g. swapping between two classes whose level
1..N learn tables the actor has already fully absorbed) still shows the
level-up line in real RPG_RT, but this codebase's `do_change_class`
silently dropped it.

## Changes

- `do_change_class` (`mruby-rpg2k/mrblib/interpreter.rb`): reverts the
  outer gate from `!new_skills.empty?` back to
  `skill_mode != Game::Actor::CLASS_SKILL_NO_CHANGE`, matching
  `ChangeClass`'s own condition exactly. The per-skill diff itself (used to
  name which skills to list under the level-up line) is untouched — that
  half was already correct.
- New `scripts/rpg2k_logic_check.rb` check.
- `docs/TODO.md` Follow-up bullet correcting the prior claim, and a
  `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] New check confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/interpreter.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 852 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1108 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_