### PR TITLE
psp: install psp-fixup-imports into $PSPDEV, and reject the stock tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1342,10 +1342,12 @@ jobs:
         # container has neither tool by default (confirmed missing by a real
         # CI run, "sh: gperf: not found", once that patch first shipped).
         #
-        # That script replaces the image's own /usr/local/pspdev/bin/
-        # psp-fixup-imports (a host tool `cmake --build` invokes automatically
-        # after linking, as part of `create_pbp_file`) with a patched build
-        # before configuring -- see the script and patches/
+        # That script replaces $PSPDEV/bin/psp-fixup-imports (a host tool
+        # `cmake --build` invokes automatically after linking, as part of
+        # `create_pbp_file`, and resolves through that same variable) with a
+        # patched build before configuring. This image exports
+        # PSPDEV=/usr/local/pspdev, so that is the path it lands on here --
+        # see the script and patches/
         # psp-fixup-imports-jal-relocation-aware.patch for why: the stock tool
         # silently mis-links several of this EBOOT's own genuine PSP imports,
         # which is what stops it booting to completion under PPSSPP-headless

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -17,6 +17,64 @@ project(rpg2k_psp C CXX ASM)
 
 set(REPO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
+# create_pbp_file's POST_BUILD chain runs "$ENV{PSPDEV}/bin/psp-fixup-imports"
+# over the freshly linked ELF (see $PSPDEV/psp/share/CreatePBP.cmake). That tool
+# has to be the JAL-relocation-aware build scripts/build_psp_fixup_imports.bash
+# produces, not pspdev's stock one: the stock tool assumes every call site
+# referencing a given PSP module is already physically contiguous in the linked
+# binary's import metadata, which main.cxx's own ordinary control flow does not
+# satisfy, and when it isn't it silently assigns some imports to the wrong
+# module and still exits 0.
+#
+# Nothing downstream notices. The EBOOT links, packs, and boots far enough to
+# print RPG2K_PSP_BOOT, but SysMemUserForUser ends up overlapping
+# ThreadManForUser's stub table, which strands sceKernelAllocPartitionMemory and
+# sceKernelGetBlockHeadAddr unbound -- so _sbrk never gets a heap, the first
+# real malloc() never returns, and user_main deadlocks before the frame loop
+# starts. That is indistinguishable at a glance from the pspuser/pspkernel
+# link-order bug the target_link_libraries comment below describes, which is
+# exactly why this is worth catching here instead of in a headless emulator run.
+#
+# Checked up here rather than beside create_pbp_file at the bottom so a stock
+# toolchain fails in seconds, not after configuring LVGL, uni-algo and mruby.
+#
+# Detected by a format string only the patched tool carries: it is built from
+# pspdev's own pinned pspsdk source, so nothing else about the binary
+# (timestamp, size, --help output) reliably separates the two.
+set(FIXUP_IMPORTS "$ENV{PSPDEV}/bin/psp-fixup-imports")
+if(NOT EXISTS "${FIXUP_IMPORTS}")
+  message(
+    FATAL_ERROR
+      "psp-fixup-imports not found at \"${FIXUP_IMPORTS}\" -- PSPDEV must "
+      "point at the pspdev installation this build links against.")
+endif()
+# Re-run configure (and so this check) whenever the tool itself is replaced;
+# installing the patched build is not a source change, so nothing else here
+# would notice it had happened.
+set_property(
+  DIRECTORY
+  APPEND
+  PROPERTY CMAKE_CONFIGURE_DEPENDS "${FIXUP_IMPORTS}")
+# REPO_ROOT is spelled relative to this directory, so normalise it before it
+# goes into a message a reader is meant to paste into a shell.
+get_filename_component(REPO_ROOT_ABS "${REPO_ROOT}" ABSOLUTE)
+file(
+  STRINGS "${FIXUP_IMPORTS}" FIXUP_IMPORTS_PATCHED
+  REGEX "Repointed .* jal instruction"
+  LIMIT_COUNT 1)
+if(NOT FIXUP_IMPORTS_PATCHED)
+  message(
+    FATAL_ERROR
+      "\"${FIXUP_IMPORTS}\" is pspdev's stock psp-fixup-imports. Building "
+      "against it produces an EBOOT whose PSP imports resolve to the wrong "
+      "modules -- it will boot far enough to look fine and then hang. Install "
+      "the patched build over it first:\n"
+      "    bash ${REPO_ROOT_ABS}/scripts/build_psp_fixup_imports.bash\n"
+      "then force a relink (rm ${CMAKE_CURRENT_BINARY_DIR}/rpg2k_psp), since "
+      "replacing the tool does not by itself make anything rebuild. See "
+      "patches/psp-fixup-imports-jal-relocation-aware.patch.")
+endif()
+
 # pspsdk static libraries are built without gp-relative small-data addressing;
 # every object linked with them (LVGL, uni-algo, mruby and our own) must match,
 # so force -G0 at directory scope before any of them are added.

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -72,12 +72,13 @@ What runs today:
 Requires the [pspdev toolchain](https://github.com/pspdev/pspdev) with `$PSPDEV`
 set (it provides `psp-gcc`, the CMake toolchain file and `create_pbp_file`).
 Run `scripts/build_psp_fixup_imports.bash` first — it replaces the
-toolchain's own `psp-fixup-imports` (normally at `$PSPDEV/bin/`) with a
-patched build; see the bug trail lower in this section for why this
-EBOOT needs it to actually boot:
+toolchain's own `$PSPDEV/bin/psp-fixup-imports` with a patched build; see
+the bug trail lower in this section for why this EBOOT needs it to
+actually boot. Configuring without it is a hard error, so there is no way
+to get a silently mis-linked EBOOT out of this build:
 
 ```sh
-scripts/build_psp_fixup_imports.bash "$PSPDEV/bin/psp-fixup-imports"
+scripts/build_psp_fixup_imports.bash
 cmake -S app/psp -B build-psp \
   -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake
 cmake --build build-psp          # -> build-psp/EBOOT.PBP

--- a/changelog.d/psp-fixup-imports-pspdev-env.fixed.md
+++ b/changelog.d/psp-fixup-imports-pspdev-env.fixed.md
@@ -1,0 +1,19 @@
+- **`scripts/build_psp_fixup_imports.bash` now installs into `$PSPDEV`, and the
+  PSP CMake configure refuses to build against the stock tool.** The script
+  hardcoded `/usr/local/pspdev/bin/psp-fixup-imports` — the path inside the
+  `pspdev/pspdev` container the `psp` CI job uses. Against a natively installed
+  pspdev it therefore wrote the patched tool somewhere nothing reads, reported
+  success, and left the toolchain's own stock `psp-fixup-imports` in place, so
+  the resulting EBOOT carried exactly the misordered imports
+  `patches/psp-fixup-imports-jal-relocation-aware.patch` exists to prevent:
+  `SysMemUserForUser`'s stub table overlapped `ThreadManForUser`'s, leaving
+  `sceKernelAllocPartitionMemory`/`sceKernelGetBlockHeadAddr` unbound, so
+  `_sbrk` never obtained a heap, the first real `malloc()` never returned, and
+  `user_main` deadlocked under PPSSPP-headless after printing `RPG2K_PSP_BOOT`.
+  The default is now `$PSPDEV/bin/psp-fixup-imports` — the same variable
+  pspdev's own `CreatePBP.cmake` resolves the tool through — falling back to
+  `/usr/local/pspdev` when `$PSPDEV` is unset; `pspdev/pspdev:latest` exports
+  `PSPDEV=/usr/local/pspdev`, so the `psp` CI job resolves the path it always
+  did. `app/psp/CMakeLists.txt` additionally fails configure outright when the
+  installed tool lacks the patch, detected by a format string only the patched
+  build carries, and re-runs the check whenever the tool is replaced.

--- a/scripts/build_psp_fixup_imports.bash
+++ b/scripts/build_psp_fixup_imports.bash
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # Build a patched replacement for pspdev's psp-fixup-imports (a host tool the
 # PSP CMake toolchain runs automatically after linking rpg2k_psp), and drop it
-# wherever the caller wants it -- normally straight over the pspdev image's
-# own /usr/local/pspdev/bin/psp-fixup-imports, so the rest of the build (an
+# wherever the caller wants it -- normally straight over the pspdev
+# installation's own bin/psp-fixup-imports, so the rest of the build (an
 # unmodified `psp-cmake` + `cmake --build`) picks it up transparently.
 #
 # Why: the stock tool requires every call site referencing a given PSP module
@@ -20,10 +20,21 @@ set -euo pipefail
 #
 # Usage:
 #   scripts/build_psp_fixup_imports.bash [OUTPUT_PATH]
-#     OUTPUT_PATH defaults to /usr/local/pspdev/bin/psp-fixup-imports, i.e.
-#     "replace the toolchain's own copy in place" -- the right default both
-#     for the psp CI job (see .github/workflows/build.yml) and for local
-#     reproduction inside the same pspdev/pspdev container the CI job uses.
+#     OUTPUT_PATH defaults to $PSPDEV/bin/psp-fixup-imports, i.e. "replace the
+#     toolchain's own copy in place". $PSPDEV is pspdev's own standard
+#     installation-root variable, so keying on it puts the patched tool on
+#     whichever SDK the build actually invokes: pspdev/pspdev:latest exports
+#     PSPDEV=/usr/local/pspdev, so the psp CI job (see
+#     .github/workflows/build.yml) resolves exactly the path this used to
+#     hardcode, while a native SDK gets its own root -- this repo's .envrc
+#     exports PSPDEV=$HOME/dev/pspdev. Hardcoding the container path instead
+#     meant a native toolchain silently kept the *stock* psp-fixup-imports:
+#     the script reported success, having installed into a /usr/local/pspdev
+#     nothing in the build ever reads, and the EBOOT it then produced had the
+#     misordered imports this whole patch exists to prevent.
+#
+#     Falls back to /usr/local/pspdev when $PSPDEV is unset, so a bare
+#     `docker run` that skips the image's environment still works.
 #
 # Needs: git, a native (host) C compiler (`cc`), and network access to
 # github.com. The pspdev/pspdev image ships neither by default; `apk add
@@ -33,7 +44,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PATCHES_DIR="$REPO_ROOT/patches"
-OUTPUT_PATH="${1:-/usr/local/pspdev/bin/psp-fixup-imports}"
+PSPDEV_ROOT="${PSPDEV:-/usr/local/pspdev}"
+OUTPUT_PATH="${1:-$PSPDEV_ROOT/bin/psp-fixup-imports}"
 
 # Pinned in patches/psp-fixup-imports-jal-relocation-aware.patch's own
 # preamble too; keep the two in sync if this ever moves. Confirmed (by


### PR DESCRIPTION
## Problem

`scripts/build_psp_fixup_imports.bash` hardcoded `/usr/local/pspdev/bin/psp-fixup-imports` — the path inside the `pspdev/pspdev` container the `psp` CI job uses.

Against a **natively installed** pspdev, that path is not what the build reads. The script wrote the patched tool there, printed `Built patched psp-fixup-imports -> ...`, exited 0 — and left the toolchain's own **stock** `psp-fixup-imports` in place. `app/psp/README.md` worked around this by telling people to pass the path explicitly, which is easy to miss.

The EBOOT built that way carries exactly the misordered imports `patches/psp-fixup-imports-jal-relocation-aware.patch` exists to prevent:

```
Importing Module SysMemUserForUser, stubs at 08a22030
  sceKernelMaxFreeMemSize   : 08a22030
  sceKernelTotalFreeMemSize : 08a22038
  [UNK: 0xe81caf8f] : 08a22040    <- sceKernelCreateCallback's NID
  [UNK: 0x82826f70] : 08a22048    <- sceKernelSleepThreadCB's
  [UNK: 0xceadeb47] : 08a22050    <- sceKernelDelayThread's
Importing Module ThreadManForUser, stubs at 08a22040   <- overlaps the above
```

`SysMemUserForUser` declares 5 imports but owns only 2 slots, so it reads past its own end into `ThreadManForUser`'s NIDs. `sceKernelAllocPartitionMemory` and `sceKernelGetBlockHeadAddr` are left unbound, `_sbrk` never obtains a heap, the first real `malloc()` never returns, and `user_main` deadlocks under PPSSPP-headless after printing `RPG2K_PSP_BOOT`.

Nothing reports this. The build succeeds and the EBOOT boots far enough to look fine.

## Fix

- **`$PSPDEV`-relative default.** `OUTPUT_PATH` now defaults to `$PSPDEV/bin/psp-fixup-imports` — the same variable pspdev's own `CreatePBP.cmake:122` resolves the tool through — falling back to `/usr/local/pspdev` when `$PSPDEV` is unset. `pspdev/pspdev:latest` exports `PSPDEV=/usr/local/pspdev`, so the `psp` CI job resolves the path it always did and its behaviour is unchanged. The now-redundant explicit argument is dropped from `app/psp/README.md`.
- **Configure-time guard.** `app/psp/CMakeLists.txt` fails outright when the installed tool lacks the patch, detected by a format string only the patched build carries (it is compiled from pspdev's own pinned pspsdk source, so timestamp/size/`--help` do not separate the two). Placed near the top so a stock toolchain fails in seconds rather than after configuring LVGL, uni-algo and mruby; the tool is added to `CMAKE_CONFIGURE_DEPENDS` so replacing it re-triggers the check.

## Verification

On a native pspdev checkout, before → after:

| | before | after | CI |
|---|---|---|---|
| `Unknown syscall` warnings | 37 | **1** | 1 |
| `sceKernelAllocPartitionMemory` | never bound | succeeds | succeeds |
| kernel objects alive | 6 | **55** | 23 |

The EBOOT now gets past heap init and display setup into real LVGL widget creation, where it hits a separate pre-existing issue (an LVGL assert on the 256 KB `LV_MEM_SIZE` pool) that is out of scope here.

Guard behaviour, both directions:

```
### stock tool ###
CMake Error at CMakeLists.txt:66 (message):
  ".../psp-fixup-imports" is pspdev's stock psp-fixup-imports.  Building
  against it produces an EBOOT whose PSP imports resolve to the wrong
  modules -- it will boot far enough to look fine and then hang. ...
exit=1

### patched tool ###
exit=0
```

`pre-commit run --files` passes on all five files (cmake-format, check-yaml, whitespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZpTj3DY5Wy8kv4kAcPnK7