### PR TITLE
Confirm native Effekseer renders real, visible pixels

### DIFF
--- a/changelog.d/native-effekseer-renders-pixels.fixed.md
+++ b/changelog.d/native-effekseer-renders-pixels.fixed.md
@@ -1,0 +1,11 @@
+- The native Effekseer particle pipeline (`MV::Effekseer.smoke_test`,
+  `mruby-mvjs/src/mvefk.cxx`) now confirmed renders real, visible pixels, not
+  just a simulated-with-no-error effect: an explicit `Manager::Flip()` call
+  before drawing (needed because `Manager::Update`'s autoFlip syncs the
+  render-visible snapshot from the *previous* frame, one step stale for a
+  one-shot simulate-then-draw call) plus switching the test fixture to
+  `Flash.efkefc` (whose particles live on real `Sprite`/`Ring` render nodes)
+  now produce real GPU draw calls and hundreds of changed pixels. The
+  earlier "zero draw calls" symptom traced to a different fixture
+  (`HitPhysical.efkefc`) whose only particles live on a `NoneType` node that
+  Effekseer's own renderer never draws by design -- not a pipeline bug.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21933,25 +21933,31 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
         `setProjectionMatrix` siblings; `Labyria` now boots clean through
         `Scene_Splash` → `Scene_Title` → `Scene_Map` and every headless
         probe (move/message/menu/save/audio/battle) reports.
-      - 🚧 **Native Effekseer: vendored, built, GL pipeline proven; visible
-        rendering still open.** `3rd/effekseer` (the real C++ SDK, MIT,
-        pinned to release tag `1807`) is now vendored and built against this
-        project's own GLES3 context, with three real upstream build gaps
-        found and fixed in this project's own CMake (a missing
-        `<EGL/egl.h>` include, two undeclared GL enums under pure GLES3, an
-        unneeded OpenAL dependency). `MV::Effekseer.smoke_test`
-        (`mruby-mvjs/src/mvefk.cxx`) creates a real context, loads a real,
-        unmodified `.efkefc` file (91 of them ship with a real downloaded MZ
-        release), and confirms genuine particle simulation (a live,
-        deterministic instance count) — but `renderer->GetDrawCallCount()`
-        still reads `0` after the draw, with no GL error anywhere, meaning
-        something still keeps every simulated particle from reaching an
-        actual GPU draw call. See docs/adr/0004's "M6.2 addendum 2" for the
-        full diagnostic trail (two other real integration bugs found and
-        fixed along the way) and what the natural next step looks like.
-        Deliberately does not touch `MZ::EFFEKSEER_SHIM_JS`'s JS bridge yet
-        — that is staged to come after this specific gap is understood, not
-        before.
+      - ✅ **Native Effekseer: vendored, built, renders real, visible
+        particles.** `3rd/effekseer` (the real C++ SDK, MIT, pinned to
+        release tag `1807`) is vendored and built against this project's own
+        GLES3 context, with three real upstream build gaps found and fixed
+        in this project's own CMake (a missing `<EGL/egl.h>` include, two
+        undeclared GL enums under pure GLES3, an unneeded OpenAL
+        dependency). `MV::Effekseer.smoke_test` (`mruby-mvjs/src/mvefk.cxx`)
+        creates a real context, loads a real, unmodified `.efkefc` file (91
+        of them ship with a real downloaded MZ release), confirms genuine
+        particle simulation, and — the milestone this was staged to prove —
+        produces real GPU draw calls and real, visible lit pixels
+        (`Flash.efkefc`: 2 draw calls, 535/4096 pixels changed from the
+        clear colour). An earlier pass at this test saw zero draw calls
+        against a different fixture (`HitPhysical.efkefc`); tracing that
+        with temporary instrumentation found its particles live entirely on
+        a `NoneType` (no assigned renderer) node, which Effekseer's own
+        `InstanceContainer::Draw` never renders by design — not a bug in
+        this project's integration. See docs/adr/0004's "M6.2 addendum 2"
+        for the full diagnostic trail, including two other real integration
+        bugs found and fixed along the way (`DrawParameter` population,
+        `GetCameraProjectionMatrix` read-ordering) and a third real fix (an
+        explicit `Manager::Flip()` before drawing, needed for a one-shot
+        simulate-then-draw call). `MZ::EFFEKSEER_SHIM_JS`'s JS bridge still
+        needs wiring to these natives — that was deliberately staged to
+        come after the native pipeline was proven, which it now is.
 
 ## Tooling
 

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -513,7 +513,7 @@ JavaScript loads and interprets the JSON.
       7x spread between first and last). Equal-area cells make the measurement
       the same 36.2% of the centre box every run.
     - **M6.2 addendum 2 — native Effekseer: vendored, built, GL pipeline
-      proven; visible rendering still open.** The blockers the previous
+      renders real, visible particles.** The blockers the previous
       addendum listed as reasons to stay unattempted are resolved: a real
       `.efkefc` now exists to test against (91 of them ship unmodified with a
       real downloaded MZ release under `data/labyria`, gitignored, present
@@ -578,37 +578,49 @@ JavaScript loads and interprets the JSON.
         the top of that call) — reading it beforehand silently returns a
         stale or unset value with no error from either library.
 
-      **Still open, deliberately not chased further this round**: even with
-      both pitfalls above fixed, `renderer->GetDrawCallCount()` reads `0`
-      after the draw — some further condition still keeps every one of the
-      40 live particle instances from reaching an actual GPU draw call, with
-      no GL error and no exception to point at it. Reading
-      `ManagerImplemented::CanDraw` (`Effekseer.Manager.cpp`) by hand did not
-      turn up a further, obviously-wrong input on this project's side: it
-      checks `drawSet.IsShown` (explicitly initialised `true` where a
-      `DrawSet` is constructed), a `CameraCullingMask & GetLayerBits()`
-      overlap (both default to `1` — a fresh effect's `layer_` defaults to
-      `0`, and `DrawParameter()`'s own constructor sets
-      `CameraCullingMask = 1`, matching), and a sphere-culling check that
-      only runs at all when the effect's own authored `Culling.Shape` is
-      `Sphere`. None of those three explains an unconditional `0`. This is
-      exactly the risk the previous addendum flagged as the hard part —
-      reconciling a native renderer's own state and conventions with no
-      browser reference to diff against — now narrowed from "nothing is
-      proven" to "one specific, further culling or submission gate, not yet
-      isolated." The natural next step is adding temporary instrumentation
-      *inside* `CanDraw`/the sprite-submission path (a local, uncommitted
-      patch to the vendored tree, the same technique this project already
-      uses for diagnosing real games' own script bugs) rather than guessing
-      further from the outside.
+      **Resolved in a follow-up pass**: `renderer->GetDrawCallCount()`
+      reading `0` for `HitPhysical.efkefc` turned out not to be a pipeline
+      bug at all. Temporary instrumentation *inside* `CanDraw`/`DrawHandle`/
+      `InstanceContainer::Draw` (a local, uncommitted patch to the vendored
+      tree, per the previous addendum's own suggested next step) walked the
+      actual instance-container tree at draw time and found the real cause:
+      every one of `HitPhysical.efkefc`'s ~40 live particles lives directly
+      on a node whose `EffectNodeType` is `NoneType` (no renderer type
+      assigned), and `InstanceContainer::Draw` (`Effekseer.InstanceContainer.cpp`)
+      unconditionally skips its whole render body for `Root`/`NoneType`
+      nodes — `if (effectNode_->GetType() != Root && ... != NoneType)` —
+      regardless of `RenderingPriority` (which this node has set, `0`, so it
+      is still walked; it is just never drawn once reached). That one file's
+      only "particles" are a behaviour-only layer with no assigned visual
+      output, so zero draw calls is *correct* for it, not a symptom of
+      anything wrong in this project's integration.
+
+      Proof the pipeline itself has no gap: re-running the same smoke test
+      against `Flash.efkefc` (another of the 91 real files, whose particles
+      sit on real `Sprite`/`Ring` nodes) produced `GetDrawCallCount() == 2`
+      and — the test that actually matters — 535 of 4096 pixels (64×64)
+      differing from the clear colour by more than the tolerance, i.e. real,
+      visible rendering. `mruby-mvjs/test/mz_test.rb`'s Effekseer test now
+      asserts on `Flash.efkefc` and requires a *positive* lit-pixel count
+      (not merely non-nil), so it fails loudly if this ever regresses.
+
+      One additional real fix landed alongside this: `mvefk::smoke_test`
+      now calls `manager->Flip()` explicitly after its warmup loop, before
+      building `DrawParameter`. `Manager::Update`'s `autoFlip` (the default,
+      used here) syncs the render-visible `DrawSet` snapshot at the *start*
+      of `Update`, from state as of the *previous* `Update` call — so
+      without an explicit extra `Flip()`, a one-shot simulate-then-draw call
+      like this one would draw state that is a full simulation step stale.
+      A real per-frame game loop never notices this (every frame's draw is
+      consistently one step behind that frame's own `Update`), but it
+      matters for a synchronous smoke test that wants to see the
+      just-completed frame.
 
       **Explicitly not started**: wiring `MZ::EFFEKSEER_SHIM_JS`'s no-op
       methods to real `mvefk`-backed natives (the JS-bridge milestone this
       addendum was staged ahead of, per the previous addendum's own
-      recommendation) — doing that before the draw-call gap above is
-      understood would make a JS-bridge bug and a native-rendering bug
-      indistinguishable from each other, the exact ordering risk landing
-      this in isolation first was meant to avoid.
+      recommendation) — now unblocked, since the native GL pipeline is
+      confirmed to render real, visible content end to end.
 
       It also shows why M6.3g's frame check is not redundant with the log: with
       the animation's sheet renamed away, `[MZ-ANIM]` still reports

--- a/mruby-mvjs/src/mvefk.cxx
+++ b/mruby-mvjs/src/mvefk.cxx
@@ -109,7 +109,8 @@ bool smoke_test(const char* path,
   }
 
   Effekseer::Handle handle = manager->Play(effect, 0.0f, 0.0f, 0.0f);
-  for (int i = 0; i < warmup_frames; ++i) manager->Update(1.0f);
+  for (int i = 0; i < warmup_frames; ++i)
+    manager->Update(1.0f);
   // Manager::Update's autoFlip (on by default, used here) syncs the
   // render-visible DrawSet snapshot at the *start* of Update, from state as
   // of the previous Update call -- so without this, DrawHandle below would

--- a/mruby-mvjs/src/mvefk.cxx
+++ b/mruby-mvjs/src/mvefk.cxx
@@ -109,8 +109,16 @@ bool smoke_test(const char* path,
   }
 
   Effekseer::Handle handle = manager->Play(effect, 0.0f, 0.0f, 0.0f);
-  for (int i = 0; i < warmup_frames; ++i)
-    manager->Update(1.0f);
+  for (int i = 0; i < warmup_frames; ++i) manager->Update(1.0f);
+  // Manager::Update's autoFlip (on by default, used here) syncs the
+  // render-visible DrawSet snapshot at the *start* of Update, from state as
+  // of the previous Update call -- so without this, DrawHandle below would
+  // draw the state as of warmup_frames-1, one full simulation step stale.
+  // A real per-frame game loop never notices (each frame's draw is always
+  // one step behind that frame's own Update, consistently), but a one-shot
+  // simulate-then-draw call like this one needs an explicit extra Flip() to
+  // see the just-completed frame's state.
+  manager->Flip();
 
   glBindFramebuffer(GL_FRAMEBUFFER, mvgl::default_framebuffer(ctx));
   glViewport(0, 0, width, height);

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -1000,24 +1000,36 @@ assert 'MV::Effekseer.available? tracks the same GLES3-capable backend as MV::GL
   end
 end
 
-assert 'MV::Effekseer.smoke_test against a real, downloaded MZ game effect' do
+assert 'MV::Effekseer.smoke_test renders real, visible pixels from a downloaded MZ effect' do
   # Not a synthetic fixture: 91 real, unmodified .efkefc files ship with a
   # real downloaded MZ release under data/labyria (gitignored -- present only
   # on a machine that has actually fetched it, absent in a bare CI checkout),
   # exercising the vendored Effekseer C++ SDK (3rd/effekseer) against content
-  # this project did not author. See mvefk.hxx for exactly what a non-nil
-  # result here proves and does not: it confirms the file parses, the effect
-  # plays and simulates (a real, deterministic instance count), and the full
-  # render pipeline runs with no GL error -- not yet that anything visible
-  # renders, which is open work (see docs/TODO.md's Effekseer entry).
+  # this project did not author. A non-zero result here is the strongest
+  # signal mvefk.hxx describes: the file parses, the effect plays and
+  # simulates, and the full render pipeline actually puts pixels on screen
+  # (not just "ran with no GL error") -- confirming the native GL pipeline
+  # renders real particle content end to end.
+  #
+  # Flash.efkefc specifically (not the smaller HitPhysical.efkefc): tracing
+  # through why an earlier pass at this test saw zero lit pixels for
+  # HitPhysical found that ALL of that effect's live particles live on a
+  # NoneType (no assigned renderer) node -- Effekseer's own
+  # InstanceContainer::Draw skips NoneType/Root nodes unconditionally,
+  # regardless of RenderingPriority, so that file has no visual output by
+  # design, not a rendering bug. Flash.efkefc's Sprite/Ring nodes hold real
+  # instances and reliably produce both draw calls and lit pixels, so it is
+  # a better fixture for a test whose job is proving the pipeline renders.
+  #
   # Relative to this test binary's own working directory (3rd/mruby, where
   # the mruby_test ctest target runs rake from -- see CMakeLists.txt's
   # WORKING_DIRECTORY on that target).
-  path = "../../data/labyria/Labyria/effects/HitPhysical.efkefc"
+  path = "../../data/labyria/Labyria/effects/Flash.efkefc"
   skip "no such fixture (data/labyria not downloaded)" unless File.exist?(path)
   skip "Effekseer backend unavailable" unless MV::Effekseer.available?
 
   result = MV::Effekseer.smoke_test(path)
   assert_true !result.nil?, "smoke_test failed to load/simulate a real effect"
-  assert_true result.is_a?(Integer) && result >= 0
+  assert_true result.is_a?(Integer) && result > 0,
+              "expected visible pixels from a real effect, got #{result.inspect}"
 end


### PR DESCRIPTION
## Summary

Follow-up to #1283 (merged), which vendored the real Effekseer C++ SDK and proved the native GL pipeline simulates real particles with no GL error, but left one thing open: `renderer->GetDrawCallCount()` read `0` after the draw against the test fixture used there (`HitPhysical.efkefc`), with no isolated cause.

- **Root-caused the "0 draw calls" gap** with temporary instrumentation inside the vendored Effekseer source (uncommitted, reverted before this PR — `3rd/effekseer` is unchanged). It traced to the specific fixture, not a pipeline bug: `HitPhysical.efkefc`'s ~40 live particles all live directly on a node whose `EffectNodeType` is `NoneType` (no assigned renderer type). Effekseer's own `InstanceContainer::Draw` unconditionally skips its whole render body for `Root`/`NoneType` nodes, regardless of `RenderingPriority` — correct behavior for that file (a behaviour-only layer with no visual output), not a bug in this project's integration.
- **Proved the pipeline itself has no gap**: re-running the same smoke test against `Flash.efkefc` (another of the 91 real files, whose particles sit on real `Sprite`/`Ring` nodes) produced `GetDrawCallCount() == 2` and, more importantly, 535 of 4096 pixels (64×64) visibly changed from the clear colour — real, visible rendering, not just "ran with no error."
- **Fixed a real timing bug found along the way**: `mvefk::smoke_test` now calls `manager->Flip()` explicitly after its warmup loop, before building `DrawParameter`. `Manager::Update`'s `autoFlip` (the default) syncs the render-visible `DrawSet` snapshot at the *start* of `Update`, from state as of the *previous* `Update` call — so a one-shot simulate-then-draw call like this one was drawing state one full simulation step stale without this. A real per-frame game loop never notices (every frame's draw is consistently one step behind that frame's own `Update`), but it matters here.
- **Strengthened the regression test**: `mruby-mvjs/test/mz_test.rb`'s Effekseer test now asserts a *positive* lit-pixel count (not merely non-nil) against `Flash.efkefc`, so a future regression back to "simulates but never draws" fails loudly instead of silently passing.

## What this is *not*

Still doesn't wire `MZ::EFFEKSEER_SHIM_JS`'s JS-bridge no-ops to these natives — that remains a separate follow-up, now unblocked since the native pipeline is confirmed to render real content end to end.

## Verification

- Full project test suite (`ctest -R mruby_test`): 1859 total, 1854 OK, 0 KO, 0 Crash.
- Manually confirmed via temporary instrumentation (reverted, not part of this diff): `Flash.efkefc` produces 2 real GPU draw calls and 535/4096 changed pixels.
- Native binary builds and links cleanly.

## Docs

- `docs/adr/0004-javascript-maker-mv-quickjs.md`'s "M6.2 addendum 2" updated with the full resolution.
- `docs/TODO.md` and `changelog.d/native-effekseer-renders-pixels.fixed.md` updated/added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_