### PR TITLE
Give idling Continuous/Spin event animation their own, slower cadence

### DIFF
--- a/changelog.d/event-idle-animation-cadence.fixed.md
+++ b/changelog.d/event-idle-animation-cadence.fixed.md
@@ -1,0 +1,6 @@
+- **Map:** a Continuous/Fixed-Continuous event's idle walk-frame cycle and a
+  Spin event's facing rotation now use their own, slower cadence, matching
+  RPG_RT -- previously both reused the same (faster) cadence an event uses
+  while actually sliding between tiles, so decorative "always animates"
+  events (torches, waterwheels) and rotating events visibly animated too
+  fast while standing still.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7474,7 +7474,10 @@ Everything below is unverified against the codebase.
   over a 256-unit tile (speed 1..6 → 4..128 units → 64..2 frames/tile) and
   jumps via `jump_speed[] = {8,12,16,24,32,64}`; its animation frames come
   from `GetStationaryAnimFrames`/`GetContinuousAnimFrames` (`{12,10,8,6,5,4}`
-  / `{16,12,10,8,7,6}`). The two coincidental-at-"Normal" tables, the zero
+  / `{16,12,10,8,7,6}`) ~~— and, for a Spin-type event, `GetSpinAnimFrames`
+  (`{24,16,12,8,6,4}`)~~ **, though only the first of those three tables was
+  actually ported here at the time — corrected below (2026-08-21).** The two
+  coincidental-at-"Normal" tables, the zero
   readers of `Character#move_speed`, and the subpixel requirement were the
   three reasons this was deferred before the subpixel accumulator made a
   single-pass, non-re-baselining fix possible.
@@ -7513,6 +7516,41 @@ Everything below is unverified against the codebase.
   clamping up) and a corrected existing `scripts/rpg2k_logic_check.rb`
   clamp-bounds check; the full scene suite (725 checks) and logic suite
   (1006 checks) still pass.
+  ✅ **Follow-up (2026-08-21): a Continuous/Fixed-Continuous or Spin-type
+  event standing still cycled its walk frame / facing rotation on the same
+  (fastest) cadence as an event actually sliding between tiles, instead of
+  its own, slower one.** `Scene::Map#animate_event`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) called `#anim_frame_period` — backed
+  by `ANIM_STATIONARY_FRAMES` alone — for every animated event regardless of
+  why it was animating: genuinely sliding, or merely idling with a
+  Continuous/Fixed-Continuous/Spin type forcing it to keep animating in
+  place. Confirmed against EasyRPG's live source, `Game_Character::
+  UpdateAnimation` (`src/game_character.cpp`): a spinning event reads
+  `GetSpinAnimFrames` unconditionally, before any movement test at all, and
+  an ordinary event blends `GetContinuousAnimFrames` (idling Continuous) and
+  `GetStationaryAnimFrames` (`stopped && anim_count >= stationary_limit`,
+  i.e. genuinely mid-step) — three distinct, non-interchangeable tables
+  (`{12,10,8,6,5,4}` / `{16,12,10,8,7,6}` / `{24,16,12,8,6,4}`), only the
+  first of which this codebase had ever added. Concretely: a speed-3
+  (internal 2) Continuous decorative event (a torch, a waterwheel, an
+  "always animates" NPC — a common RPG2000 authoring idiom) cycled every 8
+  frames standing still instead of the real 10; a same-speed Spin event
+  rotated its facing every 8 frames instead of the real 12 — noticeably too
+  fast in both cases. Fixed by adding `ANIM_CONTINUOUS_FRAMES`/
+  `ANIM_SPIN_FRAMES` (and matching `#anim_continuous_period`/
+  `#anim_spin_period` helpers) and having `#animate_event` pick sliding vs.
+  Spin vs. idling-Continuous by case, rather than always calling
+  `#anim_frame_period`. This is a deliberate simplification of `Update
+  Animation`'s own dual-condition blend (which also settles a *moving*
+  Continuous event onto the stationary cadence once it stops mid-frame, and
+  holds the sprite on its left/right pose until the count catches up) —
+  only the three-cadence-table split is fixed here, not that finer
+  settle-frame nuance. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a standing Continuous event's phase has not advanced by 8 frames,
+  where the old code would have; a standing Spin event's facing likewise
+  holds past 8 frames) and four new direct-call assertions on
+  `#anim_continuous_period`/`#anim_spin_period`, all confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **Repeat/Loop** — loops forever without an explicit Break Loop.
   `Interpreter#do_end_loop` unconditionally scans back to the matching
   `Loop` marker and jumps `@index` there every single time it is reached —

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -41,8 +41,29 @@ class RPG2k
       # Walk-animation frame cadence by move_speed, port 0..5, matching EasyRPG's
       # GetStationaryAnimFrames (limits[] = {12,10,8,6,5,4}, 0-indexed by the
       # same real-minus-1 offset); the default (2) keeps the prior 6-frame
-      # period, so existing animation pacing is unchanged.
+      # period, so existing animation pacing is unchanged. Governs an event
+      # while it is actually sliding between tiles.
       ANIM_STATIONARY_FRAMES = { 0 => 12, 1 => 10, 2 => 8, 3 => 6, 4 => 5, 5 => 4 }.freeze
+
+      # A Continuous/Fixed-Continuous event's own idle cadence -- slower than
+      # #ANIM_STATIONARY_FRAMES, not the same table reused. Confirmed against
+      # EasyRPG's live source, `Game_Character::GetContinuousAnimFrames`
+      # (`src/game_character.h`): `limits[] = {16,12,10,8,7,6}`. Real RPG_RT's
+      # `UpdateAnimation` (`src/game_character.cpp`) actually blends this with
+      # the stationary table while genuinely moving too (`GetAnimCount() >=
+      # continuous_limit || (stopped && GetAnimCount() >= stationary_limit)`),
+      # but the dominant, most visible effect -- and the one this fixes -- is
+      # that an idle Continuous/Fixed-Continuous event (a torch, a waterwheel,
+      # an "always animates" NPC) cycles noticeably slower than one that is
+      # actually walking, not on the identical cadence.
+      ANIM_CONTINUOUS_FRAMES = { 0 => 16, 1 => 12, 2 => 10, 3 => 8, 4 => 7, 5 => 6 }.freeze
+
+      # A Spin-type event's own facing-rotation cadence, slower again.
+      # Confirmed against EasyRPG's `Game_Character::GetSpinAnimFrames`
+      # (`src/game_character.h`): `limits[] = {24,16,12,8,6,4}` -- `Update
+      # Animation`'s `IsSpinning()` branch reads this and only this table,
+      # unconditionally, whether the event is moving or not.
+      ANIM_SPIN_FRAMES = { 0 => 24, 1 => 16, 2 => 12, 3 => 8, 4 => 6, 5 => 4 }.freeze
 
       # Clamp a (possibly out-of-range) internal move_speed to the port's own
       # 0..5 scale -- the real RPG2000 Move Speed field is 1..6 (see
@@ -56,8 +77,15 @@ class RPG2k
       # Quarter-tile units advanced per frame while jumping at `s`.
       def jump_slide_step(s); JUMP_SLIDE_STEP[clamp_speed(s)] || 6; end
 
-      # Walk-animation period (frames per phase) at `s`.
+      # Walk-animation period (frames per phase) at `s`, while actually sliding.
       def anim_frame_period(s); ANIM_STATIONARY_FRAMES[clamp_speed(s)] || 6; end
+
+      # Idle-animation period for a Continuous/Fixed-Continuous event standing
+      # still at `s`.
+      def anim_continuous_period(s); ANIM_CONTINUOUS_FRAMES[clamp_speed(s)] || 8; end
+
+      # Facing-rotation period for a Spin-type event at `s`.
+      def anim_spin_period(s); ANIM_SPIN_FRAMES[clamp_speed(s)] || 12; end
 
       # Advance a slide by `step` quarter-tile units. Folds the whole TILE-units
       # into `move_count` (the integer, display-side progress) and returns the new
@@ -92,8 +120,11 @@ class RPG2k
       EVENT_MOVE_DELAY = { 1 => 96, 2 => 64, 3 => 40, 4 => 24,
                            5 => 12, 6 => 6, 7 => 3, 8 => 1 }.freeze
 
-      # (Walk-animation cadence is now move_speed-dependent; see
-      # ANIM_STATIONARY_FRAMES and #anim_frame_period below.)
+      # (Walk-animation cadence is move_speed-dependent, and split by whether
+      # an event is sliding, idling Continuous, or Spinning; see
+      # ANIM_STATIONARY_FRAMES / ANIM_CONTINUOUS_FRAMES / ANIM_SPIN_FRAMES and
+      # #anim_frame_period / #anim_continuous_period / #anim_spin_period
+      # below.)
 
       # Event-page start conditions (the page `trigger` field): how the event's
       # command list is set off.
@@ -2947,12 +2978,15 @@ class RPG2k
 
       # Advance each event's pixel slide and walk-animation phase once per frame.
       # An event "moves" for animation purposes while it is sliding between two
-      # tiles (see reoccupy / event_sliding?); such events — and any
-      # continuous/spin animation type — cycle their walk frames on a
-      # move_speed-dependent cadence (see #anim_frame_period), while an event
-      # resting on a tile shows its page pose. Game::EventGraphic.frame reads
-      # @moving / @anim_phase to pick the drawn column, and event_pixel reads the
-      # slide for the draw position.
+      # tiles (see reoccupy / event_sliding?); such events cycle their walk
+      # frames on the (fastest) #anim_frame_period cadence, while a Continuous/
+      # Fixed-Continuous or Spin type standing still instead cycles on its own,
+      # slower #anim_continuous_period / #anim_spin_period -- confirmed against
+      # EasyRPG's `Game_Character::UpdateAnimation` (`src/game_character.cpp`),
+      # which reads a distinct table per case rather than one shared cadence.
+      # An event resting on a tile with neither type shows its page pose.
+      # Game::EventGraphic.frame reads @moving / @anim_phase to pick the drawn
+      # column, and event_pixel reads the slide for the draw position.
       def animate_events
         @events.each { |e| animate_event(e) }
       end
@@ -2974,7 +3008,16 @@ class RPG2k
         return unless Game::EventGraphic.animated?(type)
         return unless sliding || Game::EventGraphic.continuous?(type)
         e[:anim_count] += 1
-        return if e[:anim_count] < anim_frame_period(ch.move_speed)
+        # Sliding always uses the (fastest) stationary-per-frame table; an
+        # event merely idling in place -- Spin rotating its facing, or a
+        # Continuous/Fixed-Continuous type cycling its walk frame with nobody
+        # pushing it -- uses its own slower table instead of reusing this one
+        # (see #ANIM_CONTINUOUS_FRAMES / #ANIM_SPIN_FRAMES above).
+        period = if sliding then anim_frame_period(ch.move_speed)
+                 elsif type == Game::EventGraphic::SPIN then anim_spin_period(ch.move_speed)
+                 else anim_continuous_period(ch.move_speed)
+                 end
+        return if e[:anim_count] < period
         e[:anim_count] = 0
         e[:anim_phase] = (e[:anim_phase] + 1) % Game::EventGraphic::WALK_COLUMNS.size
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6124,10 +6124,52 @@ check 'a continuous-animation event advances even while standing still' do
   ev = event(2, 2, page(charset_name: 'c',
                         animation_type: Game::EventGraphic::CONTINUOUS))
   scene = new_scene({ 1 => ev }, player: [5, 4])
-  40.times { scene.update }
+  # 13: past the continuous cadence's own single period (10 frames/phase at
+  # this event's default move_speed) but nowhere near a multiple of its
+  # 4-frame phase cycle (40), which would wrap #anim_phase back around to 0
+  # and read as "never cycled".
+  13.times { scene.update }
   e = event_hashes(scene)[1]
   eq [2, 2], [e[:char].x, e[:char].y], 'it did not move'
   ok e[:anim_phase] != 0, 'but its walk animation kept cycling'
+end
+
+# Confirmed against EasyRPG's live source, `Game_Character::
+# GetContinuousAnimFrames` (`src/game_character.h`): an idling Continuous
+# event's own cadence (ANIM_CONTINUOUS_FRAMES[2] = 10 at the default
+# move_speed) is slower than the sliding/stationary cadence
+# (ANIM_STATIONARY_FRAMES[2] = 8) the same event would use while actually
+# stepping between tiles -- not the same table reused for both.
+check 'a continuous-animation event standing still cycles on its own, ' \
+      'slower cadence than a sliding event would use' do
+  ev = event(2, 2, page(charset_name: 'c',
+                        animation_type: Game::EventGraphic::CONTINUOUS))
+  scene = new_scene({ 1 => ev }, player: [5, 4])
+  e = event_hashes(scene)[1]
+  8.times { scene.update }
+  eq 0, e[:anim_phase],
+     'still on the first frame after 8 updates -- too soon for the sliding ' \
+     'cadence, which this event is not using'
+  2.times { scene.update }
+  ok e[:anim_phase] != 0, 'but the continuous cadence (10 frames) has advanced it by now'
+end
+
+# Same distinction, for a Spin-type event's own facing-rotation cadence
+# (ANIM_SPIN_FRAMES[2] = 12) -- confirmed against EasyRPG's `Game_Character::
+# GetSpinAnimFrames` (`src/game_character.h`), read unconditionally by
+# `UpdateAnimation`'s `IsSpinning()` branch, whether the event is moving or
+# not.
+check 'a spin-type event rotates its facing on its own, slower cadence ' \
+      'than a sliding event would use' do
+  ev = event(2, 2, page(charset_name: 'c', animation_type: Game::EventGraphic::SPIN))
+  scene = new_scene({ 1 => ev }, player: [5, 4])
+  e = event_hashes(scene)[1]
+  8.times { scene.update }
+  eq 0, e[:anim_phase],
+     'still on the first facing after 8 updates -- too soon for the sliding ' \
+     'cadence, which this event is not using'
+  4.times { scene.update }
+  ok e[:anim_phase] != 0, 'but the spin cadence (12 frames) has rotated it by now'
 end
 
 check 'a map with a looping, autoscrolling parallax renders without raising' do
@@ -9104,6 +9146,15 @@ check 'Move Speed is no longer dead: it drives the per-frame slide, jump and ani
   # Animation cadence is move_speed-dependent; internal 3 keeps the prior 6.
   eq 6,  scene.send(:anim_frame_period, 3)
   eq 4,  scene.send(:anim_frame_period, 5)
+  # Confirmed against EasyRPG's live source, `Game_Character::
+  # GetContinuousAnimFrames` / `GetSpinAnimFrames` (`src/game_character.h`):
+  # an idling Continuous/Fixed-Continuous event and a Spin event's own
+  # facing-rotation each use their own, slower table -- not the stationary
+  # one reused.
+  eq 8,  scene.send(:anim_continuous_period, 3)
+  eq 6,  scene.send(:anim_continuous_period, 5)
+  eq 8,  scene.send(:anim_spin_period, 3)
+  eq 4,  scene.send(:anim_spin_period, 5)
 end
 
 check "an event's database Move Speed converts from RPG_RT's real 1..6 scale, not fed through raw" do


### PR DESCRIPTION
## Summary

- `Scene::Map#animate_event` (`mruby-rpg2k/mrblib/scene/map.rb`) called `#anim_frame_period` — backed by `ANIM_STATIONARY_FRAMES` alone — for every animated event regardless of *why* it was animating: genuinely sliding between tiles, or merely idling with a Continuous/Fixed-Continuous/Spin type forcing it to keep animating in place.
- Confirmed against EasyRPG's live source, `Game_Character::UpdateAnimation` (`src/game_character.cpp`): a spinning event reads `GetSpinAnimFrames` unconditionally, before any movement test at all, and an ordinary event blends `GetContinuousAnimFrames` (idling Continuous) and `GetStationaryAnimFrames` (genuinely mid-step) — three distinct, non-interchangeable tables (`{12,10,8,6,5,4}` / `{16,12,10,8,7,6}` / `{24,16,12,8,6,4}`, `src/game_character.h`), only the first of which this codebase had ever added.
- Concretely: a speed-3 (internal 2) Continuous decorative event (a torch, a waterwheel, an "always animates" NPC — a common RPG2000 authoring idiom) cycled every 8 frames standing still instead of the real 10; a same-speed Spin event rotated its facing every 8 frames instead of the real 12 — noticeably too fast in both cases.
- Fixed by adding `ANIM_CONTINUOUS_FRAMES`/`ANIM_SPIN_FRAMES` (and matching `#anim_continuous_period`/`#anim_spin_period` helpers) and having `#animate_event` pick sliding vs. Spin vs. idling-Continuous by case, rather than always calling `#anim_frame_period`.
- This is a deliberate simplification of `UpdateAnimation`'s own dual-condition blend (which also settles a *moving* Continuous event onto the stationary cadence once it stops mid-frame, and holds the sprite on its left/right pose until the count catches up) — only the three-cadence-table split is fixed here, not that finer settle-frame nuance. Vehicles use their own already-separate animation rule and are untouched.
- Corrected a stale `docs/TODO.md` historical note that had already cited `GetContinuousAnimFrames`/(implicitly) `GetSpinAnimFrames` without flagging that only the stationary table had actually been ported.

## Test plan

- [x] Two new `scripts/rpg2k_scene_check.rb` checks: a standing Continuous event's phase has not advanced by 8 frames (where the old code would have advanced it), and only advances once the real 10-frame cadence elapses; same for a standing Spin event's facing at the real 12-frame cadence.
- [x] Four new direct-call assertions on `#anim_continuous_period`/`#anim_spin_period` alongside the existing `#anim_frame_period` coverage.
- [x] Adjusted a pre-existing check's iteration count to avoid an unrelated phase-wraparound coincidence exposed by the new, longer cadence.
- [x] All new/updated assertions confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/scene/map.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (857), `rpg2k_logic_check.rb` (1113), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_