### PR TITLE
Reposition the shop status/gold panels to match RPG_RT

### DIFF
--- a/changelog.d/shop-status-gold-panel-position.fixed.md
+++ b/changelog.d/shop-status-gold-panel-position.fixed.md
@@ -1,0 +1,4 @@
+- **Shop screen:** the status and gold panels are now positioned like
+  RPG_RT's — right-aligned, status panel stacked directly above the gold
+  panel, both the same width — instead of the status panel sitting at the
+  screen's left edge with a narrower gold box pinned to the top-right.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1532,6 +1532,33 @@ The work below is roughly ordered by the critical path to a walkable game
   button press alone no longer dismisses the confirmation; the screen only
   advances once 60 frames have actually elapsed), all confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-22): the status and gold panels were positioned
+  wrong, not just wrong-shaped — the status panel sat at the screen's left
+  edge and the gold panel was a narrower box pinned to the top-right,
+  independently re-verified and corrected against genuine RPG_RT.exe rather
+  than left on the EasyRPG-sourced visibility fix above.** Reached a live
+  Shop scene with zero synthetic event editing — Nepheshel's own shop NPC
+  (`Map0016.lmu`, event 4, an authentic, shipped Open Shop) — by editing a
+  genuine save's position/gold fields and driving real `RPG_RT.exe` under
+  wine. Border-color pixel scan of the captured frame's right-hand column
+  gave exact native geometry: a status box (136px wide, 45px tall) directly
+  above a gold box, same 136px width, 29px tall — both right-aligned, not
+  the status panel's own 6px-from-the-left position or the gold panel's old
+  88px width. Fixed by moving `#draw_shop_status`'s window construction to
+  `SCREEN_W - SHOP_STATUS_W - 6` (from a hardcoded `6`) and
+  `#build_shop_gold_window`/`#draw_shop_gold` to share `SHOP_STATUS_W`
+  (dropping the separate `gw = 88`) and dock directly beneath the status
+  panel instead of beside it at the same `y`. **Known, deliberately
+  out-of-scope gap this surfaced but did not fix**: real RPG_RT's Buy list
+  itself narrows to make room for the side panels (measured at roughly 55%
+  of the window's width), while this codebase's list window stays full-width
+  on every shop screen regardless of panel visibility — a separate, larger
+  layout change left for a future pass, the same way this shop UI's own
+  history above has repeatedly scoped fixes narrowly. Covered by four new
+  assertions in the existing `scripts/rpg2k_scene_check.rb` status-panel
+  check (status panel x, gold panel x matches it, status sits above gold,
+  gold panel width matches the status panel's), confirmed to fail against
+  the pre-fix code before the fix.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5311,9 +5311,17 @@ class RPG2k
         end
       end
 
+      # Docks under the status panel, sharing its own width -- confirmed
+      # against genuine RPG_RT.exe under wine: a live shop's right-hand
+      # column (border-color pixel scan against a real frame) shows the
+      # status box then the gold box directly beneath it, both the same
+      # 136px width, not a narrower box pinned to the top like this used to
+      # draw. #draw_shop_status's own window uses the identical SHOP_STATUS_W
+      # / SHOP_LINE_H*2+BORDER*2 shape this stacks below.
       def build_shop_gold_window
-        gw = 88
-        win = Window.new(SCREEN_W - gw - 6, 6, gw, SHOP_LINE_H + Window::BORDER * 2)
+        gw = SHOP_STATUS_W
+        win = Window.new(SCREEN_W - gw - 6, 6 + SHOP_LINE_H * 2 + Window::BORDER * 2,
+                         gw, SHOP_LINE_H + Window::BORDER * 2)
         win.z = 300
         win.windowskin = @windowskin
         win
@@ -5394,7 +5402,7 @@ class RPG2k
         visible = SHOP_PANELS_VISIBLE_ON.include?(@shop[:screen])
         @shop[:gold].visible = visible
         return unless visible
-        gw = 88
+        gw = SHOP_STATUS_W
         c = Bitmap.new(gw - Window::BORDER * 2, SHOP_LINE_H)
         c.font.color = Color.new(255, 255, 255, 255)
         c.draw_text 0, 0, c.width, SHOP_LINE_H,
@@ -5441,7 +5449,12 @@ class RPG2k
         end
         win = @shop[:status]
         unless win
-          win = Window.new(6, 6, SHOP_STATUS_W, SHOP_LINE_H * 2 + Window::BORDER * 2)
+          # Right-aligned, not the screen's left edge -- confirmed against
+          # genuine RPG_RT.exe under wine (see #build_shop_gold_window's own
+          # doc comment for the capture this and the gold panel's position
+          # both come from).
+          win = Window.new(SCREEN_W - SHOP_STATUS_W - 6, 6,
+                           SHOP_STATUS_W, SHOP_LINE_H * 2 + Window::BORDER * 2)
           win.z = 300
           win.windowskin = @windowskin
           @shop[:status] = win

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15451,6 +15451,20 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   ok texts.include?('2'), 'two Potions already held'
   ok texts.include?('1'), 'one Potion equipped across the party'
 
+  # Confirmed against genuine RPG_RT.exe under wine (border-color pixel scan
+  # of a live shop's right-hand column): the status panel and the gold panel
+  # sit right-aligned, status stacked directly above gold, both the same
+  # width -- not the status panel pinned to the screen's left edge with a
+  # narrower gold box at the top-right, the layout this used to draw.
+  status_win = shop[:status]
+  gold_win = scene.instance_variable_get(:@shop)[:gold]
+  status_x = RPG2k::Scene::Map::SCREEN_W - RPG2k::Scene::Map::SHOP_STATUS_W - 6
+  eq status_x, status_win.x, "the status panel is right-aligned, not at the screen's left edge"
+  eq status_x, gold_win.x, 'the gold panel shares the same right-aligned x as the status panel'
+  ok status_win.y < gold_win.y, 'the status panel sits above the gold panel, not beside it'
+  eq RPG2k::Scene::Map::SHOP_STATUS_W, gold_win.width,
+     "the gold panel is the status panel's own width, not a narrower fixed box"
+
   RGSS::Input.triggered = [RGSS::Input::DOWN] # move to the second good (Herb, id 5)
   scene.update
   RGSS::Input.triggered = []


### PR DESCRIPTION
## Summary

- Both shop side panels were already the right shape but the wrong position: the status panel sat flush against the screen's left edge, and the gold panel was a narrower (88px) box pinned to the top-right instead of docking under the status panel.
- Confirmed against genuine `RPG_RT.exe` under wine: reached a live Shop scene via Nepheshel's own shop NPC (`Map0016.lmu`, event 4 — an authentic, shipped Open Shop, no synthetic event editing needed) and border-color pixel scanned the captured frame's right-hand column — a 136px-wide status box directly above a 136px-wide gold box, both right-aligned.
- Fixed by moving the status panel's window to `SCREEN_W - SHOP_STATUS_W - 6` (from a hardcoded `6`) and having the gold panel share `SHOP_STATUS_W`'s width, docked beneath the status panel instead of beside it at the same `y`.
- **Known, deliberately out-of-scope gap this surfaced**: real RPG_RT's Buy list itself narrows to make room for these panels (measured at roughly 55% of the window's width); this codebase's list window stays full-width on every shop screen regardless of panel visibility — a separate, larger layout change left for a future pass.

## Test plan

- [x] Added four position assertions to the existing status-panel `scripts/rpg2k_scene_check.rb` check: status panel x, gold panel x matches it, status sits above gold, gold panel width matches the status panel's.
- [x] Confirmed via `git stash` to fail against the pre-fix code and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb` (891 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_