### PR TITLE
Always roll the auto-release RNG draw, even at 0% chance

### DIFF
--- a/changelog.d/state-auto-release-rng-draw-at-zero-percent.fixed.md
+++ b/changelog.d/state-auto-release-rng-draw-at-zero-percent.fixed.md
@@ -1,0 +1,6 @@
+- **Battle:** a status that can never auto-release on its own
+  (`auto_release_prob` 0 -- a typical "must be cured" ailment) now still
+  burns its RNG draw every turn once eligible, matching RPG_RT -- the
+  guaranteed-fail roll was previously skipped outright, silently drifting
+  this build's shared RNG stream out of sync with a real seeded run for
+  the rest of the fight.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1519,7 +1519,28 @@ The work below is roughly ordered by the critical path to a walkable game
   afflicts the foe, which then slips or skips via the per-turn processing above.
   A state also **auto-recovers**: a per-battler turn counter lets `apply_turn_
   states` roll `auto_release_prob` once the state has held past its `hold_turn`,
-  so a temporary ailment wears off. Three more of the 状態 row's fields are read
+  so a temporary ailment wears off.
+  ~~That roll was itself skipped outright whenever `auto_release_prob` was
+  0, on the reasoning that a guaranteed-fail roll is a pure no-op.~~
+  ✅ **Follow-up (2026-08-21): it is not a no-op — RPG_RT still burns the RNG
+  draw.** Confirmed via curl against EasyRPG's live `Game_Battler::
+  BattleStateHeal` (`src/game_battler.cpp`): `states[i] > hold_turn &&
+  Rand::ChanceOf(auto_release_prob, 100) && RemoveState(...)`. C++'s `&&`
+  only short-circuits on the `hold_turn` test; `Rand::ChanceOf` (`src/
+  rand.cpp`) is `GetRandomNumber(1, m) <= n` and always calls
+  `GetRandomNumber`, whatever `n` is. `#recovers_from_state?` used to check
+  `auto_release_prob <= 0` *before* the `hold_turn` test and return early,
+  skipping `@rng.random` entirely — for any state configured "never auto-
+  releases" (a common design for Poison/Curse-style ailments meant to
+  require a cure item), that silently dropped one RNG draw per turn from
+  the shared stream for the rest of the fight once the state's counter
+  passed `hold_turn`, permanently desyncing this build's sequence from a
+  real seeded RPG_RT run. Fixed by reordering the two checks so the
+  `hold_turn` gate runs first and the roll always happens after
+  (`@rng.random(100) < auto_release_prob`, which is always false at 0%
+  regardless, so the observable auto-release outcome is unchanged — only
+  the draw itself is now consumed).
+  Three more of the 状態 row's fields are read
   now, and they are the ones that give the genre's most familiar statuses their
   meaning (ADR 0032): **`reduce_hit_ratio`** scales the afflicted attacker's
   accuracy, the lowest ratio winning when several apply, so **Blind blinds** —

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -11287,12 +11287,22 @@ module Game
 
     # Whether `b` shakes off state `id` this turn: only once it has held for more
     # than the state's `hold_turn`, then an `auto_release_prob`% roll (0 = never
-    # auto-releases). Grounded on EasyRPG's BattleStateHeal.
+    # auto-releases). Grounded on EasyRPG's live `Game_Battler::BattleStateHeal`
+    # (`src/game_battler.cpp`): `states[i] > hold_turn && Rand::ChanceOf(auto_
+    # release_prob, 100) && RemoveState(...)`. C++'s `&&` only short-circuits on
+    # the `hold_turn` test -- `Rand::ChanceOf` (`src/rand.cpp`) is
+    # `GetRandomNumber(1, m) <= n` and always draws, whatever `n` is. A prior
+    # version of this method checked `prob <= 0` *before* the `hold_turn` test
+    # and returned early, skipping the RNG draw outright once a state's counter
+    # passed `hold_turn` -- for any state configured with `auto_release_prob ==
+    # 0` (a common "must be cured" ailment), that silently dropped one draw per
+    # turn from the shared stream for the rest of the fight, permanently
+    # desyncing this build's RNG sequence from a real seeded RPG_RT run.
+    # `@rng.random(100) < 0` is always false, so the observable outcome at 0%
+    # is unchanged -- only the draw itself is now consumed, same as RPG_RT.
     def recovers_from_state?(b, id, d)
-      prob = state_field(d, :auto_release_prob)
-      return false if prob <= 0
       return false unless b.state_turns[id] > state_field(d, :hold_turn)
-      @rng.random(100) < prob
+      @rng.random(100) < state_field(d, :auto_release_prob)
     end
 
     # Whether `b` counts as out of the fight *for the ally side's own

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14980,6 +14980,29 @@ check 'battle state at 0% auto_release_prob never wears off on its own' do
   eq true, hero.state?(5)                            # 0% -> stays for the whole fight
 end
 
+# EasyRPG's Game_Battler::BattleStateHeal (src/game_battler.cpp) always rolls
+# Rand::ChanceOf(auto_release_prob, 100) once state_turns exceeds hold_turn --
+# Rand::ChanceOf (src/rand.cpp) is GetRandomNumber(1, m) <= n and always draws,
+# whatever n is; C++'s && only short-circuits on the hold_turn test, never on
+# the probability. A 0%-chance state must still burn that RNG draw every turn
+# once eligible, or this build's shared RNG stream desyncs from a real seeded
+# RPG_RT run for the rest of the fight.
+check 'battle state auto-release always consumes an RNG draw once eligible, even at 0% chance' do
+  states = { 5 => FakeStateDef.new(0, 0, 0, 0, 0, 0, 0) } # hold_turn 0, prob 0
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [5]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  rng = Game::Rng.new(1)
+  bat = Game::Battle.new([hero], [slime], rng, states)
+  bat.send(:apply_turn_states, hero) # counter 0 -> 1, > hold_turn 0: eligible, must roll
+
+  reference = Game::Rng.new(1)
+  reference.next_int
+  eq reference.instance_variable_get(:@state), rng.instance_variable_get(:@state),
+     'an always-fails-at-0% auto-release check must still burn exactly one RNG draw, matching ' \
+     "Rand::ChanceOf's unconditional GetRandomNumber call"
+end
+
 check 'battle: curing a state resets its turn-held counter, so a ' \
       'reinflicted state does not inherit a stale duration' do
   # RPG_RT's own State::Add/State::Remove (src/state.cpp) share one literal


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Battler::BattleStateHeal` (`src/game_battler.cpp`) always calls `Rand::ChanceOf(auto_release_prob, 100)` once a state's held-turn count exceeds `hold_turn`:

```cpp
if (states[i] > lcf::Data::states[i].hold_turn
        && Rand::ChanceOf(lcf::Data::states[i].auto_release_prob, 100)
        && RemoveState(i + 1, false)
        ) {
```

`Rand::ChanceOf` (`src/rand.cpp`) is `GetRandomNumber(1, m) <= n` and **always draws**, regardless of `n`. C++'s `&&` only short-circuits on the `hold_turn` test — never on the probability itself.

`Game::Battle#recovers_from_state?` checked `auto_release_prob <= 0` *before* the `hold_turn` test and returned early, skipping the RNG draw outright for any state configured to never auto-release on its own (a common design for "must be cured" ailments like Poison/Curse). Once such a state's turn counter passed `hold_turn`, this silently dropped one RNG draw per turn from the shared stream for the rest of the fight — permanently desyncing this build's RNG sequence from a real seeded RPG_RT run from that point on.

This is the same bug class already fixed for `#critical?` and `#shake_off_states` earlier in this codebase's history (both now always roll rather than short-circuiting on a zero chance); `#recovers_from_state?` was simply missed.

## Fix

Reordered the two checks in `mruby-rpg2k/mrblib/game.rb`'s `recovers_from_state?` so the `hold_turn` gate runs first (the only real short-circuit in the C++), and the roll always happens after:

```ruby
def recovers_from_state?(b, id, d)
  return false unless b.state_turns[id] > state_field(d, :hold_turn)
  @rng.random(100) < state_field(d, :auto_release_prob)
end
```

`@rng.random(100) < 0` is always false, so the observable auto-release outcome at 0% is unchanged — only the RNG draw itself is now consumed, matching RPG_RT.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb` that seeds a `Game::Rng`, inflicts a `hold_turn: 0, auto_release_prob: 0` state, calls `apply_turn_states` once, and asserts the RNG's internal state matches a reference RNG that was manually advanced by exactly one `next_int` call.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb`: the new test fails pre-fix (`expected 224, got 2` — the RNG state never advanced) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1118), `rpg2k_scene_check.rb` (863), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Documented in `docs/TODO.md` (struck through the prior "guaranteed-fail roll is a pure no-op" assumption with a dated Follow-up) and `changelog.d/state-auto-release-rng-draw-at-zero-percent.fixed.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_