### PR TITLE
Stop skipping a knocked-out member's map-step SP drain

### DIFF
--- a/changelog.d/map-step-damage-dead-member-sp.fixed.md
+++ b/changelog.d/map-step-damage-dead-member-sp.fixed.md
@@ -1,0 +1,4 @@
+- **Map:** a knocked-out party member's map-step status condition now still
+  drains/regens SP, matching RPG_RT -- previously it was skipped outright,
+  even though only the HP half of the same effect is supposed to silently
+  no-op on a dead member.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9945,6 +9945,36 @@ not yet verified:
   `#map_step_damaged?` itself (LOSE, bare GAIN, and mixed LOSE+GAIN-net-heal)
   and a new `scripts/rpg2k_scene_check.rb` end-to-end walking check, both
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **A knocked-out party member's map-step status condition is no longer
+  skipped outright -- its SP component still applies, matching RPG_RT, even
+  though its HP component silently no-ops.**
+  `Game::Party#apply_map_step_damage` (`mruby-rpg2k/mrblib/game.rb`) opened
+  its per-actor loop with `next if actor.nil? || actor.dead?`, skipping a
+  KO'd member's affliction entirely. Confirmed against EasyRPG's actual C++
+  source: `Game_Party::ApplyStateDamage` (`src/game_party.cpp`) iterates
+  `GetActors()` with no alive/dead filter at all, for both its HP loop and
+  its SP loop. The dead-guard lives one level down, and asymmetrically:
+  `Game_Battler::ChangeHp` (`src/game_battler.cpp`) opens with `if
+  (IsDead()) { return 0; }`, but its sibling `Game_Battler::ChangeSp` has no
+  such guard whatsoever — an SP-draining or SP-regenerating state keeps
+  ticking on a KO'd member exactly as it would on a living one. RPG_RT's own
+  `damage` bool (this codebase's `#map_step_damaged?`) is likewise set
+  unconditionally in the lose branch, regardless of whether `ChangeHp`
+  actually changed anything. This codebase's own `#change_hp`/`#change_mp`
+  already correctly mirror that asymmetry (`return @hp if dead?` only on the
+  HP side) — the caller-side `actor.dead?` skip was the sole bug, discarding
+  a dead member's SP change, its "hit"-array membership, and its
+  contribution to `#map_step_damaged?` all at once. ~~The method's own doc
+  comment previously claimed "A member who is already down slips nothing at
+  all" as if it were a confirmed RPG_RT rule~~ — no such guard exists in the
+  cited source; corrected in place. Fixed by removing `|| actor.dead?` from
+  the loop's `next` guard, relying on `#change_hp`'s own existing internal
+  no-op for the HP half. Covered by extending the existing `scripts/
+  rpg2k_logic_check.rb` "map slip damage cannot kill" check (which had
+  locked in the old, wrong exclusion) to expect the dead member in the
+  returned array, and a new check proving a dead member's SP-only state
+  component still lands and still sets `#map_step_damaged?`, both confirmed
+  to fail against the pre-fix code before the fix.
 - ✅ **A Conditional Branch of an unrecognized type now takes the else branch,
   instead of always taking the true one.** Confirmed against EasyRPG's
   actual C++ source: `Game_Interpreter::CommandConditionalBranch`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3723,8 +3723,21 @@ module Game
     # RPG_RT's rule, and it is why nothing on this path has to re-check for a
     # game over the way the twelve event commands that *can* wipe the party
     # do. A **gain** clamps to max_hp/max_sp the same way change_hp/change_mp
-    # already clamp an ordinary heal. A member who is already down slips
-    # nothing at all.
+    # already clamp an ordinary heal.
+    #
+    # A member who is already down does NOT slip nothing: EasyRPG's
+    # `Game_Party::ApplyStateDamage` (`src/game_party.cpp`) iterates
+    # `GetActors()` with no alive/dead filter at all, for both the HP and SP
+    # loops, and `Game_Battler::ChangeSp` (`src/game_battler.cpp`) carries no
+    # `IsDead()` guard of its own -- only `ChangeHp` does (`if (IsDead())
+    # return 0;`, matching this class's own `#change_hp`'s `return @hp if
+    # dead?`). So a KO'd member's own HP loss silently no-ops (already true
+    # via #change_hp), but an SP-draining/regenerating state on that same
+    # member still applies in full, and RPG_RT's `damage` bool -- set
+    # unconditionally in the lose branch regardless of whether `ChangeHp`
+    # actually changed anything -- still fires. This method mirrors that: it
+    # must not skip a dead actor outright, only rely on #change_hp's own
+    # internal no-op for the HP half.
     #
     # `table` is the database `situation` array; a caller without one (the seeded
     # harness fixtures) drains nothing. Returns the actors actually affected
@@ -3734,7 +3747,7 @@ module Game
       hit = []
       @map_step_damaged = false
       @actors.each do |actor|
-        next if actor.nil? || actor.dead?
+        next if actor.nil?
         hp = 0
         sp = 0
         actor.states.each do |id|

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15729,11 +15729,37 @@ check 'map slip damage cannot kill: it floors at 1 HP' do
   eq 1, hero.hp, 'and walking on keeps it there'
   eq false, st.party.all_dead?
 
-  # A member already down slips nothing at all.
+  # A member already down is not skipped outright -- EasyRPG's
+  # `Game_Party::ApplyStateDamage` iterates every actor with no alive/dead
+  # filter, and only `ChangeHp` (not the caller) has its own dead-guard, so a
+  # dead member's affliction is still reported as "hit" even though the HP
+  # loss itself silently no-ops via #change_hp.
   ally = st.party.actor_by_id(2)
   ally.add_state(2)
   ally.set_hp(0)
-  eq [hero], st.party.apply_map_step_damage(table, 3)
+  eq [hero, ally], st.party.apply_map_step_damage(table, 3)
+  eq 0, ally.hp, 'the HP loss itself still no-ops on a dead member'
+end
+
+# Ports EasyRPG's `Game_Battler::ChangeSp` (`src/game_battler.cpp`), which --
+# unlike `ChangeHp` -- carries no `IsDead()` guard at all: a map-step state's
+# SP component keeps applying to a KO'd member exactly as it would to a
+# living one, even though that same member's HP component is silently
+# absorbed by `ChangeHp`'s own dead-guard.
+check "a dead member's SP-draining state still applies, unlike its HP half" do
+  table = { 2 => fake_state(name: 'Drain', hp_map_steps: 1, hp_map_val: 5,
+                             sp_map_steps: 1, sp_map_val: 3) }
+  st = party_state
+  ally = st.party.actor_by_id(2)
+  ally.add_state(2)
+  ally.set_hp(0)
+  before_mp = ally.mp
+  hit = st.party.apply_map_step_damage(table, 1)
+  eq [ally], hit
+  eq 0, ally.hp, 'a dead member cannot lose HP it does not have'
+  eq before_mp - 3, ally.mp, 'but the same state\'s SP loss still lands'
+  eq true, st.party.map_step_damaged?,
+     'a dead-only affected member\'s own lose-type state still counts as damage'
 end
 
 check 'map slip damage: a GAIN-type state heals instead of draining, clamped to max_hp/max_sp' do


### PR DESCRIPTION
## Summary

- `Game::Party#apply_map_step_damage` (`mruby-rpg2k/mrblib/game.rb`) opened its per-actor loop with `next if actor.nil? || actor.dead?`, skipping a KO'd member's afflicted state entirely.
- RPG_RT's own `Game_Party::ApplyStateDamage` (`src/game_party.cpp`) iterates `GetActors()` with no alive/dead filter at all, for both its HP loop and its SP loop.
- The dead-guard lives one level down, and asymmetrically: `Game_Battler::ChangeHp` (`src/game_battler.cpp`) opens with `if (IsDead()) { return 0; }`, but its sibling `Game_Battler::ChangeSp` has no such guard whatsoever — an SP-draining/regenerating state keeps ticking on a KO'd member exactly as it would on a living one. RPG_RT's own `damage` bool (this codebase's `#map_step_damaged?`) is likewise set unconditionally in the lose branch, regardless of whether `ChangeHp` actually changed anything.
- This codebase's own `#change_hp`/`#change_mp` already correctly mirror that asymmetry (`return @hp if dead?` only on the HP side) — the caller-side `actor.dead?` skip was the sole bug, discarding a dead member's SP change, its "hit"-array membership, and its contribution to `#map_step_damaged?` all at once.
- The method's own doc comment previously claimed "A member who is already down slips nothing at all" as if it were a confirmed RPG_RT rule; no such guard exists in the cited source, so it's corrected in place.
- Fixed by removing `|| actor.dead?` from the loop's `next` guard, relying on `#change_hp`'s own existing internal no-op for the HP half.

## Test plan

- [x] Extended the existing `scripts/rpg2k_logic_check.rb` "map slip damage cannot kill" check (which had locked in the old, wrong exclusion) to expect the dead member in the returned array, and confirmed the HP loss itself still no-ops.
- [x] New check proving a dead member's SP-only state component still lands and still sets `#map_step_damaged?` — confirmed to fail pre-fix (`expected [...], got []`) and pass post-fix.
- [x] All four suites green: `rpg2k_scene_check.rb` (854), `rpg2k_logic_check.rb` (1113), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_