### PR TITLE
Implement Window#viewport= (RGSS3/VX Ace)

### DIFF
--- a/changelog.d/window-viewport-assign.fixed.md
+++ b/changelog.d/window-viewport-assign.fixed.md
@@ -1,0 +1,10 @@
+- Fixed a real gap in `mruby-rgss`: `Window#viewport=` (RGSS3/VX Ace,
+  reassigning an existing window to a Viewport so it clips and scrolls with
+  it) did not exist at all, raising `NoMethodError` the moment a script
+  called it. Found because a real RPG Maker VX Ace game's `Scene_Battle`
+  assigns all its battle windows (`Window_BattleStatus` among them) to a
+  dedicated viewport, and crashed on the very first one. Reparents the
+  window's canvas via LVGL's own `lv_obj_set_parent` -- the same mechanism
+  Sprite/Plane/Tilemap already use at construction, just made reassignable
+  after the fact -- so it clips and scrolls with the target viewport (or
+  moves back to the screen for `nil`) exactly like those already do.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21114,6 +21114,28 @@ screen (544×416). Full rationale:
     simplifications versus real Ruby, and confirmation that the same
     release now runs its normal frame loop with no crash at all where this
     used to be a hard stop.
+  - ✅ **`Window#viewport=` was not implemented at all.** With `defined?`
+    no longer masking the crash, the same real release's headless run under
+    `--test_play` turned out to skip straight to `Scene_Battle#start`
+    (RGSS3's `$BTEST`-gated Test Battle convention, triggered by VX Ace's
+    editor F9) rather than a title screen, immediately hitting a sixth wall:
+    `NoMethodError: undefined method 'viewport=' for Window_BattleStatus`.
+    Scene_Battle's own stock `create_all_windows` assigns every battle
+    window to a dedicated Viewport so it clips/scrolls with the battle
+    background, an RGSS3 capability this engine's native `Window` class
+    never got at all -- not a documented gap, a genuine blind spot:
+    `Window#initialize` already threads an optional viewport through to
+    construction (unused in practice, since VX Ace's own
+    `Window.new(x, y, width, height)` shape never passes one), but nothing
+    let a script reassign it afterward, which is what real games actually
+    call. Fixed with one new native method, `window_set_viewport`
+    (`mruby-rgss/src/lib.cxx`), reparenting the window's canvas via LVGL's
+    `lv_obj_set_parent` -- the same mechanism Sprite/Plane/Tilemap already
+    use at construction, just made reassignable -- and updating the shared
+    z-order pass, which already groups every display object by its live
+    LVGL parent each frame with no further changes needed. With this fix,
+    the same real release's headless run goes several minutes into
+    `Scene_Battle` with no crash at all.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -904,13 +904,35 @@ lookup with `defined?(SceneManager)`.
   all: attaching gdb to a running headless instance mid-boot shows it
   inside `Graphics.update`'s own frame-throttling `nanosleep`, i.e.
   genuinely executing its normal per-frame game loop rather than stuck or
-  crashed. Whether its title screen responds to the engine's headless
-  auto-confirm tooling the way the XP/2000/2003 hosts' do is not yet
-  confirmed — no `[RPGXP-HOST-SCENE]` log was observed within several
-  minutes of headless run, which may mean a slow intro/logo sequence ahead
-  of a stock `Scene_Title`, a custom title screen this game's own scripts
-  substitute for it, or simply more boot time than was given. Left for the
-  next round to trace further.
+  crashed. It turns out the absence of `[RPGXP-HOST-SCENE]` logging was not
+  a sign of a slow title screen: under `--test_play`, this release's own
+  `Main` script skips straight to `Scene_Battle#start` (RGSS3's own
+  `$BTEST`-gated Test Battle convention, which VX Ace's editor triggers via
+  F9) without ever constructing a `Scene_Title`, which surfaced the next
+  bug below immediately.
+
+- **Fixed: `Window#viewport=` was not implemented at all.** `Scene_Battle`'s
+  own stock `create_info_viewport`/`create_all_windows` assign every battle
+  window (`Window_BattleStatus` among them) to a dedicated Viewport so they
+  clip and scroll with the battle background, the same way RGSS3 (VX Ace)
+  lets any `Window` be (re)assigned to a `Viewport` after construction —
+  this engine's native `Window` class had no `viewport`/`viewport=` method
+  at all, so the very first battle window construction raised
+  `NoMethodError: undefined method 'viewport=' for Window_BattleStatus`.
+  Not a documented, deliberate gap: `Window#initialize` already threads an
+  optional viewport argument through to the same `parent_object` helper
+  `Sprite`/`Plane`/`Tilemap` use at construction (VX Ace's own
+  `Window.new(x, y, width, height)` shape just never passes one, so that
+  path was silently dead), and the shared z-order pass in `gfx_update`
+  already groups every display object by its *live* LVGL parent each
+  frame — so reassignment only needed one new native method,
+  `window_set_viewport` (`mruby-rgss/src/lib.cxx`), reparenting the
+  window's canvas via LVGL's own `lv_obj_set_parent` (clipped and scrolled
+  by the target viewport's content layer exactly like a Sprite, or back to
+  the root screen for `nil`) and updating the z-order. No compositing,
+  clipping, or z-sort changes needed elsewhere. With this fix, the same
+  real release's headless run no longer crashes within the first several
+  minutes of `Scene_Battle`, well past this wall.
 
 ## What this means for turning the host on
 
@@ -928,15 +950,17 @@ only item left in the six sections above; item 7's `$!`/bare-`raise` gap is
 now fixed too (`patches/mruby-dollar-bang-scoped.patch`, above), so the same
 real release's own crash-reporter add-on now sees the actual exception
 instead of masking it behind an unrelated `NoMethodError`, and re-raises it
-correctly. Sixteen real bugs have been found and fixed this way so far
+correctly. Seventeen real bugs have been found and fixed this way so far
 (`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
 `Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`,
 `Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`,
 `Sprite#width`/`#height`, the `::Const = value` compiler bug, `$!`/bare-
 `raise` itself, the `Tilemap`/`Plane` `ox=`/`oy=` redundant-refresh hang,
 `Audio.bgs_play`'s `pos` argument, `Marshal`'s `marshal_dump`/
-`marshal_load` protocol mismatches, and the missing `defined?` keyword) —
-the first ten via the temporary VM probe, finding the real exception
-directly regardless of `$!` being masked at the time. With `defined?` fixed,
-the same real release now runs its normal frame loop with no crash at all;
-where its next wall stands (if any) past that is not yet traced.
+`marshal_load` protocol mismatches, the missing `defined?` keyword, and the
+missing `Window#viewport=`) — the first ten via the temporary VM probe,
+finding the real exception directly regardless of `$!` being masked at the
+time. With `defined?` and `Window#viewport=` both fixed, the same real
+release's headless Test Battle run now goes several minutes into
+`Scene_Battle` with no crash at all; where its next wall stands (if any)
+past that is not yet traced.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -934,9 +934,13 @@ module RGSS
   # whole surface is native — `initialize`, `contents=`, `windowskin=`, `x=`,
   # `y=`, `width=`, `height=`, `ox=`, `oy=`, `opacity=`, `back_opacity=`,
   # `contents_opacity=`, `cursor_rect=`, `active=`, `pause=`, `stretch=`,
-  # `update`, `z=`, `visible`/`visible=`, `dispose`/`disposed?`. `stretch=` picks
-  # between the stretched (default) and tiled windowskin background. This reopening
-  # only adds the plain readers and their RGSS defaults.
+  # `viewport=`, `update`, `z=`, `visible`/`visible=`, `dispose`/`disposed?`.
+  # `stretch=` picks between the stretched (default) and tiled windowskin
+  # background. `viewport=` (RGSS3/VX Ace) reparents the window's canvas into
+  # the given Viewport's clipped, scrollable content layer -- or back to the
+  # screen for `nil` -- the same mechanism `initialize`'s own optional
+  # viewport argument uses, just reassignable afterward. This reopening only
+  # adds the plain readers and their RGSS defaults.
   class Window
     attr_reader :contents, :windowskin, :x, :y, :width, :height, :ox, :oy, :z,
                 :viewport, :contents_opacity

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -5609,6 +5609,29 @@ mrb_value window_set_stretch(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// RGSS3 (VX Ace) added `Window#viewport=`: a window can be (re)assigned to a
+// Viewport after construction, the same way Scene_Battle's stock windows are,
+// so they clip and scroll with the battle viewport instead of the screen.
+// `window_init` already threads an optional viewport through to
+// `parent_object` at construction time, matching Sprite's own constructor --
+// but nothing reassigns it afterward, which is what real games actually call
+// (VX Ace's `Window.new(x, y, width, height)` never passes one). Reparenting
+// via LVGL is the whole mechanism: the window's canvas becomes a child of the
+// new viewport's (clipped, scrollable) content layer -- or the root screen
+// for `nil`, via the same `parent_object` construction uses -- and
+// `gfx_update`'s z-sort already groups by each object's live LVGL parent
+// every frame, so no further z-order or compositing change is needed.
+mrb_value window_set_viewport(mrb_state* M, mrb_value self) {
+  mrb_value vp;
+  mrb_get_args(M, "o", &vp);
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  lv_obj_set_parent(obj, parent_object(M, vp));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@viewport"), vp);
+  update_z(M);
+  return vp;
+}
+
 // A single number standing for a Tone's four channels, so a change can be
 // spotted with one comparison. Shared with the viewport's tone tracking.
 double vp_tone_key(const Tone& t);
@@ -6540,6 +6563,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, window, "active=", window_set_active, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "pause=", window_set_pause, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "stretch=", window_set_stretch, MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "viewport=", window_set_viewport, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "update", window_update, MRB_ARGS_NONE());
   // RGSS2 / RGSS3 (VX, VX Ace): the open/close animation and the background
   // tone. Native because both have to redraw -- and so they must NOT be

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -6563,7 +6563,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, window, "active=", window_set_active, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "pause=", window_set_pause, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "stretch=", window_set_stretch, MRB_ARGS_REQ(1));
-  mrb_define_method(M, window, "viewport=", window_set_viewport, MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "viewport=", window_set_viewport,
+                    MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "update", window_update, MRB_ARGS_NONE());
   // RGSS2 / RGSS3 (VX, VX Ace): the open/close animation and the background
   // tone. Native because both have to redraw -- and so they must NOT be

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1790,7 +1790,7 @@ assert "RGSS::Window API surface" do
   %i[contents= x= y= width= height= ox= oy= contents_opacity= z= visible
      visible= dispose disposed? windowskin windowskin= cursor_rect cursor_rect=
      opacity opacity= back_opacity back_opacity= cursor_rect= active active=
-     pause pause= stretch stretch= update].each do |m|
+     pause pause= stretch stretch= viewport= update].each do |m|
     assert_true RGSS::Window.method_defined?(m), "Window##{m} missing"
   end
 end

--- a/scripts/rgss_cruby_compat.rb
+++ b/scripts/rgss_cruby_compat.rb
@@ -2173,6 +2173,10 @@ module RGSS
       @stretch = v
     end
 
+    def viewport=(v)
+      @viewport = v
+    end
+
     def update
       nil
     end


### PR DESCRIPTION
## Summary

- The native `Window` class had no `viewport`/`viewport=` method at all. `Window#initialize` already threads an optional viewport through to construction (the same `parent_object` helper `Sprite`/`Plane`/`Tilemap` use), but nothing let a script reassign it afterward — which is what real games actually call, since VX Ace's own `Window.new(x, y, width, height)` shape never passes one at construction.
- Found via a real RPG Maker VX Ace release ("Sanctuary Of the Ruler") running headlessly under `--test_play`: with the `defined?` keyword fixed last round (#1265), it turned out to skip straight to `Scene_Battle#start` (RGSS3's `$BTEST`-gated Test Battle convention, triggered by VX Ace's editor F9) rather than a title screen, and crashed immediately on `Scene_Battle`'s own `create_all_windows` assigning `Window_BattleStatus` to a viewport.
- Fixed with one new native method, `window_set_viewport` (`mruby-rgss/src/lib.cxx`), reparenting the window's canvas via LVGL's own `lv_obj_set_parent` — the exact mechanism `Sprite`/`Plane`/`Tilemap` already use at construction, just made reassignable. No compositing, clipping, or z-sort changes needed elsewhere: the shared z-order pass in `gfx_update` already groups every display object by its *live* LVGL parent each frame.
- With this fix, the same real release's headless run goes several minutes into `Scene_Battle` with no crash at all.

## Test plan

- [x] `rake test` from a fully clean `3rd/mruby` submodule rebuild (all three existing `3rd/mruby` patches applied through the real `cmake`/`ninja` build path): 1847 OK / 0 KO / 0 Crash, no regressions.
- [x] Added `viewport=` to the existing `RGSS::Window` API-surface method-presence test in `mruby-rgss/test/test.rb`, matching how the rest of `Window`'s native setters are covered there (real compositing behavior needs a live display the headless mrbtest binary lacks, same as `Sprite`/`Viewport`/`Tilemap`).
- [x] Full app build (`ninja rpg_maker_clone`) and a real headless run against "Sanctuary Of the Ruler" confirms no crash at the previous `Window_BattleStatus#viewport=` failure point — the game now runs a full 3-minute headless session inside `Scene_Battle` with no crash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_