### PR TITLE
Default the End Game confirm cursor to Yes, matching RPG_RT

### DIFF
--- a/changelog.d/menu-end-game-confirm-cursor-default.fixed.md
+++ b/changelog.d/menu-end-game-confirm-cursor-default.fixed.md
@@ -1,0 +1,5 @@
+- **Field menu:** the End Game Yes/No confirmation now starts with the
+  cursor on "Yes", matching RPG_RT — previously it defaulted to "No", based
+  on an unverified, since-discarded claim about the reference reimplementation's
+  source; a genuine RPG_RT.exe (Nepheshel, under wine) shows the cursor
+  opening on "Yes" instead.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5445,6 +5445,24 @@ The work below is roughly ordered by the critical path to a walkable game
   that End Game "hands control back to the app immediately, with no
   confirmation message to dismiss first" -- now replaced). See
   `changelog.d/menu-end-game-confirmation.fixed.md`.
+  ✅ **Follow-up (2026-08-22): the cursor-default half of the bullet above was
+  itself wrong -- it cited EasyRPG's `Scene_End::CreateCommandWindow`
+  defaulting to index 1 ("No"), and that citation was never checked against
+  genuine RPG_RT.** Reached the confirm prompt on a real `RPG_RT.exe`
+  (Nepheshel, wine) by loading a `--clear-scene` save on map 371, dismissing
+  its wake-up dialogue, opening the field menu (Escape) and confirming the
+  last command (this database relabels End Game as "…に戻る", but it still
+  raises the same Yes/No prompt any RPG2000 End Game does). The cursor opens
+  on "はい" (Yes), the top row, not "いいえ" (No) -- reproduced identically on
+  a second, independent save+launch. This also matches the Inn Accept/Cancel
+  prompt's own already-fixed default (cursor starts on the affirmative
+  option there too), rather than being an isolated case. Fixed by changing
+  `#open_end_game_confirm`'s `@confirm_index` default from `END_GAME_NO` to
+  `END_GAME_YES` (`mruby-rpg2k/mrblib/scene/menu.rb`); the three
+  `scripts/rpg2k_scene_check.rb` checks above were updated to match (the
+  "confirm No" check now presses Down before confirming, since the cursor no
+  longer opens there; the "confirm Yes" check drops its now-redundant Up
+  press). See `changelog.d/menu-end-game-confirm-cursor-default.fixed.md`.
   ✅ **The top-level field menu never showed the party's own Gold at all,
   even though the Status screen's own identical gap was already found and
   fixed (2026-08-20) — this screen still had nothing.** Confirmed against

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -501,17 +501,19 @@ class RPG2k
       end
 
       # End Game never quits outright -- it opens a Yes/No confirmation on
-      # top of the command list, matching EasyRPG's own `Scene_End` (pushed
-      # by `Scene_Menu::UpdateCommand`'s `case Quit`, right after the
-      # Decision SE #select_command already plays above). `Scene_End::
-      # CreateCommandWindow` defaults the cursor to "No" (index 1) -- a
-      # stray confirm press does not quit the game.
+      # top of the command list. Confirmed directly against a genuine
+      # RPG_RT.exe (Nepheshel, wine): opening the prompt from a fresh menu
+      # shows the cursor already on "はい" (Yes), the top row -- not "No", as
+      # an earlier, EasyRPG-sourced note here had wrongly claimed (that
+      # finding was discarded; see docs/TODO.md). "Yes" defaulting first
+      # matches this same menu's Inn Accept/Cancel prompt, whose cursor also
+      # starts on the affirmative option.
       END_GAME_YES = 0
       END_GAME_NO = 1
 
       def open_end_game_confirm
         @focus = :end_game_confirm
-        @confirm_index = END_GAME_NO
+        @confirm_index = END_GAME_YES
         @command.active = false
         build_end_game_confirm_windows
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17891,10 +17891,9 @@ end
 
 check 'Scene::Menu: End Game opens a Yes/No confirmation instead of quitting ' \
       'outright' do
-  # Confirmed against EasyRPG's own Scene_Menu::UpdateCommand (`case Quit:`
-  # plays the Decision SE and pushes Scene_End, never touching the title
-  # directly) and Scene_End::CreateCommandWindow (cursor defaults to index
-  # 1, "No" -- a stray confirm press must not quit the game).
+  # Selecting End Game must not quit outright; confirmed against a genuine
+  # RPG_RT.exe (Nepheshel, wine) that the cursor opens already on "はい"
+  # (Yes), the top row -- see #open_end_game_confirm's own comment.
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
   scene.instance_variable_set(:@index, 4)  # End Game, last of RPG2K_COMMAND_KEYS
   RGSS::Input.triggered = [RGSS::Input::C]
@@ -17904,8 +17903,8 @@ check 'Scene::Menu: End Game opens a Yes/No confirmation instead of quitting ' \
      'selecting End Game alone must not hand control back to the app'
   eq :end_game_confirm, scene.instance_variable_get(:@focus),
      'a Yes/No prompt opens instead'
-  eq 1, scene.instance_variable_get(:@confirm_index),
-     'the cursor starts on "No" (index 1), matching Scene_End::CreateCommandWindow'
+  eq 0, scene.instance_variable_get(:@confirm_index),
+     'the cursor starts on "Yes" (index 0), matching genuine RPG_RT'
 end
 
 check 'Scene::Menu: confirming "No" on the End Game prompt returns to the ' \
@@ -17913,9 +17912,15 @@ check 'Scene::Menu: confirming "No" on the End Game prompt returns to the ' \
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
   scene.instance_variable_set(:@index, 4)
   RGSS::Input.triggered = [RGSS::Input::C]
-  scene.update                                    # open the prompt (cursor on No)
+  scene.update                                    # open the prompt (cursor on Yes)
   RGSS::Input.reset
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN]      # move the cursor to "No"
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@confirm_index)
   RGSS::Audio.reset_bgm
+
   RGSS::Input.triggered = [RGSS::Input::C]         # confirm "No"
   scene.update
   RGSS::Input.reset
@@ -17944,16 +17949,12 @@ check 'Scene::Menu: confirming "Yes" on the End Game prompt fades the BGM ' \
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
   scene.instance_variable_set(:@index, 4)
   RGSS::Input.triggered = [RGSS::Input::C]
-  scene.update                                    # open the prompt (cursor on No)
+  scene.update                                    # open the prompt (cursor on Yes)
   RGSS::Input.reset
   RGSS::Audio.reset_bgm
-
-  RGSS::Input.triggered = [RGSS::Input::UP]        # move the cursor to "Yes"
-  scene.update
-  RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@confirm_index)
 
-  RGSS::Input.triggered = [RGSS::Input::C]         # confirm "Yes"
+  RGSS::Input.triggered = [RGSS::Input::C]         # confirm "Yes" outright
   scene.update
   RGSS::Input.reset
   ok scene.parent.returned_to_title,


### PR DESCRIPTION
## Summary

- RPG_RT's field-menu End Game confirmation opens with the cursor already on "はい" (Yes), the top row — confirmed directly against a genuine RPG_RT.exe (Nepheshel, under wine): loading a `--clear-scene` save on map 371, dismissing its wake-up dialogue, opening the field menu, and confirming the last command (this database relabels End Game as "…に戻る" but still raises the same stock Yes/No prompt). Reproduced identically on two independent save+launch runs.
- `#open_end_game_confirm` (`mruby-rpg2k/mrblib/scene/menu.rb`) previously defaulted the cursor to `END_GAME_NO`, based on a comment citing EasyRPG's `Scene_End::CreateCommandWindow` — an unverified, EasyRPG-sourced claim predating this project's no-EasyRPG-source methodology, never actually checked against genuine RPG_RT. It was wrong.
- Fixed by changing the default to `END_GAME_YES`, matching the already-fixed Inn Accept/Cancel prompt's own affirmative-first default. Comment rewritten to cite the genuine RPG_RT verification instead of EasyRPG source.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on directly observed genuine RPG_RT.exe output under wine.

## Test plan

- Updated three `scripts/rpg2k_scene_check.rb` checks that had encoded the old "starts on No" assumption (opening-state assertion, the "confirm No" check now presses Down first since the cursor no longer opens there, the "confirm Yes" check drops its now-redundant Up press).
- Confirmed via `git stash` that 3 of 898 checks fail against the pre-fix code and all pass post-fix (898/898).
- All four suites green: `rpg2k_scene_check.rb` (898 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_