### PR TITLE
Auto-dismiss the shop purchase/sale confirmation on a timer, not a button

### DIFF
--- a/changelog.d/shop-purchased-confirmation-timed-dismiss.fixed.md
+++ b/changelog.d/shop-purchased-confirmation-timed-dismiss.fixed.md
@@ -1,0 +1,4 @@
+- **Menus:** the shop's "Thank you!" purchase/sale confirmation now
+  auto-dismisses after a flat one-second timer, matching RPG_RT -- previously
+  it waited for a button press, and a button press during it had no effect
+  at all in the original game.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1390,6 +1390,28 @@ The work below is roughly ordered by the critical path to a walkable game
   cancelling back out leaves the cursor on Sell, not reset to Buy),
   confirmed to fail against the pre-fix code (`expected 1, got 0`) before
   the fix.
+  ✅ **Follow-up (2026-08-21): the purchased/sold confirmation line waited
+  for a button press to dismiss, instead of auto-dismissing after a flat
+  one-second timer with no input read at all.** `#drive_shop_confirm`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — introduced by the fix directly
+  above, whose own doc comment ~~called this "button-driven ... to match
+  every other message screen in this scene", flagging EasyRPG's timed
+  auto-dismiss as a deliberate deviation~~ — waited on `Input.trigger?(C) ||
+  Input.trigger?(B)`. Confirmed against EasyRPG's actual C++ source:
+  `Scene_Shop::vUpdate`'s `Bought`/`Sold` cases (`src/scene_shop.cpp`) are a
+  bare `timer--; if (timer == 0) SetMode(Buy/Sell);`, with `SetMode` arming
+  `timer = DEFAULT_FPS` (`src/options.h`: `#define DEFAULT_FPS 60`) on
+  entry; `UpdateNumberInput` — the only place this scene's Buy/Sell flow
+  reads `Input::` — has no `Bought`/`Sold` case at all, so a button press
+  neither dismisses the confirmation early nor does anything else while it
+  is up. Fixed by replacing the input check with a `@shop[:confirm_timer]`
+  countdown (armed to 60 the same frame `#drive_shop_quantity` enters
+  `:purchased`/`:sold`), the same per-frame countdown idiom already used
+  elsewhere in this file (e.g. the Wait command's own frame timer). Covered
+  by extending four existing `scripts/rpg2k_scene_check.rb` checks (a
+  button press alone no longer dismisses the confirmation; the screen only
+  advances once 60 frames have actually elapsed), all confirmed to fail
+  against the pre-fix code before the fix.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5383,14 +5383,19 @@ class RPG2k
       end
 
       # The purchased / sold confirmation shown right after a transaction
-      # commits (Game::Shop#buy / #sell): a single line, dismissed on a
-      # button press the same way the battle event message panel is (see
-      # #drive_battle_event_message), then back to the list it came from --
-      # EasyRPG's own Scene_Shop::Bought / Sold modes return to Buy / Sell
-      # respectively (a timed auto-dismiss there; button-driven here to match
-      # every other message screen in this scene).
+      # commits (Game::Shop#buy / #sell): a single line, auto-dismissed after
+      # a flat one-second timer, then back to the list it came from.
+      # Confirmed directly against EasyRPG's live source, `Scene_Shop::
+      # vUpdate` (src/scene_shop.cpp): its `Bought` / `Sold` cases are a bare
+      # `timer--; if (timer == 0) SetMode(Buy/Sell);`, and `SetMode` arms
+      # `timer = DEFAULT_FPS` (`src/options.h`: `#define DEFAULT_FPS 60`) on
+      # entry. `UpdateNumberInput` -- the only place this scene reads
+      # `Input::` during the Buy/Sell flow -- has no `Bought`/`Sold` case at
+      # all, so a button press neither dismisses the confirmation early nor
+      # does anything else while it is up.
       def drive_shop_confirm
-        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        @shop[:confirm_timer] -= 1
+        return if @shop[:confirm_timer] > 0
         @shop[:screen] = @shop[:screen] == :purchased ? :buy : :sell
         @shop[:quantity] = nil
         draw_shop
@@ -5432,6 +5437,7 @@ class RPG2k
           # panel there still needs its item id (see #shop_status_item_id) --
           # and is only cleared once #drive_shop_confirm leaves the screen.
           @shop[:screen] = mode == :buy ? :purchased : :sold
+          @shop[:confirm_timer] = 60
           draw_shop
           play_system_se(SFX_DECISION)
         elsif Input.trigger?(Input::B)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6467,10 +6467,10 @@ check 'Open Shop scene: buying then leaving runs the Transaction branch' do
   scene.update
   eq 400, st.party.gold, 'one Potion bought'
   eq 1, st.party.item_count(3)
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the "purchased" confirmation
-  scene.update
-  RGSS::Input.triggered = []
-  scene.update
+  # The "purchased" confirmation only leaves once its own 60-frame timer
+  # expires -- Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) never
+  # reads Input::, so a button press does not skip it.
+  60.times { scene.update }
   RGSS::Input.triggered = [RGSS::Input::B] # leave the shop
   scene.update
   scene.update # the Transaction branch runs
@@ -6623,9 +6623,15 @@ check 'Open Shop scene: confirming the counter buys the whole stack at once' do
   eq 3, st.party.item_count(3), 'three bought in one confirm'
   shop = scene.instance_variable_get(:@shop)
   eq :purchased, shop[:screen], 'the "purchased" confirmation shows first'
+  # RPG_RT auto-dismisses the confirmation after a flat one-second (60 frame)
+  # timer -- Scene_Shop::vUpdate's Bought/Sold cases (src/scene_shop.cpp)
+  # never read Input:: at all -- so a button press alone does nothing here.
   press(scene, RGSS::Input::C)
   shop = scene.instance_variable_get(:@shop)
-  eq :buy, shop[:screen], 'and dismissing it returns to the buy list'
+  eq :purchased, shop[:screen], 'a button press does not dismiss it early'
+  59.times { scene.update }
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen], 'and the timer expiring on its own returns to the buy list'
 end
 
 check 'Open Shop scene: cancelling the counter buys nothing' do
@@ -6829,10 +6835,10 @@ check 'Open Shop issued from a Parallel Process opens the shop screen too' do
   scene.update
   eq 400, st.party.gold, 'one Potion bought'
   eq 1, st.party.item_count(3)
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the "purchased" confirmation
-  scene.update
-  RGSS::Input.triggered = []
-  scene.update
+  # The "purchased" confirmation only leaves once its own 60-frame timer
+  # expires -- Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) never
+  # reads Input::, so a button press does not skip it.
+  60.times { scene.update }
   RGSS::Input.triggered = [RGSS::Input::B] # leave the shop
   scene.update
   scene.update
@@ -14804,13 +14810,20 @@ check 'Open Shop scene: buying shows the shop_purchased confirmation, then retur
   ok window_texts(shop[:window]).any? { |t| t.include?('毎度あり！') },
      'the confirmation line uses the database shop_purchased term'
 
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the confirmation
+  # Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) is a bare
+  # `timer--; if (timer == 0) SetMode(Buy);` with no Input:: read at all, so
+  # a button press does nothing here -- only the flat 60-frame timer (armed
+  # by SetMode, DEFAULT_FPS in src/options.h) dismisses it.
+  RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.triggered = []
-  scene.update
   shop = scene.instance_variable_get(:@shop)
-  eq :buy, shop[:screen], 'a button press returns to the buy list, same as EasyRPG\'s ' \
-                          'Bought -> Buy transition'
+  eq :purchased, shop[:screen], 'a button press does not dismiss it early'
+
+  59.times { scene.update }
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen], 'the timer expiring on its own returns to the buy list, ' \
+                          'same as EasyRPG\'s Bought -> Buy transition'
 end
 
 check 'Open Shop scene: selling shows the shop_sold confirmation, then returns ' \
@@ -14842,12 +14855,18 @@ check 'Open Shop scene: selling shows the shop_sold confirmation, then returns '
   ok window_texts(shop[:window]).any? { |t| t.include?('毎度！') },
      'the confirmation line uses the database shop_sold term'
 
-  RGSS::Input.triggered = [RGSS::Input::B] # dismiss the confirmation (B works too)
+  # Scene_Shop::vUpdate's Sold case (src/scene_shop.cpp) never reads Input::
+  # either -- B does not dismiss it early any more than C does.
+  RGSS::Input.triggered = [RGSS::Input::B]
   scene.update
   RGSS::Input.triggered = []
-  scene.update
   shop = scene.instance_variable_get(:@shop)
-  eq :sell, shop[:screen], 'and returns to the sell list, same as EasyRPG\'s Sold -> Sell'
+  eq :sold, shop[:screen], 'a button press does not dismiss it early'
+
+  59.times { scene.update }
+  shop = scene.instance_variable_get(:@shop)
+  eq :sell, shop[:screen], 'the timer expiring on its own returns to the sell list, ' \
+                           'same as EasyRPG\'s Sold -> Sell'
 end
 
 # Confirmed against RPG_RT's own live source: `Window_ShopSell`
@@ -14953,9 +14972,10 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   ok !shop[:status].nil?,
      'the purchase confirmation keeps the status panel visible too (Scene_Shop::SetMode\'s Bought case)'
 
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the confirmation, back to the buy list
-  scene.update
-  RGSS::Input.triggered = []
+  # The confirmation only leaves once its own 60-frame timer runs out --
+  # Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) never reads
+  # Input:: at all.
+  60.times { scene.update } # the timer expires, back to the buy list
   shop = scene.instance_variable_get(:@shop)
   eq :buy, shop[:screen]
   ok !shop[:status].nil?, 'the panel returns once a good is highlighted again'


### PR DESCRIPTION
## Summary

- `#drive_shop_confirm` (`mruby-rpg2k/mrblib/scene/map.rb`) waited for `Input.trigger?(C)`/`Input.trigger?(B)` to leave the shop's "Thank you!" purchase/sale confirmation screen. Its own doc comment flagged this as a deliberate deviation from EasyRPG's timed auto-dismiss.
- Confirmed against EasyRPG's actual C++ source: `Scene_Shop::vUpdate`'s `Bought`/`Sold` cases (`src/scene_shop.cpp`) are a bare `timer--; if (timer == 0) SetMode(Buy/Sell);`, with `SetMode` arming `timer = DEFAULT_FPS` (`src/options.h`: `#define DEFAULT_FPS 60`) on entry. `UpdateNumberInput` — the only place this scene's Buy/Sell flow reads `Input::` — has no `Bought`/`Sold` case at all, so a button press neither dismisses the confirmation early nor does anything else while it is up.
- So real RPG_RT never requires a button press to leave "Thank you!", and a button press during it does nothing — it's a flat one-second timed screen.
- Fixed by replacing the input check in `#drive_shop_confirm` with a `@shop[:confirm_timer]` countdown, armed to 60 the same frame `#drive_shop_quantity` enters `:purchased`/`:sold` — the same per-frame countdown idiom already used elsewhere in this file.
- Corrected the stale doc comment that called the old button-driven behavior deliberate.

## Test plan

- [x] Extended four existing `scripts/rpg2k_scene_check.rb` checks (buy confirmation, sell confirmation, status-panel-visibility-through-confirmation, buy-then-leave-Transaction-branch, and the Parallel-Process-issued Open Shop variant) to assert a button press alone no longer dismisses the confirmation, and that the screen only advances once 60 frames have actually elapsed.
- [x] All six affected assertions confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/scene/map.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (854), `rpg2k_logic_check.rb` (1113), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_