### PR TITLE
rgss: fix Tilemap/Plane ox=/oy= hang, Audio.bgs_play pos, Marshal protocol

### DIFF
--- a/changelog.d/audio-bgs-play-pos-argument.fixed.md
+++ b/changelog.d/audio-bgs-play-pos-argument.fixed.md
@@ -1,0 +1,5 @@
+- Fixed `Audio.bgs_play` rejecting RGSS3's 4th (`pos`) argument, the same gap
+  already fixed for `Audio.bgm_play`. Real stock `RPG::BGS#play` passes `pos`
+  the same way `RPG::BGM#play` does, even though BGS has no seekable backend
+  to resume it with; `Audio.bgs_play` now accepts and ignores a nonzero
+  `pos` (warning once) instead of raising `ArgumentError`.

--- a/changelog.d/mruby-marshal-dump-load-protocol.fixed.md
+++ b/changelog.d/mruby-marshal-dump-load-protocol.fixed.md
@@ -1,0 +1,10 @@
+- Fixed two real bugs in the vendored `mruby-marshal` gem: `Marshal.dump`
+  called a custom `marshal_dump` with a stray argument instead of the zero
+  arguments real Ruby's protocol defines, and `Marshal.load` called a custom
+  `marshal_load` as a class factory method instead of allocating an instance
+  and calling the real instance-level protocol on it. Found because a real
+  VX Ace game's own `Game_Interpreter` defines both the standard way to
+  snapshot its state for a battle. Since this project doesn't control this
+  gem's upstream remote, the fix ships as
+  `patches/mruby-marshal-dump-load-protocol.patch`, applied idempotently at
+  build time by `scripts/apply_mruby_patch.bash`.

--- a/changelog.d/tilemap-plane-ox-oy-redundant-refresh.fixed.md
+++ b/changelog.d/tilemap-plane-ox-oy-redundant-refresh.fixed.md
@@ -1,0 +1,7 @@
+- Fixed `Tilemap#ox=`/`#oy=` and `Plane#ox=`/`#oy=` re-compositing the whole
+  visible tile grid or fog layer on every single frame, even when the camera
+  did not move -- real RGSS treats these as cheap draw-time offsets, since
+  stock `Spriteset_Map#update` reassigns them unconditionally every frame.
+  Found because a real VX Ace game hung for minutes on a stationary camera
+  before drawing its first frame. Fixed by skipping the re-composite when the
+  new value equals the one already stored.

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -112,6 +112,27 @@ function(rpg2k_add_mruby)
   set(mruby_dollar_bang_patch
       "${ARG_REPO_ROOT}/patches/mruby-dollar-bang-scoped.patch")
 
+  # The vendored mruby-marshal gem
+  # (patches/mruby-marshal-dump-load-protocol.patch's own preamble has the full
+  # trail) deviates from real Ruby's marshal_dump/marshal_load protocol two
+  # ways: Marshal.dump calls a custom marshal_dump with a stray nil argument
+  # instead of the zero arguments real Ruby passes it, and Marshal.load calls a
+  # custom marshal_load as a class factory method instead of allocating an
+  # instance and calling the real instance-level protocol on it. Found via a
+  # real VX Ace game's own Game_Interpreter, which defines a real,
+  # standards-conforming pair to control what a battle-start snapshot serializes
+  # -- every VX Ace game reaches this the first time an event's "Battle
+  # Processing" command runs. This gem is its own separate submodule
+  # (`take-cheeze/mruby-marshal`, vendored under 3rd/mruby-marshal rather than
+  # nested in 3rd/mruby's own gem tree), not one this project's own mrbgem tree
+  # carries, so it gets the same patch-in-place treatment as the two 3rd/mruby
+  # patches above -- apply_mruby_patch.bash takes the target directory as a
+  # parameter, so it patches this second checkout, in a different location, with
+  # no changes of its own.
+  set(mruby_marshal_protocol_patch
+      "${ARG_REPO_ROOT}/patches/mruby-marshal-dump-load-protocol.patch")
+  set(mruby_marshal_prefix "${ARG_REPO_ROOT}/3rd/mruby-marshal")
+
   # Point mruby's rake at the vendored mgem-list (the mgem index) via symlinks
   # in its repos/ dir so it resolves gems locally instead of cloning from
   # GitHub. Both repos/host and repos/<TARGET_NAME> are linked: a cross build
@@ -128,6 +149,8 @@ function(rpg2k_add_mruby)
             "${mruby_colon3_patch}"
     COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
             "${mruby_dollar_bang_patch}"
+    COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash"
+            "${mruby_marshal_prefix}" "${mruby_marshal_protocol_patch}"
     COMMAND
       mkdir -p ${mruby_build_dir}/repos/host
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME} && ln -sfn
@@ -137,7 +160,8 @@ function(rpg2k_add_mruby)
       -v
     WORKING_DIRECTORY "${mruby_prefix}"
     DEPENDS "${ARG_REPO_ROOT}/build_config.rb" "${mruby_colon3_patch}"
-            "${mruby_dollar_bang_patch}" ${mrb_files})
+            "${mruby_dollar_bang_patch}" "${mruby_marshal_protocol_patch}"
+            ${mrb_files})
   add_custom_target(mruby_build DEPENDS "${libmruby_a}")
   add_dependencies(mruby mruby_build)
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20863,6 +20863,45 @@ screen (544×416). Full rationale:
     zero-argument case simply re-raises the same tracked value). Ships as
     `patches/mruby-dollar-bang-scoped.patch`; see the item 7 write-up for
     the two earlier, rejected approaches and the full mechanism.
+  - ✅ **`Tilemap#ox=`/`#oy=` and `Plane#ox=`/`#oy=` refreshed on every
+    frame even when unchanged, hanging the same real release for minutes
+    past the `$!` fix.** With `$!` no longer masking it, the release's own
+    crash-reporter stopped hiding the real exception -- and the game hung
+    on something unrelated: real RGSS's stock `Spriteset_Map#update`
+    reassigns `tilemap.ox`/`oy` (and a fog `Plane`'s own) every single
+    frame whether the camera moved or not, cheap in real RGSS (a
+    hardware-composited draw offset) but not in this engine, whose
+    `ox=`/`oy=` re-composited the whole visible tile grid or fog layer
+    from scratch on every call, guard-less. Diagnosed with `gdb` attached
+    to the hung headless process (a real C++ backtrace, not the `$!`
+    write-up's Ruby-level probe) and a temporary call counter confirming
+    hundreds of consecutive calls at the same already-stored value. Fixed
+    by adding a same-value early return to all four setters
+    (`mruby-rgss/src/lib.cxx`); see the item 7 write-up for the fuller
+    trace.
+  - ✅ **`Audio.bgs_play` rejected RGSS3's 4th (`pos`) argument, the same
+    gap `Audio.bgm_play` already had fixed.** Real stock `RPG::BGS#play`
+    passes `pos` the same way `RPG::BGM#play` does, but BGS's own backend
+    has no seekable position to resume (unlike BGM's `Mix_Music`). Fixed
+    by accepting and warning once on a nonzero `pos` rather than raising,
+    matching BGM's own fix history before real seeking was added there --
+    BGS has no seekable backend to build that half on.
+  - ✅ **`Marshal.dump`/`Marshal.load` (vendored `mruby-marshal` gem, its
+    own separate submodule) violated real Ruby's `marshal_dump`/
+    `marshal_load` protocol two ways** — a stray argument passed to
+    `marshal_dump` (real Ruby passes none), and `marshal_load` invoked as
+    a class factory method instead of an allocated instance's own method.
+    Both found via a real VX Ace game's own `Game_Interpreter`, which
+    defines both the real, standard way to control what
+    `BattleManager#save_battle_start_objects` serializes -- reached the
+    first time any event's "Battle Processing" command runs. Ships as
+    `patches/mruby-marshal-dump-load-protocol.patch`; see the item 7
+    write-up for the CRuby confirmation and the fuller trace.
+  - Next wall past all four fixes above: `defined?` called as a method
+    (`NoMethodError: undefined method 'defined?' for Module`) inside the
+    same release's bundled 吹きだしウィンドウ speech-bubble add-on's own
+    event-driven call path -- not yet traced to a specific mruby codegen
+    path.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -780,6 +780,95 @@ existed, the wrapping was never needed for `raise` either — `mrb_f_raise`'s
 zero-argument case now just re-raises `mrb->errinfo` directly when one is
 in scope. Both are fixed by `patches/mruby-dollar-bang-scoped.patch`.
 
+**Found and fixed: with `$!` finally working, the same real VX Ace release's
+crash-reporter add-on stopped masking exceptions -- and the game hung for
+minutes instead, on something that had nothing to do with `$!` at all.**
+Booting past the `マップフォグ` fix with `$!` in place produced total
+silence: no scene transition, no exception, no `[RPGXP-HOST-SCENE]` marker,
+just CPU pinned at 100% for as long as the run was given (tested past four
+minutes). Diagnosed by attaching `gdb` to the running headless process mid-hang
+(a real C++ backtrace, not the temporary `OP_EXCEPT` `fprintf` probe used
+above -- this hang was native, not a masked Ruby exception) and sampling it
+repeatedly: every sample landed inside `Tilemap#ox=`/`#oy=` or
+`Plane#ox=`/`#oy=` (`mruby-rgss/src/lib.cxx`), specifically inside their own
+`tilemap_refresh`/`plane_retile` — a full CPU-side re-composite of the visible
+tile grid or fog layer into an offscreen canvas. A temporary call counter
+confirmed why: hundreds of consecutive calls to the exact same already-stored
+`ox`/`oy` value. Real RGSS's stock `Spriteset_Map#update` reassigns
+`tilemap.ox`/`oy` (and a fog `Plane`'s own ox/oy) unconditionally every
+single frame, whether the camera moved or not — real RGSS treats this as a
+cheap, hardware-composited draw offset, so the redundant reassignment costs
+nothing there. This engine's `ox=`/`oy=` had no such guard, so a
+**stationary** camera still paid a full re-composite every frame. Fixed by
+adding a same-value early return to both setters on both classes (`tilemap_set_ox`/
+`_oy`, `plane_set_ox`/`_oy`) — one frame's worth of camera position, camera
+position, cheap to compare, wildly cheaper than the composite it used to
+force every time regardless. Past this fix, the release now reaches real
+event/battle content within seconds, not minutes.
+
+That real content immediately needed three more, smaller fixes, each just
+past where the last one stopped:
+
+- **Fixed: `Audio.bgs_play` rejected RGSS3's 4th (`pos`) argument** — the
+  same class of gap `Audio.bgm_play`'s `pos` argument fix (above) closed for
+  BGM, left open for BGS. Real RGSS3's stock `RPG::BGS#play` passes `pos` the
+  same way `RPG::BGM#play` does, but BGS's own backend
+  (`Mix_PlayChannel`-based, `src/sdl_audio.cxx`) has no seekable position to
+  resume the way `Mix_Music` does for BGM (this project's own earlier
+  `RPG::BGM#replay` work already noted this: "BGS's own `pos` field exists
+  for save-format fidelity, but its sample-channel backend never reports one
+  to resume from"). Every VX Ace game whose event system plays a BGS via the
+  stock 4-argument call raised `ArgumentError: wrong number of arguments
+  (given 4, expected 1..3)` the moment it ran. Fixed by accepting a 4th
+  `pos = 0` argument and warning once (`RGSS.warn_once`) if it is ever
+  actually nonzero, rather than raising — matching the *first* step of BGM's
+  own fix history, before real seeking was implemented there; BGS has no
+  seekable backend to build the rest of that fix on.
+- **Fixed: `Marshal.dump` called a custom `marshal_dump` with a stray
+  argument.** A real bug in the vendored `mruby-marshal` gem (its own
+  separate submodule, `take-cheeze/mruby-marshal` — not nested in
+  `3rd/mruby`'s own gem tree, so it gets its own patch file the same way):
+  `Marshal.dump` called a class's `marshal_dump` with one argument (a
+  literal `nil`) instead of the zero arguments real Ruby's documented
+  protocol defines for it — a leftover copy/paste from the `marshal_load`
+  call two cases below it in the same function, which legitimately does take
+  one argument (the dumped data). Found via a real VX Ace game's own
+  `Game_Interpreter`, which defines a real, standards-conforming
+  `marshal_dump` (RGSS3's own `BattleManager#save_battle_start_objects`
+  reached the first time any event's "Battle Processing" command runs, to
+  snapshot the interpreter's own state) — `ArgumentError: wrong number of
+  arguments (given 1, expected 0)`, raised from inside
+  `Game_Interpreter#marshal_dump` itself.
+- **Fixed: `Marshal.load` called a custom `marshal_load` as a class method
+  instead of real Ruby's instance-level protocol.** Fixing the argument
+  count above immediately surfaced a second, deeper incompatibility in the
+  same gem: `Marshal.load` called `SomeClass.marshal_load(data)` — a
+  *class*-level factory method expected to return a whole new, fully-restored
+  object — instead of real Ruby's actual protocol, which allocates a new
+  instance *without* running `#initialize` (`Class#allocate`) and then calls
+  the *instance* method `#marshal_load(data)` on that allocation to restore
+  its state in place. `Game_Interpreter#marshal_load` is defined the real,
+  standard way (an instance method), so calling it as a class method raised
+  `NoMethodError: undefined method 'marshal_load' for Class`. Both fixes
+  ship together as `patches/mruby-marshal-dump-load-protocol.patch` (that
+  patch's own preamble has the full trail, including a CRuby confirmation of
+  both directions and why this gem's own bundled test needed updating to the
+  corrected protocol alongside the fix itself).
+
+With all four of these in place, the same real release now runs its own
+`BattleManager#setup` (a full object-graph `Marshal` round-trip) and reaches
+into its bundled 吹きだしウィンドウ ("bubble window") speech-bubble add-on's
+own event-driven call path — new ground for this whole investigation, not
+reached even briefly before. It stops there on a fifth, different-shaped
+issue: `NoMethodError: undefined method 'defined?' for Module`, from inside
+that add-on's own `call_sceman_hukidasi`. `defined?` is ordinarily a Ruby
+*keyword* (`defined?(expr)`), not a real method invoked with a receiver, so
+this reads like an mruby compiler corner case in how some particular
+argument shape to `defined?` gets compiled — plausibly related in spirit to
+the `::Const = value` compiler bug found and fixed earlier in this same
+document, but not yet traced to a specific codegen path the way that one
+was. Left for the next round.
+
 ## What this means for turning the host on
 
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
@@ -796,11 +885,14 @@ only item left in the six sections above; item 7's `$!`/bare-`raise` gap is
 now fixed too (`patches/mruby-dollar-bang-scoped.patch`, above), so the same
 real release's own crash-reporter add-on now sees the actual exception
 instead of masking it behind an unrelated `NoMethodError`, and re-raises it
-correctly. Eleven real bugs have been found and fixed this way so far
+correctly. Fifteen real bugs have been found and fixed this way so far
 (`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
 `Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`,
 `Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`,
-`Sprite#width`/`#height`, the `::Const = value` compiler bug, and `$!`/bare-
-`raise` itself) — the first ten via the temporary VM probe, finding the real
-exception directly regardless of `$!` being masked at the time. Where the
-next wall stands past the `マップフォグ` fix is not yet traced.
+`Sprite#width`/`#height`, the `::Const = value` compiler bug, `$!`/bare-
+`raise` itself, the `Tilemap`/`Plane` `ox=`/`oy=` redundant-refresh hang,
+`Audio.bgs_play`'s `pos` argument, and `Marshal`'s `marshal_dump`/
+`marshal_load` protocol mismatches) — the first ten via the temporary VM
+probe, finding the real exception directly regardless of `$!` being masked
+at the time. Where the next wall stands past `defined?` being called as a
+method inside 吹きだしウィンドウ's own event path is not yet traced.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1142,7 +1142,14 @@ module RGSS
         _bgm_pos
       end
 
-      def bgs_play(filename, volume = 100, pitch = 100)
+      # `pos` mirrors #bgm_play's 4th argument -- RGSS3's stock RPG::BGS#play
+      # passes it the same way RPG::BGM#play does -- but BGS has no seekable
+      # backend to honour it with (see #play_packed's own comment: its
+      # sample-channel playback never reports a position to resume from), so
+      # it is accepted and, if actually nonzero, warned about once rather
+      # than raising ArgumentError on every game that calls #play this way.
+      def bgs_play(filename, volume = 100, pitch = 100, pos = 0)
+        RGSS.warn_once("Audio.bgs_play: pos is not supported; ignoring") if pos != 0
         path = resolve(filename, MUSIC_DIRS)
         return _bgs_play(path, volume, pitch) if path
         play_packed(:bgs, filename, volume, pitch)

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -3817,9 +3817,17 @@ mrb_value plane_set_bmp(mrb_state* M, mrb_value self) {
   return bmp;
 }
 
+// Same same-value guard as Tilemap#ox=/#oy= (see the comment there): real
+// RGSS reassigns a Plane's ox/oy every frame regardless of whether it moved
+// (a fog/parallax layer scrolling with the map), and this engine's retile is
+// a CPU-side re-composite rather than a cheap draw-time offset, so without
+// this guard a stationary Plane still pays a full retile every frame.
 mrb_value plane_set_ox(mrb_state* M, mrb_value self) {
   mrb_int ox;
   mrb_get_args(M, "i", &ox);
+  const mrb_value cur = mrb_iv_get(M, self, mrb_intern_lit(M, "@ox"));
+  if (mrb_fixnum_p(cur) && mrb_fixnum(cur) == ox)
+    return self;
   mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(ox));
   plane_retile(M, self);
   return self;
@@ -3828,6 +3836,9 @@ mrb_value plane_set_ox(mrb_state* M, mrb_value self) {
 mrb_value plane_set_oy(mrb_state* M, mrb_value self) {
   mrb_int oy;
   mrb_get_args(M, "i", &oy);
+  const mrb_value cur = mrb_iv_get(M, self, mrb_intern_lit(M, "@oy"));
+  if (mrb_fixnum_p(cur) && mrb_fixnum(cur) == oy)
+    return self;
   mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(oy));
   plane_retile(M, self);
   return self;
@@ -5000,9 +5011,21 @@ mrb_value tilemap_set_visible(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// Real RGSS treats `ox`/`oy` as a cheap, hardware-composited draw offset --
+// stock Spriteset_Map#update reassigns it every single frame regardless of
+// whether the camera actually moved. This engine instead re-composites the
+// whole visible tile grid into a CPU-side canvas on every assignment, so
+// without a same-value guard, a stationary camera still pays a full refresh
+// every frame -- observed via a real VX Ace game's boot hanging for minutes
+// on hundreds of consecutive `ox=`/`oy=` calls, each to the exact same
+// value already stored, before the game's own script host ever reaches its
+// first Graphics.update.
 mrb_value tilemap_set_ox(mrb_state* M, mrb_value self) {
   mrb_int v;
   mrb_get_args(M, "i", &v);
+  const mrb_value cur = mrb_iv_get(M, self, mrb_intern_lit(M, "@ox"));
+  if (mrb_fixnum_p(cur) && mrb_fixnum(cur) == v)
+    return self;
   mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(v));
   tilemap_refresh(M, self);
   return self;
@@ -5011,6 +5034,9 @@ mrb_value tilemap_set_ox(mrb_state* M, mrb_value self) {
 mrb_value tilemap_set_oy(mrb_state* M, mrb_value self) {
   mrb_int v;
   mrb_get_args(M, "i", &v);
+  const mrb_value cur = mrb_iv_get(M, self, mrb_intern_lit(M, "@oy"));
+  if (mrb_fixnum_p(cur) && mrb_fixnum(cur) == v)
+    return self;
   mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(v));
   tilemap_refresh(M, self);
   return self;

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -126,6 +126,46 @@ assert "RGSS::Color equality and marshal" do
   assert_true a == loaded
 end
 
+# Regression test for two real bugs in the vendored 3rd/mruby-marshal gem
+# (patches/mruby-marshal-dump-load-protocol.patch's own preamble has the
+# full trail), both found via a real VX Ace game's own Game_Interpreter
+# (which defines a real, standards-conforming marshal_dump/marshal_load pair
+# to control what its own battle-start snapshot serializes --
+# BattleManager#setup, reached the first time any event's "Battle
+# Processing" command runs):
+#
+#   - Marshal.dump called a custom marshal_dump with one (stray nil)
+#     argument instead of the zero arguments real Ruby's protocol defines,
+#     raising ArgumentError on any class that defines one.
+#   - Marshal.load called a custom marshal_load as a *class* factory method
+#     (`klass.marshal_load data`, returning a whole new object) instead of
+#     real Ruby's protocol -- allocate a new instance without running
+#     #initialize, then call the *instance* method `#marshal_load(data)` on
+#     it to restore state in place -- raising NoMethodError on any class
+#     whose marshal_load is defined the standard way (an instance method,
+#     not `self.`).
+class RGSSTestMarshalDump
+  def initialize(v = nil)
+    @v = v
+  end
+
+  attr_reader :v
+
+  def marshal_dump
+    @v
+  end
+
+  def marshal_load(v)
+    @v = v
+  end
+end
+
+assert "Marshal round-trips a custom marshal_dump/marshal_load pair" do
+  loaded = Marshal.load(Marshal.dump(RGSSTestMarshalDump.new(42)))
+  assert_true loaded.is_a?(RGSSTestMarshalDump)
+  assert_equal 42, loaded.v
+end
+
 assert "RGSS::Tone basics and clamping" do
   t = RGSS::Tone.new(-300, 20, 30, 400)
   assert_equal(-255.0, t.red) # clamped to -255..255
@@ -1585,6 +1625,15 @@ end
 # accepted it.
 assert "RGSS::Audio.bgm_play accepts RGSS3's 4th (pos) argument" do
   assert_nil RGSS::Audio.bgm_play("Theme1", 80, 90, 5)
+end
+
+# Same RGSS3 4th (pos) argument as bgm_play above, but real stock RPG::BGS#play
+# passes it too -- BGS has no seekable backend to honour it with (unlike BGM,
+# its playback is a one-shot sample channel), so unlike bgm_play this accepts
+# and ignores a nonzero pos rather than raising ArgumentError on every VX Ace
+# game whose event system plays a BGS the stock way.
+assert "RGSS::Audio.bgs_play accepts RGSS3's 4th (pos) argument" do
+  assert_nil RGSS::Audio.bgs_play("Theme1", 80, 90, 5)
 end
 
 assert "RGSS::Audio.se_play resolves a name to a real file" do

--- a/patches/mruby-marshal-dump-load-protocol.patch
+++ b/patches/mruby-marshal-dump-load-protocol.patch
@@ -1,0 +1,110 @@
+mruby-marshal bugs: two ways `Marshal.dump`/`Marshal.load` deviate from
+real Ruby's documented `marshal_dump`/`marshal_load` protocol for a class
+that defines both.
+
+1. `Marshal.dump` called a custom `marshal_dump` with one (stray) argument
+   -- a literal `nil` -- instead of the zero arguments real Ruby's protocol
+   defines for it. Only the load half, `marshal_load(data)`, takes an
+   argument. `mrb_funcall(M, v, "marshal_dump", 1, mrb_nil_value())` at the
+   dump call site looks like a copy/paste of the load call two cases below
+   it, never given its own zero-argument fix.
+
+2. `Marshal.load` called a custom `marshal_load` as a *class* factory
+   method -- `klass.marshal_load(data)`, expected to return a whole new,
+   fully-restored object -- instead of real Ruby's protocol: allocate a new
+   instance *without* running `#initialize` (`Class#allocate`, the same
+   public entry point user code would reach for), then call the *instance*
+   method `#marshal_load(data)` on that allocated instance to restore its
+   state in place. `Marshal.load`'s own result is always this allocated-
+   then-restored object, not whatever `marshal_load` itself happens to
+   return.
+
+Found via a real VX Ace game whose `Game_Interpreter` defines a real,
+standards-conforming `marshal_dump`/`marshal_load` pair (an instance
+method, not `self.marshal_load`, and `marshal_dump` takes no arguments) to
+control what its own battle-start snapshot serializes
+(`BattleManager#save_battle_start_objects`, a stock RGSS3 mechanism --
+every VX Ace game reaches this the first time an event's "Battle
+Processing" command runs). Bug 1 alone raised `ArgumentError: wrong number
+of arguments (given 1, expected 0)` from inside `Game_Interpreter
+#marshal_dump` itself; fixing only that surfaced bug 2 immediately after,
+as `NoMethodError: undefined method 'marshal_load' for Class` -- the class
+object has no `marshal_load` of its own, only the instance method the dump
+half's real counterpart defines.
+
+Confirmed against real CRuby: `class Foo; def marshal_dump; 1; end; def
+marshal_load(v); @v = v; end; end; Marshal.load(Marshal.dump(Foo.new))`
+round-trips correctly with marshal_dump taking no arguments and
+marshal_load defined as an ordinary instance method -- the reverse of what
+this gem required before this patch (a required argument on marshal_dump
+raises `ArgumentError: wrong number of arguments (given 0, expected 1)` in
+real Ruby, proof it calls marshal_dump with zero; a `self.marshal_load`
+class method is never invoked by real `Marshal.load` at all).
+
+This gem's own bundled test/marshal.rb exercised the old, incorrect
+protocol directly (`ObjectDumper` defined `self.marshal_load` returning a
+new instance), so it is updated here too to the real protocol its
+`check_load_dump` helper already tests through (`assert_equal obj,
+load(data)`, which only needs the loaded object to compare `==` true, not
+to preserve identical internal state) -- otherwise this fix would leave
+the gem's own test suite calling a class method that no longer exists on
+`ObjectDumper` and asserting behavior no real Ruby class actually needs.
+
+This project doesn't control this gem's upstream remote (a separate
+`take-cheeze/mruby-marshal` repository, vendored as its own submodule under
+`3rd/mruby-marshal` rather than nested in `3rd/mruby`'s own gem tree), so
+the fix ships the same way as the `3rd/mruby` patches above it: applied
+idempotently at build time by `scripts/apply_mruby_patch.bash`, which
+takes the target directory as a parameter and so needs no changes of its
+own to patch a second, differently-located submodule checkout.
+
+--- a/src/marshal.cpp
++++ b/src/marshal.cpp
+@@ -253,7 +253,11 @@ write_context<Out>& write_context<Out>::marshal(mrb_value const& v, mrb_int limi
+
+   // check marshal_dump
+   if(mrb_obj_respond_to(M, cls, mrb_intern_lit(M, "marshal_dump"))) {
+-    return klass('U', v, false).marshal(mrb_funcall(M, v, "marshal_dump", 1, mrb_nil_value()), limit);
++    // marshal_dump takes no arguments (unlike marshal_load below, which takes
++    // the one dumped value back) -- this used to pass a stray nil, raising
++    // ArgumentError on any class defining a standards-conforming
++    // marshal_dump, such as a real VX Ace game's own Game_Interpreter.
++    return klass('U', v, false).marshal(mrb_funcall(M, v, "marshal_dump", 0), limit);
+   }
+   // check _dump
+   if(mrb_obj_respond_to(M, cls, mrb_intern_lit(M, "_dump"))) {
+@@ -546,8 +550,17 @@ mrb_value read_context<In>::marshal() {
+
+     case 'U': { // marshal_load / marshal_dump defined class
+       mrb_sym const cls = symbol();
+-      ret = mrb_funcall(M, mrb_obj_value(path2class(cls)),
+-                         "marshal_load", 1, marshal());
++      // Real Ruby's protocol: allocate a new instance *without* calling
++      // #initialize (Class#allocate, the same public entry point user code
++      // would reach for), then call the *instance* method
++      // #marshal_load(data) on it to restore state in place -- not a
++      // class-level factory method returning a fresh object. Marshal.load's
++      // own result is always this allocated-then-restored object, not
++      // whatever marshal_load itself happens to return.
++      mrb_value const obj = mrb_funcall(M, mrb_obj_value(path2class(cls)),
++                                         "allocate", 0);
++      mrb_funcall(M, obj, "marshal_load", 1, marshal());
++      ret = obj;
+       register_link(id, ret);
+       break;
+     }
+--- a/test/marshal.rb
++++ b/test/marshal.rb
+@@ -186,10 +186,9 @@ assert 'user defined marshal method' do
+   check_load_dump BinaryDumper.new, "u:\x11BinaryDumper\ttest"
+
+   class ObjectDumper
+-    def marshal_dump a = 0; 'test' end
+-    def self.marshal_load str, a = 0
++    def marshal_dump; 'test' end
++    def marshal_load str
+       assert_equal 'test', str
+-      ObjectDumper.new
+     end
+     def == o; o.kind_of? ObjectDumper end
+   end


### PR DESCRIPTION
## Summary

Continuing straight from the just-merged `$!`/bare-`raise` fix (#1256): with that masking gone, a real VX Ace game's own crash-reporter add-on stopped hiding exceptions — and immediately hit four more real bugs, each discovered by fixing the one before it and re-running the boot.

- **`Tilemap#ox=`/`#oy=` and `Plane#ox=`/`#oy=` hung the game for minutes on a stationary camera.** Real RGSS's stock `Spriteset_Map#update` reassigns these every single frame whether the camera moved or not — cheap in real RGSS (a hardware-composited draw offset), but this engine re-composited the whole visible tile grid / fog layer from scratch on every call, with no same-value guard. Diagnosed by attaching `gdb` to the hung headless process and a temporary call counter confirming hundreds of consecutive calls at the same already-stored value. Fixed with a same-value early return on all four setters.
- **`Audio.bgs_play` rejected RGSS3's 4th (`pos`) argument** — the same gap already fixed for `Audio.bgm_play`. BGS has no seekable backend to honor it with, so it's now accepted and warned about once rather than raising `ArgumentError`.
- **`Marshal.dump`/`Marshal.load` (vendored `mruby-marshal` gem) violated real Ruby's protocol two ways**: a stray argument passed to `marshal_dump` (real Ruby passes none), and `marshal_load` invoked as a class factory method instead of the real instance-level protocol on an allocated object. Both found via the same game's own `Game_Interpreter`, which defines both the standard way to snapshot state for `BattleManager#setup`.

Ships as `patches/mruby-marshal-dump-load-protocol.patch` (this gem is its own separate submodule, `take-cheeze/mruby-marshal`, not nested in this project's own mrbgem tree) alongside the `mruby-rgss` native/mrblib fixes. Full trace for all four in `docs/rpgvx-rgss-api-gap.md`.

## Verification

- [x] Full mruby test suite: 1846 OK, 0 KO, 0 Crash.
- [x] New regression tests: `Tilemap`/`Plane` guards are exercised implicitly through the existing engine test paths; `Audio.bgs_play` and `Marshal.dump`/`load` round-trip get dedicated new tests in `mruby-rgss/test/test.rb`.
- [x] Verified against the real, unmodified VX Ace release these were all found on: with all four fixes, the game now runs its own `BattleManager#setup` (a full `Marshal` round-trip) and reaches into its bundled speech-bubble add-on's own event-driven call path — new ground not reached even briefly before this PR. It stops there on a fifth, different-shaped issue (`defined?` called as a method, `NoMethodError: undefined method 'defined?' for Module`) — documented as the next lead in `docs/TODO.md` and `docs/rpgvx-rgss-api-gap.md`, not fixed here.
- [x] Verified the new `mruby-marshal` patch applies cleanly from a clean submodule checkout, and that the normal CMake/ninja build path applies all three patches (colon3, dollar-bang, marshal) automatically.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_