### PR TITLE
Layer RPG2003 row bonus and state-adjusted stats into auto-battle attack ranking

### DIFF
--- a/changelog.d/auto-battle-attack-rank-row-and-state-adjusted-stats.fixed.md
+++ b/changelog.d/auto-battle-attack-rank-row-and-state-adjusted-stats.fixed.md
@@ -1,0 +1,5 @@
+- **Battle:** a Forced-AI actor's own ranking of a plain Attack now layers
+  the same RPG2003 front/back-row bonus and state-adjusted Defence/Spirit
+  the attack would actually deal, matching RPG_RT -- previously it ranked
+  off raw, unadjusted stats, so a front-row actor (or one targeting a
+  weakened foe) could under-rank Attack against a competing Skill.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10066,6 +10066,43 @@ not yet verified:
   `#auto_battle_raw_cost` directly against both an RPG2000 and an RPG2003
   `Game::Battle`, confirmed to fail against the pre-fix code (`expected 10,
   got 50`) before the fix.
+- ✅ **A Forced-AI actor's own plain-Attack ranking now layers the same
+  RPG2003 row bonus/penalty and state-adjusted Defence/Spirit the real
+  attack deals, instead of a flatter, unadjusted approximation.**
+  `Game::Battle#auto_battle_attack_target_rank` (`mruby-rpg2k/mrblib/
+  game.rb`) computed `Battle.attack_damage(b.atk, target.def)` straight off
+  each combatant's raw base stats. RPG_RT's own
+  `CalcNormalAttackAutoBattleTargetRank` (`src/autobattle.cpp`) instead
+  calls `Algo::CalcNormalAttackEffect` (`src/algo.cpp`) for its
+  `base_effect` term — the *identical* function
+  `Game_BattleAlgorithm::Normal::Execute` (`src/game_battlealgorithm.cpp`)
+  calls to resolve the real swing. That function reads `Game_Battler::
+  GetAtk`/`GetDef` (already state- and equipment-adjusted via
+  `AdjustParam`) and, when `Feature::HasRow()`, applies the same
+  `IsRowAdjusted` 125%/75% front/back-row multiplier the real attack gets.
+  So a Forced-AI actor's own ranking of a plain Attack shares its formula
+  with the attack it would actually deal, not an independent
+  approximation — a front-row Forced-AI actor (or one targeting a
+  back-row/state-weakened foe) under-ranked plain Attack relative to a
+  competing Skill, and could pick the worse of the two. Fixed by routing
+  through the same `#effective_atk`/`#effective_def` (`AdjustParam`-based)
+  helpers and `#row_adjusted?` 125%/75% multiplier `#deal_attack_with_
+  current_weapon` already uses for the real attack.
+  ~~A prior version of this file's `#choose_auto_battle_command` doc
+  comment claimed ranking "deliberately... does not layer the RPG2003 row
+  modifiers... a ranking heuristic need not double-count them."~~ That was
+  an unverified, plausible-sounding inference rather than something read
+  off `CalcNormalAttackAutoBattleTargetRank`'s own source, and is corrected
+  in both doc comments now. Covered by two new `scripts/
+  rpg2k_logic_check.rb` checks calling `#auto_battle_attack_target_rank`
+  directly: a front-row-vs-back-row `Game::Battle.from_actor` attacker pair
+  (rigged with a low-Defence enemy so the 25% swing survives Ruby's
+  integer-division truncation, plus a front-row "dummy" ally on each side
+  so the constructor's own RPG2003 row-safety-net — which force-resets
+  every ally to front row if none of them can otherwise act from
+  there — doesn't overwrite the lone back-row attacker under test), and a
+  plain-vs-Defence-halving-state target pair, both confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **Enter Hero Name (10740) issued from a Parallel Process now actually
   opens the name-entry screen, instead of silently doing nothing.**
   Confirmed against EasyRPG's actual C++ source:

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -12041,13 +12041,18 @@ module Game
     # the one real, un-patched RPG_RT always runs; EasyRPG's other two named
     # algorithms, `AttackOnly` and `RpgRtImproved`, are its own optional,
     # non-default customizations and are not modelled here). The ranking
-    # deliberately mirrors EasyRPG's `CalcNormalAttackAutoBattleTargetRank` /
-    # `CalcSkillAutoBattleTargetRank` at `apply_variance: false` and does not
-    # layer the RPG2003 row modifiers (#row_adjusted?) into its per-target
-    # score -- the actual hit/damage a thrown attack lands (#deal_attack /
-    # #to_hit) is where those apply, and a ranking heuristic need not double-
-    # count them, so a front-row actor's +25% shows up in the damage it deals
-    # rather than being pre-empted in its auto-battle preference.
+    # mirrors EasyRPG's `CalcNormalAttackAutoBattleTargetRank` /
+    # `CalcSkillAutoBattleTargetRank` at `apply_variance: false` --
+    # `CalcNormalAttackAutoBattleTargetRank` (`src/autobattle.cpp`) computes
+    # its own `base_effect` via `Algo::CalcNormalAttackEffect`
+    # (`src/algo.cpp`), the *identical* function the real attack execution
+    # calls (`Game_BattleAlgorithm::Normal::Execute`,
+    # `src/game_battlealgorithm.cpp:716`) -- so real RPG_RT's ranking pass
+    # and the damage a thrown attack actually deals share the same RPG2003
+    # row modifiers (#row_adjusted?) and state-adjusted ATK/DEF
+    # (#effective_atk/#effective_def) by construction, not merely as an
+    # equivalent approximation. `#auto_battle_attack_target_rank` layers
+    # both in for exactly that reason (see its own citation).
     def choose_auto_battle_command(b)
       best_skill = nil
       best_sid = nil
@@ -12211,23 +12216,42 @@ module Game
     # EasyRPG's `CalcNormalAttackAutoBattleTargetRank`, `apply_variance:
     # false` (RpgRtCompat's own `attack_variance` flag) -- the base swing
     # (`Battle.attack_damage`, the same `atk/2 - def/4` formula #deal_attack
-    # itself hits with) is never spread by variance here, only scaled by the
-    # attacker's own weapon-Attribute multiplier. `emulate_bugs: true` skips
-    # the dual-wield swing-count multiplier entirely -- real RPG_RT's own
-    # documented bug, "Dual Attack is ignored" for ranking purposes, even
-    # though the swing itself still lands twice once actually thrown (see
-    # `Combatant#strike_count`, untouched by this). The `*1.5+0.5` first-
-    # enemy bonus and the final jitter-plus-`*1.5` reshaping both mirror
-    # `#auto_battle_damage_rank`'s and this function's own C++ counterpart
-    # exactly -- note the jitter step here runs unconditionally whenever
-    # `target` exists and this rank is positive, stacking with (not
-    # replacing) the first-enemy bonus above it, matching the source's own
-    # two independent `rank = rank*1.5+...` lines rather than folding them
-    # into one.
+    # itself hits with) is never spread by variance here. Confirmed against
+    # RPG_RT's own live source: `CalcNormalAttackAutoBattleTargetRank`
+    # (`src/autobattle.cpp`) computes its own `base_effect` by calling
+    # `Algo::CalcNormalAttackEffect` (`src/algo.cpp`) -- the *identical*
+    # function `Game_BattleAlgorithm::Normal::Execute`
+    # (`src/game_battlealgorithm.cpp:716`) calls to resolve the real swing --
+    # so the ranking pass reads the same state-adjusted ATK/DEF
+    # (`Game_Battler::GetAtk`/`GetDef`, ported here as #effective_atk/
+    # #effective_def) and the same RPG2003 attacker/defender row adjustment
+    # (`Feature::HasRow() && IsRowAdjusted(...)`, ported here as
+    # #row_adjusted?) the real attack applies, in the same order (attacker
+    # row -> weapon-Attribute multiplier -> defender row) -- not merely an
+    # equivalent approximation, but literally the same calculation call. A
+    # prior version of this comment (and of `#choose_auto_battle_command`'s
+    # own, see its citation) claimed the opposite -- that RPG_RT's own
+    # ranking pass deliberately omits row modifiers to avoid "double
+    # counting" them against the real attack -- an unverified, plausible-
+    # sounding inference rather than something read off this function's own
+    # source; the two calculations are not independent at all. `emulate_bugs:
+    # true` skips the dual-wield swing-count multiplier entirely -- real
+    # RPG_RT's own documented bug, "Dual Attack is ignored" for ranking
+    # purposes, even though the swing itself still lands twice once actually
+    # thrown (see `Combatant#strike_count`, untouched by this). The
+    # `*1.5+0.5` first-enemy bonus and the final jitter-plus-`*1.5`
+    # reshaping both mirror `#auto_battle_damage_rank`'s and this function's
+    # own C++ counterpart exactly -- note the jitter step here runs
+    # unconditionally whenever `target` exists and this rank is positive,
+    # stacking with (not replacing) the first-enemy bonus above it, matching
+    # the source's own two independent `rank = rank*1.5+...` lines rather
+    # than folding them into one.
     def auto_battle_attack_target_rank(b, target)
       return 0.0 unless target && !target.out_of_play?
-      dmg = Battle.attack_damage(b.atk || 0, target.def || 0)
+      dmg = Battle.attack_damage(effective_atk(b), effective_def(target))
+      dmg = 125 * dmg / 100 if row_adjusted?(b, true)
       dmg = apply_attr_multiplier(dmg, b.atk_attrs, target)
+      dmg = 75 * dmg / 100 if row_adjusted?(target, false)
       tgt_hp = target.hp
       return 0.0 if tgt_hp <= 0
       rank = [dmg, tgt_hp].min.to_f / tgt_hp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -18951,6 +18951,76 @@ check "battle: auto_battle_raw_cost's percent-cost branch is RPG2003-only, match
      'RPG2003: the percent formula applies -- 100 max_mp * 50% = 50'
 end
 
+check 'battle: auto_battle_attack_target_rank includes the RPG2003 attacker ' \
+      "row bonus, matching the real attack's own formula" do
+  # Confirmed directly against RPG_RT's live source: `Calc
+  # NormalAttackAutoBattleTargetRank` (`src/autobattle.cpp`) computes its own
+  # `base_effect` via `Algo::CalcNormalAttackEffect` (`src/algo.cpp`) -- the
+  # *identical* function `Game_BattleAlgorithm::Normal::Execute`
+  # (`src/game_battlealgorithm.cpp`) calls to resolve the real swing -- so a
+  # front-row attacker's ranking must include the same +25% bonus its real
+  # attack deals, not merely the raw, unadjusted damage. Two otherwise-
+  # identical battles seeded identically isolate the row difference from the
+  # ranking's own random jitter, since both draw the same first random value.
+  # #ally? (the row-adjustment attacker gate) keys off a Combatant carrying a
+  # live Game::Actor snapshot (`battler.actor`), so the attacker must be
+  # built via #from_actor, not the bare #combatant fixture #row_adjusted?
+  # would then always read as an enemy (never row-adjusted) regardless of
+  # #row. A second, front-row-and-able ally rides along in each battle so
+  # the constructor's own RPG2003 row safety net (every ally snaps to the
+  # front row if none of them can act from there) does not overwrite the
+  # single back-row attacker under test.
+  st1 = party_state
+  st2 = party_state
+  dummy_front1 = Game::Battle.from_actor(st1.party.actor_by_id(2))
+  attacker_front = Game::Battle.from_actor(st1.party.actor_by_id(1)) # atk 10, def 8
+  attacker_front.row = Game::Battle::ROW_FRONT
+  dummy_front2 = Game::Battle.from_actor(st2.party.actor_by_id(2))
+  attacker_back = Game::Battle.from_actor(st2.party.actor_by_id(1))
+  attacker_back.row = Game::Battle::ROW_BACK
+  # def 0, so the base swing (atk/2 - def/4 = 5) is large enough that the
+  # front row's +25% survives integer division (125*5/100 = 6, not rounded
+  # back down to 5) instead of being masked by truncation.
+  target_front = combatant('Foe', 0, 0, 5, 1000) # high hp, keeps the rank unsaturated
+  target_back = combatant('Foe', 0, 0, 5, 1000)
+
+  bat_front = Game::Battle.new([dummy_front1, attacker_front], [target_front], Game::Rng.new(1),
+                               nil, false, false, false, false, nil, nil, rpg2003: true)
+  bat_back = Game::Battle.new([dummy_front2, attacker_back], [target_back], Game::Rng.new(1),
+                              nil, false, false, false, false, nil, nil, rpg2003: true)
+  rank_front = bat_front.send(:auto_battle_attack_target_rank, attacker_front, bat_front.enemies.first)
+  rank_back = bat_back.send(:auto_battle_attack_target_rank, attacker_back, bat_back.enemies.first)
+  ok rank_front > rank_back,
+     "a front-row attacker's own +25% row bonus should rank higher than an " \
+     "identical back-row one, got front=#{rank_front} back=#{rank_back}"
+end
+
+check 'battle: auto_battle_attack_target_rank reads the target\'s ' \
+      'state-adjusted Defence, not its raw base stat' do
+  # Same citation as the row check above -- `CalcNormalAttackAutoBattleTarget
+  # Rank` shares `Algo::CalcNormalAttackEffect` with the real attack, and
+  # `Game_Battler::GetDef` (`src/game_battler.cpp`) folds in a currently-
+  # afflicted state's own halve/double Defence flag. A target whose Defence
+  # is halved by an active state must rank as easier to damage than an
+  # identical, unafflicted one.
+  states = { 2 => fake_state(affect_type: 0, affect_defense: true) } # 0 = halve
+  attacker1 = combatant('Attacker', 20, 0, 5, 100)
+  attacker2 = combatant('Attacker', 20, 0, 5, 100)
+  target_plain = combatant('Foe', 0, 10, 5, 1000)
+  target_halved = combatant('Foe', 0, 10, 5, 1000)
+  target_halved.states = [2]
+
+  bat_plain = Game::Battle.new([attacker1], [target_plain], Game::Rng.new(1), states)
+  bat_halved = Game::Battle.new([attacker2], [target_halved], Game::Rng.new(1), states)
+  rank_plain = bat_plain.send(:auto_battle_attack_target_rank, bat_plain.allies.first,
+                              bat_plain.enemies.first)
+  rank_halved = bat_halved.send(:auto_battle_attack_target_rank, bat_halved.allies.first,
+                                bat_halved.enemies.first)
+  ok rank_halved > rank_plain,
+     "a target with a halved Defence should rank easier to damage than an " \
+     "unafflicted one, got plain=#{rank_plain} halved=#{rank_halved}"
+end
+
 check 'battle: a Forced-AI actor picks a clearly-better Skill over Attack, with no manual command' do
   # 強制AI (mruby-lcf/mrblib/schema.rb, player/job field 23, force_ai) --
   # parsed but never read anywhere in mruby-rpg2k before this fix. Ported


### PR DESCRIPTION
## Summary

- `Game::Battle#auto_battle_attack_target_rank` (`mruby-rpg2k/mrblib/game.rb`) ranked a Forced-AI actor's plain Attack off raw, unadjusted `atk`/`def`. RPG_RT's own `CalcNormalAttackAutoBattleTargetRank` (`src/autobattle.cpp`) instead calls `Algo::CalcNormalAttackEffect` (`src/algo.cpp`) — the *identical* function `Game_BattleAlgorithm::Normal::Execute` (`src/game_battlealgorithm.cpp`) calls to resolve the real swing — which reads state-adjusted `Game_Battler::GetAtk`/`GetDef` (via `AdjustParam`) and, when `Feature::HasRow()`, applies the same row-adjusted 125%/75% front/back-row multiplier the real attack gets.
- So a Forced-AI actor's own ranking of a plain Attack must share its formula with the attack it would actually deal, not use an independent, flatter approximation — a front-row Forced-AI actor (or one targeting a back-row/state-weakened foe) could under-rank Attack relative to a competing Skill and pick the worse option.
- Fixed by routing the ranking formula through the same `#effective_atk`/`#effective_def` (`AdjustParam`-based) helpers and `#row_adjusted?` 125%/75% multiplier `#deal_attack_with_current_weapon` already uses for the real attack.
- Corrected two doc comments (on `#choose_auto_battle_command` and `#auto_battle_attack_target_rank` itself) that previously claimed ranking "deliberately... does not layer the RPG2003 row modifiers" — an unverified, plausible-sounding inference rather than something read off `CalcNormalAttackAutoBattleTargetRank`'s own source.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a front-row vs. back-row `Game::Battle.from_actor` attacker pair (low-Defence enemy so the 25% swing survives Ruby's integer-division truncation, plus a front-row "dummy" ally on each side so the constructor's own RPG2003 row-safety-net doesn't overwrite the lone back-row attacker under test) — confirmed to fail pre-fix (`front=1.00125 back=1.00125`, identical) and pass post-fix.
- [x] New check: a plain-vs-Defence-halving-state target pair — confirmed to fail pre-fix (`plain=1.008 halved=1.008`, identical) and pass post-fix.
- [x] All four suites green: `rpg2k_scene_check.rb` (854), `rpg2k_logic_check.rb` (1112), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_