### PR TITLE
Persist the screen tint transition through Save/Continue (chunk 102)

### DIFF
--- a/changelog.d/screen-tint-save-continue.fixed.md
+++ b/changelog.d/screen-tint-save-continue.fixed.md
@@ -1,0 +1,5 @@
+- **Save/Continue:** a screen tint set by Tint Screen -- whether already
+  settled or still mid-transition -- now survives a real save/load, matching
+  RPG_RT's `Game_Screen::SetSaveData` -- previously the screen silently
+  snapped back to neutral on Continue, and a fade that hadn't finished lost
+  its remaining frames instead of resuming exactly where it left off.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12404,6 +12404,47 @@ not yet verified:
   before this landed, missing chunk 110 entirely, also round-trips to the
   same defaults rather than crashing), confirmed to fail against the
   pre-fix code.
+  ✅ **Follow-up (2026-08-21): the screen tint transition (Tint Screen,
+  11030) had the identical Save/Continue gap — chunk 102 this time, and
+  unlike every fix above, the schema itself had never even modelled the
+  chunk.** `mruby-lcf/mrblib/schema.rb`'s own comment on `SAVE_DATA` already
+  flagged this honestly: *"Chunk 102 (screen effects) ... left out until
+  confirmed."* Confirmed directly against RPG_RT's live source:
+  `Scene_Save::Save` (`src/scene_save.cpp`) writes `save.screen = Main_Data
+  ::game_screen->GetSaveData()` unconditionally on every save, and `Player::
+  LoadSavegame` (`src/player.cpp`) restores it unconditionally on every load
+  via `Game_Screen::SetSaveData` (`src/game_screen.cpp`) — a wholesale
+  struct replace (`data = std::move(screen);`), so a tint mid-transition
+  resumes interpolating from exactly where it left off, not merely snapped
+  to its finish value. liblcf's own generator table (`generator/csv/
+  fields.csv`) confirms the wire format: `SaveScreen, tint_finish_red, f,
+  Int32, 0x01, 100` through `tint_time_left, f, Int32, 0x0F, 0` (fields 1-4,
+  11-14, 15), and `Save, screen, f, SaveScreen, 0x66` places the whole chunk
+  at id 102 (0x66) on the top-level Save struct. `Game::Screen` already
+  modelled every one of these fields one-for-one (`@r/@g/@b/@sat` current,
+  `@tr/@tg/@tb/@tsat` finish, `@frames` time left) — it just never crossed
+  the save-file boundary; `#to_lsd`/`.from_lsd` never referenced `@screen`
+  at all. Scoped narrowly to tint only: liblcf's `SaveScreen` also carries
+  flash/shake/pan/weather/battle-animation fields, but `Game::Screen`
+  doesn't model those as persistent state at all yet (a separate, larger
+  gap, left as a future extension — not this fix). Fixed by adding a new
+  `SAVE_SCREEN` table to `schema.rb` and registering chunk 102, two small
+  new `Game::Screen#tint_save_data`/`#restore_tint` methods, and one stanza
+  each in `#to_lsd` (omitted entirely when the tint is settled at neutral,
+  the same convention the unplaced-vehicle chunks follow) and `.from_lsd`.
+  Also corrected two adjacent stale doc comments found along the way while
+  editing this exact code: `Game::State#initialize`'s comment on `@screen`
+  still claimed shake/flash/fade *and tint* stayed transient (true only for
+  shake/flash/fade now), and `@pictures`'/the parallax override's own
+  comments still described `@pictures` as *not* round-tripping through
+  Save/Continue — stale since the chunk 103 fix earlier this session (see
+  above). Covered by a new `scripts/rpg2k_logic_check.rb` check (a
+  mid-transition tint — current values partway to a not-yet-reached finish,
+  frames-remaining nonzero — round-trips through `to_lsd`/`.from_lsd`
+  exactly; a State that never tinted writes no chunk 102 at all and
+  round-trips to neutral; a save written before this landed, missing chunk
+  102 entirely, also round-trips to the same neutral defaults rather than
+  crashing), confirmed to fail against the pre-fix code.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1519,16 +1519,34 @@ module LCF
       28 => { name: :face4_index, type: :int, default: 0 },
     }
 
+    # liblcf's SaveScreen (generator/csv/fields.csv), the screen-tint subset
+    # only -- flash/shake/pan/weather/battle-animation are a separate, larger
+    # save-state surface this codebase does not yet model at all in
+    # Game::Screen, and are left out here too.
+    SAVE_SCREEN = {
+      1 => { name: :tint_finish_red, type: :int, default: 100 },
+      2 => { name: :tint_finish_green, type: :int, default: 100 },
+      3 => { name: :tint_finish_blue, type: :int, default: 100 },
+      4 => { name: :tint_finish_sat, type: :int, default: 100 },
+      11 => { name: :tint_current_red, type: :double, default: 100.0 },
+      12 => { name: :tint_current_green, type: :double, default: 100.0 },
+      13 => { name: :tint_current_blue, type: :double, default: 100.0 },
+      14 => { name: :tint_current_sat, type: :double, default: 100.0 },
+      15 => { name: :tint_time_left, type: :int, default: 0 },
+    }
+
     # https://w.atwiki.jp/rpg2kpsp/pages/13.html documents the LcfSaveData chunk
     # map. Chunks 109 (inventory) and 114 (common-event state), still marked
     # unanalysed on that wiki, were identified against a real Save01.lsd (see
-    # ADR 0011). Chunk 102 (screen effects), 112 (a one-byte flag) and 200 (a
+    # ADR 0011). Chunk 102 (screen effects) is now handled for its tint fields
+    # only (see SAVE_SCREEN above). Chunk 112 (a one-byte flag) and 200 (a
     # non-standard high-id extension chunk) are still left out until confirmed.
     SAVE_DATA = {
       name: :Save, type: :Array1D,
       elements: {
         100 => { name: :title, type: :Array1D, elements: SAVE_TITLE },
         101 => { name: :system, type: :Array1D, elements: SAVE_SYSTEM },
+        102 => { name: :screen, type: :Array1D, elements: SAVE_SCREEN },
         103 => { name: :pictures, type: :Array2D, elements: SAVE_PICTURE },
         104 => { name: :hero, type: :Array1D, elements: SAVE_MOVABLE },
         105 => { name: :boat, type: :Array1D, elements: SAVE_MOVABLE },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8065,6 +8065,23 @@ module Game
       end
     end
 
+    # The raw tint state for `.lsd` chunk 102: [finish_rgbs, current_rgbs,
+    # frames_left], matching liblcf's SaveScreen fields one-for-one (see
+    # #restore_tint, its inverse).
+    def tint_save_data
+      [[@tr, @tg, @tb, @tsat], [@r, @g, @b, @sat], @frames]
+    end
+
+    # Restore a tint transition read back from `.lsd` chunk 102: `finish` and
+    # `current` are each [red, green, blue, sat], `frames` the frames still
+    # left. Unlike #tint_to, `current` need not equal `finish` -- a save made
+    # mid-transition resumes interpolating from exactly where it left off.
+    def restore_tint(finish, current, frames)
+      @tr, @tg, @tb, @tsat = finish
+      @r, @g, @b, @sat = current
+      @frames = frames
+    end
+
     # Begin a timed shake of the given power and speed for `frames` frames
     # (frames <= 0 stops the shake immediately). Power/speed clamp to sane ranges.
     def shake(power, speed, frames)
@@ -14060,17 +14077,28 @@ module Game
       @vehicles = { boat: Vehicle.new(:boat), ship: Vehicle.new(:ship),
                     airship: Vehicle.new(:airship) }
       @boarded = nil
-      # Screen effects: tint transition/shake/flash/fade stay transient (not
-      # serialised, so a reloaded game starts with them neutral) -- but the
-      # Pan Screen offset/lock *does* now survive a save/load, see
-      # Game::Screen#to_h/#load_h.
+      # Screen effects: the tint transition now round-trips through a real
+      # Save/Continue too (#to_lsd/.from_lsd, chunk 102's tint_finish_*/
+      # tint_current_*/tint_time_left fields -- liblcf's SaveScreen, verified
+      # against EasyRPG's own `Game_Screen::SetSaveData` (`src/game_screen.
+      # cpp`), a wholesale struct replace so a mid-transition tint resumes
+      # interpolating exactly where it left off, not merely snapped to its
+      # finish value). Shake/flash/fade/weather/battle-animation stay
+      # transient (not serialised, so a reloaded game starts them neutral) --
+      # a real gap vs RPG_RT's own SaveScreen, which models those too, left
+      # as a separate future extension. The Pan Screen offset/lock *does*
+      # also survive a save/load, but only through the internal Marshal-style
+      # snapshot (`Game::Screen#to_h`/`#load_h`, `Game::State#to_h`/`.load`,
+      # `main.rb`) used for quick-resume, not through `.lsd` chunk 102 itself.
       @screen = Screen.new
-      # Shown pictures, id => Game::Picture. Transient like @screen (RPG2000's
-      # HUD pictures are re-shown by parallel events on load), so not serialised.
+      # Shown pictures, id => Game::Picture. DOES round-trip through a real
+      # Save/Continue (#to_lsd/.from_lsd, chunk 103, SAVE_PICTURE) -- a prior
+      # version of this comment claimed otherwise; corrected the same day
+      # chunk 103 was added (see docs/TODO.md).
       @pictures = {}
       # Runtime parallax override from a Change Parallax Background command (nil =
       # use the map's own panorama). Reset on a map change (#clear_parallax,
-      # called alongside #erase_all_pictures) -- but, unlike @pictures, DOES
+      # called alongside #erase_all_pictures) -- and, like @pictures, DOES
       # round-trip through a real Save/Continue on the same map (#to_lsd/
       # .from_lsd, chunk 111 fields 32-38): confirmed against RPG_RT's own
       # live source, `Game_Map::SetupFromSave` (`src/game_map.cpp`) restores
@@ -14489,6 +14517,29 @@ module Game
         actors[a.id] = e
       end
       save[108] = actors
+
+      # Chunk 102 is the screen tint transition (Tint Screen, 11030) --
+      # confirmed against RPG_RT's live source: `Scene_Save::Save`
+      # (`src/scene_save.cpp`) writes `save.screen = Main_Data::game_screen->
+      # GetSaveData()` unconditionally on every save, and `Player::
+      # LoadSavegame` (`src/player.cpp`) restores it unconditionally on every
+      # load via `Game_Screen::SetSaveData`, a wholesale struct replace (`src/
+      # game_screen.cpp`) -- so a tint mid-transition resumes interpolating
+      # exactly where it left off, not merely snapped to its finish value.
+      # Only tint is modelled here (see @screen's own comment above); the
+      # shake/flash/fade/weather/battle-animation fields liblcf's SaveScreen
+      # also carries are a separate, larger gap this codebase doesn't model
+      # in Game::Screen at all yet, left as a future extension. Only written
+      # when a tint is actually in effect or in flight, the same "omit when
+      # neutral" convention the unplaced-vehicle chunks already follow.
+      unless @screen.tint == [Screen::NEUTRAL] * 4 && !@screen.tinting?
+        scr = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SCREEN })
+        finish, current, frames = @screen.tint_save_data
+        scr[1], scr[2], scr[3], scr[4] = finish
+        scr[11], scr[12], scr[13], scr[14] = current
+        scr[15] = frames
+        save[102] = scr
+      end
 
       # Chunk 103 is every currently-shown picture (Show Picture, 11110) --
       # confirmed against RPG_RT's live source: `Scene_Save::Prepare`
@@ -14932,6 +14983,19 @@ module Game
             party.leader.name = nm
           end
         end
+      end
+      # Chunk 102 is the screen tint transition; only #restore_tint's tint
+      # sub-fields are modelled here (see #to_lsd's own comment on chunk 102
+      # for why). An absent chunk (a save written before this fix, or one
+      # made while the tint genuinely sat at neutral) leaves the fresh
+      # `Screen.new` neutral defaults in place.
+      scr = save[102]
+      if scr
+        state.screen.restore_tint([scr.tint_finish_red, scr.tint_finish_green,
+                                    scr.tint_finish_blue, scr.tint_finish_sat],
+                                   [scr.tint_current_red, scr.tint_current_green,
+                                    scr.tint_current_blue, scr.tint_current_sat],
+                                   scr.tint_time_left)
       end
       restore_pictures(state, save[103])
       # Both Timer Operation countdowns (inventory chunk 109 fields 23-30); a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11303,6 +11303,60 @@ check 'to_lsd/from_lsd round-trips Set Teleport Target / Set Escape Target ' \
   eq({}, old.teleport_targets)
 end
 
+check 'to_lsd/from_lsd round-trips a live screen tint transition (chunk 102)' do
+  # Confirmed directly against RPG_RT's live source: `Scene_Save::Save`
+  # (`src/scene_save.cpp`) writes `save.screen = Main_Data::game_screen->
+  # GetSaveData()` unconditionally on every save, and `Player::LoadSavegame`
+  # (`src/player.cpp`) restores it unconditionally on every load via
+  # `Game_Screen::SetSaveData` (`src/game_screen.cpp`), a wholesale struct
+  # replace -- so a Tint Screen (11030) transition still in flight when the
+  # game is saved must resume interpolating from exactly where it left off,
+  # not restart or snap to its finish value. #to_lsd/.from_lsd previously
+  # never touched chunk 102 at all -- schema.rb's own comment on SAVE_DATA
+  # flagged it as "left out until confirmed" -- so a real Save/Continue
+  # silently dropped every standing or in-progress tint.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.screen.tint_to(50, 60, 70, 80, 40) # a transition still 40 frames from done
+  st.screen.instance_variable_set(:@r, 62.5) # partway through interpolating
+  st.screen.instance_variable_set(:@g, 68.0)
+  st.screen.instance_variable_set(:@b, 73.5)
+  st.screen.instance_variable_set(:@sat, 82.0)
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq [50, 60, 70, 80],
+     [round.screen.instance_variable_get(:@tr), round.screen.instance_variable_get(:@tg),
+      round.screen.instance_variable_get(:@tb), round.screen.instance_variable_get(:@tsat)]
+  eq [62.5, 68.0, 73.5, 82.0],
+     [round.screen.instance_variable_get(:@r), round.screen.instance_variable_get(:@g),
+      round.screen.instance_variable_get(:@b), round.screen.instance_variable_get(:@sat)]
+  eq 40, round.screen.instance_variable_get(:@frames),
+     'a mid-transition tint must resume with its remaining frame count intact, not restart or settle'
+  ok round.screen.tinting?, 'the restored tint must still report itself as in-flight'
+
+  # A tint that had already settled (frames == 0, current == finish) writes
+  # nothing at all -- chunk 102 is omitted entirely, the same "omit when
+  # neutral" convention the unplaced-vehicle chunks already follow -- and a
+  # State that never tinted at all must not invent a tint on round-trip.
+  never_tinted = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  saved = never_tinted.to_lsd
+  eq nil, saved[102], 'a State that never tinted must not write chunk 102 at all'
+  round2 = Game::State.from_lsd(db, saved)
+  eq [100, 100, 100, 100], round2.screen.tint
+  eq false, round2.screen.tinting?
+
+  # A save written before this landed simply omits chunk 102 entirely;
+  # from_lsd must leave the fresh Screen.new neutral defaults alone rather
+  # than crash reading an absent chunk.
+  st2 = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st2.screen.tint_to(0, 0, 0, 100, 30)
+  legacy = st2.to_lsd
+  legacy.delete(102)
+  old = Game::State.from_lsd(db, legacy)
+  eq [100, 100, 100, 100], old.screen.tint
+  eq false, old.screen.tinting?
+end
+
 # liblcf's SaveMapEventBase.facing (generator/csv/fields.csv, 0x16 == 22) is
 # 0=up/1=right/2=down/3=left (Game_Character::Direction's own enum order),
 # not this runtime's numpad convention (2/4/6/8) -- the two schemes only


### PR DESCRIPTION
## Summary

RPG_RT writes the screen's tint state unconditionally on every save and restores it unconditionally on every load, as a wholesale struct replace — so a tint left standing (or still mid-transition) resumes exactly where it was, not merely snapped to its finish value or reset to neutral. This codebase's own `schema.rb` already flagged the save chunk carrying this state as "left out until confirmed," and `Game::State#to_lsd`/`.from_lsd` never touched it at all, even though `Game::Screen` already modelled every one of the underlying fields (current/finish/target channels, frames remaining) — the state just never crossed the save-file boundary.

## Where it diverged

- `mruby-lcf/mrblib/schema.rb`: the save-chunk schema had no entry at all for the screen-tint chunk.
- `mruby-rpg2k/mrblib/game.rb`: `Game::State#to_lsd`/`.from_lsd` never referenced `@screen`.
- A game saved mid-tint-transition (or simply holding a non-neutral tone) silently reverted to neutral on Continue, with any in-progress fade dropped entirely instead of resuming.

## Fix

- Added a `SAVE_SCREEN` schema table (tint fields only — flash/shake/pan/weather/battle-animation are a separate, larger gap `Game::Screen` doesn't model as persistent state at all yet, left for a future extension) and registered the new chunk in `SAVE_DATA`.
- Added two small `Game::Screen` accessor methods (`#tint_save_data`/`#restore_tint`) so a restore can set a *distinct* current value mid-interpolation, not just re-target a fresh transition.
- Added one stanza each to `#to_lsd` (omitted entirely when the tint is settled at neutral, matching this codebase's existing "omit when nothing to restore" convention) and `.from_lsd`.
- Corrected two adjacent doc comments that had gone stale from an earlier fix this session: `Game::State#initialize`'s comment on `@screen` still claimed the tint stayed transient, and the `@pictures`/parallax-override comments still described `@pictures` as *not* round-tripping through Save/Continue.

## Testing

- New `scripts/rpg2k_logic_check.rb` check: a mid-transition tint (current values partway toward a not-yet-reached finish, frames-remaining nonzero) round-trips through `to_lsd`/`.from_lsd` exactly; a `State` that never tinted writes no chunk at all and round-trips to neutral; a save written before this landed (missing the chunk entirely) also round-trips to the same neutral defaults rather than crashing.
- Confirmed the new check fails against the pre-fix code via `git stash`, then passes after restoring the fix.
- All four suites green: `rpg2k_scene_check.rb` (868), `rpg2k_logic_check.rb` (1128), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_