### PR TITLE
Exempt a Through-Mode blocker from the hero/event collision test

### DIFF
--- a/changelog.d/through-mode-blocker-exemption.fixed.md
+++ b/changelog.d/through-mode-blocker-exemption.fixed.md
@@ -1,0 +1,4 @@
+- **Events:** a same-layer map event with its own Through Mode turned on
+  now lets the hero, or another event's own Move Route, walk straight
+  through it, matching RPG_RT -- previously it still blocked outright,
+  even though a boat or ship already correctly passed through it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16236,6 +16236,40 @@ not yet verified:
   rewritten in place to assert the opposite of its own final assertion
   (Through Mode no longer lets the airship land), confirmed to fail against
   the pre-fix code before the fix.
+- ✅ **A same-layer map event with its own Through Mode on now lets the
+  hero, or another event's own Move Route, walk straight through it —
+  distinct from the vehicle-specific Through-Mode rules the two bullets
+  above already cover, which are about a boat/ship's or airship's own
+  separate collision path, not the general character-vs-character one
+  every ordinary step (hero or event) goes through (2026-08-21).**
+  Confirmed against RPG_RT's own live source: `WouldCollide` (`src/
+  game_map.cpp`) — the single collision primitive `Game_Character::Move`'s
+  `MakeWay` bottoms out in, for the hero, a map event, or a boarded
+  vehicle alike (`Game_Player::MakeWay` delegates straight to
+  `GetVehicle()->MakeWay`/`Game_Character::MakeWay` depending on
+  `IsAboard()`) — opens with `if (self.GetThrough() || other.GetThrough())
+  { return false; }`, *before* the overlap-forbidden or layer-match tests
+  that follow it, uniformly for every mover type. `Scene::Map#passable?`
+  (the hero's own on-foot step check) and `#char_passable?`/`#char_can_
+  land?` (the shared mover-vs-event test every map event's own Move Route,
+  and the party's forced-route mirror, use) each only ever tested a
+  blocker's *layer* (`b[:layer] == LAYER_SAME` / `b[:layer] == character.
+  layer`, plus `overlap_forbidden` for event-vs-event) — never the
+  blocker's own Through flag — unlike `#vehicle_passable?`, which already
+  carried the correct `!b[:char].through` idiom for its own boat/ship
+  branch. An NPC authored with Through Mode on (a common technique so it
+  never blocks the party) therefore still blocked the hero and every other
+  event's own movement outright, when real RPG_RT lets anything walk
+  straight through it. Fixed by adding the identical `!b[:char].through`
+  guard `#vehicle_passable?` already used to all three blocker checks —
+  `#passable?`'s single layer test, and `#char_passable?`/`#char_can_
+  land?`'s combined layer-or-overlap-forbidden test (the Through exemption
+  has to gate the *whole* disjunction, not just the layer half, since
+  `WouldCollide`'s own Through check runs before either sub-test). Covered
+  by two new `scripts/rpg2k_scene_check.rb` checks (a same-layer event with
+  Through Mode on lets the hero walk through it; the same for another
+  event's own Move Route crossing it), both confirmed to fail against the
+  pre-fix code before the fix.
 
 **Save / Load persistence — consolidated master list**
 Runtime state that does **not** survive a map re-visit (leave and return,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4367,9 +4367,15 @@ class RPG2k
         return false unless @map.in_bounds?(nx, ny)
         return false if nx == @state.x && ny == @state.y && character.layer == LAYER_SAME
         hero = character.event_id == MOVE_TARGET_PLAYER
+        # A blocker's own Through Mode exempts it from every collision test
+        # below, not just the layer one -- `WouldCollide` (`src/
+        # game_map.cpp`) checks `self.GetThrough() || other.GetThrough()`
+        # first and unconditionally, before either the overlap-forbidden or
+        # the layer test, uniformly for the hero, another event, or a
+        # vehicle (see `#passable?`'s own citation).
         return false if blockers_at(nx, ny).any? do |b|
-          b[:layer] == character.layer ||
-            (!hero && (character.overlap_forbidden || b[:overlap_forbidden]))
+          !b[:char].through && (b[:layer] == character.layer ||
+            (!hero && (character.overlap_forbidden || b[:overlap_forbidden])))
         end
         return false if vehicle_blocks?(nx, ny, block_airship: !hero)
         return true if @chipset.nil?
@@ -4399,12 +4405,13 @@ class RPG2k
         # anything on screen to notice it by.
         return true if x == character.x && y == character.y
         return false unless @map.in_bounds?(x, y)
-        # Same layer-gated occupancy rule as #char_passable? (see its comment).
+        # Same layer-gated occupancy rule as #char_passable? (see its
+        # comment) -- including the same blocker-Through exemption.
         return false if x == @state.x && y == @state.y && character.layer == LAYER_SAME
         hero = character.event_id == MOVE_TARGET_PLAYER
         return false if blockers_at(x, y).any? do |b|
-          b[:layer] == character.layer ||
-            (!hero && (character.overlap_forbidden || b[:overlap_forbidden]))
+          !b[:char].through && (b[:layer] == character.layer ||
+            (!hero && (character.overlap_forbidden || b[:overlap_forbidden])))
         end
         return false if vehicle_blocks?(x, y, block_airship: !hero)
         return true if @chipset.nil?
@@ -8446,8 +8453,16 @@ class RPG2k
         # the fuller citation). Every event on the tile gets a say
         # (#blockers_at), not just one of them: a below-characters decal and
         # a same-as-characters NPC can share a tile, and the NPC must still
-        # block even though the decal alone would not.
-        return false if blockers_at(x, y).any? { |b| b[:layer] == LAYER_SAME }
+        # block even though the decal alone would not. A blocker's own
+        # Through Mode exempts it from this entirely, the same as the
+        # mover's: `WouldCollide` (`src/game_map.cpp`) checks `self.
+        # GetThrough() || other.GetThrough()` before any layer test at all,
+        # uniformly for the hero, another event, or a vehicle -- an NPC
+        # authored with Through Mode on (a common technique so it never
+        # blocks the party) must let the hero walk straight through it,
+        # matching `#vehicle_passable?`'s own already-correct `!b[:char].
+        # through` idiom just above.
+        return false if blockers_at(x, y).any? { |b| b[:layer] == LAYER_SAME && !b[:char].through }
         # An unridden boat/ship blocks the hero on foot exactly like a
         # same-layer event would (see #vehicle_blocks?); an unridden airship
         # never does, on foot or otherwise (block_airship: false — the hero

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1484,6 +1484,25 @@ check 'a same-layer event still blocks the hero' do
   eq [0, 0], [st.x, st.y], 'a same-layer event still blocks like a normal character'
 end
 
+check "a same-layer event with its own Through Mode on lets the hero walk " \
+      'straight through it' do
+  # Confirmed against EasyRPG's actual C++ source: `WouldCollide` (`src/
+  # game_map.cpp`) checks `self.GetThrough() || other.GetThrough()` first
+  # and unconditionally, before any layer test at all -- a blocker's own
+  # Through Mode (a common authoring technique so an NPC never blocks the
+  # party) exempts it from collision the same way the mover's own Through
+  # Mode already does, uniformly for the hero, another event, or a vehicle.
+  pg = page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_SAME)
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  chars(scene)[1].through = true
+  RGSS::Input.dir_value = 6
+  12.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [1, 0], [st.x, st.y],
+     "Through Mode on the blocking event should let the hero pass it, got #{[st.x, st.y]}"
+end
+
 check 'events on different layers pass through each other via Move Route' do
   # A below-layer event sits at (3,2); an above-layer event runs a custom
   # route straight through its column. #char_passable? gates layer on an
@@ -1535,6 +1554,26 @@ check 'two below-layer events collide with each other via Move Route' do
   40.times { scene.update }
   eq [2, 2], [ch.x, ch.y],
      "two below-layer events should still collide with each other, got #{[ch.x, ch.y]}"
+end
+
+check "an event's own Through Mode lets another event's Move Route pass " \
+      'through it, even on a matching layer' do
+  # The event-vs-event equivalent of "a same-layer event with its own
+  # Through Mode on lets the hero walk straight through it" above:
+  # `WouldCollide` (`src/game_map.cpp`) checks `self.GetThrough() ||
+  # other.GetThrough()` before the layer-match test, so a blocking event's
+  # own Through Mode exempts it from #char_passable?'s layer gate too, not
+  # just #passable?'s.
+  below = event(3, 2, page(layer: RPG2k::Scene::Map::LAYER_BELOW))
+  mover = event(1, 2, page(x_move_type: Game::MoveType::CUSTOM,
+                           route: move_route([R::MOVE_RIGHT, R::MOVE_RIGHT], repeat: false),
+                           layer: RPG2k::Scene::Map::LAYER_BELOW))
+  scene = new_scene({ 1 => below, 2 => mover }, player: [0, 0])
+  chars(scene)[1].through = true
+  ch = chars(scene)[2]
+  40.times { scene.update }
+  eq [3, 2], [ch.x, ch.y],
+     "Through Mode on the blocking event should let the mover cross it, got #{[ch.x, ch.y]}"
 end
 
 check 'overlap_forbidden does not block the hero on an ordinary step' do


### PR DESCRIPTION
## Summary

RPG_RT's single character-vs-character collision primitive exempts a
Through-Mode blocker before any layer or overlap-forbidden test, uniformly
for the hero, another map event, or a boarded vehicle.

`Game_Player::MakeWay` (`src/game_player.cpp`) delegates to the same
`MakeWay` machinery whether boarded or on foot:

```cpp
bool Game_Player::MakeWay(int from_x, int from_y, int to_x, int to_y) {
    if (IsAboard()) {
        return GetVehicle()->MakeWay(from_x, from_y, to_x, to_y);
    }
    return Game_Character::MakeWay(from_x, from_y, to_x, to_y);
}
```

Both bottom out in `WouldCollide` (`src/game_map.cpp`):

```cpp
static bool WouldCollide(const Game_Character& self, const Game_Character& other, bool self_conflict) {
    if (self.GetThrough() || other.GetThrough()) {
        return false;
    }
    ...
    if (other.GetLayer() == lcf::rpg::EventPage::Layers_same && self_conflict) { return true; }
    if (self.GetLayer() == other.GetLayer()) { return true; }
    return false;
}
```

`other.GetThrough()` — the blocker's own Through Mode — is checked *before*
either the layer-match test or the overlap-forbidden test, for any mover.

This codebase's `Scene::Map#passable?` (the hero's own step check) and
`#char_passable?`/`#char_can_land?` (the shared mover-vs-event test every
map event's own Move Route, and the party's forced-route mirror, use) only
ever tested a blocker's *layer*, never its own Through flag — unlike
`#vehicle_passable?`, which already carries the correct `!b[:char].through`
idiom for its own boat/ship branch (already documented in `docs/TODO.md`).
An NPC authored with Through Mode on — a common technique so it never
blocks the party — therefore still blocked the hero and every other event's
own movement outright.

## Changes

- `mruby-rpg2k/mrblib/scene/map.rb`: `#passable?`, `#char_passable?`, and
  `#char_can_land?` each add the identical `!b[:char].through` guard
  `#vehicle_passable?` already uses. In `#char_passable?`/`#char_can_land?`
  the guard wraps the *whole* layer-or-overlap-forbidden disjunction, since
  `WouldCollide`'s own Through check runs before either sub-test.
- Two new `scripts/rpg2k_scene_check.rb` checks: a same-layer event with
  Through Mode on lets the hero walk through it, and the same for another
  event's own Move Route crossing it.
- `docs/TODO.md` bullet (distinguished from the existing vehicle-specific
  Through-Mode bullets, which cover a separate collision path) and a
  `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] Both new checks confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/scene/map.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 854 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1109 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_