### PR TITLE
Give boat/ship disembarking its own one-sided passability check

### DIFF
--- a/changelog.d/ship-disembark-one-sided-check.fixed.md
+++ b/changelog.d/ship-disembark-one-sided-check.fixed.md
@@ -1,0 +1,4 @@
+- **Map:** disembarking a boat/ship now only tests the landing tile's own
+  passability, matching RPG_RT -- previously it also tested the water tile
+  being left and refused a landing blocked by another parked vehicle,
+  neither of which the original game's own disembark check does.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8124,6 +8124,34 @@ Everything below is unverified against the codebase.
   failed) but still runs the NPC's event — confirmed to fail against the
   pre-fix code (the NPC's Control Switches command never ran) before the
   fix.
+  ✅ **Follow-up (2026-08-21): `#disembark_vehicle`'s boat/ship branch reused
+  the ordinary two-sided `#passable?` step check, but RPG_RT's own disembark
+  test is one-sided and lighter.** Confirmed against EasyRPG's live source:
+  `Game_Player::GetOffVehicle`'s boat/ship branch (already cited above)
+  calls `Game_Map::CanDisembarkShip` (`src/game_map.cpp`), which (1) only
+  tests the *landing* tile's own entry passability — `GetPassableMask(x, y,
+  player.GetX(), player.GetY())` derives a single direction bit at `(x, y)`
+  alone, and the water tile the party is standing on is never passed to a
+  passability check at all, unlike an ordinary step's own two-sided
+  `#passable?` — and (2) has no equivalent of `#vehicle_blocks?`, unlike
+  `Game_Map::CanLandAirship` a few lines above it in the same file, which
+  does loop `{ Boat, Ship }` explicitly: a different boat/ship parked on the
+  landing tile never blocks disembarking. This build's `#passable?`-based
+  check tested both sides of the boundary (the water tile's own exit
+  passability too) and called `#vehicle_blocks?`, so a mapper who authored a
+  directionally-restricted water autotile (a current or waterfall edge, not
+  the common fully-open case) could see a disembark real RPG_RT allows
+  silently refused, and a boat/ship parked on the shore tile could block a
+  disembark real RPG_RT never checks for at all. Fixed by adding a
+  dedicated `#ship_disembark_passable?` (landing-tile-only chipset test,
+  same-layer/non-Through blocker check, no `#vehicle_blocks?` call) and
+  routing `#disembark_vehicle`'s boat/ship branch through it instead of
+  `#passable?`; the airship branch (`#airship_landable?`, already verified
+  against `CanLandAirship` separately) is untouched. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (`#ship_disembark_passable?` asks
+  the chipset about exactly one tile, the landing tile, not two; a different
+  vehicle parked on the landing tile no longer blocks disembarking), both
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **Battle Event** — separate command set from Map/Common events
   entirely (`Game::Interpreter`'s battle-only opcodes — `CHANGE_MONSTER_HP`/
   `MP`/`CONDITION`, `SHOW_HIDDEN_MONSTER`, `FORCE_FLEE`, `TERMINATE_BATTLE`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2452,13 +2452,38 @@ class RPG2k
           return
         end
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
-        return false unless passable?(fx, fy, @state.direction)
+        return false unless ship_disembark_passable?(fx, fy, @state.direction)
         follow_vehicle # the vehicle is left where the party is getting off
         @state.x = fx
         @state.y = fy
         @state.boarded = nil
         restore_pre_vehicle_bgm # the map BGM resumes
         true
+      end
+
+      # Whether the landing tile (x, y) admits a disembarking boat/ship,
+      # heading `dir`. A dedicated, one-sided test -- NOT #passable? -- since
+      # RPG_RT's own disembark check is narrower than an ordinary step.
+      # Confirmed against EasyRPG's live source: `Game_Player::GetOffVehicle`
+      # (`src/game_player.cpp`) calls `Game_Map::CanDisembarkShip` (`src/
+      # game_map.cpp`), which (1) only tests the *landing* tile's own entry
+      # passability (`GetPassableMask(x, y, player.GetX(), player.GetY())`
+      # derives just the one direction bit at `(x, y)`; the water tile the
+      # party is standing on is never passed to `IsPassableTile` at all,
+      # unlike an ordinary step's own two-sided `#passable?` check), (2)
+      # calls `IsPassableTile(nullptr, bit, x, y)` with a null mover -- no
+      # `boat_pass`/`ship_pass` terrain gate applies to *landing*, only to
+      # sailing there in the first place -- and (3) has no equivalent of
+      # `#vehicle_blocks?` at all (unlike `Game_Map::CanLandAirship`, a few
+      # lines above it in the same file, which does loop `{ Boat, Ship }`
+      # explicitly): a boat/ship parked on the landing tile never blocks
+      # disembarking here. Only a same-layer, non-Through event still does.
+      def ship_disembark_passable?(x, y, dir)
+        return false unless @map.in_bounds?(x, y)
+        return false if blockers_at(x, y).any? { |b| b[:layer] == LAYER_SAME && !b[:char].through }
+        return true if @chipset.nil?
+        @chipset.passable_tile?(@map.lower(x, y), @map.upper(x, y),
+                                 Game::Character::TURN_180[dir] || dir)
       end
 
       # Whether the airship may land on tile (x, y): the database terrain's

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8694,6 +8694,59 @@ check 'boarding a boat and disembarking onto the shore' do
   eq [0, 1], [boat.x, boat.y], 'the boat stayed where the party left it'
 end
 
+# Confirmed against EasyRPG's live source: `Game_Player::GetOffVehicle`
+# (`src/game_player.cpp`) calls `Game_Map::CanDisembarkShip` (`src/
+# game_map.cpp`), which only ever tests the *landing* tile's own passability
+# (`GetPassableMask(x, y, player.GetX(), player.GetY())` derives a single
+# direction bit at `(x, y)` alone) -- unlike an ordinary step's own two-sided
+# `#passable?`, the water tile the party is leaving is never consulted.
+check 'a boat disembark only tests the landing tile\'s own passability, ' \
+      'not the water tile being left' do
+  scene = new_scene({}, player: [0, 0])
+  calls = []
+  fake_chipset = Object.new
+  fake_chipset.define_singleton_method(:passable_tile?) do |lower, upper, dir|
+    calls << [lower, upper, dir]
+    true
+  end
+  scene.instance_variable_set(:@chipset, fake_chipset)
+  scene.send(:ship_disembark_passable?, 0, 1, 2)
+  eq 1, calls.size, 'exactly one tile is asked about passability -- the landing tile alone'
+end
+
+# Confirmed against EasyRPG's live source: `Game_Map::CanDisembarkShip` has
+# no equivalent of `#vehicle_blocks?` at all -- unlike `Game_Map::
+# CanLandAirship`, a few lines above it in the same file, which does loop
+# `{ Boat, Ship }` explicitly to block a landing -- so a different boat/ship
+# parked on the landing tile never blocks disembarking here.
+check 'disembarking a boat is not blocked by a different vehicle parked on ' \
+      'the landing tile' do
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face down, toward (0, 1)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat ahead'
+
+  # Park the ship right on the shore tile the party is about to step onto.
+  ship = st.vehicle(:ship)
+  ship.map_id = st.map_id
+  ship.x = 0
+  ship.y = 0
+
+  st.direction = 8 # face up, toward (0, 0) -- the parked ship's tile
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'disembarked despite the parked ship on the landing tile'
+  eq [0, 0], [st.x, st.y], 'stepped onto the tile the ship occupies'
+end
+
 check 'each vehicle type has exactly one boarding trigger: the airship only ' \
       'by standing on it, a boat/ship only by facing it' do
   # Confirmed against RPG_RT's own live source: `Game_Player::GetOnVehicle`


### PR DESCRIPTION
## Summary

- `Scene::Map#disembark_vehicle`'s boat/ship branch (`mruby-rpg2k/mrblib/scene/map.rb`) reused the ordinary two-sided `#passable?` step check — testing both the water tile the party is leaving and the landing tile, plus `#vehicle_blocks?` for a parked vehicle.
- Confirmed against EasyRPG's live source: `Game_Player::GetOffVehicle`'s boat/ship branch (`src/game_player.cpp`) calls `Game_Map::CanDisembarkShip` (`src/game_map.cpp`), which (1) only tests the *landing* tile's own entry passability — `GetPassableMask(x, y, player.GetX(), player.GetY())` derives a single direction bit at `(x, y)` alone, and the water tile is never passed to a passability check at all — and (2) has no equivalent of `#vehicle_blocks?` at all, unlike `Game_Map::CanLandAirship` a few lines above it in the same file, which does loop `{ Boat, Ship }` explicitly.
- So real RPG_RT's disembark check is narrower: a mapper who authors a directionally-restricted water autotile (a current or waterfall edge — not the common fully-open case) could see this build silently refuse a disembark real RPG_RT allows, and a boat/ship parked on the shore tile could block a disembark real RPG_RT never checks for at all.
- Fixed by adding a dedicated `#ship_disembark_passable?` (landing-tile-only chipset test, same-layer/non-Through blocker check, no `#vehicle_blocks?` call) mirroring `CanDisembarkShip`, and routing `#disembark_vehicle`'s boat/ship branch through it instead of `#passable?`. The airship branch (`#airship_landable?`, already separately verified against `CanLandAirship`) is untouched.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: `#ship_disembark_passable?` asks the chipset about exactly one tile (the landing tile), not two, via a stubbed chipset that records calls.
- [x] New check: a different vehicle (a ship) parked on the landing tile no longer blocks a boat disembark.
- [x] Both confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/scene/map.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (862), `rpg2k_logic_check.rb` (1115), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_