### PR TITLE
Tally the "Other" battle counters at battle end, not scattered across it

### DIFF
--- a/changelog.d/battle-counters-tally-at-battle-end.fixed.md
+++ b/changelog.d/battle-counters-tally-at-battle-end.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** the Control Variables "Other" battle counters (battles
+  entered / won / lost / escaped) now tally only once a fight actually
+  concludes, matching RPG_RT -- previously the battle-entered count ticked
+  the instant an Enemy Encounter was armed, well before the fight screen
+  even opened, and a game-over-ending defeat never counted at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15901,10 +15901,16 @@ not yet verified:
   table has no `:abort` key either, so an unmatched lookup (`want = nil`)
   never finds a `[Victory]`/`[Escape]`/`[Defeat]` marker and instead lands on
   the encounter's own `END_BATTLE` — resuming the event right after Branch
-  End, exactly as the site describes. `battle_count` (the "a battle was
+  End, exactly as the site describes. ~~`battle_count` (the "a battle was
   entered" tally the site's "battle-count stat" bullet half refers to) is
   bumped once at `do_enemy_encounter`, independent of any outcome, so it is
-  untouched by this path either way. No code change was needed for the game
+  untouched by this path either way.~~ **Wrong about *when* `battle_count`
+  bumps, corrected below (2026-08-21): real RPG_RT bumps it at battle *end*,
+  not the instant the encounter is armed** — see the Follow-up bullet right
+  after this one. The claim that Terminate Battle's own outcome leaves it
+  untouched either way still held (it is bumped for every outcome, Abort
+  included), just not at the moment or by the mechanism originally
+  described. No code change was needed for the game
   logic — but the existing `scripts/rpg2k_scene_check.rb` check that looked
   like it already covered this (`'Terminate Battle from a page ends the
   fight and resumes the event'`) had a loop bug: `12.times { scene.update;
@@ -15923,6 +15929,38 @@ not yet verified:
   `win_count`/`escape_count`/`defeat_count` all `0` and neither handler
   switch set — confirmed to fail against both an injected win-count bug and
   an injected `BATTLE_HANDLERS[:abort]` mapping.
+  ✅ **Follow-up (2026-08-21): the "Other" battle counters were tallied
+  scattered across the wrong moments — `battle_count` at the instant an
+  encounter is armed rather than when the fight actually ends, and
+  `win_count`/`defeat_count`/`escape_count` in a resume path a game-over-
+  ending defeat skips entirely.** `Interpreter#do_enemy_encounter` and
+  `#start_random_battle` (`mruby-rpg2k/mrblib/interpreter.rb`) both bumped
+  `@state.battle_count` the instant the encounter was armed, before the
+  fight screen had even opened; `#resume_battle` bumped `win_count`/
+  `defeat_count`/`escape_count` — but `Scene::Battle#finish_battle`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) only calls `owner.resume_battle`
+  in its non-game-over branch, so a defeat ending the game (no custom
+  [Defeat] handler, whole party down) never reached it at all. Confirmed
+  against EasyRPG's actual C++ source: `Scene_Battle::EndBattle`
+  (`src/scene_battle.cpp`) is the single choke point for all four —
+  `Main_Data::game_party->IncBattleCount();` unconditionally, then a
+  `switch (result)` bumping the matching Victory/Escape/Defeat counter
+  (`Abort` does nothing extra) — called only once the fight actually
+  concludes, with the Game-Over `Scene::Push` itself wired in as
+  `EndBattle`'s own `on_battle_end` callback, invoked *after* the counters
+  update, so a game-over-ending defeat still counts. Fixed by moving all
+  four increments into `Scene::Battle#finish_battle`, run unconditionally
+  before its `game_over`/`else` branch (mirroring `EndBattle`'s own
+  ordering), and deleting the scattered increments from
+  `do_enemy_encounter`, `#start_random_battle` and `#resume_battle`.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (the
+  battle-entry count stays at 0 while the fight is still open, only ticking
+  once it actually closes; a game-over-ending defeat still counts as both a
+  battle entered and a defeat) and a rewritten `scripts/rpg2k_logic_check.rb`
+  check (arming an encounter and resuming its outcome no longer touch any
+  of the four counters at the bare-interpreter level at all, now that the
+  tally lives solely in `Scene::Battle#finish_battle`), all three confirmed
+  to fail against the pre-fix code before the fix.
 - ✅ **Enemy Appearance (Show Hidden Monster) already gets both halves of this
   right.** Targeting an already-appeared enemy is a silent no-op:
   `Scene::Map#reveal_battle_monster` (`mruby-rpg2k/mrblib/scene/map.rb`)

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -807,17 +807,15 @@ module Game
 
     # Resume an Enemy Encounter with the battle's outcome (:victory, :escape or
     # :defeat). Rewards (EXP / gold on victory) are granted by the scene, which
-    # owns the battle; this only steers event flow. Escape with the "end event
-    # processing" mode abandons the rest of the event; otherwise, when the
-    # command carries [Victory] / [Escape] / [Defeat] handler branches, jump into
-    # the matching one. A game-over on defeat is the scene's concern.
+    # owns the battle; this only steers event flow. The Control Variables
+    # "Other" battle counters are already tallied by the time this runs --
+    # Scene::Battle#finish_battle's job now, unconditionally, matching
+    # EasyRPG's `Scene_Battle::EndBattle` -- so a game-over-ending defeat
+    # (which skips this method entirely) still counts. Escape with the "end
+    # event processing" mode abandons the rest of the event; otherwise, when
+    # the command carries [Victory] / [Escape] / [Defeat] handler branches,
+    # jump into the matching one. A game-over on defeat is the scene's concern.
     def resume_battle(result)
-      # Tally the outcome for the Control Variables "Other" operand.
-      case result
-      when :victory then @state.win_count += 1
-      when :defeat  then @state.defeat_count += 1
-      when :escape  then @state.escape_count += 1
-      end
       if result == :escape && @battle_escape_aborts
         @index = @list.size
         @call_stack = []
@@ -1490,7 +1488,6 @@ module Game
       when 1 then @battle_request[:background] = cmd.string.to_s
       when 2 then @battle_request[:terrain_id] = cmd.param(8)
       end
-      @state.battle_count += 1 # a battle was entered (Control Variables "Other")
       @wait_kind = :battle
       @waiting = true
     end
@@ -1506,8 +1503,8 @@ module Game
     # into the [Escape] handler if the command carries one, ending the event
     # outright under the "abort on escape" escape mode, or otherwise simply
     # falling through to the command right after the encounter -- but does not
-    # bump the win/escape/defeat "Other" battle counters (#resume_battle's
-    # job), since no battle was ever actually fought.
+    # bump the "Other" battle counters (Scene::Battle#finish_battle's job),
+    # since no battle was ever actually fought.
     def skip_invalid_troop(troop_id)
       $stderr.puts "[RPG2k] Enemy Encounter: enemy group #{troop_id} not " \
                    'found, skipping battle'
@@ -1525,8 +1522,10 @@ module Game
     # not a command in any list. Same request shape #do_enemy_encounter
     # builds and the same :battle wait, but with no [Victory]/[Escape]/[Defeat]
     # handler to route into and nothing to end early on an "abort" escape
-    # mode, so #resume_battle's job shrinks to tallying the outcome and
-    # clearing the wait. Only valid while this interpreter is otherwise idle
+    # mode, so #resume_battle's job shrinks to just clearing the wait --
+    # Scene::Battle#finish_battle tallies the "Other" battle counters for
+    # every encounter, scripted or random alike. Only valid while this
+    # interpreter is otherwise idle
     # (Scene::Map only calls it from ordinary player movement, never while an
     # event is running); escape is always allowed. A wipe is game over unless
     # the database's own RPG2003 Death Handler is active
@@ -1557,7 +1556,6 @@ module Game
                           first_strike: first_strike,
                           defeat_game_over: !party.death_handler?, random: true,
                           headless: headless ? true : false }
-      @state.battle_count += 1
       @wait_kind = :battle
       @waiting = true
     end

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2604,6 +2604,20 @@ class RPG2k
         # this is RPG2000's "turns passed in latest battle" (Game::State
         # #last_battle_turns, LCF inventory chunk 109 field 41).
         @state.last_battle_turns = @ui[:battle].turn
+        # Tally the Control Variables "Other" battle counters here, together and
+        # unconditionally, matching EasyRPG's `Scene_Battle::EndBattle`
+        # (`src/scene_battle.cpp`): `IncBattleCount()` runs for every result
+        # (victory/escape/defeat/abort alike) before the individual win/escape/
+        # defeat counter and before the game-over dispatch that can follow a
+        # defeat -- not scattered across the moment the encounter is armed (long
+        # before the fight has actually concluded) and a resume path a
+        # game-over-ending defeat skips entirely.
+        @state.battle_count += 1
+        case result
+        when :victory then @state.win_count += 1
+        when :defeat  then @state.defeat_count += 1
+        when :escape  then @state.escape_count += 1
+        end
         # A defeat in "game over" mode (no custom [Defeat] handler) with the whole
         # party knocked out ends the game; every other outcome resumes the event.
         game_over = result == :defeat && @req[:defeat_game_over] &&

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8268,16 +8268,28 @@ ensure
   RGSS::Audio.bgm_pos = nil
 end
 
-check 'battle counters advance: Enemy Encounter and its outcome' do
+# Confirmed against EasyRPG's actual C++ source: `Scene_Battle::EndBattle`
+# (`src/scene_battle.cpp`) tallies all four "Other" battle counters together,
+# unconditionally, at battle *end* -- not scattered across the moment an
+# Enemy Encounter arms its wait (well before the fight has even opened) and
+# a resume path a game-over-ending defeat can skip. This codebase's own
+# counterpart is `Scene::Battle#finish_battle` (`mruby-rpg2k/mrblib/scene/
+# battle.rb`, covered end-to-end by `scripts/rpg2k_scene_check.rb`'s "the
+# battle-entry count does not tick until the fight actually ends" and "a
+# game-over-ending fight still counts as a battle entered" checks); at the
+# bare-interpreter level exercised here, neither arming the encounter nor
+# #resume_battle touches any of the four counters any more.
+check 'Enemy Encounter and #resume_battle leave the "Other" battle counters ' \
+      'untouched -- that tally now happens only in Scene::Battle#finish_battle' do
   st = new_state
   it = Game::Interpreter.new(st)
   # Enemy Encounter (troop 1, no handlers): suspends on a :battle wait.
   it.start([FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 1, 0, 0, 0, 0])])
   it.update
-  eq 1, st.battle_count, 'entering a battle bumps the battle count'
-  eq 0, st.win_count
+  eq 0, st.battle_count, 'arming the encounter alone does not bump it here'
   it.resume_battle(:victory)
-  eq 1, st.win_count, 'a victory bumps the win count'
+  eq 0, st.battle_count, 'nor does resuming the outcome'
+  eq 0, st.win_count
   eq 0, st.defeat_count
   eq 0, st.escape_count
 end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7657,6 +7657,13 @@ check 'Enemy Encounter scene: a game-over defeat returns to the title' do
   RGSS::Input.triggered = []
   ok parent.game_over_shown, 'a game-over defeat reached the Game Over screen'
   ok !st.switches[5], 'the rest of the event never ran'
+  # Confirmed against EasyRPG's `Scene_Battle::EndBattle` (`src/
+  # scene_battle.cpp`): the "Other" battle counters are bumped there,
+  # unconditionally, before the Game Over dispatch that can follow a
+  # defeat -- a game-over-ending defeat still counts, even though the event
+  # that opened the fight is abandoned and never resumed.
+  eq 1, st.battle_count, 'a game-over-ending fight still counts as a battle entered'
+  eq 1, st.defeat_count, 'and still counts as a defeat, even though the event never resumes'
 end
 
 check 'Game Over event command returns to the title, abandoning the event' do
@@ -14283,6 +14290,31 @@ check 'Terminate Battle matches neither Win/Escape/Defeat and only bumps the bat
   eq 0, st.win_count
   eq 0, st.escape_count
   eq 0, st.defeat_count
+end
+
+# Confirmed against EasyRPG's actual C++ source: `Scene_Battle::EndBattle`
+# (`src/scene_battle.cpp`) only ever bumps `IncBattleCount()` there, at
+# battle *end* -- not when the encounter is first armed, well before the
+# fight screen has even opened.
+check "the battle-entry count does not tick until the fight actually ends, " \
+      'not the instant it is entered' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }
+  scene, st = battle_scene_with_pages(pages)
+  eq 0, st.battle_count, 'not yet entered'
+  10.times do
+    scene.update
+    break if battle_ui(scene)
+  end
+  ok battle_ui(scene), 'the battle screen is up'
+  eq 0, st.battle_count,
+     'still not counted -- the fight has not concluded yet, only opened'
+  100.times do
+    scene.update
+    break if battle_ui(scene).nil?
+  end
+  eq nil, battle_ui(scene), 'the battle closed'
+  eq 1, st.battle_count, 'and only now does the count tick, once'
 end
 
 check 'a battle-valid Timer reaching 0:00 force-ends the fight (yado.tk)' do


### PR DESCRIPTION
## Summary

- The Control Variables "Other" battle counters (`battle_count`/`win_count`/`defeat_count`/`escape_count`) were bookkept inconsistently with RPG_RT, in two related ways:
  1. `battle_count` was incremented the instant an Enemy Encounter was armed (`Interpreter#do_enemy_encounter`/`#start_random_battle`, `mruby-rpg2k/mrblib/interpreter.rb`), well before the fight screen had even opened.
  2. `win_count`/`defeat_count`/`escape_count` were only tallied in `Interpreter#resume_battle` — but `Scene::Battle#finish_battle` (`mruby-rpg2k/mrblib/scene/battle.rb`) only calls `owner.resume_battle` in its non-game-over branch, so a defeat that ends the game (no custom [Defeat] handler, whole party down) never reached it, and the defeat never counted at all.
- Confirmed against EasyRPG's actual C++ source: `Scene_Battle::EndBattle` (`src/scene_battle.cpp`) is the single choke point for all four counters — `Main_Data::game_party->IncBattleCount();` unconditionally, then a `switch (result)` bumping the matching Victory/Escape/Defeat counter (`Abort` does nothing extra) — called only once the fight actually concludes. The Game-Over `Scene::Push` is wired in as `EndBattle`'s own `on_battle_end` callback, invoked *after* the counters update, so a game-over-ending defeat still counts in real RPG_RT.
- Fixed by moving all four increments into `Scene::Battle#finish_battle`, run unconditionally before its `game_over`/`else` branch (mirroring `EndBattle`'s own ordering), and deleting the scattered increments from `do_enemy_encounter`, `#start_random_battle`, and `#resume_battle`.
- Corrected a prior `docs/TODO.md` bullet that had asserted `battle_count`'s old at-encounter-start timing was correct.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks: the battle-entry count stays at 0 while the fight is still open, only ticking once it actually closes; a game-over-ending defeat still counts as both a battle entered and a defeat.
- [x] Rewrote a `scripts/rpg2k_logic_check.rb` check that had locked in the old behavior — it now confirms arming an encounter and resuming its outcome no longer touch any of the four counters at the bare-interpreter level, since the tally lives solely in `Scene::Battle#finish_battle`.
- [x] All three new/rewritten assertions confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/interpreter.rb mruby-rpg2k/mrblib/scene/battle.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (855), `rpg2k_logic_check.rb` (1113), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_