### PR TITLE
Independently re-verify pause-arrow blink timing against RPG_RT

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6522,6 +6522,41 @@ The work below is roughly ordered by the critical path to a walkable game
   frame by frame confirms the down arrow starts on, flips off at exactly
   the 20th frame, and swaps places with the up arrow once scrolled to the
   last slot.
+  ✅ **Follow-up (2026-08-22): the pause-arrow `ARROW_BLINK_FRAMES = 20` this
+  screen's own scroll arrows reused is now independently re-verified against
+  a genuine RPG_RT.exe, not just EasyRPG's source -- confirmed correct, no
+  code change.** `RPG2k::Window`'s own comment on it said outright there was
+  "no real RPG_RT frame in this repo to measure this against" when it was
+  ported from EasyRPG Player's `src/window.cpp` -- exactly the kind of
+  citation this session's methodology (verify against the real runtime, not
+  a reimplementation) now treats as worth re-checking on its own, and
+  Nepheshel's own genuine `RPG_RT.exe` supplies that frame now. Built a
+  synthetic autostart map event (a plain, non-transparent 3-line Show
+  Message, terminated with the mandatory `code 10` BlankLine) injected into
+  a copy of a genuine Nepheshel map, resumed on real RPG_RT.exe under wine
+  from a genuine save positioned there (`gen-lcf-save-wine.bash` +
+  `gen-rpg2k-save.rb --map --clear-scene`), landing the message box's pause
+  arrow on screen the instant the map loads with nothing else animating.
+  Burst-capturing ~10 frames/sec while it sat paused and thresholding the
+  arrow glyph's mean brightness gave a clean two-level signal: 14 on-runs
+  averaging ~0.20s, 14 off-runs averaging ~0.24s (both coarse, at this
+  sampling grain), and — the more reliable measure, since it cancels
+  per-transition sampling jitter — a 13-cycle average on-to-on period of
+  **0.654s**, which lands on the 40-frame (20-on + 20-off) cycle this
+  engine already codes at RPG_RT's confirmed 60fps (ADR 0021: 0.667s) far
+  closer than any other plausible frame count (a 30-frame cycle would be
+  0.5s, 48 frames 0.8s). The arrow also started in its "on" phase the
+  instant the window paused in every capture, matching `Window#pause=`'s own
+  immediate-visible behaviour. No fix needed — reported as a confirmed-
+  correct negative result, and the comment on `ARROW_BLINK_FRAMES` updated
+  to record the re-verification rather than just citing EasyRPG. This had no
+  regression test at all before now (the existing frame-by-frame coverage
+  above only pins the *SaveLoad scroll arrows*, which reuse the constant
+  but are a structurally different call site) — covered by a new
+  `scripts/rpg2k_scene_check.rb` check driving `RPG2k::Window#pause=`/
+  `#update` directly and asserting the arrow sprite's `visible` flag through
+  one full 40-frame cycle (on at frame 0, off at frame 20, on again at the
+  frame-40 wrap).
   ✅ **This screen always opened with the cursor on slot 1, when real RPG_RT
   opens on whichever slot was saved most recently (2026-08-20).** Confirmed
   against EasyRPG's own live source: `Scene_File::Start` (`src/

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -41,10 +41,18 @@ class RPG2k
 
     # Geometry of the blinking "waiting for input" arrow: an 8px-tall strip
     # inside the frame block (32,0)-(64,32) of the System windowskin, blitted
-    # centred at the bottom of the window. Unlike Game::WindowCursor, there is
-    # no real RPG_RT frame in this repo to measure this against, so the source
-    # rect and the 20-frames-on/20-frames-off blink are ported from EasyRPG
-    # Player's src/window.cpp.
+    # centred at the bottom of the window. The source rect and the
+    # 20-frames-on/20-frames-off blink were originally ported from EasyRPG
+    # Player's src/window.cpp with no genuine-RPG_RT measurement behind them.
+    # Independently re-verified since (2026-08-22): a synthetic autostart Show
+    # Message event injected into a genuine Nepheshel map, resumed on real
+    # RPG_RT.exe under wine from a genuine save, burst-captured while the
+    # message sat paused -- the arrow's on/off runs and a 13-cycle average
+    # full period of 0.654s land squarely on the 40-frame (20 on + 20 off)
+    # cycle this engine already coded, at RPG_RT's confirmed 60fps (ADR 0021),
+    # and it starts in the "on" phase the instant the window pauses, exactly
+    # as coded here. See scripts/rpg2k_scene_check.rb's "pause arrow blinks
+    # on a 20-frame-on/20-frame-off cycle" check.
     ARROW_SRC_X = 40
     ARROW_SRC_Y = 16
     ARROW_W = 16

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -994,6 +994,40 @@ check 'RPG2k::Window blinks its selection cursor between the windowskin\'s ' \
   eq 64, bmp.blt_calls.first[3].x, 'wraps back to the steady cursor block (64)'
 end
 
+check 'RPG2k::Window pause arrow blinks on a 20-frame-on/20-frame-off cycle, ' \
+      'starting visible, matching RPG_RT' do
+  # ARROW_BLINK_FRAMES (main.rb) was ported from EasyRPG Player's
+  # src/window.cpp with no genuine-RPG_RT measurement behind it -- the
+  # comment on it said so outright. Independently re-verified under wine: a
+  # synthetic autostart Show Message event injected into a genuine Nepheshel
+  # map, resumed on real RPG_RT.exe from a genuine save, burst-captured at
+  # ~10 fps while the message sat paused. The pause arrow's on/off runs
+  # measured ~0.20s / ~0.24s (coarse, ~0.1s sampling grain) and a full
+  # on-to-on cycle averaged 0.654s over 13 cycles -- matching the 40-frame
+  # (20 on + 20 off) cycle at RPG_RT's confirmed 60fps (ADR 0021) far closer
+  # than any other plausible frame count, and starting in the "on" phase the
+  # instant the window paused, exactly as coded here. No fix needed; this
+  # pins the now-confirmed-correct behaviour, which had no regression test.
+  win = RPG2k::Window.new(0, 0, 64, 64)
+  win.windowskin = Bitmap.new('System/Skin1', true)
+  arrow = win.instance_variable_get(:@arrow_sprite)
+
+  win.pause = true
+  ok arrow.visible, 'the arrow starts visible the instant pause begins'
+
+  19.times { win.update } # frames 1..19: still the "on" half
+  ok arrow.visible, 'still on through frame 19'
+
+  win.update # frame 20: the last "on" frame (arrow_anim now 20)
+  ok !arrow.visible, 'off from frame 20 (arrow_anim == ARROW_BLINK_FRAMES) onward'
+
+  19.times { win.update } # frames 21..39: still the "off" half
+  ok !arrow.visible, 'still off through frame 39'
+
+  win.update # frame 40 wraps arrow_anim back to 0: on again
+  ok arrow.visible, 'back on at the 40-frame wrap'
+end
+
 check "RPG2k::Window keeps its selection cursor visible, frozen, once " \
       'inactive -- it does not hide it' do
   # Confirmed against RPG_RT's own live source: `Window::Draw`'s cursor


### PR DESCRIPTION
## Summary

- `RPG2k::Window`'s pause-arrow `ARROW_BLINK_FRAMES = 20` (`mruby-rpg2k/mrblib/main.rb`) was ported from EasyRPG Player's `src/window.cpp`, with the comment on it admitting outright there was "no real RPG_RT frame in this repo to measure this against" — an acknowledged, never-closed gap from before this project's genuine-RPG_RT-only methodology.
- Confirmed against genuine RPG_RT.exe under wine: a synthetic autostart Show Message event injected into a copy of a genuine Nepheshel map, resumed on real RPG_RT.exe from a genuine save positioned there, burst-captured at ~10fps while the message sat paused. A 13-cycle average on-to-on period of **0.654s** lands on the 40-frame (20-on + 20-off) cycle this codebase already codes at RPG_RT's confirmed 60fps (0.667s expected) far more closely than any other plausible frame count. The arrow also starts in its "on" phase the instant the window pauses, matching the existing code.
- **No behavioral fix needed** — this is a confirmed-correct negative result. The stale EasyRPG-only-sourced comment is rewritten to cite the re-verification instead.
- This had no regression test at all before this PR (the existing frame-by-frame coverage only pins the structurally different `Scene::SaveLoad` scroll arrows, which merely reuse the same constant) — added one.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check driving `RPG2k::Window#pause=`/`#update` directly, asserting the arrow sprite's `visible` flag through one full 40-frame cycle (on at frame 0, off at frame 20, back on at the frame-40 wrap) — the frame arithmetic matches `@arrow_anim`/`draw_arrow_visibility`'s actual implementation exactly.
- All four suites green: `rpg2k_scene_check.rb` (899 checks, up from 898), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).
- No changelog fragment — no user-visible behavior changed, matching this session's convention for doc-only confirmed-correct cycles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_