### PR TITLE
Implement RPG::UsableItem#battle_ok?/#menu_ok?

### DIFF
--- a/changelog.d/usable-item-battle-menu-ok.fixed.md
+++ b/changelog.d/usable-item-battle-menu-ok.fixed.md
@@ -1,0 +1,9 @@
+- Fixed a real gap in `mruby-rpgvx`: `RPG::UsableItem#battle_ok?`/`#menu_ok?`
+  (RGSS3/VX Ace, checked by the stock `Game_BattlerBase#occasion_ok?` to
+  decide whether a skill/item can be used in battle vs. from the menu) did
+  not exist at all, raising `NoMethodError` the moment an actor or enemy AI
+  tried to use one. Found because a real RPG Maker VX Ace game's enemy AI
+  hit it selecting its very first battle action. Matches the editor's
+  Occasion dropdown exactly (0 Always, 1 Only in Battle, 2 Only from the
+  Menu, 3 Never) -- confirmed against RPG Maker MV's own `isOccasionOk`, a
+  line-for-line port of the same VX Ace logic.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21171,6 +21171,24 @@ screen (544×416). Full rationale:
     LVGL parent each frame with no further changes needed. With this fix,
     the same real release's headless run goes several minutes into
     `Scene_Battle` with no crash at all.
+  - ✅ **`RPG::UsableItem#battle_ok?`/`#menu_ok?` were not implemented at
+    all.** Past the `Window#viewport=` wall, the same real release's enemy
+    AI hit a seventh: `NoMethodError: undefined method 'battle_ok?' for
+    RPG::Skill`, from `Game_BattlerBase#occasion_ok?` deciding whether an
+    enemy's skill is usable during `Game_Enemy#make_actions`. RGSS3's own
+    stock `occasion_ok?` dispatches on these two rather than comparing
+    `occasion` directly -- confirmed against RPG Maker MV's own
+    `rpg_objects.js` (`isOccasionOk`, a line-for-line port of VX Ace's Ruby
+    that inlines the identical two checks). This engine's `RPG::UsableItem`
+    (the real ancestor of `RPG::Skill`/`RPG::Item`, confirmed via
+    `mruby-rpgxp/mrblib/rgss_data.rb`'s own `class Skill < UsableItem`)
+    had the `occasion` field itself but never the two convenience methods
+    real games' own default scripts call. Fixed with two small mrblib
+    methods on `UsableItem` (`mruby-rpgvx/mrblib/rgss2_data.rb`), matching
+    the editor's Occasion dropdown exactly (0 Always, 1 Only in Battle, 2
+    Only from the Menu, 3 Never). With this fix, the same real release's
+    headless Test Battle run gets past its enemies' first action-selection
+    pass with no crash.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -934,6 +934,29 @@ lookup with `defined?(SceneManager)`.
   real release's headless run no longer crashes within the first several
   minutes of `Scene_Battle`, well past this wall.
 
+- **Fixed: `RPG::UsableItem#battle_ok?`/`#menu_ok?` were not implemented at
+  all.** Once past the `Window#viewport=` wall, the same real release's
+  enemy AI hit a seventh: `NoMethodError: undefined method 'battle_ok?' for
+  RPG::Skill`, from `Game_BattlerBase#occasion_ok?` deciding whether an
+  enemy's skill is usable during `Game_Enemy#make_actions`. RGSS3's own
+  stock `occasion_ok?` dispatches on these two methods rather than
+  comparing the `occasion` field directly (`item.battle_ok?` in battle,
+  `item.menu_ok?` from the menu) — confirmed against RPG Maker MV's own
+  `rpg_objects.js` (`Game_BattlerBase.prototype.isOccasionOk`, a line-for-
+  line port of VX Ace's Ruby that inlines the same two checks:
+  `occasion === 0 || occasion === 1` for battle, `occasion === 0 ||
+  occasion === 2` for the menu). This engine's `RPG::UsableItem` (the real
+  ancestor of `RPG::Skill`/`RPG::Item` — confirmed via
+  `mruby-rpgxp/mrblib/rgss_data.rb`'s own `class Skill < UsableItem`
+  declaration, VX Ace's `rgss2_data.rb` only reopens it to add fields, not
+  redeclaring the hierarchy) had the `occasion` field itself but never the
+  two convenience methods real games' own default scripts call. Added as
+  two small mrblib methods on `UsableItem`
+  (`mruby-rpgvx/mrblib/rgss2_data.rb`), matching the editor's Occasion
+  dropdown exactly (0 Always, 1 Only in Battle, 2 Only from the Menu, 3
+  Never). With this fix, the same real release's headless Test Battle run
+  gets past its enemies' very first action-selection pass with no crash.
+
 ## What this means for turning the host on
 
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
@@ -950,17 +973,19 @@ only item left in the six sections above; item 7's `$!`/bare-`raise` gap is
 now fixed too (`patches/mruby-dollar-bang-scoped.patch`, above), so the same
 real release's own crash-reporter add-on now sees the actual exception
 instead of masking it behind an unrelated `NoMethodError`, and re-raises it
-correctly. Seventeen real bugs have been found and fixed this way so far
+correctly. Eighteen real bugs have been found and fixed this way so far
 (`Dir.glob`, `Color.new`/`Tone.new`, the desktop heap, `Window#contents`,
 `Audio.bgm_play`'s `pos` argument, `RPG::CommonEvent#autorun?`/`#parallel?`,
 `Bitmap#draw_text`'s non-`String` coercion, `RPG::EventCommand#initialize`,
 `Sprite#width`/`#height`, the `::Const = value` compiler bug, `$!`/bare-
 `raise` itself, the `Tilemap`/`Plane` `ox=`/`oy=` redundant-refresh hang,
 `Audio.bgs_play`'s `pos` argument, `Marshal`'s `marshal_dump`/
-`marshal_load` protocol mismatches, the missing `defined?` keyword, and the
-missing `Window#viewport=`) — the first ten via the temporary VM probe,
-finding the real exception directly regardless of `$!` being masked at the
-time. With `defined?` and `Window#viewport=` both fixed, the same real
-release's headless Test Battle run now goes several minutes into
-`Scene_Battle` with no crash at all; where its next wall stands (if any)
-past that is not yet traced.
+`marshal_load` protocol mismatches, the missing `defined?` keyword, the
+missing `Window#viewport=`, and the missing
+`RPG::UsableItem#battle_ok?`/`#menu_ok?`) — the first ten via the temporary
+VM probe, finding the real exception directly regardless of `$!` being
+masked at the time. With `defined?`, `Window#viewport=` and
+`battle_ok?`/`menu_ok?` all fixed, the same real release's headless Test
+Battle run now gets past its enemies' first action-selection pass with no
+crash at all; where its next wall stands (if any) past that is not yet
+traced.

--- a/mruby-rpgvx/mrblib/rgss2_data.rb
+++ b/mruby-rpgvx/mrblib/rgss2_data.rb
@@ -100,6 +100,19 @@ module RPG
   class UsableItem < BaseItem
     include UsableItemFields
 
+    # RGSS3's own stock Game_BattlerBase#occasion_ok? dispatches on these two
+    # rather than comparing `occasion` itself, so a skill/item needs them
+    # directly: the editor's Occasion dropdown is 0 (Always), 1 (Only in
+    # Battle), 2 (Only from the Menu), 3 (Never) -- 0/1 usable in battle,
+    # 0/2 usable from the menu.
+    def battle_ok?
+      occasion == 0 || occasion == 1
+    end
+
+    def menu_ok?
+      occasion == 0 || occasion == 2
+    end
+
     # An RGSS3 damage formula: `type` (none/HP damage/MP recover/...), the
     # element, the Ruby `formula` string the engine evals, its `variance`
     # percentage and whether it can crit.

--- a/mruby-rpgvx/test/rpgvx_test.rb
+++ b/mruby-rpgvx/test/rpgvx_test.rb
@@ -154,6 +154,27 @@ assert "VX RPG::Skill carries the fixed damage fields" do
   assert_nil loaded.features
 end
 
+assert "RPG::UsableItem#battle_ok?/#menu_ok? dispatch on occasion, RGSS3's own Game_BattlerBase#occasion_ok? logic" do
+  # The editor's Occasion dropdown: 0 Always, 1 Only in Battle, 2 Only from
+  # the Menu, 3 Never -- 0/1 usable in battle, 0/2 usable from the menu.
+  [
+    [0, true, true],
+    [1, true, false],
+    [2, false, true],
+    [3, false, false],
+  ].each do |occasion, battle_ok, menu_ok|
+    skill = RPG::Skill.new
+    skill.occasion = occasion
+    assert_equal battle_ok, skill.battle_ok?, "occasion #{occasion} battle_ok?"
+    assert_equal menu_ok, skill.menu_ok?, "occasion #{occasion} menu_ok?"
+
+    item = RPG::Item.new
+    item.occasion = occasion
+    assert_equal battle_ok, item.battle_ok?, "occasion #{occasion} battle_ok?"
+    assert_equal menu_ok, item.menu_ok?, "occasion #{occasion} menu_ok?"
+  end
+end
+
 assert "VX RPG::Map is a three-layer table with plain troop encounters" do
   map = RPG::Map.new
   map.width = 3


### PR DESCRIPTION
## Summary

- RGSS3's own stock `Game_BattlerBase#occasion_ok?` dispatches on `item.battle_ok?`/`item.menu_ok?` rather than comparing an item's `occasion` field directly. Confirmed against RPG Maker MV's own `rpg_objects.js` (`Game_BattlerBase.prototype.isOccasionOk`), a line-for-line port of the same VX Ace logic that inlines the identical two checks (`occasion === 0 || occasion === 1` for battle, `occasion === 0 || occasion === 2` for the menu).
- Found via a real RPG Maker VX Ace release ("Sanctuary Of the Ruler") running headlessly under `--test_play`: past the `Window#viewport=` fix (#1268), its enemy AI hit `NoMethodError: undefined method 'battle_ok?' for RPG::Skill` selecting its very first battle action. `RPG::UsableItem` (the real ancestor of `RPG::Skill`/`RPG::Item` — confirmed via `mruby-rpgxp/mrblib/rgss_data.rb`'s own `class Skill < UsableItem` declaration) had the `occasion` field itself but never these two convenience methods.
- Added as two small mrblib methods on `UsableItem` (`mruby-rpgvx/mrblib/rgss2_data.rb`), matching the editor's Occasion dropdown exactly (0 Always, 1 Only in Battle, 2 Only from the Menu, 3 Never).
- With this fix, the same real release's headless Test Battle run gets past its enemies' first action-selection pass with no crash, running a full 5 minutes into `Scene_Battle` with no crash at all.

## Test plan

- [x] `rake test` from a fully clean `3rd/mruby` submodule rebuild (all three existing `3rd/mruby` patches applied through the real `cmake`/`ninja` build path): 1848 OK / 0 KO / 0 Crash, no regressions.
- [x] New regression test in `mruby-rpgvx/test/rpgvx_test.rb` covering all four Occasion values for both `RPG::Skill` and `RPG::Item`.
- [x] `ruby scripts/rgss_cruby_test_check.rb` and `ruby scripts/rpgvx_testbed_check.rb` both pass clean.
- [x] Full app build (`ninja rpg_maker_clone`) and a real 5-minute headless run against "Sanctuary Of the Ruler" confirms no crash at the previous `battle_ok?` failure point.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_