### PR TITLE
Inn prompt window docks as a fixed 320x80 panel, not inset 10px

### DIFF
--- a/changelog.d/inn-window-geometry.fixed.md
+++ b/changelog.d/inn-window-geometry.fixed.md
@@ -1,0 +1,5 @@
+- **Inn screen:** the greeting/prompt window is now a fixed 320x80 panel
+  flush to the screen's bottom-left corner — the same panel the message
+  window uses — instead of a content-sized box inset 10px from the screen's
+  edges, closing the same stale "inset 10px" shape already fixed for the
+  message window and the shop list window.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1422,6 +1422,40 @@ The work below is roughly ordered by the critical path to a walkable game
   charged, holds through the heal, then fades back in), plus fade assertions
   added to the existing cancel and unaffordable-Accept checks confirming
   neither ever starts a fade.
+  ✅ **Follow-up (2026-08-22): the inn's own greeting/prompt window carried
+  the same stale "inset 10px, content-sized" shape already fixed for the
+  message window and the shop list window.** `#open_inn_window`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) built a content-sized panel
+  (`x=10, width=SCREEN_W-20, height=` the four greeting/prompt lines' own
+  height) instead of the fixed 320x80 panel flush to the bottom-left corner
+  every other prompt-style window in this codebase already uses. Confirmed
+  against genuine RPG_RT.exe under wine: a synthetic Show Inn autostart
+  event on a genuine Nepheshel map (no editor-authored Inn NPC exists in
+  Nepheshel, so this was the one recent shop/inn fix needing injected event
+  data rather than an authentic in-game NPC), resumed under both runtimes —
+  real RPG_RT's prompt window border touches the screen's left, right and
+  bottom edges with no gap, at exactly the message window's own 320x80
+  size (logical `x=0, y=160, width=320, height=80`), while this codebase's
+  old box measured `x=10, y=162, width=300, height=72` — matching its own
+  `10, SCREEN_H - inner_h - Window::BORDER*2 - 6, SCREEN_W - 20, inner_h +
+  Window::BORDER*2` arithmetic exactly, and leaving a visible strip of map
+  background on both sides and below it. The gold window
+  (`#build_inn_gold_window`, same file) was
+  independently pixel-checked and is already correct — pixel-identical
+  between both runtimes — so only the greeting window needed the fix.
+  Fixed by reusing the message window's own `MSG_WIN_W`/`MSG_WIN_H`
+  constants directly (`Window.new(0, SCREEN_H - MSG_WIN_H, MSG_WIN_W,
+  MSG_WIN_H)`) rather than inventing a separate but numerically-identical
+  pair. Covered by a new `scripts/rpg2k_scene_check.rb` check asserting the
+  prompt window's exact `x`/`y`/`width`/`height`, confirmed to fail against
+  the pre-fix code before the fix.
+  **Known, deliberately out-of-scope observation from the same wine
+  capture, not yet independently confirmed**: with the test party's gold
+  below the inn's price, real RPG_RT's cursor still defaulted to Accept
+  (the first choice), not Cancel — this codebase's `@inn_choice = req[:
+  can_afford] ? 0 : 1` defaults to Cancel when unaffordable. Only one
+  unaffordable data point was captured, so this is flagged for its own
+  follow-up investigation rather than folded into the geometry fix above.
   **Open Shop** (10720) is a playable game-mode too: a `Game::Shop` holds the
   goods and buy / sell rules and performs the transactions (buy at the database
   price, sell at half, party 99-item / gold caps enforced), tracking whether

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5163,10 +5163,18 @@ class RPG2k
         gold_term = nonblank(db.term.gold, 'G')
         lines = ["#{terms[:greet1]} #{req[:price]}#{gold_term} #{terms[:greet2]}".strip,
                  terms[:greet3], terms[:accept], terms[:cancel]]
-        inner_w = SCREEN_W - 20 - Window::BORDER * 2
-        inner_h = lines.length * INN_LINE_H
-        win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
-                         SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        # Fixed 320x80 panel flush to the screen's bottom-left corner, the
+        # same panel the message window uses (MSG_WIN_W/MSG_WIN_H) -- not a
+        # content-sized box inset 10px, the same stale anti-pattern already
+        # fixed for the message window (ADR 0021) and the shop list window.
+        # Confirmed against genuine RPG_RT.exe under wine: a live Inn
+        # prompt's border touches the screen's left, right and bottom edges
+        # with no gap, at exactly this size -- this codebase's own
+        # content-sized box left a visible strip of map background on both
+        # sides and below it.
+        inner_w = MSG_WIN_W - Window::BORDER * 2
+        inner_h = MSG_WIN_H - Window::BORDER * 2
+        win = Window.new(0, SCREEN_H - MSG_WIN_H, MSG_WIN_W, MSG_WIN_H)
         win.z = 300
         win.windowskin = @windowskin
         contents = Bitmap.new(inner_w, inner_h)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3163,6 +3163,24 @@ check 'Show Inn scene: accepting heals the party, spends gold, runs Stay branch'
   ok !st.switches[2], 'the No Stay branch was skipped'
 end
 
+check 'Show Inn scene: the prompt window is a fixed 320x80 panel flush to ' \
+      'the screen\'s bottom-left corner, not a content-sized box inset 10px' do
+  # Confirmed against genuine RPG_RT.exe under wine: a live Inn prompt's
+  # border touches the screen's left, right and bottom edges with no gap --
+  # the same fixed panel the message window uses (MSG_WIN_W/MSG_WIN_H), not
+  # this window's old content-sized, 10px-inset box (the same stale
+  # anti-pattern already fixed for the message window and the shop list
+  # window).
+  scene, = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  5.times { scene.update } # inn command runs; the greeting prompt opens
+  win = scene.instance_variable_get(:@inn_window)[:window]
+  map_mod = RPG2k::Scene::Map
+  eq 0, win.x, "the prompt window is flush to the screen's left edge"
+  eq map_mod::MSG_WIN_W, win.width, 'and the message window\'s own fixed width'
+  eq map_mod::SCREEN_H - map_mod::MSG_WIN_H, win.y, 'flush to the bottom edge'
+  eq map_mod::MSG_WIN_H, win.height, 'and the message window\'s own fixed height'
+end
+
 check 'Show Inn scene: an accepted stay fades to black, holds through the heal, ' \
       'then fades back in over the RPG_RT default 35 frames' do
   # Real RPG_RT (EasyRPG's Scene_Map::UpdateInn / FinishInn, the async


### PR DESCRIPTION
## Summary

- `#open_inn_window` carried the same stale "inset 10px, content-sized" shape already fixed for the message window (ADR 0021) and the shop list window (previous cycle) — never revisited for the Inn screen.
- Confirmed against genuine `RPG_RT.exe` under wine: a synthetic Show Inn autostart event on a genuine Nepheshel map (no editor-authored Inn NPC exists in Nepheshel, so this needed injected event data rather than an authentic NPC), resumed under both runtimes. Real RPG_RT's prompt window border touches the screen's left, right and bottom edges with no gap, at exactly the message window's own 320x80 size; this codebase's old box (`x=10, y=162, width=300, height=72`) left a visible strip of map background on both sides and below it.
- The gold window (`#build_inn_gold_window`, same file) was independently pixel-checked and is already correct — pixel-identical between both runtimes — so only the greeting window needed the fix.
- Fixed by reusing the message window's own `MSG_WIN_W`/`MSG_WIN_H` constants directly (`Window.new(0, SCREEN_H - MSG_WIN_H, MSG_WIN_W, MSG_WIN_H)`) rather than inventing a separate but numerically identical pair.
- **Known, deliberately out-of-scope observation from the same capture, not folded into this fix**: with the test party's gold below the inn's price, real RPG_RT's cursor still defaulted to Accept (the first choice), not Cancel — this codebase defaults to Cancel when unaffordable. Only one unaffordable data point was captured, so this is flagged for its own follow-up investigation.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check asserting the prompt window's exact `x`/`y`/`width`/`height`.
- [x] Confirmed via `git stash` to fail against the pre-fix code and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb` (892 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_