### PR TITLE
Write the camera scroll to save-exported chunk 111 (fields 1/2)

### DIFF
--- a/changelog.d/save-camera-scroll-write.fixed.md
+++ b/changelog.d/save-camera-scroll-write.fixed.md
@@ -1,0 +1,6 @@
+- **Save/Continue export:** RPG_RT restores the camera from the save instead
+  of deriving it from the hero, so a save this engine exported for a genuine
+  RPG_RT or EasyRPG to load now carries the camera's top-left pixel (chunk
+  111 fields 1/2) — previously it was never written, so loading one of our
+  saves in the real runtime rendered the map's top-left corner instead of
+  the hero-centred view.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -257,6 +257,43 @@ The work below is roughly ordered by the critical path to a walkable game
     position and remaining frames, and keeps advancing on a further
     `#update`; a picture at rest still round-trips unchanged), confirmed to
     fail against the pre-fix code.
+    ✅ **Follow-up (2026-08-22): `to_lsd` now writes the camera scroll too
+    (chunk 111 fields 1/2, `scroll_x`/`scroll_y`) — every save this engine
+    exported for a genuine RPG_RT/EasyRPG to load rendered the map's
+    top-left corner instead of the hero-centred view, and the write was
+    skipped entirely (the whole chunk 111 was omitted) on the common case
+    of an untouched map with no live event/substitution/encounter/parallax
+    override.** This codebase's own `game.rb` doc comment on the write site
+    had claimed the omission was fine, "matching the 'view derives from the
+    hero' fallback ADR 0021 documents" — backwards: ADR 0021's own
+    "comparing an ordinary map" addendum, added 2026-08-04 from a genuine
+    RPG_RT capture, already recorded the opposite finding directly above
+    that comment's citation — RPG_RT restores the camera from the save
+    rather than deriving it from the hero, and an edited save with these
+    fields absent drew (0, 0), the map's top-left corner, regardless of
+    the hero's tile. That finding was acted on for `scripts/gen-rpg2k-save.rb`
+    (a test-harness helper that edits a save to move the party) at the
+    time, but never for this engine's own `#to_lsd`, the code path a real
+    player's Save actually runs. Fixed by computing the same 1/16-pixel
+    top-left `Game.camera_offset` already derives every frame in
+    `Scene::Map#camera_position` — `Game.camera_offset(hero_px + TILE/2,
+    SCREEN_W/H, self.map.width/height * TILE)` — from `State#x`/`#y` (tile
+    coordinates, matching the hero record's own chunk 104 fields) and the
+    now-attached `State#map`, and widening the chunk-111 write guard to
+    fire whenever a map is loaded (previously it fired only when some
+    *other* chunk-111 field was also live). This is a write-only fix:
+    `.from_lsd` still does not consume `scroll_x`/`scroll_y` and does not
+    need to — this engine's own renderer derives the camera live from the
+    hero every frame regardless, so an unmodelled reader is not a gap, only
+    real RPG_RT/EasyRPG needs the field populated on the way out. Covered
+    by a new `scripts/rpg2k_logic_check.rb` check (a 30x30-tile map, hero
+    at tile (10, 10) — far enough from every edge that the camera centres
+    rather than clamps, disambiguating "hero-centred" from both "always
+    (0, 0)" and an unclamped "hero pixel verbatim" — asserts the exact
+    expected `scroll_x`/`scroll_y`, and that chunk 111 is written at all
+    with no other override live; a State with no map loaded still omits
+    chunk 111 entirely, unaffected), confirmed to fail against the pre-fix
+    code.
   - ✅ **`Game::State#to_lsd` output is loadable by RPG_RT.** It round-tripped
     through our own parser (`scripts/lcf_save_roundtrip.rb`) but the genuine
     runtime left "Continue" dead, with no error anywhere. The assumed cause —

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14723,19 +14723,32 @@ module Game
       # own live event table, mirrored straight from #map_event_positions/
       # #map_event_route_index, plus its Tile Substitution table
       # (#tile_substitutions, fields 21/22), a live Change Encounter Rate
-      # override (#encounter_rate, field 3) and a live Change Parallax
-      # Background override (#parallax, fields 32-38) -- all five already
-      # scoped to the current map only, see their own doc comments above.
-      # Camera scroll (SAVE_MAP_EVENT fields 1/2) is not modelled by this
-      # codebase, so it stays absent, matching the "view derives from the
-      # hero" fallback ADR 0021 documents. Omitted entirely on a State with
-      # none of these four recorded (e.g. a fresh, unplayed save), the same
-      # "absent means nothing to restore" rule the unplaced-vehicle chunks
-      # above use.
+      # override (#encounter_rate, field 3), a live Change Parallax
+      # Background override (#parallax, fields 32-38), and the camera scroll
+      # (fields 1/2) -- all six scoped to the current map only, see their own
+      # doc comments above. Camera scroll is the view's top-left pixel in
+      # 1/16 pixel, computed the same way `Scene::Map#camera_position` does
+      # every frame (`Game.camera_offset` against the hero's pixel centre and
+      # the map's own size). RPG_RT restores this from the save rather than
+      # deriving it from the hero -- confirmed against the genuine runtime:
+      # an edited save missing these fields drew the map's top-left corner,
+      # not a hero-centred view, and a correct pair reproduced the exact same
+      # frame our own hero-centred renderer already draws (ADR 0021's
+      # "comparing an ordinary map" addendum). Omitted entirely on a State
+      # with no map loaded (e.g. a fresh, unplayed save), the same "absent
+      # means nothing to restore" rule the unplaced-vehicle chunks above use.
       lower_subs, upper_subs = @tile_substitutions
-      unless @map_event_positions.empty? && lower_subs.empty? && upper_subs.empty? &&
-             !@encounter_rate && !@parallax
+      if self.map || !@map_event_positions.empty? || !lower_subs.empty? ||
+         !upper_subs.empty? || @encounter_rate || @parallax
         mapev = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MAP_EVENT })
+        if self.map
+          hero_px = @x * TILE + TILE / 2
+          hero_py = @y * TILE + TILE / 2
+          cam_x = Game.camera_offset(hero_px, SCREEN_W, self.map.width * TILE)
+          cam_y = Game.camera_offset(hero_py, SCREEN_H, self.map.height * TILE)
+          mapev[1] = cam_x * LCF::Schema::SCROLL_UNITS_PER_PIXEL
+          mapev[2] = cam_y * LCF::Schema::SCROLL_UNITS_PER_PIXEL
+        end
         unless @map_event_positions.empty?
           events = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
           @map_event_positions.each do |id, pos|

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9641,6 +9641,46 @@ check 'to_lsd writes the system graphic / font override at the correct ' \
   eq 1, round.font_id
 end
 
+check 'to_lsd writes the camera scroll (chunk 111 fields 1/2) from the ' \
+      'hero position, not just when some other chunk-111 override is live' do
+  # RPG_RT restores the camera from the save rather than deriving it from the
+  # hero -- confirmed against the genuine runtime (ADR 0021's "comparing an
+  # ordinary map" addendum): a save missing chunk 111 fields 1/2 drew the
+  # map's top-left corner regardless of the hero's tile, and the correct
+  # 1/16-pixel pair reproduced the exact hero-centred frame this engine's own
+  # renderer already draws. #to_lsd never wrote them at all -- worse, the
+  # whole chunk was omitted whenever no map event / tile substitution /
+  # encounter-rate / parallax override was also live, which is the common
+  # case on an untouched map -- so any save this engine exported for a real
+  # RPG_RT/EasyRPG to load rendered the wrong part of the map.
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5,
+                                     max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  # A 30x30-tile map (480x480px) is larger than the 320x240 screen on both
+  # axes, so the hero at tile (10, 10) sits far enough from every edge that
+  # the camera centres rather than clamps -- a witness that disambiguates
+  # "centred on the hero" from both "always (0, 0)" and a naive unclamped
+  # "hero pixel verbatim".
+  map = Game::Map.new(1, FakeMapUnit.new(30, 30, 1, [], []))
+  st = Game::State.new(Game::Party.new(db), 1, 10, 10)
+  st.map = map
+
+  saved = st.to_lsd
+  mapev = saved[111]
+  ok mapev, 'chunk 111 is written even with no event/substitution/encounter/parallax override live'
+  # cam = clamp(hero_px + TILE/2 - screen_px/2, 0, map_px - screen_px)
+  # x: clamp(10*16+8 - 160, 0, 480-320) = clamp(8, 0, 160) = 8 -> *16 = 128
+  # y: clamp(10*16+8 - 120, 0, 480-240) = clamp(48, 0, 240) = 48 -> *16 = 768
+  eq 128, mapev.scroll_x, 'scroll_x is the hero-centred camera in 1/16 pixel'
+  eq 768, mapev.scroll_y, 'scroll_y is the hero-centred camera in 1/16 pixel'
+
+  # A map with no camera loaded at all (State#map still nil) keeps omitting
+  # chunk 111 when nothing else is live, matching the pre-existing "absent
+  # means nothing to restore" rule for a fresh, unplayed save.
+  bare = Game::State.new(Game::Party.new(db), 1, 10, 10)
+  eq nil, bare.to_lsd[111], 'no loaded map means no chunk 111 at all'
+end
+
 # -- Enter Hero Name (Name Input) ---------------------------------------------
 
 check 'Enter Hero Name suspends on :name_input and resume renames the actor' do


### PR DESCRIPTION
## Summary

- RPG_RT restores the camera from the save rather than deriving it from the hero — confirmed against a genuine `RPG_RT.exe` (documented in ADR 0021's "comparing an ordinary map" addendum): a save missing chunk 111's `scroll_x`/`scroll_y` renders the map's top-left corner regardless of the hero's tile.
- `Game::State#to_lsd` never wrote these two fields, and omitted the whole chunk 111 entirely whenever no other chunk-111 override (map events / tile substitutions / encounter rate / parallax) was also live — the common case on an untouched map. So every save this engine exported for a real RPG_RT/EasyRPG to load rendered the wrong part of the map.
- Fixed by computing the same hero-centred, edge-clamped camera `Scene::Map#camera_position` already derives every frame (`Game.camera_offset` against the hero's pixel centre and the loaded map's tile size), from `State#x`/`#y` and the now-attached `State#map`, and widening the chunk-111 write guard to fire whenever a map is loaded. Write-only fix — `.from_lsd` still doesn't consume these fields and doesn't need to, since this engine's own renderer derives the camera live from the hero every frame regardless.
- A stale doc comment on the write site had claimed the omission was fine, "matching the 'view derives from the hero' fallback ADR 0021 documents" — backwards from what ADR 0021 itself already recorded from a real RPG_RT capture. Comment corrected in place; `docs/TODO.md` gets a new dated Follow-up on the existing chunk-111 bullet.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check: a 30x30-tile map with the hero at tile (10, 10) — far enough from every edge to disambiguate "hero-centred" from both "always (0,0)" and an unclamped "hero pixel verbatim" — asserts the exact expected `scroll_x`/`scroll_y`, that chunk 111 is written with no other override live, and that a `State` with no map loaded still omits chunk 111 entirely.
- [x] Confirmed via `git stash` that the new check fails against the pre-fix code and passes after.
- [x] All four suites green: `rpg2k_scene_check.rb`, `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_