### PR TITLE
Rewrite F9 debug menu's Switch/Variable pages to match RPG_RT

### DIFF
--- a/changelog.d/debug-menu-switch-variable-two-level-navigation.fixed.md
+++ b/changelog.d/debug-menu-switch-variable-two-level-navigation.fixed.md
@@ -1,0 +1,19 @@
+- **Debugging tooling:** The F9 debug menu's Switch/Variable pages now match
+  real RPG_RT.exe's own two-level, two-window navigation, verified directly
+  against the genuine runtime under wine rather than guessed. RPG_RT draws
+  these two pages as a left window listing ten coarse "blocks" of ten ids
+  each and a right window previewing the highlighted block's own ten
+  individual ids, with independent block-focus (Up/Down +-1 block,
+  wrapping within the current 100-id screen; Left/Right pages a whole
+  screen, preserving the highlighted block's index; C drills into the
+  block) and row-focus (Up/Down +-1 id, wrapping within the block; C
+  toggles a switch or opens the variable editor; B returns to block focus)
+  cursors, both auto-repeating on a held key. This codebase previously drew
+  a single flat, ten-row list per screen with Up/Down moving by one id,
+  L/R jumping by ten, and Left/Right always cycling to the next of this
+  codebase's five debug pages -- none of which matches the genuine
+  runtime. Left/Right no longer cycles pages on Switch/Variable (that
+  input pages the screen there now); cycling those two pages moved to the
+  L/R shoulder buttons instead, freed up by that change. Map, Chipset and
+  Animation (this codebase's own additions, not part of genuine RPG_RT's
+  F9 menu) are unchanged, including still cycling on Left/Right.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6166,6 +6166,58 @@ The work below is roughly ordered by the critical path to a walkable game
   same `|| Input.repeat?(...)` way or explicitly confirmed (with a citation
   and a regression test) to be correctly discrete-only, except
   `debug_menu.rb`, left open pending a genuine classic-F9-menu reference.
+  ✅ **Follow-up (2026-08-22): `debug_menu.rb`'s own Switch/Variable pages
+  finally got that genuine reference — and it turned out the deferred
+  key-repeat gap was the least of what was wrong.** Confirmed directly
+  against real RPG_RT.exe under wine (a genuine Nepheshel save, its own
+  switch table edited directly, F9 opened under Test Play): RPG_RT does not
+  draw a single flat per-id list at all — it draws *two* windows side by
+  side, a left one listing ten coarse "blocks" of ten ids each (e.g.
+  `S[ 0041-0050 ]`) and a right one previewing the highlighted block's own
+  ten individual ids — with two independent cursor/focus levels. Block
+  focus (the default on opening): Up/Down moves the block cursor ±1,
+  *wrapping* within the current 100-id screen (verified: Up from block 0
+  landed on block 9, same screen); Left/Right instead pages the whole
+  screen by 100 ids, *preserving* the highlighted block's index (verified:
+  block index 3 stayed index 3 after paging); C drills into the
+  highlighted block's row focus. Row focus: Up/Down moves ±1 among the
+  block's own ten ids, wrapping *locally* within that block (verified: row
+  9 + Down → row 0 of the same block, not the next); Left/Right do nothing
+  there; C toggles a switch instantly (confirmed OFF→ON on a real save) or
+  opens the variable editor unchanged; B returns to block focus, a second B
+  closes the menu (confirmed with two real Escape presses). Both levels
+  auto-repeat on a held key, closing the deferred key-repeat gap this
+  bullet left open as a side effect. A Switch row's value draws bracketed,
+  `[ ON ]`/`[ OFF ]`, confirmed by pixel crop; a Variable row's own format
+  was never independently reached this session, so it stays untouched
+  rather than guessed. What actually cycles a genuine RPG_RT install
+  between just these two pages was not identified — Left/Right, Q/W,
+  PageUp/PageDown, Tab, Shift, Space and more were all tried and none of
+  them flipped the page — so that binding is left unasserted; this
+  codebase's own Map/Chipset/Animation additions (not genuine RPG_RT pages
+  at all) keep cycling on Left/Right as before, while Switch/Variable now
+  cycle on the L/R shoulder buttons instead, freed up since Left/Right
+  means "page the screen" there now — both purely this engine's own
+  tooling wiring for a five-page menu real RPG_RT never had, not an RPG_RT
+  fidelity claim. `debug_menu.rb` rewritten with a `@focus` (`:block`/
+  `:row`) state machine, two `Window`s (`@left_window`/`@right_window`,
+  geometry measured directly off the wine screenshot: y=32, height 176,
+  split at x=96 of the 320px screen), wrap-around `move_block`/`move_row`,
+  a cursor-preserving `turn_page`, and `Input.repeat?` throughout. Covered
+  by new `scripts/rpg2k_scene_check.rb` checks (block/row focus, wrap,
+  paging, toggle and the L/R mode-cycle; the two-window geometry; the
+  Switch bracket format), plus updates to the pre-existing Map/Animation
+  mode-cycle checks whose steps assumed the old Left/Right binding — 7 of
+  898 confirmed to fail against the pre-fix code before the fix. **A prior
+  cycle's independent investigation of this same screen was discarded
+  before reaching this entry**: its transcript showed it had read EasyRPG
+  Player's own `window_actortarget.cpp`/`scene_actortarget.cpp`/
+  `game_targets.cpp` (an unrelated screen, the item/skill target-confirm
+  UI, not this one) while investigating, violating this whole series' own
+  no-EasyRPG-source rule even though its final report never disclosed
+  having done so — its finding was discarded unshipped, and this entry is
+  the result of a from-scratch redo that consulted no EasyRPG/Player
+  source at any point.
   ✅ **Follow-up (2026-08-19): Right/Left did nothing at all during
   ally-target selection, when real RPG_RT treats them as full equivalents
   of Down/Up there — correcting this bullet's own claim that

--- a/mruby-rpg2k/mrblib/scene/debug_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/debug_menu.rb
@@ -1,25 +1,58 @@
 class RPG2k
   module Scene
     # RPG_RT's F9 debug menu (see Scene::Map#try_open_debug_menu -- Test Play
-    # only, opened from the field map). Five flip-able pages, Switch,
-    # Variable, Map, Chipset and Animation, cycled with Left/Right. On the
-    # Switch/Variable pages, each listing ten ids at a time, Up/Down moves the
-    # cursor by one row (scrolling into the neighbouring block of ten at
-    # either edge), L/R jumps a full block of ten, and C acts on the selected
-    # row (toggle a switch instantly, or open a signed number editor for a
-    # variable). Map, Chipset and Animation (this codebase's own additions --
-    # not part of genuine RPG_RT's F9 menu) have no row list: Map instead lets
-    # Up/Down step its own selected map id by one and L/R by ten (the same
-    # convention Animation uses below), with C opening that id's
-    # Scene::MapViewer (a whole-map debug overview and, in its own Edit mode,
-    # the actual Map Editor) -- the player's own live map when it's the id
-    # selected, or any other map loaded fresh off disk otherwise, so a project
-    # can be browsed and edited one map at a time without first walking there.
-    # C on Chipset opens Scene::ChipsetEditor (the current map's chipset
-    # passability grid); Animation lets Up/Down step an animation id by one
-    # and L/R by ten, with C playing it back on the field map through
-    # Scene::Map's own animation player (see #play_animation). B closes the
-    # menu.
+    # only, opened from the field map).
+    #
+    # The Switch/Variable pages are two genuine RPG_RT pages, and their own
+    # navigation was directly re-verified against real RPG_RT.exe under wine
+    # for this fix (a prior version of this file guessed a single flat,
+    # one-level list -- wrong on every axis below). RPG_RT draws them as
+    # *two* borderless-gap, edge-to-edge windows side by side, flush with the
+    # screen: a LEFT_W-wide left window listing SCREEN_BLOCKS "blocks" of
+    # BLOCK_SIZE ids each (e.g. "S[ 0041-0050 ]"), and a right window
+    # previewing the ten individual ids of whichever block is highlighted --
+    # confirmed by editing a genuine Nepheshel save's switch table and
+    # reading back real RPG_RT.exe screenshots, not by inspecting any other
+    # engine's source. Two independent cursor/focus levels, not one:
+    #   * Block focus (the default on opening, and after B backs out of row
+    #     focus): Up/Down moves the highlighted block by +-1, *wrapping*
+    #     within the current screen's ten blocks (block 9 + Down -> block 0,
+    #     same screen -- verified directly, holding Up from block 0 landed on
+    #     block 9 without changing the id range shown). Left/Right instead
+    #     pages the whole screen by a full SCREEN_SIZE (=BLOCK_SIZE *
+    #     SCREEN_BLOCKS) ids, *preserving* the highlighted block's index
+    #     (verified: highlighting block index 3, then Right, landed on block
+    #     index 3 of the next screen, not index 0). C enters row focus on the
+    #     highlighted block, always starting at its first row. Holding Down
+    #     visibly outran a single-tap's one-block move (auto-repeat, the same
+    #     trigger-then-repeat convention every other confirmed list cursor in
+    #     this codebase already follows -- see item_menu.rb/skill_menu.rb).
+    #   * Row focus: Up/Down moves the row cursor by +-1 among the
+    #     highlighted block's own BLOCK_SIZE ids, wrapping locally (row 9 +
+    #     Down -> row 0 of the *same* block -- verified directly; it does not
+    #     cross into the neighbouring block). Left/Right do nothing here
+    #     (verified). C acts on the selected row (toggle a switch instantly,
+    #     confirmed OFF->ON on a real save; or open the signed number editor
+    #     for a variable, unchanged from before this fix). B returns to block
+    #     focus without closing the menu; a second B (now in block focus)
+    #     closes it, matching the two real Escape presses this was verified
+    #     with (open -> row focus -> block focus -> closed).
+    # What actually cycles a genuine RPG_RT install between just these two
+    # pages was not identified -- Left/Right, Q/W (this codebase's own L/R
+    # keys), PageUp/PageDown, Tab, Shift, Space, and a dozen more all left the
+    # Switch page showing Switch, so it is not asserted here.
+    #
+    # Map, Chipset and Animation (this codebase's own additions -- not part
+    # of genuine RPG_RT's F9 menu at all, so nothing above constrains them)
+    # keep their pre-existing single-panel look and their own Up/Down
+    # +-1/L/R +-10 id stepping, C opening the relevant tool, unchanged by
+    # this fix; Left/Right still cycles between all five pages on these
+    # three, exactly as before. Switch/Variable can no longer use Left/Right
+    # to cycle -- that input means screen-paging there now, confirmed above
+    # -- so they cycle on L/R (shoulder) instead, which is otherwise unused
+    # on those two pages. Both bindings are purely this engine's own
+    # tooling wiring for a five-page menu real RPG_RT never had (only
+    # Switch/Variable are genuine), not an RPG_RT fidelity claim.
     #
     # The id range shown extends to cover every switch/variable the project
     # actually names (its LDB "switch"/"variable" tables, chunks 23/24 --
@@ -38,6 +71,18 @@ class RPG2k
       FLOOR_ID = 100
       MODES = [:switch, :variable, :map, :chipset, :animation].freeze
 
+      # Switch/Variable page geometry, measured directly off real RPG_RT.exe
+      # screenshots (a 640x480 2x-scaled capture, halved back to the game's
+      # native 320x240): two windows flush to the screen edges, y=32..208
+      # (height (BLOCK_SIZE * LINE_H) + Window::BORDER*2 = 176, no title
+      # row -- the block labels are the left window's own ten rows, there is
+      # no separate header), left window x=0..96, right window x=96..320.
+      BLOCK_SIZE = 10
+      SCREEN_BLOCKS = 10
+      SCREEN_SIZE = BLOCK_SIZE * SCREEN_BLOCKS
+      LEFT_W = 96
+      SW_TOP = 32
+
       def initialize(parent, state)
         super parent
         @state = state
@@ -45,7 +90,9 @@ class RPG2k
         @background = build_field_background(@skin)
         @mode = :switch
         @page = 0
-        @cursor = 0
+        @block = 0
+        @row = 0
+        @focus = :block
         @anim_id = 1
         # The Map page's own selected id -- defaults to the player's actual
         # current map (so C still opens straight onto it unchanged, same as
@@ -60,61 +107,104 @@ class RPG2k
         close_editor
         @background.dispose if @background
         @window.dispose if @window
+        @left_window.dispose if @left_window
+        @right_window.dispose if @right_window
       end
 
       def update
         return update_editor if @editor
+        case @mode
+        when :map then update_map_page
+        when :chipset then update_chipset_page
+        when :animation then update_animation
+        else update_switch_or_variable
+        end
+      end
+
+      private
+
+      # Block/row focus (see the class comment) for the two genuine RPG_RT
+      # pages.
+      def update_switch_or_variable
+        @focus == :row ? update_row_focus : update_block_focus
+      end
+
+      def update_block_focus
+        if Input.trigger?(Input::B)
+          @parent.pop
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+          move_block(1)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+          move_block(-1)
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
+          turn_page(1)
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
+          turn_page(-1)
+        elsif Input.trigger?(Input::L)
+          cycle_mode(-1)
+        elsif Input.trigger?(Input::R)
+          cycle_mode(1)
+        elsif Input.trigger?(Input::C)
+          enter_row_focus
+        end
+      end
+
+      def update_row_focus
+        if Input.trigger?(Input::B)
+          @focus = :block
+          refresh
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+          move_row(1)
+        elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+          move_row(-1)
+        elsif Input.trigger?(Input::C)
+          activate_row
+        end
+      end
+
+      # Chipset has no id of its own to step, so unlike Map/Animation below it
+      # has no L/R stepping to avoid clashing with -- cycles on Left/Right
+      # the same as Map/Animation do, for one consistent "how do I flip
+      # between these three invented pages" answer across all three.
+      def update_chipset_page
         if Input.trigger?(Input::B)
           @parent.pop
         elsif Input.trigger?(Input::RIGHT)
           cycle_mode(1)
         elsif Input.trigger?(Input::LEFT)
           cycle_mode(-1)
-        elsif @mode == :map
-          update_map_page
-        elsif @mode == :chipset
-          activate_row if Input.trigger?(Input::C)
-        elsif @mode == :animation
-          update_animation
-        elsif Input.trigger?(Input::DOWN)
-          move_cursor(1)
-        elsif Input.trigger?(Input::UP)
-          move_cursor(-1)
-        elsif Input.trigger?(Input::R)
-          turn_page(1)
-        elsif Input.trigger?(Input::L)
-          turn_page(-1)
         elsif Input.trigger?(Input::C)
           activate_row
         end
       end
 
-      private
-
       def cycle_mode(delta)
         idx = (MODES.index(@mode) + delta) % MODES.length
         @mode = MODES[idx]
         @page = 0
-        @cursor = 0
+        @block = 0
+        @row = 0
+        @focus = :block
         refresh
       end
 
       def max_page
-        (max_id - 1) / PAGE_SIZE
+        (max_id - 1) / SCREEN_SIZE
       end
 
-      def move_cursor(delta)
-        n = @cursor + delta
-        if n.negative?
-          return if @page.zero?
-          @page -= 1
-          n = PAGE_SIZE - 1
-        elsif n >= PAGE_SIZE
-          return if @page >= max_page
-          @page += 1
-          n = 0
-        end
-        @cursor = n
+      def move_block(delta)
+        @block = (@block + delta) % SCREEN_BLOCKS
+        refresh
+      end
+
+      def move_row(delta)
+        @row = (@row + delta) % BLOCK_SIZE
+        refresh
+      end
+
+      def enter_row_focus
+        @focus = :row
+        @row = 0
         refresh
       end
 
@@ -122,12 +212,11 @@ class RPG2k
         p = @page + delta
         return if p.negative? || p > max_page
         @page = p
-        @cursor = 0
         refresh
       end
 
       def current_id
-        @page * PAGE_SIZE + @cursor + 1
+        @page * SCREEN_SIZE + @block * BLOCK_SIZE + @row + 1
       end
 
       def max_id
@@ -146,7 +235,13 @@ class RPG2k
       end
 
       def update_animation
-        if Input.trigger?(Input::C)
+        if Input.trigger?(Input::B)
+          @parent.pop
+        elsif Input.trigger?(Input::RIGHT)
+          cycle_mode(1)
+        elsif Input.trigger?(Input::LEFT)
+          cycle_mode(-1)
+        elsif Input.trigger?(Input::C)
           play_animation
         elsif Input.trigger?(Input::UP) || Input.trigger?(Input::DOWN)
           @anim_id = [@anim_id + (Input.trigger?(Input::UP) ? 1 : -1), 1].max
@@ -158,12 +253,18 @@ class RPG2k
       end
 
       # Same Up/Down +-1, L/R +-10 stepping #update_animation uses for
-      # @anim_id (Left/Right are already claimed by #cycle_mode above, so
-      # neither page can use them for its own id) -- C opens the selected
-      # @map_id's Scene::MapViewer rather than always the player's own current
-      # map, the way plain C used to before @map_id existed.
+      # @anim_id (Left/Right cycle pages instead, so neither page can use
+      # them for its own id) -- C opens the selected @map_id's
+      # Scene::MapViewer rather than always the player's own current map, the
+      # way plain C used to before @map_id existed.
       def update_map_page
-        if Input.trigger?(Input::C)
+        if Input.trigger?(Input::B)
+          @parent.pop
+        elsif Input.trigger?(Input::RIGHT)
+          cycle_mode(1)
+        elsif Input.trigger?(Input::LEFT)
+          cycle_mode(-1)
+        elsif Input.trigger?(Input::C)
           activate_row
         elsif Input.trigger?(Input::UP) || Input.trigger?(Input::DOWN)
           @map_id = [@map_id + (Input.trigger?(Input::UP) ? 1 : -1), 1].max
@@ -238,8 +339,16 @@ class RPG2k
         name.nil? ? '' : name
       end
 
+      # RPG_RT draws a Switch row's value bracketed -- "[ ON ]"/"[ OFF ]",
+      # confirmed directly off the same real RPG_RT.exe screenshots the
+      # block/row navigation above was verified against. A Variable row's
+      # own value format was not independently confirmed (this session never
+      # got real RPG_RT onto the Variable page -- see the class comment), so
+      # it stays exactly as it already was rather than guessing the bracket
+      # applies there too.
       def row_value_text(id)
-        @mode == :switch ? (@state.switches[id] ? 'ON' : 'OFF') : @state.variables[id].to_s
+        return @state.variables[id].to_s unless @mode == :switch
+        "[ #{@state.switches[id] ? 'ON' : 'OFF'} ]"
       end
 
       # Zero-padded to (at least) 4 digits, e.g. 7 -> "0007", 12345 -> "12345".
@@ -259,30 +368,75 @@ class RPG2k
         @window.windowskin = @skin
         @contents = Bitmap.new(w - Window::BORDER * 2, (PAGE_SIZE + 1) * LINE_H)
         @window.contents = @contents
+
+        # The two genuine RPG_RT pages: see the class comment for how this
+        # geometry and the block/row split were measured.
+        sh = BLOCK_SIZE * LINE_H + Window::BORDER * 2
+        @left_window = Window.new(0, SW_TOP, LEFT_W, sh)
+        @left_window.z = 400
+        @left_window.windowskin = @skin
+        @left_contents = Bitmap.new(LEFT_W - Window::BORDER * 2, BLOCK_SIZE * LINE_H)
+        @left_window.contents = @left_contents
+
+        rw = SCREEN_W - LEFT_W
+        @right_window = Window.new(LEFT_W, SW_TOP, rw, sh)
+        @right_window.z = 400
+        @right_window.windowskin = @skin
+        @right_contents = Bitmap.new(rw - Window::BORDER * 2, BLOCK_SIZE * LINE_H)
+        @right_window.contents = @right_contents
+
         refresh
       end
 
       def refresh
         return unless @contents
+        switch_or_variable = @mode == :switch || @mode == :variable
+        @window.visible = !switch_or_variable
+        @left_window.visible = switch_or_variable
+        @right_window.visible = switch_or_variable
+        return refresh_switch_or_variable if switch_or_variable
         @contents.clear
         @contents.font.color = Color.new(255, 255, 255, 255)
         return refresh_map_page if @mode == :map
         return refresh_chipset_page if @mode == :chipset
-        return refresh_animation_page if @mode == :animation
-        title = @mode == :switch ? 'Switch' : 'Variable'
-        first = @page * PAGE_SIZE + 1
-        last = [first + PAGE_SIZE - 1, max_id].min
-        @contents.draw_text 0, 0, @contents.width, LINE_H,
-                            "#{title}  [#{id_label(first)}-#{id_label(last)}]"
-        (0...PAGE_SIZE).each do |i|
-          id = first + i
-          break if id > max_id
-          y = (i + 1) * LINE_H
-          @contents.draw_text 0, y, NAME_COL_W, LINE_H, "#{id_label(id)}:#{row_name(id)}"
-          @contents.draw_text NAME_COL_W, y, @contents.width - NAME_COL_W, LINE_H,
-                              row_value_text(id), 2
+        refresh_animation_page
+      end
+
+      # Two windows, two cursors -- see the class comment for the real
+      # RPG_RT behaviour this reproduces. The left cursor stays drawn (on
+      # the highlighted block) in both focus states, exactly as measured;
+      # the right cursor is empty in block focus and shows the row only once
+      # row focus is entered.
+      def refresh_switch_or_variable
+        @left_contents.clear
+        @right_contents.clear
+        @left_contents.font.color = Color.new(255, 255, 255, 255)
+        @right_contents.font.color = Color.new(255, 255, 255, 255)
+        prefix = @mode == :switch ? 'S' : 'V'
+        screen_first = @page * SCREEN_SIZE + 1
+        (0...SCREEN_BLOCKS).each do |b|
+          block_first = screen_first + b * BLOCK_SIZE
+          break if block_first > max_id
+          block_last = [block_first + BLOCK_SIZE - 1, max_id].min
+          y = b * LINE_H
+          label = "#{prefix}[ #{id_label(block_first)}-#{id_label(block_last)} ]"
+          @left_contents.draw_text 0, y, @left_contents.width, LINE_H, label
         end
-        @window.cursor_rect = Rect.new(0, (@cursor + 1) * LINE_H, @contents.width, LINE_H)
+        block_first = screen_first + @block * BLOCK_SIZE
+        (0...BLOCK_SIZE).each do |r|
+          id = block_first + r
+          break if id > max_id
+          y = r * LINE_H
+          @right_contents.draw_text 0, y, NAME_COL_W, LINE_H, "#{id_label(id)}:#{row_name(id)}"
+          @right_contents.draw_text NAME_COL_W, y, @right_contents.width - NAME_COL_W, LINE_H,
+                                    row_value_text(id), 2
+        end
+        @left_window.cursor_rect = Rect.new(0, @block * LINE_H, @left_contents.width, LINE_H)
+        @right_window.cursor_rect = if @focus == :row
+                                       Rect.new(0, @row * LINE_H, @right_contents.width, LINE_H)
+                                     else
+                                       Rect.new(0, 0, 0, 0)
+                                     end
       end
 
       # No row list to select from, so no cursor bar either -- clear whatever

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -22483,27 +22483,102 @@ check 'F9 does nothing during a battle outside Test Play' do
   ok scene.parent.pushed.empty?, 'a released game never sees F9 open anything, mid-battle either'
 end
 
-check 'the debug menu toggles a switch on C and flips to Variable on Left/Right' do
+check 'the debug menu toggles a switch on C (after C first enters row focus), pages the ' \
+     'screen on Right/Left, and flips to Variable on R -- verified directly against real ' \
+     'RPG_RT.exe: it opens in block focus (a coarse, ten-block-per-screen list, not a flat ' \
+     'per-id one), C drills into the highlighted block\'s own ten ids, and Right/Left there ' \
+     'means "page the screen" rather than "cycle to Variable" (that lives on the L/R shoulder ' \
+     'instead, freed up by this)' do
   st = menu_state
   st.switches[1] = false
+  st.switches[150] = true # pushes max_id past the FLOOR_ID=100 floor, so screen 1 exists to page to
   scene = menu_scene(RPG2k::Scene::DebugMenu, st)
+  eq :block, scene.instance_variable_get(:@focus), 'opens in block focus, not row focus'
+
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
-  ok st.switches[1], 'C toggled switch 1 (the cursor starts on row 1) on'
+  eq :row, scene.instance_variable_get(:@focus), 'C from block focus enters row focus'
+  ok !st.switches[1], 'entering row focus alone does not touch the switch'
+
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  ok st.switches[1], 'C in row focus toggled switch 1 (the row cursor starts on row 1) on'
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   ok !st.switches[1], 'a second C toggles it back off'
 
   RGSS::Input.triggered = [RGSS::Input::RIGHT]
   scene.update
-  eq :variable, scene.instance_variable_get(:@mode), 'Left/Right flips to the Variable page'
+  eq :switch, scene.instance_variable_get(:@mode), 'Right in row focus is a no-op, not a mode flip'
+
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  eq :block, scene.instance_variable_get(:@focus), 'B backs row focus out to block focus'
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  eq :switch, scene.instance_variable_get(:@mode), 'Right in block focus pages the screen, ' \
+     'it does not flip the mode either'
+  eq 1, scene.instance_variable_get(:@page), 'and it actually paged (screen 0 -> screen 1)'
+
+  RGSS::Input.triggered = [RGSS::Input::R]
+  scene.update
+  eq :variable, scene.instance_variable_get(:@mode), 'R (shoulder) flips to the Variable page'
+end
+
+check 'the debug menu Switch/Variable page geometry matches real RPG_RT.exe, measured ' \
+     'directly off a screenshot (a 640x480 2x capture, halved back to native 320x240): two ' \
+     'windows flush to the screen edges at y=32, height 176 (ten BLOCK_SIZE rows plus the ' \
+     '8px border on each side, no separate title row), split at x=96 of 320' do
+  scene = menu_scene(RPG2k::Scene::DebugMenu, menu_state)
+  left = scene.instance_variable_get(:@left_window)
+  right = scene.instance_variable_get(:@right_window)
+  eq 0, left.x, 'left window flush to the screen\'s left edge'
+  eq 32, left.y
+  eq 96, left.width
+  eq 176, left.height
+  eq 96, right.x, 'right window starts exactly where the left one ends'
+  eq 32, right.y
+  eq 224, right.width, 'right window fills the rest of the 320px screen width'
+  eq 176, right.height
+  ok left.visible, 'both windows are visible in the default (Switch) mode'
+  ok right.visible
+
+  RGSS::Input.triggered = [RGSS::Input::R]
+  scene.update # Switch -> Variable: still the same two windows, still visible
+  ok left.visible, 'still visible on the Variable page (a genuine RPG_RT page too)'
+  ok right.visible
+
+  RGSS::Input.triggered = [RGSS::Input::R]
+  scene.update # Variable -> Map: the invented single-panel page takes over
+  ok !left.visible, 'the two-window layout hides on Map (not a genuine RPG_RT page)'
+  ok !right.visible
+  ok scene.instance_variable_get(:@window).visible, 'the single legacy panel shows instead'
+end
+
+check 'the debug menu draws a Switch row\'s value bracketed, "[ ON ]"/"[ OFF ]", matching a ' \
+     'real RPG_RT.exe screenshot; a Variable row\'s own value format was never independently ' \
+     'confirmed against the genuine runtime, so it is deliberately left exactly as it was' do
+  st = menu_state
+  st.switches[1] = true
+  st.variables[1] = 42
+  scene = menu_scene(RPG2k::Scene::DebugMenu, st)
+  eq '[ ON ]', scene.send(:row_value_text, 1), 'a Switch row is bracketed'
+  st.switches[1] = false
+  eq '[ OFF ]', scene.send(:row_value_text, 1)
+  scene.instance_variable_set(:@mode, :variable)
+  eq '42', scene.send(:row_value_text, 1), 'a Variable row is untouched -- no brackets'
 end
 
 check 'the debug menu edits a variable through the signed number editor' do
   st = menu_state
   st.variables[1] = 5
   scene = menu_scene(RPG2k::Scene::DebugMenu, st)
+  # This check is only about the number editor, not block/row navigation
+  # (see the block/row check above), so drop straight into row focus on
+  # variable 1's own row rather than re-driving C through block focus first.
   scene.instance_variable_set(:@mode, :variable)
+  scene.instance_variable_set(:@focus, :row)
   scene.send(:refresh)
 
   RGSS::Input.triggered = [RGSS::Input::C] # open the editor on variable 1
@@ -22530,6 +22605,7 @@ check 'B cancels the debug menu variable editor without changing the value' do
   st.variables[1] = 5
   scene = menu_scene(RPG2k::Scene::DebugMenu, st)
   scene.instance_variable_set(:@mode, :variable)
+  scene.instance_variable_set(:@focus, :row)
   scene.send(:refresh)
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
@@ -22554,6 +22630,7 @@ check "the debug menu variable editor widens to 7 digits on an RPG2003 database"
   st.variables[1] = 5
   scene = menu_scene(RPG2k::Scene::DebugMenu, st)
   scene.instance_variable_set(:@mode, :variable)
+  scene.instance_variable_set(:@focus, :row)
   scene.send(:refresh)
   eq 7, scene.send(:editor_digits), 'RPG2003 widens the editor to 7 digits'
 
@@ -22576,11 +22653,14 @@ end
 
 check 'the debug menu Map page opens Scene::MapViewer on C' do
   scene = menu_scene(RPG2k::Scene::DebugMenu, menu_state)
-  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  # Switch/Variable cycle mode on R (shoulder) -- Right/Left means "page the
+  # screen" there instead, verified against real RPG_RT.exe (see the block/
+  # row focus check above); Map/Chipset/Animation still cycle on Right/Left.
+  RGSS::Input.triggered = [RGSS::Input::R]
   scene.update # Switch -> Variable
-  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  RGSS::Input.triggered = [RGSS::Input::R]
   scene.update # Variable -> Map
-  eq :map, scene.instance_variable_get(:@mode), 'two Rights cycle to the Map page'
+  eq :map, scene.instance_variable_get(:@mode), 'two Rs cycle to the Map page'
 
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
@@ -22595,9 +22675,9 @@ check "the debug menu Map page's @map_id defaults to the player's own current ma
   st = menu_state
   st.map = fake_map(7, {})
   scene = menu_scene(RPG2k::Scene::DebugMenu, st)
-  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  RGSS::Input.triggered = [RGSS::Input::R]
   scene.update # Switch -> Variable
-  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  RGSS::Input.triggered = [RGSS::Input::R]
   scene.update # Variable -> Map
   eq 7, scene.instance_variable_get(:@map_id), "defaults to the player's own current map id"
 
@@ -22617,9 +22697,9 @@ check "the debug menu Map page's own Up/Down/L/R step @map_id (Up/Down +-1, L/R 
   st = menu_state
   st.map = fake_map(7, {})
   scene = menu_scene(RPG2k::Scene::DebugMenu, st)
-  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  RGSS::Input.triggered = [RGSS::Input::R]
   scene.update
-  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  RGSS::Input.triggered = [RGSS::Input::R]
   scene.update # -> Map page, @map_id == 7
 
   RGSS::Input.triggered = [RGSS::Input::UP]
@@ -23179,11 +23259,19 @@ check 'the debug menu Animation page adjusts an id (Up/Down by one, L/R by ten) 
      'C plays it back on the live map scene, then closes to the map' do
   st = menu_state
   scene = menu_scene(RPG2k::Scene::DebugMenu, st)
-  4.times do # Switch -> Variable -> Map -> Chipset -> Animation
+  # Switch -> Variable -> Map both cycle on R (shoulder, see the block/row
+  # focus check above -- Variable is the same block/row-focus code path as
+  # Switch); once on Map, Map -> Chipset -> Animation cycle on Right same as
+  # always (only Switch/Variable's Right/Left changed meaning).
+  2.times do
+    RGSS::Input.triggered = [RGSS::Input::R]
+    scene.update
+  end
+  2.times do
     RGSS::Input.triggered = [RGSS::Input::RIGHT]
     scene.update
   end
-  eq :animation, scene.instance_variable_get(:@mode), 'four Rights cycle to the Animation page'
+  eq :animation, scene.instance_variable_get(:@mode), 'two Rs then two Rights cycle to Animation'
 
   RGSS::Input.triggered = [RGSS::Input::R] # +10
   scene.update


### PR DESCRIPTION
## Summary

- RPG_RT's F9 debug menu draws its Switch/Variable pages as **two side-by-side windows** with two independent cursor/focus levels — not the single flat per-id list this codebase had. Confirmed directly against genuine RPG_RT.exe under wine (a genuine Nepheshel save with its own switch table edited directly, F9 opened under Test Play):
  - **Left window**: ten coarse "blocks" of ten ids each (e.g. `S[ 0041-0050 ]`).
  - **Right window**: the highlighted block's own ten individual ids.
  - **Block focus** (default on open): Up/Down moves the block cursor ±1, *wrapping* within the current 100-id screen; Left/Right pages the whole screen by 100 ids, *preserving* the highlighted block's index; C drills into row focus.
  - **Row focus**: Up/Down moves ±1 among the block's own ten ids, wrapping *locally*; Left/Right do nothing; C toggles a switch (confirmed OFF→ON on a real save) or opens the variable editor; B returns to block focus, a second B closes the menu.
  - Both levels auto-repeat on a held key, closing a key-repeat gap this codebase's own prior key-repeat series had deliberately left open pending exactly this kind of reference.
  - A Switch row's value draws bracketed (`[ ON ]`/`[ OFF ]`, pixel-confirmed); a Variable row's format was never independently reached this session, so it's left untouched rather than guessed.
- `mruby-rpg2k/mrblib/scene/debug_menu.rb` rewritten with a `@focus` (`:block`/`:row`) state machine, two `Window`s with geometry measured directly off the wine screenshot, wrap-around block/row movement, a cursor-preserving page turn, and `Input.repeat?` throughout. Left/Right no longer cycles Switch/Variable to the next debug page (that's now the L/R shoulder buttons, freed up since Left/Right means "page the screen" there); Map/Chipset/Animation (this codebase's own non-RPG_RT additions) are unchanged.
- **Note on methodology**: an earlier investigation of this same screen was discarded before this PR — its transcript showed it had read EasyRPG Player's `window_actortarget.cpp`/`scene_actortarget.cpp`/`game_targets.cpp` (investigating an unrelated screen) without disclosing it in its final report, violating this project's no-EasyRPG-source rule. This PR is a from-scratch redo that consulted no EasyRPG/Player source at any point.

## Test plan

- New `scripts/rpg2k_scene_check.rb` checks: block/row focus transitions, wrap-around, screen paging (index-preserving), the L/R mode-cycle, the two-window geometry, and the Switch bracket format — plus updates to pre-existing Map/Animation mode-cycle checks whose steps assumed the old Left/Right binding.
- Confirmed via `git stash` that 7 of 898 checks fail against the pre-fix code and all pass post-fix (898/898).
- All four suites green: `rpg2k_scene_check.rb` (898 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).
- Beyond the CRuby harness, the actual engine was rebuilt and driven under the same wine/Xvfb setup with a real edited Nepheshel save, confirming the live mruby runtime renders the identical two-window layout, bracket format, wrap/page/toggle behavior, and mode-cycle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_