### PR TITLE
Persist a live Change Parallax Background override through Save/Continue

### DIFF
--- a/changelog.d/parallax-override-save-continue.fixed.md
+++ b/changelog.d/parallax-override-save-continue.fixed.md
@@ -1,0 +1,5 @@
+- **Saves:** a live Change Parallax Background override now survives a
+  real Save/Continue, matching RPG_RT's `SaveMapInfo.parallax_*` fields --
+  it previously reverted to the map's own panorama the moment a genuine
+  `.lsd` save was reloaded, even though it correctly reset on an actual
+  map change.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12229,6 +12229,40 @@ not yet verified:
   `nil`; a save written before this landed, missing field 3 entirely, also
   round-trips to `nil` rather than crashing), confirmed to fail against the
   pre-fix code (`expected 7, got nil`).
+  ✅ **Follow-up (2026-08-21): a live Change Parallax Background (11720)
+  override had the identical Save/Continue gap Change Encounter Rate just
+  got fixed for above — the exact same `SaveMapInfo`/chunk 111 struct, a
+  different set of its fields.** This codebase's own `Game::State#@parallax`
+  doc comment claimed "RPG2000 resets it to the map's default on every map
+  change... so it is not serialised," conflating two genuinely different
+  triggers in real RPG_RT: a map change (Teleport, confirmed correct —
+  `Game_Map::Setup` calls `Parallax::ClearChangedBG()`) versus a Save/
+  Continue on the *same* map (a separate code path, `SetupFromSave`, which
+  never calls `ClearChangedBG`). Confirmed directly against RPG_RT's live
+  source: `SetupFromSave` (`src/game_map.cpp`) does `map_info =
+  std::move(save_map)` unconditionally — the same `SaveMapInfo` struct
+  `encounter_steps` lives in — then ends with `Parallax::ChangeBG(
+  GetParallaxParams())`, whose own helper reads `map_info.parallax_name`
+  first and only falls back to the map's own default when that field is
+  blank; `Parallax::ChangeBG` itself (the Change Parallax Background
+  command's own handler) writes straight onto `map_info.parallax_*`, so a
+  live override sits in the same struct a Save chunk carries wholesale.
+  liblcf's own generator table confirms the wire format: `SaveMapInfo,
+  parallax_name,f,String,0x20,...` through `...,parallax_vert_speed,f,
+  Int32,0x26,...` (`generator/csv/fields.csv`), seven fields (32-38)
+  in the same chunk 111. `LCF::Schema::SAVE_MAP_EVENT` had none of them;
+  `#to_lsd`/`.from_lsd` never wrote or read `#parallax` at all — a genuine
+  Save/Continue silently reverted a live override to the map's own
+  panorama the moment the save reloaded. Fixed the identical way: added
+  fields 32-38 to `SAVE_MAP_EVENT`, wrote them from `#parallax`'s existing
+  `{name:, loop_x:, loop_y:, auto_x:, sx:, auto_y:, sy:}` hash shape
+  (`Interpreter#do_change_parallax`'s own opts) when live, and read them
+  back in `.from_lsd` — a blank/absent name means "no override," matching
+  `GetParallaxParams`'s own check (real RPG_RT cannot distinguish "never
+  overridden" from "overridden to blank" either, since `ClearChangedBG`
+  itself writes a default-constructed, empty-name `Params`). Covered by a
+  new `scripts/rpg2k_logic_check.rb` check mirroring the encounter-rate
+  test's structure exactly, confirmed to fail against the pre-fix code.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1330,6 +1330,20 @@ module LCF
       # `SaveMapInfo,encounter_steps,f,Int32,0x03,-1,...`, matching
       # `Game_Map::PrepareSave`/`SetEncounterSteps` (`src/game_map.cpp`).
       3 => { name: :encounter_steps, type: :int, default: -1 },
+      # A live Change Parallax Background (11720) override, or an absent/
+      # blank name for "no override, use the map's own panorama" --
+      # confirmed against liblcf's own generator table
+      # (`generator/csv/fields.csv`): `SaveMapInfo,parallax_name,f,String,
+      # 0x20,...` through `...,parallax_vert_speed,f,Int32,0x26,...`, seven
+      # fields matching `Game_Map::Parallax::ChangeBG`/`GetParallaxParams`
+      # (`src/game_map.cpp`) exactly.
+      32 => { name: :parallax_name, type: :string, default: '' },
+      33 => { name: :parallax_horz, type: :bool, default: false },
+      34 => { name: :parallax_vert, type: :bool, default: false },
+      35 => { name: :parallax_horz_auto, type: :bool, default: false },
+      36 => { name: :parallax_horz_speed, type: :int, default: 0 },
+      37 => { name: :parallax_vert_auto, type: :bool, default: false },
+      38 => { name: :parallax_vert_speed, type: :int, default: 0 },
       11 => { name: :events, type: :Array2D, elements: SAVE_MOVABLE },
       21 => { name: :chip_replacement_lower, type: :int8_array }, # uint8[144]
       22 => { name: :chip_replacement_upper, type: :int8_array }, # uint8[144]

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13992,8 +13992,16 @@ module Game
       # HUD pictures are re-shown by parallel events on load), so not serialised.
       @pictures = {}
       # Runtime parallax override from a Change Parallax Background command (nil =
-      # use the map's own panorama). Transient like @pictures: RPG2000 resets it
-      # to the map's default on every map change, so it is not serialised.
+      # use the map's own panorama). Reset on a map change (#clear_parallax,
+      # called alongside #erase_all_pictures) -- but, unlike @pictures, DOES
+      # round-trip through a real Save/Continue on the same map (#to_lsd/
+      # .from_lsd, chunk 111 fields 32-38): confirmed against RPG_RT's own
+      # live source, `Game_Map::SetupFromSave` (`src/game_map.cpp`) restores
+      # `SaveMapInfo`/`map_info` wholesale (the same struct a live Change
+      # Parallax Background writes onto) and only a genuine map change
+      # (`Game_Map::Setup`) calls `Parallax::ClearChangedBG()` -- two
+      # genuinely different triggers a prior, uncited version of this
+      # comment had conflated.
       @parallax = nil
     end
 
@@ -14439,16 +14447,19 @@ module Game
       # Chunk 111 (SAVE_MAP_EVENT/SAVE_MOVABLE) is the currently-loaded map's
       # own live event table, mirrored straight from #map_event_positions/
       # #map_event_route_index, plus its Tile Substitution table
-      # (#tile_substitutions, fields 21/22) and a live Change Encounter Rate
-      # override (#encounter_rate, field 3) -- all four already scoped to the
-      # current map only, see their own doc comments above. Camera scroll
-      # (SAVE_MAP_EVENT fields 1/2) is not modelled by this codebase, so it
-      # stays absent, matching the "view derives from the hero" fallback ADR
-      # 0021 documents. Omitted entirely on a State with none of these three
-      # recorded (e.g. a fresh, unplayed save), the same "absent means
-      # nothing to restore" rule the unplaced-vehicle chunks above use.
+      # (#tile_substitutions, fields 21/22), a live Change Encounter Rate
+      # override (#encounter_rate, field 3) and a live Change Parallax
+      # Background override (#parallax, fields 32-38) -- all five already
+      # scoped to the current map only, see their own doc comments above.
+      # Camera scroll (SAVE_MAP_EVENT fields 1/2) is not modelled by this
+      # codebase, so it stays absent, matching the "view derives from the
+      # hero" fallback ADR 0021 documents. Omitted entirely on a State with
+      # none of these four recorded (e.g. a fresh, unplayed save), the same
+      # "absent means nothing to restore" rule the unplaced-vehicle chunks
+      # above use.
       lower_subs, upper_subs = @tile_substitutions
-      unless @map_event_positions.empty? && lower_subs.empty? && upper_subs.empty? && !@encounter_rate
+      unless @map_event_positions.empty? && lower_subs.empty? && upper_subs.empty? &&
+             !@encounter_rate && !@parallax
         mapev = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MAP_EVENT })
         unless @map_event_positions.empty?
           events = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
@@ -14467,6 +14478,15 @@ module Game
         mapev[21] = self.class.tile_replacement_bytes(lower_subs) unless lower_subs.empty?
         mapev[22] = self.class.tile_replacement_bytes(upper_subs) unless upper_subs.empty?
         mapev[3] = @encounter_rate if @encounter_rate
+        if @parallax
+          mapev[32] = @parallax[:name].to_s
+          mapev[33] = @parallax[:loop_x]
+          mapev[34] = @parallax[:loop_y]
+          mapev[35] = @parallax[:auto_x]
+          mapev[36] = @parallax[:sx]
+          mapev[37] = @parallax[:auto_y]
+          mapev[38] = @parallax[:sy]
+        end
         save[111] = mapev
       end
 
@@ -14813,6 +14833,21 @@ module Game
       # Scene::Map#current_encounter_steps.
       steps = map_events && map_events.encounter_steps
       state.encounter_rate = steps if steps && steps >= 0
+      # The same chunk's own Change Parallax Background override (fields
+      # 32-38): a blank/absent name means "no override, use the map's own
+      # panorama" -- matching `GetParallaxParams`'s own `map_info.
+      # parallax_name.empty()` check (`src/game_map.cpp`), which real RPG_RT
+      # itself cannot distinguish from "never overridden" either (`Parallax::
+      # ClearChangedBG` writes a default-constructed, empty-name Params).
+      pname = map_events && map_events.parallax_name
+      if pname && !pname.empty?
+        state.set_parallax(name: pname, loop_x: !!map_events.parallax_horz,
+                           loop_y: !!map_events.parallax_vert,
+                           auto_x: !!map_events.parallax_horz_auto,
+                           sx: map_events.parallax_horz_speed,
+                           auto_y: !!map_events.parallax_vert_auto,
+                           sy: map_events.parallax_vert_speed)
+      end
       state
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11117,6 +11117,48 @@ check 'to_lsd/from_lsd round-trips a live Change Encounter Rate override ' \
   eq nil, old.encounter_rate, 'no saved override means the map\'s own rate applies'
 end
 
+check 'to_lsd/from_lsd round-trips a live Change Parallax Background ' \
+      'override (chunk 111 fields 32-38)' do
+  # Real RPG_RT's SaveMapInfo.parallax_name/horz/vert/horz_auto/horz_speed/
+  # vert_auto/vert_speed (liblcf generator/csv/fields.csv: `SaveMapInfo,
+  # parallax_name,f,String,0x20,...` through `...,parallax_vert_speed,f,
+  # Int32,0x26,...`) restore a Save/Continue on the same map to whatever
+  # Change Parallax Background (11720) had overridden --
+  # Game_Map::Parallax::ChangeBG/GetParallaxParams (src/game_map.cpp)
+  # confirmed directly against EasyRPG's own live source, the same `map_info`
+  # struct `SetupFromSave` restores wholesale before ChangeBG re-derives the
+  # live panorama from it. #to_lsd/.from_lsd previously never touched these
+  # fields at all, so the override silently reverted to the map's own
+  # panorama the moment a real save was reloaded.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.set_parallax(name: 'Clouds', loop_x: true, loop_y: false,
+                  auto_x: true, sx: 2, auto_y: false, sy: 0)
+
+  saved = st.to_lsd
+  round = Game::State.from_lsd(db, saved)
+  eq({ name: 'Clouds', loop_x: true, loop_y: false, auto_x: true, sx: 2,
+       auto_y: false, sy: 0 }, round.parallax)
+
+  # A blank/absent name is real RPG_RT's own "no override" sentinel
+  # (GetParallaxParams' `map_info.parallax_name.empty()` check) -- a State
+  # that never ran Change Parallax Background must not write these fields at
+  # all, and from_lsd must leave a fresh State's own nil (use the map's own
+  # panorama) alone rather than invent an override.
+  never_overridden = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq nil, Game::State.from_lsd(db, never_overridden.to_lsd).parallax,
+     'no Change Parallax Background this session means no override round-trips'
+
+  # A save written before this landed simply omits fields 32-38 (or chunk
+  # 111 entirely, if no event ever recorded a position/substitution either);
+  # from_lsd must leave that same nil alone rather than crash reading absent
+  # fields.
+  legacy = st.to_lsd
+  (32..38).each { |f| legacy[111].delete(f) }
+  old = Game::State.from_lsd(db, legacy)
+  eq nil, old.parallax, 'no saved override means the map\'s own panorama applies'
+end
+
 # liblcf's SaveMapEventBase.facing (generator/csv/fields.csv, 0x16 == 22) is
 # 0=up/1=right/2=down/3=left (Game_Character::Direction's own enum order),
 # not this runtime's numpad convention (2/4/6/8) -- the two schemes only


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Map::SetupFromSave` (`src/game_map.cpp`) restores `map_info` wholesale on Continue:

```cpp
void Game_Map::SetupFromSave(..., lcf::rpg::SaveMapInfo save_map, ...) {
	map = std::move(map_in);
	map_info = std::move(save_map);
	...
	Game_Map::Parallax::ChangeBG(GetParallaxParams());
}
```

`map_info` is the same `SaveMapInfo` struct a live Change Parallax Background command writes onto (`Game_Map::Parallax::ChangeBG`), and `GetParallaxParams` reads `map_info.parallax_name` first, only falling back to the map's own default when that field is blank:

```cpp
static Game_Map::Parallax::Params GetParallaxParams() {
	...
	if (!map_info.parallax_name.empty()) {
		params.name = map_info.parallax_name;
		params.scroll_horz = map_info.parallax_horz;
		...
	} else if (map->parallax_flag) {
		// Default case when map parallax hasn't been overwritten.
		...
```

Only a genuine map change (`Game_Map::Setup`) calls `Parallax::ClearChangedBG()` — a Save/Continue on the *same* map is a separate code path that never clears it. liblcf's own generator table confirms the wire format (verified against a shallow clone of `EasyRPG/liblcf`):

```
SaveMapInfo,parallax_name,f,String,0x20,...
SaveMapInfo,parallax_horz,f,Boolean,0x21,...
... through ...
SaveMapInfo,parallax_vert_speed,f,Int32,0x26,...
```

Seven fields (32-38) in the same chunk 111 (`Save.map_info`, liblcf id `0x6F`) `encounter_steps` (field 3, fixed in the previous PR) already lives in.

## Where this codebase diverged

`LCF::Schema::SAVE_MAP_EVENT` (`mruby-lcf/mrblib/schema.rb`) had none of these fields. `Game::State#to_lsd`/`.from_lsd` (`mruby-rpg2k/mrblib/game.rb`) never wrote or read `#parallax` at all — a genuine Save/Continue silently reverted a live Change Parallax Background (11720) override to the map's own panorama the moment the save reloaded. This codebase's own doc comment on `@parallax` had conflated the two triggers: it correctly described the map-change reset but claimed that meant the override was never serialised — wrong for the separate Save/Continue-on-the-same-map case.

## Fix

- `mruby-lcf/mrblib/schema.rb`: added fields 32-38 (`parallax_name`/`parallax_horz`/`parallax_vert`/`parallax_horz_auto`/`parallax_horz_speed`/`parallax_vert_auto`/`parallax_vert_speed`) to `SAVE_MAP_EVENT`.
- `mruby-rpg2k/mrblib/game.rb#to_lsd`: writes these fields from `#parallax`'s existing `{name:, loop_x:, loop_y:, auto_x:, sx:, auto_y:, sy:}` hash shape when an override is live.
- `mruby-rpg2k/mrblib/game.rb#.from_lsd`: reads them back — a blank/absent name means "no override," matching `GetParallaxParams`'s own check (real RPG_RT can't distinguish "never overridden" from "overridden to blank" either, since `ClearChangedBG` itself writes a default-constructed, empty-name `Params`).
- Corrected the stale `@parallax` doc comment.

This is a pure state-persistence change — it never touches turn order, damage, or any RNG call site.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb` mirroring the existing Change Encounter Rate round-trip test's structure: sets a parallax override, round-trips through `to_lsd`/`.from_lsd`, and asserts it comes back unchanged; a State that never overrode the panorama round-trips to `nil`; a save written before this landed (missing fields 32-38) also round-trips to `nil` rather than crashing.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb mruby-lcf/mrblib/schema.rb`: the new test fails pre-fix (`expected {...}, got nil`) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1120), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_