### PR TITLE
Fix the map Timer widget's overflow-past-99-minutes rendering

### DIFF
--- a/changelog.d/timer-overflow-past-99-minutes.fixed.md
+++ b/changelog.d/timer-overflow-past-99-minutes.fixed.md
@@ -1,0 +1,5 @@
+- **Map:** the on-screen Timer widget now matches RPG_RT's actual (odd but
+  real) overflow behavior once a Timer Set pushes it past 99 minutes --
+  previously it read a windowskin offset past the end of the digit strip and
+  drew whatever pixels happened to be there instead of RPG_RT's own
+  duplicated-colon, dropped-ones-digits pattern.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8666,6 +8666,39 @@ not yet verified:
   variable-sourced, lands at exactly 9999 s / `9999 * FPS + (FPS - 1)`
   frames, not clamped to 5999), confirmed to fail against the pre-fix
   code (`expected 9999, got 5999`) before the fix.
+  ✅ **Follow-up (2026-08-22): the "reproduces the garbled-past-99 quirk for
+  free" half of that correction was itself wrong. ~~`Sprite_Timer::Draw`
+  indexes its digit strip at an unbounded `32 + 8 * (mins / 10)` ... this
+  port's own pixel-digit renderer already indexes its windowskin digit strip
+  the identical unbounded way ... reproduces the same garbled-past-99 quirk
+  for free.~~** That whole claim was reasoned from EasyRPG's source alone,
+  never checked against a genuine RPG_RT.exe's actual on-screen output —
+  exactly the kind of uncited claim this session has repeatedly found wrong
+  elsewhere. Confirmed by editing a genuine save's Timer chunk (109 fields
+  23-26) to values with `mins / 10` a genuine two-digit overflow (10-99) and
+  resuming under a real RPG_RT.exe: the widget does NOT simply index the
+  digit strip out of range and read whatever garbage windowskin pixels
+  happen to sit there (what an unbounded single-glyph index — matching this
+  port's pre-fix code — would produce, and did: for 107 min 34 s it drew
+  `mins/10=10` as index 10 into the strip, `mins%10=7`, and `secs%10=4`
+  normally). Instead RPG_RT draws the two-digit `mins/10` value's own tens
+  and ones digits across the first two cells, the colon glyph a *second*
+  time in the cell that would otherwise be minutes-ones, then only
+  seconds-tens in the last cell — minutes-ones and seconds-ones are dropped
+  entirely, not merely miscomputed. Confirmed on four mutually-
+  disambiguating samples (`mins/10` = 10, 10, 11, 25, each individually
+  distinguishable per this session's cycle-#95 lesson about symmetric
+  witnesses), and the glyphs verified to land on the identical 8px-aligned
+  columns as the normal case (ruling out a switch to proportional-width
+  text rendering). `mins >= 1000` (`mins/10 >= 100`, reachable only past
+  ~16.7 real hours) departs from even this pattern on the one sample tried
+  and is left unhandled, same as before — not worth characterizing for
+  something that far outside normal play. Fixed in `Scene::Map
+  #draw_timer_digits` (`mruby-rpg2k/mrblib/scene/map.rb`) and the stale
+  claim struck from `Game::Timer#set`'s own comment
+  (`mruby-rpg2k/mrblib/game.rb`). Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (107 min 34 s renders the five cells
+  exactly as above), confirmed to fail against the pre-fix code.
 - ✅ **Special-skill HP recovery is capped at 999 per use** — the same
   fixed-3-digit-popup reasoning as the battle damage cap above, for the
   opposite direction. `Game::Battle#apply_skill_hit`'s recovery branch

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -13776,7 +13776,7 @@ module Game
     # `ValueOrVariable`-sourced seconds straight through with no clamp
     # either -- so a Control Variables value above 99:59 (5999 s, an
     # arbitrary, player-reachable overflow) genuinely reaches the frame
-    # counter uncapped in real RPG_RT. `Sprite_Timer::Draw`
+    # counter uncapped in real RPG_RT. ~~`Sprite_Timer::Draw`
     # (`src/sprite_timer.cpp`) indexes its digit strip at an unbounded
     # `32 + 8 * (mins / 10)` with no ceiling either, so real RPG_RT's own
     # on-screen minutes display genuinely garbles past 99 rather than
@@ -13784,7 +13784,12 @@ module Game
     # (`Scene::Map#draw_timer_digits`, `mruby-rpg2k/mrblib/scene/map.rb`)
     # already indexes its own windowskin digit strip the identical
     # unbounded way, so it reproduces the same garbled-past-99 quirk for
-    # free once this class stops clamping first.
+    # free once this class stops clamping first.~~ Correction: confirmed
+    # against a genuine RPG_RT.exe, not just its source, this claim was
+    # wrong -- RPG_RT does not garble past 99 the same way a naive
+    # unbounded single-glyph index would. See `Scene::Map#draw_timer_digits`
+    # (`mruby-rpg2k/mrblib/scene/map.rb`) for the actual, empirically
+    # characterized overflow behavior.
     def set(seconds)
       @frames = seconds * FPS + (FPS - 1)
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8887,15 +8887,33 @@ class RPG2k
       # off for the first half of every real second, on for the second half --
       # independent of the four digit cells either side of it, which always
       # draw regardless of the blink.
+      #
+      # `mins` overflowing past 99 (reachable via an uncapped Control-
+      # Variables-sourced Timer Set, see `Game::Timer#set`'s own comment) is
+      # NOT the naive "index the digit strip past its end" garble a single
+      # unbounded `mins / 10` lookup would produce -- confirmed against a
+      # genuine RPG_RT.exe: for `mins` 100..999 (i.e. `mins / 10` itself a
+      # two-digit 10..99), the widget draws that two-digit value's own tens
+      # and ones digits in cells 0-1, the colon glyph a SECOND time in cell 3
+      # (not `mins % 10`, and not `secs % 10` either), and only `secs / 10`
+      # in cell 4 -- `mins % 10` and `secs % 10` are both dropped entirely,
+      # not merely miscomputed. `mins >= 1000` (over 16.7 real hours) departs
+      # from even this pattern and is left unhandled, same as before.
       def draw_timer_digits(bmp, timer)
         s = timer.seconds
         mins = s / 60
         secs = s % 60
-        cells = [mins / 10, mins % 10, nil, secs / 10, secs % 10]
+        mins_tens = mins / 10
+        cells =
+          if mins_tens >= 10 && mins_tens < 100
+            [mins_tens / 10, mins_tens % 10, nil, nil, secs / 10]
+          else
+            [mins_tens, mins % 10, nil, secs / 10, secs % 10]
+          end
         bmp.clear
         blink_off = (timer.frames % Game::Timer::FPS) < Game::Timer::FPS / 2
         cells.each_with_index do |digit, i|
-          next if digit.nil? && blink_off # the colon cell, mid-blink-off
+          next if digit.nil? && blink_off # a colon cell, mid-blink-off
           src_x = digit.nil? ? TIMER_COLON_SRC_X : TIMER_DIGIT_SRC_X + TIMER_DIGIT_W * digit
           bmp.blt i * TIMER_DIGIT_W, 0, @windowskin,
                   Rect.new(src_x, TIMER_DIGIT_SRC_Y, TIMER_DIGIT_W, TIMER_DIGIT_H)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11043,6 +11043,32 @@ check 'the timer draws M:SS as digit-sprite cells cut from the System graphic, a
   ok !spr.visible, 'clearing visibility hides the timer sprite'
 end
 
+check 'a timer past 99 minutes draws its minute-tens value across both ' \
+      'leading cells, a duplicated colon, and only the seconds-tens digit -- ' \
+      'not the naive out-of-range single-glyph index' do
+  # Confirmed against a genuine RPG_RT.exe, not EasyRPG's source: 107 min 34 s
+  # (mins / 10 == 10, a genuine two-digit overflow, reachable via an uncapped
+  # Control-Variables-sourced Timer Set -- see Game::Timer#set's own comment)
+  # draws [1, 0, :, :, 3] across the five 8x16 cells -- the two decimal digits
+  # of mins/10 (10 -> "1","0"), the colon glyph a second time in the cell that
+  # would otherwise be seconds-tens... er, minutes-ones, then seconds-tens
+  # alone. minutes-ones (7) and seconds-ones (4) are both dropped entirely,
+  # not merely miscomputed -- the previous unbounded single-index formula
+  # instead read an out-of-range windowskin offset for cell 0 and still drew
+  # minutes-ones/seconds-ones normally, which does not match real RPG_RT.
+  scene = new_scene({})
+  scene.instance_variable_set(:@windowskin, RGSS::Bitmap.new('System/skin'))
+  st = scene.instance_variable_get(:@state)
+  st.timer(0).frames = (107 * 60 + 34) * 60 + 30 # blink-on half of the second
+  st.timer(0).visible = true
+  scene.update
+  spr = scene.instance_variable_get(:@timer_sprites)[0]
+  calls = spr.bitmap.blt_calls
+  eq [[0, 0, 40, 32, 8, 16], [8, 0, 32, 32, 8, 16], [16, 0, 112, 32, 8, 16],
+      [24, 0, 112, 32, 8, 16], [32, 0, 56, 32, 8, 16]],
+     calls.map { |x, y, src, r| [x, y, r.x, r.y, r.width, r.height] }
+end
+
 check 'the timer colon blinks off for the first half of each second' do
   scene = new_scene({})
   scene.instance_variable_set(:@windowskin, RGSS::Bitmap.new('System/skin'))


### PR DESCRIPTION
## Summary

`Scene::Map#draw_timer_digits` indexed the windowskin digit strip at an unbounded `mins / 10` once a Timer Set pushed the displayed minutes past 99 (reachable via an uncapped Control-Variables-sourced Timer Operation "set" — `Game::Timer#set` has no upper bound, confirmed in a prior cycle). This read garbage/off-strip windowskin pixels for the minutes-tens cell while still drawing minutes-ones and seconds-ones normally — not what real RPG_RT does.

## Where it diverged

A prior cycle's doc comment on `Game::Timer#set` claimed, citing only EasyRPG's source, that this port's existing unbounded indexing already "reproduces the same garbled-past-99 quirk for free" as real RPG_RT. That claim was never checked against a genuine RPG_RT.exe's actual output.

## How this was verified

Against a genuine `RPG_RT.exe` under wine, not EasyRPG's source. A real save's Timer chunk (109, fields 23-26) was edited directly to specific `mins`/`secs` values with `mins / 10` in the two-digit 10-99 range, resumed under the real runtime, and the widget's 40×16px on-screen region captured and diffed pixel-by-pixel against a known-correct baseline.

Four mutually-disambiguating samples (`mins/10` = 10, 10, 11, 25 — each individually distinguishable, following this session's own lesson from an earlier cycle about symmetric witnesses that can't disambiguate a hypothesis) all agree on the same rule: real RPG_RT draws the two-digit `mins/10` value's own tens and ones digits across the first two 8px cells, the colon glyph a *second* time in the cell that would otherwise be minutes-ones, then only seconds-tens in the last cell — minutes-ones and seconds-ones are both dropped entirely. The glyphs were confirmed to land on the exact same 8px-aligned pixel columns as the normal (non-overflow) case, ruling out a switch to proportional-width text rendering as an alternative explanation.

`mins >= 1000` (`mins/10 >= 100`, reachable only past ~16.7 real hours of Timer value) departs from even this pattern on the one sample tried and is deliberately left unhandled — not worth characterizing for something that far outside normal play.

## Fix

- `mruby-rpg2k/mrblib/scene/map.rb`: `#draw_timer_digits` now special-cases `mins / 10` in the 10-99 range with the confirmed cell layout, falling back to the original formula otherwise (unchanged for normal in-range timers and for the uncharacterized `>= 1000` minute range).
- `mruby-rpg2k/mrblib/game.rb`: struck the stale, uncited claim from `Game::Timer#set`'s doc comment.
- `docs/TODO.md`: dated Follow-up on the bullet that introduced the wrong claim.

## Testing

New `scripts/rpg2k_scene_check.rb` check (107 min 34 s renders the five cells exactly as described above, matching one of the four verified real-RPG_RT samples). Confirmed it fails against the pre-fix code via `git stash` (`expected [[0,0,40,32,8,16],...], got [[0,0,112,32,8,16],...]` — the old code's out-of-range index for `mins/10=10` happened to land on the colon glyph's own offset, a red herring the pixel-exact fix now avoids).

All four suites green: `rpg2k_scene_check.rb` (869, +1), `rpg2k_logic_check.rb` (1129), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_