### PR TITLE
Read state-adjusted Defence/Spirit in Simulated Attack's damage formula

### DIFF
--- a/changelog.d/simulated-attack-state-adjusted-def-spi.fixed.md
+++ b/changelog.d/simulated-attack-state-adjusted-def-spi.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** a Simulated Attack command now computes its damage from the
+  target's state-adjusted Defence and Spirit, matching RPG_RT -- previously
+  it read the raw base stat, so a Weaken-type status (including one an
+  RPG2003 cursed item is currently forcing on) had no effect on the
+  damage dealt.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14389,6 +14389,30 @@ not yet verified:
     already sitting in the result variable survives a Simulated Attack
     naming a nonexistent actor id, instead of being zeroed), confirmed to
     fail against the pre-fix code before the fix.
+  - **Follow-up (2026-08-21): Simulated Attack read the target's raw, unadjusted
+    Defence/Spirit instead of its state-adjusted value — a fourth correction
+    to this same command, this time to the damage formula's own stat inputs.**
+    Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+    CommandSimulatedAttack` (`src/game_interpreter.cpp`) computes `atk -
+    actor->GetDef() * def / 400 - actor->GetSpi() * spi / 800`, and
+    `Game_Battler::GetDef`/`GetSpi` (`src/game_battler.cpp`) both route
+    through `AdjustParam`, which folds in a currently-afflicted state's own
+    halve/double Defence/Spirit flag (`affect_defense`/`affect_spirit`) —
+    the same accessor every other damage formula reads, in or out of
+    battle. `Interpreter#do_simulated_attack`
+    (`mruby-rpg2k/mrblib/interpreter.rb`) instead read the target's raw
+    `.def`/`.int` fields directly, so a party member afflicted by a
+    Weaken-type status — including one an RPG2003 cursed item is currently
+    forcing on — took the wrong amount of damage from a Simulated Attack,
+    e.g. a damage-floor trap event silently ignoring an active debuff.
+    `Game::Party#effective_def`/`#effective_int` (`mruby-rpg2k/mrblib/
+    game.rb`) already port that exact formula for this identical map-side,
+    non-battle-actor situation (`scene/status_menu.rb` already uses them
+    the same way) — fixed by wiring those in instead of the raw fields, no
+    new methods needed. Covered by a new `scripts/rpg2k_logic_check.rb`
+    check (a target with an active halve-Defence state takes damage
+    computed off its halved Defence, not its raw base stat), confirmed to
+    fail against the pre-fix code before the fix.
 - ✅ **A troop member still `hidden` at the moment of victory — never
   revealed by its own Show Hidden Monster page, or sent running by that
   page's Force Flee — used to still hand over its EXP, gold and treasure

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2252,7 +2252,23 @@ module Game
       atk = cmd.param(2)
       store_result = cmd.param(6) != 0
       stat_targets(cmd).each do |a|
-        damage = atk - (a.def * cmd.param(3)) / 400 - (a.int * cmd.param(4)) / 800
+        # Reads the target's state-adjusted Defence/Spirit, not the raw base
+        # stat -- `Game_Interpreter::CommandSimulatedAttack` (`src/
+        # game_interpreter.cpp`) computes `atk - actor->GetDef() * def /
+        # 400 - actor->GetSpi() * spi / 800`, and `Game_Battler::GetDef`/
+        # `GetSpi` (`src/game_battler.cpp`) both route through `AdjustParam`,
+        # which folds in a currently-afflicted state's own halve/double
+        # Defence/Spirit flag (`affect_defense`/`affect_spirit`) -- the same
+        # accessor every other damage formula reads, in or out of battle.
+        # `Game::Party#effective_def`/`#effective_int`
+        # (`mruby-rpg2k/mrblib/game.rb`) already port that exact formula for
+        # this identical "map-side, non-battle actor" situation (see
+        # `scene/status_menu.rb`'s own use of them), so a target afflicted
+        # by a Weaken-type status -- including one an RPG2003 cursed item is
+        # currently forcing on -- now takes the correct amount of damage
+        # instead of one computed off its unadjusted stat.
+        damage = atk - (party.effective_def(a) * cmd.param(3)) / 400 -
+                 (party.effective_int(a) * cmd.param(4)) / 800
         damage = 0 if damage < 0
         damage = simulated_attack_variance(damage, cmd.param(5))
         damage = 0 if damage < 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -16584,6 +16584,30 @@ check 'Simulated Attack damages the target by atk less its defence share' do
   eq 58, hero.hp # 100 HP less (50 - 8 * 400 / 400) = 42 damage
 end
 
+check "Simulated Attack reads the target's state-adjusted Defence/Spirit, " \
+      'not its raw base stat' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  # CommandSimulatedAttack` (`src/game_interpreter.cpp`) computes `atk -
+  # actor->GetDef() * def / 400 - actor->GetSpi() * spi / 800`, and
+  # `Game_Battler::GetDef`/`GetSpi` (`src/game_battler.cpp`) both route
+  # through `AdjustParam`, which folds in a currently-afflicted state's own
+  # halve/double Defence flag -- the same accessor every other damage
+  # formula reads, in or out of battle. A target whose Defence is halved by
+  # an active state must take more damage than its raw stat alone would
+  # suggest.
+  states = { 2 => fake_state(affect_type: 0, affect_defense: true) } # 0 = halve
+  st = party_state_with_states(states)
+  hero = st.party.actor_by_id(1) # def 8, hp 100
+  hero.add_state(2)
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 1, atk 50, def-weight 400, spi-weight 0, variance 0,
+  # store-damage flag 0.
+  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 50, 400, 0, 0, 0, 0])])
+  it.update
+  eq 54, hero.hp, '100 HP less (50 - halved-def 4 * 400 / 400) = 46 damage, ' \
+                  'not 42 off the raw, unhalved def of 8'
+end
+
 check 'Simulated Attack stores the damage it dealt in a variable' do
   st = party_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

RPG_RT's Simulated Attack computes its damage using the target's
*state-adjusted* Defence/Spirit, not the raw base stat.

`Game_Interpreter::CommandSimulatedAttack` (`src/game_interpreter.cpp`,
code 10500):

```cpp
result -= (actor->GetDef() * def) / 400;
result -= (actor->GetSpi() * spi) / 800;
```

`Game_Battler::GetDef`/`GetSpi` (`src/game_battler.cpp`) both route through
`AdjustParam`, which folds in a currently-afflicted state's own
halve/double Defence/Spirit flag:

```cpp
int Game_Battler::GetDef(Weapon weapon) const {
	return AdjustParam(GetBaseDef(weapon), def_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
}
```

— the same accessor every other damage formula reads, in or out of battle.

`Interpreter#do_simulated_attack` instead read the target's raw `.def`/
`.int` fields directly, so a party member afflicted by a Weaken-type status
— including one an RPG2003 cursed item is currently forcing on — took the
wrong amount of damage from a Simulated Attack (e.g. a damage-floor trap
event silently ignoring an active debuff).

`Game::Party#effective_def`/`#effective_int` (`mruby-rpg2k/mrblib/game.rb`)
already port the exact `AdjustParam` formula for this identical map-side,
non-battle-actor situation — `scene/status_menu.rb` already uses them the
same way — so this wires those in instead of the raw fields, no new
methods needed.

## Changes

- `do_simulated_attack` (`mruby-rpg2k/mrblib/interpreter.rb`): reads
  `party.effective_def(a)`/`party.effective_int(a)` instead of `a.def`/
  `a.int`.
- New `scripts/rpg2k_logic_check.rb` check.
- `docs/TODO.md` Follow-up bullet (a fourth correction to this same
  command, alongside the prior variance/cap/result-variable-placement
  fixes) and a `changelog.d/*.fixed.md` fragment.

## Test plan

- [x] New check confirmed to fail against the pre-fix code via
      `git stash push -- mruby-rpg2k/mrblib/interpreter.rb`, then pass after
      `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 854 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1110 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 18 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_