### PR TITLE
Restart BGM on same-file replay after a Fade Out BGM

### DIFF
--- a/changelog.d/bgm-restart-after-fadeout.fixed.md
+++ b/changelog.d/bgm-restart-after-fadeout.fixed.md
@@ -1,0 +1,6 @@
+- **Audio:** Play BGM / Play Memorized BGM now restart a track that was
+  faded out by Fade Out BGM, even when it's the same file -- matching
+  RPG_RT's `music_stopping` flag -- previously a same-name replay right
+  after a fade-out silently resumed the fade's leftover volume instead of
+  restarting from the top, unlike an ordinary same-file replay with no
+  intervening fade.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14161,6 +14161,44 @@ not yet verified:
   value, not just the default, so a chunk that silently fell back to 50
   couldn't pass by accident), all confirmed to fail against the pre-fix
   code before the fix.
+  ✅ **Follow-up (2026-08-21): the same-file "does not restart" shortcut
+  itself had a missing exception — a Fade Out BGM of the current track
+  should force the very next same-name Play BGM/Play Memorized BGM to
+  restart it, and this codebase never modelled that.** Confirmed directly
+  against RPG_RT's live source: `Game_System::BgmPlay` (`src/
+  game_system.cpp`) gates its whole "same track: adjust volume in place"
+  branch on `if (!data.music_stopping && previous_music.name == bgm.name)`
+  — not name equality alone — and `Game_System::BgmFade` (Fade Out BGM,
+  11520) always sets `data.music_stopping = true` alongside the fade
+  itself, regardless of duration; `BgmPlay` clears the flag back to `false`
+  unconditionally at its very end, restart or not. liblcf's own
+  `SaveSystem.music_stopping` field (`generator/csv/fields.csv`, field
+  `0x3D`/61) documents the exact same rule in its own description: "Music
+  is being faded out or had been stopped (Play music with the same music
+  as currently playing will restart the music when this flag is set)."
+  `Game::Interpreter#play_audio`'s `:bgm` branch and
+  `#do_play_memorized_bgm` (`mruby-rpg2k/mrblib/interpreter.rb`) both
+  computed their own `same_file_already_playing` from name equality alone,
+  so a track faded out and then immediately replayed by name wrongly took
+  the silent in-place-volume path instead of actually restarting — audible
+  any time a project fades a track out on some trigger and later replays
+  the identical file (a very common pattern). Fixed by adding a new
+  `Game::State#bgm_stopping` flag (`mruby-rpg2k/mrblib/game.rb`), set by
+  `#do_fadeout_bgm`, folded into both same-file checks as an additional
+  `&& !@state.bgm_stopping` term, and cleared unconditionally at the end of
+  every BGM-playing path (including the blank/`(OFF)` stop branch), the
+  same shape `data.music_stopping`'s own read/write sites take in
+  `BgmPlay`. Also corrected this file's own doc comment, which had cited
+  yado.tk for the general same-file no-restart behaviour where a direct
+  citation of `BgmPlay`'s own source (already established elsewhere in this
+  file) was available and more precise. `mruby-lcf/mrblib/schema.rb`'s
+  `SAVE_SYSTEM` table does not yet model liblcf field 61 at all, so
+  `#bgm_stopping` does not currently round-trip through a real
+  Save/Continue either — a separately-scoped follow-up, left for later.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (a same-file
+  Play BGM, and a Play Memorized BGM, each restart the track after an
+  intervening Fade Out BGM, distinguished from the existing "no restart"
+  checks' own fixture), both confirmed to fail against the pre-fix code.
 - ✅ **A map's own configured BGM now actually auto-plays, on the initial map
   load and every Transfer Player alike — a genuine, previously-undocumented
   gap found while cross-checking this same BGM cluster for anything else the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13803,6 +13803,17 @@ module Game
     # a new BGM starts; set by Scene::Map, which watches `RGSS::Audio.bgm_pos`
     # and treats a playback position that jumped backwards as a loop.
     attr_accessor :bgm_looped
+    # Whether the current BGM has been faded/stopped since it last actually
+    # started playing -- RPG_RT's own `music_stopping` flag
+    # (`Game_System::BgmFade`, `src/game_system.cpp`: `data.music_stopping =
+    # true;`, set by Fade Out BGM/11520). `Game_System::BgmPlay`'s "same
+    # track: adjust volume in place, don't restart" shortcut is gated on
+    # `!data.music_stopping` -- so a Play BGM/Play Memorized BGM of the same
+    # track right after a fade-out DOES restart it from the top, unlike an
+    # ordinary same-name replay. Cleared unconditionally at the end of every
+    # `BgmPlay` call, restart or not (`data.music_stopping = false;`), which
+    # `#play_audio`'s `:bgm` branch and `#do_play_memorized_bgm` both mirror.
+    attr_accessor :bgm_stopping
     # Whether the party leader's map sprite is hidden, toggled by the Set
     # Transparent Flag / Change Player Visibility (11310) event command. Defaults
     # off (the hero is shown) and is persisted in the save.
@@ -13959,6 +13970,7 @@ module Game
       @current_bgm = nil
       @memorized_bgm = nil
       @bgm_looped = false
+      @bgm_stopping = false
       @player_transparent = false
       @encounter_rate = nil
       @encounter_total = 0

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3976,6 +3976,10 @@ module Game
     # `Scene::Menu`'s own End Game call passes `bgm_fade(400)` directly.
     def do_fadeout_bgm(cmd)
       @state.bgm_looped = false
+      # `Game_System::BgmFade` (`src/game_system.cpp`) always sets `data.
+      # music_stopping = true` alongside the fade itself -- see Game::State
+      # #bgm_stopping's own doc comment for what this ungates.
+      @state.bgm_stopping = true
       RGSS::Audio.bgm_fade(cmd.param(0))
     rescue StandardError => e
       $stderr.puts "[RPG2k] BGM fade-out failed: #{e.message}"
@@ -4117,7 +4121,12 @@ module Game
     def do_play_memorized_bgm(_cmd)
       bgm = @state.memorized_bgm
       return if bgm.nil? || bgm[:name].nil? || bgm[:name].empty?
-      same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == bgm[:name]
+      # Gated on !#bgm_stopping too, same as #play_audio's :bgm branch --
+      # `PlayMemorizedBGM` is a bare `BgmPlay` call, so it shares that
+      # method's own `!data.music_stopping` restart gate (see
+      # Game::State#bgm_stopping's own doc comment).
+      same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == bgm[:name] &&
+                                   !@state.bgm_stopping
       if same_file_already_playing
         RGSS::Audio.bgm_volume(bgm[:volume] || 100)
       else
@@ -4132,6 +4141,9 @@ module Game
       # `Music` struct straight to a new play call either way.
       RGSS::Audio.bgm_pan(bgm[:balance] || 50)
       @state.current_bgm = bgm.dup
+      # Cleared unconditionally, restart or not -- see #play_audio's own
+      # matching reset.
+      @state.bgm_stopping = false
     rescue StandardError => e
       $stderr.puts "[RPG2k] memorized BGM playback failed: #{e.message}"
       nil
@@ -4158,6 +4170,10 @@ module Game
         if blank || name == '(OFF)'
           RGSS::Audio.bgm_stop
           @state.current_bgm = nil
+          # `Game_System::BgmPlay` clears `data.music_stopping` unconditionally
+          # at the very end, including this stop branch -- see Game::State
+          # #bgm_stopping's own doc comment.
+          @state.bgm_stopping = false
           return
         end
       elsif blank
@@ -4175,19 +4191,27 @@ module Game
         balance = cmd.parameters.size > 3 ? cmd.param(3) : 50
         # BGM has a single channel, and RPG_RT special-cases re-triggering Play
         # BGM with the file that's already current: it does NOT break and
-        # restart the track from the top the way any other Play BGM does
-        # (yado.tk), but it does re-apply the command's own volume to the
-        # still-playing track (`RGSS::Audio.bgm_volume`, backed by
-        # `Mix_VolumeMusic` — see `src/sdl_audio.cxx`, which applies live with
-        # no restart, unlike `bgm_play`'s `Mix_PlayMusic`). Tempo stays
-        # unaddressed: SDL_mixer has no live pitch control for a playing music
-        # stream (only a freshly started one). Balance/pan is wired the same
-        # live-update way via `RGSS::Audio.bgm_pan` (backed by
-        # `Mix_SetPanning(MIX_CHANNEL_POST, ...)` — the only technique that
-        # reaches a Mix_Music stream at all, see `src/sdl_audio.cxx`), applied
-        # on every Play BGM regardless of same-file-or-not since it has no
-        # per-track state to restart.
-        same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == name
+        # restart the track from the top the way any other Play BGM does --
+        # confirmed against `Game_System::BgmPlay` (`src/game_system.cpp`)
+        # itself, not merely a fan-wiki claim -- but it does re-apply the
+        # command's own volume to the still-playing track
+        # (`RGSS::Audio.bgm_volume`, backed by `Mix_VolumeMusic` — see
+        # `src/sdl_audio.cxx`, which applies live with no restart, unlike
+        # `bgm_play`'s `Mix_PlayMusic`). Tempo stays unaddressed: SDL_mixer has
+        # no live pitch control for a playing music stream (only a freshly
+        # started one). Balance/pan is wired the same live-update way via
+        # `RGSS::Audio.bgm_pan` (backed by `Mix_SetPanning(MIX_CHANNEL_POST,
+        # ...)` — the only technique that reaches a Mix_Music stream at all,
+        # see `src/sdl_audio.cxx`), applied on every Play BGM regardless of
+        # same-file-or-not since it has no per-track state to restart.
+        #
+        # That no-restart shortcut is itself gated on `!data.music_stopping`
+        # in real RPG_RT (`BgmPlay`'s own `if (!data.music_stopping &&
+        # previous_music.name == bgm.name)`) -- a Fade Out BGM (11520) of this
+        # exact track since it last started DOES force a fresh restart here,
+        # matching `#bgm_stopping`'s own doc comment.
+        same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == name &&
+                                     !@state.bgm_stopping
         # Track what is playing so Memorize BGM can stash it (RPG_RT keeps this
         # as the "current system BGM" regardless of whether playback succeeds)
         # -- balance included, since `Game_System::MemorizeBGM`
@@ -4200,6 +4224,9 @@ module Game
           @state.bgm_looped = false # a fresh track has not looped yet
           RGSS::Audio.bgm_play(name, volume, pitch)
         end
+        # Cleared unconditionally, restart or not -- `BgmPlay`'s own `data.
+        # music_stopping = false;` runs after the if/else either way.
+        @state.bgm_stopping = false
         RGSS::Audio.bgm_pan(balance)
       else
         # PlaySE parameters: [volume, tempo, balance].

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3370,6 +3370,48 @@ check 'Play BGM with the file already playing does not restart it' do
   eq [50], volumes, 'the still-playing track had its volume re-applied live instead of doing nothing'
 end
 
+check 'Play BGM with the same file restarts it after a Fade Out BGM, unlike ' \
+      'an ordinary same-file replay' do
+  # Confirmed directly against RPG_RT's live source: `Game_System::BgmPlay`
+  # (`src/game_system.cpp`) gates its "same track: adjust volume in place,
+  # don't restart" shortcut on `!data.music_stopping`, and
+  # `Game_System::BgmFade` (Fade Out BGM, 11520) always sets `data.
+  # music_stopping = true` alongside the fade -- so a Play BGM of the exact
+  # track just faded out DOES restart it from the top, unlike the ordinary
+  # same-file no-restart case the check just above this one covers.
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::FADEOUT_BGM, [400]),
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+  ])
+  it.update
+  names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
+  eq %w[town town], names, 'the second Play BGM restarted the track after the fade-out, ' \
+                           'not skipped as an in-place volume tick'
+end
+
+check 'Play Memorized BGM restarts its track after a Fade Out BGM, unlike ' \
+      'an ordinary same-file replay' do
+  # Same gate as the check above, on Play Memorized BGM's own restart path --
+  # `Game_System::PlayMemorizedBGM` is a bare `BgmPlay` call, so it shares
+  # the identical `!data.music_stopping` shortcut.
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::MEMORIZE_BGM, []),
+    FakeCmd.new(IC::FADEOUT_BGM, [400]),
+    FakeCmd.new(IC::PLAY_MEMORIZED_BGM, []),
+  ])
+  it.update
+  names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
+  eq %w[town town], names, 'Play Memorized BGM restarted the track after the fade-out'
+end
+
 check 'Play BGM with a different file still restarts (or starts) playback' do
   RGSS::Audio.log = []
   st = new_state


### PR DESCRIPTION
## Summary

RPG_RT's `Game_System::BgmPlay` (`src/game_system.cpp`) gates its "same track: adjust volume in place, don't restart" shortcut on a flag, not name equality alone:

```cpp
if (!data.music_stopping && previous_music.name == bgm.name) {
    // adjust volume/tempo/balance in place, no restart
} else {
    Audio().BGM_Stop();
    // ...request + start fresh playback...
}
...
data.music_stopping = false;
```

`Game_System::BgmFade` (Fade Out BGM, code 11520) always sets `data.music_stopping = true` alongside the fade itself, regardless of duration:

```cpp
void Game_System::BgmFade(int duration, bool clear_current_music) {
	Audio().BGM_Fade(duration);
	if (clear_current_music) {
		data.current_music.name = "(OFF)";
	}
	data.music_stopping = true;
}
```

`Game_System::PlayMemorizedBGM` is a bare `BgmPlay(data.stored_music)` call, so it shares the identical gate. liblcf's own `SaveSystem.music_stopping` field description confirms the same rule verbatim: "Music is being faded out or had been stopped (Play music with the same music as currently playing will restart the music when this flag is set)."

## Where this codebase diverged

`Game::Interpreter#play_audio`'s `:bgm` branch and `#do_play_memorized_bgm` (`mruby-rpg2k/mrblib/interpreter.rb`) both computed `same_file_already_playing` from name equality alone — so a track faded out via Fade Out BGM and then immediately replayed by name wrongly took the silent in-place-volume path instead of restarting from the top. This is audible, not cosmetic: a common pattern (fade out on a cutscene trigger, replay the same track once it ends) would silently resume the fade-out's leftover volume/position instead of restarting.

## Fix

- `mruby-rpg2k/mrblib/game.rb`: added `Game::State#bgm_stopping` (default `false`).
- `mruby-rpg2k/mrblib/interpreter.rb`: `#do_fadeout_bgm` sets it `true`; `#play_audio`'s `:bgm` branch and `#do_play_memorized_bgm` both fold `&& !@state.bgm_stopping` into their `same_file_already_playing` check, and clear the flag unconditionally at the end of every BGM-playing path (including the blank/`(OFF)` stop branch) — matching `BgmPlay`'s own unconditional reset.

Also corrected a doc comment in `#play_audio` that had cited yado.tk for the general same-file no-restart behavior, where a direct citation of `BgmPlay`'s own source (already established elsewhere in this file) was available and more precise.

`mruby-lcf/mrblib/schema.rb`'s `SAVE_SYSTEM` table doesn't model liblcf field 61 (`music_stopping`) at all yet, so this flag doesn't currently round-trip through a real Save/Continue — noted as a separately-scoped follow-up in `docs/TODO.md`, not folded into this fix.

This is a pure flag-bookkeeping change — it never touches turn order, damage, or any RNG call site.

## Testing

Added two regression tests to `scripts/rpg2k_logic_check.rb`: a same-file Play BGM, and a Play Memorized BGM, each restart the track after an intervening Fade Out BGM — distinguished from the existing "no restart" tests' own fixture (same file, no fade in between).

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb mruby-rpg2k/mrblib/interpreter.rb`: both new tests fail pre-fix (`expected ["town", "town"], got ["town"]`) and pass post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1124), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_