### PR TITLE
Fix field menu command list width to match RPG_RT (88px, not 108px)

### DIFF
--- a/changelog.d/menu-command-list-width.fixed.md
+++ b/changelog.d/menu-command-list-width.fixed.md
@@ -1,0 +1,5 @@
+- **Field menu:** the command list (Item/Skill/Equip/Save/End Game) is now
+  88px wide, matching RPG_RT — previously it hardcoded an uncited 108px,
+  visibly misaligning it against the Gold window directly beneath it (both
+  windows share the same 88px width and left edge on a genuine RPG_RT.exe
+  frame, Nepheshel under wine).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5483,6 +5483,32 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check (Gold renders on open; the panel
   hides on `#suspend` and returns with a refreshed figure on `#resume`),
   confirmed to fail against the pre-fix code.
+  ✅ **Follow-up (2026-08-22): the command list itself (Item/Skill/Equip/
+  Save/End Game, top-left) was 20px too wide, visibly misaligning it
+  against the Gold window directly beneath it -- an EasyRPG-source-citation
+  audit (this session's methodology: re-check every pre-methodology-change
+  claim against genuine RPG_RT, not just take it on trust) turned this up
+  even though `build_windows`'s `cw = 108` carried no citation at all, not
+  even an EasyRPG one -- it was simply an old, uncited guess.** Reached a
+  live field menu on a genuine `RPG_RT.exe` (Nepheshel, wine) by loading a
+  `--clear-scene`, `--map 16` save (moving off the starting bedroom map,
+  371, sidesteps a long unskippable wake-up narrative its own autostart
+  event runs even after declining the "play the opening demo" prompt
+  Continue shows first -- landing on a plain, already-explored town map
+  instead reaches the menu in five keypresses with no narrative to wait
+  out), then Escape. Pixel-scanning the captured frame's left column: the
+  command window's own right border and the Gold window's own right border
+  (already 88px, `GOLD_WINDOW_W`, itself only ever cited from EasyRPG
+  before now) land at the *exact same x* -- both windows forming one
+  continuous 88px-wide column, not the command window's own separate,
+  wider 108px box the old code drew. Fixed by replacing the bare `108`
+  with a new shared `LEFT_COLUMN_W = 88` constant that `GOLD_WINDOW_W` now
+  aliases too, documenting the visual relationship the pixel evidence
+  showed rather than two independent magic numbers that happened to almost
+  match. Covered by a new `scripts/rpg2k_scene_check.rb` check (the command
+  list's width is exactly 88, and matches the Gold window's own width and
+  left edge), confirmed to fail against the pre-fix code (`expected 88,
+  got 108`).
   ✅ **The field menu screens now play RPG2000's four system sound effects
   (cursor-move, decision, cancel, buzzer), the "bigger, separate piece of
   work" the disabled-Save fix above left open.** Confirmed against three

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -23,6 +23,16 @@ class RPG2k
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
 
+      # Width of the command list (top-left) and the Gold window (bottom-
+      # left, see GOLD_WINDOW_W) -- independently pixel-measured against a
+      # genuine `RPG_RT.exe` frame (Nepheshel, wine): both windows' right
+      # borders land at the exact same x, forming one continuous column with
+      # the party status panel filling the rest of the screen beside them.
+      # The command window used to hardcode a bare, uncited `108` here --
+      # 20px too wide, visibly misaligning it against the Gold window
+      # directly beneath it.
+      LEFT_COLUMN_W = 88
+
       # RPG2000's field menu is a *fixed* five commands with no separate Status
       # entry -- EasyRPG's `Scene_Menu::CreateCommandWindow`'s `Player::IsRPG2k()`
       # branch hardcodes exactly Item / Skill / Equipment / Save / Quit
@@ -280,7 +290,7 @@ class RPG2k
       end
 
       def build_windows
-        cw = 108
+        cw = LEFT_COLUMN_W
         @command = Window.new(0, 0, cw, @commands.size * LINE_H + Window::BORDER * 2)
         @command.z = 400
         @command.windowskin = @skin
@@ -323,8 +333,10 @@ class RPG2k
       # alike. `Window_Gold::Refresh` (`src/window_gold.cpp`) draws the
       # amount then the `gold` term via `DrawCurrencyValue`
       # (`src/window_base.cpp`) -- the identical no-space "amount then term"
-      # rendering `Scene::StatusMenu`'s own Gold line already uses.
-      GOLD_WINDOW_W = 88
+      # rendering `Scene::StatusMenu`'s own Gold line already uses. Its
+      # width is the same `LEFT_COLUMN_W` the command list above it uses --
+      # see that constant's own citation.
+      GOLD_WINDOW_W = LEFT_COLUMN_W
       GOLD_WINDOW_H = 32
 
       def build_gold_window

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17762,6 +17762,21 @@ check 'Scene::Menu shows the party\'s own Gold, and keeps it current across ' \
      "Gold is refreshed on resume, matching Scene_Menu::Continue's own gold_window->Refresh()"
 end
 
+# The command list's width was a bare, uncited `108` -- independently
+# pixel-measured against a genuine `RPG_RT.exe` frame (Nepheshel, wine): the
+# command window (top-left) and the Gold window (bottom-left, directly
+# beneath it) share the exact same right border x, one continuous 88px-wide
+# column, not 108.
+check "Scene::Menu's command list is the same width as the Gold window " \
+      'directly beneath it (88px, not the old uncited 108)' do
+  scene = menu_scene(RPG2k::Scene::Menu, menu_state)
+  cmd = scene.instance_variable_get(:@command)
+  gold = scene.instance_variable_get(:@gold)
+  eq 88, cmd.width, 'command list width matches the pixel-measured RPG_RT frame'
+  eq cmd.width, gold.width, 'command list and Gold window are the same width'
+  eq cmd.x, gold.x, 'command list and Gold window share the same left edge'
+end
+
 check 'opening Scene::Menu auto-cancels an Erase Screen black-out (yado.tk)' do
   st = menu_state
   st.screen.erase(Game::Transition::FADE_OUT, 1) # settle fully erased


### PR DESCRIPTION
## Summary

- RPG_RT's field-menu command list (Item/Skill/Equip/Save/End Game, top-left) and the Gold window directly beneath it share the exact same right border — one continuous 88px-wide column, not a separately-sized command box. Confirmed by pixel-scanning a captured frame from genuine RPG_RT.exe under wine (Nepheshel): reaching a clean field menu required moving the save off the starting bedroom map (its own autostart event runs a long unskippable wake-up narrative even after declining the demo prompt) to a plain, already-explored town map instead.
- `Scene::Menu#build_windows` (`mruby-rpg2k/mrblib/scene/menu.rb`) hardcoded `cw = 108` with no citation at all — not even an EasyRPG one, just an old uncited guess — while `GOLD_WINDOW_W = 88` (the window directly beneath it) was independently defined. The two disagreed, visibly misaligning the command list against the gold panel.
- Fixed by replacing both with a shared `LEFT_COLUMN_W = 88` constant, documenting the pixel-measured relationship instead of two independent magic numbers.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on directly observed genuine RPG_RT.exe output under wine.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check asserting the command list is exactly 88px wide and shares both width and left edge with the Gold window.
- Confirmed via `git stash` that the new check fails against the pre-fix code (`expected 88, got 108`) and passes post-fix (900/900).
- All four suites green: `rpg2k_scene_check.rb` (900 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_