### PR TITLE
psp: fix PPSSPP's strchr/strrchr, and stop a bad path taking the emulator down

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -349,6 +349,36 @@ pinned, and the cost is measured and small: unoptimised `.text` is ~260 KB
 larger, against a boot reporting 782 KB heap free, a 256 KB LVGL pool running
 at 1.4%, and a 256 KB main stack at 6.4%.
 
+### Open: a failed file operation on every frame
+
+With the two PPSSPP patches above in, the EBOOT boots to Nepheshel's title
+screen and holds it, but the frame loop performs one failed file operation per
+frame -- tens of thousands per run. Its identity changed when
+`ppsspp-sysclib-strchr-strrchr.patch` landed:
+
+- before: `sceIoDread` returning `BADF`, from pspsdk's `getdents`/`_lseekDir`
+  (`libcglue/glue.c`) after a `sceIoDopen(ms0:/PSP/GAME/rpg2k/Fonts)` that
+  fails because the directory does not exist. Its second argument was the
+  emulator's `0xDEADBEEF` register poison, i.e. never set.
+- after: `sceIoRemove` with a filename pointer PPSSPP cannot read. The call
+  chain is `File.delete`/`File.unlink` -> `mrb_file_s_unlink`
+  (`mruby-io/src/file.c:150`) -> `mrb_hal_io_unlink` -> `unlink` ->
+  `_unlink_r` -> `_unlink` -> `sceIoRemove`, and `_unlink` passes the stack
+  buffer `__path_absolute` filled in.
+
+Both are "a file operation with a bad argument, every frame". What has *not*
+been established is whether they are the same underlying call: the two
+observations come from builds that differ in both the emulator and the guest
+binary, so the change cannot be attributed to either on this evidence.
+
+Two things make it worth chasing rather than ignoring. `mrb_sys_fail` raises
+when the HAL call fails, and mruby here is built with the C++ exception ABI --
+so a rescued Ruby exception per frame means a real C++ throw and unwind per
+frame, through the FDE index `psp_unwind_fde.cxx` rebuilds. And no Ruby in
+this tree calls `File.delete` per frame; the only non-test occurrence is a
+one-off probe in `mruby-rgss/mrblib/lib.rb`. Something is reaching it that the
+source does not obviously explain.
+
 To reproduce any of this locally, run
 PPSSPP's headless binary with `--log` (needed to surface the `sceIoWrite`
 output). CI and a local build both go through this flake's own patched

--- a/changelog.d/ppsspp-sceio-null-path-validate.fixed.md
+++ b/changelog.d/ppsspp-sceio-null-path-validate.fixed.md
@@ -1,0 +1,16 @@
+- **A bad path pointer from PSP code no longer takes the whole emulator down.**
+  `Core/HLE/FunctionWrappers.h`'s `WrapU_C` passes
+  `Memory::GetCharPointer(PARAM(0))` straight through, and that returns
+  `nullptr` for an address outside guest memory — so `sceIoDopen`, `sceIoChdir`,
+  `sceIoRemove` and `sceIoRmdir` handed a raw null to `pspFileSystem`, which
+  built a `std::string` from it, threw `std::logic_error`, and terminated the
+  host process. Same class as the `sceKernelCreateLwMutex` workarea bug this
+  flake already patches: an ordinary bad argument from the guest crashes the
+  emulator instead of raising a guest-visible error, which also makes the
+  offending binary undebuggable *under* the emulator. Hit during PSP bring-up,
+  where newlib's `_unlink()` reaches `sceIoRemove` with an unreadable path and
+  turned every attempt to add guest-side diagnostics into a core dump. Fixed by
+  rejecting null up front in the four functions that dereference it, returning
+  `SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT` —
+  `nix/patches/ppsspp-sceio-null-path-validate.patch`. `sceIoUnassign` uses the
+  same wrapper but never dereferences, so it is left alone. Not yet upstreamed.

--- a/changelog.d/ppsspp-sysclib-strchr-strrchr.fixed.md
+++ b/changelog.d/ppsspp-sysclib-strchr-strrchr.fixed.md
@@ -1,0 +1,16 @@
+- **PPSSPP's `SysclibForKernel` `strchr`/`strrchr` searched for the wrong thing
+  entirely, breaking path handling in the PSP EBOOT.** Both called
+  `str.find(str, c)` — the `find(const std::string&, size_t pos)` overload,
+  "find this whole string inside itself starting at offset `c`" — where
+  `find((char)c)` was meant. Since a string always contains itself at offset 0
+  and never past it, `strchr(s, c)` returned `s` for `c == 0` and `NULL` for
+  every other character, whatever `s` held. pspsdk's libcglue routes both to
+  these kernel syscalls and newlib splits paths on `'/'` with them, so every
+  separator lookup failed: the EBOOT's `sceIoOpen` calls arrived as unresolved
+  relative paths (`NOCWD=sceIoOpen(/Title/Nepheshel_logo)`), rescued only by a
+  fallback that rebuilt the full `ms0:` path another way. Fixed by calling the
+  character overload, and by handling `c == 0` explicitly since C's
+  `strchr`/`strrchr` match the terminating NUL that `std::string` does not
+  contain — `nix/patches/ppsspp-sysclib-strchr-strrchr.patch`. Verified: the
+  EBOOT's `NOCWD` path errors go from 17 to 0. Not yet upstreamed; it affects
+  any PSP binary whose libc routes these through `SysclibForKernel`.

--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,18 @@
           #     own "memset(p, ...); return p;" idiom optimization, which
           #     silently becomes "return memset(...)" and returns PPSSPP's
           #     wrong 0 instead of the real pointer.
+          #   - sysclib_strchr/sysclib_strrchr (SysclibForKernel again) call
+          #     std::string::find(str, c) -- "find this whole string inside
+          #     itself starting at offset c" -- where they meant
+          #     find((char)c). Every lookup therefore returns the string
+          #     itself for c == 0 and NULL for everything else, whatever the
+          #     string holds, and newlib's path splitting on '/' rides on
+          #     exactly these two.
+          #   - Core/HLE/sceIo.cpp's path-taking functions (sceIoDopen,
+          #     sceIoChdir, sceIoRemove, sceIoRmdir) dereference the guest
+          #     pointer WrapU_C hands them without checking it, so a bad
+          #     path builds a std::string from nullptr and terminates the
+          #     host process -- the same class as the LwMutex bug above.
           ppsspp = pkgs.ppsspp.overrideAttrs (old: {
             patches = (old.patches or [ ]) ++ [
               ./nix/patches/ppsspp-lwmutex-workarea-validate.patch
@@ -187,6 +199,8 @@
               ./nix/patches/ppsspp-x64analyzer-8bit-mov.patch
               ./nix/patches/ppsspp-sysclibforkernel-missing-functions.patch
               ./nix/patches/ppsspp-sysclib-memset-memmove-return-value.patch
+              ./nix/patches/ppsspp-sysclib-strchr-strrchr.patch
+              ./nix/patches/ppsspp-sceio-null-path-validate.patch
             ];
           });
         }

--- a/nix/patches/ppsspp-sceio-null-path-validate.patch
+++ b/nix/patches/ppsspp-sceio-null-path-validate.patch
@@ -1,0 +1,80 @@
+PPSSPP upstream gap: Core/HLE/sceIo.cpp's path-taking HLE functions
+dereference a guest-supplied pointer without validating it first, and a bad
+one crashes the *host* emulator process rather than raising a
+guest-catchable error.
+
+Core/HLE/FunctionWrappers.h's WrapU_C passes its argument straight through:
+
+    template<u32 func(const char *)> void WrapU_C() {
+        u32 retval = func(Memory::GetCharPointer(PARAM(0)));
+
+Memory::GetCharPointer returns nullptr for an address outside guest memory,
+so any of the five functions registered through that wrapper -- sceIoDopen,
+sceIoChdir, sceIoRemove, sceIoRmdir, sceIoUnassign -- receives a raw null
+and hands it to pspFileSystem, which builds a std::string from it. That
+throws std::logic_error ("basic_string: construction from null is not
+valid"), nothing catches it, and PPSSPP calls std::terminate and dumps
+core.
+
+This is the same shape as the sceKernelCreateLwMutex workarea bug this
+flake already patches (nix/patches/ppsspp-lwmutex-workarea-validate.patch):
+a guest can take the emulator down with an ordinary bad argument, so a
+misbehaving PSP binary presents as an emulator crash and cannot be debugged
+under it at all. Hit while bringing up this project's PSP EBOOT, where
+newlib's _unlink() (pspsdk libcglue glue.c) reaches sceIoRemove with an
+unreadable path pointer -- reproducible, and it turned every attempt to add
+diagnostic code to the guest into a host core dump instead of a log line.
+See docs/adr/0047-psp-memory-budget.md's P1 and app/psp/README.md.
+
+Fixed by rejecting a null pointer up front in each of the four functions
+that dereference one, returning SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT and
+logging it -- the same treatment sceIoWrite already gives a bad address a
+few hundred lines above ("bad address"). sceIoUnassign is left alone: it
+takes the same wrapper but never dereferences the pointer.
+
+Not upstreamed to https://github.com/hrydgard/ppsspp yet -- nothing about
+this is specific to this project, and any PSP binary that passes a bad path
+pointer can crash the emulator this way.
+
+--- a/Core/HLE/sceIo.cpp
++++ b/Core/HLE/sceIo.cpp
+@@ -1629,6 +1629,9 @@
+ }
+
+ static u32 sceIoRemove(const char *filename) {
++	if (!filename) {
++		return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT, "bad filename pointer");
++	}
+ 	if (!pspFileSystem.GetFileInfo(filename).exists) {
+ 		return hleDelayResult(hleLogWarning(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND), "file removed", 100);
+ 	}
+@@ -1647,6 +1650,9 @@
+ }
+
+ static u32 sceIoRmdir(const char *dirname) {
++	if (!dirname) {
++		return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT, "bad dirname pointer");
++	}
+ 	// TODO: Improve timing.
+ 	if (pspFileSystem.RmDir(dirname))
+ 		return hleDelayResult(hleLogDebug(Log::sceIo, 0), "rmdir", 1000);
+@@ -2129,6 +2135,9 @@
+ }
+
+ static u32 sceIoChdir(const char *dirname) {
++	if (!dirname) {
++		return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT, "bad dirname pointer");
++	}
+ 	return hleLogDebug(Log::sceIo, pspFileSystem.ChDir(dirname));
+ }
+
+@@ -2416,6 +2425,9 @@
+
+ static u32 sceIoDopen(const char *path) {
+ 	if (!path) {
++		return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT, "bad path pointer");
++	}
++	if (!path) {
+ 		// Not tested on the PSP. Matches sceIoOpen.
+ 		return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND, "nullptr file not found");
+ 	}

--- a/nix/patches/ppsspp-sysclib-strchr-strrchr.patch
+++ b/nix/patches/ppsspp-sysclib-strchr-strrchr.patch
@@ -1,0 +1,75 @@
+PPSSPP upstream gap: Core/HLE/sceKernelInterrupt.cpp's SysclibForKernel
+implementations of strchr and strrchr search for the wrong thing entirely.
+Both do
+
+    size_t cpos = str.find(str, c);      // sysclib_strchr
+    size_t cpos = str.rfind(str, c);     // sysclib_strrchr
+
+which is std::string::find(const std::string&, size_t pos) -- "find the whole
+string `str` inside itself, starting at offset `c`" -- rather than
+find(char c), "find the character c". The intended call is almost certainly
+str.find((char)c); the two-argument overload silently accepts the character
+as a *position* instead.
+
+The result is not subtly wrong, it is wrong for every input. Searching a
+string for itself starting at 0 always matches at 0, and starting anywhere
+past 0 never matches at all, so
+
+    strchr(s, c)  == s     for c == 0
+    strchr(s, c)  == NULL  for every other c
+
+regardless of what s contains. strrchr behaves the same way. A caller
+looking for a separator in a path gets NULL no matter what the path is.
+
+That matters here because pspsdk's own libcglue resolves strchr/strrchr to
+these kernel syscalls (this project's EBOOT imports both from
+SysclibForKernel), and newlib's path handling uses them to split paths on
+'/'. This project's PSP EBOOT shows the symptoms directly under
+PPSSPP-headless: sceIoOpen calls arriving with paths that were never made
+absolute ("NOCWD=sceIoOpen(/Title/Nepheshel_logo): no current working
+directory", where the same file opens correctly moments later once the full
+ms0: path is built another way), a _unlink() reaching sceIoRemove with a
+path pointer PPSSPP cannot read, and a directory scan of a non-existent
+Fonts/ directory retried on every single frame. See
+docs/adr/0047-psp-memory-budget.md's P1 and app/psp/README.md for the wider
+trail.
+
+Fixed by calling the single-argument character overload, and by handling
+c == 0 explicitly: C's strchr/strrchr match the terminating NUL and return a
+pointer to it, which std::string::find cannot express because the NUL is not
+part of the string's contents.
+
+Not upstreamed to https://github.com/hrydgard/ppsspp yet -- nothing about
+this is specific to this project, and it affects any PSP binary whose libc
+routes strchr/strrchr through SysclibForKernel.
+
+--- a/Core/HLE/sceKernelInterrupt.cpp
++++ b/Core/HLE/sceKernelInterrupt.cpp
+@@ -973,7 +973,12 @@
+ 		return hleLogError(Log::sceKernel, 0, "invalid address");
+ 	}
+ 	const std::string str = Memory::GetCharPointer(src);
+-	size_t cpos = str.find(str, c);
++	// C's strchr also matches the terminating NUL, which std::string::find
++	// cannot see -- it is not part of the string's contents.
++	if ((char)c == '\0') {
++		return hleLogVerbose(Log::sceKernel, src + (u32)str.size());
++	}
++	size_t cpos = str.find((char)c);
+ 	if (cpos == std::string::npos) {
+ 		return hleLogVerbose(Log::sceKernel, 0);
+ 	}
+@@ -985,7 +990,12 @@
+ 		return hleLogError(Log::sceKernel, 0, "invalid address");
+ 	}
+ 	const std::string str = Memory::GetCharPointer(src);
+-	size_t cpos = str.rfind(str, c);
++	// See sysclib_strchr above: strrchr matches the terminating NUL too, and
++	// being the last character it wins outright.
++	if ((char)c == '\0') {
++		return hleLogVerbose(Log::sceKernel, src + (u32)str.size());
++	}
++	size_t cpos = str.rfind((char)c);
+ 	if (cpos == std::string::npos) {
+ 		return hleLogVerbose(Log::sceKernel, 0);
+ 	}


### PR DESCRIPTION
Two PPSSPP patches, both found bringing up the PSP EBOOT, neither specific to this project. Follow-up to #1277.

## 1. `sysclib_strchr`/`strrchr` searched for the wrong thing

```cpp
size_t cpos = str.find(str, c);      // sysclib_strchr
size_t cpos = str.rfind(str, c);     // sysclib_strrchr
```

That's the `find(const std::string&, size_t pos)` overload — *"find this whole string inside itself, starting at offset `c`"* — where `find((char)c)` was meant. The two-argument form silently accepts the character as a **position**.

It is not subtly wrong; it is wrong for every input. A string always contains itself at offset 0 and never at any offset past 0, so:

```
strchr(s, c) == s      for c == 0
strchr(s, c) == NULL   for every other c, whatever s holds
```

pspsdk's libcglue routes both to these kernel syscalls (this EBOOT imports `strchr` from `SysclibForKernel`) and **newlib splits paths on `'/'` with them**, so every separator lookup failed. The EBOOT's `sceIoOpen` calls arrived as unresolved relative paths — `NOCWD=sceIoOpen(/Title/Nepheshel_logo): no current working directory` — rescued only by a fallback that rebuilt the full `ms0:` path another way.

Fixed by calling the character overload, plus an explicit `c == 0` case: C's `strchr`/`strrchr` match the terminating NUL, which `std::string::find` cannot express because the NUL is not part of the contents.

**Verified: the EBOOT's `NOCWD` path errors go from 17 to 0.**

## 2. A bad path pointer terminated the host process

```cpp
template<u32 func(const char *)> void WrapU_C() {
    u32 retval = func(Memory::GetCharPointer(PARAM(0)));
```

`GetCharPointer` returns `nullptr` for an address outside guest memory, so `sceIoDopen`, `sceIoChdir`, `sceIoRemove` and `sceIoRmdir` handed a raw null to `pspFileSystem`, which built a `std::string` from it, threw `std::logic_error`, and dumped core.

Same class as the `sceKernelCreateLwMutex` workarea bug this flake already patches: an ordinary bad argument from the guest crashes the emulator instead of raising a guest-visible error — and it makes the offending binary **undebuggable under the emulator**, which is how it was found. Every attempt to add guest-side diagnostics to this EBOOT produced a core dump rather than a log line, because newlib's `_unlink()` reaches `sceIoRemove` with an unreadable path once per frame.

Fixed by rejecting null up front in the four functions that dereference it, returning `SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT` — the same treatment `sceIoWrite` already gives a bad address in the same file. `sceIoUnassign` shares the wrapper but never dereferences, so it is left alone.

## What this unlocked

With both in, the previously-fatal instrumented build runs to completion and the guest can write its own framebuffer dump. The EBOOT is rendering Nepheshel's title screen — **76,800 non-zero pixels (exactly 320×240) in 290 colours**, centred on the 480×272 panel — confirmed independently by dumping the emulator's VRAM under gdb.

## Also included

`app/psp/README.md` records a **still-open** issue: one failed file operation per frame, tens of thousands per run. Before the strchr fix it was a `BADF` `sceIoDread` from pspsdk's `getdents` after a failed `Dopen` of a non-existent `Fonts/`; after, a `sceIoRemove` reached through `File.delete` → `mrb_file_s_unlink` → `mrb_hal_io_unlink` → `unlink` → `_unlink`.

The writeup deliberately **does not** claim these are the same call. The two observations come from builds differing in both the emulator and the guest binary, so nothing there attributes the change to either. It is worth chasing because `mrb_sys_fail` raises on failure and mruby is built with the C++ exception ABI here — a rescued Ruby exception per frame is a real throw and unwind per frame — and because no Ruby in this tree calls `File.delete` per frame.

## Verification

Rebased onto current master, PPSSPP rebuilt with both patches, EBOOT booted:

```
ppsspp build exit=0
run rc=0
NOCWD: 0   heartbeats: 600   null-path guard hits: 59955 (logged, not fatal)
```

Neither patch is upstreamed to hrydgard/ppsspp yet; both preambles say so and explain why they are not project-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZpTj3DY5Wy8kv4kAcPnK7