### PR TITLE
mruby: implement $! (currently handled exception) and bare-raise re-raise

### DIFF
--- a/changelog.d/mruby-dollar-bang-scoped.fixed.md
+++ b/changelog.d/mruby-dollar-bang-scoped.fixed.md
@@ -1,0 +1,12 @@
+- Fixed a real gap in the vendored mruby VM: `$!` (the exception a currently
+  executing `rescue` clause is handling) was never implemented -- it always
+  read `nil`, even inside an active rescue, and a bare `raise` (no arguments)
+  always raised a fresh, empty `RuntimeError` instead of re-raising it. Found
+  because a real RPG Maker VX Ace game's bundled crash-reporter add-on relies
+  on `$!.message` and a bare re-raise inside its own rescue clause, and got a
+  `NoMethodError` instead of a real error report. Scoped to the call frame
+  containing the `rescue` clause, using mruby's own existing frame-pop as the
+  point where it goes out of scope again. Since this project doesn't control
+  the `3rd/mruby` submodule's upstream remote, the fix ships as
+  `patches/mruby-dollar-bang-scoped.patch`, applied idempotently at build time
+  by `scripts/apply_mruby_patch.bash`.

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -100,6 +100,19 @@ function(rpg2k_add_mruby)
   set(mruby_colon3_patch
       "${ARG_REPO_ROOT}/patches/mruby-colon3-assign-setmcnst.patch")
 
+  # Vendored mruby never implemented `$!` (Kernel#$!, "the exception the
+  # current rescue clause is handling") -- it always reads nil, even inside
+  # an active rescue (patches/mruby-dollar-bang-scoped.patch's own preamble
+  # has the full trail, including two rejected earlier approaches). Found
+  # via a real VX Ace game's bundled crash-reporter add-on
+  # (docs/rpgvx-rgss-api-gap.md, item 7), which calls `$!.message` inside
+  # its own rescue clause and got a NoMethodError instead, masking the
+  # game's original exception behind an unrelated crash. Same patch-in-place
+  # treatment as the colon3 patch above, for the same reason (no fork of
+  # upstream mruby/mruby this project controls).
+  set(mruby_dollar_bang_patch
+      "${ARG_REPO_ROOT}/patches/mruby-dollar-bang-scoped.patch")
+
   # Point mruby's rake at the vendored mgem-list (the mgem index) via symlinks
   # in its repos/ dir so it resolves gems locally instead of cloning from
   # GitHub. Both repos/host and repos/<TARGET_NAME> are linked: a cross build
@@ -114,6 +127,8 @@ function(rpg2k_add_mruby)
     OUTPUT "${libmruby_a}"
     COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
             "${mruby_colon3_patch}"
+    COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
+            "${mruby_dollar_bang_patch}"
     COMMAND
       mkdir -p ${mruby_build_dir}/repos/host
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME} && ln -sfn
@@ -123,7 +138,7 @@ function(rpg2k_add_mruby)
       -v
     WORKING_DIRECTORY "${mruby_prefix}"
     DEPENDS "${ARG_REPO_ROOT}/build_config.rb" "${mruby_colon3_patch}"
-            ${mrb_files})
+            "${mruby_dollar_bang_patch}" ${mrb_files})
   add_custom_target(mruby_build DEPENDS "${libmruby_a}")
   add_dependencies(mruby mruby_build)
 

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -100,16 +100,15 @@ function(rpg2k_add_mruby)
   set(mruby_colon3_patch
       "${ARG_REPO_ROOT}/patches/mruby-colon3-assign-setmcnst.patch")
 
-  # Vendored mruby never implemented `$!` (Kernel#$!, "the exception the
-  # current rescue clause is handling") -- it always reads nil, even inside
-  # an active rescue (patches/mruby-dollar-bang-scoped.patch's own preamble
-  # has the full trail, including two rejected earlier approaches). Found
-  # via a real VX Ace game's bundled crash-reporter add-on
-  # (docs/rpgvx-rgss-api-gap.md, item 7), which calls `$!.message` inside
-  # its own rescue clause and got a NoMethodError instead, masking the
-  # game's original exception behind an unrelated crash. Same patch-in-place
-  # treatment as the colon3 patch above, for the same reason (no fork of
-  # upstream mruby/mruby this project controls).
+  # Vendored mruby never implemented `$!` (Kernel#$!, "the exception the current
+  # rescue clause is handling") -- it always reads nil, even inside an active
+  # rescue (patches/mruby-dollar-bang-scoped.patch's own preamble has the full
+  # trail, including two rejected earlier approaches). Found via a real VX Ace
+  # game's bundled crash-reporter add-on (docs/rpgvx-rgss-api-gap.md, item 7),
+  # which calls `$!.message` inside its own rescue clause and got a
+  # NoMethodError instead, masking the game's original exception behind an
+  # unrelated crash. Same patch-in-place treatment as the colon3 patch above,
+  # for the same reason (no fork of upstream mruby/mruby this project controls).
   set(mruby_dollar_bang_patch
       "${ARG_REPO_ROOT}/patches/mruby-dollar-bang-scoped.patch")
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20831,17 +20831,9 @@ screen (544×416). Full rationale:
     `false` even after execution reaches unrelated code far past it), so
     a later event's own "Script" command that expects `MapFog` fails.
     Narrowed this far across two rounds of isolated reproduction without
-    fully explaining it; see the item 7 write-up for the full trace.
-    Fixing `$!` itself is
-    fixable only by wrapping `Kernel#raise` itself (the sole point where the
-    about-to-be-raised object is observable), which would add overhead and
-    stack depth to *every* exception in the shared build across every maker
-    and every platform (PSP's stack headroom included) for what is mostly
-    log-message fidelity in one utility script — see the item 7 write-up for
-    the full reasoning on why that trade isn't taken here; the temporary VM
-    probe keeps finding the real gaps without it. That tenth masked
-    exception is now fixed: the real bug was in the vendored mruby compiler
-    itself, not the class variable — `gen_colon3_assign`
+    fully explaining it; see the item 7 write-up for the full trace. That
+    tenth masked exception is now fixed: the real bug was in the vendored
+    mruby compiler itself, not the class variable — `gen_colon3_assign`
     (`3rd/mruby/mrbgems/mruby-compiler/core/codegen.c`), the codegen for an
     explicit top-level `::Const = value`, emitted `OP_SETCONST` instead of
     `OP_SETMCNST`, so the pushed `Object` base was silently ignored and the
@@ -20856,6 +20848,21 @@ screen (544×416). Full rationale:
     `patches/mruby-colon3-assign-setmcnst.patch`, applied at build time by
     `scripts/apply_mruby_patch.bash`; see the item 7 write-up for the full
     trace.
+  - ✅ **`$!` and bare `raise` re-raise, previously left unfixed** — item
+    7's own long-standing gap: mruby's VM never wrote `$!` anywhere
+    Ruby-visible, so the crash-reporter add-on that gap kept masking
+    exceptions behind (`rescue; TKG::ErrorLog.save(); raise; end`, reading
+    `exception = $!` as `nil`) always crashed with an unrelated
+    `NoMethodError` instead of logging the real one. An earlier pass ruled
+    out the only fix then apparent — wrapping every `raise` call in the
+    shared build to stash the about-to-be-raised object, too broad a change
+    for one utility script's log fidelity. Fixed instead by scoping `$!` to
+    the call frame containing its `rescue` clause via mruby's own existing
+    frame-pop (`cipop`), which needed no such wrapping and, as a direct
+    consequence, made the bare-`raise` fix trivial too (`mrb_f_raise`'s
+    zero-argument case simply re-raises the same tracked value). Ships as
+    `patches/mruby-dollar-bang-scoped.patch`; see the item 7 write-up for
+    the two earlier, rejected approaches and the full mechanism.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -492,23 +492,52 @@ memory consumer 256 MB did not cover: the game aborted with
 it. Desktop-only, same as before (`include/lv_conf.h`; the PSP and Wio
 builds keep their own separately-tuned pools).
 
-**Still open, and deeper than `module_function`: mruby's VM has no `$!`
-("currently handled exception") at all.** `rescue => e` binds the exception
-to the clause's own local variable, but the special global CRuby code
-routinely reads instead — `$!`, what `Exception#message`/`#backtrace`
-resolve through implicitly when a method's default argument or a nested
-`raise` (no arguments — CRuby re-raises `$!`) needs "whatever is currently
-being rescued" without it being threaded through as an explicit parameter —
-is simply never written anywhere accessible from Ruby. Traced to the VM
-opcode itself: `OP_EXCEPT` in `3rd/mruby/src/vm.c` copies the caught
-exception into a bytecode *register* (a local stack slot) and immediately
-clears `mrb->exc` to `NULL`, with no call to `mrb_gv_set` or any other
-globally-visible store. Confirmed with an isolated reproduction — even a bare
-`rescue => e; $! ...` inside the *same* method reads `nil`, so this is not
-specific to crossing a call boundary. It is why the same error-log utility's
-`save(filename = nil, exception = $!)` — called as `TKG::ErrorLog.save()`
-from directly inside `rescue; TKG::ErrorLog.save(); raise; end` — receives
-`exception = nil` and crashes on `exception.message`.
+**Fixed: mruby's VM had no `$!` ("currently handled exception") at all.**
+`rescue => e` binds the exception to the clause's own local variable, but
+the special global CRuby code routinely reads instead — `$!`, what
+`Exception#message`/`#backtrace` resolve through implicitly when a method's
+default argument or a nested `raise` (no arguments — CRuby re-raises `$!`)
+needs "whatever is currently being rescued" without it being threaded
+through as an explicit parameter — was simply never written anywhere
+accessible from Ruby. Traced to the VM opcode itself: `OP_EXCEPT` in
+`3rd/mruby/src/vm.c` copied the caught exception into a bytecode *register*
+(a local stack slot) and immediately cleared `mrb->exc` to `NULL`, with no
+call to `mrb_gv_set` or any other globally-visible store. Confirmed with an
+isolated reproduction — even a bare `rescue => e; $! ...` inside the *same*
+method read `nil`, so this was not specific to crossing a call boundary. It
+is why the same error-log utility's `save(filename = nil, exception = $!)`
+— called as `TKG::ErrorLog.save()` from directly inside `rescue;
+TKG::ErrorLog.save(); raise; end` — received `exception = nil` and crashed
+on `exception.message`.
+
+Fixed by `patches/mruby-dollar-bang-scoped.patch` (that patch's own preamble
+has the full trail, including two earlier approaches that were tried and
+rejected: codegen-level save/restore around rescue bodies, which regressed
+the compiler's register allocation, and a sticky global that leaked into
+unrelated code and broke three core mrbtest cases). The fix that stuck adds
+`errinfo`/`errinfo_ci_depth` to `mrb_state`: `OP_EXCEPT` sets `errinfo` to
+the caught exception and records the call-frame depth that owns it — by the
+time `OP_EXCEPT` runs, mruby's own exception search has already popped
+every frame between the raise site and the frame whose `rescue` matches, so
+that depth is simply the current one, no deferred capture needed — and
+`cipop` (mruby's existing frame-pop) clears `errinfo` once execution returns
+to a shallower depth, so it is visible for the whole rescue body (including
+calls the body itself makes) but never leaks past the owning frame's
+return. `mrb_gv_get`/`mrb_gv_set` special-case the `"$!"` symbol to read and
+write `errinfo` directly, so both a Ruby-level `$!` and a bare `raise`
+(kernel.c) see the same value uniformly. Companion fix in the same patch: a
+bare `raise` — CRuby's documented way to re-raise `$!` — always raised a
+fresh, empty `RuntimeError` instead, since `mrb_f_raise` had nothing to fall
+back to; with `errinfo` now tracked, its zero-argument case re-raises it
+directly, no wrapping of every `raise` call needed (the earlier, rejected
+idea for fixing this half on its own). One known gap versus real Ruby: this
+scopes `$!` to the whole call frame, not to each individual `rescue`
+clause, so two `rescue` clauses in the same frame with no intervening call
+share one slot — not believed to matter for any known real game script.
+Verified against a real repro of this exact pattern (`$!` readable and
+correct inside the rescue and from a callee it invokes, `nil` again once the
+frame returns; a bare `raise` re-raising the original class and message)
+and the full mruby test suite (zero regressions from a core VM change).
 
 That `SceneManager.run` rescue wraps the game's *entire* run loop, so this is
 not a one-time cosmetic loss: every fatal exception this game hits, of any
@@ -736,22 +765,20 @@ regressions from a compiler-level change), and the real, unmodified
 516-line script — `Object.const_defined?(:MapFog)` now returns `true`
 after it runs.
 
-mruby's bare `raise` (no arguments) has the same
-root cause from the other side: real Ruby re-raises `$!`, but mruby's
-`mrb_f_raise` has no `$!` to fall back to, so a bare `raise` always raises a
-fresh, empty `RuntimeError` instead of re-raising what was actually caught.
-Both are fixable *only* by hooking `Kernel#raise` itself (there is no other
-point where the about-to-be-raised object is observable in time to stash it)
-— wrapping every `raise` call in the whole engine in an extra begin/rescue to
-capture and stash the exception before it propagates, on every platform this
-build targets, PSP included, where call-stack depth is already the tightest
-constraint. That blast radius — every exception, in every maker's runtime,
-sharing this one build — is a different order of risk than a script that
-opts into the bare `module_function` idiom or calls `Time#strftime`, for a
-fix whose payoff is mostly log-message fidelity in one utility script's
-crash handler. Left alone rather than patched; a project that genuinely needs
-`$!` semantics would want this revisited with its own scoped, targeted
-design rather than a global `raise` wrapper.
+mruby's bare `raise` (no arguments) had the same root cause from the other
+side: real Ruby re-raises `$!`, but mruby's `mrb_f_raise` had no `$!` to
+fall back to, so a bare `raise` always raised a fresh, empty `RuntimeError`
+instead of re-raising what was actually caught. An earlier pass at this
+considered both fixable *only* by hooking `Kernel#raise` itself — wrapping
+every `raise` call in the whole engine in an extra begin/rescue to capture
+and stash the exception before it propagates, on every platform this build
+targets, PSP included, where call-stack depth is already the tightest
+constraint — and left both alone rather than take on that blast radius for
+one utility script's log fidelity. `$!` itself turned out to have a much
+smaller, VM-internal fix (see above); once that fix's `mrb->errinfo` field
+existed, the wrapping was never needed for `raise` either — `mrb_f_raise`'s
+zero-argument case now just re-raises `mrb->errinfo` directly when one is
+in scope. Both are fixed by `patches/mruby-dollar-bang-scoped.patch`.
 
 ## What this means for turning the host on
 
@@ -765,14 +792,15 @@ tints, flashes and fades the screen, dissolves between scenes, unrolls and tints
 its windows, and — packed or loose — finds its graphics and its music, and
 reopens its own stock `RPG::` script sections without a superclass mismatch.
 Tilemap item 1's remaining polish (the flat "above characters" layer) is the
-only item left in the six sections above; item 7's `$!`/bare-`raise` gap
-stands, and per a real release it is the reason each fix above only reveals
-the *next* wall one at a time rather than the game running to completion in
-one pass. Ten real bugs have been found and fixed this way so far
+only item left in the six sections above; item 7's `$!`/bare-`raise` gap is
+now fixed too (`patches/mruby-dollar-bang-scoped.patch`, above), so the same
+real release's own crash-reporter add-on now sees the actual exception
+instead of masking it behind an unrelated `NoMethodError`, and re-raises it
+correctly. Eleven real bugs have been found and fixed this way so far
 (`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
 `Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`,
 `Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`,
-`Sprite#width`/`#height`, and the `::Const = value` compiler bug above)
-without needing `$!` itself fixed — the temporary VM probe finds the real
-exception directly regardless. Where the next wall stands past the
-`マップフォグ` fix is not yet traced.
+`Sprite#width`/`#height`, the `::Const = value` compiler bug, and `$!`/bare-
+`raise` itself) — the first ten via the temporary VM probe, finding the real
+exception directly regardless of `$!` being masked at the time. Where the
+next wall stands past the `マップフォグ` fix is not yet traced.

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -5,6 +5,60 @@
 GAME_DIR = "" unless Object.const_defined?(:GAME_DIR)
 RTP_DIR = "" unless Object.const_defined?(:RTP_DIR)
 
+# Regression test for the vendored mruby VM bug fixed by
+# patches/mruby-dollar-bang-scoped.patch: `$!` (the exception a currently
+# executing rescue clause is handling) was never implemented, so it always
+# read `nil` inside a rescue clause -- silently breaking any script (a real
+# VX Ace game's crash-reporter add-on, docs/rpgvx-rgss-api-gap.md item 7,
+# among them) that inspects `$!` rather than the block-local variable bound
+# by `rescue => e`. Scoped to the call frame containing the rescue clause,
+# using mruby's existing frame-pop (cipop) as the point where it goes out of
+# scope again -- so it is readable for the whole rescue body, including from
+# a helper the rescue body calls, but does not leak into unrelated code that
+# runs after that frame has returned.
+assert "$! is set for the duration of the frame containing a rescue clause" do
+  def rgss_test_dollar_bang_message
+    # Read from a call the rescue body makes, not just the rescue body
+    # itself, to prove $! is visible to callees within the same frame.
+    $!.message
+  end
+
+  def rgss_test_dollar_bang_rescue
+    raise ArgumentError, "boom"
+  rescue => e
+    assert_equal e, $!
+    assert_equal "boom", rgss_test_dollar_bang_message
+  end
+
+  assert_nil $!
+  rgss_test_dollar_bang_rescue
+  assert_nil $!
+end
+
+# Companion regression test, same patch: a bare `raise` (no arguments) is
+# meant to re-raise whatever `$!` currently holds -- CRuby's own documented
+# behavior, used by a real VX Ace game's crash-reporter add-on to re-raise
+# after logging (docs/rpgvx-rgss-api-gap.md item 7's `rescue;
+# TKG::ErrorLog.save(); raise; end`). Without a working `$!`, mruby's
+# `mrb_f_raise` (src/kernel.c) had nothing to fall back to, so a bare
+# `raise` always raised a fresh, empty RuntimeError instead -- silently
+# discarding the original exception's class and message.
+assert "a bare raise re-raises the exception $! currently holds" do
+  def rgss_test_bare_raise_rescue
+    raise ArgumentError, "original"
+  rescue
+    raise # no arguments -- re-raise $!, not a fresh RuntimeError
+  end
+
+  begin
+    rgss_test_bare_raise_rescue
+    assert_true false # must not reach here
+  rescue => e
+    assert_equal ArgumentError, e.class
+    assert_equal "original", e.message
+  end
+end
+
 # Regression test for the vendored mruby compiler bug fixed by
 # patches/mruby-colon3-assign-setmcnst.patch: `::Const = value`, written from
 # inside a nested module, used to silently land on the enclosing module

--- a/patches/mruby-dollar-bang-scoped.patch
+++ b/patches/mruby-dollar-bang-scoped.patch
@@ -1,0 +1,213 @@
+mruby gap: `$!` (Kernel#$!, "the exception currently being handled") is not
+implemented at all -- it always reads `nil`, even from inside an active
+`rescue` clause. Real Ruby scopes it dynamically to the nearest enclosing
+rescue: `begin; raise "x"; rescue => e; $!.message; end` returns `"x"` in
+CRuby, but raises `NoMethodError: undefined method 'message' for nil` in
+unpatched mruby.
+
+Found via a real VX Ace game (docs/rpgvx-rgss-api-gap.md, item 7) whose
+bundled crash-reporter add-on relies on `$!.message` inside its own
+rescue clause to build a user-facing error report; with `$!` always nil,
+the report itself blew up with a NoMethodError, masking the game's
+original exception behind a second, unrelated crash.
+
+Two earlier approaches were tried and rejected before this one:
+
+  1. Save/restore `$!` at the codegen level, around each rescue body.
+     Rejected: interacts badly with the compiler's register allocation
+     across rescue/ensure boundaries, causing hard-to-isolate regressions
+     elsewhere in the compiler test suite.
+  2. A sticky global, written in OP_EXCEPT and never cleared. Passed an
+     initial smoke test but leaks the last-seen exception into unrelated
+     code that runs later in the same or a deeper call frame -- broke
+     three core mrbtest cases (`Kernel.raise`, `Kernel#raise`,
+     `Exception 5`) that rely on `$!`-equivalent state NOT surviving past
+     the rescue that set it.
+
+This patch instead scopes `$!` to the call frame that contains the
+`rescue` clause, using mruby's own existing frame-pop (`cipop`, vm.c) as
+the hook for detecting when that scope ends -- no codegen or register-
+allocation changes needed, and no leaking past the owning frame's return.
+
+Mechanics, added to `mrb_state` (include/mruby.h):
+
+  - `errinfo` / `errinfo_ci_depth`: OP_EXCEPT (vm.c) sets `errinfo` to the
+    exception the rescue clause it is entering will handle, and captures
+    the current call-frame depth (`mrb->c->ci - mrb->c->cibase`) as the
+    depth that owns it. This capture is correct as-is, not one frame too
+    deep: by the time OP_EXCEPT runs, mruby's own exception search
+    (`L_RAISE` in vm.c) has already popped every frame between the raise
+    site and the frame whose `rescue` matches, so `mrb->c->ci` already IS
+    that owning frame. `cipop` then clears `errinfo` once execution
+    returns to a shallower depth than that -- i.e. once the frame owning
+    the rescue (or an enclosing one) has itself returned. Calls the
+    rescue body makes push a deeper frame and pop back down to the same
+    depth, so they never trip this early.
+  - `errinfo_sym`: `$!`'s interned symbol, cached on first use so every
+    ordinary global-variable access does not pay for re-interning it.
+  - GC marking for `errinfo` (src/gc.c), alongside the existing marking
+    for `mrb->exc`, so a `$!` value survives a collection during the
+    rescue body.
+  - `mrb_gv_get`/`mrb_gv_set` (src/variable.c) special-case the `$!`
+    symbol to read/write `errinfo` directly instead of the ordinary
+    globals table -- transparent to both a Ruby-level `$!` reference and
+    a bare `raise` re-raise (mrbgems/mruby-error's C-level lookup goes
+    through the same `mrb_gv_get`), so both see the same value uniformly.
+
+Known gap versus real Ruby: this scopes to the whole call frame, not to
+each individual `rescue` clause. Two `rescue` clauses in the *same* frame
+with no intervening call (e.g. two sequential `begin/rescue` blocks in
+one method) share one slot, so the second one's `$!` remains set (masking
+whatever the first one saw) until the whole frame returns, rather than
+being restored the moment the first rescue's own block ends. This did not
+warrant chasing further: no known real game script nests rescues this way
+within a single method, and doing better would need per-rescue codegen
+changes -- exactly the approach rejected above for its regression risk.
+
+Companion fix, same real game (docs/rpgvx-rgss-api-gap.md item 7's own
+notes on this had previously ruled it out): a bare `raise` (no arguments)
+is documented CRuby behavior for re-raising whatever `$!` currently holds
+-- used by this game's crash-reporter add-on to re-raise after logging.
+`mrb_f_raise` (src/kernel.c) had no `$!` to fall back to, so a bare
+`raise` always raised a fresh, empty RuntimeError instead, discarding the
+original exception's class and message. Earlier analysis considered this
+fixable only by wrapping every `raise` call in the engine in an extra
+begin/rescue to stash the about-to-be-raised object -- too broad a change
+to take on for one utility script's log fidelity. `errinfo` above removes
+that obstacle: `mrb_f_raise`'s zero-argument case now simply re-raises
+`mrb->errinfo` when one is in scope, with no wrapping needed anywhere.
+
+--- a/include/mruby.h
++++ b/include/mruby.h
+@@ -269,6 +269,33 @@ typedef struct mrb_state {
+
+   struct RObject *exc;                    /* exception */
+
++  /* `$!` -- the exception a currently-executing rescue clause is handling.
++   * Set in OP_EXCEPT (vm.c) to the innermost caught exception, captured at
++   * the call-frame depth OP_EXCEPT runs at: by the time it runs, mruby's
++   * exception search (L_RAISE in vm.c) has already popped every frame
++   * between the raise site and the frame owning the matching rescue clause,
++   * so mrb->c->ci at that point already IS the owning frame. Cleared in
++   * cipop once that frame (or a shallower one) returns, so it does not leak
++   * into unrelated code that runs after the rescue's own frame has exited;
++   * calls the rescue body itself makes push and pop back to the same depth,
++   * so they never trip this. Read and written exclusively through
++   * mrb_gv_get/mrb_gv_set's special case for the "$!" symbol (variable.c) --
++   * never stored in the ordinary globals table -- so both `$!` from Ruby and
++   * a bare `raise` (kernel.c) see it uniformly. Coarser than real Ruby's
++   * per-rescue-clause scoping: two `rescue` clauses nested in the *same*
++   * frame (no intervening call) share one slot, so the inner one's `$!`
++   * masks the outer's until the whole frame returns, rather than restoring
++   * right at the inner rescue's end.
++   */
++  struct RObject *errinfo;
++  mrb_int errinfo_ci_depth;
++  mrb_sym errinfo_sym;                    /* "$!", interned lazily and
++                                              cached (mrb_gv_get/set,
++                                              variable.c) so every ordinary
++                                              global access does not re-intern
++                                              it; 0 (never a valid mrb_sym)
++                                              means not yet cached. */
++
+   struct RObject *top_self;
+   struct RClass *object_class;            /* Object class */
+   struct RClass *class_class;
+--- a/src/gc.c
++++ b/src/gc.c
+@@ -1047,6 +1047,7 @@ root_scan_phase(mrb_state *mrb, mrb_gc *gc)
+   mrb_gc_mark(mrb, (struct RBasic*)mrb->top_self);
+   /* mark exception */
+   mrb_gc_mark(mrb, (struct RBasic*)mrb->exc);
++  mrb_gc_mark(mrb, (struct RBasic*)mrb->errinfo);
+
+   mark_context(mrb, mrb->c);
+   if (mrb->root_c != mrb->c) {
+@@ -1144,6 +1145,7 @@ final_marking_phase(mrb_state *mrb, mrb_gc *gc)
+     mark_context(mrb, mrb->root_c);
+   }
+   mrb_gc_mark(mrb, (struct RBasic*)mrb->exc);
++  mrb_gc_mark(mrb, (struct RBasic*)mrb->errinfo);
+
+   /* mark pre-allocated exception */
+   clear_error_object(mrb, mrb->nomem_err);
+--- a/src/variable.c
++++ b/src/variable.c
+@@ -1579,6 +1579,10 @@ mrb_gv_get(mrb_state *mrb, mrb_sym sym)
+ {
+   mrb_value v;
+
++  if (mrb->errinfo_sym == 0) mrb->errinfo_sym = mrb_intern_lit(mrb, "$!");
++  if (sym == mrb->errinfo_sym) {
++    return mrb->errinfo ? mrb_obj_value(mrb->errinfo) : mrb_nil_value();
++  }
+   if (iv_get(mrb, mrb->globals, sym, &v))
+     return v;
+   return mrb_nil_value();
+@@ -1599,6 +1603,16 @@ mrb_gv_set(mrb_state *mrb, mrb_sym sym, mrb_value v)
+ {
+   iv_tbl *t;
+
++  if (mrb->errinfo_sym == 0) mrb->errinfo_sym = mrb_intern_lit(mrb, "$!");
++  if (sym == mrb->errinfo_sym) {
++    /* Never stored in the ordinary globals table -- see mrb_gv_get and the
++     * mrb_state field's own comment (mruby.h). An explicit `$! = x` from
++     * Ruby (rare, but legal) sets the *current* frame's scope directly,
++     * same as OP_EXCEPT would. */
++    mrb->errinfo = mrb_nil_p(v) ? NULL : mrb_obj_ptr(v);
++    mrb->errinfo_ci_depth = mrb->c->ci - mrb->c->cibase;
++    return;
++  }
+   if (!mrb->globals) {
+     mrb->globals = iv_new(mrb);
+   }
+--- a/src/vm.c
++++ b/src/vm.c
+@@ -502,6 +502,13 @@ cipop(mrb_state *mrb)
+     mrb_exc_raise(mrb, mrb_obj_value(mrb->nomem_err));
+   }
+   c->ci--;
++  /* `$!` (mrb->errinfo) is scoped to the call frame that contained the
++   * rescue clause which set it; once that frame (or a shallower one) has
++   * returned, it can no longer be in scope. See the mrb_state field's own
++   * comment (mruby.h). */
++  if (mrb->errinfo && (c->ci - c->cibase) < mrb->errinfo_ci_depth) {
++    mrb->errinfo = NULL;
++  }
+   return c->ci;
+ }
+
+@@ -2139,6 +2146,17 @@ RETRY_TRY_BLOCK:
+           exc = mrb_nil_value();
+           break;
+         }
++        if (mrb->exc->tt == MRB_TT_EXCEPTION) {
++          /* `$!` for the rescue clause this exception is entering; see the
++           * mrb_state field's own comment (mruby.h) for the scoping this
++           * gives and its one known gap (nested rescues sharing a frame).
++           * By the time OP_EXCEPT runs, the exception search (L_RAISE) has
++           * already popped every frame between the raise site and the
++           * frame owning this rescue clause, so mrb->c->ci here already IS
++           * that owning frame -- captured directly, no deferral needed. */
++          mrb->errinfo = mrb->exc;
++          mrb->errinfo_ci_depth = mrb->c->ci - mrb->c->cibase;
++        }
+         mrb->exc = NULL;
+       }
+       regs[a] = exc;
+--- a/src/kernel.c
++++ b/src/kernel.c
+@@ -515,6 +515,13 @@ mrb_f_raise(mrb_state *mrb, mrb_value self)
+   mrb->c->ci->mid = 0;
+   switch (argc) {
+   case 0:
++    /* Real Ruby re-raises `$!` -- see the mrb_state field's own comment
++     * (mruby.h) -- when a rescue clause is still active; only fall back to
++     * a fresh, empty RuntimeError outside of one, matching CRuby's own
++     * "no `$!` to re-raise" behavior for a bare `raise` outside rescue. */
++    if (mrb->errinfo) {
++      mrb_exc_raise(mrb, mrb_obj_value(mrb->errinfo));
++    }
+     mrb_raise(mrb, E_RUNTIME_ERROR, "");
+     break;
+   case 1:


### PR DESCRIPTION
## Summary

- Implements `$!` ("the exception the current `rescue` clause is handling") in vendored mruby, which was never written anywhere Ruby-visible before — it always read `nil`, even inside an active `rescue`.
- Fixes the companion gap: a bare `raise` (no arguments) always raised a fresh, empty `RuntimeError` instead of re-raising `$!`, as real Ruby documents.
- Found via a real VX Ace game's own bundled crash-reporter add-on (`docs/rpgvx-rgss-api-gap.md`, item 7), which calls `$!.message` and a bare `raise` inside its own rescue clause — this used to crash with an unrelated `NoMethodError` instead of logging (and re-raising) the game's real exception.

## Approach

Two earlier approaches were tried and rejected before this one (both documented in the patch's own preamble):
1. Codegen-level save/restore of `$!` around each rescue body — regressed the compiler's register allocation.
2. A sticky global, written on catch and never cleared — leaked the last-seen exception into unrelated later code, breaking three core mrbtest cases.

This instead scopes `$!` to the call frame containing the `rescue` clause, using mruby's own existing frame-pop (`cipop`) as the hook for detecting when that scope ends — no codegen or register-allocation changes needed, and nothing leaks past the owning frame's return. That same mechanism made the bare-`raise` fix trivial too: `mrb_f_raise`'s zero-argument case now simply re-raises the tracked exception, removing the need (an earlier pass had ruled out) to wrap every `raise` call in the engine just to stash the about-to-be-raised object.

Since this project doesn't control `3rd/mruby`'s upstream remote, the fix ships as `patches/mruby-dollar-bang-scoped.patch`, applied idempotently at build time by `scripts/apply_mruby_patch.bash` — the same convention already used for `patches/mruby-colon3-assign-setmcnst.patch`.

## Test plan

- [x] New permanent regression tests in `mruby-rgss/test/test.rb`: `$!` is set (and visible to a callee the rescue body invokes) for the duration of the frame containing a rescue clause, and reads `nil` again once that frame returns; a bare `raise` re-raises the original exception's class and message.
- [x] Full mruby test suite: 1844 OK, 0 KO, 0 Crash — zero regressions from a core VM change.
- [x] Verified the patch applies cleanly from a clean submodule checkout, and that the normal CMake/ninja build (not just the manual `rake test` path) applies it and builds the whole project successfully.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_