### PR TITLE
Block Erase Screen / Show Screen while a message window is open

### DIFF
--- a/changelog.d/erase-show-screen-block-and-retry.fixed.md
+++ b/changelog.d/erase-show-screen-block-and-retry.fixed.md
@@ -1,0 +1,7 @@
+- **Events:** Erase Screen and Show Screen now block (not run) while a
+  message window or choice list is open, retrying once it closes -- the
+  same block-and-retry family Show/Move/Erase Picture, Transfer Player,
+  Battle Processing/Enemy Encounter, Change EXP/Level, Key Input
+  Processing and Message Options/Change Face Graphic already join --
+  previously a still-running parallel process could cut the screen to
+  black (or back) out from under an on-screen message window.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2934,6 +2934,25 @@ The work below is roughly ordered by the critical path to a walkable game
   `message_config` untouched and the command right after it un-run, then
   both apply once that window closes), confirmed to fail against the
   pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-21): Erase Screen (11010) and Show Screen (11020)
+  had the exact same gap — a seventh and eighth sibling missing from the
+  block-and-retry family.** `Interpreter#do_erase_screen`/`#do_show_screen`
+  ran their screen transition immediately, even while a message window from
+  another event/parallel process was still on screen — visibly cutting the
+  screen to black (or back) mid-message, something real RPG_RT never does.
+  Confirmed against EasyRPG's live source: `Game_Interpreter::
+  CommandEraseScreen`/`CommandShowScreen` (`src/game_interpreter.cpp`, codes
+  11010/11020) both open with `if (Game_Message::IsMessageActive()) { return
+  false; }`, unconditionally — not gated behind `IsEnglish()`/
+  `IsPatchUnlockPics()` the way Show/Move/Erase Picture are, so this is base
+  RPG2000 behaviour with no edition exception at all. Fixed the identical
+  way: a new `#block_pending_screen_command` helper, called first in both
+  `do_erase_screen`/`do_show_screen`, plus a new `:screen_blocked` wait kind
+  wired into `Scene::Map`'s three existing `_blocked`-kind dispatch points.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a Parallel
+  Process's own Erase Screen reached while a message window is open leaves
+  the screen unfaded and the command right after it un-run, then both apply
+  once that window closes), confirmed to fail against the pre-fix code.
 - ✅ **Long messages now paginate.** RPG2000's message window shows four 16px
   rows (the 64px interior of the 80px-tall window); a Show Text that runs past
   that many lines used to draw its later lines straight off the bottom of the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3505,6 +3505,7 @@ module Game
     # an instant style (the cuts, or a transition onto a screen already in that
     # state) settles at once and does not wait at all.
     def do_erase_screen(cmd)
+      return if block_pending_screen_command
       style = Game::Transition.erase_style(cmd.param(0), teleport_transition(0))
       @state.screen.erase(style)
       return unless @state.screen.fading?
@@ -3513,6 +3514,7 @@ module Game
     end
 
     def do_show_screen(cmd)
+      return if block_pending_screen_command
       style = Game::Transition.show_style(cmd.param(0), teleport_transition(1))
       @state.screen.show(style)
       return unless @state.screen.fading?
@@ -3702,6 +3704,26 @@ module Game
       return false unless message_window_blocks_command?
       @index -= 1
       @wait_kind = :teleport_blocked
+      @waiting = true
+      true
+    end
+
+    # Real RPG_RT does not run an Erase Screen / Show Screen command while a
+    # message window or choice list is open either -- the identical
+    # block-and-retry shape #block_pending_picture_command already ports, on
+    # a fourth pair of commands. Confirmed directly against RPG_RT's live
+    # source: `Game_Interpreter::CommandEraseScreen`/`CommandShowScreen`
+    # (`src/game_interpreter.cpp`, codes 11010/11020) both open with `if
+    # (Game_Message::IsMessageActive()) { return false; }`, unconditionally --
+    # not gated behind `IsEnglish()`/`IsPatchUnlockPics()` the way Show/Move/
+    # Erase Picture are, so this is base RPG2000 behaviour with no edition
+    # exception at all. Without this guard, a still-running parallel process
+    # could cut the screen to black (or back) out from under an on-screen
+    # message window instead of waiting for it to close first.
+    def block_pending_screen_command
+      return false unless message_window_blocks_command?
+      @index -= 1
+      @wait_kind = :screen_blocked
       @waiting = true
       true
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1832,14 +1832,17 @@ class RPG2k
           # `src/game_interpreter.cpp`) has the identical `return false`
           # shape, so it joins the list too, and so does Message Options /
           # Change Face Graphic's own block (`CommandMessageOptions`/
-          # `CommandChangeFaceGraphic`, `src/game_interpreter.cpp`). Other
-          # wait kinds keep their old one-frame-per-call pacing.
+          # `CommandChangeFaceGraphic`, `src/game_interpreter.cpp`), and so
+          # does Erase/Show Screen's own block (`CommandEraseScreen`/
+          # `CommandShowScreen`, `src/game_interpreter.cpp`). Other wait
+          # kinds keep their old one-frame-per-call pacing.
           unless (wait_kind == :wait || wait_kind == :animation ||
                   wait_kind == :screen || wait_kind == :picture ||
                   wait_kind == :sprite_flash || wait_kind == :movement ||
                   wait_kind == :picture_blocked || wait_kind == :teleport_blocked ||
                   wait_kind == :battle_blocked || wait_kind == :exp_level_blocked ||
-                  wait_kind == :key_input_blocked || wait_kind == :message_config_blocked) &&
+                  wait_kind == :key_input_blocked || wait_kind == :message_config_blocked ||
+                  wait_kind == :screen_blocked) &&
                  !it.waiting?
             apply_interpreter_requests(it, p[:event])
             return record_parallel_progress(p)
@@ -2114,6 +2117,13 @@ class RPG2k
           # list is open -- the parallel-process equivalent of #drive_event's
           # own :message_config_blocked case, see
           # Interpreter#block_pending_message_config_command for the citation.
+          it.resume unless message_window_open?
+        elsif it.wait_kind == :screen_blocked
+          # An Erase Screen / Show Screen command issued from a Parallel
+          # Process while a message window or choice list is open -- the
+          # parallel-process equivalent of #drive_event's own :screen_blocked
+          # case, see Interpreter#block_pending_screen_command for the
+          # citation.
           it.resume unless message_window_open?
         elsif it.wait_kind == :sprite_flash
           # Flash Sprite's own wait flag, the parallel-process equivalent of
@@ -4832,6 +4842,21 @@ class RPG2k
             # same-frame reasoning (`Game_Interpreter::CommandMessageOptions`/
             # `CommandChangeFaceGraphic`, `src/game_interpreter.cpp`, the
             # identical `return false` with the index untouched).
+            @interpreter.resume unless message_window_open?
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
+          when :screen_blocked
+            # An Erase Screen / Show Screen command reached while a message
+            # window or choice list is open (#block_pending_screen_command)
+            # -- the identical block-and-retry shape as :picture_blocked/
+            # :teleport_blocked/:battle_blocked/:exp_level_blocked/
+            # :key_input_blocked/:message_config_blocked above, see that
+            # method's own citation and :picture_blocked's own same-frame
+            # reasoning (`Game_Interpreter::CommandEraseScreen`/
+            # `CommandShowScreen`, `src/game_interpreter.cpp`, the identical
+            # `return false` with the index untouched).
             @interpreter.resume unless message_window_open?
             unless @interpreter.waiting?
               @interpreter.update

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2676,6 +2676,39 @@ check "a common event's Parallel Process's own Message Options command is " \
   ok st.variables[4] >= 1, 'and the command after it then runs too'
 end
 
+check "a common event's Parallel Process's own Erase Screen command is " \
+      'blocked (not dropped) while a message window is open, and retries ' \
+      'once it closes' do
+  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
+  # CommandEraseScreen`/`CommandShowScreen` (`src/game_interpreter.cpp`,
+  # codes 11010/11020) both open with `if (Game_Message::IsMessageActive()) {
+  # return false; }`, unconditionally -- not gated behind
+  # `IsEnglish()`/`IsPatchUnlockPics()` the way Show/Move/Erase Picture are --
+  # the same block-and-retry shape already ported for Show/Move/Erase
+  # Picture, Transfer Player/Recall to Location, Battle Processing/Enemy
+  # Encounter, Change EXP/Level, Key Input Processing and Message
+  # Options/Change Face Graphic (see #block_pending_screen_command).
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [add_var_cmd(3), ECmd.new(ic::ERASE_SCREEN, [0]),
+                              add_var_cmd(4)])
+  scene = new_scene({}, common: { 7 => ce })
+  st = scene.instance_variable_get(:@state)
+  scene.send(:open_message, ['hi'], false)
+
+  10.times { scene.update }
+  eq 1, st.variables[3], "marker A still runs on the process's first pass"
+  ok !st.screen.fading? && !st.screen.erased?,
+     'Erase Screen must not apply while a message window is open'
+  eq 0, st.variables[4],
+     'the command right after the blocked Erase Screen must not run either'
+
+  scene.send(:close_message)
+  60.times { scene.update }
+  ok st.screen.erased?, 'Erase Screen retries and applies once the window closes'
+  ok st.variables[4] >= 1, 'and the command after it then runs too'
+end
+
 check "an unrelated event's page change does not restart another event's " \
       'own Parallel Process' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Interpreter::CommandEraseScreen`/`CommandShowScreen` (`src/game_interpreter.cpp`, codes 11010/11020) both open with an unconditional guard:

```cpp
bool Game_Interpreter::CommandEraseScreen(lcf::rpg::EventCommand const& com) { // code 11010
	if (Game_Message::IsMessageActive()) {
		return false;
	}
	...
bool Game_Interpreter::CommandShowScreen(lcf::rpg::EventCommand const& com) { // code 11020
	if (Game_Message::IsMessageActive()) {
		return false;
	}
	...
```

Unlike Show/Move/Erase Picture (which only block on this in `!Player::IsEnglish() && !Player::IsPatchUnlockPics()` builds), Erase/Show Screen have no edition exception at all — this is base RPG2000 behaviour.

This codebase's `Interpreter#do_erase_screen`/`#do_show_screen` (`mruby-rpg2k/mrblib/interpreter.rb`) ran the screen transition immediately regardless of message-window state — the two commands were simply missing from the block-and-retry family that already covers their six siblings (Show/Move/Erase Picture, Transfer Player/Recall to Location, Battle Processing/Enemy Encounter, Change EXP/Level, Key Input Processing, Message Options/Change Face Graphic). Without the guard, a still-running Parallel Process could cut the screen to black (or back) out from under an on-screen message window — visibly interrupting it, something real RPG_RT never does.

## Fix

- `interpreter.rb`: added `block_pending_screen_command` (identical shape to the six existing `block_pending_*_command` helpers), called first in both `do_erase_screen`/`do_show_screen`.
- `scene/map.rb`: wired a new `:screen_blocked` wait kind into the three existing `_blocked`-kind dispatch points — the same-frame retry list, the parallel-process `drive_parallel_wait` branch, and the foreground `drive_event` case switch — mirroring `:message_config_blocked`'s own wiring exactly.

## Testing

Added a regression test to `scripts/rpg2k_scene_check.rb`: a common event's Parallel Process issues Erase Screen while a different message window is open — asserts the screen stays unfaded and the command right after it doesn't run, then closes the message window and asserts the Erase Screen retries and the trailing command runs too.

- Verified via `git stash push -- mruby-rpg2k/mrblib/interpreter.rb mruby-rpg2k/mrblib/scene/map.rb`: the new test fails pre-fix (`Erase Screen must not apply while a message window is open`) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1118), `rpg2k_scene_check.rb` (864), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

Documented in `docs/TODO.md` (Follow-up on the existing Message Options block-and-retry bullet) and `changelog.d/erase-show-screen-block-and-retry.fixed.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_