### PR TITLE
Revert title cursor default to New Game, even when a save exists

### DIFF
--- a/changelog.d/title-cursor-starts-on-continue.fixed.md
+++ b/changelog.d/title-cursor-starts-on-continue.fixed.md
@@ -1,4 +1,5 @@
-- **Title screen:** The cursor now starts on Continue instead of New Game
-  when a save exists, matching RPG_RT (`Scene_Title::Refresh`'s
-  `command_window->SetIndex(1)`). Covered by two new
-  `scripts/rpg2k_scene_check.rb` checks.
+- **Title screen:** The cursor always starts on New Game, whether or not a
+  save exists — a prior fix here had it start on Continue whenever a save
+  exists, sourced only from EasyRPG's source; confirmed against a genuine
+  RPG_RT.exe that this was wrong, and reverted. A save's presence still
+  ungrays Continue, it just does not move the initial cursor.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5557,8 +5557,10 @@ The work below is roughly ordered by the critical path to a walkable game
   file already does), confirmed to fail against the pre-fix code (zero
   matching blend calls, since the flat-gray branch never blends at all)
   before the fix.
-  ✅ **The title cursor's *starting position* ignored whether a save exists,
-  a separate gap from either fix just above (2026-08-20).** `Scene::Title#initialize`
+  ~~The title cursor's *starting position* ignored whether a save exists,
+  a separate gap from either fix just above (2026-08-20).~~ **The 2026-08-20
+  fix below turned out to be wrong — reverted; see the dated Follow-up.**
+  ~~`Scene::Title#initialize`
   (`mruby-rpg2k/mrblib/scene/title.rb`) hardcoded `@selected_index = 0` before
   `@continue_available` was even computed, so the cursor always opened on New
   Game regardless of save data. Confirmed against EasyRPG Player's actual
@@ -5576,7 +5578,25 @@ The work below is roughly ordered by the critical path to a walkable game
   with no other change needed. Covered by two new `scripts/rpg2k_scene_check.rb`
   checks (a save present starts the cursor on Continue; no save data still
   starts it on New Game), the first confirmed to fail against the pre-fix
-  code (`expected 1, got 0`) before the fix.
+  code (`expected 1, got 0`) before the fix.~~
+  ✅ **Follow-up (2026-08-22): the 2026-08-20 fix above was itself wrong —
+  reverted.** That fix was sourced only from EasyRPG's source, not a genuine
+  RPG_RT.exe, and this session's own move away from EasyRPG-as-verification
+  caught it: booting real `RPG_RT.exe` (Nepheshel, under wine) three separate
+  times against a valid, working save — Continue confirmed enabled and
+  un-grayed by successfully opening a correctly-populated file-select screen
+  from it — the title cursor sat on **最初から (New Game)** every single
+  time, never on 続きから (Continue). `@selected_index = 0` unconditionally
+  now, with the wrong doc comment replaced by this citation.
+  `@continue_available` is unaffected and still correctly gates the
+  grayed-out rendering and the disabled-Continue buzz. The
+  `--rpg2k_continue` CLI flag's own explicit `@selected_index = 1` (used by
+  the save-based wine comparison harness itself) is untouched, since it sets
+  the index *after* `initialize` runs. The existing "save present starts on
+  Continue" check in `scripts/rpg2k_scene_check.rb` is flipped to assert 0,
+  the same non-symmetric witness (only `any_save_flag` varies from its
+  sibling "no save data" check) now pointed the other way, confirmed to
+  fail against the pre-fix (2026-08-20) code before this fix.
   ✅ **The same disabled-swatch gap existed on the save/load file-select
   screen too, and there every line was flat, not just the disabled one
   (2026-08-18).** `Scene::SaveLoad#draw_slot_box` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -42,13 +42,16 @@ class RPG2k
         # is now Scene::SaveLoad's own question to ask once Continue opens it.
         @continue_available = continue_available?
 
-        # RPG_RT starts the cursor on Continue, not New Game, whenever a save
-        # exists -- confirmed against EasyRPG's own `Scene_Title::Refresh`
-        # (`src/scene_title.cpp`): `if (continue_enabled)
-        # command_window->SetIndex(1);` fires unconditionally alongside (not
-        # instead of) `SetItemEnabled(1, continue_enabled)`, so a save's
-        # presence moves the initial selection, not just the grayed-out look.
-        @selected_index = @continue_available ? 1 : 0
+        # The cursor always starts on New Game, whether or not a save exists
+        # to Continue -- confirmed against a genuine RPG_RT.exe (Nepheshel,
+        # under wine): booted three separate times against a valid, working
+        # save (Continue enabled and un-grayed, confirmed by successfully
+        # opening a correctly-populated file-select screen from it), the
+        # title cursor sat on 最初から (New Game) every time, never on 続きから
+        # (Continue). `@continue_available` still gates the grayed-out
+        # rendering and the disabled-selection buzz below; only the initial
+        # cursor position was wrong.
+        @selected_index = 0
 
         # RPG_RT sizes the window to the widest label plus one border on each
         # side — no extra padding — and one 16px row per entry.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13160,11 +13160,18 @@ end
 # whenever a save exists, unconditionally alongside `SetItemEnabled` -- the
 # cursor starts on Continue, not New Game, so a returning player does not have
 # to move down manually before resuming.
-check 'a save exists: the title cursor starts on Continue, not New Game' do
+check 'a save exists: the title cursor still starts on New Game, not Continue' do
+  # Confirmed against a genuine RPG_RT.exe (Nepheshel, under wine): booted
+  # three separate times against a valid, working save (Continue enabled and
+  # un-grayed, confirmed by successfully opening a correctly-populated
+  # file-select screen from it), the title cursor sat on New Game every
+  # time. A prior version of this check asserted the opposite, sourced only
+  # from EasyRPG's source rather than the genuine runtime -- see the dated
+  # Follow-up on the title-screen entry in docs/TODO.md.
   parent = TitleParent.new(fake_db, nil, false, true)
   scene = RPG2k::Scene::Title.new(parent)
-  eq 1, scene.instance_variable_get(:@selected_index),
-     'RPG_RT starts the cursor on Continue when a save exists (Scene_Title::Refresh)'
+  eq 0, scene.instance_variable_get(:@selected_index),
+     "a save's presence only ungrays Continue, it does not move the initial cursor"
 end
 
 check 'no save data: the title cursor still starts on New Game' do


### PR DESCRIPTION
## Summary

- A prior fix (2026-08-20, PR history in `docs/TODO.md`) made the title screen's cursor start on **Continue** whenever a save exists, sourced only from EasyRPG's `Scene_Title::Refresh` source — not from a genuine RPG_RT.exe. This session's methodology has since moved away from EasyRPG-source citations toward empirical verification against the real runtime, and re-checking this specific claim found it was wrong.
- Confirmed against a genuine `RPG_RT.exe` (Nepheshel, under wine, ADR 0021's harness): booted three separate times against a valid, working save — Continue confirmed enabled and un-grayed by successfully opening a correctly-populated file-select screen from it — the title cursor sat on **最初から (New Game)** every time, never on 続きから (Continue).
- Reverted `Scene::Title#initialize` (`mruby-rpg2k/mrblib/scene/title.rb`) to unconditionally start at index 0 (New Game). `@continue_available` is unaffected — it still gates the grayed-out rendering and the disabled-Continue buzz on select, only the *initial cursor position* was wrong. The `--rpg2k_continue` CLI flag's own explicit `@selected_index = 1` override (set after `initialize` runs, used by the save-based wine comparison harness itself) is untouched.
- `docs/TODO.md`'s existing entry for the 2026-08-20 fix is struck through with a dated Follow-up explaining the revert and citing the new empirical evidence; the stale `changelog.d/title-cursor-starts-on-continue.fixed.md` fragment (describing the now-reverted behavior, never yet released) is rewritten in place rather than left alongside a contradicting new one.

## Test plan

- [x] Flipped the existing `scripts/rpg2k_scene_check.rb` check ("a save exists: the title cursor starts on...") from asserting index 1 to asserting index 0 — same non-symmetric witness as before (only `any_save_flag` varies from the sibling "no save data" check), confirmed via `git stash` to fail against the pre-fix code and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb` (869 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_