### PR TITLE
Block-and-retry Message Options / Change Face Graphic like their siblings

### DIFF
--- a/changelog.d/message-options-face-graphic-block-and-retry.fixed.md
+++ b/changelog.d/message-options-face-graphic-block-and-retry.fixed.md
@@ -1,0 +1,6 @@
+- **Events:** Message Options and Change Face Graphic now block and retry
+  while a different message window is already open, matching RPG_RT --
+  previously both applied immediately regardless, so a still-running
+  Parallel Process could mutate the shared message window's
+  transparency/position/face graphic mid-display over another event's
+  open text.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2844,6 +2844,41 @@ The work below is roughly ordered by the critical path to a walkable game
    `\s[4]` message through `Scene::Map` end to end, all confirmed to fail
    against the old code, which dropped `\s[]` outright and revealed at a flat
    rate regardless of it.
+  ✅ **Follow-up (2026-08-21): Message Options (10120) and Change Face
+  Graphic (10130) never blocked-and-retried while a *different* message
+  window was already open, unlike every sibling command in the same C++
+  function family.** `Interpreter#do_message_options`/`#do_change_face`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) applied their state (`@state.
+  message_config` mutations, `@face_owner`) unconditionally and
+  synchronously, with no guard at all — unlike the already-ported
+  block-and-retry family (Show/Move/Erase Picture, Transfer Player/Recall
+  to Location, Battle Processing/Enemy Encounter, Change EXP/Level, Key
+  Input Processing), which all call a `block_pending_*_command` guard
+  first. Confirmed against EasyRPG's live source: `Game_Interpreter::
+  CommandMessageOptions`/`CommandChangeFaceGraphic` (`src/
+  game_interpreter.cpp`, codes 10120/10130) both open with the identical
+  guard Show Message/Show Choices/Input Number themselves use, `if
+  (!Game_Message::CanShowMessage(main_flag)) { return false; }` —
+  unconditionally, the same base RPG2000 behaviour as every other
+  block-and-retry command in this family. Without this guard, a
+  still-running Parallel Process (Message Options' own "continue events"
+  flag lets one keep advancing past another event's open Show Text) could
+  mutate the shared, global message window's transparency/position/face
+  image while a *different* event's window was already showing on screen —
+  visibly altering it mid-display instead of only taking effect once that
+  window closes and this one's own message opens. Fixed by adding
+  `#block_pending_message_config_command` (the identical shape as the five
+  existing `block_pending_*_command` helpers) and calling it first in both
+  `do_message_options`/`do_change_face`, plus wiring a new
+  `:message_config_blocked` wait kind into `Scene::Map`'s three existing
+  `_blocked`-kind dispatch points (the foreground `drive_event` switch,
+  `step_parallel`'s equivalent switch, and the same-frame-continuation
+  list) exactly the way `:key_input_blocked` already is. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a Parallel Process's own Message
+  Options reached while a different message window is open leaves
+  `message_config` untouched and the command right after it un-run, then
+  both apply once that window closes), confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **Long messages now paginate.** RPG2000's message window shows four 16px
   rows (the 64px interior of the 80px-tall window); a Show Text that runs past
   that many lines used to draw its later lines straight off the bottom of the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1212,8 +1212,11 @@ module Game
     # position (0 top / 1 middle / 2 bottom), param2 whether the window may move
     # aside to avoid the hero (0 fixed / 1 auto-position — so `position_fixed`
     # is the param2 == 0 case, matching RPG_RT), param3 whether other events keep
-    # running while the message shows. Sets global state; it does not pause.
+    # running while the message shows. Sets global state; blocks-and-retries
+    # first while a *different* message window is already open (see
+    # #block_pending_message_config_command), same as Show Message itself.
     def do_message_options(cmd)
+      return if block_pending_message_config_command
       cfg = @state.message_config
       cfg.transparent = cmd.param(0) != 0
       cfg.position = cmd.param(1)
@@ -1224,11 +1227,13 @@ module Game
     # Change Face Graphic: select the face shown beside the next messages. The
     # command string is the FaceSet file name (empty clears the face); param0 is
     # the cell index (0..15), param1 puts the face on the right, param2 mirrors
-    # it. Persists for the rest of *this* event's execution content (does not
-    # pause), but -- unlike Message Options -- is not sticky game-wide: #update
-    # auto-clears it once this interpreter's own command list genuinely
-    # finishes, via the @face_owner claim set/dropped here.
+    # it. Persists for the rest of *this* event's execution content, but --
+    # unlike Message Options -- is not sticky game-wide: #update auto-clears it
+    # once this interpreter's own command list genuinely finishes, via the
+    # @face_owner claim set/dropped here. Blocks-and-retries first while a
+    # *different* message window is already open, same as Message Options.
     def do_change_face(cmd)
+      return if block_pending_message_config_command
       cfg = @state.message_config
       name = cmd.string || ''
       if name.empty?
@@ -3728,6 +3733,28 @@ module Game
       return false unless wait && message_window_blocks_command?
       @index -= 1
       @wait_kind = :key_input_blocked
+      @waiting = true
+      true
+    end
+
+    # Message Options (10120) / Change Face Graphic (10130) block-and-retry
+    # the same way too -- confirmed directly against RPG_RT's live source:
+    # `Game_Interpreter::CommandMessageOptions`/`CommandChangeFaceGraphic`
+    # (`src/game_interpreter.cpp`) both open with the identical guard Show
+    # Message/Show Choices/Input Number themselves use, `if (!Game_Message::
+    # CanShowMessage(main_flag)) { return false; }` -- unconditionally, the
+    # same base RPG2000 behaviour as the other block-and-retry commands.
+    # Without this guard, a still-running parallel process (Message Options'
+    # own "continue events" flag lets one keep advancing past another
+    # event's open Show Text) could mutate the shared, global message
+    # window's transparency/position/face image while a *different* event's
+    # window is already showing on screen, visibly altering it mid-display
+    # instead of only taking effect once that window closes and this one's
+    # own message opens.
+    def block_pending_message_config_command
+      return false unless message_window_blocks_command?
+      @index -= 1
+      @wait_kind = :message_config_blocked
       @waiting = true
       true
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1830,14 +1830,16 @@ class RPG2k
           # #drive_event's foreground dispatcher exactly. A waiting Key
           # Input Processing command's own block (`CommandKeyInputProc`,
           # `src/game_interpreter.cpp`) has the identical `return false`
-          # shape, so it joins the list too. Other wait kinds keep their
-          # old one-frame-per-call pacing.
+          # shape, so it joins the list too, and so does Message Options /
+          # Change Face Graphic's own block (`CommandMessageOptions`/
+          # `CommandChangeFaceGraphic`, `src/game_interpreter.cpp`). Other
+          # wait kinds keep their old one-frame-per-call pacing.
           unless (wait_kind == :wait || wait_kind == :animation ||
                   wait_kind == :screen || wait_kind == :picture ||
                   wait_kind == :sprite_flash || wait_kind == :movement ||
                   wait_kind == :picture_blocked || wait_kind == :teleport_blocked ||
                   wait_kind == :battle_blocked || wait_kind == :exp_level_blocked ||
-                  wait_kind == :key_input_blocked) &&
+                  wait_kind == :key_input_blocked || wait_kind == :message_config_blocked) &&
                  !it.waiting?
             apply_interpreter_requests(it, p[:event])
             return record_parallel_progress(p)
@@ -2105,6 +2107,13 @@ class RPG2k
           # parallel-process equivalent of #drive_event's own
           # :key_input_blocked case, see
           # Interpreter#block_pending_key_input_command for the citation.
+          it.resume unless message_window_open?
+        elsif it.wait_kind == :message_config_blocked
+          # A Message Options / Change Face Graphic command issued from a
+          # Parallel Process while a *different* message window or choice
+          # list is open -- the parallel-process equivalent of #drive_event's
+          # own :message_config_blocked case, see
+          # Interpreter#block_pending_message_config_command for the citation.
           it.resume unless message_window_open?
         elsif it.wait_kind == :sprite_flash
           # Flash Sprite's own wait flag, the parallel-process equivalent of
@@ -4808,6 +4817,21 @@ class RPG2k
             # same-frame reasoning (`Game_Interpreter::CommandKeyInputProc`,
             # `src/game_interpreter.cpp`, the identical `return false` with
             # the index untouched).
+            @interpreter.resume unless message_window_open?
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
+          when :message_config_blocked
+            # A Message Options / Change Face Graphic command reached while a
+            # *different* message window or choice list is open
+            # (#block_pending_message_config_command) -- the identical
+            # block-and-retry shape as :picture_blocked/:teleport_blocked/
+            # :battle_blocked/:exp_level_blocked/:key_input_blocked above, see
+            # that method's own citation and :picture_blocked's own
+            # same-frame reasoning (`Game_Interpreter::CommandMessageOptions`/
+            # `CommandChangeFaceGraphic`, `src/game_interpreter.cpp`, the
+            # identical `return false` with the index untouched).
             @interpreter.resume unless message_window_open?
             unless @interpreter.waiting?
               @interpreter.update

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2638,6 +2638,44 @@ check "a common event's Parallel Process's own Transfer Player command is " \
   eq 1, st.variables[4], 'and the command after it then runs too'
 end
 
+check "a common event's Parallel Process's own Message Options command is " \
+      'blocked (not dropped) while a different message window is open, and ' \
+      'retries once it closes' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  # CommandMessageOptions`/`CommandChangeFaceGraphic` (`src/
+  # game_interpreter.cpp`, codes 10120/10130) both open with `if (!Game_
+  # Message::CanShowMessage(main_flag)) { return false; }` -- the identical
+  # guard Show Message/Show Choices/Input Number themselves use, and the
+  # same block-and-retry shape already ported for Show/Move/Erase Picture,
+  # Transfer Player/Recall to Location, Battle Processing/Enemy Encounter,
+  # Change EXP/Level and Key Input Processing (see
+  # #block_pending_message_config_command).
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [add_var_cmd(3), ECmd.new(ic::MESSAGE_OPTIONS, [1, 0, 0, 0]),
+                              add_var_cmd(4)])
+  scene = new_scene({}, common: { 7 => ce })
+  st = scene.instance_variable_get(:@state)
+  scene.send(:open_message, ['hi'], false)
+
+  10.times { scene.update }
+  eq 1, st.variables[3], "marker A still runs on the process's first pass"
+  eq false, st.message_config.transparent,
+     'Message Options must not apply while a different message window is open'
+  eq 0, st.variables[4],
+     'the command right after the blocked Message Options must not run either'
+
+  scene.send(:close_message)
+  5.times { scene.update }
+  eq true, st.message_config.transparent,
+     'Message Options retries and applies once the window closes'
+  # >= 1, not == 1: unlike Transfer Player's own multi-frame map load,
+  # Message Options is instantaneous, so the Parallel Process's own
+  # "loops forever" behavior (see the Transfer Player check above) can carry
+  # it around the whole command list more than once within these frames.
+  ok st.variables[4] >= 1, 'and the command after it then runs too'
+end
+
 check "an unrelated event's page change does not restart another event's " \
       'own Parallel Process' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

- `Interpreter#do_message_options`/`#do_change_face` (`mruby-rpg2k/mrblib/interpreter.rb`) applied their state (`@state.message_config` mutations, `@face_owner`) unconditionally and synchronously, with no guard against a different message window already being open — unlike every sibling command in the same C++ function family (Show/Move/Erase Picture, Transfer Player/Recall to Location, Battle Processing/Enemy Encounter, Change EXP/Level, Key Input Processing), which all call a `block_pending_*_command` guard first.
- Confirmed against EasyRPG's live source: `Game_Interpreter::CommandMessageOptions`/`CommandChangeFaceGraphic` (`src/game_interpreter.cpp`, codes 10120/10130) both open with the identical guard Show Message/Show Choices/Input Number themselves use, `if (!Game_Message::CanShowMessage(main_flag)) { return false; }` — unconditionally, the same base RPG2000 behaviour as every other block-and-retry command in this family.
- Without this guard, a still-running Parallel Process (Message Options' own "continue events" flag lets one keep advancing past another event's open Show Text) could mutate the shared, global message window's transparency/position/face image while a *different* event's window was already showing on screen — visibly altering it mid-display instead of only taking effect once that window closes and this one's own message opens.
- Fixed by adding `#block_pending_message_config_command` (the identical shape as the five existing `block_pending_*_command` helpers) and calling it first in both `do_message_options`/`do_change_face`, plus wiring a new `:message_config_blocked` wait kind into `Scene::Map`'s three existing `_blocked`-kind dispatch points (the foreground `drive_event` switch, `step_parallel`'s equivalent switch, and the same-frame-continuation list) exactly the way `:key_input_blocked` already is.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: a Parallel Process's own Message Options reached while a different message window is open leaves `message_config` untouched and the command right after it un-run, then both apply once that window closes.
- [x] Confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/interpreter.rb mruby-rpg2k/mrblib/scene/map.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (863), `rpg2k_logic_check.rb` (1115), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_