### PR TITLE
Write chunk 103 (shown pictures) in to_lsd

### DIFF
--- a/changelog.d/picture-save-continue-chunk-103.fixed.md
+++ b/changelog.d/picture-save-continue-chunk-103.fixed.md
@@ -1,0 +1,6 @@
+- **Saves:** a shown picture (Show Picture) now survives a real
+  Save/Continue -- `Game::State#to_lsd` previously never wrote chunk 103
+  at all, matching RPG_RT's `Scene_Save::Prepare`/`Player::LoadSavegame`,
+  which round-trip it unconditionally on every save; a picture up during
+  a cutscene used to silently vanish the instant this engine's own
+  Save/Continue ran.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -191,6 +191,36 @@ The work below is roughly ordered by the critical path to a walkable game
     covered by a synthetic-chunk round-trip in `rpg2k_logic_check.rb` (`to_lsd`
     does not write chunk 103 itself yet, so there is no live save to round-trip
     through).
+    ✅ **Follow-up (2026-08-21): `to_lsd` now writes chunk 103 too — a shown
+    picture used to vanish the instant this engine's own Save/Continue ran,
+    even though loading a genuine external RPG_RT save with one already
+    worked correctly (that path only ever exercised `.from_lsd`, never
+    `.to_lsd`).** Confirmed directly against RPG_RT's live source:
+    `Scene_Save::Prepare` (`src/scene_save.cpp`) writes `save.pictures =
+    Main_Data::game_pictures->GetSaveData()` unconditionally on every save,
+    and `Player::LoadSavegame` (`src/player.cpp`) restores it unconditionally
+    on every load. Fixed by mirroring `.restore_pictures`' own read exactly —
+    same field ids (1 name, 31/32 current_x/current_y, 33 zoom, 34
+    transparency, 41-44 tone), same conversions, just in the write direction
+    — iterating `@pictures` (only ever currently-shown pictures;
+    `#erase_picture` deletes the entry outright, so presence alone means
+    live). A new `Game.opacity_to_trans` (the inverse of the existing
+    `#trans_to_opacity`) converts `Game::Picture#opacity` (0..255) back to
+    the save field's own 0..100 scale. Worth noting: this codebase's
+    `Game::Picture` keeps `opacity` (not RPG_RT's own native 0..100
+    transparency) as its live ground truth, so a save round-trip through
+    both integer-truncating conversions is not perfectly lossless (e.g.
+    opacity 191 round-trips to 188) — real RPG_RT has no such drift
+    (`Game_Pictures::Picture::data.current_top_trans` is the 0..100 value
+    directly, confirmed against `src/game_pictures.cpp`), a separate,
+    pre-existing precision gap left as-is rather than folded into this fix.
+    Covered by a new `scripts/rpg2k_logic_check.rb` check (`to_lsd` writes a
+    shown picture's exact field values, including the expected 191→26
+    transparency conversion; a full `to_lsd`/`.from_lsd` round-trip at
+    opacity 255/trans 0 — a fixed point of both conversions — restores every
+    field exactly; a State with no shown pictures gets no chunk 103 at all),
+    confirmed to fail against the pre-fix code (`NoMethodError` on a nil
+    chunk).
   - ✅ **`Game::State#to_lsd` output is loadable by RPG_RT.** It round-tripped
     through our own parser (`scripts/lcf_save_roundtrip.rb`) but the genuine
     runtime left "Continue" dead, with no error anywhere. The assumed cause —
@@ -200,10 +230,20 @@ The work below is roughly ordered by the critical path to a walkable game
     then the field: `to_lsd` wrote the file-screen date as `0.0`, and zero on
     the OLE-automation scale is 1899-12-30, which RPG_RT reads as an *empty
     slot*. It now defaults to the current time, and a from-scratch `to_lsd` save
-    loads in the real runtime. A `to_lsd` save still carries no picture,
-    map-event or vehicle state, so it resumes into a bare scene — enough to
-    prove the file loads, not enough to compare rendering, which is why the
-    comparison harness still edits a genuine save.
+    loads in the real runtime. ~~A `to_lsd` save still carries no picture,
+    map-event or vehicle state, so it resumes into a bare scene~~ — partly
+    stale as of 2026-08-21: `to_lsd` now writes map-event positions/tile
+    substitutions/encounter-rate/parallax overrides (chunk 111) and shown
+    pictures (chunk 103, the Follow-up just above) too. **Vehicle placement
+    (chunks 105-107) is still the one real gap left in this list** —
+    `.from_lsd` already reads `save.boat`/`.ship`/`.airship` back
+    (`state.vehicle(:boat).load_movable(save.boat)` etc.), but `#to_lsd`
+    never writes any of the three, the identical "reader exists, writer
+    doesn't" shape every fix in this section has been closing one chunk at a
+    time — left open for a future pass rather than folded into this one. A
+    from-scratch `to_lsd` save is enough to prove the file loads, not enough
+    to compare rendering against a real cutscene mid-playthrough, which is
+    why the comparison harness still edits a genuine save.
 - ✅ Parallax background — `Scene::Map` draws the map's `Panorama/<name>`
   backdrop behind the tile layers (a sprite at z = -1). `Game::Parallax` ports
   EasyRPG's parallax model: a looping axis tiles the image and scrolls it at

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -609,6 +609,13 @@ module Game
     (100 - clamp(top_trans, 0, 100)) * 255 / 100
   end
 
+  # The inverse of .trans_to_opacity, for writing a live picture's current
+  # `Game::Picture#opacity` (0..255) back to chunk 103 field 34's own 0..100
+  # transparency scale on Save (Game::State#to_lsd).
+  def self.opacity_to_trans(opacity)
+    100 - clamp(opacity, 0, 255) * 100 / 255
+  end
+
   # Top-left pixel of the view so the player is centred, clamped so the camera
   # never scrolls past the edges of a map smaller/larger than the screen.
   def self.camera_offset(player_px, screen_px, map_px)
@@ -14412,6 +14419,38 @@ module Game
         actors[a.id] = e
       end
       save[108] = actors
+
+      # Chunk 103 is every currently-shown picture (Show Picture, 11110) --
+      # confirmed against RPG_RT's live source: `Scene_Save::Prepare`
+      # (`src/scene_save.cpp`) writes `save.pictures = Main_Data::
+      # game_pictures->GetSaveData()` unconditionally on every save, and
+      # `Player::LoadSavegame` (`src/player.cpp`) restores it unconditionally
+      # on every load -- the same chunk `.from_lsd`/`.restore_pictures`
+      # (above) already reads, just never written here. Field mapping is the
+      # exact mirror of `.restore_pictures`' own read (see its comment for
+      # why the numbers need no separate guesswork): 1 name, 31/32 current_x/
+      # current_y, 33 zoom, 34 transparency (`Game.opacity_to_trans`, the
+      # inverse of the live command's own `#trans_to_opacity`), 41-44 the
+      # red/green/blue/saturation tone. `@pictures` only ever holds currently
+      # -shown pictures (#erase_picture deletes the entry outright), so every
+      # entry present is live and belongs in the save.
+      unless @pictures.empty?
+        pics = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+        @pictures.each do |id, p|
+          e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+          e[1] = p.name
+          e[31] = p.x
+          e[32] = p.y
+          e[33] = p.zoom
+          e[34] = Game.opacity_to_trans(p.opacity)
+          e[41] = p.red
+          e[42] = p.green
+          e[43] = p.blue
+          e[44] = p.saturation
+          pics[id] = e
+        end
+        save[103] = pics
+      end
 
       inv = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_INVENTORY })
       inv[1] = @party.actors.map { |a| a.id }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4329,6 +4329,64 @@ check 'restore_pictures restores zoom, opacity and tone, not just name/position'
   eq 100, plain.saturation
 end
 
+check 'to_lsd writes chunk 103 (shown pictures), not just from_lsd reading it' do
+  # Confirmed directly against RPG_RT's live source: `Scene_Save::Prepare`
+  # (`src/scene_save.cpp`) writes `save.pictures = Main_Data::game_pictures->
+  # GetSaveData()` unconditionally on every save, and `Player::LoadSavegame`
+  # (`src/player.cpp`) restores it unconditionally on every load -- so a
+  # picture shown via Show Picture (11110) survives a genuine Save/Continue.
+  # `#to_lsd` never wrote chunk 103 at all (see the "restore_pictures..."
+  # check above, whose own comment used to note this), so any shown picture
+  # silently vanished the instant this engine's own Save/Continue ran, even
+  # though loading a genuine external RPG_RT save with pictures already
+  # worked (that path only ever exercises .from_lsd, never .to_lsd).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.show_picture(3, name: 'backdrop', x: 200, y: 150, zoom: 150,
+                  opacity: Game.trans_to_opacity(25), # == 191, see the check above
+                  red: 50, green: 60, blue: 70, saturation: 80)
+
+  saved = st.to_lsd[103][3]
+  ok !saved.nil?, 'chunk 103 carries the shown picture'
+  eq 'backdrop', saved.name
+  eq 200, saved.current_x.to_i
+  eq 150, saved.current_y.to_i
+  eq 150, saved.zoom
+  # Game.opacity_to_trans(191) == 100 - 191*100/255 == 26 -- not 25: this
+  # codebase's own Game::Picture keeps opacity (0..255), not RPG_RT's own
+  # native 0..100 transparency, as its live ground truth (#trans_to_opacity
+  # only ever converts one way for the live command), so a save round-trip
+  # through both integer-truncating conversions is not perfectly lossless.
+  # Real RPG_RT itself has no such drift (`Game_Pictures::Picture::data.
+  # current_top_trans` is the 0..100 value directly, confirmed against
+  # `src/game_pictures.cpp`) -- a pre-existing, separate precision gap noted
+  # in docs/TODO.md, out of scope for this fix.
+  eq 26, saved.transparency
+  eq 50, saved.tone_red
+  eq 60, saved.tone_green
+  eq 70, saved.tone_blue
+  eq 80, saved.tone_saturation
+
+  # End-to-end through .from_lsd too, at the two values that round-trip
+  # exactly (0 and 255 are each other's fixed point under both conversions,
+  # see the arithmetic above) so this assertion is not itself muddied by the
+  # same rounding the transparency check above already covers directly.
+  st.show_picture(4, name: 'clean', x: 10, y: 20, opacity: 255)
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.pictures[4]
+  ok !restored.nil?, 'the picture round-trips through a real .lsd write/read'
+  eq 'clean', restored.name
+  eq 10, restored.x
+  eq 20, restored.y
+  eq 255, restored.opacity, 'opacity 255 (trans 0) is a fixed point of both conversions'
+
+  # A State with no pictures shown must not gain a stray chunk 103 at all --
+  # the same "absent means nothing to restore" rule chunk 111's own fields
+  # already follow.
+  empty_st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq nil, empty_st.to_lsd[103], 'no shown pictures means no chunk 103 at all'
+end
+
 # -- the permanent actor roster (Game::Actors) --------------------------------
 #
 # Nepheshel drives its whole party mechanic through Change Party Member: it adds


### PR DESCRIPTION
## Summary

RPG_RT's `Scene_Save::Prepare` (`src/scene_save.cpp`) writes chunk 103 unconditionally on every save:

```cpp
save.pictures = Main_Data::game_pictures->GetSaveData();
```

and `Player::LoadSavegame` (`src/player.cpp`) restores it unconditionally on every load:

```cpp
Main_Data::game_pictures->SetSaveData(std::move(save->pictures));
```

`Game::State#to_lsd` (`mruby-rpg2k/mrblib/game.rb`) never wrote chunk 103 at all — `.from_lsd`/`.restore_pictures` already read it correctly (exercised against real external RPG_RT saves, per the existing `rpg2k_logic_check.rb` test), but a picture shown via Show Picture (11110) silently vanished the instant this engine's own Save/Continue ran. The codebase's own comments already flagged this as a known open gap (`scripts/rpg2k_logic_check.rb:4281-4283`, `docs/TODO.md`).

## Fix

- `mruby-rpg2k/mrblib/game.rb`: added a `save[103]` write in `#to_lsd`, mirroring `.restore_pictures`' own read exactly — same field ids (1 name, 31/32 current_x/current_y, 33 zoom, 34 transparency, 41-44 tone) and conversions, just in the write direction. Iterates `@pictures` (only ever currently-shown pictures — `#erase_picture` deletes the entry outright, so presence alone means live).
- Added `Game.opacity_to_trans`, the inverse of the existing `#trans_to_opacity`, to convert `Game::Picture#opacity` (0..255) back to the save field's own 0..100 scale.

Worth noting: this codebase's `Game::Picture` keeps `opacity` (not RPG_RT's own native 0..100 transparency) as its live ground truth, so a save round-trip through both integer-truncating conversions is not perfectly lossless (e.g. opacity 191 round-trips to 188). Real RPG_RT has no such drift (`Game_Pictures::Picture::data.current_top_trans` is the 0..100 value directly). This is a separate, pre-existing precision gap, left as-is rather than folded into this fix, and noted in `docs/TODO.md`.

Also corrected two now-stale `docs/TODO.md` claims found along the way: the "`to_lsd` carries no picture/map-event/vehicle state" note (now partly fixed by this and recent PRs), and flagged vehicle placement (chunks 105-107) as the one item in that list still genuinely unwritten by `to_lsd` — `.from_lsd` already reads it, left open for a future pass.

This is a pure state-persistence change — it never touches turn order, damage, or any RNG call site.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb`: shows a picture, asserts `to_lsd`'s raw chunk-103 field values match expectations (including the exact 191→26 transparency conversion), then round-trips a second picture through `to_lsd`/`.from_lsd` at opacity 255/trans 0 (a fixed point of both conversions) to confirm every field restores exactly end-to-end; a State with no shown pictures gets no chunk 103 at all.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb`: the new test fails pre-fix (`NoMethodError` on a nil chunk) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1121), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_