### PR TITLE
Remove dead no-effect message code from item/skill special branches

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4316,6 +4316,60 @@ The work below is roughly ordered by the critical path to a walkable game
   switch and closes the whole menu stack with no message), both confirmed
   to fail against the pre-fix code (`NoMethodError: undefined method
   'use_special_switch_item'` / `expected true, got false`).
+  ✅ **Follow-up (2026-08-22): the "no confirmation message" fact this whole
+  passage's fixes rest on had never actually been checked against a genuine
+  RPG_RT.exe — every citation above is EasyRPG Player's own C++ source,
+  mislabeled in a few places as "RPG_RT's own live source" from before this
+  session's methodology change. Directly confirmed now, and the four leftover
+  `show_message("It had no effect.")` calls this same passage's fixes left
+  behind (in `Scene::ItemMenu#apply_switch_item`/`#apply_escape_item`/
+  `#apply_special_switch_item`/`#apply_teleport_item`, plus three siblings in
+  `Scene::SkillMenu#apply_switch_skill`/`#apply_escape_skill`/
+  `#apply_teleport_skill`) removed as dead, self-contradicting code.**
+  Reached a genuine field Item-menu target-confirm screen on a real
+  `RPG_RT.exe` (Nepheshel, wine): loaded a `--map 16 --clear-scene` save (this
+  cycle's own scratch-edit of chunk 109 added a single held Antidote, item
+  #8 — a status-cure medicine with no HP/SP recovery of its own, so using it
+  on a target with none of its six curable states is unconditionally a
+  no-effect use with no other game state to arrange), opened the field menu,
+  Item, the one held item, and Decision on the only party member. Screenshots
+  before and after the Decision press are pixel-identical: no message window
+  appears, the screen stays on the same target-confirm list, and the item's
+  displayed count is unchanged (not consumed) — matching `#apply_item`'s
+  already-implemented Buzzer-only handling exactly. This confirms the
+  no-message behavior on solid ground for the first time, but it also exposed
+  that `#apply_switch_item` and its six siblings above still called
+  `show_message("It had no effect.")` in their own failure branches — code
+  this same passage's history (see `#apply_item`'s citation, added
+  2026-08-20) had already established was wrong for the ordinary medicine/
+  skill case and removed there, but never revisited in these seven
+  special-item/switch/Escape/Teleport siblings, leaving them showing a
+  message the rest of the file had just proven RPG_RT never shows. Every one
+  of these seven branches turns out to be unreachable through ordinary play
+  regardless: `#choose_item`/`#choose_skill` (see the `escape_skill_
+  available?`/`teleport_skill_available?` pre-checks a few paragraphs up, and
+  the plain `it.type == ITEM_SWITCH`/held-item-list membership for the switch
+  case) already buzz-and-return before ever dispatching into a branch whose
+  own use/cast could still fail — so this is dead-code cleanup with no
+  observable behavior change, not a live gameplay fix, and is reported as
+  such rather than as a reachable discrepancy. Fixed by dropping the
+  `show_message` call from all seven (leaving the existing `play_system_se
+  (SFX_BUZZER)` alone), and removing the now-fully-unused `show_message`/
+  `drive_message`/`close_message` methods and `@message` ivar/dispatch from
+  both `item_menu.rb` and `skill_menu.rb` entirely — that machinery only ever
+  existed to serve these calls and (long since removed) the ordinary-case
+  "Used on X."/"casts Y!" success message; nothing else in either file reads
+  or writes `@message`. `#show_message`'s own window (`Window.new(20,
+  SCREEN_H - 40, w, 14 + Window::BORDER * 2)`, uncited, content-sized rather
+  than RPG_RT's real fixed message panel — the exact "inset 10px,
+  content-sized" shape already fixed elsewhere) goes with it rather than
+  being reshaped, since nothing draws it any more. `scripts/rpg2k_scene_
+  check.rb`'s one test that had asserted the opposite ("Scene::ItemMenu: a
+  switch item that consumed nothing reports 'no effect' and leaves the menu
+  open") is rewritten to assert Buzzer-only/no-message instead, confirmed to
+  fail against the pre-fix code (`@message` was truthy). No EasyRPG/Player
+  source was consulted to reach this conclusion — only the screenshots above
+  and reading this codebase's own existing citations for self-contradiction.
   **Dual-wield equipping is done too, the opposite rule to two-handed.** A
   weapon's own *combat* effect (a 二刀流 weapon swinging twice) was read
   already (ADR 0033); what remained was the *actor*-row 二刀流 (`double_hand`,

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -51,13 +51,11 @@ class RPG2k
         @target_lock = nil
         @teleport_index = 0
         @pending_item = nil
-        @message = nil
         build_desc_window
         build_item_window
       end
 
       def dispose
-        close_message
         @desc_window.dispose if @desc_window
         @item_window.dispose if @item_window
         @target_window.dispose if @target_window
@@ -65,7 +63,6 @@ class RPG2k
       end
 
       def update
-        return drive_message if @message
         case @mode
         when :target then update_target
         when :teleport_target then update_teleport_target
@@ -306,10 +303,19 @@ class RPG2k
       # and consumes one -- then closes the whole menu stack at once, the same
       # as a special item invoking Escape or Teleport (RPG_RT never leaves a
       # switch item's user sitting in the item list afterwards, since flipping
-      # a switch is typically what a waiting map event is watching for). No
-      # confirmation message on success, matching that same Escape/Teleport
-      # precedent; a use that consumed nothing (not actually a held switch
-      # item) reports "It had no effect." and stays put instead.
+      # a switch is typically what a waiting map event is watching for). A use
+      # that consumed nothing (not actually a held switch item) plays Buzzer
+      # and stays put, with no message -- see #apply_item's own citation
+      # (confirmed directly against a genuine RPG_RT.exe under wine: a
+      # no-effect Decision on this menu's target/confirm screen shows no
+      # message window at all, just the buzzer, and leaves the screen open)
+      # for why this file no longer fabricates one here either. This branch
+      # is unreachable through ordinary play -- #choose_item only ever
+      # dispatches here for an id already known to be a held switch item
+      # (`it.type == ITEM_SWITCH`, from the held-items list `#items` builds),
+      # so `#use_switch_item`'s own `switch_item?(id) && item_count(id) > 0`
+      # guard can never actually fail -- but it is kept in the same no-message
+      # shape as every reachable sibling below for consistency.
       def apply_switch_item(id)
         sid = @state.party.use_switch_item(id)
         if sid
@@ -317,7 +323,6 @@ class RPG2k
           @parent.pop_to_map
         else
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         end
       end
 
@@ -326,14 +331,16 @@ class RPG2k
       # A successful cast closes the whole menu stack at once, matching
       # Scene::SkillMenu#apply_escape_skill -- there is no field-menu message
       # shown afterwards, since the map that would show it is gone before the
-      # next frame draws.
+      # next frame draws. The failure branch is likewise unreachable in
+      # ordinary play (`#choose_item` already buzzes-and-returns via
+      # `#escape_skill_available?` before ever calling this), kept
+      # message-free for the same reason #apply_switch_item is above.
       def apply_escape_item(id)
         target = @state.party.use_special_escape_item(id, @state.party.leader, @state)
         if target
           queue_teleport(target)
         else
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         end
       end
 
@@ -341,6 +348,7 @@ class RPG2k
       # no confirmation message -- a successful cast closes the whole menu
       # stack at once, matching Scene::SkillMenu#apply_switch_skill (and
       # this scene's own #apply_switch_item, the plain switch-item case).
+      # Failure is unreachable the same way as that sibling.
       def apply_special_switch_item(id)
         switch = @state.party.use_special_switch_item(id, @state.party.leader)
         if switch
@@ -348,19 +356,19 @@ class RPG2k
           @parent.pop_to_map
         else
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         end
       end
 
       # The same for a Teleport-type skill, once a destination is chosen from
-      # the list built by #build_teleport_window.
+      # the list built by #build_teleport_window. Failure is unreachable the
+      # same way #apply_escape_item's is (`#teleport_skill_available?` gates
+      # `#choose_item` first).
       def apply_teleport_item(id, map_id)
         target = @state.party.use_special_teleport_item(id, @state.party.leader, @state, map_id)
         if target
           queue_teleport(target)
         else
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         end
       end
 
@@ -711,29 +719,6 @@ class RPG2k
         end
       end
 
-      def drive_message
-        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        close_message
-      end
-
-      def show_message(text)
-        return if @message
-        w = SCREEN_W - 40
-        win = Window.new(20, SCREEN_H - 40, w, 14 + Window::BORDER * 2)
-        win.z = 500
-        win.windowskin = @skin
-        c = Bitmap.new(w - Window::BORDER * 2, 14)
-        c.font.color = Color.new(255, 255, 255, 255)
-        c.draw_text 0, 0, c.width, 14, text
-        win.contents = c
-        @message = { window: win }
-      end
-
-      def close_message
-        return unless @message
-        @message[:window].dispose
-        @message = nil
-      end
     end
 
   end

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -53,13 +53,11 @@ class RPG2k
         @teleport_index = 0
         @pending_skill = nil
         @mode = :skills          # :skills list, :target selection, or :teleport_target
-        @message = nil
         build_desc_window
         build_skill_window
       end
 
       def dispose
-        close_message
         @desc_window.dispose if @desc_window
         @skill_window.dispose if @skill_window
         @target_window.dispose if @target_window
@@ -67,7 +65,6 @@ class RPG2k
       end
 
       def update
-        return drive_message if @message
         case @mode
         when :target then update_target
         when :teleport_target then update_teleport_target
@@ -286,7 +283,12 @@ class RPG2k
       # no confirmation message at all -- the identical shape as `Type_
       # escape` right below it, not the ordinary target-mode cast's
       # stay-open-and-show-a-message flow (`Algo::IsNormalOrSubskill`'s own
-      # arm, which pushes a `Scene_ActorTarget` instead).
+      # arm, which pushes a `Scene_ActorTarget` instead). The failure branch
+      # is unreachable through ordinary play -- `#choose_skill` already
+      # buzzes-and-returns on an uncastable skill before ever calling this
+      # (see `#apply_skill`'s own citation for the direct-against-RPG_RT
+      # confirmation that a no-effect Decision never shows a message) -- but
+      # it is kept message-free for consistency with every reachable sibling.
       def apply_switch_skill(sid)
         switch = @state.party.cast_switch_skill(caster, sid)
         if switch
@@ -295,7 +297,6 @@ class RPG2k
           @parent.pop_to_map
         else
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         end
       end
 
@@ -393,7 +394,8 @@ class RPG2k
       # picker (see the class comment). A successful cast closes the whole menu
       # stack at once, matching RPG_RT: there is no field-menu message shown
       # afterwards, since the map that would show it is gone before the next
-      # frame draws.
+      # frame draws. Failure is unreachable the same way #apply_switch_skill's
+      # is (`#escape_skill_available?` gates `#choose_skill` first).
       def apply_escape_skill(sid)
         target = @state.party.cast_escape_skill(caster, sid, @state)
         if target
@@ -401,19 +403,18 @@ class RPG2k
           queue_teleport(target)
         else
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         end
       end
 
       # Teleport (type 2), once a destination is chosen from the list built by
-      # #build_teleport_window.
+      # #build_teleport_window. Failure is unreachable the same way
+      # (`#teleport_skill_available?` gates `#choose_skill` first).
       def apply_teleport_skill(sid, map_id)
         target = @state.party.cast_teleport_skill(caster, sid, @state, map_id)
         if target
           queue_teleport(target)
         else
           play_system_se(SFX_BUZZER)
-          show_message("It had no effect.")
         end
       end
 
@@ -641,29 +642,6 @@ class RPG2k
         @teleport_window.cursor_rect = Rect.new(x, y, teleport_col_w, h)
       end
 
-      def drive_message
-        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        close_message
-      end
-
-      def show_message(text)
-        return if @message
-        w = SCREEN_W - 40
-        win = Window.new(20, SCREEN_H - 40, w, 14 + Window::BORDER * 2)
-        win.z = 500
-        win.windowskin = @skin
-        c = Bitmap.new(w - Window::BORDER * 2, 14)
-        c.font.color = Color.new(255, 255, 255, 255)
-        c.draw_text 0, 0, c.width, 14, text
-        win.contents = c
-        @message = { window: win }
-      end
-
-      def close_message
-        return unless @message
-        @message[:window].dispose
-        @message = nil
-      end
     end
 
   end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19232,15 +19232,19 @@ check 'Scene::ItemMenu: a switch item flips its switch, consumes one, and closes
   ok scene.instance_variable_get(:@message).nil?, 'no confirmation message, matching Escape/Teleport'
 end
 
-check 'Scene::ItemMenu: a switch item that consumed nothing reports "no effect" and ' \
-      'leaves the menu open' do
+check 'Scene::ItemMenu: a switch item that consumed nothing plays only Buzzer and ' \
+      'leaves the menu open with no message -- matching a genuine RPG_RT.exe under ' \
+      'wine, which shows no message window at all for a no-effect Decision on this ' \
+      'screen (see #apply_item\'s own citation)' do
   parent = fake_parent(fake_db)
   state = Game::State.new(SwitchItemStubParty.new, 1, 0, 0)
   scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  RGSS::Audio.reset_se
   scene.send(:apply_switch_item, 999) # not a switch item this stub recognises -- #use_switch_item returns nil
   ok state.party.use_switch_item_calls.empty?, 'nothing consumed'
   ok !parent.pop_to_map_called, 'the menu stays open'
-  ok !scene.instance_variable_get(:@message).nil?, 'a message is shown'
+  eq 'Buzzer1', RGSS::Audio.se_calls.last&.first, 'Buzzer plays'
+  ok !scene.instance_variable_get(:@message), 'no message window (the ivar no longer exists at all)'
 end
 
 # A party whose only item is a special (type 9) one invoking an all-ally scope


### PR DESCRIPTION
## Summary

- Confirmed against genuine RPG_RT.exe under wine that a no-effect Decision on the field Item-menu target-confirm screen shows no message window at all (Buzzer only, screen stays open, item not consumed) — matching `Scene::ItemMenu#apply_item`'s already-fixed handling. Reached this via a `--clear-scene` save with a scratch-added single held Antidote (no HP/SP recovery, so using it on a target with none of its curable states is unconditionally a no-effect use); before/after screenshots of the Decision press are pixel-identical.
- This exposed that seven **sibling** branches — `Scene::ItemMenu#apply_switch_item`/`#apply_escape_item`/`#apply_special_switch_item`/`#apply_teleport_item` and `Scene::SkillMenu#apply_switch_skill`/`#apply_escape_skill`/`#apply_teleport_skill` — still called `show_message("It had no effect.")` on failure, the same "inset 10px, content-sized" window anti-pattern already fixed elsewhere in this codebase, and directly contradicting the now-confirmed no-message behavior.
- All seven branches are **unreachable through ordinary play**: `#choose_item`/`#choose_skill` already buzz-and-return (via `escape_skill_available?`/`teleport_skill_available?` pre-checks, or plain item-type/held-item-list membership) before ever dispatching into a call whose own use/cast could still fail. So this is dead-code cleanup with no observable behavior change, not a live gameplay fix — reported as such.
- Dropped the `show_message` calls (Buzzer alone remains) and removed the now-fully-unused `show_message`/`drive_message`/`close_message` methods and `@message` ivar/dispatch from both `item_menu.rb` and `skill_menu.rb` — nothing else in either file reads or writes `@message`.
- No EasyRPG/Player source was consulted to reach this conclusion — only genuine RPG_RT.exe screenshots and reading this codebase's own existing citations for self-contradiction.

## Test plan

- Rewrote the one `scripts/rpg2k_scene_check.rb` check that had asserted the opposite ("a switch item that consumed nothing reports 'no effect' and leaves the menu open") to assert Buzzer-only/no-message instead.
- Confirmed via `git stash` that the rewritten check fails against the pre-fix code (`@message` was truthy) and passes post-fix (900/900).
- All four suites green: `rpg2k_scene_check.rb` (900 checks), `rpg2k_logic_check.rb` (1132 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).
- No changelog fragment — no observable user-facing behavior changed (the removed branches were unreachable dead code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_