### PR TITLE
Fix battle-event message panel to RPG_RT's fixed 320x80 size

### DIFF
--- a/changelog.d/battle-event-message-panel-size.fixed.md
+++ b/changelog.d/battle-event-message-panel-size.fixed.md
@@ -1,0 +1,5 @@
+- **Battle screen:** a troop battle-event page's Show Message panel is now
+  RPG_RT's fixed 320x80 rect flush against the screen edge, matching every
+  other battle window — previously it was a box sized to fit its own
+  content and inset 10px, the same stale shape already fixed for the field
+  message window, the shop list window and the Inn prompt window.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11773,11 +11773,42 @@ not yet verified:
   `@state.party.rpg2003?` — `BATTLE_EVENT_MSG_Y` (top) for RPG2003, or
   flush against the screen's bottom edge (`SCREEN_H - inner_h -
   Window::BORDER * 2`, computed from the panel's own content height since
-  this codebase's message panel is content-fit rather than RPG_RT's fixed
-  size) for RPG2000. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  ~~this codebase's message panel is content-fit rather than RPG_RT's fixed
+  size~~ **(corrected below: RPG_RT's panel is not content-fit either — it's
+  the same fixed 320x80 rect this file's other battle windows already
+  use)**) for RPG2000. Covered by a new `scripts/rpg2k_scene_check.rb` check
   (an RPG2000 battle-event message sits flush against the bottom edge; an
   RPG2003 one sits at `BATTLE_EVENT_MSG_Y`), confirmed to fail against the
   pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-22): the battle-event message panel itself still
+  carried the same stale "inset 10px, content-sized" shape already fixed for
+  the (field) message window, the shop list window and the Inn prompt
+  window — only its top/bottom position (above) had been corrected, not its
+  size.** `#battle_text_window` built `Window.new(10, y, SCREEN_W - 20,
+  inner_h + Window::BORDER*2)` with `inner_h` sized to the message's own
+  line count. Confirmed against genuine RPG_RT.exe under wine: Nepheshel's
+  own troop battle-event pages never use Show Message
+  (`analyze_game.rb --troops` finds none across all 3265 troop pages), so
+  this needed a synthetic turn-0 troop page injected into a copy of the
+  database plus a synthetic autostart Enemy Encounter (with its full
+  canonical Victory/Escape/EndBattle trailing structure) injected into a
+  copy of a map, both restored afterward — real RPG_RT's resulting panel
+  border sat flush against the screen's left edge (physical `x=0..1`),
+  right edge (`x=638..639`) and bottom edge, top edge at physical `y=320`,
+  i.e. exactly `x=0, y=BATTLE_PANEL_Y (160), width=SCREEN_W (320),
+  height=BATTLE_PANEL_H (80)` — the identical fixed rect
+  `#battle_panel_window` and this file's status/command/target windows
+  already share, not a box measuring `x=10, width=300,
+  height=` one line's worth. Fixed by building
+  `Window.new(0, y, SCREEN_W, BATTLE_PANEL_H)` instead, keeping the
+  RPG2000-vs-RPG2003 `y` split above untouched since only the size was
+  wrong. Covered by a new `scripts/rpg2k_scene_check.rb` check asserting
+  the panel's exact `x`/`width`/`height`/`y` against
+  `BATTLE_PANEL_Y`/`BATTLE_PANEL_H`/`SCREEN_W` — the existing check above
+  only ever compared `win2k.y` against `SCREEN_H - win2k.height`, which
+  holds tautologically regardless of what `height` actually is, so it could
+  not have caught this on its own — confirmed to fail against the pre-fix
+  code before the fix.
 - ✅ **Weather Effects now clamps an RPG2003-only weather type back to none on
   RPG2000, and clamps strength to at most 2 on every edition — both used to
   be stored verbatim off the raw command bytes with no bound at all.**

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -3727,18 +3727,36 @@ class RPG2k
         win
       end
 
-      # A text panel of `lines` at depth `z`, sized to fit its content -- used
-      # for the battle-event page message window. Positioned at the top
-      # (`BATTLE_EVENT_MSG_Y`) for an RPG2003 database, or flush against the
-      # bottom edge for RPG2000 -- see that constant's own citation.
+      # A text panel of `lines` at depth `z`, used for the battle-event page
+      # message window -- RPG_RT's own fixed 320x80 panel (`BATTLE_PANEL_Y`/
+      # `BATTLE_PANEL_H`, the exact rect this file's other battle windows
+      # already share -- see their own citation above `BATTLE_PANEL_Y`),
+      # never a box sized to fit its content. Confirmed against genuine
+      # RPG_RT.exe under wine: Nepheshel's own troop pages never use Show
+      # Message (`analyze_game.rb --troops` finds none), so this needed a
+      # synthetic turn-0 troop battle-event page injected directly into a
+      # copy of the database and a synthetic autostart Enemy Encounter
+      # event injected into a copy of a map (both restored afterward) --
+      # the resulting screen (640x480 physical, RPG2000's 320x240 logical
+      # doubled) showed the message panel's border flush against the
+      # screen's left edge (x=0..1), right edge (x=638..639) and bottom
+      # edge, its top edge at physical y=320 == logical y=160, i.e. exactly
+      # `x=0, y=BATTLE_PANEL_Y (160), width=SCREEN_W (320), height=
+      # BATTLE_PANEL_H (80)` -- while this method's old box measured
+      # `x=10, width=SCREEN_W-20 (300), height=` the message's own one-line
+      # content height, the same stale "inset 10px, content-sized" shape
+      # already fixed for the (field) message window, the shop list window
+      # and the Inn prompt window. Positioned at the top (`BATTLE_EVENT_MSG_Y`)
+      # for an RPG2003 database, or flush against the bottom edge
+      # (`BATTLE_PANEL_Y`) for RPG2000 -- only the size was wrong; the
+      # RPG2000/RPG2003 y split above was already correct and untouched.
       def battle_text_window(lines, z)
-        inner_w = SCREEN_W - 20 - Window::BORDER * 2
-        inner_h = [lines.length, 1].max * BATTLE_LINE_H
-        y = @state.party.rpg2003? ? BATTLE_EVENT_MSG_Y : SCREEN_H - inner_h - Window::BORDER * 2
-        win = Window.new(10, y, SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        inner_w = SCREEN_W - Window::BORDER * 2
+        y = @state.party.rpg2003? ? BATTLE_EVENT_MSG_Y : BATTLE_PANEL_Y
+        win = Window.new(0, y, SCREEN_W, BATTLE_PANEL_H)
         win.z = z
         win.windowskin = windowskin
-        c = Bitmap.new(inner_w, inner_h)
+        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
         c.font.color = Color.new(255, 255, 255, 255)
         lines.each_with_index do |line, i|
           c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, line

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15198,6 +15198,34 @@ check 'a battle-event page message sits at the bottom for RPG2000, the ' \
   eq RPG2k::Scene::Battle::BATTLE_EVENT_MSG_Y, win2k3.y, 'RPG2003 sits at the top'
 end
 
+# Confirmed against genuine RPG_RT.exe under wine (see #battle_text_window's
+# own citation): a synthetic turn-0 troop battle-event page's Show Message
+# drew a panel flush against the screen's left, right and bottom edges,
+# logically `x=0, y=160, width=320, height=80` -- the same fixed 320x80 panel
+# every other battle window in this file already uses (`BATTLE_PANEL_Y`/
+# `BATTLE_PANEL_H`), not a box sized to its one-line content. The check above
+# only ever compared `win2k.y` against `SCREEN_H - win2k.height`, which holds
+# tautologically regardless of what `height` actually is, so it could not
+# have caught the pre-fix content-fit box (a single short line -> ~30px tall,
+# 10px inset) on its own.
+check "a battle-event page message panel is RPG_RT's fixed 320x80 rect, " \
+      'not a box sized to its content' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_MESSAGE, [], string: 'Hi')]) }
+  scene, _st = battle_scene_with_pages(pages)
+  90.times do
+    scene.update
+    ui = battle_ui(scene)
+    break if ui && ui[:event_win]
+  end
+  win = battle_ui(scene)[:event_win]
+  ok win, 'the message panel is up'
+  eq 0, win.x, 'flush against the left edge, not inset 10px'
+  eq RPG2k::Scene::Battle::SCREEN_W, win.width, 'the fixed 320px width, not 300px'
+  eq RPG2k::Scene::Battle::BATTLE_PANEL_H, win.height, 'the fixed 80px height, not content-fit'
+  eq RPG2k::Scene::Battle::BATTLE_PANEL_Y, win.y, 'flush against the bottom edge at the fixed y'
+end
+
 check 'a hidden troop member is not targetable until it is revealed' do
   scene, _st = battle_scene_with_pages(nil)
   90.times do


### PR DESCRIPTION
## Summary

- RPG_RT draws a troop battle-event page's Show Message panel as its own fixed 320x80 rect flush against the screen edge — the identical panel `#battle_panel_window` and this file's status/command/target windows already share — never a box sized to fit the message's own content.
- `#battle_text_window` (`mruby-rpg2k/mrblib/scene/battle.rb`) still built a content-sized panel inset 10px (`Window.new(10, y, SCREEN_W - 20, inner_h + Window::BORDER*2)`), the same stale "inset 10px, content-sized" shape already fixed for the field message window, the shop list window and the Inn prompt window. Only its RPG2000-vs-RPG2003 top/bottom position had been corrected in an earlier pass — not its size.
- Confirmed against genuine RPG_RT.exe under wine: Nepheshel's own troop pages never use Show Message (`analyze_game.rb --troops` finds none across all 3265 troop pages), so this needed a synthetic turn-0 troop battle-event page injected into a copy of the database, plus a synthetic autostart Enemy Encounter (with its full canonical Victory/Escape/EndBattle trailing structure) injected into a copy of a map — both restored afterward, `data/` is gitignored. Real RPG_RT's resulting panel border sat flush against the screen's left, right and bottom edges, top edge at logical `y=160` — exactly `x=0, y=BATTLE_PANEL_Y (160), width=SCREEN_W (320), height=BATTLE_PANEL_H (80)`.
- Fixed by building `Window.new(0, y, SCREEN_W, BATTLE_PANEL_H)` instead, keeping the existing RPG2000/RPG2003 `y` split untouched.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check asserting the panel's exact `x`/`width`/`height`/`y` against `BATTLE_PANEL_Y`/`BATTLE_PANEL_H`/`SCREEN_W` — the pre-existing check only ever compared `win2k.y` against `SCREEN_H - win2k.height`, which holds tautologically regardless of the actual height, so it could not have caught this on its own.
- Confirmed via `git stash` that the new check fails against the pre-fix code (1 of 894 checks failed) and passes post-fix (894/894).
- All four suites green: `rpg2k_scene_check.rb` (894 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_