### PR TITLE
Fix missing setRestorationOfStatesFlag on the MZ Effekseer stub

### DIFF
--- a/changelog.d/mz-effekseer-shim-restoration-flag.fixed.md
+++ b/changelog.d/mz-effekseer-shim-restoration-flag.fixed.md
@@ -1,0 +1,14 @@
+- Fixed a real gap in RPG Maker MZ's Effekseer diagnostic stub
+  (`mruby-mvjs/mrblib/mz.rb`): it defined `init()` but not the
+  `setRestorationOfStatesFlag()` method real `effekseer.min.js` also
+  exposes, which `rmmz_core.js`'s `Graphics._createEffekseerContext` calls
+  right after `init()` unconditionally. The resulting `TypeError` was
+  swallowed by that function's own `try/catch`, which resets
+  `Graphics._app` to `null` on any exception -- so MZ boot failed with a
+  generic "Failed to initialize graphics." one call later, with nothing
+  pointing at Effekseer. Found against a real downloaded MZ game
+  (Labyria), which never got past this. Fixed by adding the missing
+  no-op method, alongside the stub's other no-ops
+  (`beginDraw`/`endDraw`/`setProjectionMatrix`); the game now boots clean
+  through the title and every headless probe (move, message, menu, save,
+  audio, battle).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21642,6 +21642,30 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
         that one release's own bundled, copyrighted corescript build, which
         this project has no standing copy of and no cause to reproduce beyond
         the general, already-fixed gap above.
+      - ✅ **`Graphics._createEffekseerContext` silently reset `Graphics._app`
+        to `null`, turning into an opaque "Failed to initialize graphics."
+        one call later.** `EFFEKSEER_SHIM_JS` (`mruby-mvjs/mrblib/mz.rb`)
+        gave the stub context an `init()` but not the
+        `setRestorationOfStatesFlag()` real `effekseer.min.js` also exposes;
+        `rmmz_core.js`'s `Graphics._createEffekseerContext` calls both back
+        to back and wraps the pair in its own `try/catch` that resets
+        `Graphics._app = null` on *any* exception, so the missing method
+        threw "not a function", was swallowed there, and only surfaced a
+        scene later as `SceneManager.initGraphics`'s generic
+        `Graphics.initialize()` false check — with no stack frame pointing
+        at Effekseer at all. Found against a real downloaded MZ game
+        (`Labyria`), whose boot never got past this even though `mz-sample`
+        and the freem.ne.jp release above both did (neither happens to hit
+        this exact call pair before something else already stops them).
+        Root-caused by temporarily instrumenting the stub's catch blocks
+        with `console.error(e.message + e.stack)` in a scratch copy of the
+        game's own `rmmz_core.js` (gitignored `data/`, never committed) to
+        get past the game's own swallowed exception, which pointed straight
+        at the missing method. Fixed with one more no-op method on the
+        stub context, exactly like its `beginDraw`/`endDraw`/
+        `setProjectionMatrix` siblings; `Labyria` now boots clean through
+        `Scene_Splash` → `Scene_Title` → `Scene_Map` and every headless
+        probe (move/message/menu/save/audio/battle) reports.
 
 ## Tooling
 

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -324,6 +324,7 @@ class MZ
     "(function(g){ " \
     "function makeContext(){ var ctx = { _handles: [] }; " \
     "ctx.init = function(){}; " \
+    "ctx.setRestorationOfStatesFlag = function(){}; " \
     "ctx.loadEffect = function(url, mag, onLoad, onError){ " \
     "var exists = (typeof g.__mv_existsSync === 'function') && " \
     "g.__mv_existsSync(url); " \

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -195,6 +195,24 @@ assert 'MZ.effekseer_shim_js replaces window.effekseer with the diagnostic stub'
   assert_true js.include?("EFKEFC")
 end
 
+assert 'the Effekseer stub survives Graphics._createEffekseerContext\'s real call sequence' do
+  # rmmz_core.js's Graphics._createEffekseerContext calls init() and then
+  # unconditionally setRestorationOfStatesFlag(false) on the context before
+  # ever touching the effect-loading API this stub otherwise exercises. A
+  # real downloaded game (Labyria) hit this: the stub had init() but not
+  # setRestorationOfStatesFlag, so the second call threw "not a function",
+  # was swallowed by rmmz_core.js's own try/catch, and silently reset
+  # Graphics._app to null -- turning into an opaque "Failed to initialize
+  # graphics." a scene later with no clue an Effekseer call was the cause.
+  MV::JS.eval(MZ.effekseer_shim_js)
+  MV::JS.eval(
+    "globalThis.__ctx3 = effekseer.createContext(); " \
+    "__ctx3.init(); __ctx3.setRestorationOfStatesFlag(false); " \
+    "globalThis.__ctx3_survived = true;"
+  )
+  assert_true MV::JS.eval("__ctx3_survived")
+end
+
 assert 'the Effekseer stub loads a real effect file and reports it, honestly' do
   # Exercised against the real host and real files on disk, through the same
   # __mv_existsSync/__mv_readFileBytes natives every other MZ asset uses.


### PR DESCRIPTION
## Summary

- `rmmz_core.js`'s `Graphics._createEffekseerContext` calls `init()` and then unconditionally `setRestorationOfStatesFlag()` on the context returned by `effekseer.createContext()`. The diagnostic stub (`EFFEKSEER_SHIM_JS` in `mruby-mvjs/mrblib/mz.rb`) only defined `init()`, so the second call threw `TypeError: not a function` — swallowed by that function's own `try/catch`, which resets `Graphics._app` to `null` on any exception. MZ boot then failed a scene later with a generic `"Failed to initialize graphics."`, with no stack frame pointing at Effekseer at all.
- Found against a real downloaded MZ game (`Labyria`), which never got past this even though `mz-sample` and an earlier freem.ne.jp release both did (neither happens to exercise this exact call pair before something else already stops them).
- Root-caused by temporarily instrumenting the game's own (gitignored, never committed) `rmmz_core.js` catch blocks with `console.error(e.message + e.stack)` to surface the exception the game itself was swallowing.
- Fixed with one more no-op method on the stub context, alongside its existing `beginDraw`/`endDraw`/`setProjectionMatrix` siblings.

## Verification

- Added a regression test (`mruby-mvjs/test/mz_test.rb`) reproducing the real call sequence (`init()` then `setRestorationOfStatesFlag(false)`) against the stub.
- Full project test suite (`ctest -R mruby_test`, includes `mruby-mvjs`): 1854 total, 1849 OK, 0 KO, 0 Crash.
- Fresh headless run against `Labyria` with every MZ probe flag (`-mz_new_game -mz_move_test -mz_menu_test -mz_message_test -mz_audio_test -mz_battle_test=1 -mz_save_test`): before the fix, boot stopped at `"Failed to initialize graphics."`; after the fix, it boots clean through `Scene_Splash` → `Scene_Title` → `Scene_Map` and every probe reports, ending with `every probe reported; ending the run`.

## Docs

- `docs/TODO.md`'s M6.3c section documents the root cause and fix.
- `changelog.d/mz-effekseer-shim-restoration-flag.fixed.md` added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_