### PR TITLE
Persist Set Teleport/Escape Target through Save/Continue (chunk 110)

### DIFF
--- a/changelog.d/target-save-continue-chunk-110.fixed.md
+++ b/changelog.d/target-save-continue-chunk-110.fixed.md
@@ -1,0 +1,6 @@
+- **Saves:** a registered Set Teleport Target / Set Escape Target
+  destination now survives a real Save/Continue, matching RPG_RT's
+  `Game_Targets::GetSaveData`/`SetSaveData` -- it previously round-tripped
+  through this engine's own in-memory save format but silently vanished
+  the moment a genuine `.lsd` save was reloaded, even though the
+  Escape/Teleport skills already read it live.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -231,17 +231,24 @@ The work below is roughly ordered by the critical path to a walkable game
     the OLE-automation scale is 1899-12-30, which RPG_RT reads as an *empty
     slot*. It now defaults to the current time, and a from-scratch `to_lsd` save
     loads in the real runtime. ~~A `to_lsd` save still carries no picture,
-    map-event or vehicle state, so it resumes into a bare scene~~ — partly
-    stale as of 2026-08-21: `to_lsd` now writes map-event positions/tile
-    substitutions/encounter-rate/parallax overrides (chunk 111) and shown
-    pictures (chunk 103, the Follow-up just above) too. **Vehicle placement
-    (chunks 105-107) is still the one real gap left in this list** —
-    `.from_lsd` already reads `save.boat`/`.ship`/`.airship` back
-    (`state.vehicle(:boat).load_movable(save.boat)` etc.), but `#to_lsd`
-    never writes any of the three, the identical "reader exists, writer
-    doesn't" shape every fix in this section has been closing one chunk at a
-    time — left open for a future pass rather than folded into this one. A
-    from-scratch `to_lsd` save is enough to prove the file loads, not enough
+    map-event or vehicle state, so it resumes into a bare scene~~ — stale as
+    of 2026-08-21: `to_lsd` now writes map-event positions/tile
+    substitutions/encounter-rate/parallax overrides (chunk 111), shown
+    pictures (chunk 103) and Set Teleport/Escape Target destinations (chunk
+    110, see the Follow-ups above and below).
+    ~~**Vehicle placement (chunks 105-107) is still the one real gap left in
+    this list** — `.from_lsd` already reads `save.boat`/`.ship`/`.airship`
+    back, but `#to_lsd` never writes any of the three.~~ **Correction, same
+    day: that claim was itself wrong.** `#to_lsd` already writes all three
+    vehicle chunks (`mruby-rpg2k/mrblib/game.rb`, the `{105=>:boat,
+    106=>:ship, 107=>:airship}.each` block, gated on `v.placed?` — a genuine
+    "not yet placed" vehicle correctly gets no chunk, matching RPG_RT) —
+    verified by actually reading the method body rather than trusting a
+    grep for a literal `save[105]` string, which misses this codebase's own
+    variable-keyed `save[chunk] = mv` assignment style. Caught while
+    investigating the next item in this list (chunk 110) and corrected
+    immediately rather than left standing. A from-scratch `to_lsd` save is
+    enough to prove the file loads, not enough
     to compare rendering against a real cutscene mid-playthrough, which is
     why the comparison harness still edits a genuine save.
 - ✅ Parallax background — `Scene::Map` draws the map's `Panorama/<name>`
@@ -12303,6 +12310,41 @@ not yet verified:
   itself writes a default-constructed, empty-name `Params`). Covered by a
   new `scripts/rpg2k_logic_check.rb` check mirroring the encounter-rate
   test's structure exactly, confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-21): Set Teleport Target (11810) / Set Escape
+  Target (11830) had the identical Save/Continue gap — chunk 110 this time,
+  not chunk 111, but the same "reader exists, writer doesn't" shape as
+  every fix above.** Confirmed directly against RPG_RT's live source:
+  `Scene_Save::Prepare`/`Player::LoadSavegame` (`src/scene_save.cpp`/`src/
+  player.cpp`) round-trip `save.targets` via `Game_Targets::GetSaveData`/
+  `SetSaveData` (`src/game_targets.cpp`) unconditionally on every save —
+  the escape target always written first, at array id 0 (a
+  default-constructed, "never set" `SaveTarget` when no Set Escape Target
+  ever ran — RPG_RT carries the slot regardless), every teleport target
+  keyed by its own destination map id (`AddTeleportTarget`'s own `tgt.ID =
+  map_id`). `mruby-lcf/mrblib/schema.rb`'s `SAVE_TARGET`/chunk-110 mapping
+  already matched liblcf's own field table exactly (fields 1-5: map_id/x/y/
+  switch_on/switch_id) — no schema change needed this time, unlike the
+  three fixes above. `Game::State#to_lsd`/`.from_lsd`
+  (`mruby-rpg2k/mrblib/game.rb`) simply never touched chunk 110 at all —
+  only this engine's own portable Marshal save (`#to_h`/`.load`)
+  round-tripped `#teleport_targets`/`#escape_target`, so a genuine
+  Save/Continue silently dropped every registered target, even though
+  `Game::Battle#cast_escape_skill`/`#cast_teleport_skill`
+  (`mruby-rpg2k/mrblib/game.rb`) already consume them live for the
+  Escape/Teleport skill types — correcting a second stale claim found along
+  the way, `Interpreter#do_set_teleport_target`/`#do_set_escape_target`'s
+  own doc comments ("nothing consumes it yet") were already wrong before
+  this fix, unrelated to the save gap itself. Fixed by mirroring chunk
+  111's own write pattern: build a `SAVE_TARGET` `Array2D`, write the
+  escape slot at id 0 (fields left at their schema defaults when
+  `#escape_target` is nil, so `map_id` reads back absent/0 — RPG_RT's own
+  sentinel), then one entry per `#teleport_targets` hash key. Covered by a
+  new `scripts/rpg2k_logic_check.rb` check (an escape target and two
+  teleport targets round-trip through `to_lsd`/`.from_lsd` exactly; a State
+  that never ran either command round-trips to `nil`/`{}`; a save written
+  before this landed, missing chunk 110 entirely, also round-trips to the
+  same defaults rather than crashing), confirmed to fail against the
+  pre-fix code.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14483,6 +14483,39 @@ module Game
       inv[41] = @last_battle_turns if @last_battle_turns
       save[109] = inv
 
+      # Chunk 110 is every Set Teleport Target (11810) / Set Escape Target
+      # (11830) destination registered so far -- confirmed against RPG_RT's
+      # live source: `Scene_Save::Prepare`/`Player::LoadSavegame`
+      # (`src/scene_save.cpp`/`src/player.cpp`) round-trip `save.targets` via
+      # `Game_Targets::GetSaveData`/`SetSaveData` (`src/game_targets.cpp`)
+      # unconditionally, every save. `GetSaveData` always writes the escape
+      # target first, at array id 0 (default-constructed/empty when never
+      # set -- RPG_RT carries it regardless), followed by every teleport
+      # target keyed by its own destination map id
+      # (`AddTeleportTarget`'s own `tgt.ID = map_id`) -- the exact shape
+      # mirrored below.
+      targets = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_TARGET })
+      esc = @escape_target
+      e0 = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_TARGET })
+      if esc
+        e0[1] = esc[:map_id]
+        e0[2] = esc[:x]
+        e0[3] = esc[:y]
+        e0[4] = !esc[:switch_id].nil?
+        e0[5] = esc[:switch_id] || 1
+      end
+      targets[0] = e0
+      @teleport_targets.each do |map_id, t|
+        e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_TARGET })
+        e[1] = map_id
+        e[2] = t[:x]
+        e[3] = t[:y]
+        e[4] = !t[:switch_id].nil?
+        e[5] = t[:switch_id] || 1
+        targets[map_id] = e
+      end
+      save[110] = targets
+
       # Chunk 111 (SAVE_MAP_EVENT/SAVE_MOVABLE) is the currently-loaded map's
       # own live event table, mirrored straight from #map_event_positions/
       # #map_event_route_index, plus its Tile Substitution table
@@ -14718,6 +14751,27 @@ module Game
       state.vehicle(:boat).load_movable(save.boat)
       state.vehicle(:ship).load_movable(save.ship)
       state.vehicle(:airship).load_movable(save.airship)
+      # Chunk 110 (SAVE_TARGET): every Set Teleport Target/Set Escape Target
+      # destination, the same shape #to_lsd writes -- see that method's own
+      # citation. Array id 0 is always the escape slot (RPG_RT's own
+      # `Game_Targets::GetSaveData` convention); `map_id` absent/0 there
+      # means "never set" (matching a default-constructed `SaveTarget`, the
+      # same sentinel real RPG_RT itself carries when Set Escape Target was
+      # never run). Every other id is a teleport target keyed by its own
+      # destination map id.
+      targets = save[110]
+      if targets
+        esc = targets[0]
+        if esc && esc.map_id && esc.map_id != 0
+          state.escape_target = { map_id: esc.map_id, x: esc.x || 0, y: esc.y || 0,
+                                  switch_id: esc.switch_on ? esc.switch_id : nil }
+        end
+        targets.each do |id, t|
+          next if id == 0 || t.map_id.nil?
+          state.teleport_targets[t.map_id] =
+            { x: t.x || 0, y: t.y || 0, switch_id: t.switch_on ? t.switch_id : nil }
+        end
+      end
       # The leader's on-map sprite override (a Change Sprite Association), stored
       # in the hero chunk's CharSet fields.
       if party.leader && hero.charset_name && !hero.charset_name.empty?

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -4012,8 +4012,13 @@ module Game
     # param1 the map id; on add, param2/param3 are the tile x/y and an optional
     # switch (param4 flags its presence, param5 is the switch id) gates the
     # target's availability. Stored in a Game::State registry keyed by map id.
-    # Nothing consumes it yet — the Teleport skill is not executed — so this is
-    # modelled purely for save fidelity, mirroring the access flags.
+    # ~~Nothing consumes it yet -- the Teleport skill is not executed -- so
+    # this is modelled purely for save fidelity, mirroring the access
+    # flags.~~ Stale: `Game::Battle#cast_teleport_skill`/`#teleport_skill_
+    # available?` (`mruby-rpg2k/mrblib/game.rb`) do consume this registry now.
+    # Also round-trips through a real Save/Continue (chunk 110,
+    # `Game::State#to_lsd`/`.from_lsd`'s own citation), not just this
+    # engine's own portable Marshal save.
     def do_set_teleport_target(cmd)
       map_id = cmd.param(1)
       if cmd.param(0) != 0
@@ -4027,9 +4032,11 @@ module Game
 
     # Set Escape Target: register the single destination the Escape skill jumps
     # to. param0 map id, param1/param2 the tile x/y, and an optional switch
-    # (param3 flags its presence, param4 the switch id). Like the teleport
+    # (param3 flags its presence, param4 the switch id). ~~Like the teleport
     # registry this is stored for save fidelity only; the Escape skill is not
-    # executed yet.
+    # executed yet.~~ Stale, same correction as #do_set_teleport_target's own
+    # comment: `Game::Battle#cast_escape_skill`/`#escape_skill_available?`
+    # already consume it, and it round-trips through a real Save/Continue too.
     def do_set_escape_target(cmd)
       switch_id = cmd.param(3) != 0 ? cmd.param(4) : nil
       @state.escape_target =

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11217,6 +11217,50 @@ check 'to_lsd/from_lsd round-trips a live Change Parallax Background ' \
   eq nil, old.parallax, 'no saved override means the map\'s own panorama applies'
 end
 
+check 'to_lsd/from_lsd round-trips Set Teleport Target / Set Escape Target ' \
+      '(chunk 110)' do
+  # Confirmed directly against RPG_RT's live source: `Scene_Save::Prepare`/
+  # `Player::LoadSavegame` (`src/scene_save.cpp`/`src/player.cpp`) round-trip
+  # `save.targets` via `Game_Targets::GetSaveData`/`SetSaveData`
+  # (`src/game_targets.cpp`) unconditionally on every save -- the escape
+  # target always at array id 0, every teleport target keyed by its own
+  # destination map id. #to_lsd/.from_lsd previously never touched chunk 110
+  # at all (only this engine's own portable Marshal save round-tripped these
+  # registries -- see the "Targets / rate / system audio round-trip through
+  # the save" check above, `to_h`/.load only), so a real Save/Continue
+  # silently dropped every registered target, even though the Escape/
+  # Teleport skills (Game::Battle#cast_escape_skill/#cast_teleport_skill)
+  # already consume them live.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.escape_target = { map_id: 8, x: 3, y: 5, switch_id: 20 }
+  st.teleport_targets[4] = { x: 7, y: 9, switch_id: 12 }
+  st.teleport_targets[6] = { x: 1, y: 2, switch_id: nil }
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq({ map_id: 8, x: 3, y: 5, switch_id: 20 }, round.escape_target)
+  eq({ x: 7, y: 9, switch_id: 12 }, round.teleport_targets[4])
+  eq({ x: 1, y: 2, switch_id: nil }, round.teleport_targets[6])
+
+  # A State that never ran either command must not invent a target on
+  # round-trip -- array id 0's own map_id reads absent/0, RPG_RT's own
+  # "never set" sentinel (a default-constructed SaveTarget), not a real
+  # destination.
+  never_set = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  round2 = Game::State.from_lsd(db, never_set.to_lsd)
+  eq nil, round2.escape_target, 'no Set Escape Target this session means no target round-trips'
+  eq({}, round2.teleport_targets, 'no Set Teleport Target this session means no targets round-trip')
+
+  # A save written before this landed simply omits chunk 110 entirely;
+  # from_lsd must leave those same defaults alone rather than crash reading
+  # an absent chunk.
+  legacy = st.to_lsd
+  legacy.delete(110)
+  old = Game::State.from_lsd(db, legacy)
+  eq nil, old.escape_target
+  eq({}, old.teleport_targets)
+end
+
 # liblcf's SaveMapEventBase.facing (generator/csv/fields.csv, 0x16 == 22) is
 # 0=up/1=right/2=down/3=left (Game_Character::Direction's own enum order),
 # not this runtime's numpad convention (2/4/6/8) -- the two schemes only


### PR DESCRIPTION
## Summary

RPG_RT's `Scene_Save::Prepare`/`Player::LoadSavegame` (`src/scene_save.cpp`/`src/player.cpp`) round-trip `save.targets` unconditionally on every save:

```cpp
save.targets = Main_Data::game_targets->GetSaveData();   // scene_save.cpp:137
Main_Data::game_targets->SetSaveData(std::move(save->targets));  // player.cpp:1235
```

`Game_Targets::GetSaveData` (`src/game_targets.cpp`) always writes the escape target first, at array id 0 (a default-constructed, "never set" `SaveTarget` when Set Escape Target never ran — RPG_RT carries the slot regardless), followed by every teleport target keyed by its own destination map id (`AddTeleportTarget`'s own `tgt.ID = map_id`):

```cpp
std::vector<lcf::rpg::SaveTarget> Game_Targets::GetSaveData() const {
	std::vector<lcf::rpg::SaveTarget> save;
	save.push_back(escape);
	save.insert(save.end(), teleports.begin(), teleports.end());
	return save;
}
```

liblcf's own generator table confirms the wire format matches this codebase's existing `SAVE_TARGET` schema exactly (fields 1-5: map_id/x/y/switch_on/switch_id) — no schema change needed this time, unlike the three prior fixes in this series.

## Where this codebase diverged

`Game::State#to_lsd`/`.from_lsd` (`mruby-rpg2k/mrblib/game.rb`) never touched chunk 110 at all — only this engine's own portable Marshal save (`#to_h`/`.load`) round-tripped `#teleport_targets`/`#escape_target`. A genuine Save/Continue silently dropped every registered target, even though `Game::Battle#cast_escape_skill`/`#cast_teleport_skill` already consume them live for the Escape/Teleport skill types.

## Fix

- `mruby-rpg2k/mrblib/game.rb#to_lsd`: added a `save[110]` write — escape slot at array id 0 (fields left at their schema defaults when `#escape_target` is nil, so `map_id` reads back absent/0, RPG_RT's own sentinel), then one entry per `#teleport_targets` hash key.
- `mruby-rpg2k/mrblib/game.rb#.from_lsd`: added the matching read.

Also corrected two stale doc comments found along the way:
- `do_set_teleport_target`/`do_set_escape_target`'s own "nothing consumes it yet" claim — `Game::Battle#cast_escape_skill`/`#cast_teleport_skill` already do.
- My own erroneous claim from the previous PR (#1245) that `to_lsd` doesn't write vehicle placement chunks 105-107 — it already does; caught by actually reading the method body instead of trusting a grep for a literal string that missed this codebase's variable-keyed `save[chunk] = mv` assignment style. Corrected in `docs/TODO.md` with a same-day strikethrough.

This is a pure state-persistence change — it never touches turn order, damage, or any RNG call site.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb` mirroring the encounter-rate/parallax round-trip tests' structure: sets an escape target and two teleport targets, round-trips through `to_lsd`/`.from_lsd`, and asserts they come back unchanged; a State that never ran either command round-trips to `nil`/`{}`; a save written before this landed (missing chunk 110 entirely) also round-trips to the same defaults rather than crashing.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb mruby-rpg2k/mrblib/interpreter.rb`: the new test fails pre-fix (`expected {...}, got nil`) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1122), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_