### PR TITLE
Prune crowded-out states when cursed armor forces a new one

### DIFF
--- a/changelog.d/cursed-armor-crowds-out-low-priority-state.fixed.md
+++ b/changelog.d/cursed-armor-crowds-out-low-priority-state.fixed.md
@@ -1,0 +1,4 @@
+- **Equipment:** equipping RPG2003 cursed/forced-state armor now crowds out
+  a much-lower-priority state the actor already carried, matching RPG_RT --
+  previously only a lethal hit or a landed skill state triggered this,
+  never an equipment-triggered infliction.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11360,6 +11360,40 @@ not yet verified:
   is, unchanged; a state already present by ordinary means is still locked
   in by the armor either way), confirmed to fail against the pre-fix code
   (`expected [], got [4]`) before the fix.
+  ✅ **Follow-up (2026-08-21): equipping cursed armor never applied RPG_RT's
+  own crowding-out rule to the state it forced, leaving a much
+  lower-priority ailment the actor already carried untouched instead of
+  clearing it, the same instant the cursed state landed — the one
+  state-infliction call site in this file that never paired `#add_state`
+  with the `#Game::States.prune` pass every other one already does.**
+  Confirmed directly against RPG_RT's live source: `State::Add`
+  (`src/state.cpp`) runs its crowding-out pass — clearing any state 10+
+  priority points below the resulting significant state, unless a
+  `PermanentStates` exemption applies — unconditionally, inside every
+  single call, with no caller-side opt-out at all; `Game_Battler::AddState`
+  (`src/game_battler.cpp`) calls it via `State::Add(...)` for every
+  infliction path in the engine, and `Game_Actor::AdjustEquipmentStates`
+  (`src/game_actor.cpp`) funnels equip-triggered infliction through that
+  identical `AddState` — so a lethal hit, a landed skill state, and a
+  cursed item's forced state all get the identical crowding-out pass in
+  real RPG_RT, with no exception for the equip-triggered one.
+  `Game::Actor#adjust_equipment_states`'s add branch
+  (`mruby-rpg2k/mrblib/game.rb`) called `#add_state` but never followed it
+  with `Game::States.prune`, unlike `#knock_out!`, `Party#cast_skill`'s own
+  skill-infliction loop, and Change Monster Condition — the three other
+  state-infliction call sites in this file, each of which already pairs
+  the two calls (`#knock_out!`'s own doc comment even already says the
+  crowding-out pass runs "after *every* state it adds, not just Death",
+  yet the equip path was still missed). Fixed by adding the identical
+  `@states = Game::States.prune(@states, state_table, keep:
+  permanent_states)` call right after `#adjust_equipment_states`'s own
+  `#add_state`, mirroring `#knock_out!`'s exact idiom. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (an actor already carrying a
+  low-priority state equips a cursed item forcing a high-priority one; the
+  low-priority state is crowded out the instant the cursed state lands,
+  the same as a lethal hit or a landed skill state already does here),
+  confirmed to fail against the pre-fix code (`expected [4], got [2, 4]`)
+  before the fix.
   ✅ **Follow-up (2026-08-19): an RPG2003 fight that started with every
   front-row ally already incapacitated (dead/hidden) never snapped
   back-row survivors to the front, leaving them fighting a whole battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2087,7 +2087,25 @@ module Game
     # itself.
     def adjust_equipment_states(item_id, add)
       cursed_armor_state_ids(item_id).each do |id|
-        add ? add_state(id, allow_battle_states: false) : remove_state(id)
+        if add
+          add_state(id, allow_battle_states: false)
+          # `State::Add` (`src/state.cpp`) runs the crowding-out pass after
+          # *every* state it adds, with no caller-side opt-out -- RPG_RT's
+          # `Game_Battler::AddState` funnels every infliction path through
+          # it uniformly, equipment included: `Game_Actor::
+          # AdjustEquipmentStates` calls the identical `AddState`
+          # `#knock_out!`/#cast_skill's own skill-infliction loop already
+          # pairs with a prune call here. A cursed item forcing a
+          # high-priority state onto an actor already carrying a
+          # low-priority ailment must clear that ailment the instant the
+          # cursed state lands, the same as a lethal hit or a landed skill
+          # state already does here -- this was the one state-infliction
+          # call site in this file that missed pairing #add_state with the
+          # prune pass every other one already does.
+          @states = Game::States.prune(@states, state_table, keep: permanent_states)
+        else
+          remove_state(id)
+        end
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4746,6 +4746,32 @@ check 'equipping RPG2003 cursed armor does NOT inflict a state left at its ' \
   eq nil, a.remove_state(4), 'and an ordinary cure still cannot touch it while the armor is worn'
 end
 
+check 'equipping RPG2003 cursed armor crowds out a lower-priority state ' \
+      'already carried, the same as a lethal hit or a landed skill state does' do
+  # Confirmed against EasyRPG's actual C++ source, fetched live: `State::Add`
+  # (`src/state.cpp`) runs its crowding-out pass -- clearing any state 10+
+  # priority points below the resulting significant state -- unconditionally,
+  # inside every single call, with no caller-side opt-out. `Game_Battler::
+  # AddState` (`src/game_battler.cpp`) calls it via `State::Add(...)`, and
+  # `Game_Actor::AdjustEquipmentStates` (`src/game_actor.cpp`) funnels equip-
+  # triggered infliction through the identical `AddState` -- so equipping a
+  # cursed item that forces a high-priority state gets the same crowding-out
+  # a lethal hit (#knock_out!) or a landed skill state already does in this
+  # codebase, which had been the one state-infliction call site here that
+  # never paired #add_state with the #Game::States.prune pass every other
+  # one already does.
+  items = { 20 => fake_item(type: 3, state_set: [0, 0, 0, 1], reverse_state: true) } # armor, state 4
+  situation = { 2 => fake_state(type: 1, priority: 10), # low priority
+                4 => fake_state(type: 1, priority: 90) } # the cursed state, high priority
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) },
+                       [1], items, {}, {}, situation, rpg2003: true)
+  a = Game::Party.new(db).leader
+  a.add_state(2)
+  eq [2], a.states, 'carrying the low-priority ailment already'
+  a.equip_item(20)
+  eq [4], a.states, 'the cursed state crowded out the ailment 10+ priority below it'
+end
+
 check 'RPG2003 cursed armor set as *starting* gear inflicts its state from the ' \
       'very first frame, not only once equipped through a later Equip command' do
   # Confirmed against EasyRPG's actual C++ source, fetched live:


### PR DESCRIPTION
## Summary

RPG_RT's state crowding-out rule — clearing any state 10+ priority points
below the resulting significant state — is not something callers opt into;
it runs unconditionally inside `State::Add` itself, for every single call.

`src/state.cpp`, `State::Add`:

```cpp
states[state_id - 1] = 1;

// Clear states that are more than 10 priority points below the
// significant state
const lcf::rpg::State* sig_state = GetSignificantState(states);

for (int i = 0; i < (int)states.size(); ++i) {
    if (lcf::Data::states[i].priority <= sig_state->priority - 10 && !ps.Has(i + 1)) {
        states[i] = 0;
    }
    ...
}
```

`Game_Battler::AddState` (`src/game_battler.cpp`) calls it via
`State::Add(...)` unconditionally, and `Game_Actor::AdjustEquipmentStates`
(`src/game_actor.cpp`) funnels equip-triggered state infliction through the
identical `AddState` — so a lethal hit, a landed skill state, and a cursed
item's forced state all get the same crowding-out pass in real RPG_RT, with
no exception for the equip-triggered one.

This codebase (`mruby-rpg2k/mrblib/game.rb`) already ports the pass as
`Game::States.prune`, but as a separate step callers must remember to
invoke after `#add_state`, rather than folding it into `#add_state` itself.
Three of the four state-infliction call sites remember to do this
(`#knock_out!`, `Party#cast_skill`'s skill-infliction loop, Change Monster
Condition) — `#adjust_equipment_states` never did, even though
`#knock_out!`'s own doc comment already notes the crowding-out pass runs
"after *every* state it adds, not just Death."

## Changes

- `Game::Actor#adjust_equipment_states` (`mruby-rpg2k/mrblib/game.rb`): adds
  the same `@states = Game::States.prune(@states, state_table, keep:
  permanent_states)` call right after `#add_state`, mirroring
  `#knock_out!`'s exact idiom.
- New `scripts/rpg2k_logic_check.rb` check.
- `docs/TODO.md` Follow-up bullet (nested under the existing cursed-armor
  cluster) and a `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] New check confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/game.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 852 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1109 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_