### PR TITLE
MV/MZ move probe: settle on a running map event, not just an open message

### DIFF
--- a/changelog.d/mv-mz-move-probe-event-running.fixed.md
+++ b/changelog.d/mv-mz-move-probe-event-running.fixed.md
@@ -1,0 +1,16 @@
+- The RPG Maker MV/MZ move probe (`--mv_move_test` / `--mz_move_test`) now
+  waits out a running map event, not just an open message window, before it
+  starts holding a direction, and its `[MV-MOVE]`/`[MZ-MOVE] end` line now
+  reports a `blocked=` field alongside `moved=`. Previously the probe's
+  settle window only checked `$gameMessage.isBusy()`, so an opening cutscene
+  that never shows text -- Show Picture, Wait, Set Move Route, Fadeout/Fadein,
+  Tint Screen and the like, chained straight from the autorun event that
+  starts the instant the map loads -- swallowed every held-direction input
+  frame and the probe reported a bare `moved=false`, indistinguishable from a
+  genuine movement bug. `MV.event_running?` (`$gameMap.isEventRunning()`)
+  closes that gap: the settle window now waits on either check, capped by the
+  same `MOVE_SETTLE_MAX_FRAMES` as before, and `blocked=true` on the end line
+  says plainly "the game's own event was still running when the probe gave
+  up" rather than making every caller re-derive that by hand. Found probing a
+  real, large freeware MV release whose opening cutscene runs entirely
+  through picture/wait event commands with no message window at all.

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -27,8 +27,9 @@ class MV
   MOVE_PROBE_FRAMES = 80
 
   # Settle window before the move probe starts holding a direction (see
-  # #maybe_move_test): only paid when $gameMessage is actually busy, and the
-  # confirm-key tap cadence within it.
+  # #maybe_move_test): only paid when $gameMessage is actually busy or
+  # $gameMap's own interpreter is still running a page, and the confirm-key
+  # tap cadence within it.
   #
   # RGSS's own script-host driver (mruby-rpgxp/mrblib/script_host.rb) taps
   # confirm every CONFIRM_EVERY frames from boot onward and only suppresses it
@@ -47,8 +48,8 @@ class MV
   # confirm-tapping were enough to blow straight through it with zero probe
   # output, because a confirm tap that actually lands on a real game can
   # advance real event logic (more loads, more rendering), not just close an
-  # empty window. #message_busy? makes the wait conditional instead: a game
-  # with no opening dialogue (message_busy? false the instant Scene_Map
+  # empty window. #message_busy? / #event_running? make the wait conditional
+  # instead: a game with no opening event (both false the instant Scene_Map
   # appears) pays nothing and moves exactly as before; MOVE_SETTLE_MAX_FRAMES
   # is only a safety cap on a game that is genuinely still busy.
   MOVE_SETTLE_MAX_FRAMES = 180
@@ -198,6 +199,27 @@ class MV
       MV::JS.eval(
         "(typeof $gameMessage !== 'undefined' && $gameMessage && " \
         "$gameMessage.isBusy()) ? true : false"
+      ) == true
+    rescue StandardError
+      false
+    end
+
+    # Whether $gameMap's own event interpreter is currently running a page —
+    # true for a Show Text/Show Choices sequence (already covered by
+    # #message_busy?) but also for one that never touches $gameMessage at all:
+    # Show Picture, Wait, Set Move Route, Fadeout/Fadein, Tint Screen and the
+    # like. A real game's opening autorun event routinely chains exactly that
+    # kind of silent-but-busy sequence before ever showing text, and
+    # #message_busy? alone reads `false` throughout it — the move probe's
+    # settle window would then never engage and would burn its whole hold
+    # budget against a player Game_Player#canMove() is refusing to move,
+    # reporting "did not move" for a game the engine never actually failed to
+    # walk. `false` (not running, or the engine is not up yet) whenever the
+    # read itself fails, matching #message_busy?'s own fail-open shape.
+    def event_running?
+      MV::JS.eval(
+        "(typeof $gameMap !== 'undefined' && $gameMap && " \
+        "$gameMap.isEventRunning()) ? true : false"
       ) == true
     rescue StandardError
       false
@@ -570,14 +592,21 @@ class MV
   # play (flag unset).
   #
   # Before any direction is held, the probe checks whether $gameMessage is
-  # already busy (see .message_busy?): a real game's opening autorun event can
+  # already busy or $gameMap's own interpreter is running a page (see
+  # .message_busy? / .event_running?): a real game's opening autorun event can
   # run a Show Text/Show Choices sequence the instant the map loads, and a
-  # blocking message window swallows movement input frame after frame — the
+  # blocking message window swallows movement input frame after frame — or it
+  # can run Show Picture/Wait/Move Route/Fadeout steps that never touch
+  # $gameMessage at all, which #message_busy? alone can't see. Either way the
   # probe would report "did not move" not because the engine failed to walk
   # the player, but because it never got a turn against the game's own event.
-  # If it is, confirm gets tapped (see .confirm_settle_tap) until the message
-  # clears or MOVE_SETTLE_MAX_FRAMES runs out; if it never was busy to begin
-  # with, movement starts immediately, exactly as before this existed.
+  # If either is true, confirm gets tapped (see .confirm_settle_tap) until
+  # both clear or MOVE_SETTLE_MAX_FRAMES runs out; if neither was busy to
+  # begin with, movement starts immediately, exactly as before this existed.
+  # If the interpreter is *still* running once the probe ends, the "end" line
+  # says so (`blocked=true`) rather than reporting a bare `moved=false`
+  # indistinguishable from a real movement bug — see the note at the bottom of
+  # this method.
   def maybe_move_test
     return if @move_test_done
     return unless move_test_requested?
@@ -585,7 +614,8 @@ class MV
 
     unless @move_settled
       @move_settle_frame ||= 0
-      if self.class.message_busy? && @move_settle_frame < MOVE_SETTLE_MAX_FRAMES
+      if (self.class.message_busy? || self.class.event_running?) &&
+         @move_settle_frame < MOVE_SETTLE_MAX_FRAMES
         self.class.confirm_settle_tap(@move_settle_frame)
         @move_settle_frame += 1
         return
@@ -612,7 +642,9 @@ class MV
     end
 
     @move_test_done = true
-    $stderr.puts "[MV-MOVE] end #{player_tile} moved=#{@move_seen ? true : false}"
+    blocked = self.class.event_running?
+    $stderr.puts "[MV-MOVE] end #{player_tile} " \
+                 "moved=#{@move_seen ? true : false} blocked=#{blocked}"
   rescue StandardError => e
     $stderr.puts "[MV] move test error: #{e.message}"
   end

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -1379,15 +1379,20 @@ class MZ
   # cycle so both runtimes are exercised the same way.
   #
   # Before any direction is held, the probe checks whether $gameMessage is
-  # already busy (see MV.message_busy?): a real game's opening autorun event
+  # already busy or $gameMap's own interpreter is running a page (see
+  # MV.message_busy? / MV.event_running?): a real game's opening autorun event
   # can run a Show Text/Show Choices sequence the instant the map loads, and a
-  # blocking message window swallows movement input frame after frame — the
-  # probe would report "did not move" not because the engine failed to walk
-  # the player, but because it never got a turn against the game's own event.
-  # If it is, confirm gets tapped (see MV.confirm_settle_tap) until the
-  # message clears or MV::MOVE_SETTLE_MAX_FRAMES runs out; if it never was
+  # blocking message window swallows movement input frame after frame — or it
+  # can run Show Picture/Wait/Move Route/Fadeout steps that never touch
+  # $gameMessage at all, which MV.message_busy? alone can't see. Either way
+  # the probe would report "did not move" not because the engine failed to
+  # walk the player, but because it never got a turn against the game's own
+  # event. If either is true, confirm gets tapped (see MV.confirm_settle_tap)
+  # until both clear or MV::MOVE_SETTLE_MAX_FRAMES runs out; if neither was
   # busy to begin with, movement starts immediately, exactly as before this
-  # existed.
+  # existed. If the interpreter is *still* running once the probe ends, the
+  # "end" line says so (`blocked=true`) rather than a bare `moved=false`
+  # indistinguishable from a real movement bug.
   def maybe_move_test
     return if @move_test_done
     return unless move_test_requested?
@@ -1405,7 +1410,8 @@ class MZ
 
     unless @move_settled
       @move_settle_frame ||= 0
-      if MV.message_busy? && @move_settle_frame < MV::MOVE_SETTLE_MAX_FRAMES
+      if (MV.message_busy? || MV.event_running?) &&
+         @move_settle_frame < MV::MOVE_SETTLE_MAX_FRAMES
         MV.confirm_settle_tap(@move_settle_frame)
         @move_settle_frame += 1
         return
@@ -1433,7 +1439,9 @@ class MZ
     end
 
     @move_test_done = true
-    $stderr.puts "[MZ-MOVE] end #{player_tile} moved=#{@move_seen ? true : false}"
+    blocked = MV.event_running?
+    $stderr.puts "[MZ-MOVE] end #{player_tile} " \
+                 "moved=#{@move_seen ? true : false} blocked=#{blocked}"
   rescue StandardError => e
     $stderr.puts "[MZ] move test error: #{e.message}"
   end

--- a/mruby-mvjs/test/input_test.rb
+++ b/mruby-mvjs/test/input_test.rb
@@ -42,6 +42,22 @@ assert 'MV.message_busy? tracks $gameMessage.isBusy, and never raises' do
   assert_false MV.message_busy?
 end
 
+assert 'MV.event_running? tracks $gameMap.isEventRunning, and never raises' do
+  # Undefined engine global: the move probe's settle window must not hang
+  # waiting on a read that can never succeed.
+  MV::JS.eval("globalThis.$gameMap = undefined;")
+  assert_false MV.event_running?
+
+  # A page with no $gameMessage traffic at all (Show Picture, Wait, Move
+  # Route, ...) still reports busy here even though MV.message_busy? cannot
+  # see it -- this is the case #message_busy? alone misses.
+  MV::JS.eval("globalThis.$gameMap = { isEventRunning: function(){ return true; } };")
+  assert_true MV.event_running?
+
+  MV::JS.eval("globalThis.$gameMap = { isEventRunning: function(){ return false; } };")
+  assert_false MV.event_running?
+end
+
 assert 'MV maps RGSS input keys to MV virtual buttons' do
   # Start from a clean slate so unrelated state can't leak in.
   [RGSS::Input::C, RGSS::Input::B, RGSS::Input::UP, RGSS::Input::DOWN,


### PR DESCRIPTION
## Summary

The move probe (`--mv_move_test` / `--mz_move_test`) only checked
`$gameMessage.isBusy()` before its settle window let it start holding a
direction. A real game's opening autorun event can run entirely through
`Show Picture`/`Wait`/`Set Move Route`/`Fadeout`/`Tint Screen` steps that
never touch `$gameMessage` at all — so the probe started walking straight
into a running interpreter and reported a bare `moved=false`, indistinguishable
from a genuine movement bug (the exact "collapsed outcomes" shape this
session already fixed once for the RGSS battle probe in #1290).

- **Root cause**: `maybe_move_test`'s settle window (`mruby-mvjs/mrblib/mv.rb`,
  reused by `mz.rb`) gated only on `MV.message_busy?`. A silent-but-busy
  cutscene (no text box) reads `message_busy? == false` throughout, so the
  settle window never engages and the probe burns its whole hold budget
  against a player `Game_Player#canMove()` is correctly refusing to move.
- **The fix**: a new `MV.event_running?` (`$gameMap.isEventRunning()`) joins
  `message_busy?` in the settle condition (same `MOVE_SETTLE_MAX_FRAMES` cap
  as before), and the `[MV-MOVE]`/`[MZ-MOVE] end` line now reports
  `blocked=<bool>` alongside `moved=<bool>`, so "still stuck in an event" is
  never conflated with "the engine failed to walk the player" again.
- **Found probing** a real, large freeware MV release (91 third-party
  plugins) whose opening cutscene runs entirely through picture/wait event
  commands with no message window at all — its move probe used to just say
  `moved=false`; now it honestly says `moved=false blocked=true`.

## Verification

- Full mruby test suite (`ctest -R mruby_test`): 1861 total, 0 KO, 0 Crash
  (new: `mruby-mvjs/test/input_test.rb`'s `MV.event_running?` coverage).
- No regression against every already-probed real MV/MZ test bed:
  `data/Lunatic-Core`, `data/mv-sample`, `data/mz-sample`,
  `data/labyria/Labyria` — all still report `moved=true blocked=false`
  exactly as before this change (`mz_boot_check.bash play` mode also passes
  end to end, screenshot checks included).
- The new field is a trailing addition; both CI assertions that grep this
  log line (`grep -q '\[M[VZ]-MOVE\].*moved=true'` in
  `scripts/mz_boot_check.bash` and `.github/workflows/build.yml`) are
  substring matches, unaffected.

## Docs

- `changelog.d/mv-mz-move-probe-event-running.fixed.md` added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RmARb1uB2F9rXRg6tQsGgR)_