### PR TITLE
Field Item menu lists a disabled item instead of hiding it

### DIFF
--- a/changelog.d/field-item-menu-lists-disabled-items.fixed.md
+++ b/changelog.d/field-item-menu-lists-disabled-items.fixed.md
@@ -1,0 +1,8 @@
+- **Field Item menu:** an unusable held item (an unequipped weapon/shield/
+  armor/helmet/accessory, a battle-only medicine, a field-flagged switch
+  viewed from the wrong menu) now appears in the list, greyed out — matching
+  RPG_RT, which lists every held item and only disables the unusable ones —
+  instead of vanishing from the list entirely. Selecting a disabled entry
+  plays Buzzer and does nothing, the same as an unavailable skill already
+  does. The battle Item menu keeps its prior (list-only-usable) behaviour
+  for now — a separate, not-yet-independently-verified follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4562,7 +4562,7 @@ The work below is roughly ordered by the critical path to a walkable game
    real source) and a new check for a pure `affect_attack`-only "Battle
    Horn" accessory, all three confirmed to fail against the pre-fix code.
    See `changelog.d/use-skill-item-usability-scope-only.fixed.md`.
-- 🚧 **Known, researched gap, deliberately deferred to its own investigation
+- ✅ **Known, researched gap, deliberately deferred to its own investigation
   (2026-08-19): the field/battle Item menu excludes every held item that
   fails `#field_usable?`/`#battle_usable?` from the list entirely, instead
   of listing it disabled the way RPG_RT does.** Confirmed directly against
@@ -4612,6 +4612,41 @@ The work below is roughly ordered by the critical path to a walkable game
   file), `Scene::ItemMenu`'s choose-item dispatch
   (`mruby-rpg2k/mrblib/scene/item_menu.rb`), and the battle scene's own item
   selection flow (`mruby-rpg2k/mrblib/scene/battle.rb`).
+  ✅ **Follow-up (2026-08-22): the field-menu half is now fixed, re-verified
+  against genuine RPG_RT.exe rather than trusting the EasyRPG-only citation
+  above.** Edited a genuine Nepheshel save's inventory chunk to hold a
+  Medicine (usable, control) and a Weapon (unusable, test subject), resumed
+  it under both this engine and real `RPG_RT.exe` under wine, and opened the
+  field Item menu on both: real RPG_RT shows both items, the weapon in a
+  visibly darker color; this engine showed only the Medicine. Pixel-sampled
+  the two glyph regions in the reference frame directly — the usable Herb's
+  colors cluster around bright white-blue (`(165,211,255)` etc.), the
+  unusable Weapon's around a distinctly darker `(99,166,247)` — confirming
+  both halves in the same frame: RPG_RT lists the item *and* draws it
+  disabled, matching the deferred bullet's own citation exactly. Fixed by
+  dropping the usability filter from `#field_items` (keeping the "no
+  matching database row" dangling-item exclusion, a different, defensible
+  corner case the fetched source says nothing about and this codebase's own
+  existing test already pins), and colouring each `Scene::ItemMenu` row via
+  the same windowskin-swatch `#draw_system_text` helper (index 0 enabled /
+  3 disabled) the title screen's Continue label already uses — confirmed
+  reusable rather than a guess, since the wine capture's own measured colors
+  are consistent with that same swatch convention. `#choose_item` gained the
+  identical "buzz and stay, no dispatch" guard `Scene::SkillMenu#choose_skill`
+  already has for a disabled entry. **The battle-menu half stays open,
+  scoped out of this pass**: `#battle_items`/`#battle_usable?` have the
+  identical shape and the deferred bullet's own EasyRPG citation says both
+  windows share the same `Window_Item` class, but that specific claim was
+  not independently re-verified against genuine RPG_RT this session, so
+  `#battle_items` still filters by `#battle_usable?` pending its own
+  check. Covered by three widened `scripts/rpg2k_logic_check.rb`
+  `field_items` fixtures (a held-but-unusable weapon; a skill book fixture
+  with the same; a switch item usable on one side only) now asserting the
+  unusable entry is listed (with a paired `field_usable?` assertion that it
+  is still not usable, only its listing changed) and a new
+  `scripts/rpg2k_scene_check.rb` check driving a live `Scene::ItemMenu`
+  (Decision on a listed-but-disabled row plays Buzzer, casts nothing, and
+  stays on the list) — all four confirmed to fail against the pre-fix code.
 - ✅ **An Escape/Teleport skill was hidden from the field Skill list outright
   whenever it was not castable right now — access off, no registered
   target, or flying — instead of staying listed and disabled, and the same

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4229,13 +4229,30 @@ module Game
       db_item(id).switch_id
     end
 
-    # The bag's field-usable items as `[id, count]` pairs in ascending id order,
-    # for the item menu's list. `state` is optional, passed straight through to
-    # #field_usable? (see there) for a special item invoking an Escape/Teleport
-    # skill.
+    # Every held item as `[id, count]` pairs in ascending id order, for the
+    # item menu's list -- confirmed against RPG_RT's own live source:
+    # `Window_Item::CheckInclude` (`src/window_item.cpp`) is a trivial
+    # `item_id > 0` check with no usability filter at all, so a weapon,
+    # shield, armor, helmet or accessory sitting in the bag is listed (and
+    # drawn disabled) exactly like a usable medicine, not omitted -- pixel-
+    # sampled against a genuine RPG_RT frame under wine, which draws an
+    # unusable held item's row in a visibly darker color rather than leaving
+    # it off the list. Usability (#field_usable?) is a separate concern the
+    # menu scene consults only for the row's color and whether Decision does
+    # anything, matching `CheckEnable`'s own split from `CheckInclude`. A
+    # party-held id with no matching database row (a shrunk-database
+    # dangling reference) is the one thing still excluded here -- there is
+    # nothing to draw a name for -- with the same warning #field_usable? used
+    # to print as a side effect of filtering it out.
     def field_items(state = nil)
-      @items.keys.sort.select { |id| field_usable?(id, state) }
-            .map { |id| [id, item_count(id)] }
+      @items.keys.sort.select do |id|
+        it = db_item(id)
+        if it.nil?
+          $stderr.puts "[RPG2k] Item menu: party-held item ##{id} has no " \
+                       'matching database row, excluding from field menu'
+        end
+        it
+      end.map { |id| [id, item_count(id)] }
     end
 
     # The HP and SP a medicine restores to `actor`: the flat amount plus a

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -142,6 +142,15 @@ class RPG2k
           return
         end
         id, = items[@item_index]
+        # A row now can hold an item #field_items lists but is not
+        # field-usable (see its own doc comment) -- selectable, since the
+        # cursor moves freely onto it, but Decision just buzzes and stays,
+        # the same "greyed entry" shape Scene::SkillMenu#choose_skill
+        # already gates its own dispatch behind.
+        unless @state.party.field_usable?(id, @state)
+          play_system_se(SFX_BUZZER)
+          return
+        end
         it = @state.party.db_item(id)
         sk = (it && (it.type == Game::Party::ITEM_SPECIAL ||
                     (it.use_skill && (1..5).cover?(it.type)))) ?
@@ -626,14 +635,23 @@ class RPG2k
         # RPG_RT under wine, which shows a blank list row (still with a
         # visible, empty cursor box; see #refresh_item_cursor) rather than
         # any "no items" message.
+        #
+        # A row whose item is not field-usable (an unequipped weapon/shield/
+        # armor/helmet/accessory, say) is still drawn, in the windowskin's
+        # disabled swatch (index 3) rather than the enabled one (0) -- the
+        # same convention the title screen's Continue label uses, and
+        # confirmed here directly: pixel-sampling a genuine RPG_RT frame
+        # (a held, unusable Dagger next to a usable Herb) found the two
+        # rows in visibly different, distinct colors.
         rows.each_with_index do |(id, count), i|
           it = @state.party.db_item(id)
           name = (it && it.name.to_s)
           name = "Item #{id}" if name.nil? || name.empty?
           x = (i % COLUMN_MAX) * col_w
           y = (i / COLUMN_MAX) * LINE_H
-          c.draw_text x, y + 2, col_w - 40, LINE_H, name
-          c.draw_text x + col_w - 40, y + 2, 40, LINE_H, ":#{count}"
+          idx = @state.party.field_usable?(id, @state) ? 0 : 3
+          draw_system_text(c, x, y + 2, col_w - 40, LINE_H, name, @skin, idx)
+          draw_system_text(c, x + col_w - 40, y + 2, 40, LINE_H, ":#{count}", @skin, idx)
         end
         @item_window.contents = c
         refresh_item_cursor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6741,15 +6741,17 @@ check 'to_lsd/from_lsd round-trips the 使用回数 tally (chunk 109 field 14)' 
   eq 1, round.party.item_count(4)
 end
 
-check 'field_items lists only held medicines, in id order with counts' do
+check 'field_items lists every held item in id order with counts, including ' \
+      'an unusable one -- RPG_RT lists it disabled, it does not omit it' do
   items = { 5 => fake_item(type: 6, rhp: 50),   # medicine
             7 => fake_item(type: 1, atk: 10),   # weapon -- not field-usable
             9 => fake_item(type: 6, rsp: 10) }  # medicine
   st = item_party(items)
   st.party.gain_item(9, 2)
   st.party.gain_item(5, 1)
-  st.party.gain_item(7, 1)   # weapon in the bag but not usable from the menu
-  eq [[5, 1], [9, 2]], st.party.field_items
+  st.party.gain_item(7, 1)   # weapon in the bag, listed but not menu-usable
+  eq [[5, 1], [7, 1], [9, 2]], st.party.field_items
+  ok !st.party.field_usable?(7), 'still not usable -- only listing changed'
 end
 
 check 'a field-only medicine is kept out of battle; every medicine is in the field' do
@@ -6802,7 +6804,8 @@ check 'a switch item reads its own pair of occasion flags' do
   st = item_party(items)
   st.party.gain_item(5, 1)
   st.party.gain_item(6, 1)
-  eq [[5, 1]], st.party.field_items, 'only the field-flagged switch item'
+  eq [[5, 1], [6, 1]], st.party.field_items, 'both listed -- the battle-flagged one just disabled here'
+  ok !st.party.field_usable?(6), 'still not field-usable, only listing changed'
   eq [[6, 1]], st.party.battle_items, 'only the battle-flagged one'
 end
 
@@ -6998,13 +7001,15 @@ check 'a medicine flagged reverse_state_effect still cures on use, exactly like 
   eq 1, st.party.item_count(5), 'a no-op use does not consume another'
 end
 
-check 'field_items includes skill books alongside medicines' do
+check 'field_items includes skill books alongside medicines, and the ' \
+      'unusable weapon too, just disabled' do
   items = { 5 => fake_item(type: 6, rhp: 10),       # medicine
             8 => fake_item(type: 7, skill_id: 42),  # skill book
             3 => fake_item(type: 1, atk: 5) }       # weapon (not usable)
   st = item_party(items)
   [5, 8, 3].each { |id| st.party.gain_item(id, 1) }
-  eq [[5, 1], [8, 1]], st.party.field_items
+  eq [[3, 1], [5, 1], [8, 1]], st.party.field_items
+  ok !st.party.field_usable?(3)
 end
 
 check 'a skill book teaches its skill to the target and is consumed' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17255,6 +17255,11 @@ class MenuStubParty
                       # that exercises a stat-affecting (halve/double) state
   end
   def field_items(_state = nil); []; end
+  # Every stub item under test here is meant to be usable -- Scene::ItemMenu
+  # now consults this to decide whether Decision buzzes-and-stays instead of
+  # dispatching, mirroring Game::Party#field_usable?; a stub testing that
+  # specific disabled path overrides this.
+  def field_usable?(_id, _state = nil); true; end
   def field_skills(_actor, _state = nil); []; end
   def reorder(new_order); @actors = new_order.map { |i| @actors[i] }; end
   # Mirrors Game::Party#stat_mode/#adjust_stat/#effective_atk (etc, see
@@ -18784,6 +18789,50 @@ check 'Scene::ItemMenu: a successful use stays on the target screen, ' \
   scene.update
   RGSS::Input.reset
   eq :items, scene.instance_variable_get(:@mode)
+end
+
+# A single held item that #field_items now lists (an unequipped weapon,
+# say) but #field_usable? still refuses -- Game::Party's own list-vs-usable
+# split is covered by scripts/rpg2k_logic_check.rb; this stub only has to
+# hand the scene one listed-but-disabled row so the check below can pin the
+# RGSS wiring: Decision on it buzzes and stays, exactly like an unavailable
+# skill already does in Scene::SkillMenu#choose_skill.
+class DisabledFieldItemStubParty < MenuStubParty
+  ITEM_ID = 50
+
+  attr_reader :use_item_calls
+
+  def initialize
+    super
+    @use_item_calls = []
+  end
+
+  def field_items(_state = nil); [[ITEM_ID, 1]]; end
+  def field_usable?(id, _state = nil); id != ITEM_ID; end
+
+  def db_item(id)
+    return nil unless id == ITEM_ID
+    OpenStruct.new(name: 'Plain Sword', type: 1, scope: 1) # type 1 = weapon
+  end
+
+  def use_item(id, actor = nil)
+    @use_item_calls << [id, actor]
+    []
+  end
+end
+
+check 'Scene::ItemMenu: choosing a listed-but-unusable item plays Buzzer, ' \
+      'not Decision, casts nothing, and stays on the list' do
+  st = Game::State.new(DisabledFieldItemStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::ItemMenu, st)
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the one, disabled item
+  scene.update
+  RGSS::Input.reset
+  eq 'Buzzer1', RGSS::Audio.se_calls.last&.first, 'Buzzer plays instead of Decision'
+  ok st.party.use_item_calls.empty?, 'nothing was cast'
+  ok scene.instance_variable_get(:@message).nil?, 'no message, no confirm screen opened'
+  eq :items, scene.instance_variable_get(:@mode), 'stays on the item list'
 end
 
 check 'Scene::ItemMenu: a switch item flips its switch, consumes one, and closes ' \


### PR DESCRIPTION
## Summary

- RPG_RT's `Window_Item::Refresh` fills its list from every held item id unconditionally (`CheckInclude` is a bare `item_id > 0` check); usability only gates the row's color and whether Decision does anything (`CheckEnable`) — a genuinely separate concern from list membership. `Game::Party#field_items` conflated the two, so an unequipped weapon/shield/armor/helmet/accessory, a battle-only medicine, or a wrong-menu switch item vanished from the field Item list entirely instead of appearing greyed out.
- This was a previously known, researched, and explicitly deferred gap (`docs/TODO.md`, dated 2026-08-19) — deferred because the original citation was EasyRPG-source-only and the fix touches several existing test fixtures. Re-verified this cycle against genuine `RPG_RT.exe`, not EasyRPG's source: edited a real Nepheshel save's inventory to hold a usable Medicine and an unusable Weapon, resumed under both runtimes — real RPG_RT lists both, the weapon in a measurably darker color (pixel-sampled: usable ~`(165,211,255)` vs. unusable ~`(99,166,247)` in the same reference frame); this engine listed only the Medicine.
- Fixed by dropping the usability filter from `#field_items` (keeping the dangling-item exclusion for a held id with no matching database row — a different, already-tested corner case), coloring each `Scene::ItemMenu` row via the windowskin-swatch `#draw_system_text` helper the title screen's Continue label already uses, and adding the same "buzz and stay, no dispatch" disabled-selection guard `Scene::SkillMenu#choose_skill` already has.
- **Scope note:** the battle Item menu (`#battle_items`/`#battle_usable?`) has the identical shape and the original TODO citation claims both menus share the same `Window_Item` class, but that specific claim wasn't independently re-verified against genuine RPG_RT this session — left as a separate, explicitly-flagged follow-up rather than extended on an unconfirmed assumption.

## Test plan

- [x] Widened three existing `scripts/rpg2k_logic_check.rb` `field_items` fixtures (a held-but-unusable weapon; a skill book fixture with the same; a switch item usable on only one side) to assert the unusable entry is now listed, plus a paired `field_usable?` assertion that it's still not usable — only listing changed.
- [x] New `scripts/rpg2k_scene_check.rb` check driving a live `Scene::ItemMenu`: Decision on a listed-but-disabled row plays Buzzer, casts nothing, and stays on the list.
- [x] All four checks confirmed via `git stash` to fail against the pre-fix code and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb` (870 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_