### PR TITLE
Clear defending/charged stance immediately on Knockout

### DIFF
--- a/changelog.d/knockout-reset-defending-charged.fixed.md
+++ b/changelog.d/knockout-reset-defending-charged.fixed.md
@@ -1,0 +1,5 @@
+- **Battle:** a defending or charged enemy that dies now immediately loses
+  that stance, matching RPG_RT's `Game_Battler::AddState` Knockout branch
+  -- a revived enemy previously kept its stale pre-death Defend/Charge
+  flag until its own next turn, wrongly halving incoming damage or
+  doubling its next attack in the meantime.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -19256,6 +19256,35 @@ above are repeated here)
   Monster HP plays the `EnemyKill` SE, matching an ordinary lethal
   Attack/Skill), confirmed to fail against the pre-fix code before the
   fix.
+  ✅ **Follow-up (2026-08-21): `apply_knockout_reset` itself had its own gap
+  — a defending or charged enemy killed and revived mid-fight kept the
+  stale stance, contradicting this very method's own doc comment.**
+  Confirmed directly against RPG_RT's live source: `Game_Battler::
+  AddState`'s Knockout branch (`src/game_battler.cpp`) also fires
+  `SetIsDefending(false)`/`SetCharged(false)` in the identical statement
+  group as the gauge/stat-modifier resets the fixes above already cover.
+  ~~This codebase's own comment on `apply_knockout_reset` had claimed
+  `#defending`/`#charged` were "deliberately not ported: this codebase
+  already resets both to false at the start of every command a battler is
+  given, dead or not, so there is no gap for a Knockout-time reset to
+  close there."~~ That is only true for an *ally* — `#end_round`
+  unconditionally clears both for every entry in `@allies` every round,
+  but never touches `@enemies` at all; an *enemy's* own `#defending` reset
+  (`#strike`'s `b.defending = false`) only fires at the start of *that
+  enemy's own next turn*, not immediately at death, and its `#charged`
+  flag is never reset short of actually being consumed by a subsequent
+  charged attack. Between a revival mid-round and that enemy's own next
+  turn, a stale `#defending` wrongly halves incoming damage from other
+  battlers, and a stale `#charged` wrongly doubles the revived enemy's own
+  next attack — both real divergences real RPG_RT's immediate,
+  unconditional reset at death closes. Fixed by porting the two fields
+  into `apply_knockout_reset` after all (`target.defending = false`/
+  `target.charged = false`, both already guarded by the method's own
+  `target.dead?` early return and `respond_to?` checks). Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a defending enemy and a charged
+  enemy, each killed by a lethal Attack, immediately lose their stance;
+  revival does not restore it either), confirmed to fail against the
+  pre-fix code (`expected false, got true`) before the fix.
   ✅ **A curative battle skill's status cure landed unconditionally, with no
   accuracy roll at all — a Silence/Poison-cure skill whose own `hit` field
   is below 100 always cured the status, never missing

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13443,7 +13443,7 @@ module Game
     # it -- an ordinary lethal hit (`ChangeHp` calls `AddState(kDeathID,
     # true)` itself once `new_hp <= 0`), a skill/weapon's own state-effect
     # list, Change Monster/Actor Condition, all alike. This method ports
-    # the four fields with no other reset path once a fight is already
+    # the fields with no other reset path once a fight is already
     # under way: the active-time gauge (`#gauge`), the persistent per-battle
     # ATK/DEF/SPI/AGI modifiers a buff/debuff skill accumulates onto
     # (`#atk_mod`/`#def_mod`/`#spi_mod`/`#agi_mod`, see #apply_stat_mods --
@@ -13451,11 +13451,24 @@ module Game
     # shift a skill has applied (`#attr_ranks`, see #apply_attr_shift --
     # `attribute_shift.clear()`, matched here by resetting to an empty
     # Hash, which every reader already treats identically to "no shift"
-    # via its own `ranks[aid] || 2`/`base[aid] || 2` fallback). `#defending`/
-    # `#charged` (`SetIsDefending`/`SetCharged`) are deliberately not
-    # ported: this codebase already resets both to false at the start of
-    # every command a battler is given, dead or not, so there is no gap
-    # for a Knockout-time reset to close there.
+    # via its own `ranks[aid] || 2`/`base[aid] || 2` fallback).
+    # ~~`#defending`/`#charged` (`SetIsDefending`/`SetCharged`) are
+    # deliberately not ported: this codebase already resets both to false
+    # at the start of every command a battler is given, dead or not, so
+    # there is no gap for a Knockout-time reset to close there.~~
+    # Corrected (2026-08-21): that is only true for an *ally* — `#end_round`
+    # unconditionally clears both for every entry in `@allies` regardless of
+    # whether it acted that round, but never touches `@enemies` at all, and
+    # an *enemy's* own `#defending` reset (`#strike`'s `b.defending = false`)
+    # only fires at the start of *that enemy's own next turn* -- not
+    # immediately at death the way real RPG_RT's `AddState` does -- and its
+    # `#charged` flag is never reset at all short of actually being consumed
+    # by a subsequent charged attack. Between a revival mid-round and that
+    # enemy's own next turn, a stale `#defending` wrongly halves incoming
+    # damage from other battlers' actions, and a stale `#charged` wrongly
+    # doubles the revived enemy's own next attack -- both real divergences
+    # real RPG_RT's immediate, unconditional reset at death closes. Fixed
+    # below by porting the two fields after all.
     #
     # Distinct from `Actor#atb_gauge`'s own cross-*battle* persistence fix
     # (`#apply_to_party` writing back 0 for an ally who ended the *fight*
@@ -13478,6 +13491,8 @@ module Game
         target.send("#{field}=", 0) if target.respond_to?(field)
       end
       target.attr_ranks = {} if target.respond_to?(:attr_ranks=)
+      target.defending = false if target.respond_to?(:defending=)
+      target.charged = false if target.respond_to?(:charged=)
     end
 
     # `target`'s live RPG2003 cursed-armor-forced states (`Actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13195,6 +13195,46 @@ check 'a lethal attack also resets stat modifiers and attribute-rank shifts, ' \
   eq 0, foe.atk_mod, 'a revived ally does not keep its stale pre-death buff'
 end
 
+# Confirmed against EasyRPG's actual C++ source, fetched live:
+# `Game_Battler::AddState`'s Knockout branch (src/game_battler.cpp) also
+# fires `SetIsDefending(false)`/`SetCharged(false)` the instant Death
+# lands, the same statement group as the gauge/stat-modifier resets the two
+# checks above already cover -- `apply_knockout_reset`'s own doc comment
+# had claimed these two fields were "deliberately not ported" because "this
+# codebase already resets both to false at the start of every command a
+# battler is given" -- true for an ally (`#end_round` unconditionally
+# clears both for every entry in `@allies` every round) but not for an
+# enemy: `#strike`'s own `b.defending = false` only fires at the start of
+# *that enemy's own next turn*, not immediately at death, and `#charged`
+# is never reset short of actually being consumed by a subsequent charged
+# attack. An enemy that Defends (or Charges), then dies, then is revived
+# before its own next turn comes up kept the stale flag -- wrongly halving
+# incoming damage from other battlers (`#defending`) or wrongly doubling
+# its own next attack (`#charged`) -- something real RPG_RT's immediate,
+# unconditional reset at death never allows.
+check 'a lethal attack also clears a defending or charged enemy\'s stance, ' \
+      'the same Knockout branch the gauge/stat-mod fixes above already cover' do
+  hero = combatant('Hero', 999, 0, 5, 100)
+  defender = combatant('Defender', 0, 0, 5, 1)
+  defender.defending = true
+  bat = Game::Battle.new([hero], [defender], Game::Rng.new(1))
+  bat.send(:deal_attack, hero, defender)
+  ok defender.dead?, 'the hit was lethal'
+  eq false, defender.defending, 'the stale Defend stance was cleared the instant Death landed'
+
+  charger = combatant('Charger', 0, 0, 5, 1)
+  charger.charged = true
+  bat2 = Game::Battle.new([hero], [charger], Game::Rng.new(1))
+  bat2.send(:deal_attack, hero, charger)
+  ok charger.dead?, 'the hit was lethal'
+  eq false, charger.charged, 'the stale Charge was cleared the instant Death landed'
+
+  # Revival does not restore either, matching the gauge/stat-mod checks above.
+  defender.hp = 10
+  ok !defender.dead?
+  eq false, defender.defending, 'a revived enemy does not keep its stale pre-death Defend stance'
+end
+
 check "Battle#apply_to_party clears a battle combo Enable Combo armed, matching RPG_RT (2026-08-19)" do
   # Confirmed against EasyRPG's actual C++ source, fetched live:
   # `Game_Battler::ResetBattle` (src/game_battler.cpp) is `battle_combo_


### PR DESCRIPTION
## Summary

RPG_RT's `Game_Battler::AddState` Knockout branch (`src/game_battler.cpp`):

```cpp
if (state_id == lcf::rpg::State::kDeathID) {
    SetAtbGauge(0);
    SetHp(0);
    SetAtkModifier(0);
    SetDefModifier(0);
    SetSpiModifier(0);
    SetAgiModifier(0);
    SetIsDefending(false);
    SetCharged(false);
    attribute_shift.clear();
}
```

`Game::Battle#apply_knockout_reset` (`mruby-rpg2k/mrblib/game.rb`) already ports the gauge, stat-modifier and attribute-rank resets from this exact statement group (fixed in earlier PRs), but its own doc comment explicitly claimed `#defending`/`#charged` were "deliberately not ported: this codebase already resets both to false at the start of every command a battler is given, dead or not, so there is no gap for a Knockout-time reset to close there."

## Where this claim breaks down

That's only true for an **ally** — `#end_round` unconditionally clears both for every entry in `@allies`, every round, regardless of whether it acted. It's not true for an **enemy**: `#strike`'s own `b.defending = false` only fires at the start of *that enemy's own next turn*, not immediately at death, and `#charged` is never reset at all short of actually being consumed by a subsequent charged attack.

Concretely: an enemy that Defends (or Charges), then dies (a lethal attack, or a battle-event Change Monster HP), then gets revived before its own next turn comes up, keeps the stale flag — wrongly halving incoming damage from other battlers' actions (`#defending`), or wrongly doubling its own next attack (`#charged`). Real RPG_RT's immediate, unconditional reset at death never allows this.

## Fix

Two lines in `apply_knockout_reset` (`mruby-rpg2k/mrblib/game.rb`):

```ruby
target.defending = false if target.respond_to?(:defending=)
target.charged = false if target.respond_to?(:charged=)
```

Both already guarded by the method's own `target.dead?` early return, matching the existing gauge/stat-mod/attr-rank resets exactly. Also corrected the method's own doc comment, which had made the now-disproven "no gap" claim.

This is a pure state-field assignment alongside the existing resets — no RNG draws touched, no reordering of any existing call site.

## Testing

Added a regression test to `scripts/rpg2k_logic_check.rb` mirroring the existing gauge/stat-modifier knockout-reset tests' structure: a defending enemy and a charged enemy, each killed by a lethal Attack, immediately lose their stance; revival does not restore it either.

- Verified via `git stash push -- mruby-rpg2k/mrblib/game.rb`: the new test fails pre-fix (`expected false, got true`) and passes post-fix.
- All four suites green post-fix: `rpg2k_logic_check.rb` (1127), `rpg2k_scene_check.rb` (865), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_