### PR TITLE
Persist a live Change Encounter Rate override through Save/Continue

### DIFF
--- a/changelog.d/encounter-rate-override-save-continue.fixed.md
+++ b/changelog.d/encounter-rate-override-save-continue.fixed.md
@@ -1,0 +1,5 @@
+- **Saves:** a live Change Encounter Rate override now survives a real
+  Save/Continue, matching RPG_RT's `SaveMapInfo.encounter_steps` -- it
+  previously round-tripped through this engine's own in-memory save
+  format but silently reverted to the map's own default rate the moment
+  a genuine `.lsd` save was reloaded.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12200,6 +12200,35 @@ not yet verified:
   change. Covered by rewriting the existing `scripts/rpg2k_logic_check.rb`
   check that had asserted the old (backwards) semantics, confirmed to fail
   against the pre-fix code (`expected 7, got 4`).
+  ✅ **Follow-up (2026-08-21): a live Change Encounter Rate (11740) override
+  had the identical Save/Continue gap Tile Substitution just got fixed for
+  above — round-tripped through this codebase's own portable Marshal save,
+  but never through a real `.lsd`.** Confirmed directly against RPG_RT's
+  live source: `Game_Map::PrepareSave`/`SetEncounterSteps`
+  (`src/game_map.cpp`) restore `SaveMapInfo.encounter_steps` verbatim on
+  Continue (a `-1` sentinel meaning "unmodified, use the map's own rate"),
+  and liblcf's own generator table confirms the wire format:
+  `SaveMapInfo,encounter_steps,f,Int32,0x03,-1,...` (`generator/csv/
+  fields.csv`) — chunk `Save.map_info` is liblcf id `0x6F` (111), the same
+  chunk this codebase's own event-position and tile-substitution fields
+  already live in. `LCF::Schema::SAVE_MAP_EVENT`
+  (`mruby-lcf/mrblib/schema.rb`) only defined fields 1/2/11/21/22 — no field
+  3 — so `Game::State#to_lsd`/`.from_lsd`
+  (`mruby-rpg2k/mrblib/game.rb`) never wrote or read a live
+  `#encounter_rate` override at all; a genuine Save/Continue silently
+  reverted it to the map's own default the moment the save reloaded, even
+  though the in-memory (Marshal) save format had round-tripped it correctly
+  all along. Fixed by adding field 3 (`encounter_steps`, default `-1`,
+  matching liblcf's own default) to `SAVE_MAP_EVENT`, writing
+  `mapev[3] = @encounter_rate if @encounter_rate` in `#to_lsd` (widening
+  the chunk-111 write guard to also fire when an override is live), and
+  reading it back in `.from_lsd` (a `-1` or absent field 3 both mean "no
+  override", the same as a fresh `#encounter_rate` of `nil`). Covered by a
+  new `scripts/rpg2k_logic_check.rb` check (an override round-trips through
+  `to_lsd`/`.from_lsd`; a State that never overrode the rate round-trips to
+  `nil`; a save written before this landed, missing field 3 entirely, also
+  round-trips to `nil` rather than crashing), confirmed to fail against the
+  pre-fix code (`expected 7, got nil`).
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1324,6 +1324,12 @@ module LCF
     SAVE_MAP_EVENT = {
       1 => { name: :scroll_x, type: :int, default: 0 }, # 1/16 px
       2 => { name: :scroll_y, type: :int, default: 0 }, # 1/16 px
+      # A live Change Encounter Rate (11740) override, or -1/absent for "no
+      # override, use the map's own encounter rate" -- confirmed against
+      # liblcf's own generator table (`generator/csv/fields.csv`):
+      # `SaveMapInfo,encounter_steps,f,Int32,0x03,-1,...`, matching
+      # `Game_Map::PrepareSave`/`SetEncounterSteps` (`src/game_map.cpp`).
+      3 => { name: :encounter_steps, type: :int, default: -1 },
       11 => { name: :events, type: :Array2D, elements: SAVE_MOVABLE },
       21 => { name: :chip_replacement_lower, type: :int8_array }, # uint8[144]
       22 => { name: :chip_replacement_upper, type: :int8_array }, # uint8[144]

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14439,16 +14439,16 @@ module Game
       # Chunk 111 (SAVE_MAP_EVENT/SAVE_MOVABLE) is the currently-loaded map's
       # own live event table, mirrored straight from #map_event_positions/
       # #map_event_route_index, plus its Tile Substitution table
-      # (#tile_substitutions, fields 21/22) -- all three already scoped to the
+      # (#tile_substitutions, fields 21/22) and a live Change Encounter Rate
+      # override (#encounter_rate, field 3) -- all four already scoped to the
       # current map only, see their own doc comments above. Camera scroll
       # (SAVE_MAP_EVENT fields 1/2) is not modelled by this codebase, so it
       # stays absent, matching the "view derives from the hero" fallback ADR
-      # 0021 documents. Omitted entirely on a State with neither recorded
-      # positions nor a live substitution (e.g. a fresh, unplayed save), the
-      # same "absent means nothing to restore" rule the unplaced-vehicle
-      # chunks above use.
+      # 0021 documents. Omitted entirely on a State with none of these three
+      # recorded (e.g. a fresh, unplayed save), the same "absent means
+      # nothing to restore" rule the unplaced-vehicle chunks above use.
       lower_subs, upper_subs = @tile_substitutions
-      unless @map_event_positions.empty? && lower_subs.empty? && upper_subs.empty?
+      unless @map_event_positions.empty? && lower_subs.empty? && upper_subs.empty? && !@encounter_rate
         mapev = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MAP_EVENT })
         unless @map_event_positions.empty?
           events = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
@@ -14466,6 +14466,7 @@ module Game
         end
         mapev[21] = self.class.tile_replacement_bytes(lower_subs) unless lower_subs.empty?
         mapev[22] = self.class.tile_replacement_bytes(upper_subs) unless upper_subs.empty?
+        mapev[3] = @encounter_rate if @encounter_rate
         save[111] = mapev
       end
 
@@ -14805,6 +14806,13 @@ module Game
           upper ? tile_replacement_hash(upper) : {},
         ]
       end
+      # The same chunk's own Change Encounter Rate override (field 3): -1 (its
+      # schema default, matching liblcf's own `SaveMapInfo.encounter_steps`)
+      # or absent both mean "no override, use the map's own rate", the same
+      # `nil` #encounter_rate already means live -- see
+      # Scene::Map#current_encounter_steps.
+      steps = map_events && map_events.encounter_steps
+      state.encounter_rate = steps if steps && steps >= 0
       state
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11081,6 +11081,42 @@ check 'to_lsd/from_lsd round-trips a live Tile Substitution table (chunk 111 fie
   eq [{}, {}], old.tile_substitutions, 'no saved table means every tile shows its own graphic'
 end
 
+check 'to_lsd/from_lsd round-trips a live Change Encounter Rate override ' \
+      '(chunk 111 field 3)' do
+  # Real RPG_RT's SaveMapInfo.encounter_steps (liblcf generator/csv/
+  # fields.csv: `SaveMapInfo,encounter_steps,f,Int32,0x03,-1,...`) restores a
+  # Save/Continue on the same map to whatever Change Encounter Rate (11740)
+  # had overridden -- Game_Map::PrepareSave/SetEncounterSteps
+  # (src/game_map.cpp) confirmed directly against EasyRPG's own live source;
+  # #to_lsd/.from_lsd previously never touched field 3 at all, so the
+  # override silently reverted to the map's own default the moment a real
+  # save was reloaded.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.encounter_rate = 7
+
+  saved = st.to_lsd
+  round = Game::State.from_lsd(db, saved)
+  eq 7, round.encounter_rate
+
+  # -1 is the schema's own "no override" sentinel (matching liblcf's real
+  # default) -- a State that never ran Change Encounter Rate must not write
+  # field 3 at all, and from_lsd must leave a fresh State's own nil (use the
+  # map's own rate) alone rather than invent an override.
+  never_overridden = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq nil, Game::State.from_lsd(db, never_overridden.to_lsd).encounter_rate,
+     'no Change Encounter Rate this session means no override round-trips'
+
+  # A save written before this landed simply omits field 3 (or chunk 111
+  # entirely, if no event ever recorded a position/substitution either);
+  # from_lsd must leave that same nil alone rather than crash reading an
+  # absent field.
+  legacy = st.to_lsd
+  legacy[111].delete(3)
+  old = Game::State.from_lsd(db, legacy)
+  eq nil, old.encounter_rate, 'no saved override means the map\'s own rate applies'
+end
+
 # liblcf's SaveMapEventBase.facing (generator/csv/fields.csv, 0x16 == 22) is
 # 0=up/1=right/2=down/3=left (Game_Character::Direction's own enum order),
 # not this runtime's numpad convention (2/4/6/8) -- the two schemes only


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Map::PrepareSave`/`SetEncounterSteps` (`src/game_map.cpp`) restore `SaveMapInfo.encounter_steps` verbatim on Continue:

```cpp
void Game_Map::PrepareSave(lcf::rpg::Save& save) {
	...
	save.map_info = map_info;
	...
	if (save.map_info.encounter_steps == GetOriginalEncounterSteps()) {
		save.map_info.encounter_steps = -1;
	}
}

void Game_Map::SetEncounterSteps(int step) {
	if (step < 0) {
		step = GetOriginalEncounterSteps();
	}
	map_info.encounter_steps = step;
}
```

`-1` is the sentinel meaning "unmodified, use the map's own rate". liblcf's own generator table confirms the wire format (verified against a shallow clone of `EasyRPG/liblcf`):

```
SaveMapInfo,encounter_steps,f,Int32,0x03,-1,0,0,int
```

Chunk `Save.map_info` is liblcf id `0x6F` (111) — the same chunk this codebase's event-position and tile-substitution fields already live in.

## Where this codebase diverged

`LCF::Schema::SAVE_MAP_EVENT` (`mruby-lcf/mrblib/schema.rb`) only defined fields 1/2/11/21/22 — no field 3. `Game::State#to_lsd`/`.from_lsd` (`mruby-rpg2k/mrblib/game.rb`) never wrote or read a live `#encounter_rate` override at all — a genuine Save/Continue silently reverted a Change Encounter Rate (11740) override to the map's own default the moment the save reloaded, even though this engine's own in-memory (Marshal) save format round-tripped it correctly all along. This is the exact same gap Tile Substitution (fields 21/22, same chunk) already had and was fixed for — encounter_steps (field 3, same struct) just never got the symmetric treatment.

## Fix

- `mruby-lcf/mrblib/schema.rb`: added field 3 (`encounter_steps`, default `-1`, matching liblcf's own default) to `SAVE_MAP_EVENT`.
- `mruby-rpg2k/mrblib/game.rb#to_lsd`: widened the chunk-111 write guard to also fire when `@encounter_rate` is live, and writes `mapev[3] = @encounter_rate if @encounter_rate`.
- `mruby-rpg2k/mrblib/game.rb#.from_lsd`: reads field 3 back — a `-1` or absent value both mean "no override" (matching a fresh `#encounter_rate` of `nil`).

This is a pure state-persistence change — it never touches turn order, damage, or any RNG call site.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb` mirroring the existing Tile Substitution round-trip test's structure: sets `encounter_rate = 7`, round-trips through `to_lsd`/`.from_lsd`, and asserts it comes back as `7`; a State that never overrode the rate round-trips to `nil`; a save written before this landed (missing field 3 entirely) also round-trips to `nil` rather than crashing.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb mruby-lcf/mrblib/schema.rb`: the new test fails pre-fix (`expected 7, got nil`) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1119), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_