### PR TITLE
Persist a live Change Parameters edit through Save/Continue

### DIFF
--- a/changelog.d/change-param-mod-save-continue.fixed.md
+++ b/changelog.d/change-param-mod-save-continue.fixed.md
@@ -1,0 +1,5 @@
+- **Save/Continue:** a live Change Parameters edit to an actor's Max HP/MP or
+  ATK/DEF/SPI/AGI now survives a real save/load, matching RPG_RT -- previously
+  it silently reverted to the bare level-curve value the instant the save
+  reloaded, even though this same adjustment already round-tripped correctly
+  through this engine's own portable save format.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11128,6 +11128,39 @@ not yet verified:
   class or command id would coincidentally already be blocked by the
   existing per-id existence checks on a table-less database, masking the
   actual gap), confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-22): the deferred Change-Parameters stat-mod
+  fields are now done too.** The "genuine unit conversion" concern that
+  deferred `attack_mod`/`defense_mod`/`spirit_mod`/`agility_mod`/`hp_mod`/
+  `sp_mod` above turns out already solved by this codebase's own existing
+  `#change_param`, which the fix reuses rather than re-deriving: `@base_raw`
+  (the absolute curve+mod running total) minus `#base_stats(level)` (the
+  bare curve at the actor's *current* level, already reading through
+  `#curve_row` so it transparently picks the class curve once Change Class
+  has run) isolates the same delta EasyRPG's own `*_mod` fields represent —
+  exactly the arithmetic `#change_param` itself already performs
+  (`@base_raw[type] - curve + delta`), just run in reverse to serialise
+  instead of to apply a new edit. Confirmed against a genuine RPG_RT.exe,
+  not EasyRPG's source: a real save was edited to set field 41
+  (`attack_mod`) on a known actor, resumed under the real runtime, and the
+  Equip screen's displayed ATK changed by exactly that amount; field 33
+  (`hp_mod`) likewise changed the Status screen's displayed Max HP by
+  exactly that amount, confirming both the field ids and that the +delta
+  lands on the *effective* stat the same way `#change_param` already
+  assumes. liblcf's own generator table (`generator/csv/fields.csv`) marks
+  `hp_mod`/`sp_mod`'s default as **-1** (its own "never touched" sentinel,
+  unlike the other four fields' plain **0**) — read specially so a genuine
+  third-party save's own untouched sentinel isn't misread as a real -1 HP
+  modifier, though this codebase's own writer never needs to care (it omits
+  the whole field range outright when nothing changed, the same
+  eliding-writer convention every sibling field on this chunk already
+  follows). Fixed in `Game::State#to_lsd`/`.from_lsd`
+  (`mruby-rpg2k/mrblib/game.rb`) and `LCF::Schema::SAVE_PARTY_ACTOR`
+  (`mruby-lcf/mrblib/schema.rb`, fields 33/34/41-44). Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (six deliberately distinguishable
+  Change Parameters deltas, one per stat, all round-trip through a real
+  `.lsd` write/read exactly; an actor nobody ever ran the command on writes
+  none of the six fields and round-trips to the bare level curve),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A Change Actor Sprite / Change Vehicle Graphic override's *index* now
   round-trips through `.lsd` at the correct liblcf tag — it was being
   written to, and read from, the wrong field of the save's hero/vehicle

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1307,6 +1307,27 @@ module LCF
       # declare yet -- 0 (RowType_front) is both liblcf's own default and the
       # only row RPG2000 ever writes.
       91 => { name: :row, type: :int, default: 0 }, # 隊列 (2003)
+
+      # The live Change Parameters shadow (Game::Actor#change_param's
+      # @base_raw, isolated from the level curve) -- confirmed against a
+      # genuine RPG_RT.exe, not just liblcf's field table: editing field 41
+      # (attack_mod) on a real save and resuming changed the Equip screen's
+      # displayed ATK by exactly that amount; editing field 33 (hp_mod)
+      # likewise changed the Status screen's Max HP by exactly that amount.
+      # liblcf's own generator table (`generator/csv/fields.csv`) marks
+      # hp_mod/sp_mod's default as -1, unlike the other four (0) -- an actor
+      # that has never had a Change Parameters edit at all always leaves
+      # this whole field range absent, so -1 vs. 0 never actually matters to
+      # this codebase's own writer (see #to_lsd's own comment), but the -1
+      # default is kept here to read a genuine third-party save's own
+      # "never touched" sentinel the same way liblcf itself does, rather
+      # than misreading it as a real -1 HP modifier.
+      33 => { name: :hp_mod, type: :int, default: -1 },
+      34 => { name: :sp_mod, type: :int, default: -1 },
+      41 => { name: :attack_mod, type: :int, default: 0 },
+      42 => { name: :defense_mod, type: :int, default: 0 },
+      43 => { name: :spirit_mod, type: :int, default: 0 },
+      44 => { name: :agility_mod, type: :int, default: 0 },
     }
 
     # https://w.atwiki.jp/rpg2kpsp/pages/37.html

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14544,6 +14544,20 @@ module Game
         # RPG2000 save (or a 2003 save whose party never touched Row) never
         # gains the field.
         e[91] = a.battle_row if a.battle_row != Battle::ROW_FRONT
+        # A live Change Parameters edit (#change_param) survives Save/
+        # Continue too -- see SAVE_PARTY_ACTOR's own comment for the
+        # genuine-RPG_RT verification. `@base_raw` is the curve plus this
+        # modifier with no equipment folded in, so subtracting the curve
+        # back out isolates the same delta #change_param itself computes;
+        # only written per-stat when actually nonzero, the same
+        # eliding-writer convention every field above follows.
+        raw = a.base_raw
+        curve = a.base_stats(a.level)
+        # Field ids in STAT_NAMES order (max_hp, max_mp, atk, def, int, agi).
+        [33, 34, 41, 42, 43, 44].each_with_index do |field, i|
+          delta = raw[i] - curve[i]
+          e[field] = delta if delta != 0
+        end
         actors[a.id] = e
       end
       save[108] = actors
@@ -14875,6 +14889,24 @@ module Game
           actor.restore_class(cid) if cid && cid != -1
           actor.set_level(sa.level) if sa.level
           actor.exp = sa.exp if sa.exp
+          # A live Change Parameters edit (#change_param) -- #set_level just
+          # above re-seeds @base/@base_raw from the level-derived baseline,
+          # discarding it, so it's restored after, the same order the
+          # Marshal-save path (Party#load_state) already uses. hp_mod/sp_mod
+          # (fields 33/34) default to -1 (liblcf's own "never touched"
+          # sentinel, distinct from a real 0 the other four fields already
+          # use); the other four default to 0 outright. Confirmed against a
+          # genuine RPG_RT.exe -- see SAVE_PARTY_ACTOR's own comment.
+          hp_mod = sa.hp_mod
+          sp_mod = sa.sp_mod
+          mods = [hp_mod && hp_mod != -1 ? hp_mod : 0,
+                  sp_mod && sp_mod != -1 ? sp_mod : 0,
+                  sa.attack_mod || 0, sa.defense_mod || 0,
+                  sa.spirit_mod || 0, sa.agility_mod || 0]
+          if mods.any? { |m| m != 0 }
+            curve = actor.base_stats(actor.level)
+            actor.restore_base(curve.each_index.map { |i| curve[i] + mods[i] })
+          end
           actor.equip(sa.equipment) if sa.equipment
           actor.skills = sa.skills if sa.skills
           actor.states = sa.states if sa.states

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4126,6 +4126,53 @@ check 'to_lsd/from_lsd round-trips a Change Battle Commands edit with no ' \
   eq false, restored.class_changed?, 'and no spurious class change was recorded'
 end
 
+check 'to_lsd/from_lsd round-trips a live Change Parameters edit on every ' \
+      'base stat' do
+  # Confirmed against a genuine RPG_RT.exe, not EasyRPG's source: a real
+  # save was edited to set chunk 108 field 41 (attack_mod) on a known actor,
+  # resumed under real RPG_RT, and the Equip screen's displayed ATK changed
+  # by exactly that amount; field 33 (hp_mod) likewise changed the Status
+  # screen's displayed Max HP by exactly that amount. #to_lsd/.from_lsd
+  # never touched fields 33/34/41-44 at all, so a live Change Parameters
+  # edit -- #change_param's own @base_raw shadow, already correctly
+  # round-tripped through this engine's own Marshal save format via
+  # Actor#restore_base -- silently reverted to the level curve's bare value
+  # the instant a genuine Save/Continue ran.
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.leader
+  # Six distinguishable deltas -- one per stat, no two the same -- so a
+  # field mixup (e.g. hp_mod's field id swapped with atk_mod's) shows up as
+  # a wrong value rather than passing by coincidence.
+  a.change_param(Game::Actor::PARAM_MAX_HP, 50)
+  a.change_param(Game::Actor::PARAM_MAX_MP, 20)
+  a.change_param(Game::Actor::PARAM_ATK, 7)
+  a.change_param(Game::Actor::PARAM_DEF, -1)
+  a.change_param(Game::Actor::PARAM_INT, 13)
+  a.change_param(Game::Actor::PARAM_AGI, 17)
+  eq [60, 25, 10, 1, 14, 21], [a.max_hp, a.max_mp, a.atk, a.def, a.int, a.agi]
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.party.leader
+  eq [60, 25, 10, 1, 14, 21],
+     [restored.max_hp, restored.max_mp, restored.atk, restored.def, restored.int, restored.agi],
+     'every Change Parameters edit survives Save/Continue via a real .lsd, not just this engine\'s own Marshal format'
+
+  # An actor nobody ever ran Change Parameters on writes none of the six
+  # fields at all -- the same "omit when nothing to restore" convention
+  # chunk 102/111's own overrides already follow -- and round-trips to the
+  # bare level curve, not some stray zero-delta entry.
+  untouched_db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1])
+  untouched_st = Game::State.new(Game::Party.new(untouched_db), 1, 0, 0)
+  saved = untouched_st.to_lsd[108][1]
+  eq 0, saved.attack_mod, 'no Change Parameters this session means no mod fields written -- reads back at the neutral default'
+  untouched_round = Game::State.from_lsd(untouched_db, untouched_st.to_lsd)
+  eq [10, 5, 3, 2, 1, 4],
+     [untouched_round.party.leader.max_hp, untouched_round.party.leader.max_mp,
+      untouched_round.party.leader.atk, untouched_round.party.leader.def,
+      untouched_round.party.leader.int, untouched_round.party.leader.agi]
+end
+
 check 'to_lsd/from_lsd leaves an actor untouched by either command exactly ' \
       'as it was' do
   players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,


### PR DESCRIPTION
## Summary

`Game::State#to_lsd`/`.from_lsd` never touched chunk 108's `attack_mod`/`defense_mod`/`spirit_mod`/`agility_mod`/`hp_mod`/`sp_mod` fields, so a live Change Parameters adjustment (a database editor's Change Parameters event command) silently reverted to the bare level-curve value the instant a real `.lsd` save reloaded — even though the same delta already round-trips correctly through this engine's own portable Marshal save format, via `Actor#restore_base`.

## How this was verified

Against a genuine `RPG_RT.exe` under wine, not EasyRPG's source. A real save was edited to set chunk 108 field 41 (`attack_mod`) on a known actor and resumed under the real runtime: the Equip screen's displayed ATK changed by exactly that amount. Field 33 (`hp_mod`) was independently tested the same way: the Status screen's displayed Max HP changed by exactly that amount — confirming both the field ids (cross-checked against liblcf's own `generator/csv/fields.csv`) and that the delta lands additively on the effective stat, matching this codebase's own `#change_param` formula.

## Why this was previously deferred

An earlier cycle's TODO.md note flagged these fields as a "distinct, deliberately deferred follow-up," reasoning that EasyRPG stores them as deltas from the *currently active* curve (the class curve, once Change Class has run) rather than this engine's own absolute `@base_raw` running total, and worried round-tripping correctly would need "a genuine unit conversion... not just a field mapping." That conversion turns out to already exist: `@base_raw[i] - #base_stats(level)[i]` isolates exactly that delta, since `#base_stats` already reads through `#curve_row` and transparently follows a live Change Class — this is literally `#change_param`'s own existing arithmetic (`@base_raw[type] - curve + delta`), just run in reverse to serialise instead of to apply a new edit.

## Fix

- `mruby-lcf/mrblib/schema.rb` (`SAVE_PARTY_ACTOR`): declares the six fields. `hp_mod`/`sp_mod` default to **-1** (liblcf's own "never touched" sentinel, distinct from a real 0) per its own field table; the other four default to plain 0.
- `mruby-rpg2k/mrblib/game.rb`: `#to_lsd` writes each field only when the isolated delta is actually nonzero (the same eliding-writer convention every sibling field on this chunk already follows). `.from_lsd` reconstructs the six-element `base_raw` array and calls the already-existing `Actor#restore_base`, positioned right after `set_level`/`exp=` — mirroring the exact ordering the Marshal-save path (`Party#load_state`) already uses, since `#set_level` re-seeds `@base_raw` from the bare curve and would otherwise discard the restored modifier.

## Testing

New `scripts/rpg2k_logic_check.rb` check: six deliberately distinguishable Change Parameters deltas (one per stat, no two the same, so a field-id mixup shows up as a wrong value rather than passing by coincidence) all round-trip through a real `.lsd` write/read exactly; an actor nobody ever ran the command on writes none of the six fields at all and round-trips to the bare level curve. Confirmed it fails against the pre-fix code via `git stash`.

All four suites green: `rpg2k_scene_check.rb` (869), `rpg2k_logic_check.rb` (1131, +1), `rpg2k3_battle_row_check.rb` (18), `rpg2k3_battle_gauge_check.rb` (15). Also rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real RPG2000/2003 test-bed data under mruby (not just CRuby) — all 3 runs reached their target scene cleanly.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_