### PR TITLE
Gate the five 2k3e system commands on RPG2003, like their neighbors

### DIFF
--- a/changelog.d/2k3e-system-commands-rpg2003-gate.fixed.md
+++ b/changelog.d/2k3e-system-commands-rpg2003-gate.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** Open Load Menu, Exit Game, Toggle ATB Mode, Toggle
+  Fullscreen and Open Video Options -- RPG2003's "English-release" system
+  commands -- now no-op outright on an RPG2000-compatible database,
+  matching RPG_RT -- previously all five applied unconditionally on any
+  edition.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2418,6 +2418,40 @@ The work below is roughly ordered by the critical path to a walkable game
   `EventCommand::Code` enum, which
   also corrected `analyze_game.rb` — it had Change Class / Change Battle Commands
   at 12610 / 12710, numbers the enum does not define at all.
+  ✅ **Follow-up (2026-08-21): all five of these "RPG2003 English-release
+  (2k3e)" commands — Open Load Menu (5001), Exit Game (5002), Toggle ATB
+  Mode (5003), Toggle Fullscreen (5004), Open Video Options (5005) — ran
+  unconditionally on any database edition, despite the section's own header
+  already labeling them 2k3e-only.** `Interpreter#do_open_load_menu`/
+  `#do_exit_game`/`#do_toggle_atb_mode`/`#do_toggle_fullscreen`/`#do_open_
+  video_options` (`mruby-rpg2k/mrblib/interpreter.rb`) carried no edition
+  gate at all, unlike Change Class/Change Battle Commands (fixed earlier
+  this session) and Force Flee/Enable Combo/Call Common Event, all in the
+  same file. Confirmed against RPG_RT's own live source: all five —
+  `CommandExitGame`/`CommandToggleFullscreen`/`CommandOpenVideoOptions`
+  (`src/game_interpreter.cpp`), `CommandOpenLoadMenu`/`CommandToggleAtbMode`
+  (`src/game_interpreter_map.cpp`) — open with `if (!Player::
+  IsRPG2k3ECommands()) { return true; }`, a hard no-op, before any other
+  logic. `IsRPG2k3ECommands()` (`src/player.h`) is technically narrower
+  still (`IsRPG2k3E()` = `IsRPG2k3() && IsEnglish()`, the *English*-release
+  2003 command set specifically) — this codebase does not model an
+  English/Japanese RPG2003 distinction anywhere (an already-established
+  simplification, see `#block_pending_picture_command`'s own citation on
+  `!Player::IsEnglish()`), so falling back to the coarser `party.rpg2003?`
+  boundary already tracked everywhere else in this file is the correct
+  in-pattern choice here too. Fixed by adding `return unless
+  party.rpg2003?` as the first line of all five methods. This codebase's
+  own `scripts/rpg2k_logic_check.rb`/`scripts/rpg2k_scene_check.rb` checks
+  for these commands had the identical, matching gap — built with the
+  default `rpg2003: false` fixture — so every existing check was silently
+  exercising edition-agnostic behavior; all affected fixtures now pass
+  `rpg2003: true` (including a battle-page check whose own separate
+  `BattleStubParty` fixture overrides `@state.party` entirely and needed
+  its own `rpg2003: true` alongside the scene-level one). Covered by a new
+  `scripts/rpg2k_logic_check.rb` check proving all five are genuine
+  RPG2000 no-ops (Toggle Fullscreen/Open Video Options checked via a
+  captured-stderr assertion, since their own effect is log-only), confirmed
+  to fail against the pre-fix code before the fix.
   **Battle-event pages now run too**: a troop's pages (`enemy_group` chunk 11)
   are evaluated by `Game::BattlePage` at the start of every turn — switch,
   variable, turn, enemy-HP and actor-HP conditions — and each matching page runs

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3413,11 +3413,31 @@ module Game
     end
 
     # -- RPG2003 English-release (2k3e) system commands ------------------------
+    #
+    # All five below are gated on `party.rpg2003?`, matching RPG_RT's own
+    # `Player::IsRPG2k3ECommands()` guard each carries (`if (!Player::
+    # IsRPG2k3ECommands()) { return true; }`, confirmed against live source
+    # for all five: `CommandExitGame`/`CommandToggleFullscreen`/
+    # `CommandOpenVideoOptions` in `src/game_interpreter.cpp`,
+    # `CommandOpenLoadMenu`/`CommandToggleAtbMode` in
+    # `src/game_interpreter_map.cpp`) -- the same "return unless
+    # party.rpg2003?" shape `#do_change_class`/`#do_change_battle_commands`
+    # already carry a few hundred lines up, and these five's own dispatch
+    # neighbors (`#do_force_flee`/`#do_enable_combo`/`#do_call_common_event`)
+    # carry too. `IsRPG2k3ECommands()` is technically narrower still (`Is
+    # RPG2k3E()` = `IsRPG2k3() && IsEnglish()`, the *English*-release 2003
+    # command set specifically) -- this codebase does not model an
+    # English/Japanese RPG2003 distinction anywhere (see
+    # `#block_pending_picture_command`'s own citation on `!Player::
+    # IsEnglish()` for the same already-established simplification), so
+    # falling back to the coarser `rpg2003?` boundary already tracked
+    # everywhere else in this file is the correct in-pattern choice here too.
 
     # Open Load Menu (5001): leave the map for the save-slot loader, the way
     # Return to Title leaves it. Raised as a :load_menu request; there is nothing
     # to resume, because whatever the player loads replaces this scene.
     def do_open_load_menu(_cmd)
+      return unless party.rpg2003?
       @wait_kind = :load_menu
       @waiting = true
     end
@@ -3426,6 +3446,7 @@ module Game
     # by an event. Raised as an :exit_game request the scene answers by leaving
     # the process; nothing resumes.
     def do_exit_game(_cmd)
+      return unless party.rpg2003?
       @wait_kind = :exit_game
       @waiting = true
     end
@@ -3439,6 +3460,7 @@ module Game
     # (`data.atb_mode = !data.atb_mode`), and RPG_RT's 2k3e "Toggle ATB Mode"
     # command is the event-driven path to the same setting. The event runs on.
     def do_toggle_atb_mode(_cmd)
+      return unless party.rpg2003?
       @state.atb_mode = @state.atb_mode == 1 ? 0 : 1
     end
 
@@ -3448,10 +3470,12 @@ module Game
     # cannot change mode — the command is a logged no-op rather than a silent
     # one, and the event runs straight on.
     def do_toggle_fullscreen(_cmd)
+      return unless party.rpg2003?
       $stderr.puts '[RPG2k] Toggle Fullscreen: this display has no fullscreen mode'
     end
 
     def do_open_video_options(_cmd)
+      return unless party.rpg2003?
       $stderr.puts '[RPG2k] Open Video Options: no video-options screen in this build'
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -18234,17 +18234,56 @@ end
 # -- RPG2003 English-release (2k3e) system commands ---------------------------
 
 check 'Open Load Menu and Exit Game raise their scene requests' do
-  it = Game::Interpreter.new(new_state)
+  it = Game::Interpreter.new(new_state(rpg2003: true))
   it.start([FakeCmd.new(IC::OPEN_LOAD_MENU, [])])
   it.update
   ok it.waiting?
   eq :load_menu, it.wait_kind
 
-  it2 = Game::Interpreter.new(new_state)
+  it2 = Game::Interpreter.new(new_state(rpg2003: true))
   it2.start([FakeCmd.new(IC::EXIT_GAME, [])])
   it2.update
   ok it2.waiting?
   eq :exit_game, it2.wait_kind
+end
+
+# Confirmed against RPG_RT's own live source: all five 2k3e system commands
+# (`CommandOpenLoadMenu`/`CommandExitGame`/`CommandToggleAtbMode`/
+# `CommandToggleFullscreen`/`CommandOpenVideoOptions`, `src/
+# game_interpreter.cpp`/`game_interpreter_map.cpp`) open with `if (!Player::
+# IsRPG2k3ECommands()) { return true; }` -- a hard no-op, not merely
+# discarding some other effect, on an RPG2000-compatible database.
+check 'all five 2k3e system commands are RPG2000 no-ops' do
+  it = Game::Interpreter.new(new_state) # rpg2003: false by default
+  it.start([FakeCmd.new(IC::OPEN_LOAD_MENU, [])])
+  it.update
+  ok !it.waiting?, 'Open Load Menu never raises its scene request on an RPG2000 database'
+
+  it2 = Game::Interpreter.new(new_state)
+  it2.start([FakeCmd.new(IC::EXIT_GAME, [])])
+  it2.update
+  ok !it2.waiting?, 'nor does Exit Game'
+
+  st = new_state
+  before_atb = st.atb_mode
+  it3 = Game::Interpreter.new(st)
+  it3.start([FakeCmd.new(IC::TOGGLE_ATB_MODE, [])])
+  it3.update
+  eq before_atb, st.atb_mode, 'Toggle ATB Mode leaves atb_mode untouched'
+
+  it4 = Game::Interpreter.new(new_state)
+  logged = capture_stderr do
+    it4.start([FakeCmd.new(IC::TOGGLE_FULLSCREEN, [])])
+    it4.update
+  end
+  eq '', logged, "Toggle Fullscreen doesn't even reach its own logged no-op message"
+
+  it5 = Game::Interpreter.new(new_state)
+  logged5 = capture_stderr do
+    it5.start([FakeCmd.new(IC::OPEN_VIDEO_OPTIONS, [])])
+    it5.update
+  end
+  eq '', logged5, "Open Video Options doesn't either"
 end
 
 # Ports EasyRPG's own `Game_Interpreter::CommandWait`
@@ -18288,7 +18327,7 @@ check 'Wait with param1 0, or on a non-RPG2003 database, or with no param1 at al
 end
 
 check 'Toggle Fullscreen / Open Video Options run on without pausing' do
-  st = new_state
+  st = new_state(rpg2003: true)
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::TOGGLE_FULLSCREEN, []),
             FakeCmd.new(IC::OPEN_VIDEO_OPTIONS, []),

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16424,7 +16424,8 @@ check 'a battle-page Toggle ATB Mode (5003) flips the live fight to wait' do
   # A TURN-gated page runs at the first turn boundary; its 5003 flips the
   # same save-system `atb_mode` the field menu Wait command flips, live.
   pages = { 1 => troop_page([ECmd.new(ic::TOGGLE_ATB_MODE, [])]) }
-  scene, st = battle_scene_with_pages(pages, rpg2003: true,
+  scene, st = battle_scene_with_pages(pages, party: BattleStubParty.new(rpg2003: true),
+                                      rpg2003: true,
                                       battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
   eq 0, st.atb_mode, 'the fight begins in active mode'
   ui = battle_until_phase(scene, :command, 250)
@@ -18406,7 +18407,7 @@ end
 
 check 'Open Load Menu pushes Scene::SaveLoad in :load mode' do
   cmds = [ECmd.new(IC2::OPEN_LOAD_MENU, []), add_var_cmd(9)]
-  scene = new_scene({}, player: [0, 0])
+  scene = new_scene({}, player: [0, 0], rpg2003: true)
   parent = scene.instance_variable_get(:@parent)
   st = scene.instance_variable_get(:@state)
   scene.instance_variable_get(:@interpreter).start(cmds)
@@ -18422,7 +18423,7 @@ end
 check 'Open Load Menu: cancelling the picker resumes the event -- unlike the old ' \
       'single-slot version, a cancelled load does not abandon it' do
   cmds = [ECmd.new(IC2::OPEN_LOAD_MENU, []), add_var_cmd(9)]
-  scene = new_scene({}, player: [0, 0])
+  scene = new_scene({}, player: [0, 0], rpg2003: true)
   parent = scene.instance_variable_get(:@parent)
   st = scene.instance_variable_get(:@state)
   scene.instance_variable_get(:@interpreter).start(cmds)
@@ -18442,7 +18443,7 @@ end
 
 check 'Open Load Menu: confirming an occupied slot resumes the app through continue_game' do
   cmds = [ECmd.new(IC2::OPEN_LOAD_MENU, []), add_var_cmd(9)]
-  scene = new_scene({}, player: [0, 0])
+  scene = new_scene({}, player: [0, 0], rpg2003: true)
   parent = scene.instance_variable_get(:@parent)
   parent.save_states[3] = menu_state
   scene.instance_variable_get(:@interpreter).start(cmds)


### PR DESCRIPTION
## Summary

- `Interpreter#do_open_load_menu`/`#do_exit_game`/`#do_toggle_atb_mode`/`#do_toggle_fullscreen`/`#do_open_video_options` (`mruby-rpg2k/mrblib/interpreter.rb`) — the five "RPG2003 English-release (2k3e)" system commands (5001-5005) — ran unconditionally on any database edition, despite the section's own header comment already labeling them 2k3e-only.
- Every other RPG2003-only command dispatched from this same file (`do_force_flee`, `do_enable_combo`, `do_call_common_event`, and — fixed earlier this session — `do_change_class`/`do_change_battle_commands`) opens with a `party.rpg2003?` gate. These five had none at all.
- Confirmed against RPG_RT's own live source: all five — `CommandExitGame`/`CommandToggleFullscreen`/`CommandOpenVideoOptions` (`src/game_interpreter.cpp`), `CommandOpenLoadMenu`/`CommandToggleAtbMode` (`src/game_interpreter_map.cpp`) — open with `if (!Player::IsRPG2k3ECommands()) { return true; }`, a hard no-op, before any other logic.
- `IsRPG2k3ECommands()` (`src/player.h`) is technically narrower still (`IsRPG2k3E()` = `IsRPG2k3() && IsEnglish()`, the *English*-release 2003 command set specifically) — this codebase doesn't model an English/Japanese RPG2003 distinction anywhere (an already-established simplification elsewhere in this file), so falling back to the coarser `party.rpg2003?` boundary already tracked everywhere else is the correct in-pattern choice here too.
- Fixed by adding `return unless party.rpg2003?` as the first line of all five methods.
- This codebase's own test fixtures across both suites had the identical, matching gap — built with the default `rpg2003: false` — so every existing check for these commands was silently exercising edition-agnostic behavior; all affected fixtures now pass `rpg2003: true`, including a battle-page check whose own separate `BattleStubParty` fixture overrides `@state.party` entirely and needed its own `rpg2003: true` alongside the scene-level one.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check proving all five commands are genuine RPG2000 no-ops (Toggle Fullscreen/Open Video Options checked via a captured-stderr assertion, since their own effect is log-only).
- [x] Confirmed to fail against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/interpreter.rb`) before the fix, then pass after `git stash pop`.
- [x] All four suites green: `rpg2k_scene_check.rb` (863), `rpg2k_logic_check.rb` (1117), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_