### PR TITLE
Resume a picture's in-flight Move Picture across Save/Continue

### DIFF
--- a/changelog.d/picture-move-save-continue.fixed.md
+++ b/changelog.d/picture-move-save-continue.fixed.md
@@ -1,0 +1,7 @@
+- **Save/Continue:** a picture saved mid-`Move Picture` now resumes gliding
+  from exactly where it was toward its target, matching RPG_RT -- previously
+  it silently snapped straight to the move's finish position the instant a
+  save reloaded, because two save-format fields this codebase's own schema
+  had mislabelled as the picture's live position were actually the move's
+  target, a gap that a still picture (where the two happen to coincide)
+  could never expose.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -221,6 +221,42 @@ The work below is roughly ordered by the critical path to a walkable game
     field exactly; a State with no shown pictures gets no chunk 103 at all),
     confirmed to fail against the pre-fix code (`NoMethodError` on a nil
     chunk).
+    ✅ **Follow-up (2026-08-22): fields 31/32 were mislabelled `current_x`/
+    `current_y` in this codebase's own schema — they are real RPG_RT's
+    `finish_x`/`finish_y`, the move's *target*, and a picture still
+    mid-Move-Picture when saved silently snapped straight to that target on
+    Continue instead of resuming its glide.** The two agree exactly at
+    rest (which is why the original field-identification experiment above
+    could not tell them apart — real RPG_RT re-syncs current to finish
+    every idle frame, the same thing `Game::Picture#update` already does
+    here), so this was never wrong for a still picture, only a moving one.
+    Confirmed against a genuine RPG_RT.exe, not EasyRPG's source: a save
+    edited so chunk 103's fields 4/5 (`current_x`/`current_y`) and 31/32
+    (`finish_x`/`finish_y`) deliberately differ, with field 51
+    (`time_left`) still counting down, resumed under the real runtime as a
+    picture visibly still gliding from the saved current position toward
+    the saved finish one over the following seconds — not sitting
+    statically at either. Fixed by declaring the genuinely-live fields
+    (`mruby-lcf/mrblib/schema.rb`'s `SAVE_PICTURE`: 4/5 current position,
+    7/8 current zoom/transparency, 11-14 current tone, 51 time_left) and
+    renaming 31/32 to `finish_x`/`finish_y` to match liblcf's own
+    `generator/csv/fields.csv`; `Game::Picture` gained small `finish_*`/
+    `frames_left` readers alongside its existing `#move_to`/`#moving?`, the
+    same shape `Game::Screen#tint_save_data`/`#restore_tint` already used
+    for the screen-tint chunk. `#to_lsd` now writes the current_*/time_left
+    fields too, only while `#moving?` (a still picture writes only
+    31-44 as before — no format change for the common case).
+    `.restore_pictures` shows a mid-move picture at its saved current
+    values, then immediately restarts the move toward the saved finish
+    values over the saved `time_left`, instead of always reading
+    31/32/etc. An old save missing these fields entirely reads `time_left`
+    as its schema default (0) and restores exactly as before — unaffected.
+    Covered by a new `scripts/rpg2k_logic_check.rb` check (a picture
+    started moving, advanced one frame, then round-tripped through
+    `to_lsd`/`.from_lsd` resumes `#moving?` with the exact same in-flight
+    position and remaining frames, and keeps advancing on a further
+    `#update`; a picture at rest still round-trips unchanged), confirmed to
+    fail against the pre-fix code.
   - ✅ **`Game::State#to_lsd` output is loadable by RPG_RT.** It round-tripped
     through our own parser (`scripts/lcf_save_roundtrip.rb`) but the genuine
     runtime left "Continue" dead, with no error anywhere. The assumed cause —

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1191,33 +1191,55 @@ module LCF
     # https://w.atwiki.jp/rpg2kpsp/pages/21.html
     #
     # Runtime state of a "show picture" command (chunk 103 of the save file),
-    # one entry per picture number. The rpg2kpsp analysis only labels a subset
-    # of the fields; the position/movement slots (2-5, 8, 11-14, 31, 32) hold
-    # `double` coordinates whose exact meaning it does not give.
+    # one entry per picture number.
     #
-    # 31/32 were identified as the *live* position by experiment against the
-    # genuine RPG_RT: each candidate pair was rewritten in a real Nepheshel save
-    # and the resumed frame compared against the unedited one. Moving 31/32 from
-    # (160,120) to (80,60) shifted the picture up-left by exactly that much,
-    # leaving black at the right and bottom edges; editing 2/3 or 4/5 changed
-    # nothing on screen. (A control confirmed the runtime really does restore
-    # picture state from the save rather than re-showing it: renaming field 1
-    # swapped the displayed image.) 2/3 and 4/5 look like a move's start and
-    # finish, which a still picture does not use -- both read 160/120 here, the
-    # centre of the 320x240 screen -- but that is not proven, so they stay
-    # unnamed. See ADR 0021.
+    # Field 31/32 were identified as *a* live position by experiment against
+    # the genuine RPG_RT (rewriting them in a real Nepheshel save and
+    # comparing the resumed frame against the unedited one moved the picture
+    # exactly as edited), but that experiment only ever exercised a picture at
+    # rest -- and liblcf's own generator table (`generator/csv/fields.csv`)
+    # names 31/32 `finish_x`/`finish_y`: the move's *target*, not its
+    # in-flight position. The two agree exactly at rest, which is why the
+    # earlier experiment could not tell them apart -- real RPG_RT re-syncs
+    # current to finish every idle frame the same way `Game::Picture#update`
+    # already does here. The genuinely live position (and zoom/transparency/
+    # tone) sit at fields 4/5/7/8/11-14 instead, confirmed by a second
+    # experiment: a save edited to have current_x/y (4/5) and finish_x/y
+    # (31/32) genuinely differ, with time_left (51) still counting down,
+    # resumed under real RPG_RT as a picture visibly still gliding from the
+    # current position toward the finish one -- not sitting statically at
+    # either.
     SAVE_PICTURE = {
       1 => { name: :name, type: :string },              # ピクチャグラフィックのファイル名
-      # RPG2000 screen coordinates of the picture's *centre*, as doubles.
-      31 => { name: :current_x, type: :double },        # 表示位置Ｘ (中心)
-      32 => { name: :current_y, type: :double },        # 表示位置Ｙ (中心)
+      # The picture's genuinely live position/zoom/transparency/tone, only
+      # meaningful while a move is still in flight (time_left > 0) -- see
+      # this table's own comment above. Defaults match a fresh Game::Picture
+      # so an old save written before these fields existed (or a picture
+      # that has never moved, time_left always 0) restores identically to
+      # before: #restore_pictures only ever reads these when time_left > 0.
+      4 => { name: :current_x, type: :double, default: 0.0 },
+      5 => { name: :current_y, type: :double, default: 0.0 },
+      7 => { name: :current_zoom, type: :double, default: 100.0 },
+      8 => { name: :current_transparency, type: :double, default: 0.0 },
+      11 => { name: :current_tone_red, type: :double, default: 100.0 },
+      12 => { name: :current_tone_green, type: :double, default: 100.0 },
+      13 => { name: :current_tone_blue, type: :double, default: 100.0 },
+      14 => { name: :current_tone_saturation, type: :double, default: 100.0 },
       9 => { name: :visible, type: :bool, default: false }, # 表示するか (0 非表示 / 1 表示)
+      # The picture's resting/target position -- see this table's own
+      # comment above for why these are named finish_*, not current_*.
+      31 => { name: :finish_x, type: :double },         # 表示位置Ｘ (中心)
+      32 => { name: :finish_y, type: :double },         # 表示位置Ｙ (中心)
       33 => { name: :zoom, type: :int },                # 拡大率
       34 => { name: :transparency, type: :int },        # 透明度
       41 => { name: :tone_red, type: :int },            # 色調：赤(R)
       42 => { name: :tone_green, type: :int },          # 色調：緑(G)
       43 => { name: :tone_blue, type: :int },           # 色調：青(B)
       44 => { name: :tone_saturation, type: :int },     # 色調：彩度(S)
+      # How many frames remain in an in-flight Move Picture; 0 (the default,
+      # covering both a still picture and an old save missing this field
+      # entirely) means fields 4/5/7/8/11-14 above are not consulted at all.
+      51 => { name: :time_left, type: :int, default: 0 },
     }
 
     # https://w.atwiki.jp/rpg2kpsp/pages/40.html

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8392,6 +8392,21 @@ module Game
     def red; @red.to_i; end
     def green; @green.to_i; end
     def blue; @blue.to_i; end
+
+    # The in-flight move's own target values and remaining frame count (nil/0
+    # when never moved or already arrived) -- for `.lsd` chunk 103's own
+    # finish_*/time_left fields, which #to_lsd writes from these while
+    # #moving?, see SAVE_PICTURE's own comment on why fields 31/32/etc are
+    # named finish_*, not current_*.
+    def finish_x; @tx; end
+    def finish_y; @ty; end
+    def finish_zoom; @tzoom; end
+    def finish_opacity; @topacity; end
+    def finish_red; @tred; end
+    def finish_green; @tgreen; end
+    def finish_blue; @tblue; end
+    def finish_saturation; @tsat; end
+    def frames_left; @frames; end
     def saturation; @saturation.to_i; end
 
     def initialize(id, opts = {})
@@ -14563,26 +14578,52 @@ module Game
       # `Player::LoadSavegame` (`src/player.cpp`) restores it unconditionally
       # on every load -- the same chunk `.from_lsd`/`.restore_pictures`
       # (above) already reads, just never written here. Field mapping is the
-      # exact mirror of `.restore_pictures`' own read (see its comment for
-      # why the numbers need no separate guesswork): 1 name, 31/32 current_x/
-      # current_y, 33 zoom, 34 transparency (`Game.opacity_to_trans`, the
-      # inverse of the live command's own `#trans_to_opacity`), 41-44 the
-      # red/green/blue/saturation tone. `@pictures` only ever holds currently
-      # -shown pictures (#erase_picture deletes the entry outright), so every
-      # entry present is live and belongs in the save.
+      # exact mirror of `.restore_pictures`' own read (see `SAVE_PICTURE`'s
+      # own comment for why 31/32/etc are finish_*, not current_*): 1 name,
+      # 31/32 finish_x/finish_y, 33 zoom, 34 transparency
+      # (`Game.opacity_to_trans`, the inverse of the live command's own
+      # `#trans_to_opacity`), 41-44 the red/green/blue/saturation tone -- a
+      # picture at rest writes its own live values as both, matching real
+      # RPG_RT's own current-tracks-finish idle sync. `@pictures` only ever
+      # holds currently-shown pictures (#erase_picture deletes the entry
+      # outright), so every entry present is live and belongs in the save.
+      # A picture still mid-Move-Picture (#moving?) additionally writes its
+      # own genuinely-live current_*/time_left fields (4/5/7/8/11-14/51) so a
+      # resumed Continue keeps gliding from exactly where it was, rather than
+      # snapping straight to the move's target the instant the save reloads.
       unless @pictures.empty?
         pics = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
         @pictures.each do |id, p|
           e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
           e[1] = p.name
-          e[31] = p.x
-          e[32] = p.y
-          e[33] = p.zoom
-          e[34] = Game.opacity_to_trans(p.opacity)
-          e[41] = p.red
-          e[42] = p.green
-          e[43] = p.blue
-          e[44] = p.saturation
+          if p.moving?
+            e[4] = p.x
+            e[5] = p.y
+            e[7] = p.zoom
+            e[8] = Game.opacity_to_trans(p.opacity)
+            e[11] = p.red
+            e[12] = p.green
+            e[13] = p.blue
+            e[14] = p.saturation
+            e[31] = p.finish_x
+            e[32] = p.finish_y
+            e[33] = p.finish_zoom
+            e[34] = Game.opacity_to_trans(p.finish_opacity)
+            e[41] = p.finish_red
+            e[42] = p.finish_green
+            e[43] = p.finish_blue
+            e[44] = p.finish_saturation
+            e[51] = p.frames_left
+          else
+            e[31] = p.x
+            e[32] = p.y
+            e[33] = p.zoom
+            e[34] = Game.opacity_to_trans(p.opacity)
+            e[41] = p.red
+            e[42] = p.green
+            e[43] = p.blue
+            e[44] = p.saturation
+          end
           pics[id] = e
         end
         save[103] = pics
@@ -15117,20 +15158,45 @@ module Game
     # 0..255 opacity for the live command. There is nothing save-format-specific
     # left to guess: the save's fields and the command's params are the same
     # numbers, so they are read the same way here.
+    #
+    # A picture still mid-Move-Picture when the save was written (time_left,
+    # field 51, > 0) is shown at its genuinely live current_*/current_x/y
+    # (fields 4/5/7/8/11-14) instead of its finish_*/31/32/etc, then
+    # immediately started moving again toward finish_*/31/32/etc over the
+    # saved time_left frames -- confirmed against a genuine RPG_RT.exe: a
+    # save edited with current and finish deliberately different, resumed
+    # under the real runtime, visibly kept gliding from the saved current
+    # position toward the saved finish one rather than sitting statically at
+    # either. See SAVE_PICTURE's own comment for the field-mapping evidence.
+    # `pic.time_left`/`current_*` both default to 0/the same neutral values a
+    # fresh `Game::Picture` starts at, so a save written before this landed
+    # (missing all of fields 4/5/7/8/11-14/51) reads time_left as 0 and
+    # restores identically to before -- unaffected by this change.
     def self.restore_pictures(state, pictures)
       return unless pictures
       pictures.each do |id, pic|
         next unless pic
         name = pic.name
         next if name.nil? || name.empty?
-        transparency = pic.transparency
+        time_left = pic.time_left || 0
+        moving = time_left > 0
+        transparency = moving ? pic.current_transparency : pic.transparency
         state.show_picture(id, name: name,
-                               x: (pic.current_x || 0).to_i,
-                               y: (pic.current_y || 0).to_i,
-                               zoom: pic.zoom,
+                               x: ((moving ? pic.current_x : pic.finish_x) || 0).to_i,
+                               y: ((moving ? pic.current_y : pic.finish_y) || 0).to_i,
+                               zoom: moving ? pic.current_zoom : pic.zoom,
                                opacity: transparency ? Game.trans_to_opacity(transparency) : nil,
-                               red: pic.tone_red, green: pic.tone_green,
-                               blue: pic.tone_blue, saturation: pic.tone_saturation)
+                               red: moving ? pic.current_tone_red : pic.tone_red,
+                               green: moving ? pic.current_tone_green : pic.tone_green,
+                               blue: moving ? pic.current_tone_blue : pic.tone_blue,
+                               saturation: moving ? pic.current_tone_saturation : pic.tone_saturation)
+        next unless moving
+        finish_trans = pic.transparency
+        state.move_picture(id, (pic.finish_x || 0).to_i, (pic.finish_y || 0).to_i,
+                           pic.zoom,
+                           finish_trans ? Game.trans_to_opacity(finish_trans) : 255,
+                           pic.tone_red, pic.tone_green, pic.tone_blue,
+                           pic.tone_saturation, time_left)
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4405,8 +4405,8 @@ check 'to_lsd writes chunk 103 (shown pictures), not just from_lsd reading it' d
   saved = st.to_lsd[103][3]
   ok !saved.nil?, 'chunk 103 carries the shown picture'
   eq 'backdrop', saved.name
-  eq 200, saved.current_x.to_i
-  eq 150, saved.current_y.to_i
+  eq 200, saved.finish_x.to_i
+  eq 150, saved.finish_y.to_i
   eq 150, saved.zoom
   # Game.opacity_to_trans(191) == 100 - 191*100/255 == 26 -- not 25: this
   # codebase's own Game::Picture keeps opacity (0..255), not RPG_RT's own
@@ -4441,6 +4441,57 @@ check 'to_lsd writes chunk 103 (shown pictures), not just from_lsd reading it' d
   # already follow.
   empty_st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   eq nil, empty_st.to_lsd[103], 'no shown pictures means no chunk 103 at all'
+end
+
+check 'to_lsd/from_lsd round-trips a picture still mid-Move-Picture, resuming ' \
+      'the glide instead of snapping straight to its target' do
+  # Confirmed against a genuine RPG_RT.exe, not EasyRPG's source: a save
+  # edited with chunk 103's current_x/y (fields 4/5) and finish_x/y (31/32)
+  # deliberately different, time_left (51) still counting down, resumed
+  # under the real runtime as a picture visibly still gliding from the
+  # current position toward the finish one -- not sitting statically at
+  # either (see SAVE_PICTURE's own comment for the full field-mapping
+  # evidence). #to_lsd previously wrote only the picture's own live values
+  # into fields 31/32/etc (the finish/rest fields) and never wrote
+  # time_left at all, so a picture saved mid-move round-tripped as though
+  # it had already arrived; #restore_pictures never read the fields needed
+  # to do otherwise.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.show_picture(5, name: 'banner', x: 10, y: 20, zoom: 100,
+                  opacity: 255, red: 100, green: 100, blue: 100, saturation: 100)
+  st.move_picture(5, 210, 120, 50, 0, 40, 60, 80, 100, 40) # -> (210, 120) over 40 frames
+  st.pictures[5].update # one frame already elapsed, so current != its own start
+
+  saved = st.to_lsd[103][5]
+  ok !saved.nil?, 'the mid-move picture is written to chunk 103'
+  eq 39, saved.time_left, 'one frame already elapsed off the saved move'
+  eq st.pictures[5].x, saved.current_x.to_i
+  eq st.pictures[5].y, saved.current_y.to_i
+  eq 210, saved.finish_x.to_i
+  eq 120, saved.finish_y.to_i
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.pictures[5]
+  ok restored.moving?, 'the restored picture resumes as still in flight'
+  eq 39, restored.frames_left
+  eq st.pictures[5].x, restored.x
+  eq st.pictures[5].y, restored.y
+  eq 210, restored.finish_x.to_i
+  eq 120, restored.finish_y.to_i
+
+  # And it keeps gliding, rather than sitting frozen at the restored position.
+  before_x = restored.x
+  restored.update
+  ok restored.x != before_x, 'the resumed move keeps advancing toward its target'
+
+  # A picture at rest (never moved) writes/restores exactly as before --
+  # time_left absent/0 means the new fields are never even consulted.
+  st.show_picture(6, name: 'still', x: 5, y: 5)
+  still_saved = st.to_lsd[103][6]
+  eq 0, (still_saved.time_left || 0)
+  still_round = Game::State.from_lsd(db, st.to_lsd)
+  ok !still_round.pictures[6].moving?, 'a picture never moved restores at rest'
 end
 
 # -- the permanent actor roster (Game::Actors) --------------------------------


### PR DESCRIPTION
## Summary

Chunk 103's save fields 31/32 were declared `current_x`/`current_y` in this codebase's own schema, but they are real RPG_RT's `finish_x`/`finish_y` — a Move Picture's *target*, not its live position (liblcf's own `generator/csv/fields.csv` names them that way; verified directly against a fresh clone). The two happen to coincide exactly at rest, which is why the original field-identification experiment (recorded in `docs/TODO.md`/ADR 0021, a still picture only) could never tell them apart — real RPG_RT re-syncs its live position to the target every idle frame, the same thing `Game::Picture#update` already does here. A picture saved while a Move Picture was still gliding silently snapped straight to its target the instant a save reloaded, instead of resuming the animation.

## How this was verified

Against a genuine `RPG_RT.exe` under wine, not EasyRPG's source. A save was edited so chunk 103's `current_x`/`current_y` (fields 4/5) and `finish_x`/`finish_y` (fields 31/32) deliberately differ, with `time_left` (field 51) still counting down, then resumed under the real runtime: the picture visibly kept gliding from the saved current position toward the saved finish one over the following seconds, rather than sitting statically at either.

## Fix

- `mruby-lcf/mrblib/schema.rb` (`SAVE_PICTURE`): declares the genuinely-live fields this codebase's schema never had at all (4/5 current position, 7/8 current zoom/transparency, 11-14 current tone, 51 `time_left`), and renames the existing 31/32 from `current_x`/`current_y` to `finish_x`/`finish_y` to match liblcf's own field table. Old-save-compatible: `time_left` defaults to 0 (its schema default, and what an old save missing the field entirely also reads as), so `.restore_pictures` never even looks at the new fields unless a genuinely new-format save says a move is in flight.
- `mruby-rpg2k/mrblib/game.rb`: `Game::Picture` gains small `finish_x`/`finish_y`/`finish_zoom`/`finish_opacity`/`finish_red`/`finish_green`/`finish_blue`/`finish_saturation`/`frames_left` readers alongside its existing `#move_to`/`#moving?` — the same shape `Game::Screen#tint_save_data`/`#restore_tint` already used for the screen-tint chunk (PR #1252). `#to_lsd` now writes the `current_*`/`time_left` fields too, but only while a picture is `#moving?` — a still picture's write is byte-for-byte unchanged. `.restore_pictures` shows a mid-move picture at its saved current values, then immediately restarts the move toward the saved finish values over the saved `time_left`.

## Testing

New `scripts/rpg2k_logic_check.rb` check: a picture started moving, advanced one frame, then round-tripped through `to_lsd`/`.from_lsd` resumes `#moving?` with the exact same in-flight position and remaining frame count, and keeps advancing on a further `#update`; a picture at rest round-trips unchanged. One pre-existing check (`to_lsd writes chunk 103...`) updated to use the corrected `finish_x`/`finish_y` accessor names. Confirmed both fail against the pre-fix code via `git stash`.

All four suites green: `rpg2k_scene_check.rb` (869), `rpg2k_logic_check.rb` (1130, +1), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15). Also rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real RPG2000/2003 test-bed data under mruby (not just CRuby) — all 3 runs reached their target scene cleanly.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_