### PR TITLE
Layer-gate a moving boat/ship's own collision, like the hero's

### DIFF
--- a/changelog.d/vehicle-passable-layer-gate.fixed.md
+++ b/changelog.d/vehicle-passable-layer-gate.fixed.md
@@ -1,0 +1,6 @@
+- **Map:** a moving boat/ship now glides straight through a below/above-
+  characters decorative event, matching RPG_RT -- previously any such event
+  stopped a boat/ship dead unless it specifically had Through Mode on, an
+  uncited fan-wiki claim that turned out to contradict the actual collision
+  rule (a moving boat/ship only collides with a same-layer event, exactly
+  like the hero).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16417,19 +16417,21 @@ not yet verified:
   for a boarded boat/ship. ("It can never land on a tile a map event occupies
   regardless of terrain" was the one genuine gap in this bullet — now fixed,
   see below.)
-- ✅ **Small/large ships can never overlap an event's tile even with a
+- ✅ ~~**Small/large ships can never overlap an event's tile even with a
   passable graphic + below-characters priority** (which *does* let the
   walking hero overlap it fine via the already-implemented priority-type
   gating) — a ship needs the *blocking event's own* move route to have
   Through Mode on instead; ships ignore priority-type/`overlap_forbidden`
   gating for this purpose entirely and just check the blocked event's own
-  Through Mode flag. `Scene::Map#vehicle_passable?`'s boat/ship branch
+  Through Mode flag.~~ **Wrong — this entire bullet's claim was sourced from
+  a fan wiki (yado.tk) and contradicts EasyRPG's actual C++ source; corrected
+  by the dated Follow-up below (2026-08-21).** `Scene::Map#vehicle_passable?`'s boat/ship branch
   (`mruby-rpg2k/mrblib/scene/map.rb`) used to reuse the exact same
   `blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]` occupancy
   test the hero's own `passable?`/`char_passable?` use, so a below-
-  characters event never blocked a ship at all — the opposite of RPG_RT,
+  characters event never blocked a ship at all — ~~the opposite of RPG_RT,
   which always blocks a ship on such a tile unless that specific event has
-  Through Mode enabled. The blocker check is now `blocker &&
+  Through Mode enabled.~~ The blocker check is now `blocker &&
   !blocker[:char].through`, reading the same `Game::Character#through`
   accessor (`attr_accessor :through`, toggled by the Set Move Route
   Through Mode ON/OFF commands) that the hero's own Through Mode already
@@ -16439,6 +16441,36 @@ not yet verified:
   by a new `scripts/rpg2k_scene_check.rb` check (a boarded boat is stopped
   by a below-characters event on an otherwise boat-passable tile; setting
   that event's own Through Mode on lets the boat sail through it).
+  ✅ **Follow-up (2026-08-21): the "ships ignore layer entirely" claim above
+  was itself wrong, sourced from an uncited fan-wiki (yado.tk) claim rather
+  than RPG_RT's own source — a moving boat/ship's collision IS layer-gated,
+  identically to the hero's own rule, not a special "always blocks unless
+  Through Mode" case.** Confirmed against EasyRPG's live source:
+  `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) routes a moving
+  boat/ship's collision (`vehicle_type != Game_Vehicle::Airship`) through the
+  exact same generic `WouldCollide` every other mover — hero, map event, or
+  vehicle alike — uses, whose own layer test is a plain `self.GetLayer() ==
+  other.GetLayer()`; no vehicle-specific bypass anywhere in that call chain.
+  `Game_Vehicle`'s constructor (`src/game_vehicle.cpp`) sets
+  `SetLayer(Layers_same)` unconditionally, for every vehicle type (Boat,
+  Ship, and Airship alike), never overridden elsewhere in that file — so a
+  moving boat/ship only ever collides with a `LAYER_SAME` event, exactly
+  like the hero, and a below/above-characters decorative event is a tile it
+  glides straight through with no Through Mode needed at all. `#vehicle_
+  passable?`'s blocker check dropped the layer test the fix above had
+  removed, reading `blockers_at(x, y).any? { |b| !b[:char].through }` with
+  no layer condition; fixed by restoring a `b[:layer] == LAYER_SAME` guard
+  alongside the existing Through-Mode check, mirroring `#char_passable?`'s
+  own layer-gated pattern rather than reusing its full occupancy test
+  (which also folds in `overlap_forbidden`, a hero/event-only rule
+  `WouldCollide` never applies to a vehicle mover). The existing
+  `scripts/rpg2k_scene_check.rb` check this bullet's own fix added was
+  rewritten into two: a `LAYER_BELOW` blocker no longer stops the boat at
+  all (no Through Mode needed, reverting to the pre-this-bullet behavior for
+  that specific case), and a new, separate check confirms a `LAYER_SAME`
+  blocker still stops it and still needs Through Mode to pass — both
+  confirmed to fail/pass appropriately against the pre-fix code before the
+  fix.
 - ✅ **An airship can never land on a tile a map event occupies, regardless
   of terrain** — the same vehicle-specific Through-Mode rule as the boat/ship
   fix directly above, applied to landing rather than sailing. Flying itself

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2779,16 +2779,20 @@ class RPG2k
       # the way, falling back to on-foot passability when the map has no terrain
       # data.
       #
-      # A boat / ship's event-blocking rule is a real divergence from the
-      # hero's own (yado.tk quirk): the walking hero is priority-type-gated —
-      # a below/above-characters event with a passable graphic never blocks it
-      # (see `passable?` / `char_passable?`, which key off `blocker[:layer]`).
-      # A ship ignores that entirely and just asks whether the blocking
-      # event's *own* move route has Through Mode on
+      # A moving boat / ship's event-blocking rule is layer-gated, exactly like
+      # the hero's own (see `passable?` / `char_passable?`, which key off
+      # `blocker[:layer]`) -- confirmed against EasyRPG's live source, not a
+      # divergence: `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) routes a
+      # moving boat/ship's collision through the exact same generic
+      # `WouldCollide` every other mover uses, whose own layer test is
+      # `self.GetLayer() == other.GetLayer()`; `Game_Vehicle`'s constructor
+      # (`src/game_vehicle.cpp`) sets `SetLayer(Layers_same)` unconditionally,
+      # for every vehicle type, never overridden elsewhere. So a below/above-
+      # characters event a boat/ship's own layer never matches is a decoration
+      # it glides straight through, the same as the hero does -- Through Mode
       # (`blocker[:char].through`, the same accessor `char_passable?` and
-      # `passable?` check for the mover's own Through Mode) — a below-
-      # characters, passable-graphic event the hero strolls over still stops
-      # a ship dead unless that specific event has Through Mode enabled.
+      # `passable?` check) is a *separate*, additional exemption on top of the
+      # layer gate, not the only one.
       def vehicle_passable?(x, y, dir, type)
         return false unless @map.in_bounds?(x, y)
         row = terrain_row_at(x, y)
@@ -2796,7 +2800,7 @@ class RPG2k
           return true if row.nil?
           return row.airship_pass ? true : false
         end
-        return false if blockers_at(x, y).any? { |b| !b[:char].through }
+        return false if blockers_at(x, y).any? { |b| !b[:char].through && b[:layer] == LAYER_SAME }
         # A moving Boat/Ship also collides with a *different* parked
         # Boat/Ship, and with a grounded Airship -- `Game_Map::
         # CheckOrMakeWayEx` (`src/game_map.cpp`) loops `{ Boat, Ship }` for

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8729,14 +8729,17 @@ check 'each vehicle type has exactly one boarding trigger: the airship only ' \
   ok !st.boarded?, 'standing on a placed boat does not board it'
 end
 
-check 'a boarded boat cannot overlap a below-characters event unless it has Through Mode on' do
-  # yado.tk: a below-characters, passable-graphic event lets the *walking*
-  # hero overlap it fine (LAYER_BELOW is not LAYER_SAME, see the priority-type
-  # checks above) -- but a ship ignores that gating entirely and just asks
-  # whether the blocking event's own move route has Through Mode on. Put a
-  # LAYER_BELOW event one tile past a boarded boat, on a boat_pass tile, and
-  # confirm the boat is stopped cold by it despite the layer mismatch that
-  # would let the hero glide over it.
+check 'a boarded boat glides straight through a below-characters event, ' \
+      'the same as the walking hero' do
+  # Confirmed against EasyRPG's live source, not a divergence from the hero's
+  # own rule: `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) routes a
+  # moving boat/ship's collision through the exact same generic `WouldCollide`
+  # every other mover uses, whose own layer test is `self.GetLayer() ==
+  # other.GetLayer()`; `Game_Vehicle`'s constructor (`src/game_vehicle.cpp`)
+  # sets `SetLayer(Layers_same)` unconditionally, for every vehicle type. So a
+  # LAYER_BELOW event never matches a boat's own LAYER_SAME and is a
+  # decoration it glides straight through, exactly as the walking hero does
+  # (see the priority-type checks above) -- Through Mode is not required.
   blocker = event(0, 2, page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_BELOW))
   scene = new_scene({ 1 => blocker }, player: [0, 0], boat_pass: true)
   st = scene.instance_variable_get(:@state)
@@ -8754,12 +8757,41 @@ check 'a boarded boat cannot overlap a below-characters event unless it has Thro
   RGSS::Input.dir_value = 2 # hold down, toward the below-characters event
   20.times { scene.update }
   RGSS::Input.dir_value = 0
+  eq 0, st.x, 'only moved along the column it was already sailing'
+  ok st.y > 1,
+     "the below-characters event's layer mismatch let the boat glide over " \
+     "it, no Through Mode needed (was at y=1, now #{st.y})"
+end
+
+check 'a boarded boat cannot overlap a same-layer event unless it has ' \
+      'Through Mode on' do
+  # The layer-matched counterpart to the check above: a LAYER_SAME event does
+  # match a boat's own fixed layer, so `WouldCollide`'s layer test fires and
+  # the boat is stopped cold, same as it would stop the walking hero -- until
+  # the blocking event's own Through Mode exempts it (`WouldCollide` checks
+  # `self.GetThrough() || other.GetThrough()` before the layer test at all).
+  blocker = event(0, 2, page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_SAME))
+  scene = new_scene({ 1 => blocker }, player: [0, 0], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face down, toward (0, 1)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat ahead'
+  eq [0, 1], [st.x, st.y], 'stepped onto the boat tile'
+
+  RGSS::Input.dir_value = 2 # hold down, toward the same-layer event
+  20.times { scene.update }
+  RGSS::Input.dir_value = 0
   eq [0, 1], [st.x, st.y],
-     'a below-characters event stops a boat even though its layer would let ' \
-     "the hero overlap it (got #{[st.x, st.y]})"
+     "a same-layer event stops a boat, matching its own layer (got #{[st.x, st.y]})"
 
   # Turn the blocking event's own Through Mode on and try again: now the boat
-  # passes it, matching real RPG_RT's ship-specific rule.
+  # passes it.
   chars(scene)[1].through = true
   RGSS::Input.dir_value = 2
   20.times { scene.update }


### PR DESCRIPTION
## Summary

- `Scene::Map#vehicle_passable?`'s boat/ship branch (`mruby-rpg2k/mrblib/scene/map.rb`) blocked movement onto any tile carrying a non-Through-Mode event, with no layer check at all — the result of an earlier fix (already merged this session, before this repository's own tracked history) whose doc comment cited a fan wiki (yado.tk) claiming "a ship ignores layer gating entirely and just checks the blocking event's own Through Mode." That claim contradicts EasyRPG's actual C++ source.
- Confirmed against EasyRPG's live source: `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) routes a moving boat/ship's collision through the exact same generic `WouldCollide` every other mover (hero, map event, or vehicle alike) uses — whose own layer test is a plain `self.GetLayer() == other.GetLayer()`, no vehicle-specific bypass anywhere in the chain.
- `Game_Vehicle`'s constructor (`src/game_vehicle.cpp`) sets `SetLayer(Layers_same)` unconditionally, for every vehicle type (Boat, Ship, Airship alike), never overridden elsewhere.
- So a moving boat/ship only ever collides with a `LAYER_SAME` event, exactly like the hero — a below/above-characters decorative event (a dock ripple, a floating log prop) is a tile it glides straight through, with no Through Mode needed at all.
- Fixed by restoring a `b[:layer] == LAYER_SAME` guard alongside the existing Through-Mode check in `#vehicle_passable?`.
- `#airship_landable?` (a separate function, confirmed against `Game_Map::CanLandAirship` — a standalone loop with no layer or Through check at all) is unaffected and untouched.
- Corrected the `docs/TODO.md` bullet that had originally introduced the wiki-sourced claim, with a strikethrough and a dated Follow-up.

## Test plan

- [x] Rewrote the existing `scripts/rpg2k_scene_check.rb` check into two: a `LAYER_BELOW` blocker no longer stops a boarded boat at all (no Through Mode needed); a new, separate check confirms a `LAYER_SAME` blocker still stops it and still needs Through Mode to pass.
- [x] Confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/scene/map.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (860), `rpg2k_logic_check.rb` (1115), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_