### PR TITLE
Read state-adjusted stats in Control Variables' actor/enemy operands

### DIFF
--- a/changelog.d/control-variables-actor-enemy-state-adjusted-stats.fixed.md
+++ b/changelog.d/control-variables-actor-enemy-state-adjusted-stats.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** Control Variables' actor Attack/Defence/Intelligence/Agility
+  operand and the RPG2003 battle-monster Attack/Defence/Spirit/Agility
+  operand now read the currently state-adjusted value, matching RPG_RT --
+  previously both read the raw base stat, so a Weaken/Boost-type status had
+  no effect on the value a Control Variables read reported.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7256,6 +7256,30 @@ Everything below is unverified against the codebase.
   one array with no dual-wield-aware branching anywhere, reading attr 11
   (Shield) on such an actor already returns the second weapon's id, not a
   literal shield's, with nothing further needed.
+  ✅ **Follow-up (2026-08-21): the Attack/Defence/Intelligence/Agility
+  attributes (5..9's own attrs 6-9) and the RPG2003 battle operand's
+  Attack/Defence/Spirit/Agility (attrs 4-7) read the actor's/enemy's raw
+  base stat, not its currently state-adjusted value.** `Interpreter
+  #actor_operand`'s attrs 6-9 read `actor.atk`/`actor.def`/`actor.int`/
+  `actor.agi` directly, and `#enemy_operand`'s attrs 4-7 read `foe.atk`/
+  `foe.def`/`foe.spi`/`foe.agi` directly — both skipping any currently
+  active Weaken/Boost-type state's own halve/double effect. Confirmed
+  against EasyRPG's live source, `ControlVariables::Actor`/`::Enemy`
+  (`src/game_interpreter_control_variables.cpp`): both route their
+  stat cases straight through `Game_Battler::GetAtk`/`GetDef`/`GetSpi`/
+  `GetAgi` (`src/game_battler.cpp`), each an `AdjustParam` call folding in
+  the same active-state halve/double this codebase already ports as
+  `Game::Party#effective_atk`/`#effective_def`/`#effective_int`/
+  `#effective_agi` (for the map-side actor operand) and `Game::Battle
+  #effective_atk`/`#effective_def`/`#effective_spi`/`#effective_agi` (for
+  the in-battle enemy operand) — both helpers already used elsewhere
+  (Simulated Attack, the Status menu, the real attack formula) but never
+  wired into these two Control Variables readers. Fixed by routing both
+  through the matching `effective_*` helper instead of the bare field.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (a Weaken-type
+  state halves an actor's Attack reading through operand type 5; the same
+  for a troop member's Defence through operand type 8), both confirmed to
+  fail against the pre-fix code before the fix.
   ✅ **"Item possession count" excludes equipped copies (must sum both for
   the true total) -- also already correct and already tested.**
   `Item#item_operand`'s two branches read `party.item_count(id)` (bag-only)

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1826,6 +1826,16 @@ module Game
     # companion, and its party status display is built out of them, so a
     # dismissed member used to be listed at level 0. Only an id the database has
     # no row for reads as 0.
+    #
+    # Attack/Defence/Intelligence/Agility read the actor's *state-adjusted*
+    # value, not its raw base stat: confirmed against EasyRPG's live source,
+    # `ControlVariables::Actor` (`src/game_interpreter_control_variables.cpp`),
+    # whose cases 6-9 call straight through `Game_Actor::GetAtk`/`GetDef`/
+    # `GetSpi`/`GetAgi` (`src/game_battler.cpp`), each routed through
+    # `AdjustParam` — the same halve/double-by-active-state mechanism this
+    # codebase's own `Game::Party#effective_atk`/`#effective_def`/
+    # `#effective_int`/`#effective_agi` already model and already use
+    # elsewhere (Simulated Attack's `#do_simulated_attack`, the Status menu).
     def actor_operand(cmd)
       actor = party.roster[cmd.param(5)]
       return 0 unless actor
@@ -1837,10 +1847,10 @@ module Game
       when 3 then actor.mp
       when 4 then actor.max_hp
       when 5 then actor.max_mp
-      when 6 then actor.atk
-      when 7 then actor.def
-      when 8 then actor.int
-      when 9 then actor.agi
+      when 6 then party.effective_atk(actor)
+      when 7 then party.effective_def(actor)
+      when 8 then party.effective_int(actor)
+      when 9 then party.effective_agi(actor)
       when 10, 11, 12, 13, 14 then actor.equipment[attr - 10] || 0
       else 0
       end
@@ -1851,6 +1861,15 @@ module Game
     # the same one Change Monster HP uses — and param6 the attribute (0 HP,
     # 1 SP, 2 max HP, 3 max SP, 4 attack, 5 defence, 6 spirit, 7 agility).
     # Outside a battle, or for a member that is not in this troop, it reads 0.
+    #
+    # Attack/Defence/Spirit/Agility read the enemy's *state-adjusted* value,
+    # the same citation as #actor_operand above (`ControlVariables::Enemy`'s
+    # cases 4-7 route through the identical `Game_Battler::GetAtk`/`GetDef`/
+    # `GetSpi`/`GetAgi`/`AdjustParam` chain) -- ported here via this class's
+    # own `Game::Battle#effective_atk`/`#effective_def`/`#effective_spi`/
+    # `#effective_agi`, the battle-Combatant-scoped counterpart of
+    # `Party#effective_*` above, already used elsewhere in this same battle
+    # engine (e.g. `#deal_attack_with_current_weapon`).
     def enemy_operand(cmd)
       foe = @battle && @battle.enemy(cmd.param(5))
       return 0 unless foe
@@ -1859,10 +1878,10 @@ module Game
       when 1 then foe.mp || 0
       when 2 then foe.max_hp
       when 3 then foe.max_mp || 0
-      when 4 then foe.atk
-      when 5 then foe.def
-      when 6 then foe.spi
-      when 7 then foe.agi
+      when 4 then @battle.effective_atk(foe)
+      when 5 then @battle.effective_def(foe)
+      when 6 then @battle.effective_spi(foe)
+      when 7 then @battle.effective_agi(foe)
       else 0
       end
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -15479,6 +15479,47 @@ def party_state_with_states(states, skills = {})
     Game::Party.new(FakeActorDB.new(players, [1, 2], {}, skills, {}, states)), 1, 0, 0)
 end
 
+# Confirmed against EasyRPG's live source, `ControlVariables::Actor`
+# (`src/game_interpreter_control_variables.cpp`): its Attack/Defence/
+# Intelligence/Agility cases (6-9) call straight through `Game_Actor::
+# GetAtk`/`GetDef`/`GetSpi`/`GetAgi` (`src/game_battler.cpp`), each routed
+# through `AdjustParam` -- the same halve/double-by-active-state mechanism
+# ported here as `Game::Party#effective_atk`/`#effective_def`/`#effective_int`/
+# `#effective_agi`, already used elsewhere (Simulated Attack, the Status
+# menu). Reading a stat straight off the actor (`actor.atk`, its raw base
+# value) skips that adjustment entirely.
+check 'Control Variables reads an actor\'s state-adjusted Attack, not its ' \
+      'raw base stat (operand type 5)' do
+  states = { 2 => fake_state(affect_type: 0, affect_attack: true) } # 0 = halve
+  st = party_state_with_states(states)
+  hero = st.party.actor_by_id(1) # base atk 10
+  hero.add_state(2)
+  ic = Game::Interpreter::Cmd
+  interp = Game::Interpreter.new(st)
+  interp.start([FakeCmd.new(ic::CONTROL_VARS, [0, 1, 1, 0, 5, 1, 6])]) # actor 1, attribute 6 = Attack
+  interp.update while interp.running? && !interp.waiting?
+  eq 5, st.variables[1], 'halved from the raw base of 10, not the raw value itself'
+end
+
+# Same citation, `ControlVariables::Enemy`'s Attack/Defence/Spirit/Agility
+# cases (4-7), routed through this class's own battle-Combatant-scoped
+# `Game::Battle#effective_atk`/`#effective_def`/`#effective_spi`/
+# `#effective_agi`.
+check 'Control Variables reads a troop member\'s state-adjusted Defence, ' \
+      'not its raw base stat (operand type 8)' do
+  states = { 2 => fake_state(affect_type: 0, affect_defense: true) } # 0 = halve
+  foe = combatant('Slime', 5, 10, 5, 100) # base def 10
+  foe.states = [2]
+  b = Game::Battle.new([combatant('Hero', 10, 0, 10, 100)], [foe], Game::Rng.new(1), states)
+  st = new_state
+  interp = Game::Interpreter.new(st)
+  interp.battle = b
+  ic = Game::Interpreter::Cmd
+  interp.start([FakeCmd.new(ic::CONTROL_VARS, [0, 1, 1, 0, 8, 0, 5])]) # troop member 0, attribute 5 = Defence
+  interp.update while interp.running? && !interp.waiting?
+  eq 5, st.variables[1], 'halved from the raw base of 10, not the raw value itself'
+end
+
 check 'Change Condition prunes a state it displaces, and one that displaces it' do
   states = { 2 => display_state(name: 'Poison', priority: 30),
              3 => display_state(name: 'Petrify', priority: 90) }


### PR DESCRIPTION
## Summary

- `Interpreter#actor_operand`'s Attack/Defence/Intelligence/Agility cases (attrs 6-9) read `actor.atk`/`actor.def`/`actor.int`/`actor.agi` directly — the actor's raw, unadjusted base stat.
- `Interpreter#enemy_operand`'s Attack/Defence/Spirit/Agility cases (attrs 4-7, RPG2003's battle operand) read `foe.atk`/`foe.def`/`foe.spi`/`foe.agi` directly, likewise raw.
- Confirmed against EasyRPG's live source, `ControlVariables::Actor`/`::Enemy` (`src/game_interpreter_control_variables.cpp`): both route their stat cases straight through `Game_Battler::GetAtk`/`GetDef`/`GetSpi`/`GetAgi` (`src/game_battler.cpp`), each an `AdjustParam` call folding in a currently active state's own halve/double effect.
- This codebase already ports that exact mechanism as `Game::Party#effective_atk`/`#effective_def`/`#effective_int`/`#effective_agi` (map-side, already used by Simulated Attack and the Status menu) and `Game::Battle#effective_atk`/`#effective_def`/`#effective_spi`/`#effective_agi` (battle-side, already used by the real attack formula) — but neither was ever wired into these two Control Variables readers.
- Fixed by routing both through the matching `effective_*` helper instead of the bare field.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a Weaken-type state halves an actor's Attack reading through Control Variables operand type 5 (actor).
- [x] New check: the same for a troop member's Defence through operand type 8 (RPG2003 battle monster).
- [x] Both confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/interpreter.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (859), `rpg2k_logic_check.rb` (1115), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_