### PR TITLE
Bump mruby-marshal to fix marshal_dump/marshal_load calling convention

### DIFF
--- a/changelog.d/mruby-marshal-dump-load-protocol-bump.fixed.md
+++ b/changelog.d/mruby-marshal-dump-load-protocol-bump.fixed.md
@@ -1,0 +1,9 @@
+- **Bumped the vendored `mruby-marshal` submodule** to pick up a fix for
+  `Marshal.dump`/`Marshal.load`'s calling convention with a custom
+  `marshal_dump`/`marshal_load` pair, found via a real RPG Maker VX Ace game
+  whose `Game_Interpreter` defines one. `Marshal.dump` passed a stray extra
+  argument to `marshal_dump` (real Ruby's protocol takes none), raising
+  `ArgumentError`; `Marshal.load` called `marshal_load` as a class factory
+  method instead of allocating a new instance and restoring it in place via
+  the instance method real Ruby's protocol defines, raising `NoMethodError`
+  once the first bug was worked around. Both now match real Ruby.


### PR DESCRIPTION
## Summary

Bumps the vendored `3rd/mruby-marshal` submodule (`c395ef3` → `7da40de`) to
pick up [take-cheeze/mruby-marshal#48](https://github.com/take-cheeze/mruby-marshal/pull/48):

- `Marshal.dump` passed a stray extra argument to a custom `marshal_dump`
  (real Ruby's protocol takes none), raising `ArgumentError`.
- `Marshal.load` called `marshal_load` as a class factory method instead of
  allocating a new instance and restoring it in place via the instance
  method real Ruby's protocol defines, raising `NoMethodError` once the
  first bug was worked around.

Found via a real RPG Maker VX Ace game whose `Game_Interpreter` defines a
standards-conforming `marshal_dump`/`marshal_load` pair. Both directions now
match real CRuby's behavior.

`rpg-maker-clone`'s own mrblib defines no `marshal_dump`/`marshal_load`
itself, so this is a pure dependency bump — no adjacent code changes.

## Test plan

- [x] Full native build (`scripts/native-build-without-nix.bash`) compiles
      and links cleanly
- [x] `cmake --build build -t test` — `mruby_test` passes (now exercising
      mruby-marshal's own corrected test suite); every other ctest passes
      except `exe_open`, which only fails because the real-game test-bed
      data isn't downloaded in this environment (pre-existing, unrelated)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 869 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1130 checks passed

---
_Generated by [Claude Code](https://claude.ai/code/session_017C1i41GuWNEwKfPSHHUTra)_