### PR TITLE
Implement battle Conditional Branch test 4 (troop member is target)

### DIFF
--- a/changelog.d/battle-conditional-branch-target-enemy.fixed.md
+++ b/changelog.d/battle-conditional-branch-target-enemy.fixed.md
@@ -1,0 +1,5 @@
+- **Events:** the RPG2003 battle-event Conditional Branch's "troop member
+  is the current target" test (13310, test type 4) is now implemented,
+  matching RPG_RT's `target_enemy_index`/`targets_single_enemy` -- it
+  previously always took the else branch regardless of actual battle
+  state.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16766,6 +16766,39 @@ not yet verified:
   the named actor never matches), confirmed to fail against the pre-fix
   code (`NoMethodError: undefined method 'battle_source='`) before the
   fix.
+  ✅ **Follow-up (2026-08-21): test 4 ("the currently-targeted troop member
+  is param1") is now implemented too, correcting this entry's own claim
+  that it "remains genuinely unimplemented."** Confirmed directly against
+  RPG_RT's live source: `Game_Interpreter_Battle::
+  CommandConditionalBranchBattle`'s `case 4` (`src/
+  game_interpreter_battle.cpp`) is `result = (targets_single_enemy &&
+  target_enemy_index == com.parameters[1]);`. Both fields are set in
+  `Scene_Battle_Rpg2k3::ProcessBattleActionBegin`
+  (`src/scene_battle_rpg2k3.cpp`), right before a page's pre-action events
+  run, from the acting ally's own `GetOriginalSingleTarget()` — the target
+  chosen at command time, before any forced-restriction (Berserk/Confuse)
+  override — and only when that target is itself an enemy; `targets_
+  single_enemy` stays false for an all-target action or one aimed at an
+  ally. Only ever set for an acting ally (`if (source->GetType() ==
+  Type_Ally)`) — an enemy-sourced page run instead inherits whatever the
+  last acting ally left behind, a real but rarely-observable quirk left
+  unmodelled in the fix below. Fixed with a new `Game::Battle
+  #target_enemy_index(source)` (`mruby-rpg2k/mrblib/game.rb`), this port's
+  own counterpart: resolves `source`'s single target from a basic Attack's
+  plain `#action` field or a single-target Skill/Item's own
+  `#command[:target]` (nil for an all-target `#command[:all]` action), then
+  looks it up in `@enemies` **by identity** (`#equal?`, not the Struct's
+  own value equality — see `#turn_order`'s own citation on why two
+  same-stat enemies would otherwise collide onto the wrong index). A new
+  `Interpreter#battle_target_enemy_condition(cmd)` (`when 4` in
+  `#eval_battle_condition`) reuses the identical `battle_source` plumbing
+  test 5 already threads, the same "reuse, don't duplicate" shape that
+  fix took. Covered by a new `scripts/rpg2k_logic_check.rb` check (no
+  `battle_source` set -- unanswerable; a basic Attack on troop slot 0
+  matches index 0 but not slot 1; a single-target Skill/Item's own
+  resolved target wins over `#action`; an all-target action or one aimed
+  at an ally never satisfies any troop-member test), confirmed to fail
+  against the pre-fix code (`expected 1, got 2`) before the fix.
 - ✅ **"Hero X is in the party" always addresses by database ID, not
   current seat/slot order; there is no built-in way to read a member's
   current seat position — confirmed correct.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -10221,6 +10221,38 @@ module Game
       source.last_battle_action
     end
 
+    # Conditional Branch (Battle) test 4, "the currently-targeted troop
+    # member is param1": the troop slot index of `source`'s own currently-
+    # resolved single enemy target, or nil when there is no such single
+    # target. Port of RPG_RT's own `target_enemy_index`/`targets_single_
+    # enemy` (set in `Scene_Battle_Rpg2k3::ProcessBattleActionBegin`, `src/
+    # scene_battle_rpg2k3.cpp`, right before a page's pre-action events
+    # run): only computed when `source->GetType() == Type_Ally`, from that
+    # action's own `GetOriginalSingleTarget()` -- the target chosen at
+    # command time, before any forced-restriction (Berserk/Confuse)
+    # override -- and only when that target is itself an enemy (`Type_
+    # Enemy`); an all-target action or one aimed at an ally leaves
+    # `targets_single_enemy` false. This port's own equivalent of "the
+    # original single target": a basic Attack's plain `#action` field, or a
+    # single-target Skill/Item's `#command[:target]` (nil for an all-target
+    # `#command[:all]` action). `@enemies.find_index` compares by identity
+    # (`#equal?`), not the Struct's own value equality, since two same-type
+    # enemies sharing every stat would otherwise collide onto the wrong
+    # index the way `#turn_order`'s own citation on this exact hazard
+    # already documents. Only ever resolved for an ally `source` -- RPG_RT
+    # itself only ever *sets* these fields for an acting ally; an
+    # enemy-sourced page run instead inherits whatever the last acting ally
+    # left behind (`// Enemy doesn't change the values...`), a real but
+    # rarely-observable quirk left unmodelled here.
+    def target_enemy_index(source)
+      return nil unless source
+      a = source.actor
+      return nil unless a
+      target = source.command ? (source.command[:all] ? nil : source.command[:target]) : source.action
+      return nil unless target
+      @enemies.find_index { |e| e.equal?(target) }
+    end
+
     # Force Flee (1006), target 0: let the party leave whenever it next tries.
     # RPG_RT grants the escape rather than performing it, so the player still has
     # to pick Flee — #attempt_escape then always succeeds.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2883,12 +2883,11 @@ module Game
     # `command_actor` trigger condition), just never threaded from
     # `#run_battle_events`'s own `source` through to the interpreter that
     # actually runs the page's in-body commands. Test 4 ("the currently-
-    # targeted troop member is param1") remains unimplemented: RPG_RT's own
-    # `target_enemy_index`/`targets_single_enemy` (set in `Scene_Battle_
-    # Rpg2k3::ProcessBattleActionBegin`, right before a page's pre-action
-    # events run) has no counterpart anywhere in this codebase yet -- a
-    # narrower, separate piece of state than `source` alone provides, left
-    # as its own follow-up.
+    # targeted troop member is param1") is now implemented too -- see
+    # #battle_target_enemy_condition/`Game::Battle#target_enemy_index`, this
+    # port's own counterpart of RPG_RT's `target_enemy_index`/`targets_
+    # single_enemy` pair, reusing the identical `battle_source` plumbing
+    # test 5 already threads.
     def do_conditional_battle(cmd)
       return if eval_battle_condition(cmd)
       skip_to([Cmd::ELSE_BRANCH_B, Cmd::END_BRANCH_B], cmd.indent)
@@ -2905,6 +2904,7 @@ module Game
         compare(variables[cmd.param(1)], rhs, cmd.param(4))
       when 2 then battle_actor_condition(cmd)
       when 3 then battle_enemy_condition(cmd)
+      when 4 then battle_target_enemy_condition(cmd)
       when 5 then battle_command_condition(cmd)
       else false
       end
@@ -2976,6 +2976,20 @@ module Game
     def battle_command_condition(cmd)
       return false unless @battle
       @battle.actor_command(cmd.param(1), battle_source) == cmd.param(2)
+    end
+
+    # Test 4, "the currently-targeted troop member is param1" -- EasyRPG's
+    # `Game_Interpreter_Battle::CommandConditionalBranchBattle` case 4:
+    # `result = (targets_single_enemy && target_enemy_index ==
+    # com.parameters[1]);`. `Game::Battle#target_enemy_index` is this port's
+    # own counterpart of RPG_RT's `target_enemy_index`/`targets_single_
+    # enemy` pair, reusing the identical `battle_source` plumbing
+    # `#battle_command_condition` (test 5) already threads from
+    # `#run_battle_events`; a nil result (no single enemy target resolved)
+    # never matches any `cmd.param(1)`.
+    def battle_target_enemy_condition(cmd)
+      return false unless @battle
+      @battle.target_enemy_index(battle_source) == cmd.param(1)
     end
 
     # -- conditional branch ---------------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -18144,6 +18144,73 @@ check 'battle Conditional Branch test 5 (actor uses the ... command) reads ' \
   eq 2, st.variables[1], 'a source that is not the named actor never matches'
 end
 
+# Test 4 ("the currently-targeted troop member is param1") was previously
+# left unimplemented (see #do_conditional_battle's own citation), falling
+# straight to `else false` regardless of actual battle state. Confirmed
+# against EasyRPG's actual C++ source: `Game_Interpreter_Battle::
+# CommandConditionalBranchBattle` case 4, `result = (targets_single_enemy
+# && target_enemy_index == com.parameters[1]);`, where both fields are set
+# in `Scene_Battle_Rpg2k3::ProcessBattleActionBegin` (src/
+# scene_battle_rpg2k3.cpp) from the acting ally's own `GetOriginalSingle
+# Target()` -- the target chosen at command time -- only when that target
+# is itself an enemy. `Game::Battle#target_enemy_index` is this port's own
+# counterpart, reusing the identical `battle_source` plumbing test 5
+# already threads.
+check 'battle Conditional Branch test 4 (troop member is the current ' \
+      "target) reads Interpreter#battle_source's own resolved target" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.actor = FakeSourceActor.new(1)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  goblin = combatant('Goblin', 0, 0, 5, 100)
+  b = Game::Battle.new([hero], [slime, goblin], Game::Rng.new(1))
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  branch = lambda do |params|
+    [FakeCmd.new(IC::CONDITIONAL_B, params, indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+     FakeCmd.new(IC::ELSE_BRANCH_B, [], indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+     FakeCmd.new(IC::END_BRANCH_B, [], indent: 0)]
+  end
+
+  # No source at all (a round-boundary check) -- unanswerable.
+  hero.action = slime
+  it.start(branch.call([4, 0]))
+  it.update
+  eq 2, st.variables[1], 'no battle_source set -- the else branch runs'
+
+  it.battle_source = hero
+
+  # A basic Attack (#action) targeting troop slot 0 (the slime).
+  it.start(branch.call([4, 0]))
+  it.update
+  eq 1, st.variables[1], 'a basic Attack on troop slot 0 matches index 0'
+
+  it.start(branch.call([4, 1]))
+  it.update
+  eq 2, st.variables[1], 'but not the other troop slot'
+
+  # A single-target Skill/Item's own #command[:target] overrides #action --
+  # targeting troop slot 1 (the goblin) this time.
+  hero.command = { target: goblin }
+  it.start(branch.call([4, 1]))
+  it.update
+  eq 1, st.variables[1], "a single-target Skill/Item's own resolved target wins over #action"
+
+  # An all-target action (#command[:all]) has no single troop-member target.
+  hero.command = { all: true }
+  it.start(branch.call([4, 0]))
+  it.update
+  eq 2, st.variables[1], 'an all-target action never satisfies any troop-member test'
+
+  # A heal aimed at an ally resolves to no troop index at all.
+  hero.command = { target: hero }
+  it.start(branch.call([4, 0]))
+  it.update
+  eq 2, st.variables[1], 'a command aimed at an ally is not a troop member'
+end
+
 # Confirmed against EasyRPG's actual C++ source, fetched live:
 # `Game_Interpreter_Battle::CommandConditionalBranchBattle`
 # (src/game_interpreter_battle.cpp) reads only `com.parameters[1]` for its


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Interpreter_Battle::CommandConditionalBranchBattle` (`src/game_interpreter_battle.cpp`) case 4:

```cpp
case 4:
    // Monster is the current target
    if (Player::IsRPG2k3Commands()) {
        result = (targets_single_enemy && target_enemy_index == com.parameters[1]);
    }
    break;
```

Both `target_enemy_index`/`targets_single_enemy` are set in `Scene_Battle_Rpg2k3::ProcessBattleActionBegin` (`src/scene_battle_rpg2k3.cpp`), right before a page's pre-action events run:

```cpp
if (source->GetType() == Game_Battler::Type_Ally) {
    ...
    auto* original_target = action->GetOriginalSingleTarget();
    if (original_target && original_target->GetType() == Game_Battler::Type_Enemy) {
        auto* enemy = static_cast<Game_Enemy*>(original_target);
        interp.SetCurrentEnemyTargetIndex(Main_Data::game_enemyparty->GetEnemyPositionInParty(enemy));
        interp.SetCurrentActionTargetsSingleEnemy(true);
    } else {
        interp.SetCurrentActionTargetsSingleEnemy(false);
    }
}
```

Only set for an acting ally, from that action's own *original* single target (the target chosen at command time, before any forced-restriction override), and only when that target is itself an enemy.

## Where this codebase diverged

`Interpreter#eval_battle_condition` (`mruby-rpg2k/mrblib/interpreter.rb`) had no `when 4` arm at all — it silently fell through to `else false`, so any troop page using this editor condition ("Monster [n] is the currently selected target") always took the else branch, unconditionally, regardless of actual battle state. This codebase's own doc comment already flagged it as a known open gap after test 5 ("Hero uses the ... command") was fixed in an earlier cycle.

## Fix

- `mruby-rpg2k/mrblib/game.rb`: added `Game::Battle#target_enemy_index(source)` — resolves `source`'s single target from a basic Attack's plain `#action` field or a single-target Skill/Item's own `#command[:target]` (nil for an all-target `#command[:all]` action), then looks it up in `@enemies` **by identity** (`#equal?`, not the Struct's own value equality — two same-stat enemies would otherwise collide onto the wrong index, the same hazard `#turn_order`'s own citation documents).
- `mruby-rpg2k/mrblib/interpreter.rb`: added `when 4 then battle_target_enemy_condition(cmd)` and the small method itself, reusing the identical `battle_source` plumbing test 5 already threads from `#run_battle_events`.

This is purely additive — no RNG draws touched, no reordering of any existing call site.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb` mirroring the existing test-5 test's structure: no `battle_source` set is unanswerable; a basic Attack on troop slot 0 matches index 0 but not slot 1; a single-target Skill/Item's own resolved target wins over `#action`; an all-target action or one aimed at an ally never satisfies any troop-member test.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb mruby-rpg2k/mrblib/interpreter.rb`: the new test fails pre-fix (`expected 1, got 2`) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1126), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_