### PR TITLE
Shop list window docks flush left, narrowing for the side panels

### DIFF
--- a/changelog.d/shop-list-window-width.fixed.md
+++ b/changelog.d/shop-list-window-width.fixed.md
@@ -1,0 +1,6 @@
+- **Shop screen:** the Buy/Sell list window now docks flush to the screen's
+  left edge — full width on the command menu and the Sell list, narrowed to
+  make room for the status/gold panel column on Buy and the quantity
+  counter — instead of a fixed, inset 300px-wide box on every screen. The
+  narrower width closes the same stale "inset 10px" shape already fixed for
+  the message window.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1559,6 +1559,41 @@ The work below is roughly ordered by the critical path to a walkable game
   check (status panel x, gold panel x matches it, status sits above gold,
   gold panel width matches the status panel's), confirmed to fail against
   the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-22): the list window's own full-width, inset-10px
+  shape is fixed too — the "roughly 55%" gap noted above, now precisely
+  measured and closed, plus a second, deeper-rooted bug it shares with the
+  message window's own already-fixed history.** Reached a live Buy/Sell
+  screen with zero synthetic event editing (Nepheshel's own shop NPC,
+  `Map0016.lmu` event 4) and corner-marker pixel-scanned genuine RPG_RT.exe
+  frames under wine: on the command menu and the Sell list (no side panels)
+  the list spans the full screen edge-to-edge; on Buy and the quantity
+  counter its right edge lands exactly where the status/gold panel column
+  begins (real x≈182, matching the already-verified `SHOP_STATUS_W+6`
+  panel offset from the right edge) — never the old `x=10, width=300`
+  inset box on any screen. That inset-10px shape is the identical stale
+  anti-pattern ADR 0021 already diagnosed and fixed for the *message*
+  window ("300px wide, inset 10px" → "fixed 320x80 at x=0") — this shop
+  list window carried the same pre-ADR-0021 shape all along, past the
+  point that fix landed, simply never revisited. Fixed by computing
+  `#draw_shop`'s window `x`/width from `@shop[:screen]`: `x = 0` always,
+  `width = SCREEN_W` when `SHOP_PANELS_VISIBLE_ON` excludes the current
+  screen (command/sell), `width = SCREEN_W - SHOP_STATUS_W - 6` when it
+  includes it (buy/quantity/purchased/sold) — reusing the already-verified
+  panel-position constants rather than a fresh magic number, so the list's
+  right edge and the panel column's left edge stay self-consistent by
+  construction. **Still open, deliberately out of scope**: the same
+  RPG_RT capture also showed a full-width item-description help bar above
+  the list+panel row, a full-width shopkeeper-prompt bar below it, and a
+  third (blank, for non-equipment goods) party window above the status
+  panel — none of which this codebase draws at all, a materially larger
+  layout gap than the width fixed here. `#open_inn_window` (same file) and
+  the battle log window (`mruby-rpg2k/mrblib/scene/battle.rb`) carry the
+  identical inset-10px shape and are worth their own follow-up. Covered by
+  five new assertions across the existing shop-panel scene checks (full
+  width on the command menu; narrowed to exactly the panel column's own
+  offset on Buy and the quantity counter, confirming the rule follows
+  `SHOP_PANELS_VISIBLE_ON` rather than being buy-only), confirmed to fail
+  against the pre-fix code before the fix.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5367,11 +5367,22 @@ class RPG2k
         header = shop_header
         offset = header ? 1 : 0
         row_count = lines.length + offset
-        inner_w = SCREEN_W - 20 - Window::BORDER * 2
+        # Docks flush to the screen's left edge, not inset 10px -- the same
+        # stale anti-pattern ADR 0021 already diagnosed and fixed for the
+        # message window ("300px wide, inset 10px" -> "fixed 320x80 at
+        # x=0"), which this window never picked up. Full screen width on the
+        # command menu and the sell list (no side panels); narrowed to leave
+        # room for the status/gold column otherwise -- confirmed against
+        # genuine RPG_RT.exe under wine: a live shop's list window right
+        # edge lands exactly where the panel column starts on Buy/the
+        # quantity counter, flush with the panel's own SHOP_STATUS_W+6
+        # offset from the screen's right edge.
+        win_w = SHOP_PANELS_VISIBLE_ON.include?(@shop[:screen]) ? SCREEN_W - SHOP_STATUS_W - 6 : SCREEN_W
+        inner_w = win_w - Window::BORDER * 2
         inner_h = [row_count, 1].max * SHOP_LINE_H
         @shop[:window].dispose if @shop[:window]
-        win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
-                         SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        win = Window.new(0, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
+                         win_w, inner_h + Window::BORDER * 2)
         win.z = 300
         win.windowskin = @windowskin
         c = Bitmap.new(inner_w, inner_h)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15439,6 +15439,13 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   shop = scene.instance_variable_get(:@shop)
   eq :command, shop[:screen]
   ok shop[:status].nil?, 'the command menu highlights no single item -- no panel'
+  # Confirmed against genuine RPG_RT.exe under wine: the command menu (no
+  # side panels) fills the whole screen, flush to the left edge -- not the
+  # old inset-10px, 300px-wide box, the same stale anti-pattern ADR 0021
+  # already fixed for the message window.
+  eq 0, shop[:window].x, 'the list window is flush to the screen\'s left edge'
+  eq RPG2k::Scene::Map::SCREEN_W, shop[:window].width,
+     'and full screen width, with no side panels to leave room for'
 
   RGSS::Input.triggered = [RGSS::Input::C] # choose Buy
   scene.update
@@ -15464,6 +15471,12 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   ok status_win.y < gold_win.y, 'the status panel sits above the gold panel, not beside it'
   eq RPG2k::Scene::Map::SHOP_STATUS_W, gold_win.width,
      "the gold panel is the status panel's own width, not a narrower fixed box"
+  # The list window itself narrows to leave room for that column -- also
+  # confirmed against genuine RPG_RT.exe (the list's own right edge lands
+  # exactly where the panel column starts), not the old full-width box.
+  eq 0, shop[:window].x, 'the buy list also stays flush to the left edge'
+  eq status_x, shop[:window].width,
+     'and narrows to exactly where the status/gold column begins, no gap or overlap'
 
   RGSS::Input.triggered = [RGSS::Input::DOWN] # move to the second good (Herb, id 5)
   scene.update
@@ -15484,6 +15497,9 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   ok !shop[:status].nil?, 'the quantity counter keeps the status panel visible, for the same item'
   texts = window_texts(shop[:status])
   ok texts.include?('0'), 'still describing the Herb the counter was opened for'
+  eq status_x, shop[:window].width,
+     'the quantity counter keeps the narrowed list width too, following ' \
+     'SHOP_PANELS_VISIBLE_ON rather than being buy-screen-only'
 
   RGSS::Input.triggered = [RGSS::Input::C] # commit the purchase
   scene.update


### PR DESCRIPTION
## Summary

- The shop list window carried the same stale "inset 10px, 300px wide" shape ADR 0021 already diagnosed and fixed for the message window — this one never picked up that fix, and stayed full-width on every shop screen regardless of whether the status/gold panels (added in the previous cycle) were showing.
- Confirmed against genuine `RPG_RT.exe` under wine: reached a live Buy/Sell screen via Nepheshel's own shop NPC (`Map0016.lmu` event 4, no synthetic event editing) and corner-marker pixel-scanned the captured frame. The command menu and Sell list span the full screen edge-to-edge; Buy and the quantity counter narrow so the list's right edge lands exactly where the status/gold panel column begins.
- Fixed by computing `#draw_shop`'s window `x`/width from `@shop[:screen]`: `x = 0` always, `width = SCREEN_W` when `SHOP_PANELS_VISIBLE_ON` excludes the current screen, `width = SCREEN_W - SHOP_STATUS_W - 6` when it includes it — reusing the already-verified panel-position constants from the previous cycle's fix, so the list's right edge and the panel column's left edge stay self-consistent by construction.
- **Known, deliberately out-of-scope gap this surfaced**: the same capture also showed a full-width item-description bar above the list+panel row, a full-width shopkeeper-prompt bar below it, and a blank party window above the status panel — none of which this codebase draws at all, a materially larger layout gap left for a future pass. `#open_inn_window` (same file) and the battle log window (`mruby-rpg2k/mrblib/scene/battle.rb`) carry the identical inset-10px shape and are worth their own follow-up.

## Test plan

- [x] Added five position assertions across the existing shop-panel `scripts/rpg2k_scene_check.rb` checks: full width on the command menu; narrowed to exactly the panel column's own offset on Buy and the quantity counter, confirming the rule follows `SHOP_PANELS_VISIBLE_ON` rather than being buy-only.
- [x] Confirmed via `git stash` to fail against the pre-fix code and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb` (891 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_