### PR TITLE
Color disabled rows in the field and battle Skill lists

### DIFF
--- a/changelog.d/skill-list-disabled-color.fixed.md
+++ b/changelog.d/skill-list-disabled-color.fixed.md
@@ -1,0 +1,6 @@
+- **Skill lists (field and battle):** a listed-but-currently-uncastable
+  skill (unaffordable SP, a sealed/missing weapon Attribute, an
+  unregistered Escape/Teleport target) now draws in the windowskin's
+  disabled swatch, matching RPG_RT and the same convention already applied
+  to the Item lists — previously every row drew in the same plain color
+  regardless of whether it could actually be cast.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4788,6 +4788,82 @@ The work below is roughly ordered by the critical path to a walkable game
   check driving a live `Scene::Battle` into its Item sub-menu (Decision on
   the one, listed-but-disabled item plays Buzzer, queues nothing, and stays
   on the list) — all four confirmed to fail against the pre-fix code.
+- ✅ **The field and battle Skill lists never coloured a listed-but-currently-
+  unusable skill in the windowskin's disabled swatch — the same gap the
+  Item lists above had, flagged but deliberately left open when those were
+  fixed ("neither the Item nor the just-fixed Skill menu models font color
+  at all") and never picked up since (2026-08-22).** Confirmed directly
+  against a genuine RPG_RT.exe under wine: a party leader with one
+  affordable (2 SP against 5 current MP) and two unaffordable (8/20 SP)
+  self-scope field skills pixel-sampled the affordable row's glyph at
+  `(165,211,255)` and an unaffordable row's at `(99,166,247)` — the exact
+  same two colours the Item-list capture measured for its own usable/
+  unusable rows, confirming the identical windowskin-swatch convention
+  (index 0 enabled / 3 disabled) applies here too. `Scene::SkillMenu
+  #build_skill_window` (`mruby-rpg2k/mrblib/scene/skill_menu.rb`) used to
+  draw every row through a flat `c.draw_text`, with no colour distinction at
+  all between a skill the caster can and cannot currently cast — the
+  underlying "listed but disabled" *behaviour* (buzz-and-stay on Decision)
+  was already correct, only the visual cue RPG_RT shows before the player
+  even tries was missing. Fixed by extracting the existing three-way
+  availability check (`#choose_skill`'s own affordability/seal/weapon-
+  Attribute/Escape-target/Teleport-target logic) into a new
+  `#skill_unavailable?(sid, sk)` shared by both `#choose_skill`'s gate and
+  `#build_skill_window`'s new per-row `draw_system_text` call (index 3 when
+  unavailable, 0 otherwise) — the same `#draw_system_text`/swatch-index
+  convention `Scene::ItemMenu#build_item_window` already uses. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (a loaded windowskin, one
+  affordable and one sealed/unaffordable skill: the unaffordable row's text
+  blends from swatch cell (48, 48) — index 3 — and the affordable row's from
+  (0, 48) — index 0), confirmed to fail against the pre-fix code (no blend
+  calls at all, since the flat `draw_text` path never blends).
+  **The battle Skill list (`Scene::Battle#draw_battle_skill`) got the
+  identical fix** — a `#battle_skill_unavailable?(cost, sk)` helper
+  extracted from `#confirm_battle_skill`'s own existing SP/weapon-Attribute
+  gate, now also driving a new `idxs:` array into `#battle_list_window`
+  (the same optional parameter `#draw_battle_item` already uses) — but
+  **this half was not independently re-verified against genuine RPG_RT this
+  session**, ported on the strength of sharing the identical
+  `battle_list_window`/`draw_system_text` machinery `#draw_battle_item`
+  already has confirmed pixel-for-pixel, plus the field-side confirmation
+  just above. Covered by a `scripts/rpg2k_scene_check.rb` check pinning
+  `#battle_skill_unavailable?`'s own verdict against a mixed affordable/
+  unaffordable pair (a full pixel-level check would need a windowskin
+  loaded in the battle test harness, which `new_scene`'s stub `db` does not
+  carry — unlike `Scene::SkillMenu`'s own check, built through `menu_scene`
+  instead).
+  **Worth recording for whoever next needs Nepheshel's own save/actor state
+  under wine**: getting *any* controlled skill-list scenario to render at
+  all took three failed approaches before this succeeded, all now understood
+  and worth not repeating. (1) Editing chunk 109's party-list field (chunk
+  109 field 1) to name a different actor id (2, or even 15 — the "real"
+  leader, see below) than whatever a fresh save already has reliably
+  blackens genuine RPG_RT on Continue, confirmed on three separate save-
+  construction methods (a hand-edited genuine EasyRPG-F9-captured save; a
+  from-scratch save built entirely by this engine's own `Game::State#to_lsd`
+  with no EasyRPG involvement at all) and three different maps (12, 204,
+  13) — even a byte-identical no-op rewrite of the *same* value round-trips
+  fine, so it is specifically forcing party membership to a *different*
+  value that breaks it, not the write path. This matches and reproduces a
+  narrower prior finding in this same investigation lineage (the "Attempted
+  and abandoned" / "not merely a valid actor id to resolve" paragraph
+  earlier in this section). (2) Nepheshel's own save lineage always
+  displays a fixed showcase leader (actor 15, デモ用, level 50, ~600-800
+  HP/MP) regardless of chunk 109's stated party — already documented above
+  ("Continue could resume with the wrong actor leading the party") — and
+  this is **not** a common-event effect (the database's own common-event
+  table has zero Auto-Start/Parallel-Process entries, checked directly) or
+  a per-map autostart (the same override persists across three unrelated
+  maps): genuine RPG_RT resolves the actually-displayed leader by some
+  mechanism independent of chunk 109, most likely matching the title
+  chunk's `hero_name` against the roster the way this engine's own
+  `Game::State.from_lsd` fix already does. (3) The fix: **edit only the
+  resolved leader's own chunk 108 record** (actor 15's skills/mp fields)
+  and leave chunk 109 completely untouched at whatever a fresh save already
+  has — exactly "the same technique that worked for the item bag" an
+  earlier pass in this same section already used successfully, just not yet
+  connected to the skill list specifically. This is the technique the
+  fresh capture above used.
 - ✅ **An Escape/Teleport skill was hidden from the field Skill list outright
   whenever it was not castable right now — access off, no registered
   target, or flying — instead of staying listed and disabled, and the same

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1681,19 +1681,28 @@ class RPG2k
         play_system_se(SFX_CURSOR)
       end
 
-      # Choose the highlighted skill: if the caster cannot afford its SP, or is
+      # Whether the highlighted skill (`sid`/`cost`/`sk`, already looked up)
+      # cannot currently be cast: the caster cannot afford its SP, or is
       # missing a weapon-type Attribute the skill requires
       # (`Game::Party#weapon_attribute_ready?` -- the same equip-gate
       # `#can_cast?` already applies to a field cast and to a Forced-AI actor's
-      # own skill eligibility, see `Game::Battle#skill_ready?`), this is
-      # RPG_RT's own Buzzer case (`SkillSelected`'s `CheckEnable` covers both);
+      # own skill eligibility, see `Game::Battle#skill_ready?`). Shared by
+      # #confirm_battle_skill's buzz-and-stay gate and #draw_battle_skill's
+      # row colour (see its own comment) so both agree by construction.
+      def battle_skill_unavailable?(cost, sk)
+        current_actor.mp < cost ||
+          !@state.party.weapon_attribute_ready?(current_actor_row, sk)
+      end
+
+      # Choose the highlighted skill: if the caster cannot afford its SP, or is
+      # missing a weapon-type Attribute the skill requires, this is RPG_RT's
+      # own Buzzer case (`SkillSelected`'s `CheckEnable` covers both);
       # otherwise Decision, then route to enemy / ally target selection (or
       # cast at once on a self-scope skill).
       def confirm_battle_skill
         sid, cost = @ui[:skills][@ui[:skill_i]]
         sk = @state.party.db_skill(sid)
-        if current_actor.mp < cost ||
-           !@state.party.weapon_attribute_ready?(current_actor_row, sk)
+        if battle_skill_unavailable?(cost, sk)
           play_system_se(SFX_BUZZER)
           return
         end
@@ -3465,10 +3474,11 @@ class RPG2k
       # skill list.
       # `idxs`, parallel to `labels`, is an optional windowskin swatch index
       # per row (0 enabled / 3 disabled, `Scene::Base#draw_system_text`'s own
-      # convention) -- nil (every caller except #draw_battle_item) keeps the
-      # plain flat-white `draw_text` every list here has always used; only
-      # the item list can hold a listed-but-disabled row (see
-      # #draw_battle_item).
+      # convention) -- nil (every caller except #draw_battle_item/
+      # #draw_battle_skill) keeps the plain flat-white `draw_text` every
+      # other list here has always used; the item and skill lists are the
+      # two that can hold a listed-but-disabled row (see #draw_battle_item /
+      # #draw_battle_skill).
       def battle_list_window(x, w, labels, sel, z, column_max: 1, idxs: nil)
         rows = BATTLE_VISIBLE_ROWS
         inner_w = w - Window::BORDER * 2
@@ -3504,15 +3514,27 @@ class RPG2k
       # width, same rect as the item menu — RPG_RT's skill and item windows
       # cover both the status and command windows while open (EasyRPG's
       # `skill_window` / `item_window`, `(0, screen_height - 80, MENU_WIDTH,
-      # 80)`).
+      # 80)`). A listed but not currently castable skill (see
+      # #battle_skill_unavailable?) draws in the windowskin's disabled
+      # swatch, matching the field Skill menu and #draw_battle_item just
+      # below -- confirmed for the field Skill list directly against a
+      # genuine RPG_RT.exe (see Scene::SkillMenu#build_skill_window's own
+      # comment for the measured colours); not independently re-verified for
+      # this battle-side sibling this session, ported on the strength of
+      # sharing the identical `battle_list_window`/`draw_system_text`
+      # machinery #draw_battle_item already has confirmed pixel-for-pixel.
       def draw_battle_skill
         @ui[:skill_win].dispose if @ui[:skill_win]
         labels = @ui[:skills].map do |sid, cost|
           sk = @state.party.db_skill(sid)
           "#{sk ? sk.name : "Skill #{sid}"}  #{cost}"
         end
+        idxs = @ui[:skills].map do |sid, cost|
+          sk = @state.party.db_skill(sid)
+          battle_skill_unavailable?(cost, sk) ? 3 : 0
+        end
         @ui[:skill_win] = battle_list_window(0, SCREEN_W, labels, @ui[:skill_i], 325,
-                                             column_max: BATTLE_LIST_COLUMN_MAX)
+                                             column_max: BATTLE_LIST_COLUMN_MAX, idxs: idxs)
       end
 
       def close_battle_skill

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -131,6 +131,23 @@ class RPG2k
         play_system_se(SFX_CURSOR)
       end
 
+      # Whether `sid` (row `sk`, already looked up) cannot currently be cast --
+      # shared by #choose_skill's buzz-and-stay gate and #build_skill_window's
+      # row colour (see its own comment): affordability/seal/weapon-Attribute
+      # (`Game::Party#can_cast?`) for an ordinary skill, or a missing
+      # registered target for Escape/Teleport. Extracted so both call sites
+      # agree by construction rather than by two separately-maintained copies
+      # of the same three-way check.
+      def skill_unavailable?(sid, sk)
+        (@state.party.respond_to?(:can_cast?) && !@state.party.can_cast?(caster, sid)) ||
+          (sk && sk.type == Game::Party::SKILL_ESCAPE &&
+           @state.party.respond_to?(:escape_skill_available?) &&
+           !@state.party.escape_skill_available?(@state)) ||
+          (sk && sk.type == Game::Party::SKILL_TELEPORT &&
+           @state.party.respond_to?(:teleport_skill_available?) &&
+           !@state.party.teleport_skill_available?(@state))
+      end
+
       def choose_skill
         if skills.empty?
           play_system_se(SFX_BUZZER)
@@ -157,15 +174,7 @@ class RPG2k
         # `Algo::IsSkillUsable` special-cases, `#escape_skill_available?`/
         # `#teleport_skill_available?` (access, a registered target, not
         # flying).
-        unavailable =
-          (@state.party.respond_to?(:can_cast?) && !@state.party.can_cast?(caster, sid)) ||
-          (sk && sk.type == Game::Party::SKILL_ESCAPE &&
-           @state.party.respond_to?(:escape_skill_available?) &&
-           !@state.party.escape_skill_available?(@state)) ||
-          (sk && sk.type == Game::Party::SKILL_TELEPORT &&
-           @state.party.respond_to?(:teleport_skill_available?) &&
-           !@state.party.teleport_skill_available?(@state))
-        if unavailable
+        if skill_unavailable?(sid, sk)
           play_system_se(SFX_BUZZER)
           return
         end
@@ -490,16 +499,30 @@ class RPG2k
         # for the analogous Item screen (see item_menu.rb), confirmed there
         # against genuine RPG_RT under wine: a blank list row with a visible,
         # empty cursor box (see #refresh_skill_cursor) rather than a message.
+        #
+        # A row whose skill is not currently castable (unaffordable SP, a
+        # sealed/missing weapon Attribute, an unregistered Escape/Teleport
+        # target -- see #skill_unavailable?) is still drawn, in the
+        # windowskin's disabled swatch (index 3) rather than the enabled one
+        # (0) -- the same convention Scene::ItemMenu#build_item_window
+        # already applies, and confirmed here directly, not just by analogy:
+        # a genuine RPG_RT.exe frame (party leader with one affordable and
+        # two unaffordable self-scope skills at 2/8/20 SP against 5 current)
+        # pixel-sampled the affordable row's glyph at (165,211,255) and an
+        # unaffordable row's at (99,166,247) -- the exact same two colours
+        # the item-list capture measured for its own usable/unusable rows.
         col_w = skill_col_w
         rows.each_with_index do |(sid, cost), i|
           x = (i % COLUMN_MAX) * col_w
           y = head_h + (i / COLUMN_MAX) * LINE_H
-          c.draw_text x, y, col_w - 40, LINE_H, skill_name(sid)
+          sk = @state.party.db_skill(sid)
+          idx = skill_unavailable?(sid, sk) ? 3 : 0
+          draw_system_text(c, x, y, col_w - 40, LINE_H, skill_name(sid), @skin, idx)
           # "-  5"-style: a separator (a plain hyphen -- confirmed via
           # EasyRPG's own Window_Skill::DrawItem, which formats this as
           # `"{separator}{cost:3d}"` with a hyphen default) then the cost
           # right-aligned in a 3-character field, no MP/SP unit suffix.
-          c.draw_text x + col_w - 40, y, 40, LINE_H, "-%3d" % cost
+          draw_system_text(c, x + col_w - 40, y, 40, LINE_H, "-%3d" % cost, @skin, idx)
         end
         @skill_window.contents = c
         refresh_skill_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11815,6 +11815,35 @@ check 'Enemy Encounter scene: confirming a skill missing its required weapon ' \
   eq 'Decision1', RGSS::Audio.se_calls.last[0]
 end
 
+check '#draw_battle_skill colours each row from the same ' \
+      '#battle_skill_unavailable? gate #confirm_battle_skill buzzes on -- ' \
+      'so a listed skill is never drawn enabled while unusable or vice versa' do
+  # #draw_battle_skill's own disabled-swatch colouring (index 0 enabled / 3
+  # disabled, matching the field Skill menu's genuine-RPG_RT-confirmed
+  # convention -- see its own comment) is driven by this exact shared
+  # helper, so pinning the helper's per-row verdict against a mixed
+  # affordable/unaffordable skill list is what keeps the two in lock-step
+  # without needing a loaded windowskin bitmap in this host harness (which
+  # `new_scene`'s stub `db` never has -- Scene::SkillMenu's own colour check
+  # loads one through `menu_scene` instead, see its own comment).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  party = BattleWeaponGateParty.new
+  party.weapon_ready = true # isolate the SP-affordability half of the gate
+  st.instance_variable_set(:@party, party)
+  battle_to_command(scene)
+
+  battle = scene.instance_variable_get(:@battle)
+  cheap_sk = party.db_skill(1) # Fire, cost 3 in BattleMagicParty's own battle_skills
+  eq false, battle.send(:battle_skill_unavailable?, 3, cheap_sk),
+     'affordable (3 SP against 10 MP) is not unavailable -- draws enabled (idx 0)'
+  eq true, battle.send(:battle_skill_unavailable?, 15, cheap_sk),
+     'unaffordable (15 SP against 10 MP) is unavailable -- draws disabled (idx 3)'
+end
+
 check 'Enemy Encounter scene: an item-triggered heal bypasses the weapon-Attribute ' \
       'gate -- no skill-eligibility check runs for it at all' do
   # Regression guard: #confirm_battle_skill's new weapon-Attribute check lives
@@ -20137,6 +20166,31 @@ check 'Scene::SkillMenu: choosing a currently-unusable skill just buzzes and sta
   RGSS::Input.reset
   eq :target, scene.instance_variable_get(:@mode), 'a usable skill still opens target-confirm'
   eq [['Decision1', 100, 100]], RGSS::Audio.se_calls
+end
+
+check 'Scene::SkillMenu: a listed-but-unusable skill row reads the windowskin\'s ' \
+      'own disabled swatch, an affordable one the enabled swatch' do
+  # Confirmed directly against a genuine RPG_RT.exe under wine, not by
+  # analogy alone: a party leader with one affordable (2 SP against 5
+  # current) and two unaffordable (8/20 SP) self-scope field skills
+  # pixel-sampled the affordable row's glyph at (165,211,255) and an
+  # unaffordable row's at (99,166,247) -- the exact two colours
+  # Scene::ItemMenu's own already-fixed disabled-swatch capture measured for
+  # its usable/unusable rows, confirming the same windowskin-swatch
+  # convention (index 0 enabled / 3 disabled) applies to the Skill list too.
+  db = fake_db
+  db.system.system_graphic = 'Skin1' # non-empty -> a real windowskin loads
+  parent = fake_parent(db)
+  state = Game::State.new(SkillGateStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  bc = scene.instance_variable_get(:@skill_window).contents.blend_calls || []
+  # colour 3 -> swatch cell (3%10*16, 3/10*16+48) = (48, 48); colour 0 ->
+  # (0, 48) -- the same geometry Scene::Menu's own disabled-command check
+  # and Scene::ItemMenu's own disabled-row check both already pin.
+  ok bc.any? { |call| call[6] == 48 && call[7] == 48 },
+     'the unaffordable (SEALED_SID) row blends from swatch index 3 (48, 48)'
+  ok bc.any? { |call| call[6] == 0 && call[7] == 48 },
+     'the affordable (READY_SID) row blends from swatch index 0 (0, 48)'
 end
 
 # A party whose four field skills exercise #apply_switch_skill /


### PR DESCRIPTION
## Summary

- RPG_RT colors a listed-but-currently-uncastable skill in the windowskin's disabled swatch, the same convention already applied to the Item lists — confirmed directly against genuine RPG_RT.exe under wine: a party leader with one affordable (2 SP against 5 current MP) and two unaffordable (8/20 SP) self-scope skills pixel-sampled the affordable row's glyph at `(165,211,255)` and an unaffordable row's at `(99,166,247)` — the exact same two colors an earlier cycle measured for the Item list's usable/unusable rows.
- `Scene::SkillMenu#build_skill_window` (`mruby-rpg2k/mrblib/scene/skill_menu.rb`) drew every row through a flat `c.draw_text` with no color distinction at all, even though the underlying "listed but disabled, buzz on select" *behavior* was already correct — only the visual cue was missing.
- Fixed by extracting the existing three-way availability check into `#skill_unavailable?(sid, sk)`, shared by `#choose_skill`'s gate and a new per-row `draw_system_text` call in `#build_skill_window`.
- `Scene::Battle#draw_battle_skill` got the identical fix (`#battle_skill_unavailable?`, wired into the existing `idxs:` parameter `#draw_battle_item` already uses) — this half was **not independently pixel-verified this session**, ported by architectural analogy since it shares the same already-confirmed rendering primitive. Flagged explicitly in the code comments and `docs/TODO.md`.
- Getting a controlled Nepheshel save scenario for the field-side capture took three failed attempts (documented in `docs/TODO.md` for future cycles): editing chunk 109's party membership to a different actor reliably blackens genuine RPG_RT on Continue; the displayed leader isn't determined by a common event or per-map autostart; the fix was editing only the resolved leader's own chunk 108 record and leaving chunk 109 untouched.

## Test plan

- New `scripts/rpg2k_scene_check.rb` checks: a field Skill list check asserting the disabled/enabled rows blend from the correct windowskin swatch cells via a loaded windowskin; a battle-side check pinning `#battle_skill_unavailable?`'s verdict against a mixed affordable/unaffordable pair.
- Confirmed via `git stash` that both new checks fail against the pre-fix code (2 of 896 failed) and pass post-fix (896/896).
- All four suites green: `rpg2k_scene_check.rb` (896 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_