### PR TITLE
Wire Effekseer JS bridge to real native simulation

### DIFF
--- a/changelog.d/effekseer-js-bridge-simulation.added.md
+++ b/changelog.d/effekseer-js-bridge-simulation.added.md
@@ -1,0 +1,12 @@
+- `MZ::EFFEKSEER_SHIM_JS`'s `loadEffect`/`play`/`update`/`stopAll` now route
+  through a real, persistent `Effekseer::Manager` (new `__mv_efk*` natives,
+  `mruby-mvjs/src/mvefk.cxx`) wherever the loaded `.efkefc` file genuinely
+  parses, so `handle.exists`/animation timing reflect the effect's own
+  authored duration instead of an arbitrary placeholder. A synthetic or
+  malformed effect (as this project's own pre-existing tests deliberately
+  use) still falls back to the original fixed-lifetime handle unchanged, so
+  nothing that worked before behaves differently now. Still doesn't draw
+  particles through this path: only simulation is wired, not
+  `EffekseerRendererGL::Renderer` -- rendering needs to share the exact GL
+  context/FBO PIXI's own WebGL renderer is using mid-frame, staged as its
+  own follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21955,9 +21955,22 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
         bugs found and fixed along the way (`DrawParameter` population,
         `GetCameraProjectionMatrix` read-ordering) and a third real fix (an
         explicit `Manager::Flip()` before drawing, needed for a one-shot
-        simulate-then-draw call). `MZ::EFFEKSEER_SHIM_JS`'s JS bridge still
-        needs wiring to these natives — that was deliberately staged to
-        come after the native pipeline was proven, which it now is.
+        simulate-then-draw call).
+      - ✅ **Effekseer JS bridge: real simulation wired, rendering still
+        deferred.** `MZ::EFFEKSEER_SHIM_JS`'s `loadEffect`/`play`/`update`/
+        `stopAll` now route through a real, persistent `Effekseer::Manager`
+        (new `__mv_efk*` natives, `mvefk.cxx`'s `context_create`/
+        `effect_load`/`play`/... and `mv_install_effekseer`) wherever the
+        loaded file genuinely parses — a synthetic or malformed effect (as
+        this project's own pre-existing shim tests deliberately use) still
+        falls back to the original fixed-20-frame handle unchanged, so this
+        is a strict superset of the prior behavior. Deliberately not the
+        rendering half: no `EffekseerRendererGL::Renderer`, no GL context —
+        drawing needs Effekseer's renderer to share the exact GL context/FBO
+        PIXI's own WebGL renderer (`mvwebgl.cxx`) is using mid-frame, a
+        separate, higher-risk integration staged as its own follow-up. See
+        docs/adr/0004's "M6.2 addendum 3" for the full design and why the
+        fallback path had to stay exact.
 
 ## Tooling
 

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -621,6 +621,41 @@ JavaScript loads and interprets the JSON.
       addendum was staged ahead of, per the previous addendum's own
       recommendation) — now unblocked, since the native GL pipeline is
       confirmed to render real, visible content end to end.
+    - **M6.2 addendum 3 — JS bridge: real simulation, rendering still
+      deferred.** The first half of the JS-bridge wiring the previous
+      addendum unblocked: `EFFEKSEER_SHIM_JS`'s `loadEffect`/`play`/
+      `update`/`stopAll` now route through a real, persistent
+      `Effekseer::Manager` (`mvefk::context_create`/`effect_load`/`play`/
+      `update`/... in `mvefk.cxx`, exposed to JS as `__mv_efk*` natives,
+      `mv_install_effekseer`) wherever that manager successfully parses the
+      loaded file — deliberately **not** the rendering half: no
+      `EffekseerRendererGL::Renderer`, no GL context. Simulation needs
+      neither; drawing needs Effekseer's renderer to share the exact GL
+      context/FBO PIXI's own WebGL renderer (`mvwebgl.cxx`) is using
+      mid-frame, which is a materially riskier integration (shared GL state,
+      a JS-side `WebGLRenderingContext` handle to translate into a native
+      one, MZ's own fixed projection/camera matrix convention in
+      `Sprite_Animation.setProjectionMatrix`/`setCameraMatrix`) staged as
+      its own follow-up rather than rushed alongside this.
+
+      A file that merely *looks* like a `.efkefc` (right magic bytes, not
+      real Effekseer data — exactly what this project's own test fixtures
+      use) fails `Effekseer::Effect::Create` and falls back to the shim's
+      original synthetic, fixed-20-frame handle, unchanged from before this
+      addendum. This was a deliberate design constraint, not an afterthought:
+      the shim's existing tests exercise garbage-but-correctly-prefixed
+      bytes, a bare `{}` passed to `play()`, and a missing file, all
+      specifically to verify the *honest-diagnostic* fallback path still
+      works — routing those same inputs through real native parsing would
+      have broken them. The fallback makes this a strict superset of the
+      previous behavior: nothing that "worked" (reported honestly) before
+      behaves differently now, proven by all three of those pre-existing
+      tests passing unchanged. A fourth, new test
+      (`mruby-mvjs/test/mz_test.rb`) loads a real, unmodified `.efkefc`
+      (`Flash.efkefc`) through the shim and confirms it takes the *other*
+      path: a nonzero native effect handle and a `play()` result whose
+      `_native` field is a real, non-negative `Effekseer::Handle` — proving
+      genuine native routing, not just that nothing broke.
 
       It also shows why M6.3g's frame check is not redundant with the log: with
       the animation's sheet renamed away, `[MZ-ANIM]` still reports

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -290,7 +290,12 @@ class MZ
     "})(globalThis);".freeze
 
   # Replaces `window.effekseer` (defined by the vendored `effekseer.min.js`,
-  # still evaluated harmlessly as part of CORE_SCRIPTS) with a diagnostic stub.
+  # still evaluated harmlessly as part of CORE_SCRIPTS) with a bridge to the
+  # real native Effekseer C++ SDK (`3rd/effekseer`, `mruby-mvjs/src/mvefk.cxx`)
+  # where it was compiled in, falling back to the original honest-diagnostic
+  # stub everywhere else (or for content that fails to parse as a real
+  # `.efkefc`) — see `__mv_efkContextCreate` and friends (mvefk.cxx) for the
+  # native half.
   #
   # `Graphics._createEffekseerContext` (rmmz_core.js) already degrades
   # gracefully when `effekseer.createContext()` returns null, which is exactly
@@ -304,62 +309,134 @@ class MZ
   # whose animations are all Effekseer looks like it is running fine with no
   # indication anything was skipped.
   #
-  # This stub does not draw particles (that needs a native Effekseer port
-  # targeting the WebGL bridge in mvgl.cxx/mvwebgl.cxx — a multi-week project
-  # of its own, tracked separately) but it does the two things a stub can do
-  # honestly in one step: it makes `Graphics.effekseer` non-null so the load
-  # path actually runs, and it reads the real `.efkefc` bytes off disk
+  # This still does not draw particles: only `Effekseer::Manager`
+  # (simulation) is wired here, not `EffekseerRendererGL::Renderer` (drawing
+  # real MZ animations needs Effekseer's renderer to share the exact GL
+  # context/FBO PIXI's own WebGL renderer, mvwebgl.cxx, is using mid-frame —
+  # a separate, higher-risk integration staged as its own follow-up; see
+  # docs/TODO.md's Effekseer entry). What real simulation buys over the old
+  # synthetic stub: `loadEffect` on a genuinely valid `.efkefc` gets a real
+  # native effect handle, and `play()` on that handle drives a real
+  # `Effekseer::Manager::Update` loop, so `handle.exists`/animation timing
+  # reflect the effect's own authored duration instead of an arbitrary
+  # 20-frame placeholder. Content that merely *looks* like an effect (right
+  # magic bytes, not real Effekseer data — as hand-built test fixtures are)
+  # fails native parsing and transparently falls back to the old synthetic
+  # handle, so this is a strict superset of the previous behavior: nothing
+  # that "worked" (i.e. reported honestly) before behaves differently now.
+  #
+  # `loadEffect` still reads the real `.efkefc` bytes off disk itself
   # (through the same `__mv_existsSync`/`__mv_readFileBytes` natives every
-  # other asset uses) to confirm the file exists and looks like a real effect
-  # container (`"EFKEFC"` magic) before logging exactly what was skipped and
-  # why. A missing effect file still reports through `onError`/`checkErrors`
-  # the same way the real engine's fetch failure would (rmmz_managers.js's
+  # other asset uses, unrelated to the native Effekseer parse attempt above)
+  # to confirm the file exists and looks like a real effect container
+  # (`"EFKEFC"` magic) before logging what native rendering still can't draw.
+  # A missing effect file still reports through `onError`/`checkErrors` the
+  # same way the real engine's fetch failure would (rmmz_managers.js's
   # `EffectManager.throwLoadError`), rather than being swallowed twice over.
   #
-  # `play()` hands back a handle with a short fixed lifetime (decremented by
-  # `update()`, which `SceneManager.updateEffekseer` already calls once a
-  # frame) so `Sprite_Animation.checkEnd` still sees `_handle.exists` go
-  # false and ends the animation normally instead of hanging on it forever.
-  EFFEKSEER_SHIM_JS =
-    "(function(g){ " \
-    "function makeContext(){ var ctx = { _handles: [] }; " \
-    "ctx.init = function(){}; " \
-    "ctx.setRestorationOfStatesFlag = function(){}; " \
-    "ctx.loadEffect = function(url, mag, onLoad, onError){ " \
-    "var exists = (typeof g.__mv_existsSync === 'function') && " \
-    "g.__mv_existsSync(url); " \
-    "if (!exists) { if (onError) onError('not found', url); " \
-    "return { isLoaded: false, url: url }; } " \
-    "var bytes = new Uint8Array(g.__mv_readFileBytes(url)); " \
-    "var magic = 'EFKEFC'; var magicOk = bytes.length >= magic.length; " \
-    "for (var i = 0; magicOk && i < magic.length; i++) { " \
-    "if (bytes[i] !== magic.charCodeAt(i)) magicOk = false; } " \
-    "if (typeof console !== 'undefined' && console.warn) { " \
-    "console.warn('[Effekseer] effect requested but native particle ' + " \
-    "'rendering is not implemented: ' + url + ' (' + bytes.length + " \
-    "' bytes' + (magicOk ? '' : ', unrecognized format') + ')'); } " \
-    "if (onLoad) onLoad(); " \
-    "return { isLoaded: true, url: url, byteLength: bytes.length, " \
-    "magicOk: magicOk }; }; " \
-    "ctx.releaseEffect = function(){}; " \
-    "ctx.update = function(){ var alive = []; " \
-    "for (var i = 0; i < this._handles.length; i++) { " \
-    "var h = this._handles[i]; h._life--; " \
-    "if (h._life <= 0) h.exists = false; else alive.push(h); } " \
-    "this._handles = alive; }; " \
-    "ctx.stopAll = function(){ for (var i = 0; i < this._handles.length; i++) " \
-    "this._handles[i].exists = false; this._handles = []; }; " \
-    "ctx.play = function(){ var h = { exists: true, _life: 20, " \
-    "setLocation: function(){}, setRotation: function(){}, " \
-    "setScale: function(){}, setSpeed: function(){}, " \
-    "stop: function(){ this.exists = false; } }; " \
-    "this._handles.push(h); return h; }; " \
-    "ctx.beginDraw = function(){}; ctx.drawHandle = function(){}; " \
-    "ctx.endDraw = function(){}; ctx.setProjectionMatrix = function(){}; " \
-    "ctx.setCameraMatrix = function(){}; " \
-    "return ctx; } " \
-    "g.effekseer = { createContext: makeContext }; " \
-    "})(globalThis);".freeze
+  # A synthetic (non-native) `play()` handle still has a short fixed lifetime
+  # (decremented by `update()`, which `SceneManager.updateEffekseer` already
+  # calls once a frame) so `Sprite_Animation.checkEnd` still sees
+  # `_handle.exists` go false and ends the animation normally instead of
+  # hanging on it forever, exactly as before.
+  EFFEKSEER_SHIM_JS = <<~'JS'
+    (function (g) {
+      var haveNative = typeof g.__mv_efkContextCreate === 'function';
+      function makeContext() {
+        var ctx = { _handles: [] };
+        var nativeCtx = haveNative ? g.__mv_efkContextCreate() : 0;
+        ctx.init = function () {};
+        ctx.setRestorationOfStatesFlag = function () {};
+        ctx.loadEffect = function (url, mag, onLoad, onError) {
+          var exists = (typeof g.__mv_existsSync === 'function') && g.__mv_existsSync(url);
+          if (!exists) {
+            if (onError) onError('not found', url);
+            return { isLoaded: false, url: url };
+          }
+          var bytes = new Uint8Array(g.__mv_readFileBytes(url));
+          var magic = 'EFKEFC';
+          var magicOk = bytes.length >= magic.length;
+          for (var i = 0; magicOk && i < magic.length; i++) {
+            if (bytes[i] !== magic.charCodeAt(i)) magicOk = false;
+          }
+          // A real .efkefc that fails to parse here (garbage past the magic
+          // bytes, an unsupported sub-format) is not treated as a load
+          // error: isLoaded/magicOk above are still honest either way, and
+          // play() below falls back to the synthetic handle for it.
+          var nativeEffect = nativeCtx ? g.__mv_efkEffectLoad(nativeCtx, bytes, mag || 1) : 0;
+          if (!nativeEffect && typeof console !== 'undefined' && console.warn) {
+            console.warn('[Effekseer] effect requested but native particle ' +
+              'rendering is not implemented: ' + url + ' (' + bytes.length +
+              ' bytes' + (magicOk ? '' : ', unrecognized format') + ')');
+          }
+          if (onLoad) onLoad();
+          return { isLoaded: true, url: url, byteLength: bytes.length, magicOk: magicOk, _native: nativeEffect };
+        };
+        ctx.releaseEffect = function (effect) {
+          if (nativeCtx && effect && effect._native) g.__mv_efkEffectRelease(nativeCtx, effect._native);
+        };
+        ctx.update = function (deltaFrame) {
+          if (nativeCtx) g.__mv_efkUpdate(nativeCtx, deltaFrame === undefined ? 1 : deltaFrame);
+          var alive = [];
+          for (var i = 0; i < this._handles.length; i++) {
+            var h = this._handles[i];
+            if (h._native !== undefined && h._native >= 0) {
+              h.exists = nativeCtx ? !!g.__mv_efkExists(nativeCtx, h._native) : false;
+            } else {
+              h._life--;
+              h.exists = h._life > 0;
+            }
+            if (h.exists) alive.push(h);
+          }
+          this._handles = alive;
+        };
+        ctx.stopAll = function () {
+          for (var i = 0; i < this._handles.length; i++) {
+            var h = this._handles[i];
+            if (nativeCtx && h._native !== undefined && h._native >= 0) g.__mv_efkStop(nativeCtx, h._native);
+            h.exists = false;
+          }
+          this._handles = [];
+        };
+        ctx.play = function (effect, x, y, z) {
+          var nativeHandle = (nativeCtx && effect && effect._native)
+            ? g.__mv_efkPlay(nativeCtx, effect._native, x || 0, y || 0, z || 0)
+            : -1;
+          var h;
+          if (nativeHandle >= 0) {
+            h = {
+              exists: true,
+              _native: nativeHandle,
+              setLocation: function (x, y, z) { g.__mv_efkSetLocation(nativeCtx, nativeHandle, x, y, z); },
+              setRotation: function (x, y, z) { g.__mv_efkSetRotation(nativeCtx, nativeHandle, x, y, z); },
+              setScale: function (x, y, z) { g.__mv_efkSetScale(nativeCtx, nativeHandle, x, y, z); },
+              setSpeed: function (s) { g.__mv_efkSetSpeed(nativeCtx, nativeHandle, s); },
+              stop: function () { g.__mv_efkStop(nativeCtx, nativeHandle); this.exists = false; }
+            };
+          } else {
+            h = {
+              exists: true,
+              _life: 20,
+              setLocation: function () {},
+              setRotation: function () {},
+              setScale: function () {},
+              setSpeed: function () {},
+              stop: function () { this.exists = false; }
+            };
+          }
+          this._handles.push(h);
+          return h;
+        };
+        ctx.beginDraw = function () {};
+        ctx.drawHandle = function () {};
+        ctx.endDraw = function () {};
+        ctx.setProjectionMatrix = function () {};
+        ctx.setCameraMatrix = function () {};
+        return ctx;
+      }
+      g.effekseer = { createContext: makeContext };
+    })(globalThis);
+  JS
 
   # Installed only for headless/CI runs (see #render_skip_enabled?, gated on
   # the same --no_render_wait flag as RGSS::Graphics.update's frame-pacing

--- a/mruby-mvjs/src/mvefk.cxx
+++ b/mruby-mvjs/src/mvefk.cxx
@@ -2,6 +2,8 @@
 
 #include "mvefk.hxx"
 
+#include "mvhost.hxx"  // mv_install_effekseer's declaration; always available.
+
 // Unlike mvgl.cxx (which decides purely from `__has_include`, since EGL/
 // GLES2 headers/libs are found via the default system search path with no
 // extra wiring needed), this gate hinges on a define mrbgem.rake sets
@@ -23,9 +25,11 @@
 
 #include <GLES3/gl3.h>
 
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "Effekseer.h"
 #include "EffekseerRendererGL.h"
@@ -205,7 +209,380 @@ bool smoke_test(const char* path,
   return true;
 }
 
+// -- persistent JS-bridge simulation context ---------------------------------
+
+namespace {
+
+// One entry per live ContextId (index + 1; 0 is the null id), mirroring
+// mvwebgl.cxx's g_gl idiom. A context outlives individual effects/handles;
+// MZ creates exactly one for the whole game (Graphics.effekseer) and never
+// destroys it, but context_destroy exists for tests.
+struct Context {
+  Effekseer::ManagerRef manager;
+  // Effects loaded into this context, by EffectId (index + 1; 0 is null),
+  // kept alive here since Effekseer::Handle alone does not hold a strong
+  // reference the caller can query back.
+  std::vector<Effekseer::EffectRef> effects;
+};
+
+std::vector<Context*> g_contexts;
+
+Context* find_context(ContextId ctx) {
+  if (ctx < 1 || static_cast<std::size_t>(ctx) > g_contexts.size())
+    return nullptr;
+  return g_contexts[static_cast<std::size_t>(ctx) - 1];
+}
+
+}  // namespace
+
+ContextId context_create() {
+  if (!available()) {
+    warn("context_create: backend not available", nullptr);
+    return 0;
+  }
+  auto* c = new Context();
+  // Same instance cap as smoke_test's own Manager::Create -- headroom for a
+  // real game's several-animations-at-once case, not tuned per-effect.
+  c->manager = Effekseer::Manager::Create(2000);
+  if (!c->manager) {
+    warn("context_create: Effekseer::Manager::Create failed", nullptr);
+    delete c;
+    return 0;
+  }
+  c->manager->SetCoordinateSystem(Effekseer::CoordinateSystem::RH);
+  g_contexts.push_back(c);
+  return static_cast<ContextId>(g_contexts.size());
+}
+
+void context_destroy(ContextId ctx) {
+  Context* c = find_context(ctx);
+  if (!c)
+    return;
+  delete c;
+  g_contexts[static_cast<std::size_t>(ctx) - 1] = nullptr;
+}
+
+EffectId effect_load(ContextId ctx,
+                     const std::uint8_t* bytes,
+                     std::size_t len,
+                     float magnification) {
+  Context* c = find_context(ctx);
+  if (!c || !bytes || len == 0)
+    return 0;
+  Effekseer::EffectRef effect = Effekseer::Effect::Create(
+      c->manager, bytes, static_cast<int32_t>(len), magnification);
+  if (!effect)
+    return 0;
+  c->effects.push_back(effect);
+  return static_cast<EffectId>(c->effects.size());
+}
+
+void effect_release(ContextId ctx, EffectId effect) {
+  Context* c = find_context(ctx);
+  if (!c || effect < 1 || static_cast<std::size_t>(effect) > c->effects.size())
+    return;
+  c->effects[static_cast<std::size_t>(effect) - 1] = nullptr;
+}
+
+std::int32_t play(ContextId ctx, EffectId effect, float x, float y, float z) {
+  Context* c = find_context(ctx);
+  if (!c || effect < 1 || static_cast<std::size_t>(effect) > c->effects.size())
+    return -1;
+  const Effekseer::EffectRef& e =
+      c->effects[static_cast<std::size_t>(effect) - 1];
+  if (!e)
+    return -1;
+  return c->manager->Play(e, x, y, z);
+}
+
+void set_location(ContextId ctx,
+                  std::int32_t handle,
+                  float x,
+                  float y,
+                  float z) {
+  Context* c = find_context(ctx);
+  if (!c || handle < 0)
+    return;
+  c->manager->SetLocation(handle, x, y, z);
+}
+
+void set_rotation(ContextId ctx,
+                  std::int32_t handle,
+                  float x,
+                  float y,
+                  float z) {
+  Context* c = find_context(ctx);
+  if (!c || handle < 0)
+    return;
+  c->manager->SetRotation(handle, x, y, z);
+}
+
+void set_scale(ContextId ctx, std::int32_t handle, float x, float y, float z) {
+  Context* c = find_context(ctx);
+  if (!c || handle < 0)
+    return;
+  c->manager->SetScale(handle, x, y, z);
+}
+
+void set_speed(ContextId ctx, std::int32_t handle, float speed) {
+  Context* c = find_context(ctx);
+  if (!c || handle < 0)
+    return;
+  c->manager->SetSpeed(handle, speed);
+}
+
+void stop(ContextId ctx, std::int32_t handle) {
+  Context* c = find_context(ctx);
+  if (!c || handle < 0)
+    return;
+  c->manager->StopEffect(handle);
+}
+
+bool handle_exists(ContextId ctx, std::int32_t handle) {
+  Context* c = find_context(ctx);
+  if (!c || handle < 0)
+    return false;
+  return c->manager->Exists(handle);
+}
+
+void update(ContextId ctx, float delta_frame) {
+  Context* c = find_context(ctx);
+  if (!c)
+    return;
+  c->manager->Update(delta_frame);
+}
+
+void stop_all(ContextId ctx) {
+  Context* c = find_context(ctx);
+  if (!c)
+    return;
+  c->manager->StopAllEffects();
+}
+
 }  // namespace mvefk
+
+// -- JS bridge (__mv_efk* natives) -------------------------------------------
+//
+// Installed unconditionally (both branches of this file define
+// mv_install_effekseer): MZ::EFFEKSEER_SHIM_JS calls these natives
+// regardless of whether the real backend is compiled in, exactly like it
+// already unconditionally calls __mv_existsSync/__mv_readFileBytes. Where
+// mvefk's real functions are unavailable, every one of them already
+// no-ops/returns its failure sentinel (see mvefk.hxx), so this stays a
+// single code path either way -- only the JS side branches (on whether
+// context_create returned a nonzero id), matching how it already branches
+// on the honest-diagnostic magic-byte check.
+
+namespace {
+
+int32_t gi(JSContext* ctx, int argc, JSValueConst* argv, int i) {
+  int32_t v = 0;
+  if (i < argc)
+    JS_ToInt32(ctx, &v, argv[i]);
+  return v;
+}
+
+double gd(JSContext* ctx, int argc, JSValueConst* argv, int i) {
+  double v = 0;
+  if (i < argc)
+    JS_ToFloat64(ctx, &v, argv[i]);
+  return v;
+}
+
+// Mirrors mvwebgl.cxx's view_bytes: accepts a TypedArray view or a bare
+// ArrayBuffer (EFFEKSEER_SHIM_JS always passes a Uint8Array, but this stays
+// consistent with the rest of the host's bridges). `*hold` must be freed by
+// the caller once done with the returned pointer.
+uint8_t* efk_view_bytes(JSContext* ctx,
+                        JSValueConst v,
+                        size_t* out_len,
+                        JSValue* hold) {
+  size_t off = 0, len = 0, bpe = 0;
+  JSValue ab = JS_GetTypedArrayBuffer(ctx, v, &off, &len, &bpe);
+  if (JS_IsException(ab)) {
+    JS_FreeValue(ctx, ab);
+    JS_FreeValue(ctx, JS_GetException(ctx));
+    size_t raw = 0;
+    uint8_t* p = JS_GetArrayBuffer(ctx, &raw, v);
+    if (!p) {
+      JS_FreeValue(ctx, JS_GetException(ctx));
+      *hold = JS_UNDEFINED;
+      *out_len = 0;
+      return nullptr;
+    }
+    *hold = JS_DupValue(ctx, v);
+    *out_len = raw;
+    return p;
+  }
+  size_t sz = 0;
+  uint8_t* p = JS_GetArrayBuffer(ctx, &sz, ab);
+  *hold = ab;
+  *out_len = len;
+  return p ? p + off : nullptr;
+}
+
+JSValue js_efk_context_create(JSContext* ctx,
+                              JSValueConst,
+                              int,
+                              JSValueConst*) {
+  return JS_NewUint32(ctx, mvefk::context_create());
+}
+
+JSValue js_efk_context_destroy(JSContext* ctx,
+                               JSValueConst,
+                               int argc,
+                               JSValueConst* argv) {
+  mvefk::context_destroy(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_effect_load(JSContext* ctx,
+                           JSValueConst,
+                           int argc,
+                           JSValueConst* argv) {
+  const mvefk::ContextId cid =
+      static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0));
+  size_t len = 0;
+  JSValue hold = JS_UNDEFINED;
+  uint8_t* bytes =
+      argc > 1 ? efk_view_bytes(ctx, argv[1], &len, &hold) : nullptr;
+  const float mag =
+      argc > 2 ? static_cast<float>(gd(ctx, argc, argv, 2)) : 1.0f;
+  const mvefk::EffectId eid = mvefk::effect_load(cid, bytes, len, mag);
+  JS_FreeValue(ctx, hold);
+  return JS_NewUint32(ctx, eid);
+}
+
+JSValue js_efk_effect_release(JSContext* ctx,
+                              JSValueConst,
+                              int argc,
+                              JSValueConst* argv) {
+  mvefk::effect_release(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+                        static_cast<mvefk::EffectId>(gi(ctx, argc, argv, 1)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_play(JSContext* ctx,
+                    JSValueConst,
+                    int argc,
+                    JSValueConst* argv) {
+  const int32_t h =
+      mvefk::play(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+                  static_cast<mvefk::EffectId>(gi(ctx, argc, argv, 1)),
+                  static_cast<float>(gd(ctx, argc, argv, 2)),
+                  static_cast<float>(gd(ctx, argc, argv, 3)),
+                  static_cast<float>(gd(ctx, argc, argv, 4)));
+  return JS_NewInt32(ctx, h);
+}
+
+JSValue js_efk_set_location(JSContext* ctx,
+                            JSValueConst,
+                            int argc,
+                            JSValueConst* argv) {
+  mvefk::set_location(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+                      gi(ctx, argc, argv, 1),
+                      static_cast<float>(gd(ctx, argc, argv, 2)),
+                      static_cast<float>(gd(ctx, argc, argv, 3)),
+                      static_cast<float>(gd(ctx, argc, argv, 4)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_set_rotation(JSContext* ctx,
+                            JSValueConst,
+                            int argc,
+                            JSValueConst* argv) {
+  mvefk::set_rotation(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+                      gi(ctx, argc, argv, 1),
+                      static_cast<float>(gd(ctx, argc, argv, 2)),
+                      static_cast<float>(gd(ctx, argc, argv, 3)),
+                      static_cast<float>(gd(ctx, argc, argv, 4)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_set_scale(JSContext* ctx,
+                         JSValueConst,
+                         int argc,
+                         JSValueConst* argv) {
+  mvefk::set_scale(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+                   gi(ctx, argc, argv, 1),
+                   static_cast<float>(gd(ctx, argc, argv, 2)),
+                   static_cast<float>(gd(ctx, argc, argv, 3)),
+                   static_cast<float>(gd(ctx, argc, argv, 4)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_set_speed(JSContext* ctx,
+                         JSValueConst,
+                         int argc,
+                         JSValueConst* argv) {
+  mvefk::set_speed(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+                   gi(ctx, argc, argv, 1),
+                   static_cast<float>(gd(ctx, argc, argv, 2)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_stop(JSContext* ctx,
+                    JSValueConst,
+                    int argc,
+                    JSValueConst* argv) {
+  mvefk::stop(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+              gi(ctx, argc, argv, 1));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_exists(JSContext* ctx,
+                      JSValueConst,
+                      int argc,
+                      JSValueConst* argv) {
+  return JS_NewBool(ctx, mvefk::handle_exists(static_cast<mvefk::ContextId>(
+                                                  gi(ctx, argc, argv, 0)),
+                                              gi(ctx, argc, argv, 1)));
+}
+
+JSValue js_efk_update(JSContext* ctx,
+                      JSValueConst,
+                      int argc,
+                      JSValueConst* argv) {
+  mvefk::update(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)),
+                static_cast<float>(gd(ctx, argc, argv, 1)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_efk_stop_all(JSContext* ctx,
+                        JSValueConst,
+                        int argc,
+                        JSValueConst* argv) {
+  mvefk::stop_all(static_cast<mvefk::ContextId>(gi(ctx, argc, argv, 0)));
+  return JS_UNDEFINED;
+}
+
+void reg(JSContext* ctx,
+         JSValue g,
+         const char* name,
+         JSCFunction* fn,
+         int argc) {
+  JS_SetPropertyStr(ctx, g, name, JS_NewCFunction(ctx, fn, name, argc));
+}
+
+}  // namespace
+
+void mv_install_effekseer(JSContext* ctx) {
+  JSValue g = JS_GetGlobalObject(ctx);
+  reg(ctx, g, "__mv_efkContextCreate", js_efk_context_create, 0);
+  reg(ctx, g, "__mv_efkContextDestroy", js_efk_context_destroy, 1);
+  reg(ctx, g, "__mv_efkEffectLoad", js_efk_effect_load, 3);
+  reg(ctx, g, "__mv_efkEffectRelease", js_efk_effect_release, 2);
+  reg(ctx, g, "__mv_efkPlay", js_efk_play, 5);
+  reg(ctx, g, "__mv_efkSetLocation", js_efk_set_location, 5);
+  reg(ctx, g, "__mv_efkSetRotation", js_efk_set_rotation, 5);
+  reg(ctx, g, "__mv_efkSetScale", js_efk_set_scale, 5);
+  reg(ctx, g, "__mv_efkSetSpeed", js_efk_set_speed, 3);
+  reg(ctx, g, "__mv_efkStop", js_efk_stop, 2);
+  reg(ctx, g, "__mv_efkExists", js_efk_exists, 2);
+  reg(ctx, g, "__mv_efkUpdate", js_efk_update, 2);
+  reg(ctx, g, "__mv_efkStopAll", js_efk_stop_all, 1);
+  JS_FreeValue(ctx, g);
+}
 
 #else  // !MVJS_HAVE_EFFEKSEER
 
@@ -223,6 +600,60 @@ bool smoke_test(const char* /*path*/,
   return false;
 }
 
+ContextId context_create() {
+  return 0;
+}
+
+void context_destroy(ContextId /*ctx*/) {}
+
+EffectId effect_load(ContextId /*ctx*/,
+                     const std::uint8_t* /*bytes*/,
+                     std::size_t /*len*/,
+                     float /*magnification*/) {
+  return 0;
+}
+
+void effect_release(ContextId /*ctx*/, EffectId /*effect*/) {}
+
+std::int32_t play(ContextId /*ctx*/,
+                  EffectId /*effect*/,
+                  float /*x*/,
+                  float /*y*/,
+                  float /*z*/) {
+  return -1;
+}
+
+void set_location(ContextId /*ctx*/,
+                  std::int32_t /*handle*/,
+                  float /*x*/,
+                  float /*y*/,
+                  float /*z*/) {}
+void set_rotation(ContextId /*ctx*/,
+                  std::int32_t /*handle*/,
+                  float /*x*/,
+                  float /*y*/,
+                  float /*z*/) {}
+void set_scale(ContextId /*ctx*/,
+               std::int32_t /*handle*/,
+               float /*x*/,
+               float /*y*/,
+               float /*z*/) {}
+void set_speed(ContextId /*ctx*/, std::int32_t /*handle*/, float /*speed*/) {}
+void stop(ContextId /*ctx*/, std::int32_t /*handle*/) {}
+
+bool handle_exists(ContextId /*ctx*/, std::int32_t /*handle*/) {
+  return false;
+}
+
+void update(ContextId /*ctx*/, float /*delta_frame*/) {}
+void stop_all(ContextId /*ctx*/) {}
+
 }  // namespace mvefk
+
+// No natives registered: EFFEKSEER_SHIM_JS feature-detects their absence
+// (typeof g.__mv_efkContextCreate !== 'function') and stays on its
+// synthetic, diagnostic-only path, exactly as it did before this bridge
+// existed.
+void mv_install_effekseer(JSContext*) {}
 
 #endif  // MVJS_HAVE_EFFEKSEER

--- a/mruby-mvjs/src/mvefk.hxx
+++ b/mruby-mvjs/src/mvefk.hxx
@@ -3,21 +3,27 @@
 // (3rd/effekseer, github.com/effekseer/Effekseer, MIT, pinned to tag 1807)
 // and the same off-screen GLES3 context mvgl.cxx already exposes.
 //
-// This header lands the foundational, isolated proof that the GL integration
-// actually works — `smoke_test` below loads a real, unmodified `.efkefc`
-// effect file (91 of them are vendored under a real downloaded MZ game's own
+// `smoke_test` below lands the foundational, isolated proof that the GL
+// integration actually works: it loads a real, unmodified `.efkefc` effect
+// file (91 of them are vendored under a real downloaded MZ game's own
 // `effects/` folder for exactly this) and renders it through Effekseer's own
-// GLES renderer into an mvgl::Context, independent of the JS/PIXI stack. This
-// is deliberately staged ahead of wiring `MZ::EFFEKSEER_SHIM_JS`'s no-ops to
+// GLES renderer into an mvgl::Context, independent of the JS/PIXI stack,
+// confirmed to produce real GPU draw calls and visible pixels. That was
+// deliberately staged ahead of wiring `MZ::EFFEKSEER_SHIM_JS`'s no-ops to
 // real native calls (ADR 0004's own recommendation): reconciling Effekseer's
 // GL state and matrix conventions against a real GLES driver, with no browser
-// reference to diff against in this headless environment, is the actual risk
-// here — proving it in isolation first means a JS-bridge bug and a
-// GL-integration bug are never both in play in the same debugging session.
+// reference to diff against in this headless environment, was the actual
+// risk there — proving it in isolation first meant a JS-bridge bug and a
+// GL-integration bug were never both in play in the same debugging session.
+//
+// The context/effect/handle API below is the first half of that JS-bridge
+// wiring: real `Effekseer::Manager` simulation, still no rendering (see its
+// own comment for why that half is staged separately).
 
 #ifndef MRUBY_MVJS_MVEFK_HXX
 #define MRUBY_MVJS_MVEFK_HXX
 
+#include <cstddef>
 #include <cstdint>
 
 namespace mvefk {
@@ -55,6 +61,65 @@ bool smoke_test(const char* path,
                 int height,
                 int warmup_frames,
                 std::uint32_t* out_lit_pixel_count);
+
+// Persistent per-game simulation context for the JS bridge
+// (MZ::EFFEKSEER_SHIM_JS's `window.effekseer.createContext()`). Backed by a
+// real `Effekseer::Manager`, so a loaded, valid `.efkefc` effect really
+// simulates (spawns, moves and expires real particle instances) instead of
+// the shim's old synthetic fixed-lifetime handle.
+//
+// Deliberately renderer-less: no `EffekseerRendererGL::Renderer`, no GL
+// context. Simulation needs neither, and drawing real MZ animations needs
+// Effekseer's renderer to share the exact GL context/FBO PIXI's own WebGL
+// renderer (mvwebgl.cxx) is using mid-frame -- a separate, higher-risk
+// integration staged as its own follow-up (see docs/TODO.md's Effekseer
+// entry). Until that lands, a context created here never draws anything;
+// it only makes handle.exists/animation timing reflect a real, deterministic
+// simulation instead of an arbitrary placeholder.
+//
+// Every function below silently no-ops/returns a failure sentinel (0 for a
+// ContextId/EffectId, -1 for a play handle, false for exists) when called on
+// an invalid id or where `available()` is false, so callers never need to
+// branch on backend availability beyond checking `available()` once.
+using ContextId = std::uint32_t;  // 0 is never a valid context.
+using EffectId = std::uint32_t;   // 0 means "no native effect" (never valid).
+
+// Backed by a real Effekseer::Manager. 0 on failure (backend unavailable).
+ContextId context_create();
+void context_destroy(ContextId ctx);
+
+// Parses `bytes` (length `len`) as a real `.efkefc` file via
+// `Effekseer::Effect::Create`, so this can and does fail (return 0) for
+// content that merely *looks* like one (e.g. right magic bytes, garbage
+// after) -- the JS bridge treats that identically to "no native effect
+// available", not as a load error: EFFEKSEER_SHIM_JS's own honest-reporting
+// magic-byte check is unrelated and unaffected either way.
+EffectId effect_load(ContextId ctx,
+                     const std::uint8_t* bytes,
+                     std::size_t len,
+                     float magnification);
+void effect_release(ContextId ctx, EffectId effect);
+
+// Effekseer::Handle is a plain int32_t; -1 means Play failed (bad context,
+// bad/unloaded effect, or the manager's instance cap).
+std::int32_t play(ContextId ctx, EffectId effect, float x, float y, float z);
+void set_location(ContextId ctx,
+                  std::int32_t handle,
+                  float x,
+                  float y,
+                  float z);
+void set_rotation(ContextId ctx,
+                  std::int32_t handle,
+                  float x,
+                  float y,
+                  float z);
+void set_scale(ContextId ctx, std::int32_t handle, float x, float y, float z);
+void set_speed(ContextId ctx, std::int32_t handle, float speed);
+void stop(ContextId ctx, std::int32_t handle);
+bool handle_exists(ContextId ctx, std::int32_t handle);
+
+void update(ContextId ctx, float delta_frame);
+void stop_all(ContextId ctx);
 
 }  // namespace mvefk
 

--- a/mruby-mvjs/src/mvhost.hxx
+++ b/mruby-mvjs/src/mvhost.hxx
@@ -35,6 +35,14 @@ const uint8_t* mv_canvas_pixels(int handle, int* w, int* h);
 // on-screen. Defined in mvwebgl.cxx.
 const uint8_t* mv_webgl_pixels(int handle, int* w, int* h);
 
+// Install the Effekseer simulation bridge: the __mv_efk* natives
+// `MZ::EFFEKSEER_SHIM_JS` (mz.rb) calls into for real (rather than
+// synthetic) effect loading/playback where the native backend is compiled
+// in. A no-op registering natives that report "unavailable" where it is not
+// (mvefk.cxx's own #else stub branch), which keeps the shim's existing
+// diagnostic-only fallback behavior. Defined in mvefk.cxx.
+void mv_install_effekseer(JSContext* ctx);
+
 // Resolve a game-relative asset path against the configured game base dir (set
 // from Ruby via `MV::JS.base_dir=`). MV's own JavaScript requests data/assets
 // with paths relative to the game root (e.g. `data/System.json`, `img/...`),

--- a/mruby-mvjs/src/mvjs.cxx
+++ b/mruby-mvjs/src/mvjs.cxx
@@ -640,6 +640,10 @@ void install_host_globals(JSContext* ctx) {
   // The WebGL bridge (getContext('webgl') -> native GLES2), defined in
   // mvwebgl.cxx. After the canvas bridge, since it extends getContext.
   mv_install_webgl(ctx);
+  // The Effekseer simulation bridge (__mv_efk* natives), defined in
+  // mvefk.cxx. MZ::EFFEKSEER_SHIM_JS (mz.rb) is evaluated later, per-game,
+  // and calls into these; independent of the canvas/WebGL bridges above.
+  mv_install_effekseer(ctx);
 }
 
 // -- the persistent host -----------------------------------------------------

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -1033,3 +1033,47 @@ assert 'MV::Effekseer.smoke_test renders real, visible pixels from a downloaded 
   assert_true result.is_a?(Integer) && result > 0,
               "expected visible pixels from a real effect, got #{result.inspect}"
 end
+
+assert 'the Effekseer shim routes a real .efkefc through native simulation, not the synthetic fallback' do
+  # The three shim tests above (survives the real call sequence / loads and
+  # reports honestly / retires handles) all exercise hand-built fixtures
+  # (garbage bytes with the right magic, a bare `{}`, a missing file) that
+  # deliberately fail native Effekseer parsing -- proving the shim's
+  # *fallback* path (see EFFEKSEER_SHIM_JS's own comment on why that is a
+  # strict superset of its old, always-synthetic behavior). This test proves
+  # the other half: genuinely real content takes the real, native-backed
+  # path instead.
+  path = "../../data/labyria/Labyria/effects/Flash.efkefc"
+  skip "no such fixture (data/labyria not downloaded)" unless File.exist?(path)
+  skip "Effekseer backend unavailable" unless MV::Effekseer.available?
+
+  MV::JS.base_dir = "mvjs_effekseer_native_fixture"
+  begin
+    Dir.mkdir("mvjs_effekseer_native_fixture") rescue nil
+    Dir.mkdir("mvjs_effekseer_native_fixture/effects") rescue nil
+    bytes = File.open(path, "rb") { |f| f.read }
+    File.open("mvjs_effekseer_native_fixture/effects/Flash.efkefc", "wb") do |f|
+      f.write(bytes)
+    end
+
+    MV::JS.eval(MZ.effekseer_shim_js)
+    MV::JS.eval(
+      "globalThis.__ctx4 = effekseer.createContext(); __ctx4.init(); " \
+      "globalThis.__effect4 = __ctx4.loadEffect('effects/Flash.efkefc', 1, " \
+      "function(){}, function(){});"
+    )
+    # A real native effect handle (nonzero) -- proof Effekseer::Effect::Create
+    # actually parsed this file, unlike the garbage/bogus fixtures above.
+    assert_true MV::JS.eval("__effect4._native") != 0
+
+    MV::JS.eval("globalThis.__h4 = __ctx4.play(__effect4, 0, 0, 0);")
+    # A real play handle is >= 0 (Effekseer::Handle); the synthetic fallback
+    # never sets `_native` on its handle at all.
+    assert_true MV::JS.eval("typeof __h4._native === 'number' && __h4._native >= 0")
+  ensure
+    File.delete("mvjs_effekseer_native_fixture/effects/Flash.efkefc") rescue nil
+    Dir.delete("mvjs_effekseer_native_fixture/effects") rescue nil
+    Dir.delete("mvjs_effekseer_native_fixture") rescue nil
+    MV::JS.base_dir = ""
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #1285 (merged), which proved the native Effekseer GL pipeline renders real, visible particles. This PR takes the next step: wiring `MZ::EFFEKSEER_SHIM_JS`'s previously-synthetic `window.effekseer` shim to that real backend for simulation.

- **New `__mv_efk*` natives** (`mruby-mvjs/src/mvefk.cxx`): a persistent, per-game `Effekseer::Manager`-backed context (`context_create`/`context_destroy`), effect loading straight from JS-supplied bytes (`effect_load`, via `Effekseer::Effect::Create`'s buffer overload — no duplicate file I/O), and full handle lifecycle (`play`/`set_location`/`set_rotation`/`set_scale`/`set_speed`/`stop`/`handle_exists`/`update`/`stop_all`). Installed unconditionally via `mv_install_effekseer` (new, called from `mvjs.cxx` alongside the canvas/WebGL installers); every function safely no-ops/returns a failure sentinel where the backend isn't compiled in.
- **`EFFEKSEER_SHIM_JS` rewritten** (`mruby-mvjs/mrblib/mz.rb`, now a heredoc instead of string concatenation for readability) to route `loadEffect`/`play`/`update`/`stopAll` through these natives wherever the loaded file genuinely parses as a real `.efkefc`. A file that only *looks* like one (right magic bytes, not real Effekseer data — exactly what this project's own pre-existing shim tests use) fails native parsing and transparently falls back to the original synthetic, fixed-20-frame handle. This makes the change a strict superset of the previous behavior: all three pre-existing shim tests (garbage-but-correct-magic content, a bare `{}` passed to `play()`, a missing file) pass **unmodified**.
- **New test** loads a real, unmodified `.efkefc` (`Flash.efkefc`, from the same `data/labyria` fixture the smoke test uses) through the shim and confirms it takes the *native* path: a nonzero native effect handle and a `play()` result carrying a real, non-negative `Effekseer::Handle` — proving genuine routing, not just that nothing broke.

## What this is *not*

Still no rendering through this path: only `Effekseer::Manager` (simulation) is wired, not `EffekseerRendererGL::Renderer`. Drawing real MZ animations needs Effekseer's renderer to share the exact GL context/FBO PIXI's own WebGL renderer (`mvwebgl.cxx`) is using mid-frame — a separate, materially higher-risk integration (shared GL state, translating a JS `WebGLRenderingContext` handle to a native one, MZ's own fixed projection/camera matrix convention) staged as its own follow-up.

## Verification

- Full project test suite (`ctest -R mruby_test`): 1860 total, 1855 OK, 0 KO, 0 Crash.
- All three pre-existing Effekseer shim tests pass unchanged (verifying the fallback path is exact).
- New test confirms real native routing for genuine `.efkefc` content.
- Native binary builds and links cleanly.

## Docs

- `docs/adr/0004-javascript-maker-mv-quickjs.md`'s new "M6.2 addendum 3" documents the design, in particular why the fallback path had to stay byte-for-byte compatible with the old synthetic behavior.
- `docs/TODO.md` and `changelog.d/effekseer-js-bridge-simulation.added.md` updated/added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_