### PR TITLE
Gate Change Class / Change Battle Commands on RPG2003, like their neighbors

### DIFF
--- a/changelog.d/change-class-battle-commands-rpg2003-gate.fixed.md
+++ b/changelog.d/change-class-battle-commands-rpg2003-gate.fixed.md
@@ -1,0 +1,6 @@
+- **Events:** Change Class and Change Battle Commands now no-op outright on
+  an RPG2000-compatible database, matching RPG_RT -- previously both
+  applied unconditionally on any edition, so a "no class" Change Class
+  could still reset an actor's EXP, and a Change Battle Commands "clear"
+  could still wipe an actor's command list, on a database that never
+  offered either command in the first place.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10817,6 +10817,41 @@ not yet verified:
   absent"), all four confirmed to fail against the pre-fix code before the
   fix. `ninja -C build test` (mruby-lcf's own suite, since schema.rb
   changed) still passes.
+  ✅ **Follow-up (2026-08-21): Change Class and Change Battle Commands
+  applied unconditionally on any database edition, instead of no-opping
+  outright on an RPG2000-compatible one.** `Interpreter#do_change_class`/
+  `#do_change_battle_commands` (`mruby-rpg2k/mrblib/interpreter.rb`) carried
+  no edition gate at all, unlike their three immediate dispatch neighbors in
+  the same file -- `#do_force_flee` (1006), `#do_enable_combo` (1007), and
+  `#do_call_common_event` (1005) -- which already open with `return unless
+  @battle && @state.party.rpg2003?`. Confirmed against RPG_RT's own live
+  source: `Game_Interpreter::CommandChangeClass`/
+  `CommandChangeBattleCommands` (`src/game_interpreter.cpp`) both open with
+  `if (!Player::IsRPG2k3Commands()) { return true; }`, before any other
+  logic. `class_id: 0` ("no class") still runs `#change_class`'s other side
+  effects (an unconditional EXP reset to the current level's threshold,
+  among others) regardless of whether the database carries a class table at
+  all, and Change Battle Commands' own "clear to Row alone" case (`id 0`,
+  remove) has no existence-table guard of its own the way its "add" branch
+  does -- a `game.rb` comment on `#change_battle_commands` had claimed
+  reusing `#battle_command_row` "makes the command correctly inert on a
+  genuine RPG2000 database... matching `IsRPG2k3Commands()`'s own gate,
+  which `#do_change_battle_commands` does not separately enforce", true
+  only of the "add" branch, not the "clear" one -- corrected in place with
+  a strikethrough. Fixed by adding `return unless party.rpg2003?` to both
+  methods (mirroring the map-side, not battle-side, gate shape, since
+  Change Class/Change Battle Commands are ordinary map/common-event
+  commands with no `@battle` requirement, unlike Force Flee/Enable
+  Combo/Call Common Event). This codebase's own `scripts/
+  rpg2k_logic_check.rb` test fixtures (`class_db`/`class_db_named_skills`)
+  had the identical, matching gap -- built without `rpg2003: true` -- so
+  every existing Change Class/Change Battle Commands check was silently
+  exercising edition-agnostic behavior; both fixtures now pass `rpg2003:
+  true`. Covered by a new check proving both commands are genuine RPG2000
+  no-ops, using `class_id: 0`/the "clear" case specifically (a positive
+  class or command id would coincidentally already be blocked by the
+  existing per-id existence checks on a table-less database, masking the
+  actual gap), confirmed to fail against the pre-fix code before the fix.
 - ✅ **A Change Actor Sprite / Change Vehicle Graphic override's *index* now
   round-trips through `.lsd` at the correct liblcf tag — it was being
   written to, and read from, the wrong field of the save's hero/vehicle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3141,10 +3141,14 @@ module Game
     # integer through -- a handful of bogus adds could silently exhaust the
     # six-slot capacity, starving a later, genuinely valid add of a slot it
     # should have had. Reusing #battle_command_row (already the exact
-    # existence check this needs) also makes the command correctly inert on
-    # a genuine RPG2000 database with no `battlecommands` table at all --
-    # matching `Player::IsRPG2k3Commands()`'s own gate on the real event
-    # command, which #do_change_battle_commands does not separately enforce.
+    # existence check this needs) also makes the *add* branch inert on a
+    # genuine RPG2000 database with no `battlecommands` table at all --
+    # ~~matching `Player::IsRPG2k3Commands()`'s own gate on the real event
+    # command, which #do_change_battle_commands does not separately
+    # enforce~~ not true of the "clear to Row alone" branch below (`id ==
+    # 0`, `add` false), which has no table lookup of its own and still
+    # clears the list even without one; #do_change_battle_commands now
+    # carries the real `IsRPG2k3Commands()` gate itself instead.
     def change_battle_commands(add, id)
       cmds = battle_commands
       if add

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2369,9 +2369,17 @@ module Game
     # than keeping the current one, param4 is the skill mode and param5 the
     # parameter mode (see Game::Actor::CLASS_SKILL_* / CLASS_PARAM_*), and param6
     # is the "show level-up message" flag the Change Level command also carries.
-    # An RPG2000 project cannot emit this, and a database without a class table
-    # leaves every actor class-less, so the command self-limits to 2003 data.
+    # Confirmed against RPG_RT's own live source: `Game_Interpreter::
+    # CommandChangeClass` (`src/game_interpreter.cpp`) opens with `if
+    # (!Player::IsRPG2k3Commands()) { return true; }`, before any other logic
+    # -- an RPG2000-compatible run no-ops the command outright. ~~An RPG2000
+    # project cannot emit this... so the command self-limits to 2003 data~~
+    # was an unverified assumption, not something read off this function's own
+    # source: `class_id: 0` ("no class") still runs `#change_class`'s other
+    # side effects (recomputing `@base`/`@exp`/clearing `@battle_commands`)
+    # regardless of whether the database carries a class table at all.
     def do_change_class(cmd)
+      return unless party.rpg2003?
       class_id = cmd.param(2)
       level_1 = cmd.param(3) != 0
       skill_mode = cmd.param(4)
@@ -2412,8 +2420,17 @@ module Game
 
     # Change Battle Commands (1009), RPG2003-only: add (param3 non-zero) or
     # remove battle command param2 from the target actor(s). Removing command 0
-    # clears the list back to the Row entry alone.
+    # clears the list back to the Row entry alone. Confirmed against RPG_RT's
+    # own live source: `Game_Interpreter::CommandChangeBattleCommands`
+    # (`src/game_interpreter.cpp`) opens with the identical `if (!Player::
+    # IsRPG2k3Commands()) { return true; }` gate Change Class carries -- an
+    # RPG2000-compatible run no-ops the command outright, including the
+    # "clear to Row alone" (id 0, remove) branch, which -- unlike the "add"
+    # branch's own `#battle_command_row` existence check -- has no table
+    # lookup of its own to make it inert on a table-less database by
+    # construction (see `Game::Actor#change_battle_commands`).
     def do_change_battle_commands(cmd)
+      return unless party.rpg2003?
       cmd_id = cmd.param(2)
       add = cmd.param(3) != 0
       stat_targets(cmd).each { |a| a.change_battle_commands(add, cmd_id) }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5251,7 +5251,11 @@ def class_db(class_id = 0, actor_learns = [[10, 1]])
   # a genuine RPG2003 database always carries this table for any project
   # that uses the command at all.
   commands = (1..8).each_with_object({}) { |i, h| h[i] = FakeBattleCommand.new("Cmd#{i}", 1) }
-  FakeActorDB.new(players, [1], {}, {}, jobs, nil, nil,
+  # rpg2003: true -- Change Class / Change Battle Commands are both
+  # RPG2003-only (Interpreter#do_change_class/#do_change_battle_commands'
+  # own IsRPG2k3Commands() gate), and every check built on this fixture
+  # exercises one or the other.
+  FakeActorDB.new(players, [1], {}, {}, jobs, nil, nil, rpg2003: true,
                   battlecommands: FakeBattleCommandsTable.new(commands, 0))
 end
 
@@ -5448,9 +5452,10 @@ def class_db_named_skills(actor_learns = [[10, 1]])
   jobs = {
     1 => JobRow.new('Warrior', job1, [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
   }
+  # rpg2003: true -- Change Class is RPG2003-only (see class_db's own note).
   FakeActorDB.new(players, [1], {},
                   { 21 => fake_skill(name: 'Slash'), 22 => fake_skill(name: 'Cleave') },
-                  jobs)
+                  jobs, nil, nil, rpg2003: true)
 end
 
 check 'Change Class announces each newly-learned skill by name, not just the level' do
@@ -5545,6 +5550,38 @@ check 'Change Battle Commands stops at six commands plus Row' do
   a = class_state.party.actor_by_id(1)
   (3..8).each { |id| a.change_battle_commands(true, id) }
   eq [1, 2, 3, 4, 5, 6, 0], a.battle_commands, 'the seventh add is dropped'
+end
+
+# Confirmed against RPG_RT's own live source: `Game_Interpreter::
+# CommandChangeClass`/`CommandChangeBattleCommands` (`src/
+# game_interpreter.cpp`) both open with `if (!Player::IsRPG2k3Commands()) {
+# return true; }`, before any other logic -- an RPG2000-compatible database
+# no-ops both commands outright, the same edition gate `#do_force_flee`/
+# `#do_enable_combo`/`#do_call_common_event` already carry. `class_id: 0`
+# ("no class") and the "clear to Row alone" battle-commands case are used
+# deliberately here: both apply their side effect (EXP reset, list clear)
+# unconditionally, with no existence-table guard of their own that would
+# otherwise coincidentally make them inert on a table-less RPG2000 database
+# regardless of this gate -- a weaker test using a positive class/command id
+# would not actually distinguish the fixed code from the broken code.
+check 'Change Class and Change Battle Commands are RPG2000 no-ops' do
+  st = party_state # rpg2003: false by default
+  a = st.party.actor_by_id(1)
+  a.exp = 99_999 # nowhere near any real level threshold
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_CLASS,
+                        [1, 1, 0, 0, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                         Game::Actor::CLASS_PARAM_NO_CHANGE, 0])])
+  it.update
+  eq 99_999, a.exp,
+     "Change Class's own unconditional EXP reset must not run on an RPG2000 database"
+
+  a.instance_variable_set(:@battle_commands, [3, 4, 0])
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CHANGE_BATTLE_COMMANDS, [1, 1, 0, 0])]) # clear (id 0, remove)
+  it2.update
+  eq [3, 4, 0], a.battle_commands,
+     "Change Battle Commands' own unconditional clear-to-Row must not run either"
 end
 
 # RPG_RT's own `Game_Actor::ChangeBattleCommands` (src/game_actor.cpp)


### PR DESCRIPTION
## Summary

- `Interpreter#do_change_class`/`#do_change_battle_commands` (`mruby-rpg2k/mrblib/interpreter.rb`) applied unconditionally on any database edition, with no gate at all — unlike their three immediate dispatch neighbors in the same file, `#do_force_flee` (1006), `#do_enable_combo` (1007), and `#do_call_common_event` (1005), which already open with a `party.rpg2003?` check.
- Confirmed against RPG_RT's own live source: `Game_Interpreter::CommandChangeClass`/`CommandChangeBattleCommands` (`src/game_interpreter.cpp`) both open with `if (!Player::IsRPG2k3Commands()) { return true; }`, before any other logic.
- `class_id: 0` ("no class") still runs `#change_class`'s other side effects (an unconditional EXP reset to the current level's threshold, among others) regardless of whether the database carries a class table at all, and Change Battle Commands' own "clear to Row alone" case (`id 0`, remove) has no existence-table guard of its own the way its "add" branch does — so neither command was accidentally inert on a table-less RPG2000 database by construction.
- Fixed by adding `return unless party.rpg2003?` to both methods.
- Corrected a `game.rb` comment on `#change_battle_commands` that had claimed the "add" branch's own existence check made the *whole command* inert on an RPG2000 database — true only of the "add" branch, not the "clear" one.
- This codebase's own `scripts/rpg2k_logic_check.rb` test fixtures (`class_db`/`class_db_named_skills`) had the identical, matching gap — built without `rpg2003: true` — so every existing Change Class/Change Battle Commands check was silently exercising edition-agnostic behavior; both fixtures now pass `rpg2003: true`.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check proving both commands are genuine RPG2000 no-ops, deliberately using `class_id: 0`/the "clear" case (a positive class or command id would coincidentally already be blocked by the existing per-id existence checks on a table-less database, masking the actual gap).
- [x] Confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/interpreter.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (863), `rpg2k_logic_check.rb` (1116), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_