### PR TITLE
Fix genuine 0%-hit dual-wield weapon defaulting to 90%

### DIFF
--- a/changelog.d/dual-wield-zero-hit-weapon.fixed.md
+++ b/changelog.d/dual-wield-zero-hit-weapon.fixed.md
@@ -1,0 +1,5 @@
+- **Battle:** an RPG2003 dual-wielding actor's swing with a weapon whose
+  own hit rate is a genuine 0% (a cursed/joke weapon meant to never land)
+  now always misses, matching RPG_RT's `Game_Actor::GetHitChance` -- it
+  previously fell back to the 90% unarmed default, the same bug class
+  already fixed for the actor's own merged hit rate elsewhere.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9525,6 +9525,32 @@ not yet verified:
   both roll the *merged* 100%-hit max rather than one weapon's own
   guaranteed-miss 10%, confirmed to fail against the pre-fix code before the
   fix.
+  ✅ **Follow-up (2026-08-21): `#weapon_roll_data` (the per-swing data
+  `#swing_weapon_data` hands each RPG2003 two-weapon swing) folded a
+  genuine 0%-hit weapon into the "nothing equipped" case and substituted
+  the 90% unarmed default — the exact same bug class `#attack_hit_rate`
+  was already fixed for elsewhere in this file (`Game_Actor::
+  GetHitChance`'s own `INT_MIN` sentinel, see that bullet's own citation),
+  just never mirrored into this newer, parallel single-weapon path.**
+  Confirmed against the identical EasyRPG source: `ForEachEquipment`'s
+  single-slot query (`weapon != slot+1` exclusion) visits exactly one item
+  for `#swing_weapon_data`'s per-swing resolution, so `hit = std::max(
+  INT_MIN, item.hit) == item.hit` verbatim — the `INT_MIN` fallback only
+  ever fires when that slot holds no weapon at all, never when the
+  equipped weapon's own `hit` field is a genuine 0. `#weapon_roll_data`
+  (`mruby-rpg2k/mrblib/game.rb`) instead wrote `it.hit && it.hit > 0 ?
+  it.hit : 90`, so an RPG2003 dual-wield actor's second weapon —
+  deliberately authored with `hit: 0` (a cursed/joke weapon meant to never
+  land) — would land that swing at the ordinary unarmed rate instead of
+  never. Fixed by replacing the `> 0` fold with the same nil-vs-present
+  distinction `#attack_hit_rate` already uses (`h = it.hit; hit = h.nil? ?
+  90 : h`) — `it` is always a real equipped weapon by the time it reaches
+  here, so the only genuinely-absent case left is a row with no `hit`
+  field at all. Covered by a new `scripts/rpg2k_logic_check.rb` check (an
+  RPG2003 two-weapon actor's hit-100 first swing always lands while its
+  cursed hit-0 second swing always misses, against a target nimble enough
+  that the old 90%-default bug would have landed it almost every roll),
+  confirmed to fail against the pre-fix code.
 - ✅ **A terrain row's negative `damage` field now heals the party each step
   instead of doing nothing, and bypasses 地形ダメージ無効 gear entirely while
   doing it.** RPG2000/2003 terrain rows carry one plain signed `damage`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2476,8 +2476,19 @@ module Game
     # `#swing_weapon_data` hands a specific weapon-governed swing, as
     # opposed to `#attack_hit_rate`/`#weapon_attributes`/`#weapon_states`/
     # `#crit_chance`'s own merge across every equipped weapon-type item.
+    #
+    # Same sentinel distinction `#attack_hit_rate`'s own citation makes:
+    # `Game_Actor::GetHitChance`'s `INT_MIN` (`src/game_actor.cpp`) only ever
+    # falls back to 90 when the queried slot holds no weapon at all --
+    # `ForEachEquipment`'s single-weapon call here visits exactly one item,
+    # so a genuine `hit == 0` on it (an intentionally "never lands" weapon)
+    # must return 0 as-is, not fold into the nothing-equipped default. `it`
+    # is always a real equipped weapon by the time it reaches here (`#swing_
+    # weapon_data`'s own `weapons.size >= 2` guard), so the only "absent"
+    # case left is a row with no `hit` field at all.
     def weapon_roll_data(it)
-      hit = it.respond_to?(:hit) && it.hit && it.hit > 0 ? it.hit : 90
+      h = it.respond_to?(:hit) ? it.hit : nil
+      hit = h.nil? ? 90 : h
       attrs = []
       set = it.respond_to?(:attribute_set) ? it.attribute_set : nil
       set.each_with_index { |on, i| attrs << (i + 1) if on } if set

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -20513,6 +20513,39 @@ check "battle: an RPG2000 two-weapon actor's swings both roll the merged " \
                         'RPG2000 never splits by weapon'
 end
 
+check "battle: an RPG2003 two-weapon actor's swing on a genuine 0%-hit " \
+      'weapon always misses, not defaulted to the 90% unarmed rate' do
+  # Same INT_MIN-sentinel distinction #attack_hit_rate's own fix already
+  # covers (see "a weapon with its own genuine 0% hit rate is used as-is,
+  # not treated as unequipped" above), now for the per-swing #swing_weapon_
+  # data/#weapon_roll_data path a two-weapon RPG2003 actor's second swing
+  # goes through. Confirmed against the same EasyRPG source: `Game_Actor::
+  # GetHitChance`'s `ForEachEquipment<true,false>(..., weapon)` call visits
+  # exactly one slot for a single-weapon query, so `hit = std::max(INT_MIN,
+  # item.hit) == item.hit` verbatim -- the `INT_MIN` fallback to 90 only
+  # ever fires when that slot holds no weapon at all, never when the
+  # equipped weapon's own `hit` field is a genuine 0.
+  items = { 1 => fake_item(type: 1, atk: 10, hit: 100), # always lands
+            2 => fake_item(type: 1, atk: 10, hit: 0) }  # cursed: never lands
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 0, agi: 10 })
+  row.double_hand = true
+  db = FakeActorDB.new({ 1 => row }, [1], items, rpg2003: true)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  actor = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(actor, 1, Game::Actor::WEAPON_SLOT)
+  ok st.party.equip_from_bag(actor, 2, Game::Actor::SHIELD_SLOT)
+  hero = Game::Battle.from_actor(actor)
+  foe = combatant('Foe', 0, 0, 20, 999) # much nimbler than the hero's agi 10
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), {}, false, false, true)
+  first, second = bat.send(:swing, hero, foe)
+  ok !first[:missed], 'swing 1 (hit 100) always lands'
+  eq true, second[:missed], "swing 2 (the cursed hit-0 weapon) always misses -- its own " \
+                            '0%, not the 90% unarmed default a masked 0 would fall back to'
+end
+
 check 'battle: #swing actually lands three attacks when strike_count is three, ' \
       'not capped at two' do
   # #swing previously hardcoded "at most two attacks" (`deal_attack` once,


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Actor::GetHitChance` (`src/game_actor.cpp`) uses `INT_MIN` as its own "nothing equipped" sentinel:

```cpp
int Game_Actor::GetHitChance(Weapon weapon) const {
	int hit = INT_MIN;
	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { hit = std::max(hit, static_cast<int>(item.hit)); }, weapon);
	if (hit != INT_MIN) {
		return hit;
	} else {
		...
		return 90;
	}
}
```

`ForEachEquipment`'s single-slot query (`weapon != slot + 1` exclusion) — used by `Game_BattleAlgorithm::Normal`'s per-swing weapon resolution under RPG2003's `Style_MultiHit` — visits exactly one item, so `hit = std::max(INT_MIN, item.hit) == item.hit` verbatim. The `INT_MIN` fallback to 90 only ever fires when that slot holds **no weapon at all**, never when the equipped weapon's own `hit` field is a genuine 0.

## Where this codebase diverged

`Actor#weapon_roll_data` (`mruby-rpg2k/mrblib/game.rb`), the per-swing data `#swing_weapon_data` hands each RPG2003 two-weapon swing, instead wrote:

```ruby
hit = it.respond_to?(:hit) && it.hit && it.hit > 0 ? it.hit : 90
```

This folds a genuine `hit == 0` into the "field absent" case — the **exact same bug class** `Actor#attack_hit_rate` was already fixed for elsewhere in this file (its own doc comment explicitly cites this `INT_MIN` sentinel), just never mirrored into this newer, parallel single-weapon path. A dual-wield actor's second weapon deliberately authored with `hit: 0` (a cursed/joke weapon meant to never land) would land that swing at the ordinary 90% unarmed rate instead of never.

## Fix

One method, `mruby-rpg2k/mrblib/game.rb`'s `weapon_roll_data`, replacing the `> 0` fold with the same nil-vs-present distinction `#attack_hit_rate` already uses:

```ruby
h = it.respond_to?(:hit) ? it.hit : nil
hit = h.nil? ? 90 : h
```

`it` is always a real equipped weapon by the time it reaches here (`#swing_weapon_data`'s own `weapons.size >= 2` guard), so the only genuinely-absent case left is a row with no `hit` field at all. No RNG-draw-order impact — this only changes which flat hit percentage feeds into the existing, unmoved to-hit roll for that swing.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb` mirroring the existing "an RPG2003 two-weapon actor's swings each carry their own weapon's..." test structure: an RPG2003 dual-wield actor with a hit-100 first weapon and a cursed hit-0 second weapon, against a target nimble enough that the old 90%-default bug would land the second swing almost every roll — asserts the first swing always lands and the second always misses.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb`: the new test fails pre-fix (`expected true, got nil`) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1125), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_