### PR TITLE
Inn prompt cursor always starts on Accept, even when unaffordable

### DIFF
--- a/changelog.d/inn-unaffordable-cursor-default.fixed.md
+++ b/changelog.d/inn-unaffordable-cursor-default.fixed.md
@@ -1,0 +1,4 @@
+- **Inn screen:** the prompt cursor now always starts on Accept, even when
+  the party can't afford the stay, matching RPG_RT — previously it defaulted
+  to Cancel whenever unaffordable, even though Accept is still shown
+  (disabled) rather than removed from the list.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1449,13 +1449,28 @@ The work below is roughly ordered by the critical path to a walkable game
   pair. Covered by a new `scripts/rpg2k_scene_check.rb` check asserting the
   prompt window's exact `x`/`y`/`width`/`height`, confirmed to fail against
   the pre-fix code before the fix.
-  **Known, deliberately out-of-scope observation from the same wine
-  capture, not yet independently confirmed**: with the test party's gold
-  below the inn's price, real RPG_RT's cursor still defaulted to Accept
-  (the first choice), not Cancel — this codebase's `@inn_choice = req[:
-  can_afford] ? 0 : 1` defaults to Cancel when unaffordable. Only one
-  unaffordable data point was captured, so this is flagged for its own
-  follow-up investigation rather than folded into the geometry fix above.
+  ✅ **Follow-up (2026-08-22): the deferred cursor-default observation above
+  is now independently re-confirmed and fixed.** Two further wine captures
+  (gold 0 and gold 25, both against a 50G price, so two separate
+  unaffordable data points rather than the earlier single one) each showed
+  real RPG_RT's cursor on Accept, matching an affordable gold-100 capture —
+  never on Cancel. Real RPG_RT implements this prompt as an ordinary Show
+  Choices pair with Accept merely *disabled* when unaffordable (the same
+  `pm.PushChoice(accept, can_afford)` shape `#drive_inn`'s own doc comment
+  already cites), and an ordinary Show Choices list starts on its first
+  entry regardless of whether that entry happens to be disabled — the same
+  listed-but-disabled convention this session's field/battle Item menu
+  fixes already established elsewhere in this codebase. Fixed by changing
+  `#open_inn_window`'s `@inn_choice = req[:can_afford] ? 0 : 1` to an
+  unconditional `@inn_choice = 0`; `#drive_inn`'s existing Confirm handler
+  already gates Accept correctly and needed no change. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (the cursor starts on Accept, index
+  0, even when unaffordable) plus fixes to two existing checks whose own
+  setup assumed the old "starts on Cancel" default (an initial Up press
+  meant to walk from Cancel to Accept, now redundant since Accept is
+  already the start; restructured to confirm Accept directly, then
+  separately move Down to Cancel and confirm that), all three confirmed to
+  fail against the pre-fix code before the fix.
   **Open Shop** (10720) is a playable game-mode too: a `Game::Shop` holds the
   goods and buy / sell rules and performs the transactions (buy at the database
   price, sell at half, party 99-item / gold caps enforced), tracking whether

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5186,8 +5186,18 @@ class RPG2k
 
         gwin = build_inn_gold_window(gold_term)
         @inn_window = { window: win, gold: gwin }
-        # Start on Accept when affordable, else on Cancel.
-        @inn_choice = req[:can_afford] ? 0 : 1
+        # The cursor always starts on Accept, even when unaffordable --
+        # confirmed against genuine RPG_RT.exe under wine: a gold-0 and a
+        # gold-25 capture against a 50G price (both unaffordable) each
+        # showed the cursor on Accept, matching an affordable gold-100
+        # capture, never on Cancel. Real RPG_RT implements this prompt as
+        # an ordinary Show Choices pair with Accept merely *disabled* when
+        # unaffordable (see #drive_inn's own citation just below), and an
+        # ordinary Show Choices list starts on its first entry regardless
+        # of whether that entry happens to be disabled -- the same
+        # listed-but-disabled shape this session's field/battle Item menu
+        # fixes already established elsewhere in this codebase.
+        @inn_choice = 0
         set_inn_cursor
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3229,12 +3229,25 @@ check 'Show Inn scene: cancelling with B spends nothing, runs No Stay, and never
   ok st.switches[2], 'the No Stay branch ran'
 end
 
+check 'Show Inn scene: the cursor starts on Accept even when unaffordable, ' \
+      'not on Cancel' do
+  # Confirmed against genuine RPG_RT.exe under wine: a gold-0 and a gold-25
+  # capture against a 50G price (both unaffordable) each showed the cursor
+  # on Accept, matching an affordable gold-100 capture -- real RPG_RT
+  # implements this prompt as an ordinary Show Choices pair with Accept
+  # merely disabled when unaffordable, and an ordinary Show Choices list
+  # starts on its first entry regardless of whether that entry is disabled.
+  scene, = inn_scene(50, inn_commands(Game::Interpreter::Cmd, 100)) # 50g < 100g
+  5.times { scene.update }
+  eq 0, scene.instance_variable_get(:@inn_choice),
+     'the cursor starts on Accept (index 0), not Cancel, despite being unaffordable'
+end
+
 check 'Show Inn scene: an unaffordable Accept is ignored' do
   scene, st = inn_scene(50, inn_commands(Game::Interpreter::Cmd, 100)) # 50g < 100g
   5.times { scene.update }
-  # Cursor starts on Cancel when broke; move up to Accept and press it.
-  RGSS::Input.triggered = [RGSS::Input::UP]
-  scene.update
+  # The cursor already starts on Accept (disabled, but still the default --
+  # see #open_inn_window's own doc comment); confirm it directly.
   RGSS::Input.triggered = [RGSS::Input::C]
   3.times { scene.update }
   ok !st.switches[1] && !st.switches[2], 'Accept is inert while unaffordable'
@@ -3253,12 +3266,7 @@ check 'Show Inn scene: plays the RPG_RT system SE on every interaction' do
   # `pm.PushChoice(accept, can_afford)` (src/game_interpreter_map.cpp): a
   # disabled Accept plays Buzzer rather than Decision.
   scene, = inn_scene(50, inn_commands(Game::Interpreter::Cmd, 100)) # 50g < 100g
-  5.times { scene.update } # cursor starts on Cancel (unaffordable)
-
-  RGSS::Audio.reset_se
-  RGSS::Input.triggered = [RGSS::Input::UP] # move to Accept
-  scene.update
-  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'moving the cursor plays the cursor SE'
+  5.times { scene.update } # cursor starts on Accept, disabled but still the default
 
   RGSS::Audio.reset_se
   RGSS::Input.triggered = [RGSS::Input::C] # confirm Accept -- unaffordable, disabled
@@ -3268,6 +3276,9 @@ check 'Show Inn scene: plays the RPG_RT system SE on every interaction' do
   RGSS::Audio.reset_se
   RGSS::Input.triggered = [RGSS::Input::DOWN] # move to Cancel
   scene.update
+  eq 'Cursor1', RGSS::Audio.se_calls.last&.first, 'moving the cursor plays the cursor SE'
+
+  RGSS::Audio.reset_se
   RGSS::Input.triggered = [RGSS::Input::C] # confirm Cancel
   scene.update
   RGSS::Input.triggered = []


### PR DESCRIPTION
## Summary

- `#open_inn_window` defaulted `@inn_choice` to Cancel when the party couldn't afford the stay. Real RPG_RT implements this prompt as an ordinary Show Choices pair with Accept merely *disabled* when unaffordable, and an ordinary Show Choices list starts on its first entry regardless of whether that entry is disabled — the same listed-but-disabled convention this session's field/battle Item menu fixes already established elsewhere in this codebase.
- This was a known, previously-deferred observation from the Inn window geometry cycle (a single unaffordable data point, not independently cross-checked). Independently re-verified this cycle with two further unaffordable captures: gold-0 and gold-25 against a 50G price each showed real RPG_RT's cursor on Accept, matching an affordable gold-100 capture, never on Cancel.
- Fixed by changing `@inn_choice = req[:can_afford] ? 0 : 1` to an unconditional `@inn_choice = 0`. `#drive_inn`'s existing Confirm handler already gates Accept correctly (buzzes instead of accepting when unaffordable) and needed no change.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: the cursor starts on Accept (index 0) even when unaffordable.
- [x] Fixed two existing checks whose own setup assumed the old "starts on Cancel" default (an initial Up press meant to walk from Cancel to Accept, now redundant/wrong since Accept is already the start).
- [x] All three confirmed via `git stash` to fail against the pre-fix code and pass after.
- [x] All four suites green: `rpg2k_scene_check.rb` (893 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb`, `rpg2k3_battle_gauge_check.rb`.
- [x] Rebuilt the native engine and ran `scripts/rpg2k_boot_check.bash` against real Nepheshel/mtf-meido-action data — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_