### PR TITLE
Fix actor growth-curve stats to read stat-major, not row-major

### DIFF
--- a/changelog.d/actor-growth-curve-stat-major.fixed.md
+++ b/changelog.d/actor-growth-curve-stat-major.fixed.md
@@ -1,0 +1,7 @@
+- **Actors:** every stat a levelled actor derives from the database's growth
+  curve (max HP/SP, ATK/DEF/SPI/AGI, for both an actor's own curve and an
+  RPG2003 class's) is now read in the correct byte order, matching RPG_RT --
+  the curve's raw shorts are six blocks of one stat across every level, not
+  the other way around, and reading it the wrong way silently gave every
+  multi-level actor (and any class-changed actor) wrong stats, worse the
+  further from level 1 the affected curve stat's growth actually was.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6002,7 +6002,34 @@ The work below is roughly ordered by the critical path to a walkable game
   logic expects at this exact story point, it is not merely a valid actor
   id to resolve, and finding out what would take more than this survey's
   established edit-and-diff technique. Left for whoever picks this up next.
-  ✅ **Continue could silently lose a save's own Save/Teleport/Escape access,
+  ✅ **Follow-up (2026-08-22): reproduced cleanly and root-caused. ~~Not fixed
+  ... needs a second, independently reproduced RPG_RT capture before acting
+  on it either way.~~** A second cycle, using `Game::State`/`Save01.lsd`
+  editing plus `Continue` (not the blind title-navigation retries that left
+  the first capture ambiguous), reproduced the exact same numbers again on
+  the same actor (デモ用, id 15) -- ruling out a mid-cascade artifact. The
+  real cause: `LCF::Array1D#int16_values(31)`'s raw shorts are laid out
+  **stat-major** -- six `max_level`-sized blocks (every level's max_hp, then
+  every level's max_mp, then atk, def, int, agi) -- not row-major (`max_level`
+  rows of six stats each) as `Game::Actor#base_stats`/`#curve_row`
+  (`mruby-rpg2k/mrblib/game.rb`) and this repo's own ADR 0015 had assumed
+  since that assumption was first written, uncited. Confirmed decisively on
+  actor 1 (リト, Nepheshel's real default party leader, chunk 109's own
+  field-1 pick over デモ用's demo-mode override) at level 50 with the same
+  five-item equipment set: real `RPG_RT.exe`'s Equip screen showed
+  ATK/DEF/SPI/AGI = 450/292/268/130, exactly matching a stat-major reading of
+  actor 1's raw curve bytes plus its equipment bonuses; a row-major reading
+  gave 270/307/118/130, wrong on three of four. Fixed by changing
+  `#base_stats`'s indexing from `curve[((lv-1)*6)+i]` to
+  `curve[(i*levels)+(lv-1)]`; `#curve_row` itself (which row supplies the
+  curve) needed no change. **A separate, narrower anomaly surfaced during the
+  same investigation and is deliberately NOT folded into this fix:** actor 15
+  specifically (not actor 1, not any other actor tried) shows a flat **+500**
+  on ATK/SPI/AGI (never DEF) whenever any weapon occupies its weapon slot,
+  independent of which weapon or of `exp`, with no database or save field
+  found that structurally explains it -- tracked as its own future follow-up,
+  likely an unmodelled item/actor mechanic specific to that one "demo"
+  character, not a `base_stats` problem.
   overridden by whatever the current map's tree happens to say instead.**
   Chasing the Save screen with the fixed crop-region retry (above) turned up
   a correctness bug, not just a UI one: `Scene::Map#initialize`

--- a/docs/adr/0015-level-scaled-base-stats-and-restore-level-on-continue.md
+++ b/docs/adr/0015-level-scaled-base-stats-and-restore-level-on-continue.md
@@ -14,8 +14,19 @@ actor's max HP/SP (and the four battle stats) from the database at the actor's
 *initial* level and never scaled them, so a resumed level-8 hero kept level-1
 maxima and `from_lsd` restored current HP/MP against the wrong ceiling. The
 database actually stores a full growth curve -- chunk 31 of each actor is six
-shorts (maxHP, maxSP, atk, def, int, agi) *per level* -- but the schema's `status`
-accessor, via its `order:` mapping, only ever surfaced the first (level-1) row.
+shorts (maxHP, maxSP, atk, def, int, agi) ~~*per level*~~ -- but the schema's
+`status` accessor, via its `order:` mapping, only ever surfaced the first
+(level-1) row.
+
+**Correction (2026-08-22):** the "six shorts per level" (row-major) layout
+above was never verified against real RPG_RT and was wrong. The raw shorts
+are actually stat-major -- six `max_level`-sized blocks, one per stat, not
+`max_level` rows of six -- confirmed against a genuine `RPG_RT.exe`'s
+displayed stats and fixed in `Game::Actor#base_stats`; see the dated
+Follow-up on the Nepheshel-Equip-screen stat-mismatch entry in
+`docs/TODO.md` for the full verification. This ADR's own decision below
+(scaling stats by level via `int16_values(31)`) was and remains correct;
+only the byte layout assumed while indexing into it was wrong.
 
 ## Decision
 

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -98,6 +98,11 @@ module LCF
             23 => { name: :force_ai, type: :bool, default: false },          # 強制AI
             24 => { name: :strong_defence, type: :bool, default: false },    # 強力防御
 
+            # `order:` names only the first six raw shorts -- a level-1-only
+            # view real code never actually reads for a multi-level curve
+            # (see Game::Actor#base_stats's own comment): the full raw array
+            # is stat-major (six max_level-sized blocks, one per stat here),
+            # confirmed against a genuine RPG_RT.exe, not row-major.
             31 => { name: :status, type: :int16_array, order: [:max_hp, :max_mp, :atk, :def, :int, :agi] },
 
             41 => { name: :exp_basic, type: :int, default: -> { LCF.exp_default } },
@@ -855,7 +860,11 @@ module LCF
             22 => { name: :equipment_fixed, type: :bool, default: false },   # 装備固定
             23 => { name: :force_ai, type: :bool, default: false },          # 強制AI
             24 => { name: :strong_defence, type: :bool, default: false },    # 強力防御
-            31 => { name: :parameters, type: :int16_array },                 # 能力値 (short[6][level])
+            # 能力値 -- stat-major: six max_level-sized blocks (max_hp, max_mp,
+            # atk, def, int, agi), read the same way as the actor row's own
+            # field 31 above (Game::Actor#base_stats/#curve_row), confirmed
+            # against a genuine RPG_RT.exe.
+            31 => { name: :parameters, type: :int16_array },
             41 => { name: :exp_basic, type: :int, default: -> { LCF.exp_default } },
             42 => { name: :exp_increase, type: :int, default: -> { LCF.exp_default } },
             43 => { name: :exp_correction, type: :int, default: 0 },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1972,18 +1972,28 @@ module Game
     end
 
     # The six base stats at `level`. Real database rows expose the full growth
-    # curve (six shorts per level) via LCF::Array1D#int16_values; index it by
-    # level, clamped to the curve's length. A row that only offers a single
-    # `status` hash (the test fixtures, or a database without a curve) is treated
-    # as level-independent. With a class set the class row's curve wins.
+    # curve via LCF::Array1D#int16_values(31) as six contiguous max_level-sized
+    # blocks -- one block per stat in STAT_NAMES order (every level's max_hp,
+    # then every level's max_mp, then atk, def, int, agi), NOT max_level rows of
+    # six stats each. Confirmed against a genuine RPG_RT.exe: an actor whose
+    # curve blocks were independently distinguishable (non-symmetric across
+    # stats) was equipped and levelled identically in this engine and under
+    # real RPG_RT, and only a stat-major (six-blocks-of-max_level) reading of
+    # the raw shorts reproduced RPG_RT's displayed ATK/DEF/SPI/AGI exactly --
+    # the previously-assumed row-major (max_level rows of six) reading was
+    # correct only by coincidence on actors whose curve happens to be
+    # level-count-1 (a single row, where the two layouts are indistinguishable)
+    # and was off by as much as 2.3x on a real multi-level curve. A row that
+    # only offers a single `status` hash (the test fixtures, or a database
+    # without a curve) is treated as level-independent. With a class set the
+    # class row's curve wins.
     def base_stats(level)
       a = curve_row
       curve = a.respond_to?(:int16_values) ? a.int16_values(31) : nil
       if curve && curve.size >= STAT_NAMES.size
         levels = curve.size / STAT_NAMES.size
         lv = level > levels ? levels : level
-        base = (lv - 1) * STAT_NAMES.size
-        return STAT_NAMES.each_index.map { |i| curve[base + i] || 0 }
+        return STAT_NAMES.each_index.map { |i| curve[(i * levels) + (lv - 1)] || 0 }
       end
       st = (a.respond_to?(:status) ? a.status : nil) || {}
       STAT_NAMES.map { |k| st[k] || 0 }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3573,6 +3573,20 @@ FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
                            # Same reasoning: appended last, nil reads as 0 via
                            # the reader methods, matching the schema default.
                            :battle_x, :battle_y, :battler_animation)
+# Transpose a level-major curve (max_level rows of six stats: L1's six
+# stats, then L2's, ...) into the stat-major layout #int16_values(31) really
+# carries (six max_level-sized blocks: every level's max_hp, then every
+# level's max_mp, then atk, def, int, agi) -- confirmed against a genuine
+# RPG_RT.exe, see Game::Actor#base_stats's own comment. Building fixtures in
+# the more readable level-major shape and transposing them here, rather than
+# hand-writing the stat-major arrays directly, keeps each fixture's per-level
+# intent easy to read and avoids re-deriving the interleaving by hand at
+# every call site.
+def to_stat_major(level_major, stat_count = 6)
+  levels = level_major.size / stat_count
+  (0...stat_count).flat_map { |i| (0...levels).map { |lv| level_major[(lv * stat_count) + i] } }
+end
+
 # Like FakePlayerRow but exposing the full growth curve the way a real LCF row
 # does (six shorts per level via #int16_values(31)), so Actor scales its base
 # stats by level instead of using a single level-independent status hash.
@@ -4069,8 +4083,8 @@ check 'to_lsd/from_lsd round-trips a live Change Class, and the battle ' \
   3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
   job1 = []
   3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
-  players = { 1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, [], 0, nil) }
-  jobs = { 1 => JobRow.new('Mage', job1) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 3, to_stat_major(actor_curve), [], 0, nil) }
+  jobs = { 1 => JobRow.new('Mage', to_stat_major(job1)) }
   db = FakeActorDB.new(players, [1], {}, {}, jobs)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   hero = st.party.leader
@@ -4130,8 +4144,8 @@ check 'to_lsd/from_lsd round-trips a Change Class back to "no class" (id 0)' do
   3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
   job1 = []
   3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
-  players = { 1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, [], 1, nil) }
-  jobs = { 1 => JobRow.new('Mage', job1) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 3, to_stat_major(actor_curve), [], 1, nil) }
+  jobs = { 1 => JobRow.new('Mage', to_stat_major(job1)) }
   db = FakeActorDB.new(players, [1], {}, {}, jobs)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   hero = st.party.leader
@@ -4741,10 +4755,36 @@ check 'Actor change_hp/change_mp/full_heal clamp within their bounds' do
   eq [100, 30], [hero.hp, hero.mp]
 end
 
+check 'Actor base stats read the growth curve stat-major, not row-major, ' \
+      'per level' do
+  # Confirmed against a genuine RPG_RT.exe, not EasyRPG's source: a real
+  # save was edited to level 50 with a known five-item equipment set on two
+  # different actors and resumed under the real Enterbrain runtime, reading
+  # the Equip screen's own displayed ATK/DEF/SPI/AGI. On a witness actor
+  # whose curve blocks are all independently distinguishable (no two stats
+  # share a coincidentally-identical sequence), only a stat-major reading
+  # (six max_level-sized blocks: every level's max_hp, then every level's
+  # max_mp, then atk, def, int, agi) reproduced RPG_RT's numbers exactly;
+  # the previously-assumed row-major reading (max_level rows of six stats)
+  # was off by as much as 2.3x. A fixture deliberately shaped the same way
+  # (no stat's per-level sequence coincides with another's) below proves the
+  # same distinction: under the old row-major reading this would instead
+  # report L1 = [11, 111, 22, 222, 33, 333] and L2 = [44, 444, 55, 555, 66,
+  # 666]. Values stay under RPG_RT's own 999 stat ceiling
+  # (#base_param_limit) so that clamp can't mask the difference between the
+  # two readings.
+  curve = [11, 111,  22, 222,  33, 333,  44, 444,  55, 555,  66, 666]
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, curve) }, [1])
+  a = Game::Party.new(db).leader
+  eq [11, 22, 33, 44, 55, 66], [a.max_hp, a.max_mp, a.atk, a.def, a.int, a.agi]
+  a.set_level(2)
+  eq [111, 222, 333, 444, 555, 666], [a.max_hp, a.max_mp, a.atk, a.def, a.int, a.agi]
+end
+
 check 'Actor base stats scale with level from the growth curve' do
-  # Two levels, six stats each: L1 = maxhp10/maxmp5/atk3/def2/int1/agi4,
-  # L2 = double each (except as listed).
-  curve = [10, 5, 3, 2, 1, 4,  20, 10, 6, 4, 2, 8]
+  # Stat-major (six max_level-sized blocks): L1 = maxhp10/maxmp5/atk3/def2/
+  # int1/agi4, L2 = double each (except as listed).
+  curve = [10, 20, 5, 10, 3, 6, 2, 4, 1, 2, 4, 8]
   db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, curve) }, [1])
   a = Game::Party.new(db).leader
   eq 1, a.level
@@ -5202,9 +5242,10 @@ check 'An ordinary level change carries a live Change Parameters adjustment ' \
   # unconditionally rebuilt both @base and @base_raw from the bare level
   # curve on every call, silently discarding any live change_param delta the
   # moment the actor's level changed by any means.
+  # Stat-major (six max_level-sized blocks): atk 50 -> 52 from level 1 to 2,
+  # every other stat flat.
   db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1,
-                                            [10, 5, 50, 2, 1, 4,   # level 1
-                                             10, 5, 52, 2, 1, 4]) }, # level 2
+                                            [10, 10, 5, 5, 50, 52, 2, 2, 1, 1, 4, 4]) },
                        [1])
   a = Game::Party.new(db).leader
   eq 50, a.atk                                  # level 1 curve atk
@@ -5338,12 +5379,12 @@ def class_db(class_id = 0, actor_learns = [[10, 1]])
   job2 = []
   3.times { |i| job2.concat([50 + i * 10, 10, 5 + i, 4, 3, 2]) }
   players = {
-    1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, actor_learns, class_id,
+    1 => ClassedRow.new('Hero', '', 0, 3, to_stat_major(actor_curve), actor_learns, class_id,
                         [1, 2, 0, -1, -1, -1, -1]),
   }
   jobs = {
-    1 => JobRow.new('Warrior', job1, [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
-    2 => JobRow.new('Mage', job2, [[31, 1]]),
+    1 => JobRow.new('Warrior', to_stat_major(job1), [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
+    2 => JobRow.new('Mage', to_stat_major(job2), [[31, 1]]),
   }
   # A real Battle Commands table (chunk 29) defining ids 1..8, so
   # #change_battle_commands' own existence check (see its citation) does
@@ -5546,11 +5587,11 @@ def class_db_named_skills(actor_learns = [[10, 1]])
   job1 = []
   3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
   players = {
-    1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, actor_learns, 0,
+    1 => ClassedRow.new('Hero', '', 0, 3, to_stat_major(actor_curve), actor_learns, 0,
                         [1, 2, 0, -1, -1, -1, -1]),
   }
   jobs = {
-    1 => JobRow.new('Warrior', job1, [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
+    1 => JobRow.new('Warrior', to_stat_major(job1), [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
   }
   # rpg2003: true -- Change Class is RPG2003-only (see class_db's own note).
   FakeActorDB.new(players, [1], {},
@@ -5891,8 +5932,8 @@ check "Game::Actor#battler_animation_id warns and returns 0 for a dangling datab
 end
 
 check "Game::Actor#battler_animation_id prefers the runtime override a Change Class event set" do
-  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 0) }
-  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [], nil, battler_animation: 4) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, to_stat_major([100, 30, 10, 8, 6, 4] * 20), [], 0) }
+  jobs = { 1 => JobRow.new('Warrior', to_stat_major([120, 40, 12, 10, 8, 6] * 20), [], nil, battler_animation: 4) }
   db = FakeActorDB.new(players, [1], {}, {}, jobs)
   a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
   a.change_class(1, 1, Game::Actor::CLASS_SKILL_NO_CHANGE, Game::Actor::CLASS_PARAM_NO_CHANGE)
@@ -5905,9 +5946,9 @@ check "Game::Actor#battler_animation_id ignores a database-default starting clas
   # RPG2003 lets an actor start in a class (chunk 11 field 57) with no Change
   # Class event ever firing -- EasyRPG's own comment on this is explicit
   # ("not applied ... only when the 'Change Class' event command is used").
-  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 1) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, to_stat_major([100, 30, 10, 8, 6, 4] * 20), [], 1) }
   players[1].battler_animation = 3
-  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [], nil, battler_animation: 4) }
+  jobs = { 1 => JobRow.new('Warrior', to_stat_major([120, 40, 12, 10, 8, 6] * 20), [], nil, battler_animation: 4) }
   anims = { 3 => FakeBattlerAnimation.new('Fighter', 20, {}) }
   db = FakeActorDB.new(players, [1], {}, {}, jobs, nil, nil, battleranimations: anims)
   a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
@@ -5928,12 +5969,12 @@ check "Game::Actor#strong_defence?/#force_ai?/#double_hand?/#equipment_fixed? al
   # method's own explicit comment: "The class settings are not applied when
   # the actor has a class on startup but only when the 'Change Class' event
   # command is used."
-  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 1) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, to_stat_major([100, 30, 10, 8, 6, 4] * 20), [], 1) }
   players[1].strong_defence = false
   players[1].force_ai = false
   players[1].double_hand = false
   players[1].equipment_fixed = false
-  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [],
+  jobs = { 1 => JobRow.new('Warrior', to_stat_major([120, 40, 12, 10, 8, 6] * 20), [],
                            strong_defence: true, force_ai: true,
                            double_hand: true, equipment_fixed: true) }
   db = FakeActorDB.new(players, [1], {}, {}, jobs)
@@ -5953,8 +5994,8 @@ end
 
 check "Game::Actor#battler_animation_id falls back to 1 when Change Class leaves the actor " \
       'in a class whose own battler_animation is 0' do
-  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 0) }
-  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [], nil, battler_animation: 0) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, to_stat_major([100, 30, 10, 8, 6, 4] * 20), [], 0) }
+  jobs = { 1 => JobRow.new('Warrior', to_stat_major([120, 40, 12, 10, 8, 6] * 20), [], nil, battler_animation: 0) }
   db = FakeActorDB.new(players, [1], {}, {}, jobs)
   a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
   a.change_class(1, 1, Game::Actor::CLASS_SKILL_NO_CHANGE, Game::Actor::CLASS_PARAM_NO_CHANGE)
@@ -6145,9 +6186,10 @@ check 'Change Parameters raises max MP with a variable operand' do
 end
 
 check 'Change Level command raises the level and rescales stats' do
-  # Two-level curve: L1 maxhp10/atk3, L2 maxhp20/atk6.
+  # Two-level curve, stat-major (six max_level-sized blocks: max_hp, max_mp,
+  # atk, def, int, agi): L1 maxhp10/atk3, L2 maxhp20/atk6.
   db = FakeActorDB.new(
-    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4, 20, 10, 6, 4, 2, 8]) }, [1])
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 20, 5, 10, 3, 6, 2, 4, 1, 2, 4, 8]) }, [1])
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   a = st.party.actor_by_id(1)
   eq [1, 10, 3], [a.level, a.max_hp, a.atk]
@@ -6163,12 +6205,14 @@ check 'Change Level command raises the level and rescales stats' do
   eq 1, a.level
 end
 
-# A three-level growth curve (six stats per level) for the level-up-message
-# checks: enough levels to gain more than one at a time.
+# A three-level growth curve, stat-major (six max_level-sized blocks), for the
+# level-up-message checks: enough levels to gain more than one at a time.
+# L1 hp10/mp5/atk3/def2/int1/agi4, L2 hp20/mp10/atk6/def4/int2/agi8,
+# L3 hp30/mp15/atk9/def6/int3/agi12.
 def three_level_db
   FakeActorDB.new(
     { 1 => CurveRow.new('Hero', '', 0, 1,
-                        [10, 5, 3, 2, 1, 4, 20, 10, 6, 4, 2, 8, 30, 15, 9, 6, 3, 12]) },
+                        [10, 20, 30, 5, 10, 15, 3, 6, 9, 2, 4, 6, 1, 2, 3, 4, 8, 12]) },
     [1])
 end
 
@@ -6216,12 +6260,13 @@ check 'Change EXP with the show-message flag announces a level-up' do
   ok !it.waiting?, 'a single level gained -> a single message'
 end
 
-# A three-level growth curve with a learn table, for the skill-learned-message
-# checks: skill 201 at level 2, skill 202 at level 3.
+# A three-level growth curve (stat-major, same values as three_level_db above)
+# with a learn table, for the skill-learned-message checks: skill 201 at
+# level 2, skill 202 at level 3.
 def skill_level_db(learns = [[201, 2], [202, 3]])
   FakeActorDB.new(
     { 1 => SkillRow.new('Hero', '', 0, 1,
-                        [10, 5, 3, 2, 1, 4, 20, 10, 6, 4, 2, 8, 30, 15, 9, 6, 3, 12],
+                        [10, 20, 30, 5, 10, 15, 3, 6, 9, 2, 4, 6, 1, 2, 3, 4, 8, 12],
                         learns) },
     [1], {},
     { 201 => fake_skill(name: 'Fireball'), 202 => fake_skill(name: 'Iceball') })
@@ -7159,12 +7204,12 @@ check 'a use_skill equipment item restricted by class_set is only usable by ' \
   items = { 4 => fake_item(type: 1, skill_id: 8, use_skill: true,
                            class_set: [false, false, true], name: 'Class Rune') }
   players = {
-    1 => ClassedRow.new('Warrior', '', 0, 3, actor_curve, [], 1, nil),
-    2 => ClassedRow.new('Mage', '', 0, 3, actor_curve, [], 2, nil),
+    1 => ClassedRow.new('Warrior', '', 0, 3, to_stat_major(actor_curve), [], 1, nil),
+    2 => ClassedRow.new('Mage', '', 0, 3, to_stat_major(actor_curve), [], 2, nil),
   }
   jobs = {
-    1 => JobRow.new('Fighter', job1),
-    2 => JobRow.new('Mage', job2),
+    1 => JobRow.new('Fighter', to_stat_major(job1)),
+    2 => JobRow.new('Mage', to_stat_major(job2)),
   }
   db = FakeActorDB.new(players, [1, 2], items, skills, jobs,
                        rpg2003: true, equipment_setting: 1)
@@ -7198,10 +7243,10 @@ check 'an ordinary medicine is gated by class_set too, under "by Class"' do
   items = { 4 => fake_item(type: 6, rhp: 40, class_set: [false, false, true],
                            name: 'Mage Draught') }
   players = {
-    1 => ClassedRow.new('Warrior', '', 0, 3, actor_curve, [], 1, nil),
-    2 => ClassedRow.new('Mage', '', 0, 3, actor_curve, [], 2, nil),
+    1 => ClassedRow.new('Warrior', '', 0, 3, to_stat_major(actor_curve), [], 1, nil),
+    2 => ClassedRow.new('Mage', '', 0, 3, to_stat_major(actor_curve), [], 2, nil),
   }
-  jobs = { 1 => JobRow.new('Fighter', job1), 2 => JobRow.new('Mage', job2) }
+  jobs = { 1 => JobRow.new('Fighter', to_stat_major(job1)), 2 => JobRow.new('Mage', to_stat_major(job2)) }
   db = FakeActorDB.new(players, [1, 2], items, {}, jobs,
                        rpg2003: true, equipment_setting: 1)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
@@ -10007,8 +10052,8 @@ check 'a fresh actor starts with the EXP for its initial level' do
 end
 
 check 'gain_exp levels the actor up across thresholds and recomputes stats' do
-  # Per-level curve (level-major, six stats per level): max_hp 100/120/140.
-  curve = [100, 20, 10, 8, 6, 5, 120, 22, 11, 9, 7, 6, 140, 24, 12, 10, 8, 7]
+  # Stat-major curve (six max_level-sized blocks): max_hp 100/120/140.
+  curve = [100, 120, 140, 20, 22, 24, 10, 11, 12, 8, 9, 10, 6, 7, 8, 5, 6, 7]
   a = exp_actor(initial_level: 1, max_level: 3, curve: curve,
                 exp_basic: 100, exp_increase: 0, exp_correction: 0)
   eq 1, a.level


### PR DESCRIPTION
## Summary

`Game::Actor#base_stats` read the database's raw per-actor and per-class growth curve (`LCF::Array1D#int16_values(31)`) as `max_level` rows of six stats each (level 1's six stats, then level 2's, ...). The real on-disk layout is stat-major instead: six `max_level`-sized blocks, one per stat (max_hp, max_mp, atk, def, int, agi) in that order. Every levelled actor's max HP/SP and battle stats were computed wrong, more so the further a curve stat's growth diverged from level 1 — and this was the same wrong assumption `docs/adr/0015` had made, uncited, when it introduced level-scaled stats.

## Where it diverged

`mruby-rpg2k/mrblib/game.rb`, `Game::Actor#base_stats` (~line 1979): indexed `curve[((level-1)*6)+i]` instead of `curve[(i*levels)+(level-1)]`. `#curve_row` itself (which row supplies the curve — the actor's own vs. an RPG2003 class row) needed no change; both feed the same fixed indexing formula.

## How this was verified

Against a genuine `RPG_RT.exe` under wine, not EasyRPG's source (this session's verification method changed after PR #1252). A real save was edited to level 50 with a known five-item equipment set on Nepheshel's actual default party leader (actor 1, whose growth-curve blocks are all independently distinguishable — no two stats share a coincidentally-identical sequence, unlike the "demo" actor an earlier survey used), resumed under the genuine runtime, and the Equip screen's displayed ATK/DEF/SPI/AGI (450/292/268/130) was reproduced exactly only by a stat-major reading; the previously-assumed row-major reading gave 270/307/118/130, wrong on three of four stats.

This also resolves a stat mismatch (870/407/868/880 vs. this engine's 484/531/352/380) that an earlier session's Nepheshel comparison survey had found but left open in `docs/TODO.md`, pending a second, unambiguous data point before acting on it.

One separate, narrower anomaly surfaced during the same investigation and is **not** part of this fix: one specific actor (id 15, the "demo" character) shows a flat +500 on ATK/SPI/AGI whenever any weapon is equipped, independent of which weapon — reproducible but not yet root-caused, tracked as its own follow-up in `docs/TODO.md`.

## Fix

- `mruby-rpg2k/mrblib/game.rb`: corrected `#base_stats`'s indexing formula and its doc comment.
- `mruby-lcf/mrblib/schema.rb`: corrected the field-31 comments on both the actor row and the RPG2003 class table, which had described (or ambiguously implied) the same wrong row-major layout.
- `docs/adr/0015-...md`: added a dated correction — the ADR's decision to scale stats by level was and remains correct, only the byte layout it assumed while indexing was wrong.
- `docs/TODO.md`: dated Follow-up on the existing stat-mismatch entry, with the full verification and the separate +500 anomaly noted as future work.

## Testing

Every existing test fixture encoding a real multi-level curve had to be re-encoded to the corrected stat-major byte order (a level-major array and its stat-major reinterpretation are different data) — 11 pre-existing checks across `Change Level`/`Change EXP`/`Change Class`/`gain_exp` genuinely regressed with only the source fix applied and the old fixture data, confirming the fixtures needed updating alongside the source. Added one new, dedicated check with a fixture deliberately shaped so no stat's per-level sequence can coincidentally match another's (ruling out the class of bug this session already hit once, where a symmetric curve made two different byte-layout hypotheses indistinguishable).

Confirmed via `git stash` that the fix + all fixture updates together are what's needed: stashing just the source fix (keeping the corrected fixtures) reproduces 11 genuine failures; restoring it is green again.

All four suites green: `rpg2k_scene_check.rb` (868), `rpg2k_logic_check.rb` (1129, +1 new), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15). Also rebuilt the native engine (`cmake --build build`) and ran `scripts/rpg2k_boot_check.bash` against real RPG2000/2003 test-bed data under mruby (not just CRuby) — all 3 runs (Nepheshel New Game, mtf-meido-action New Game, mtf-meido-action battle) reached their target scene cleanly.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_