### PR TITLE
psp: fix C++ exceptions by working around libgcc's broken FDE sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
 /build-psp
+/build-psp-docker
 /wasm-build
 /emsdk
 # Downloaded test-bed games live under data/ and are not committed, except the

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -177,8 +177,12 @@ rpg2k_add_mruby(
 # PSP_BUILD the same way it always was. Compiling it here directly too, as the
 # earlier HAL-only bring-up did, would double-define every symbol in it
 # (psp_display_create, psp_input_scan, ...) once both this executable and
-# libmruby.a define them.
-add_executable(rpg2k_psp main.cxx)
+# libmruby.a define them. psp_unwind_fde.cxx must stay listed here, ahead of
+# every library: it overrides two libgcc symbols and only wins the link because
+# objects named in add_executable() precede the libraries under
+# -Wl,--allow-multiple-definition (set below). See the file's own preamble for
+# what it works around.
+add_executable(rpg2k_psp main.cxx psp_unwind_fde.cxx)
 
 target_compile_definitions(rpg2k_psp PRIVATE PSP_BUILD LV_CONF_INCLUDE_SIMPLE)
 target_include_directories(rpg2k_psp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -15,6 +15,39 @@ cmake_minimum_required(VERSION 3.13)
 
 project(rpg2k_psp C CXX ASM)
 
+# Pin the optimisation level. CMake initialises CMAKE_BUILD_TYPE from the
+# environment variable of the same name, and this repo's nix devshell exports
+# CMAKE_BUILD_TYPE=RelWithDebInfo -- so a local build inside `nix develop` got
+# -O2 -g -DNDEBUG while the `psp` CI job, which runs in a bare pspdev container
+# with no such variable, got an empty build type and therefore no optimisation
+# flags at all. Two different builds of the same commit, neither declared
+# anywhere, and the difference is not cosmetic: at -O2 this EBOOT halts on
+# LVGL's TLSF assert (`!block_is_free(block)` in lv_tlsf_realloc,
+# 3rd/lvgl/src/stdlib/builtin/lv_tlsf.c:1215) during display setup, while the
+# unoptimised build boots to completion. Confirmed by building in the *same*
+# container both ways: only the flag changed, and only the -O2 build asserts.
+#
+# So this is deliberately the unoptimised build, plus -g: it is the only
+# configuration proven to reach RPG2K_PSP_MRUBY_OPEN and a running
+# RPG2K_PSP_BRINGUP heartbeat, and while the port is still in bring-up (ADR
+# 0047's P1 is about measuring this target at all) accurate line info and absent
+# inlining are worth more than code size. The cost is measured and affordable:
+# unoptimised .text is ~260 KB larger, against a boot that reports 782 KB heap
+# free, a 256 KB LVGL pool running at 1.4%, and a 256 KB main stack at 6.4%. -g
+# adds no RAM cost -- debug sections are not in a PT_LOAD.
+#
+# Provisional. Once the -O2 failure is root-caused, MinSizeRel (-Os -DNDEBUG) is
+# the better long-term answer for a target whose whole image is RAM-resident at
+# launch. Override deliberately with -DRPG2K_PSP_BUILD_TYPE=<type>; setting
+# CMAKE_BUILD_TYPE directly (or via the environment) is intentionally ignored,
+# since that ambient behaviour is the bug this pin exists to prevent.
+set(RPG2K_PSP_BUILD_TYPE
+    "Debug"
+    CACHE STRING "Optimisation level for the PSP EBOOT")
+set(CMAKE_BUILD_TYPE
+    "${RPG2K_PSP_BUILD_TYPE}"
+    CACHE STRING "" FORCE)
+
 set(REPO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
 # create_pbp_file's POST_BUILD chain runs "$ENV{PSPDEV}/bin/psp-fixup-imports"

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -299,6 +299,56 @@ Since it is only reachable when something actually throws, it was
 presumably dormant through the nine-bug trail above rather than newly
 introduced.
 
+### The `-O2` build is broken, and the build type is now pinned
+
+`app/psp/CMakeLists.txt` pins `CMAKE_BUILD_TYPE` (through
+`RPG2K_PSP_BUILD_TYPE`) because it used to be *ambient*: CMake initialises it
+from the environment variable of the same name, and this repo's nix devshell
+exports `CMAKE_BUILD_TYPE=RelWithDebInfo`. A local build inside `nix develop`
+therefore got `-O2 -g -DNDEBUG` while the `psp` CI job, in a bare container
+with no such variable, got an empty build type and no optimisation at all --
+two undeclared, different builds of the same commit, which is how an
+`-O2`-only failure went unnoticed.
+
+At `-O2` the EBOOT halts on LVGL's TLSF assert
+(`!block_is_free(block)` in `lv_tlsf_realloc`) during `lv_init()`, before
+anything here has touched LVGL's pool. Unoptimised it boots to completion.
+Confirmed by building in the *same* container both ways, so the environment
+is not the variable -- only the flag is. **Open.** Eliminated so far, each by
+measurement:
+
+- **The draw buffers.** `psp_display_create` reports its post-condition
+  (`RPG2K_PSP_DRAWBUF`); both pointers are non-null and both sizes exact at
+  `-O2`, and the assert fires before that marker is even reached. Not a
+  recurrence of bug 7's `std::vector` miscompile.
+- **Strict aliasing.** `lv_tlsf.c` type-puns block headers heavily, but
+  `-fno-strict-aliasing` at `-O2` still asserts.
+- **`lv_tlsf.c` itself.** Compiling only that translation unit at `-O0` with
+  the rest at `-O2` does not fix it -- the failure *moves*, to near-null guest
+  reads and a PPSSPP host segfault. TLSF's assert is a consistency check on
+  headers living in memory anything can scribble on, so it is where the damage
+  is noticed, not necessarily where it is caused.
+- **`psp_unwind_fde.cxx`.** Compiling only it at `-O0` leaves the failure
+  intact. (This does not establish that file is *correct* under optimisation --
+  the `-O2` build never runs far enough to throw -- only that it is not the
+  cause.)
+- **PPSSPP's sysclib return values.** Near-null pointers at `-O2` are bug 9's
+  signature (GCC exploiting its knowledge that `memset` returns its first
+  argument against an HLE returning 0), so every sysclib function was
+  re-audited: `memcpy`/`strcpy`/`strcat`/`strncpy` return their destination,
+  `memset`/`memmove` do too via
+  `nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch`, and the four
+  added by `nix/patches/ppsspp-sysclibforkernel-missing-functions.patch`
+  (`tolower`/`strtoul`/`memchr`/`strncat`) are all correct. Not a recurrence.
+
+The failure mode changes when unrelated code shifts the binary -- the same
+layout sensitivity bug 7 showed -- so per-translation-unit bisection does not
+converge on it. Whoever picks this up should probably reach for pool canaries
+or guarded allocations rather than more bisecting. Until then `Debug` is
+pinned, and the cost is measured and small: unoptimised `.text` is ~260 KB
+larger, against a boot reporting 782 KB heap free, a 256 KB LVGL pool running
+at 1.4%, and a 256 KB main stack at 6.4%.
+
 To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -117,7 +117,7 @@ idle path (`RPG2K_PSP_GAME_START none not_found`). The job is currently
 **non-blocking** (the required build gate is the `psp` job) — a holdover
 from when the EBOOT did not boot to completion under PPSSPP-headless; now
 that it does (see below), promoting `psp-smoke` to a required check is
-worth revisiting. Nine independent bugs were found and root-caused
+worth revisiting. Ten independent bugs were found and root-caused
 chasing that boot-to-completion goal; eight of them fixed, the remaining
 one (pspsdk's own upstream bug) no longer reachable — **boot now
 completes**:
@@ -264,8 +264,42 @@ none not_found` → a continuous `RPG2K_PSP_BRINGUP` heartbeat, running
 cleanly for over 850,000 frames with zero errors, stopped only by the
 test harness's own timeout. See
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)'s
-P1 for the full nine-bug trail, including the eliminated theories along
-the way. To reproduce any of this locally, run
+P1 for the full trail, including the eliminated theories along
+the way.
+
+That state no longer reproduces on `master`. Boot now dies inside
+`mrb_open()` again, on a **tenth bug** — this one in the toolchain, not
+in this project or the emulator. Any C++ `throw` aborts in libgcc's
+`uw_init_context_1` (`unwind-dw2.c`, `gcc_assert (code ==
+_URC_NO_REASON)`), which fires when `uw_frame_state_for` cannot find an
+FDE for the frame it is unwinding. mruby is built with the C++ exception
+ABI — automatic, because gems here ship `.cxx` sources — so `MRB_THROW`
+is a real throw and the first one during interpreter init is fatal. The
+defect is not the CFI: `.eh_frame` is complete, correctly bracketed,
+inside a `PT_LOAD`, and registered before `main()` by `crt0` → `_init` →
+`frame_dummy` → `__register_frame_info`. It is libgcc's own
+`fde_radixsort` — an 8-bit-digit radix sort needing four passes to cover
+a 32-bit address, whose output is exactly the state after two. Measured
+on this EBOOT: the array it produces has 1460 inversions against the
+full `pc_begin` and **zero** against `pc_begin & 0xffff`, so it is
+perfectly sorted on the low halfword. Every code address here is
+`0x08xxxxxx`, so that ordering is useless and `search_object`'s binary
+search misses every entry; a linear scan finds the FDE immediately.
+Eliminated first, each by measurement rather than argument: the CFI data
+itself, registration, `__builtin_return_address(0)`, libgcc's packed
+unaligned read in `unwind-pe.h`, and `memmove`/`memset` through the
+emulator's HLE. Worked around in `psp_unwind_fde.cxx`, which overrides
+`__register_frame_info`/`_Unwind_Find_FDE`/`__deregister_frame_info` and
+answers lookups from an index it sorts itself; with it, boot reaches
+`RPG2K_PSP_MRUBY_OPEN ok` → `RPG2K_PSP_GAME_START` → a continuous
+`RPG2K_PSP_BRINGUP` heartbeat again. Not upstreamed to pspdev yet, and
+worth reporting there: nothing about it is specific to this project, and
+it breaks C++ exceptions for every PSP binary this toolchain builds.
+Since it is only reachable when something actually throws, it was
+presumably dormant through the nine-bug trail above rather than newly
+introduced.
+
+To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched
 `ppsspp` package output (see above) rather than nixpkgs' unpatched one —

--- a/app/psp/psp_unwind_fde.cxx
+++ b/app/psp/psp_unwind_fde.cxx
@@ -1,0 +1,281 @@
+// Work around a broken FDE sort in this pspdev toolchain's libgcc, which stops
+// C++ exceptions from working at all on the PSP.
+//
+// Symptom: any `throw` -- including mruby's own, since gems shipping .cxx
+// sources make mruby build with the C++ exception ABI (MRB_USE_CXX_EXCEPTION),
+// so MRB_THROW is a real throw -- aborts inside libgcc's
+// uw_init_context_1 (`unwind-dw2.c`, `gcc_assert (code == _URC_NO_REASON)`).
+// That assert fires when uw_frame_state_for cannot find an FDE for the frame
+// it is unwinding.
+//
+// Cause: the CFI itself is fine. `.eh_frame` is complete, correctly bracketed
+// by __EH_FRAME_BEGIN__/__FRAME_END__, inside a PT_LOAD, and registered before
+// main() by crt0 -> _init -> frame_dummy -> __register_frame_info. What fails
+// is libgcc's own `fde_radixsort`: an 8-bit-digit radix sort that needs four
+// passes to cover a 32-bit address, but whose output is exactly the state
+// after two. Measured on this EBOOT: the array it produces has 1460 inversions
+// against the full pc_begin, and *zero* against pc_begin & 0xffff -- perfectly
+// sorted on the low halfword. Every code address here is 0x08xxxxxx, so
+// ordering by the low halfword is meaningless, and the binary search in
+// search_object misses every entry. Ruled out along the way: the CFI data,
+// registration, __builtin_return_address, libgcc's packed unaligned read in
+// unwind-pe.h, and memmove/memset through the emulator's HLE -- all verified
+// correct. See docs/adr/0047-psp-memory-budget.md.
+//
+// Fix: take over the two entry points that matter and do the search here.
+// frame_dummy hands the .eh_frame base to __register_frame_info as its first
+// argument, so capturing it needs no linker-script symbol and no reach into
+// libgcc's file-static registry; _Unwind_Find_FDE is then answered from an
+// index this file builds and sorts itself. Both overrides win the link
+// because this translation unit is listed in add_executable() ahead of every
+// library, under the -Wl,--allow-multiple-definition the EBOOT already sets
+// (see app/psp/CMakeLists.txt) -- first definition wins, and libgcc's copies
+// are simply never reached.
+//
+// Deliberately narrow. It reads each CIE's augmentation to find the FDE
+// pointer encoding, and requires every one of them to be a 4-byte absolute
+// form (absptr/udata4/sdata4) -- which is what this toolchain emits, and what
+// libgcc itself concluded, since it set mixed_encoding=0 on this object. This
+// EBOOT carries three CIEs: one "zR" and two "zPLR", so stepping over a 'P'
+// (personality routine: an encoding byte plus an encoded pointer) and an 'L'
+// (LSDA encoding byte) is required, not optional. Anything it does not
+// recognise disables the whole override, leaving libgcc's behaviour untouched
+// rather than guessing. Drop the whole file once pspdev's libgcc sorts
+// correctly; psp_unwind_fde_ok() is what tells you whether it engaged.
+
+#include <stdlib.h>
+
+namespace {
+
+// libgcc's dwarf_eh_bases, which _Unwind_Find_FDE fills in for its caller.
+struct DwarfEhBases {
+  void* tbase;
+  void* dbase;
+  void* func;
+};
+
+const unsigned char* g_eh_frame = nullptr;
+const unsigned char** g_fdes = nullptr;
+unsigned g_count = 0;
+bool g_built = false;
+bool g_disabled = false;
+
+unsigned read_u32(const unsigned char* p) {
+  return static_cast<unsigned>(p[0]) | (static_cast<unsigned>(p[1]) << 8) |
+         (static_cast<unsigned>(p[2]) << 16) |
+         (static_cast<unsigned>(p[3]) << 24);
+}
+
+// The FDE's pc_begin, for the 4-byte absolute encodings this file accepts.
+unsigned fde_pc_begin(const unsigned char* fde) {
+  return read_u32(fde + 8);
+}
+unsigned fde_pc_range(const unsigned char* fde) {
+  return read_u32(fde + 12);
+}
+
+const unsigned char* skip_uleb(const unsigned char* p) {
+  while (*p & 0x80)
+    ++p;
+  return p + 1;
+}
+
+// Step over one encoded pointer of the given encoding, or null if it is a form
+// this file does not decode (DW_EH_PE_aligned in particular, which would need
+// the section's own alignment).
+const unsigned char* skip_encoded(const unsigned char* p, unsigned char enc) {
+  if (enc == 0xff)  // DW_EH_PE_omit
+    return p;
+  switch (enc & 0x07) {
+    case 0x00:
+      return p + 4;  // absptr, 32-bit target
+    case 0x02:
+      return p + 2;  // udata2
+    case 0x03:
+      return p + 4;  // udata4
+    case 0x04:
+      return p + 8;  // udata8
+    case 0x01:       // uleb128
+    case 0x05:
+      return skip_uleb(p);
+    default:
+      return nullptr;
+  }
+}
+
+// The FDE pointer encoding named by a CIE's 'R' augmentation character, or
+// 0xff if this CIE is not a shape we handle. Requires a 'z' augmentation, so
+// that the augmentation data is self-describing, then walks the remaining
+// characters consuming what each one contributes.
+unsigned char cie_fde_encoding(const unsigned char* cie) {
+  const unsigned char* p = cie + 8;  // past length and the zero CIE id
+  const unsigned char version = *p++;
+  if (version != 1 && version != 3)
+    return 0xff;
+  const unsigned char* const aug = p;
+  while (*p)
+    ++p;
+  ++p;  // past the augmentation string's NUL
+  if (aug[0] != 'z')
+    return 0xff;
+  p = skip_uleb(p);  // code alignment factor
+  p = skip_uleb(p);  // data alignment factor (SLEB, same continuation rule)
+  p = (version == 1) ? p + 1 : skip_uleb(p);  // return address register
+  p = skip_uleb(p);                           // augmentation data length
+  for (const unsigned char* c = aug + 1; *c; ++c) {
+    switch (*c) {
+      case 'R':
+        return *p;
+      case 'L':
+        ++p;
+        break;
+      case 'P': {
+        const unsigned char enc = *p++;
+        p = skip_encoded(p, enc);
+        if (!p)
+          return 0xff;
+        break;
+      }
+      case 'S':  // signal frame: no augmentation data
+        break;
+      default:
+        return 0xff;
+    }
+  }
+  return 0xff;
+}
+
+bool encoding_is_absolute_4byte(unsigned char enc) {
+  if ((enc & 0x70) != 0x00)  // anything but absptr application
+    return false;
+  const unsigned char format = enc & 0x0f;
+  return format == 0x00 || format == 0x03 ||
+         format == 0x0b;  // absptr/udata4/sdata4
+}
+
+void sift(const unsigned char** a, unsigned root, unsigned n) {
+  for (;;) {
+    unsigned child = root * 2u + 1u;
+    if (child >= n)
+      return;
+    if (child + 1u < n && fde_pc_begin(a[child]) < fde_pc_begin(a[child + 1u]))
+      ++child;
+    if (fde_pc_begin(a[root]) >= fde_pc_begin(a[child]))
+      return;
+    const unsigned char* t = a[root];
+    a[root] = a[child];
+    a[child] = t;
+    root = child;
+  }
+}
+
+void sort_fdes(const unsigned char** a, unsigned n) {
+  for (unsigned start = n / 2u; start-- > 0u;)
+    sift(a, start, n);
+  for (unsigned end = n; end > 1u;) {
+    --end;
+    const unsigned char* t = a[0];
+    a[0] = a[end];
+    a[end] = t;
+    sift(a, 0u, end);
+  }
+}
+
+// Walk the table once to count FDEs and vet every CIE, then again to fill the
+// index. Two passes rather than a growing array: this runs once, on the first
+// throw, and a fixed allocation keeps it out of the way of whatever the
+// program was doing.
+void build_index() {
+  g_built = true;
+  if (!g_eh_frame) {
+    g_disabled = true;
+    return;
+  }
+  for (int pass = 0; pass < 2; ++pass) {
+    const unsigned char* p = g_eh_frame;
+    unsigned n = 0;
+    for (;;) {
+      const unsigned length = read_u32(p);
+      if (length == 0 || length == 0xffffffffu)  // terminator, or 64-bit DWARF
+        break;
+      const unsigned char* const next = p + 4 + length;
+      if (read_u32(p + 4) == 0) {  // CIE
+        if (pass == 0 && !encoding_is_absolute_4byte(cie_fde_encoding(p))) {
+          g_disabled = true;
+          return;
+        }
+      } else {
+        if (pass == 1)
+          g_fdes[n] = p;
+        ++n;
+      }
+      p = next;
+    }
+    if (pass == 0) {
+      if (n == 0) {
+        g_disabled = true;
+        return;
+      }
+      g_fdes = static_cast<const unsigned char**>(malloc(n * sizeof(*g_fdes)));
+      if (!g_fdes) {
+        g_disabled = true;
+        return;
+      }
+      g_count = n;
+    }
+  }
+  sort_fdes(g_fdes, g_count);
+}
+
+}  // namespace
+
+extern "C" {
+
+// frame_dummy's call. The `object` libgcc wants to thread onto its own list is
+// unused here: nothing in this file consults libgcc's registry, and the
+// matching __deregister_frame_info below keeps its bookkeeping consistent.
+void __register_frame_info(const void* begin, void* /*object*/) {
+  g_eh_frame = static_cast<const unsigned char*>(begin);
+}
+
+// __do_global_dtors_aux's counterpart. libgcc's own version walks its registry
+// and asserts when the object is missing -- which it always would be here --
+// so this has to be overridden too, or shutdown aborts. The result is
+// discarded by every caller in crtstuff.
+void* __deregister_frame_info(const void* /*begin*/) {
+  return nullptr;
+}
+
+const void* _Unwind_Find_FDE(void* pc, DwarfEhBases* bases) {
+  if (!g_built)
+    build_index();
+  if (g_disabled)
+    return nullptr;
+
+  const unsigned target = reinterpret_cast<unsigned>(pc);
+  unsigned lo = 0, hi = g_count;
+  while (lo < hi) {
+    const unsigned mid = lo + (hi - lo) / 2u;
+    const unsigned begin = fde_pc_begin(g_fdes[mid]);
+    if (target < begin) {
+      hi = mid;
+    } else if (target >= begin + fde_pc_range(g_fdes[mid])) {
+      lo = mid + 1u;
+    } else {
+      bases->tbase = nullptr;
+      bases->dbase = nullptr;
+      bases->func = reinterpret_cast<void*>(begin);
+      return g_fdes[mid];
+    }
+  }
+  return nullptr;
+}
+
+// Non-zero when the index built cleanly, for a caller that wants to report it.
+int psp_unwind_fde_ok(void) {
+  if (!g_built)
+    build_index();
+  return (!g_disabled && g_count != 0) ? static_cast<int>(g_count) : 0;
+}
+
+}  // extern "C"

--- a/changelog.d/psp-build-type-pin.fixed.md
+++ b/changelog.d/psp-build-type-pin.fixed.md
@@ -1,0 +1,17 @@
+- **The PSP EBOOT's optimisation level is now pinned instead of inherited from
+  the environment.** Nothing set `CMAKE_BUILD_TYPE`, and CMake initialises it
+  from the environment variable of the same name — which this repo's nix
+  devshell exports as `RelWithDebInfo`. A local build inside `nix develop`
+  therefore compiled at `-O2 -g -DNDEBUG` while the `psp` CI job, running in a
+  bare pspdev container, got an empty build type and no optimisation flags at
+  all: two undeclared, different builds of the same commit. That matters
+  because the `-O2` build is broken — it halts on LVGL's TLSF assert
+  (`!block_is_free(block)` in `lv_tlsf_realloc`) during `lv_init()`, while the
+  unoptimised build boots to completion; confirmed by building in the *same*
+  container both ways, so only the flag differs. Pinned to `Debug` through a
+  `RPG2K_PSP_BUILD_TYPE` cache variable, so an explicit override stays possible
+  while the ambient one is ignored. Provisional: `MinSizeRel` is the better
+  long-term answer for a target whose whole image is RAM-resident, once the
+  `-O2` failure is root-caused. `app/psp/README.md` records what that
+  investigation has already eliminated (the draw buffers, strict aliasing,
+  `lv_tlsf.c` alone, `psp_unwind_fde.cxx`, and PPSSPP's sysclib return values).

--- a/changelog.d/psp-docker-build-script.added.md
+++ b/changelog.d/psp-docker-build-script.added.md
@@ -1,0 +1,12 @@
+- **`scripts/build_psp_docker.bash` builds the PSP EBOOT in the same
+  `pspdev/pspdev` container CI uses**, instead of against a locally installed
+  pspdev plus the Nix devshell. It mirrors the `psp` CI job step for step: same
+  image, same apk packages, same hash-pinned Unicode mapping tables wired
+  through `$cp932_table`/`$jis0208_table`, same `psp-cmake`/`cmake --build`.
+  Output goes to `build-psp-docker/` by default rather than `build-psp/`, so a
+  container build and a native build can sit side by side and be compared —
+  which is how the two were found to differ: building `master` natively yields
+  an EBOOT that halts on an LVGL TLSF assert under PPSSPP-headless, while the
+  container build of the same commit does not. The PSP cross-toolchain is not
+  the variable there (both `$PSPDEV/build.txt` manifests are byte-for-byte
+  identical); what differs is the host half of the build.

--- a/changelog.d/psp-unwind-fde-sort.fixed.md
+++ b/changelog.d/psp-unwind-fde-sort.fixed.md
@@ -1,0 +1,26 @@
+- **C++ exceptions now work in the PSP EBOOT, which unblocks booting past
+  `mrb_open()`.** Any `throw` aborted inside libgcc's `uw_init_context_1`
+  (`gcc_assert (code == _URC_NO_REASON)`), which fires when the unwinder cannot
+  find an FDE for the frame it is unwinding. mruby is built with the C++
+  exception ABI — automatic, since gems here ship `.cxx` sources — so
+  `MRB_THROW` is a real throw and the first one during interpreter init killed
+  the boot. The CFI was never the problem: `.eh_frame` is complete, correctly
+  bracketed, inside a `PT_LOAD`, and registered before `main()`. The defect is
+  libgcc's own `fde_radixsort`, an 8-bit-digit radix sort that needs four
+  passes to cover a 32-bit address but whose output is exactly the state after
+  two — the array it builds has 1460 inversions against the full `pc_begin` and
+  zero against `pc_begin & 0xffff`, i.e. it is perfectly sorted on the low
+  halfword. Since every code address in the EBOOT is `0x08xxxxxx`, that
+  ordering is useless and the binary search in `search_object` misses every
+  entry. Eliminated by measurement first: the CFI data, registration,
+  `__builtin_return_address(0)`, libgcc's packed unaligned read in
+  `unwind-pe.h`, and `memmove`/`memset` through the emulator's HLE.
+  `app/psp/psp_unwind_fde.cxx` works around it by overriding
+  `__register_frame_info`, `_Unwind_Find_FDE` and `__deregister_frame_info` and
+  answering lookups from an index it builds and sorts itself; it reads each
+  CIE's augmentation for the FDE pointer encoding and disables itself on any
+  shape it does not recognise rather than guessing. With it the EBOOT reaches
+  `RPG2K_PSP_MRUBY_OPEN ok` → `RPG2K_PSP_GAME_START` → a continuous
+  `RPG2K_PSP_BRINGUP` heartbeat (5442 heartbeats, 544k frames, zero errors).
+  Not yet upstreamed to pspdev, where the real fix belongs — the bug breaks C++
+  exceptions for every PSP binary built with this toolchain.

--- a/mruby-rgss/src/psp.cxx
+++ b/mruby-rgss/src/psp.cxx
@@ -114,6 +114,33 @@ void flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
 
 }  // namespace
 
+// Emit the draw-buffer post-condition as a libc-free marker, for the reason
+// psp_display_create's call site explains. Same hand-rolled hex as
+// psp_lvgl_assert_halt: pspsdk's sysclib_snprintf is not dependable here.
+void psp_report_drawbufs(const void* b1,
+                         const void* b2,
+                         size_t n1,
+                         size_t n2,
+                         size_t want) {
+  static const char kLabel[] = "RPG2K_PSP_DRAWBUF ";
+  const unsigned vals[5] = {
+      static_cast<unsigned>(reinterpret_cast<uintptr_t>(b1)),
+      static_cast<unsigned>(reinterpret_cast<uintptr_t>(b2)),
+      static_cast<unsigned>(n1), static_cast<unsigned>(n2),
+      static_cast<unsigned>(want)};
+  char line[8 + 5 * 9];
+  int len = 0;
+  for (unsigned i = 0; i < sizeof(kLabel) - 1; ++i)
+    line[len++] = kLabel[i];
+  for (int v = 0; v < 5; ++v) {
+    for (int i = 0; i < 8; ++i)
+      line[len++] = "0123456789abcdef"[(vals[v] >> ((7 - i) * 4)) & 0xf];
+    line[len++] = (v == 4) ? '\n' : ' ';
+  }
+  sceIoWrite(1, line, len);
+  sceIoWrite(2, line, len);
+}
+
 lv_display_t* psp_display_create(int32_t hor_res, int32_t ver_res) {
   // Point the display controller at the start of VRAM (uncached mirror) with a
   // 512-pixel stride in RGB565.
@@ -181,6 +208,16 @@ lv_display_t* psp_display_create(int32_t hor_res, int32_t ver_res) {
   // free" assert deeper in this ADR's P1 trail actually traced back to.
   g_buf1.resize(buf_bytes);
   g_buf2.resize(buf_bytes);
+  // Check the post-condition rather than trusting it. This toolchain has
+  // already been caught miscompiling vector growth in exactly this spot
+  // (bug 7, assign()), and the failure mode is silent: a null or wild data()
+  // is handed to lv_display_set_buffers, LVGL and flush_cb write through it,
+  // and the damage only surfaces much later and far away as TLSF's
+  // "block already marked as free" in lv_tlsf_realloc. Reporting the pointers
+  // here turns that into a one-line answer. Cheap -- it runs once, at display
+  // creation.
+  psp_report_drawbufs(g_buf1.data(), g_buf2.data(), g_buf1.size(),
+                      g_buf2.size(), buf_bytes);
 
   lv_display_set_buffers(disp, g_buf1.data(), g_buf2.data(),
                          static_cast<uint32_t>(buf_bytes),
@@ -255,9 +292,37 @@ uint64_t psp_input_scan(void) {
 // failure (rather than a silent halt) before this loops forever, matching the
 // libc-free-write reasoning app/psp/main.cxx's StrBuf/psp_write already use.
 extern "C" void psp_lvgl_assert_halt(void) {
-  static const char kMarker[] = "RPG2K_PSP_LVGL_ASSERT\n";
-  sceIoWrite(1, kMarker, sizeof(kMarker) - 1);
-  sceIoWrite(2, kMarker, sizeof(kMarker) - 1);
+  static const char kMarker[] = "RPG2K_PSP_LVGL_ASSERT at 0x";
+  // LV_ASSERT_HANDLER expands at the failing assert's own call site, so this
+  // return address is the LVGL instruction that tripped -- resolve it with
+  // `psp-addr2line -f -i -e build-psp/rpg2k_psp <addr>`. Without it the marker
+  // says only "an LVGL assert fired", which is not enough to act on:
+  // LV_USE_LOG is 0 (app/psp/lv_conf.h) so nothing else names which one, and
+  // this binary links hundreds of distinct call sites to this handler -- far
+  // too many to narrow by disassembly. Finding the TLSF assert in
+  // lv_tlsf_realloc took exactly this.
+  //
+  // $ra is read directly rather than via __builtin_return_address(0): this
+  // function never returns, and GCC's analysis of that makes the builtin
+  // report an address inside the caller that is not its call site (measured:
+  // it named lv_tlsf_realloc's epilogue rather than either
+  // `jal psp_lvgl_assert_halt` return address in that function). The MIPS
+  // prologue only saves $ra, it does not clobber it, so reading the register
+  // before any call here is exact.
+  unsigned pc;
+  __asm__ volatile("move %0, $ra" : "=r"(pc));
+  // Formatted by hand rather than with snprintf: PPSSPP logs pspsdk's
+  // sysclib_snprintf as "Not fully implemented", and this has to survive a
+  // halt with no working libc -- the same reasoning app/psp/main.cxx's
+  // StrBuf/psp_write already use.
+  char hex[9];
+  for (int i = 0; i < 8; ++i)
+    hex[i] = "0123456789abcdef"[(pc >> ((7 - i) * 4)) & 0xf];
+  hex[8] = '\n';
+  for (int fd = 1; fd <= 2; ++fd) {
+    sceIoWrite(fd, kMarker, sizeof(kMarker) - 1);
+    sceIoWrite(fd, hex, sizeof(hex));
+  }
   for (;;)
     sceKernelDelayThread(1000000);  // 1s; never returns.
 }

--- a/scripts/build_psp_docker.bash
+++ b/scripts/build_psp_docker.bash
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Build the PSP EBOOT in the same pspdev container CI uses, instead of against a
+# locally installed pspdev + the Nix devshell.
+#
+# Why this exists: the two environments do not produce the same EBOOT. Building
+# `master` natively (a local pspdev install, host tools from `nix develop`)
+# yielded a binary that halts on an LVGL assert under PPSSPP-headless, while
+# CI's container build of the *same commit* boots cleanly -- 23 kernel objects
+# and a graceful sceKernelExitGame(), against 55 objects and
+# RPG2K_PSP_LVGL_ASSERT. The PSP cross-toolchain is not the variable: the two
+# pspdev installs' build manifests ($PSPDEV/build.txt) are byte-for-byte
+# identical, down to the same pspsdk commit this repo already pins in
+# patches/psp-fixup-imports-jal-relocation-aware.patch. What differs is the
+# host half of the build -- the native compiler that builds `mrbc` and mruby's
+# other host-side tools, glibc/nix here versus musl/Alpine there. So this
+# script is both the way to reproduce a CI EBOOT locally and the A/B control
+# for that class of bug (app/psp/README.md's bug 7 was exactly one: a pspdev
+# g++ miscompile of std::vector<uint8_t>::assign).
+#
+# It mirrors `.github/workflows/build.yml`'s `psp` job step for step: same
+# image, same apk packages, same Unicode-table plumbing, same
+# psp-cmake/cmake --build invocation. Keep the two in sync -- if that job
+# grows a step, this needs it too.
+#
+# Usage:
+#   scripts/build_psp_docker.bash [BUILD_DIR]     # default: build-psp-docker
+#   CLEAN=1 scripts/build_psp_docker.bash         # wipe BUILD_DIR first
+#
+#   The default deliberately is *not* `build-psp`, which is where the native
+#   build lands: keeping them apart is what lets you boot both EBOOTs under
+#   PPSSPP and compare, which is the whole point above. Pass `build-psp`
+#   explicitly to match CI's own path.
+#
+# Needs: docker, curl and python3 on the host. Everything else -- the PSP
+# toolchain, ruby, rake, a native compiler, gperf, bison -- comes from the
+# image. Network access is required: apk installs those packages, and
+# scripts/build_psp_fixup_imports.bash fetches pspsdk at its pinned commit.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${1:-build-psp-docker}"
+IMAGE=pspdev/pspdev:latest
+TABLES_DIR=.native-build-tables
+
+cd "$REPO_ROOT"
+
+command -v docker >/dev/null || { echo "docker not found on PATH" >&2; exit 1; }
+
+# The submodules are the EBOOT's actual content (LVGL, mruby, uni-algo); a
+# fresh clone leaves them empty and the configure fails on a missing
+# CMakeLists rather than on anything to do with this script.
+if [ ! -f 3rd/lvgl/CMakeLists.txt ]; then
+  echo "3rd/lvgl is empty -- run: git submodule update --init --recursive" >&2
+  exit 1
+fi
+
+if [ "${CLEAN:-0}" = 1 ]; then
+  echo "== wiping $BUILD_DIR"
+  rm -rf "${BUILD_DIR:?}"
+fi
+
+# mruby-lcf/cp932_to_unicode.rb and mruby-rgss/gen_shinonome_data.rb are
+# rake-time generators that read $cp932_table / $jis0208_table. The nix
+# devshell sets those from fetchurl derivations; a bare container has neither,
+# so fetch them here and verify against flake.nix's own sha256 pins -- same
+# approach, and the same two pins, as the `psp` CI job and
+# scripts/native-build-without-nix.bash. Downloading on the host rather than
+# in the container keeps them cached across runs, and Alpine ships no python3
+# to check the hash with anyway.
+echo "== Unicode mapping tables"
+mkdir -p "$TABLES_DIR"
+fetch_table() {
+  local url="$1" dest="$2" want="$3"
+  if [ ! -s "$dest" ]; then
+    curl -fsSL -o "$dest" "$url"
+  fi
+  local got
+  got="$(python3 -c 'import hashlib,base64,sys; print(base64.b64encode(hashlib.sha256(open(sys.argv[1],"rb").read()).digest()).decode())' "$dest")"
+  if [ "$got" != "$want" ]; then
+    echo "hash mismatch for $dest" >&2
+    echo "  flake.nix pins $want" >&2
+    echo "  downloaded     $got" >&2
+    exit 1
+  fi
+  echo "$(basename "$dest"): hash matches flake.nix"
+}
+fetch_table \
+  'https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WindowsBestFit/bestfit932.txt' \
+  "$TABLES_DIR/bestfit932.txt" 'JhTP6jXDyGxB0zGYeTqEykTt7jzw7gATphpD+6Ts4zE='
+fetch_table \
+  'https://www.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/JIS0208.TXT' \
+  "$TABLES_DIR/JIS0208.TXT" 'HFcYcEV/Gcl3IGMfqD7kkVSalroUNtoSlnhqZ9hjLoc='
+
+# -q for the same reason the CI job passes it: an implicit pull from
+# `docker run` prints a per-layer progress block, which -q reduces to the
+# resolved digest. Worth keeping visible -- pspdev/pspdev is a moving :latest
+# tag, so the digest is the only record of which toolchain a build used.
+echo "== $IMAGE"
+docker pull -q "$IMAGE"
+
+# The container runs as root, so everything it writes into the bind mount --
+# BUILD_DIR, and the generated lex.def / y.tab.c and applied patches inside
+# 3rd/mruby -- lands root-owned in the working tree. Hand them back at the end
+# rather than running as the host user throughout, which would break `apk add`.
+echo "== building $BUILD_DIR"
+docker run --rm \
+  -v "$REPO_ROOT:/src" -w /src \
+  -e "cp932_table=/src/$TABLES_DIR/bestfit932.txt" \
+  -e "jis0208_table=/src/$TABLES_DIR/JIS0208.TXT" \
+  -e "BUILD_DIR=$BUILD_DIR" \
+  -e "HOST_UID=$(id -u)" -e "HOST_GID=$(id -g)" \
+  "$IMAGE" sh -euc '
+    apk add --no-cache ruby ruby-rake build-base git gperf bison
+    bash scripts/build_psp_fixup_imports.bash
+    psp-cmake -S app/psp -B "$BUILD_DIR"
+    cmake --build "$BUILD_DIR" -j"$(nproc)"
+    chown -R "$HOST_UID:$HOST_GID" "$BUILD_DIR" 3rd/mruby
+  '
+
+echo
+echo "built $BUILD_DIR/EBOOT.PBP"
+ls -la "$BUILD_DIR/EBOOT.PBP"

--- a/scripts/build_psp_docker.bash
+++ b/scripts/build_psp_docker.bash
@@ -28,6 +28,7 @@ set -euo pipefail
 # Usage:
 #   scripts/build_psp_docker.bash [BUILD_DIR]     # default: build-psp-docker
 #   CLEAN=1 scripts/build_psp_docker.bash         # wipe BUILD_DIR first
+#   REBUILD_IMAGE=1 scripts/build_psp_docker.bash # rebuild the derived image
 #
 #   The default deliberately is *not* `build-psp`, which is where the native
 #   build lands: keeping them apart is what lets you boot both EBOOTs under
@@ -41,8 +42,15 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${1:-build-psp-docker}"
-IMAGE=pspdev/pspdev:latest
+BASE_IMAGE=pspdev/pspdev:latest
 TABLES_DIR=.native-build-tables
+
+# Packages the pspdev image does not ship. Keep this list identical to the
+# `apk add` in .github/workflows/build.yml's `psp` job -- CI installs them per
+# run, this script bakes them into a derived image instead (see PREPARED_IMAGE
+# below), and the two silently diverging would mean local builds stop matching
+# CI's.
+APK_PACKAGES="ruby ruby-rake build-base git gperf bison"
 
 cd "$REPO_ROOT"
 
@@ -97,13 +105,70 @@ fetch_table \
 # `docker run` prints a per-layer progress block, which -q reduces to the
 # resolved digest. Worth keeping visible -- pspdev/pspdev is a moving :latest
 # tag, so the digest is the only record of which toolchain a build used.
-echo "== $IMAGE"
-docker pull -q "$IMAGE"
+echo "== $BASE_IMAGE"
+docker pull -q "$BASE_IMAGE"
+
+# Bake the two slow per-run setup steps -- installing $APK_PACKAGES, and
+# building the patched psp-fixup-imports (which fetches pspsdk over the
+# network and compiles a host tool) -- into a derived image, and reuse it.
+# CI does both inline every run because its container is thrown away; locally
+# they are pure repeated cost, and the whole point of this script is a build
+# you can iterate on.
+#
+# The tag is a digest of everything the derived layers depend on: the base
+# image's own digest (pspdev/pspdev is a moving :latest tag), the package
+# list, and the fixup script plus the patch files it applies. Any of those
+# changing produces a different tag and therefore a rebuild, so a stale image
+# cannot silently survive an update -- which matters more here than the time
+# saved, since a stale psp-fixup-imports is exactly the failure this repo
+# already spent a PR on.
+PREPARED_TAG="$(
+  {
+    docker image inspect --format '{{index .Id}}' "$BASE_IMAGE"
+    echo "$APK_PACKAGES"
+    cat "$REPO_ROOT/scripts/build_psp_fixup_imports.bash" \
+        "$REPO_ROOT/patches/psp-fixup-imports-jal-relocation-aware.patch" \
+        "$REPO_ROOT/patches/psp-fixup-imports-config.h"
+  } | sha256sum | cut -c1-16
+)"
+PREPARED_IMAGE="rpg2k-pspdev:$PREPARED_TAG"
+
+if [ "${REBUILD_IMAGE:-0}" = 1 ]; then
+  docker image rm -f "$PREPARED_IMAGE" >/dev/null 2>&1 || true
+fi
+
+if docker image inspect "$PREPARED_IMAGE" >/dev/null 2>&1; then
+  echo "== reusing $PREPARED_IMAGE"
+else
+  echo "== preparing $PREPARED_IMAGE (one-off; reused by later runs)"
+  # A minimal build context rather than the repo: $REPO_ROOT carries the
+  # submodules, and handing docker a multi-gigabyte context to copy three
+  # files out of would cost more than the setup this is avoiding. The script
+  # resolves its own repo root from its location, so the layout below is what
+  # puts patches/ where it expects to find it.
+  CTX="$(mktemp -d)"
+  trap 'rm -rf "$CTX"' EXIT
+  mkdir -p "$CTX/scripts" "$CTX/patches"
+  cp "$REPO_ROOT/scripts/build_psp_fixup_imports.bash" "$CTX/scripts/"
+  cp "$REPO_ROOT/patches/psp-fixup-imports-jal-relocation-aware.patch" \
+     "$REPO_ROOT/patches/psp-fixup-imports-config.h" "$CTX/patches/"
+  cat > "$CTX/Dockerfile" <<DOCKERFILE
+FROM $BASE_IMAGE
+RUN apk add --no-cache $APK_PACKAGES
+COPY scripts/ /ctx/scripts/
+COPY patches/ /ctx/patches/
+RUN bash /ctx/scripts/build_psp_fixup_imports.bash && rm -rf /ctx
+DOCKERFILE
+  docker build -q -t "$PREPARED_IMAGE" "$CTX" >/dev/null
+  rm -rf "$CTX"
+  trap - EXIT
+fi
 
 # The container runs as root, so everything it writes into the bind mount --
 # BUILD_DIR, and the generated lex.def / y.tab.c and applied patches inside
 # 3rd/mruby -- lands root-owned in the working tree. Hand them back at the end
-# rather than running as the host user throughout, which would break `apk add`.
+# rather than running as the host user throughout, which would break `apk add`
+# when the image is being prepared.
 echo "== building $BUILD_DIR"
 docker run --rm \
   -v "$REPO_ROOT:/src" -w /src \
@@ -111,9 +176,7 @@ docker run --rm \
   -e "jis0208_table=/src/$TABLES_DIR/JIS0208.TXT" \
   -e "BUILD_DIR=$BUILD_DIR" \
   -e "HOST_UID=$(id -u)" -e "HOST_GID=$(id -g)" \
-  "$IMAGE" sh -euc '
-    apk add --no-cache ruby ruby-rake build-base git gperf bison
-    bash scripts/build_psp_fixup_imports.bash
+  "$PREPARED_IMAGE" sh -euc '
     psp-cmake -S app/psp -B "$BUILD_DIR"
     cmake --build "$BUILD_DIR" -j"$(nproc)"
     chown -R "$HOST_UID:$HOST_GID" "$BUILD_DIR" 3rd/mruby


### PR DESCRIPTION
## Problem

Any C++ `throw` in the PSP EBOOT aborts:

```
uw_init_context_1 (libgcc/unwind-dw2.c)
  gcc_assert (code == _URC_NO_REASON);   <- fails -> abort()
```

That assert fires when `uw_frame_state_for` cannot find an FDE for the frame it is unwinding. mruby is built with the C++ exception ABI — automatic, since gems here ship `.cxx` sources — so `MRB_THROW` is a real throw, and the first one during interpreter init kills the boot. It never reaches `RPG2K_PSP_MRUBY_OPEN`, collapsing instead through `abort()` → `_kill` → `sceKernelDeleteThread(current)` → crt0's `_exit`.

The `app/psp/README.md` trail records boot completing after bug 9. That no longer reproduces on `master`. Since this defect is only reachable when something actually throws, it was presumably dormant then rather than newly introduced.

## Root cause

**Not the CFI.** `.eh_frame` is complete, correctly bracketed by `__EH_FRAME_BEGIN__`/`__FRAME_END__`, inside a `PT_LOAD`, and registered before `main()` by crt0 → `_init` → `frame_dummy` → `__register_frame_info`.

It is libgcc's own `fde_radixsort` — an 8-bit-digit radix sort needing four passes to cover a 32-bit address, whose output is exactly the state after two:

| key | inversions |
|---|---|
| full `pc_begin` | 1460 |
| `pc_begin & 0xffff` | **0** |

Perfectly sorted on the low halfword. Every code address in this EBOOT is `0x08xxxxxx`, so that ordering is worthless: `search_object`'s binary search misses every entry, while a linear scan finds the FDE immediately (index 1118 of 3310, zero nulls).

Each of these was a live hypothesis, eliminated by measurement rather than argument:

- CFI data — 3310 FDEs, target FDE present, correct `pc_begin`/`count`/`encoding`
- registration — `seen_objects` populated, chain verified executing
- `__builtin_return_address(0)` — matches asm `$ra` exactly
- libgcc's packed unaligned read (`unwind-pe.h`) — replicated, **0** mismatches over 3314 entries
- `memmove` through the HLE — both overlap directions, **0** errors
- a second import mis-dispatch — the `memset` in `fde_radixsort`'s prologue disassembles as `jal … <sceKernelSignalSema>`, but that is the stale post-fixup symtab; PPSSPP binds `memset` there correctly

## Fix

`app/psp/psp_unwind_fde.cxx` overrides `__register_frame_info`, `_Unwind_Find_FDE` and `__deregister_frame_info`, answering lookups from an index it builds and sorts itself.

- `frame_dummy` hands it the `.eh_frame` base as an argument, so it needs no linker-script symbol and never touches libgcc's file-static registry.
- Overriding `__deregister_frame_info` is **not** optional — libgcc's asserts when the object is missing, which it now always is, so shutdown would abort.
- It reads each CIE's augmentation for the FDE pointer encoding. This EBOOT carries one `"zR"` and two `"zPLR"`, so stepping over `'P'` (encoding byte + encoded pointer) and `'L'` is required, not optional. Anything it does not recognise disables the override rather than guessing.
- The overrides win the link because the file is listed in `add_executable()` ahead of every library, under the `-Wl,--allow-multiple-definition` the EBOOT already sets. There is a comment on that line, since reordering it would silently disable the fix.

**Not upstreamed to pspdev, where the real fix belongs** — nothing about this is specific to this project, and it breaks C++ exceptions for every PSP binary built with this toolchain.

## Verification

Container build, headless PPSSPP:

```
RPG2K_PSP_BOOT
RPG2K_PSP_MRUBY_OPEN ok
RPG2K_PSP_GAME_START RPG2k ok
RPG2K_PSP_BRINGUP frame=0      free=782336 maxfree=524288 lvgl_used=3620 lvgl_max=4192 stack_free=245264 stack_used_max=16880
RPG2K_PSP_BRINGUP frame=544000 ...
5442 heartbeats, zero aborts
```

`RPG2K_PSP_BRINGUP` is the marker `psp-smoke` checks for and has never once emitted — CI has always passed on `RPG2K_PSP_BOOT` alone. The ADR 0047 telemetry it exists to collect is flat across 544k frames: LVGL pool 3,620 B of 256 KB, main stack 16,880 B of 256 KB.

## Also included

`scripts/build_psp_docker.bash` builds the EBOOT in the same `pspdev/pspdev` container CI uses, mirroring the `psp` job step for step. Output defaults to `build-psp-docker/` so a container build and a native build can sit side by side — which is how they were found to differ: the native build of the same commit *additionally* halts on an LVGL TLSF assert (`lv_tlsf.c:1215`, `"block already marked as free"`). That is untouched here and remains open; the PSP cross-toolchain is not the variable, since both `$PSPDEV/build.txt` manifests are byte-for-byte identical.

`pre-commit run --files` passes on all seven files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZpTj3DY5Wy8kv4kAcPnK7

---

## Second commit: pin the optimisation level, and cache the container build's setup

**`CMAKE_BUILD_TYPE` was ambient.** Nothing in the repo set it, and CMake initialises it from the environment variable of the same name — which this repo's nix devshell exports as `RelWithDebInfo`. So a local build inside `nix develop` got `-O2 -g -DNDEBUG`, while the `psp` CI job in a bare container got an empty build type and no optimisation flags at all. Two undeclared, different builds of the same commit.

Not cosmetic: at `-O2` the EBOOT halts on LVGL's TLSF assert (`!block_is_free(block)` in `lv_tlsf_realloc`) during LVGL init; unoptimised it boots to completion. Confirmed by building **in the same container both ways** — only the flag changed, so the environment is exonerated.

Pinned to `Debug` (the configuration proven to reach `MRUBY_OPEN` and a running heartbeat) through a `RPG2K_PSP_BUILD_TYPE` cache variable, so an explicit override stays possible while the ambient one is ignored. Provisional — `MinSizeRel` is the better long-term answer for a RAM-resident image once `-O2` is root-caused.

**The LVGL assert now names its call site.** `LV_USE_LOG` is 0 and hundreds of call sites reach that handler, so the bare marker could not be acted on. It prints `$ra` via inline asm — `__builtin_return_address(0)` reports a non-call-site address in a never-returning function, measured. This is what located the TLSF assert.

**Draw-buffer post-condition check.** This toolchain was already caught miscompiling vector growth in this exact spot (bug 7, `assign()`), and the failure is silent. `psp_display_create` now reports both pointers and sizes — and it immediately earned its place, proving the buffers are correct at `-O2` and eliminating a vector recurrence in a single run:

```
RPG2K_PSP_DRAWBUF 0948dd40 09497350 00009600 00009600 00009600
```

**`build_psp_docker.bash` caches its setup.** `apk add` and the patched `psp-fixup-imports` build ran on every invocation; both are now baked into a derived image tagged by a digest of the base image ID, the package list, and the fixup script plus its patches — so no stale image survives an update of any of them. `REBUILD_IMAGE=1` forces a rebuild.

```
run 1 (prepare + build)  1:22
run 2 (reuse)            0:03
```

Verified the baked tool carries the patch and that an EBOOT built through the cached image still boots to the heartbeat — a stale `psp-fixup-imports` is exactly the silent failure #1266 fixed, so the cache is checked rather than trusted. Local only; CI still installs inline because its container is discarded, and `$APK_PACKAGES` is commented to stay in sync with the workflow.

### Still open

The `-O2` TLSF failure itself. It fires *before* the draw buffers exist, so it is inside `lv_init()` and independent of anything in `psp.cxx` — pointing at `lv_tlsf.c` being miscompiled, or containing UB the optimiser exposes. Not addressed here; the pin sidesteps it.
