### PR TITLE
Color the Status screen's HP/MP figures at low health

### DIFF
--- a/changelog.d/status-screen-hp-mp-low-health-color.fixed.md
+++ b/changelog.d/status-screen-hp-mp-low-health-color.fixed.md
@@ -1,0 +1,6 @@
+- **Status screen:** the current HP figure now shows in the windowskin's
+  own gray "knocked out" swatch at 0 HP, and the current HP/MP figure
+  shows in the "critical" swatch at a quarter of max or below -- matching
+  RPG_RT's `Window_Base::GetValueFontColor` -- previously the whole HP/MP
+  row always drew in a flat default color regardless of how low either
+  figure was.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17355,6 +17355,38 @@ correcting this file's own class comment, which had asserted the old
 `#next_level_exp`/`#exp_to_next` distinct values, 420 vs 120, so the
 check can tell which one the screen actually reads — it must show 420,
 never 120), confirmed to fail against the pre-fix code.
+✅ **Follow-up (2026-08-21): the field Status screen's HP/MP row never
+recolored its current figures at low health, unlike RPG_RT.** Confirmed
+directly against RPG_RT's live source: `Window_Base::GetValueFontColor`
+(`src/window_base.cpp`), the shared routine behind `DrawActorHp`/
+`DrawActorSp` (in turn used by `Window_ActorStatus::DrawStatus`,
+`src/window_actorstatus.cpp` — this screen's own EasyRPG counterpart) —
+`if (can_knockout && have == 0) return ColorKnockout; if (max > 0 &&
+have <= max / 4) return ColorCritical; return ColorDefault;` — colors
+only the *current* HP/SP figure, never its label or max: knockout gray
+(palette index 5) at exactly 0 HP, critical red/orange (index 4) at or
+below a quarter of max, else the ordinary default (index 0); SP never
+shows the knockout colour even at 0 (`DrawActorSp` always passes
+`can_knockout` false). `Scene::StatusMenu#build_window`
+(`mruby-rpg2k/mrblib/scene/status_menu.rb`) drew its whole HP/MP line as
+one flat-white string, no color logic at all. Fixed by porting
+`GetValueFontColor` verbatim as a new `#value_font_color` helper on
+`Scene::Base` (`mruby-rpg2k/mrblib/scene/base.rb`, alongside
+`#draw_actor_state`'s own palette-index convention), and pulling the
+HP/MP row out of the screen's flat-line pass into a new
+`#draw_hp_mp_row`/`#draw_stat_segment` pair that draws each stat's
+label, current figure (through `#value_font_color`) and `/max` as three
+separately-colored runs via the existing `#draw_system_text`. The
+battle status panel's own HP/SP columns (`Scene::Battle#battle_status_row`,
+`mruby-rpg2k/mrblib/scene/battle.rb`) have the identical gap — a single
+flat-colored `"HP n/max"` segment — but splitting that shared-column
+layout the same way is a separate, larger change (its renderer lays out
+fixed-width columns by explicit x offsets rather than a single flowing
+line) and is left for a future pass. Covered by a new
+`scripts/rpg2k_scene_check.rb` check asserting a knocked-out HP figure
+and a critical MP figure blend from their own distinct windowskin
+swatch cells (indices 5 and 4) while the HP max figure stays on the
+default swatch (index 0), confirmed to fail against the pre-fix code.
 ✅ **A dangling battle-animation id no longer draws nothing with no trace** —
 the "battle animation" case from the "invalid hero, skill, item, enemy,
 enemy group, battle animation, terrain, chipset, common event" list above.

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -133,6 +133,21 @@ class RPG2k
         draw_system_text bmp, x, y, w, h, text, skin, color, align
       end
 
+      # The palette colour index an actor's live HP/SP figure draws in --
+      # ported verbatim from EasyRPG's live `Window_Base::GetValueFontColor`
+      # (`src/window_base.cpp`), the shared routine behind `DrawActorHp`/
+      # `DrawActorSp`: knockout gray (5) at exactly 0 with `can_knockout` set
+      # (HP only -- `DrawActorSp` always passes false, so SP never shows this
+      # colour even at 0), else critical red/orange (4) at or below a quarter
+      # of `max`, else the ordinary default (0). These are `\c[n]`-style
+      # system-palette indices, the same ones #state_display already returns
+      # for a status condition's own name.
+      def value_font_color(have, max, can_knockout)
+        return 5 if can_knockout && have == 0
+        return 4 if max && max > 0 && have <= max / 4
+        0
+      end
+
       # The database's word for "no condition" (RPG_RT shows it rather than
       # leaving the column blank), or a plain English stand-in for a database
       # that leaves the term unset.

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -17,6 +17,11 @@ class RPG2k
       STATE_ROW = 5
       STATE_LABEL = "State".freeze
       STATE_VALUE_X = 48
+      # The HP/MP row: which line of the panel it is. Drawn separately from
+      # the flat `lines` pass below (see #draw_hp_mp_row) since, unlike every
+      # other line on this screen, its two current-value figures each need
+      # their own palette colour.
+      HP_MP_ROW = 3
 
       # `actor_index` is which party member the screen opens on -- the one
       # `Scene::Menu#enter_actor_selection` preselected from the menu's own
@@ -138,8 +143,8 @@ class RPG2k
           "Class: #{a.respond_to?(:class_name) ? a.class_name : ''}",
           "#{term(:level_short, 'Lv')} #{a.level}    " \
           "#{term(:exp_short, 'EXP')} #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
-          "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}    " \
-          "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}",
+          # Drawn separately, after this flat pass -- see #draw_hp_mp_row.
+          '',
           # ATK/DEF/Int(Spirit)/AGI, state-adjusted -- confirmed against
           # RPG_RT's own live source: `Window_ParamStatus::Refresh`
           # (`src/window_paramstatus.cpp`) draws `actor.GetAtk()`/`GetDef()`/
@@ -176,6 +181,7 @@ class RPG2k
         lines.each_with_index do |line, i|
           c.draw_text 0, i * LINE_H, inner_w, LINE_H, line
         end
+        draw_hp_mp_row c, a, HP_MP_ROW * LINE_H, inner_w
         draw_actor_state c, a, STATE_VALUE_X, STATE_ROW * LINE_H,
                          inner_w - STATE_VALUE_X, LINE_H, @skin
         draw_battle_row(c, a, inner_w) if rpg2003_party?
@@ -198,6 +204,38 @@ class RPG2k
       # own `"Class: ..."` precedent for the same situation.
       def rpg2003_party?
         @state.party.respond_to?(:rpg2003?) && @state.party.rpg2003?
+      end
+
+      # This screen's HP/MP row: RPG_RT's own `Window_ActorStatus::DrawStatus`
+      # (`src/window_actorstatus.cpp`) draws it through the same
+      # `DrawActorHp`/`DrawActorSp` (`src/window_base.cpp`) the battle status
+      # panel uses, so it carries the identical per-value colouring (see
+      # #draw_stat_segment) -- only ever applied to this screen's *current*
+      # HP/MP figures, never their label or max.
+      def draw_hp_mp_row(c, a, y, inner_w)
+        gutter = c.text_size('    ').width
+        x = draw_stat_segment(c, 0, y, inner_w, term(:hp_short, 'HP') + ' ',
+                               a.hp, a.display_max_hp, true)
+        draw_stat_segment(c, x + gutter, y, inner_w, term(:mp_short, 'MP') + ' ',
+                           a.mp, a.display_max_mp, false)
+      end
+
+      # One "LABEL current/max" run starting at `x`: `label` and the `/max`
+      # suffix draw in the default palette colour, `cur` alone through
+      # #value_font_color (`can_knockout` true only for HP, matching
+      # `DrawActorHp`'s own call -- `DrawActorSp` never passes it). Returns
+      # the x position just past the drawn run, so a caller can chain another
+      # stat after it (see #draw_hp_mp_row's own MP call).
+      def draw_stat_segment(c, x, y, inner_w, label, cur, max, can_knockout)
+        draw_system_text c, x, y, inner_w - x, LINE_H, label, @skin
+        x += c.text_size(label).width
+        color = value_font_color(cur, max, can_knockout)
+        cur_s = cur.to_s
+        draw_system_text c, x, y, inner_w - x, LINE_H, cur_s, @skin, color
+        x += c.text_size(cur_s).width
+        rest = "/#{max}"
+        draw_system_text c, x, y, inner_w - x, LINE_H, rest, @skin
+        x + c.text_size(rest).width
       end
 
       def draw_battle_row(bmp, actor, inner_w)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -20567,6 +20567,35 @@ check 'the status screen shows the RPG2003 battle row, gated on rpg2003?' do
   ok texts.include?('Back'), "back row shows once toggled, got: #{texts.inspect}"
 end
 
+# Confirmed directly against RPG_RT's live source: `Window_Base::
+# GetValueFontColor` (`src/window_base.cpp`), the shared routine behind
+# `DrawActorHp`/`DrawActorSp` (in turn used by `Window_ActorStatus::
+# DrawStatus`, `src/window_actorstatus.cpp`) -- the *current* HP/MP figure
+# alone recolors: knockout gray (index 5) at exactly 0 HP, critical
+# red/orange (index 4) at or below a quarter of max, the ordinary default
+# (index 0) otherwise. SP never shows the knockout colour even at 0
+# (`DrawActorSp` always passes `can_knockout` false).
+check 'the status screen colours a knocked-out HP figure and a critical MP ' \
+      'figure through the windowskin\'s own swatches, not a flat colour' do
+  db = fake_db
+  db.system.system_graphic = 'Skin1' # non-empty -> make_windowskin returns a real Bitmap
+  st = Game::State.new(MenuStubParty.new, 1, 0, 0)
+  hero = st.party.actors.first
+  hero.instance_variable_set(:@hp, 0) # knocked out -- HP figure draws in index 5
+  hero.instance_variable_set(:@mp, 5) # <= a quarter of max_mp (30) -- index 4
+  scene = menu_scene(RPG2k::Scene::StatusMenu, st, db)
+  bc = scene.instance_variable_get(:@window).contents.blend_calls || []
+  # swatch cell (idx % 10 * 16, idx / 10 * 16 + 48) -- see Game::MessagePalette.
+  ok bc.any? { |call| call[4] == '0' && call[6] == 80 && call[7] == 48 },
+     "the knocked-out HP figure must blend from swatch index 5 (80, 48), got: " \
+     "#{bc.map { |c| [c[4], c[6], c[7]] }.inspect}"
+  ok bc.any? { |call| call[4] == '5' && call[6] == 64 && call[7] == 48 },
+     "the critical MP figure must blend from swatch index 4 (64, 48), got: " \
+     "#{bc.map { |c| [c[4], c[6], c[7]] }.inspect}"
+  ok bc.any? { |call| call[4] == '/120' && call[6] == 0 && call[7] == 48 },
+     'the HP max figure stays the default colour (index 0)'
+end
+
 check 'Scene::StatusMenu: the actor cursor wraps around' do
   scene = menu_scene(RPG2k::Scene::StatusMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@actor_index), 'starts on the first actor'


### PR DESCRIPTION
## Summary

RPG_RT's `Window_Base::GetValueFontColor` (`src/window_base.cpp`) is the shared routine behind `DrawActorHp`/`DrawActorSp`:

```cpp
int Window_Base::GetValueFontColor(int have, int max, bool can_knockout) const {
    if (can_knockout && have == 0) return Font::ColorKnockout;
    if (max > 0 && (have <= max / 4)) return Font::ColorCritical;
    return Font::ColorDefault;
}
```

`ColorDefault=0, ColorCritical=4, ColorKnockout=5` — ordinary indices into the same 20-swatch system-color palette this codebase's `\c[n]` message codes and `Game::States.color` already use. Only the *current* HP/SP figure recolors — never its label or max — and SP never shows the knockout color even at 0 (`DrawActorSp` always passes `can_knockout` false). This is used by `Window_ActorStatus::DrawStatus` (`src/window_actorstatus.cpp`), the field Status screen's own EasyRPG counterpart.

`Scene::StatusMenu#build_window` (`mruby-rpg2k/mrblib/scene/status_menu.rb`) drew its whole HP/MP line as one flat-white string via `c.draw_text`, with no color logic at all — so a party member at critical or 0 HP never showed the visual cue real RPG_RT gives.

## Fix

- `scene/base.rb`: added `#value_font_color`, a verbatim port of `GetValueFontColor`, alongside `#draw_actor_state`'s own palette-index convention.
- `scene/status_menu.rb`: pulled the HP/MP row out of the screen's flat-line pass into a new `#draw_hp_mp_row`/`#draw_stat_segment` pair, which draws each stat's label, current figure (colored via `#value_font_color`) and `/max` as three separately-colored runs through the existing `#draw_system_text`.

The battle status panel (`Scene::Battle#battle_status_row`) has the identical gap, but its fixed-column layout needs a larger change to split label/value/max the same way — noted as a follow-up in `docs/TODO.md`, left for a future pass rather than folded into this one.

## Testing

Added a regression test to `scripts/rpg2k_scene_check.rb`: sets an actor's HP to 0 and MP to a quarter-or-below value, then asserts the drawn HP figure blends from the windowskin's knockout swatch (index 5) and the MP figure from the critical swatch (index 4), while the HP max figure stays on the default swatch (index 0) — mirroring the existing `Scene::EquipMenu` swatch-color test's structure.

- Verified via `git stash push -- mruby-rpg2k/mrblib/scene/status_menu.rb mruby-rpg2k/mrblib/scene/base.rb`: the new test fails pre-fix and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1118), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_