### PR TITLE
RGSS host battle probe: distinguish "never asked" from "asked, never came up"

### DIFF
--- a/changelog.d/rgss-host-battle-probe-called-field.fixed.md
+++ b/changelog.d/rgss-host-battle-probe-called-field.fixed.md
@@ -1,0 +1,10 @@
+- The RGSS script host's `--rgss_host_battle_test` probe now reports a
+  `called=` field alongside `reached=` in its `[RPGXP-HOST-BATTLE]` log line,
+  distinguishing "the game's own `Game_Temp` does not implement the stock
+  battle-calling attributes, so the probe never even asked for a battle"
+  (`called=false`) from "the battle really was requested but the game's own
+  engine never brought `Scene_Battle` up" (`called=true reached=false`) --
+  previously both reported identically as `reached=false`, indistinguishable
+  without re-deriving which one happened by hand. Found tracing a real,
+  large freeware VX Ace release whose own `Game_Temp` is fully replaced by a
+  custom one with none of the stock battle-calling attributes at all.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -987,5 +987,32 @@ VM probe, finding the real exception directly regardless of `$!` being
 masked at the time. With `defined?`, `Window#viewport=` and
 `battle_ok?`/`menu_ok?` all fixed, the same real release's headless Test
 Battle run now gets past its enemies' first action-selection pass with no
-crash at all; where its next wall stands (if any) past that is not yet
-traced.
+crash at all.
+
+**Traced (as far as `--rgss_host_battle_test` can go): the standing
+CLI-flag probe cannot drive this specific release into battle at all, and
+that is expected, not a new wall.** `battle_probe` (`script_host.rb`) has
+always guarded `call_battle` on `$game_temp.respond_to?(:battle_calling=)`,
+with a comment noting a game may ship its own `Game_Temp` — and this real
+release does exactly that: its `Game_Temp` is fully replaced by a custom
+one (`Game_Temp.instance_methods(false)` is `[:clear_common_event,
+:common_event_id, :common_event_reserved?, :event_state_changing,
+:event_state_changing=, :fade_type, :fade_type=, :last_gain_holder,
+:last_gain_holder=, :last_gain_material, :last_gain_material=,
+:reserve_common_event, :reserved_common_event]` — no `battle_calling`,
+`battle_troop_id`, or any of the other stock battle-calling attributes at
+all), so the probe's guard was always going to no-op for it. Confirmed by
+temporarily instrumenting `call_battle` (uncommitted, reverted) to print
+exactly that. The probe's own log used to report this identically to "the
+battle scene never came up" (`reached=false` either way) — indistinguishable
+from a real crash without re-deriving this by hand — so
+`[RPGXP-HOST-BATTLE]` now also reports `called=..`: `false` means the probe
+never got to ask (this case); `true reached=false` would mean it asked and
+the game's own engine still never brought `Scene_Battle` up. This says
+nothing about whether this release's *own* battle system works when played
+normally — only that the CLI-flag probe's stock-`Game_Temp` assumption
+cannot exercise it, the same category of probe-methodology limit as the
+move-test settle window elsewhere in this project. Driving this specific
+release past its own custom battle entry point (if that is ever wanted)
+would need a probe built around whatever this release's own scripts use
+instead of `Game_Temp.battle_calling` — not attempted here.

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -546,7 +546,8 @@ class RPGXP
 
     def self.call_battle
       temp = $game_temp
-      return if temp.nil? || !temp.respond_to?(:battle_calling=)
+      @battle_called = !temp.nil? && temp.respond_to?(:battle_calling=)
+      return unless @battle_called
       temp.battle_troop_id = BATTLE_TROOP_ID
       temp.battle_can_escape = true
       temp.battle_can_lose = true
@@ -558,8 +559,20 @@ class RPGXP
       @battle_done = true
       scene = current_scene
       name = scene.nil? ? "?" : scene.class.to_s
+      # `called=false` means the probe never got as far as asking for a
+      # battle at all -- this game's own Game_Temp does not implement the
+      # stock battle-calling attributes (a real, if unusual, case: a real
+      # freeware VX Ace release was found replacing Game_Temp with a custom
+      # one that has no battle_calling/battle_troop_id/etc. at all, presumably
+      # because it starts battles some other way). Distinguishing that from
+      # `reached=false` with `called=true` (the battle *was* requested but the
+      # game's own engine never brought Scene_Battle up) matters: the two mean
+      # completely different things to whoever reads this log next, and
+      # without it, telling them apart takes re-deriving this from scratch
+      # with a temporary debug patch every time, as this one did.
       $stderr.puts "[RPGXP-HOST-BATTLE] scene=#{name} " \
-                   "reached=#{name.include?("Scene_Battle")} frame=#{@frames}"
+                   "reached=#{name.include?("Scene_Battle")} " \
+                   "called=#{@battle_called} frame=#{@frames}"
     end
 
     def self.finish_menu_probe

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -32,11 +32,17 @@
 #     on the released game.
 #   * a second pass over the editor bed calls a battle the way the game's own
 #     Battle Processing command does and reports
-#     `[RPGXP-HOST-BATTLE] scene=.. reached=..`. Its own pass because a battle
-#     is called from the map and the pass above ends inside the menu; the editor
-#     bed only, because a released game's opening is an event sequence a battle
-#     call would land in the middle of. This is the biggest surface of the lot:
-#     every enemy in it is a `Sprite_Battler`, on top of `RPG::Sprite`.
+#     `[RPGXP-HOST-BATTLE] scene=.. reached=.. called=..`. Its own pass
+#     because a battle is called from the map and the pass above ends inside
+#     the menu; the editor bed only, because a released game's opening is an
+#     event sequence a battle call would land in the middle of -- and, found
+#     tracing a real release by hand (not through this script), because a
+#     real game may replace `Game_Temp` entirely with a custom one that has
+#     none of the stock battle-calling attributes this probe sets, in which
+#     case `called=false` (the probe never even got to ask) rather than
+#     `reached=false` (it asked, but the game's own engine never brought
+#     `Scene_Battle` up). This is the biggest surface of the lot: every enemy
+#     in it is a `Sprite_Battler`, on top of `RPG::Sprite`.
 #   * a third pass opens the game's own save screen the same way
 #     (`--rgss_host_save_test`, `[RPGXP-HOST-SAVE]`). That is the one place a
 #     game reads a file's timestamp back — its `Window_SaveFile` stamps each

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -176,11 +176,17 @@ DEFINE_bool(
     "For the RGSS makers under the script host: once the game is on its own "
     "map, start a battle the way its own Battle Processing event command does "
     "(setting the same five $game_temp fields) and log which scene the game "
-    "reached as [RPGXP-HOST-BATTLE] (implies --rgss_host_new_game). The rung "
-    "above the menu: a battle builds the game's own Spriteset_Battle, so every "
-    "enemy is a Sprite_Battler on top of RPG::Sprite. Unlike the other probes "
-    "this writes to the game's globals, because no keypress starts a battle. "
-    "Used by scripts/rpgxp_boot_check.bash");
+    "reached as [RPGXP-HOST-BATTLE] scene=.. reached=.. called=.. (implies "
+    "--rgss_host_new_game). The rung above the menu: a battle builds the "
+    "game's own Spriteset_Battle, so every enemy is a Sprite_Battler on top "
+    "of RPG::Sprite. Unlike the other probes this writes to the game's "
+    "globals, because no keypress starts a battle. called=false means the "
+    "probe never got that far: the game's own Game_Temp does not implement "
+    "the stock battle-calling attributes (a real game may replace Game_Temp "
+    "entirely with a custom one, e.g. a custom battle system) -- distinct "
+    "from called=true reached=false, where the battle really was requested "
+    "but the game's own engine never brought Scene_Battle up. Used by "
+    "scripts/rpgxp_boot_check.bash");
 DEFINE_bool(
     rgss_host_save_test,
     false,


### PR DESCRIPTION
## Summary

`docs/rpgvx-rgss-api-gap.md` closed its long investigation log of a real, large freeware VX Ace release with an open question: "where its next wall stands (if any) past [enemies' first action-selection pass] is not yet traced." This traces it — and finds the standing `--rgss_host_battle_test` probe can't actually drive this specific release into battle at all, for a reason its own code already anticipated but never surfaced.

- **Root cause**: `--rgss_host_battle_test`'s `call_battle` (`mruby-rpgxp/mrblib/script_host.rb`) has always guarded on `$game_temp.respond_to?(:battle_calling=)`, with a comment noting "a game may ship its own Game_Temp." This release does exactly that: its `Game_Temp` is fully replaced by a custom one — `Game_Temp.instance_methods(false)` has no `battle_calling`, `battle_troop_id`, or any other stock battle-calling attribute at all. Confirmed by temporarily instrumenting `call_battle` (uncommitted, reverted before this diff).
- **The actual bug**: the probe's `[RPGXP-HOST-BATTLE]` log reported `reached=false` identically whether the battle scene crashed, never came up, or the guard above silently no-op'd — three very different outcomes collapsed into one indistinguishable line, forcing anyone investigating to re-derive which one happened by hand (as this PR did).
- **The fix**: a new `called=` field. `false` means the probe never got as far as asking for a battle at all; `true reached=false` means it asked and the game's own engine still never brought `Scene_Battle` up — a real crash or hang, not this. Verified unchanged (`called=true reached=true`) against the stock RPG Maker XP editor test bed.

## What this is *not*

This says nothing about whether the release's *own* custom battle system works when actually played — only that this specific CLI-flag probe's stock-`Game_Temp` assumption can't exercise it. Driving this release past its own custom battle entry point (if ever wanted) needs a probe built around whatever it uses instead, not attempted here.

## Verification

- Full project test suite (`ctest -R mruby_test`): 1860 total, 1855 OK, 0 KO, 0 Crash.
- Manually confirmed against the real release: `[RPGXP-HOST-BATTLE] scene=Scene_Map reached=false called=false frame=267`.
- Manually confirmed against the stock editor test bed (unchanged behavior): `[RPGXP-HOST-BATTLE] scene=Scene_Battle reached=true called=true frame=221`.
- `scripts/rpgxp_boot_check.bash`'s own `reached=true` assertion regex is a substring match, unaffected by the new trailing field (verified).

## Docs

- `docs/rpgvx-rgss-api-gap.md` closes the open question with this finding.
- `src/main.cxx`'s `--rgss_host_battle_test` help text and `scripts/rpgxp_boot_check.bash`'s own comment updated to describe the new field.
- `changelog.d/rgss-host-battle-probe-called-field.fixed.md` added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_