### PR TITLE
Battle Item menu lists a disabled item instead of hiding it

### DIFF
--- a/changelog.d/battle-item-menu-lists-disabled-items.fixed.md
+++ b/changelog.d/battle-item-menu-lists-disabled-items.fixed.md
@@ -1,0 +1,7 @@
+- **Battle Item menu:** an unusable held item (a field-only medicine, an
+  ordinary weapon/shield/armor/helmet/accessory) now appears in the battle
+  Item list, greyed out — matching RPG_RT, which lists every held item and
+  only disables the unusable ones — instead of vanishing from the list
+  entirely. Selecting a disabled entry plays Buzzer and does nothing, the
+  same as the field Item menu's identical fix. Completes that earlier fix,
+  which had left the battle side open pending its own verification.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4647,6 +4647,36 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check driving a live `Scene::ItemMenu`
   (Decision on a listed-but-disabled row plays Buzzer, casts nothing, and
   stays on the list) — all four confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-22): the battle-menu half is now fixed too,
+  independently re-verified against genuine RPG_RT.exe rather than trusting
+  the "same `Window_Item` class" EasyRPG citation.** Got a live battle open
+  under wine against real `RPG_RT.exe` (a genuine, pre-existing Nepheshel
+  autostart event's command list swapped for an Enemy Encounter, keeping its
+  original trailing `[Victory]`/`[Escape]`/End Battle markers — a bare,
+  dangling Enemy Encounter with nothing after it, tried first, is silently
+  tolerated by this engine's own interpreter but never actually runs on real
+  RPG_RT, which is what made an earlier attempt at this comparison
+  misleading) with a controlled inventory: item 1 (薬草, battle-usable) and
+  item 15 (気付け薬, `occasion_field1` set — field-only, battle-unusable).
+  Real RPG_RT's battle Item window listed **both**, the unusable one in
+  glyph color `(99,166,247)` — the exact same measured "disabled" swatch
+  color the field-menu fix found — while this engine's own `#battle_items`
+  on the identical save/inventory showed only the usable one. Fixed with the
+  identical shape as the field-menu fix: `#battle_items` drops its
+  `#battle_usable?` filter (keeping the dangling-item exclusion),
+  `Scene::Battle#drive_battle_item`'s Decision handler gained the same
+  "buzz and stay" guard, and `#draw_battle_item` now colors each row via
+  `#draw_system_text` (index 0/3) through a new optional `idxs:` parameter
+  on the shared `#battle_list_window` helper — `nil` for every other caller
+  (skill/target/ally-target lists), so their own flat-white rendering is
+  unchanged. Covered by three widened `scripts/rpg2k_logic_check.rb`
+  `battle_items` fixtures (mirroring the field-menu ones: a field-only
+  medicine; the same switch-item-usable-on-one-side fixture, now also
+  asserting the battle side; a three-item fixture adding a field-only
+  medicine and a plain weapon) and a new `scripts/rpg2k_scene_check.rb`
+  check driving a live `Scene::Battle` into its Item sub-menu (Decision on
+  the one, listed-but-disabled item plays Buzzer, queues nothing, and stays
+  on the list) — all four confirmed to fail against the pre-fix code.
 - ✅ **An Escape/Teleport skill was hidden from the field Skill list outright
   whenever it was not castable right now — access off, no registered
   target, or flying — instead of staying listed and disabled, and the same

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5954,10 +5954,26 @@ module Game
       end
     end
 
-    # The bag's battle-usable items as `[id, count]` pairs in ascending id order.
+    # Every held item as `[id, count]` pairs in ascending id order, for the
+    # battle item list -- mirrors #field_items exactly (see its own doc
+    # comment for the full citation): confirmed against genuine RPG_RT.exe,
+    # not just EasyRPG's "same Window_Item class" claim #field_items already
+    # warned this method's own inclusion still needed independent checking --
+    # a live battle with a usable Herb and a field-only (battle-unusable)
+    # Smelling Salts held listed *both* in the item window, the unusable one
+    # in the identical measured "disabled" swatch color the field-menu fix
+    # found. #battle_usable? is now consulted only for enablement, the same
+    # split as the field menu. The dangling-item exclusion (and its warning)
+    # stays, the same defensible corner case #field_items keeps.
     def battle_items
-      @items.keys.sort.select { |id| battle_usable?(id) }
-            .map { |id| [id, item_count(id)] }
+      @items.keys.sort.select do |id|
+        it = db_item(id)
+        if it.nil?
+          $stderr.puts "[RPG2k] Item menu: party-held item ##{id} has no " \
+                       'matching database row, excluding from battle menu'
+        end
+        it
+      end.map { |id| [id, item_count(id)] }
     end
 
     # The HP / SP a medicine restores to a battle `target` (Combatant snapshot)

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1824,8 +1824,18 @@ class RPG2k
         elsif (Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)) && !items.empty?
           move_battle_item_cursor(-1)
         elsif Input.trigger?(Input::C)
-          play_system_se(SFX_DECISION)
           item_id, _count = @ui[:items][@ui[:item_i]]
+          # A row now can hold an item #battle_items lists but is not
+          # battle-usable (see its own doc comment) -- selectable, since the
+          # cursor moves freely onto it, but Decision just buzzes and stays,
+          # the same "greyed entry" shape the field Item menu's
+          # Scene::ItemMenu#choose_item already gates its own dispatch
+          # behind.
+          unless @state.party.battle_usable?(item_id)
+            play_system_se(SFX_BUZZER)
+            return
+          end
+          play_system_se(SFX_DECISION)
           it = @state.party.db_item(item_id)
           @ui[:pending] = { kind: :item, item_id: item_id, it: it }
           close_battle_item
@@ -3449,7 +3459,13 @@ class RPG2k
       # *rows* scrolls, keeping `sel`'s own row in view, the way
       # `Window_Selectable`'s own scrolling does for an oversized troop or
       # skill list.
-      def battle_list_window(x, w, labels, sel, z, column_max: 1)
+      # `idxs`, parallel to `labels`, is an optional windowskin swatch index
+      # per row (0 enabled / 3 disabled, `Scene::Base#draw_system_text`'s own
+      # convention) -- nil (every caller except #draw_battle_item) keeps the
+      # plain flat-white `draw_text` every list here has always used; only
+      # the item list can hold a listed-but-disabled row (see
+      # #draw_battle_item).
+      def battle_list_window(x, w, labels, sel, z, column_max: 1, idxs: nil)
         rows = BATTLE_VISIBLE_ROWS
         inner_w = w - Window::BORDER * 2
         col_w = inner_w / column_max
@@ -3465,7 +3481,12 @@ class RPG2k
           row = i / column_max
           next if row < scroll || row >= scroll + rows
           col = i % column_max
-          c.draw_text col * col_w, (row - scroll) * BATTLE_LINE_H, col_w, BATTLE_LINE_H, label
+          y = (row - scroll) * BATTLE_LINE_H
+          if idxs
+            draw_system_text(c, col * col_w, y, col_w, BATTLE_LINE_H, label, windowskin, idxs[i])
+          else
+            c.draw_text col * col_w, y, col_w, BATTLE_LINE_H, label
+          end
         end
         win.contents = c
         unless labels.empty?
@@ -3496,15 +3517,18 @@ class RPG2k
         @ui[:skill_win] = nil
       end
 
-      # The party's battle items as "Name  xN", with a cursor.
+      # The party's battle items as "Name  xN", with a cursor. A listed but
+      # not battle-usable item (see Game::Party#battle_items) draws in the
+      # windowskin's disabled swatch, matching the field Item menu.
       def draw_battle_item
         @ui[:item_win].dispose if @ui[:item_win]
         labels = @ui[:items].map do |id, count|
           it = @state.party.db_item(id)
           "#{it ? it.name : "Item #{id}"}  x#{count}"
         end
+        idxs = @ui[:items].map { |id, _count| @state.party.battle_usable?(id) ? 0 : 3 }
         @ui[:item_win] = battle_list_window(0, SCREEN_W, labels, @ui[:item_i], 325,
-                                            column_max: BATTLE_LIST_COLUMN_MAX)
+                                            column_max: BATTLE_LIST_COLUMN_MAX, idxs: idxs)
       end
 
       def close_battle_item

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6771,7 +6771,7 @@ check 'a field-only medicine is kept out of battle; every medicine is in the fie
   eq [[5, 1], [6, 1]], st.party.field_items
   ok st.party.battle_usable?(5), 'the ordinary medicine is usable in battle'
   ok !st.party.battle_usable?(6), 'the field-only one is not'
-  eq [[5, 1]], st.party.battle_items
+  eq [[5, 1], [6, 1]], st.party.battle_items, 'both listed -- the field-only one just disabled here'
 end
 
 # A database shrink can leave a party-held item id dangling -- shown as "?"
@@ -6806,7 +6806,8 @@ check 'a switch item reads its own pair of occasion flags' do
   st.party.gain_item(6, 1)
   eq [[5, 1], [6, 1]], st.party.field_items, 'both listed -- the battle-flagged one just disabled here'
   ok !st.party.field_usable?(6), 'still not field-usable, only listing changed'
-  eq [[6, 1]], st.party.battle_items, 'only the battle-flagged one'
+  eq [[5, 1], [6, 1]], st.party.battle_items, 'both listed here too -- the field-flagged one disabled'
+  ok !st.party.battle_usable?(5), 'still not battle-usable, only listing changed'
 end
 
 check 'a switch item is field-usable, effective, and flips its switch on use' do
@@ -15095,9 +15096,11 @@ check 'battle_items lists battle medicines; battle_item_command recovers' do
   st.party.gain_item(5, 2)
   st.party.gain_item(6, 1)
   st.party.gain_item(7, 1)
-  eq [[5, 2]], st.party.battle_items, 'only the battle-flagged medicine'
+  eq [[5, 2], [6, 1], [7, 1]], st.party.battle_items,
+     'every held item is listed -- the field-only medicine and the weapon just disabled'
   ok st.party.battle_usable?(5)
   ok !st.party.battle_usable?(6), 'a field-only medicine is not battle-usable'
+  ok !st.party.battle_usable?(7), 'a plain weapon is not battle-usable'
   target = combatant('T', 0, 0, 5, 100)
   target.max_mp = 30
   eq({ hp: 40, mp: 0, cured: [] },

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11486,6 +11486,11 @@ class BattleMagicParty
   def battle_items
     @items.keys.sort.select { |id| item_count(id) > 0 }.map { |id| [id, item_count(id)] }
   end
+  # Every item this stub can hold is meant to be battle-usable -- none of
+  # these checks model a disabled entry, which Scene::Battle now consults to
+  # decide whether Decision buzzes-and-stays instead of dispatching,
+  # mirroring Game::Party#battle_usable?.
+  def battle_usable?(id); item_count(id) > 0; end
   def db_item(id); id == 5 ? OpenStruct.new(name: 'Potion') : nil; end
   def battle_item_command(_it, _target); { hp: 20, mp: 0 }; end
   def item_all_allies?(it); it.respond_to?(:scope) && it.scope == 1; end
@@ -12346,6 +12351,42 @@ check 'Enemy Encounter scene: the item list cursor is a column-locked ' \
 
   press_key(scene, RGSS::Input::LEFT)
   eq 0, ui[:item_i], 'Left moves back to column 0'
+end
+
+# A single held item that #battle_items now lists (a field-only medicine,
+# say) but #battle_usable? still refuses -- Game::Party's own list-vs-usable
+# split is covered by scripts/rpg2k_logic_check.rb; this stub only has to
+# hand the scene one listed-but-disabled row so the check below can pin the
+# RGSS wiring: Decision on it buzzes and stays, exactly like the field Item
+# menu's identical fix already does (see Scene::ItemMenu's own check).
+class BattleDisabledItemParty < BattleMagicParty
+  def initialize
+    super()
+    @items = { 5 => 1 }
+  end
+  def battle_usable?(_id); false; end
+end
+
+check 'Enemy Encounter scene: choosing a listed-but-unusable battle item ' \
+      'plays Buzzer, not Decision, casts nothing, and stays on the list' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleDisabledItemParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  eq :item, ui[:phase]
+
+  RGSS::Audio.reset_se
+  press_key(scene, RGSS::Input::C)    # try the one, disabled item
+  eq :item, ui[:phase], 'stays on the item list'
+  eq 'Buzzer1', RGSS::Audio.se_calls.last&.first, 'Buzzer plays instead of Decision'
+  ok ui[:pending].nil?, 'nothing was queued to cast'
 end
 
 # A two-actor party, so the ally-target cursor (heal skill / medicine) has


### PR DESCRIPTION
## Summary

- Completes the field-menu fix from the previous cycle (#1267): real RPG_RT's battle Item window follows the identical list-everything/grey-out-if-unusable convention as the field one. That earlier fix explicitly left the battle side open, since its only citation for "both windows share the same `Window_Item` class" was EasyRPG's source, not genuine RPG_RT.
- Independently re-verified this cycle: got a live battle open under wine against real `RPG_RT.exe` with a controlled inventory (item 1 薬草, battle-usable; item 15 気付け薬, field-only/battle-unusable). Real RPG_RT's battle Item window listed **both**, the unusable one in glyph color `(99,166,247)` — the exact same measured "disabled" swatch color the field-menu fix found. This engine's own `#battle_items` on the identical save/inventory showed only the usable one.
- Fixed with the same shape as the field-menu fix: `#battle_items` drops its `#battle_usable?` filter (keeping the dangling-item exclusion), `Scene::Battle#drive_battle_item`'s Decision handler gained the same "buzz and stay" guard on a disabled selection, and `#draw_battle_item` now colors each row via `#draw_system_text` through a new optional `idxs:` parameter on the shared `#battle_list_window` helper — `nil` for every other caller (skill/target/ally-target lists), so their rendering is unaffected.

## Test plan

- [x] Widened three existing `scripts/rpg2k_logic_check.rb` `battle_items` fixtures (a field-only medicine; the switch-item-usable-on-one-side fixture, now also asserted on the battle side; a three-item fixture adding a field-only medicine and a plain weapon) to assert the unusable entries are now listed, paired with `battle_usable?` assertions that they're still not usable.
- [x] New `scripts/rpg2k_scene_check.rb` check driving a live `Scene::Battle` into its Item sub-menu: Decision on the one, listed-but-disabled item plays Buzzer, queues nothing, and stays on the list.
- [x] All four checks confirmed via `git stash` to fail against the pre-fix code and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb` (890 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_