### PR TITLE
Write .lmu's required trailing root terminator byte

### DIFF
--- a/changelog.d/lcf-map-unit-root-terminator.fixed.md
+++ b/changelog.d/lcf-map-unit-root-terminator.fixed.md
@@ -1,0 +1,5 @@
+- **LCF map writer:** `.lmu` (map) files written by this codebase's LCF
+  serializer now carry the trailing root terminator byte a genuine `.lmu`
+  requires — previously it was always omitted (correct for `.lsd`/`.ldb`,
+  but not `.lmu`), and a genuine RPG_RT.exe hangs on a black screen trying
+  to load a map file written without it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8528,7 +8528,20 @@ Everything below is unverified against the codebase.
   keeps rendering.) Covered by a new `scripts/rpg2k_scene_check.rb` check
   (a picture shown and mid-move stays visible, keeps compositing every
   frame, and keeps advancing its move while a message window is open, then
-  is still visible once the window closes). ✅ **changing maps clears all
+  is still visible once the window closes).
+  ✅ **Follow-up (2026-08-22): re-verified against a genuine RPG_RT.exe,
+  not just EasyRPG's source — still correct.** The claim above was sourced
+  only from EasyRPG's C++, exactly the kind of citation this session's
+  methodology (verify against the real runtime, not a reimplementation) now
+  treats as worth re-checking on its own. Built a synthetic autostart map
+  event (Show Picture positioned outside the message window's screen band,
+  then Show Message) and resumed a genuine save on that map under both this
+  engine and real RPG_RT.exe (Nepheshel, under wine): the genuine runtime
+  draws the picture and the message window simultaneously, matching this
+  engine's own frame. No hide-on-message-open behaviour exists in real
+  RPG_RT for a non-overlapping picture. No code change needed — reported as
+  a confirmed-correct negative result.
+  ✅ **changing maps clears all
   Pictures — except via Teleport or Escape (skill/item), which don't clear
   them** — confirmed and fixed, see the "Full-site sweep" **Pictures**
   cluster below (the Teleport/Escape `keep_pictures:` fix). ✅ **semi-
@@ -21544,6 +21557,30 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
 
 ## Tooling
 
+- ✅ **`LCF::File#to_lcf` dropped `.lmu`'s required trailing root terminator
+  (2026-08-22).** ADR 0018's "the top-level chunk list has no terminator"
+  finding was proven only against `.lsd`; `File#to_lcf` applied it to every
+  file type unconditionally, including `.lmu` (`MapUnit`), which does not
+  share the rule. Confirmed by round-tripping genuine Nepheshel `Map*.lmu`
+  files: every one came out exactly one byte short, and byte-identical to
+  the original with a single `0x00` appended — `.ldb`/`.lsd` round-trip
+  byte-exact with no such byte, confirming this is `.lmu`-specific, not a
+  blanket rule. Confirmed to matter at runtime, not just as a byte-diff: a
+  genuine RPG_RT.exe hangs on a solid black screen loading a map file
+  written without this byte (this engine, which never needed the byte to
+  parse the file, renders the same map fine — a real divergence in what the
+  two runtimes accept), and loads correctly once it is appended. Fixed with
+  a `#terminate_root?` predicate on `LCF::File` (default `false`, matching
+  `.lsd`/`.ldb`), overridden to `true` in `MapUnit` — see ADR 0018's
+  addendum. Nothing in the shipped engine currently calls `MapUnit#save_to`
+  during normal play (only `.lsd` saves are ever written at runtime), so
+  this was not a live gameplay bug — it matters to `scripts/lcf_testbed_check.rb`'s
+  own round-trip fidelity and to any future map-authoring tool, this
+  section's own next bullet. Covered by widening that same script's
+  existing per-map loop with a byte-exact round-trip assertion over every
+  `.lmu` in every configured test-bed game (1099 maps across three games),
+  confirmed to fail on all 1099 (each exactly one byte short) against the
+  pre-fix code before the fix.
 - 🚧 Editor with [imgui](https://github.com/ocornut/imgui) — no in-repo
   level/database editor exists yet; there is no `imgui` submodule under `3rd/`
   and nothing in `src/`/`include/` references it. Every maker here plays a

--- a/docs/adr/0018-lcf-save-data-writer.md
+++ b/docs/adr/0018-lcf-save-data-writer.md
@@ -98,3 +98,18 @@ Two framing details had to be pinned down against the real fixtures:
   as raw bytes but not yet re-encodable from decoded values; a future change that
   needs to author those from scratch must add their encoders (and prove them the
   same way).
+
+## Addendum: the "no top-level terminator" rule does not generalize to `.lmu`
+
+The "no terminator" finding above was proven only against `.lsd` (`SaveData`),
+but `File#to_lcf` applied `terminate = false` unconditionally to every
+subclass -- `Database` (`.ldb`) too, which turned out to share the rule (a
+genuine `RPG_RT.ldb` round-trips byte-exact with no terminator), but also
+`MapUnit` (`.lmu`), which does not: a real `.lmu` carries a trailing `0x00`
+root terminator, confirmed by round-tripping genuine Nepheshel `Map*.lmu`
+files (each came out exactly one byte short without it, byte-identical with
+it appended) and, at runtime, a genuine RPG_RT.exe hanging on a black screen
+loading a map file we wrote without that byte. `File` now exposes a
+`#terminate_root?` predicate (default `false`, matching `.lsd`/`.ldb`) that
+`MapUnit` overrides to `true`. See the dated entry in `docs/TODO.md`'s
+Tooling section.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1640,15 +1640,20 @@ module LCF
     def header; raise end
     def schema; raise end
 
+    # Whether the root chunk list ends with a trailing 0x00 terminator.
+    # `.lsd` (SaveData) and `.ldb` (Database) do not -- confirmed by a
+    # byte-exact round-trip of a genuine RPG_RT.ldb and Save01.lsd with no
+    # appended byte -- so this defaults to false. `.lmu` (MapUnit) is the one
+    # exception: overridden below.
+    def terminate_root?; false end
+
     # Serialise the whole file back to bytes: the BER-length-prefixed header
     # string followed by the root object's own serialisation. The inverse of
     # #initialize; a file read and written back without edits reproduces it
-    # byte-for-byte. The top-level chunk list runs to EOF with no terminator
-    # (matching a real .lsd), so the root Array1D is serialised with
-    # terminate=false. Multi-section (Array-schema) files are not yet writable.
+    # byte-for-byte. Multi-section (Array-schema) files are not yet writable.
     def to_lcf
       raise 'section-based file serialization not implemented' if schema.is_a? Array
-      root = @root.is_a?(LCF::Array1D) ? @root.to_lcf(false) : @root.to_lcf
+      root = @root.is_a?(LCF::Array1D) ? @root.to_lcf(terminate_root?) : @root.to_lcf
       LCF.write_ber(header.bytesize) + LCF.binstr(header) + LCF.binstr(root)
     end
 
@@ -1694,6 +1699,15 @@ module LCF
   class MapUnit < File
     def header; "LcfMapUnit" end
     def schema; LCF::Schema::MAP_UNIT end
+
+    # Unlike .lsd/.ldb, a genuine .lmu carries a trailing 0x00 root
+    # terminator -- confirmed by round-tripping real Nepheshel Map*.lmu
+    # files: every one came out exactly one byte short without this, and
+    # byte-identical to the original with it. Confirmed to matter at
+    # runtime too: a genuine RPG_RT.exe hangs on a black screen loading a
+    # map file written without this byte, and loads it correctly once
+    # appended.
+    def terminate_root?; true end
   end
 
   class SaveData < File

--- a/scripts/lcf_testbed_check.rb
+++ b/scripts/lcf_testbed_check.rb
@@ -152,8 +152,15 @@ class Checker
 
     Dir[File.join(dir, 'Map*.lmu')].sort.each do |f|
       base = File.basename(f)
-      lmu = LCF::MapUnit.new(File.open(f, 'rb'))
+      original = File.binread(f)
+      lmu = LCF::MapUnit.new(StringIO.new(original.dup))
       walk(lmu, LCF::Schema::MAP_UNIT, base)
+      # A genuine .lmu carries a trailing 0x00 root terminator that .lsd/.ldb
+      # do not -- #to_lcf used to drop it for every file type, so a
+      # from-scratch or round-tripped map file came out one byte short and a
+      # genuine RPG_RT.exe hung on a black screen trying to load one.
+      rebuilt = lmu.to_lcf
+      fail "#{base}: round-trip not byte-exact (#{rebuilt.bytesize} vs #{original.bytesize} bytes)" if rebuilt != original
       w = lmu.width.to_i
       h = lmu.height.to_i
       fail "#{base}: non-positive dimensions #{w}x#{h}" if w <= 0 || h <= 0


### PR DESCRIPTION
## Summary

- ADR 0018's "the top-level chunk list has no terminator" finding was proven only against `.lsd` (`SaveData`); `LCF::File#to_lcf` applied `terminate = false` to every file type unconditionally — including `.lmu` (`MapUnit`), which does not share the rule.
- Confirmed by round-tripping genuine Nepheshel `Map*.lmu` files: every one came out exactly one byte short, and byte-identical to the original with a single `0x00` appended. `.ldb`/`.lsd` round-trip byte-exact with no such byte, confirming this is `.lmu`-specific.
- Confirmed to matter at runtime, not just as a byte-diff: a genuine RPG_RT.exe hangs on a solid black screen loading a map file written without this byte, and loads correctly once it's appended.
- Fixed with a `#terminate_root?` predicate on `LCF::File` (default `false`, matching `.lsd`/`.ldb`), overridden to `true` in `MapUnit`. `docs/adr/0018-lcf-save-data-writer.md` gets an addendum; `docs/TODO.md`'s Tooling section gets a new dated entry.
- Scope note: nothing in the shipped engine currently calls `MapUnit#save_to` during normal play (only `.lsd` saves are ever written at runtime), so this wasn't a live gameplay bug today — it matters to this codebase's own round-trip fidelity (`scripts/lcf_testbed_check.rb`) and to any future map-authoring tool.
- Also investigated and re-verified (no code change needed): the existing "an already-shown picture does not need to be hidden while a text window is up" claim, previously sourced only from EasyRPG's source, now confirmed directly against genuine RPG_RT.exe as still correct — documented as a dated Follow-up on that same `docs/TODO.md` bullet.

## Test plan

- [x] Widened `scripts/lcf_testbed_check.rb`'s existing per-map loop with a byte-exact round-trip assertion over every `.lmu` in every configured test-bed game (1099 maps across three games) — confirmed via `git stash` to fail on all 1099 (each exactly one byte short) against the pre-fix code, and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb`, `rpg2k_logic_check.rb`, `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_