### PR TITLE
Fix headless RGSS probes reading $scene, blind on VX Ace's SceneManager

### DIFF
--- a/changelog.d/rgss3-scene-manager-probe-visibility.fixed.md
+++ b/changelog.d/rgss3-scene-manager-probe-visibility.fixed.md
@@ -1,0 +1,15 @@
+- Fixed the headless probe harness (`--rgss_host_new_game`/`move_test`/
+  `menu_test`/`battle_test`/`save_test`) being silently blind on every real
+  RPG Maker VX Ace game. `RPGXP::ScriptHost` read `$scene` directly to see
+  what scene a game was in -- correct for XP/VX (RGSS/RGSS2), but VX Ace
+  (RGSS3) replaced that convention with `SceneManager`, and its stock
+  scripts never assign `$scene` at all. Confirmed against a real downloaded
+  VX Ace release's full 213-section bundle: zero `$scene =` assignments,
+  every scene threaded through `SceneManager` instead. The game itself ran
+  fine the whole time -- gdb caught it mid-`Tilemap#refresh` on a real map
+  -- but every probe waiting on `$scene` silently never started, producing
+  no crash and no scene-change log output at all, which read as an inert or
+  hung run. Fixed with `ScriptHost.current_scene`, which falls back to
+  `SceneManager.scene` when `$scene` is `nil`. The same release now reports
+  `Scene_Title` at frame 1 and `Scene_Map` at frame 87. This affected every
+  VX Ace game's headless testability, not any one release's playability.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21236,6 +21236,34 @@ screen (544×416). Full rationale:
     Only from the Menu, 3 Never). With this fix, the same real release's
     headless Test Battle run gets past its enemies' first action-selection
     pass with no crash.
+  - ✅ **The headless probe harness (`--rgss_host_new_game`/`move_test`/
+    `menu_test`/`battle_test`/`save_test`) was silently blind on every real
+    VX Ace game.** `RPGXP::ScriptHost.report_scene` and every probe's finish
+    method read `$scene` directly -- correct for XP and VX (RGSS/RGSS2),
+    whose stock `Main` runs `$scene.main while $scene`, but VX Ace (RGSS3)
+    replaced that with `SceneManager` (`Main` calls `SceneManager.run`, which
+    loops `SceneManager.scene.main`), and its stock scripts never assign
+    `$scene` at all. Confirmed against a real downloaded VX Ace release's
+    full 213-section bundle: zero `$scene =` assignments anywhere, every
+    scene threaded through `SceneManager` instead -- so `$scene` stayed `nil`
+    for the life of the process, `report_scene` never fired, `@map_frame`
+    never got set, and every probe that waits on it silently never started.
+    The game itself was running fine the whole time: a headless run against
+    it produced no crash and no probe output at all (not even
+    `[RPGXP-HOST-SCENE]`, logged on every scene change), which read as an
+    inert or hung run. Two rounds of gdb sampling ruled out a hang -- the
+    process was caught mid-`Tilemap#refresh` on a real map in one sample and
+    in `Graphics.update`'s frame-pacing sleep in the next, healthy per-frame
+    variation -- before a temporary, never-committed frame counter confirmed
+    `$scene` was `nil` at frame 600 while real rendering work was
+    demonstrably happening. Fixed with `ScriptHost.current_scene`, which
+    reads `$scene` first (cheaper, and still correct for XP/VX) and falls
+    back to `SceneManager.scene` when it is `nil` and `SceneManager` is
+    defined; every prior `$scene` read now goes through it. With this fix
+    the same release reports `Scene_Title` at frame 1 and `Scene_Map` at
+    frame 87 -- probe visibility restored with no change to the game's own
+    scripts. This affected every RGSS3 game's headless testability, not any
+    one release's playability.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -260,12 +260,38 @@ class RPGXP
     @scene_name = nil
     @map_frame = nil
 
+    # The game's own idea of "what scene is up", across two different real
+    # conventions this engine's three RGSS variants use. XP and VX (RGSS/RGSS2)
+    # run `$scene.main while $scene`, a plain global `Main` assigns and reads
+    # directly. VX Ace (RGSS3) replaced that with `SceneManager` (`Main` calls
+    # `SceneManager.run`, which loops `SceneManager.scene.main`) and its stock
+    # scripts never touch `$scene` at all -- confirmed against a real VX Ace
+    # release's full 213-section bundle: zero `$scene =` assignments, every
+    # scene class threaded through `SceneManager` instead. Every probe below
+    # used to key on `$scene` alone, so on a real VX Ace game it stayed nil
+    # forever: `report_scene` never fired, `@map_frame` never got set, and
+    # every probe that waits on it (move/menu/battle/save) silently never
+    # started, even though the game itself was booting and running fine --
+    # confirmed by gdb, which caught the process mid-`Tilemap#refresh` on a
+    # real map with no crash, just an invisible one to every probe here.
+    # `$scene` is checked first since it is cheaper and still correct for
+    # XP/VX.
+    def self.current_scene
+      return $scene unless $scene.nil?
+      return nil unless defined?(SceneManager) && SceneManager.respond_to?(:scene)
+      begin
+        SceneManager.scene
+      rescue StandardError
+        nil
+      end
+    end
+
     # Called once per driven frame, from the wrapper above. Two jobs, both about
     # being able to *see* what a game's own engine is doing from a log:
     #
-    #   * report each scene the game moves to. `$scene` is the game's own global
-    #     (RGSS's Main loops `$scene.main while $scene != nil`), so this reads
-    #     what it already publishes and modifies nothing.
+    #   * report each scene the game moves to (see #current_scene above for
+    #     what "the game's own scene" means across RGSS/RGSS2/RGSS3), so this
+    #     reads what the game already publishes and modifies nothing.
     #   * with --rgss_host_new_game, tap the confirm key so a headless run gets
     #     off the game's own title screen without a keyboard.
     #   * with --rgss_host_move_test, walk the party once the game's own map
@@ -290,7 +316,7 @@ class RPGXP
     end
 
     def self.report_scene
-      scene = $scene
+      scene = current_scene
       return if scene.nil?
       name = scene.class.to_s
       return if name == @scene_name
@@ -350,7 +376,7 @@ class RPGXP
     # a keyboard.
     #
     # `$game_player` is the game's own global; only its published `x`/`y` are
-    # read (see report_scene, which reads `$scene` the same way).
+    # read (see report_scene, which reads the game's own scene the same way).
     #
     # The two counts are a budget, not a preference: the probe finishes
     # MOVE_SETTLE + MOVE_HOLD * MOVE_DIRS frames after the map appears, and a
@@ -479,7 +505,7 @@ class RPGXP
 
     def self.finish_save_probe
       @save_done = true
-      scene = $scene
+      scene = current_scene
       name = scene.nil? ? "?" : scene.class.to_s
       $stderr.puts "[RPGXP-HOST-SAVE] scene=#{name} " \
                    "reached=#{been_through?("Scene_Save")} frame=#{@frames}"
@@ -530,7 +556,7 @@ class RPGXP
 
     def self.finish_battle_probe
       @battle_done = true
-      scene = $scene
+      scene = current_scene
       name = scene.nil? ? "?" : scene.class.to_s
       $stderr.puts "[RPGXP-HOST-BATTLE] scene=#{name} " \
                    "reached=#{name.include?("Scene_Battle")} frame=#{@frames}"
@@ -538,7 +564,7 @@ class RPGXP
 
     def self.finish_menu_probe
       @menu_done = true
-      scene = $scene
+      scene = current_scene
       name = scene.nil? ? "?" : scene.class.to_s
       # "Opened" means the game left its map for something else — which is what
       # cancel does on a stock map, and what a game with its own menu script

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -287,6 +287,55 @@ assert "ScriptHost.run returns false when the project ships no scripts" do
   assert_false RPGXP::ScriptHost.run(FakeScriptDB.new([]))
 end
 
+# current_scene is what every probe (move/menu/battle/save) and report_scene
+# key on to see the game's own scene. A real VX Ace release's full script
+# bundle never assigns `$scene` at all (RGSS3 replaced it with `SceneManager`,
+# see the method's own comment) -- confirmed against a real downloaded VX Ace
+# game's 213-section bundle, which left every probe silently inert (the game
+# ran and rendered fine; `$scene` alone just never went non-nil).
+assert "ScriptHost.current_scene reads $scene first, when set (XP/VX)" do
+  previous = $scene
+  begin
+    $scene = "fake XP/VX scene"
+    assert_equal "fake XP/VX scene", RPGXP::ScriptHost.current_scene
+  ensure
+    $scene = previous
+  end
+end
+
+assert "ScriptHost.current_scene falls back to SceneManager.scene (VX Ace)" do
+  previous_scene = $scene
+  had_scene_manager = Object.const_defined?(:SceneManager)
+  previous_scene_manager = had_scene_manager ? SceneManager : nil
+  begin
+    $scene = nil
+    fake_manager = Object.new
+    def fake_manager.scene
+      "fake VX Ace scene"
+    end
+    Object.const_set(:SceneManager, fake_manager)
+    assert_equal "fake VX Ace scene", RPGXP::ScriptHost.current_scene
+  ensure
+    $scene = previous_scene
+    Object.send(:remove_const, :SceneManager) if Object.const_defined?(:SceneManager)
+    Object.const_set(:SceneManager, previous_scene_manager) if had_scene_manager
+  end
+end
+
+assert "ScriptHost.current_scene is nil with neither $scene nor SceneManager" do
+  previous_scene = $scene
+  had_scene_manager = Object.const_defined?(:SceneManager)
+  previous_scene_manager = had_scene_manager ? SceneManager : nil
+  begin
+    $scene = nil
+    Object.send(:remove_const, :SceneManager) if had_scene_manager
+    assert_nil RPGXP::ScriptHost.current_scene
+  ensure
+    $scene = previous_scene
+    Object.const_set(:SceneManager, previous_scene_manager) if had_scene_manager
+  end
+end
+
 # The RGSS standard library (mrblib/rgss_library.rb) — the classes RGSS104E.dll
 # supplies and no project ships. These tests run in the *built* engine, where
 # RPG::Sprite really does subclass the native RGSS::Sprite; they are what would


### PR DESCRIPTION
## Summary

- `RPGXP::ScriptHost.report_scene` and every probe's finish method (`finish_save_probe`, `finish_battle_probe`, `finish_menu_probe`) read `$scene` directly to see the game's own current scene — correct for XP and VX (RGSS/RGSS2), whose stock `Main` runs `$scene.main while $scene`, but **VX Ace (RGSS3) replaced that with `SceneManager`** (`Main` calls `SceneManager.run`, which loops `SceneManager.scene.main`), and its stock scripts never assign `$scene` at all.
- Confirmed against a real downloaded VX Ace release's full 213-section script bundle: **zero `$scene =` assignments anywhere**, every scene threaded through `SceneManager` instead. `$scene` stayed `nil` for the life of the process, so `report_scene` never fired, `@map_frame` never got set, and every probe waiting on it (`--rgss_host_move_test`/`menu_test`/`battle_test`/`save_test`) silently never started — even though the game itself was running fine the whole time. A headless run produced no crash and no probe output at all, reading as an inert or hung run.
- Root-caused by ruling out a hang first (two gdb samples 15-20s apart showed healthy per-frame variation: real `Tilemap#refresh` work in one, `Graphics.update`'s frame-pacing sleep in the next) and then a temporary, never-committed frame counter confirming `$scene` was `nil` at frame 600 while real rendering was demonstrably happening.
- Fixed with `ScriptHost.current_scene`, which reads `$scene` first (cheaper, still correct for XP/VX) and falls back to `SceneManager.scene` when `$scene` is `nil` and `SceneManager` is defined. Every prior direct `$scene` read now goes through it.

**Impact**: this affected every VX Ace game's headless testability, not any one release's playability — the probe harness was essentially non-functional for the entire RGSS3 line until now.

## Verification

- Added 3 regression tests (`mruby-rpgxp/test/rpgxp_test.rb`) covering `current_scene`'s `$scene`-first read, its `SceneManager.scene` fallback, and the nil case.
- Full project test suite (`ctest -R mruby_test`): 1857 total, 1852 OK, 0 KO, 0 Crash.
- Fresh headless run against a real VX Ace release with every probe flag: before the fix, zero `[RPGXP-HOST-*]` log lines over a 7-minute run despite the game genuinely running (confirmed via gdb); after the fix, `[RPGXP-HOST-SCENE] Scene_Title frame=1` and `Scene_Map frame=87` are reported, and every probe now runs.
- Confirmed the shared XP path is unaffected: `scripts/rpgxp_boot_check.bash` still reports both its games reaching their maps (`Scene_Save`/`Scene_Map` transitions logged as before).

## Docs

- `docs/TODO.md`'s RGSS section documents the root cause and fix.
- `changelog.d/rgss3-scene-manager-probe-visibility.fixed.md` added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_