### PR TITLE
Draw Save/Load face thumbnails from the title-chunk snapshot

### DIFF
--- a/changelog.d/save-load-face-thumbnail-snapshot.fixed.md
+++ b/changelog.d/save-load-face-thumbnail-snapshot.fixed.md
@@ -1,0 +1,6 @@
+- **Save/Load screen:** the face-thumbnail row now draws from the save's own
+  title-chunk snapshot (taken at save time), matching RPG_RT — previously it
+  re-derived faces from the currently-loaded party's live data, which could
+  disagree with what a real save actually shows. The row is also now
+  flush with the slot box's right edge with no trailing gap, correcting an
+  8px-too-far-left position.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5102,6 +5102,40 @@ The work below is roughly ordered by the critical path to a walkable game
   from their own FaceSet cell at the right position/pitch; a blank-named
   member and a 5th-and-beyond member both draw nothing), both confirmed to
   fail against the pre-fix code before the fix.
+  ✅ **Follow-up (2026-08-22): this whole passage's own citations were
+  EasyRPG Player's C++ source, not genuine RPG_RT — and once actually
+  checked, both the data source and the row's exact position were wrong.**
+  Confirmed directly against a genuine RPG_RT.exe under wine: the file-select
+  screen draws each slot's face row from the *save's own title-chunk
+  snapshot* (chunk 100, fields 21-28 — the same fields `#to_lsd` already
+  wrote at save time but `#from_lsd` never read back), not from whatever the
+  slot's party/actor data says once loaded. A synthetic save whose title
+  chunk pointed all four face fields at an unrelated FaceSet the actual
+  (single-member) party's own actor never carried showed exactly that
+  unrelated FaceSet on the real screen — proving the two are independent,
+  and that `draw_slot_faces` deriving from `state.party.actors` at render
+  time (as the fix above did) was reading the wrong data entirely, live
+  actor state a title-chunk snapshot exists specifically to bypass. The same
+  capture also pixel-measured the row's exact position — four faces at
+  logical x=96/152/208/264, the fourth's right edge landing exactly on the
+  box's own content-edge (312 = 320-8) with **no trailing 8px gap past the
+  last face** — showing the old `inner_w - MAX_SLOT_FACES * FACE_SPACING`
+  right-anchor formula (which reserved a phantom fifth gap) put the whole
+  row 8px too far left. Fixed by adding `Game::State#preview_faces`
+  (`mruby-rpg2k/mrblib/game.rb`) — up to four `[faceset_name, faceset_index]`
+  pairs read from the title chunk's face1-4 fields by `.from_lsd`, nil for a
+  state that never carried one (a Marshal round-trip, which loses nothing
+  and so needs no separate snapshot) — and having `draw_slot_faces`
+  (`mruby-rpg2k/mrblib/scene/save_load.rb`) prefer it, falling back to
+  deriving from live party members only when nil; the right-anchor formula
+  is now `inner_w - ((MAX_SLOT_FACES - 1) * FACE_SPACING + FACE_SIZE)`,
+  flush with no trailing gap. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (a deliberately-mismatched `preview_faces` overrides the live
+  party's own faceset data) and a new `scripts/rpg2k_logic_check.rb` check
+  (`to_lsd`/`from_lsd` round-trips the snapshot independent of actor data; a
+  party with no FaceSet set round-trips to `nil`, not four blank pairs), plus
+  corrected x-coordinates in the two pre-existing position checks — all
+  confirmed to fail against the pre-fix code before the fix.
   ✅ **Continue could resume with the wrong actor leading the party.**
   Found by comparing against a genuine `RPG_RT.exe` under wine on a real
   Nepheshel save: chunk 109's party list (field 1) named actor 1 ("リト"),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14029,6 +14029,26 @@ module Game
     # inventory chunk (109 fields 32-35).
     attr_accessor :save_count, :battle_count, :win_count, :defeat_count,
                   :escape_count
+    # The file-select screen's own face-thumbnail snapshot (title chunk 100,
+    # fields 21/22..27/28, `LCF::Schema::SAVE_TITLE`'s face1..face4
+    # name/index pairs) -- up to four `[faceset_name, faceset_index]` pairs,
+    # or nil for a state that never carried one (a Marshal round-trip, or a
+    # state built directly rather than loaded from a genuine `.lsd`).
+    # Confirmed against a genuine RPG_RT.exe under wine: the save/load
+    # file-select screen draws each occupied slot's face row from exactly
+    # these title-chunk fields, not from whatever the slot's own party/actor
+    # data says at preview time -- a synthetic save edited so the title
+    # chunk's four face fields point at an unrelated FaceSet the actual
+    # single-member party's own actor never carries showed precisely that
+    # unrelated FaceSet on the real screen. `#to_lsd` already writes this
+    # snapshot from the party's own members at save time (see its own
+    # comment); only the read side was missing. `Scene::SaveLoad
+    # #draw_slot_faces` reads this when present, falling back to deriving
+    # from the live party's own members only when it is nil -- correct for
+    # the Marshal round-trip path, which is not lossy (unlike `.lsd`'s own
+    # per-actor chunk, which has no FaceSet fields at all) and so needs no
+    # separate snapshot.
+    attr_accessor :preview_faces
     # Teleport / Escape skill destinations registered by Set Teleport Target
     # (11810) and Set Escape Target (11830). `teleport_targets` is a hash keyed
     # by map id → `{ x:, y:, switch_id: }`; `escape_target` is nil or one such
@@ -15156,6 +15176,22 @@ module Game
             party.leader.name = nm
           end
         end
+      end
+      if title
+        # The file-select screen's own face-thumbnail snapshot -- see
+        # State#preview_faces. Read straight off the title chunk's four
+        # name/index pairs, each skipped (nil) when its name is blank (an
+        # unfilled slot, e.g. a save written by tooling -- EasyRPG's own F9
+        # debug-menu Save -- that never populates them), the same "blank
+        # name -> no face" rule Scene::SaveLoad#draw_slot_faces already
+        # applies elsewhere.
+        faces = [[title.face1_name, title.face1_index],
+                 [title.face2_name, title.face2_index],
+                 [title.face3_name, title.face3_index],
+                 [title.face4_name, title.face4_index]].map do |name, index|
+          name && !name.empty? ? [name, index] : nil
+        end
+        state.preview_faces = faces if faces.any?
       end
       # Chunk 102 is the screen tint transition; only #restore_tint's tint
       # sub-fields are modelled here (see #to_lsd's own comment on chunk 102

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -52,11 +52,11 @@ class RPG2k
       # already matches this exactly, which is why a slot box fits one row
       # of faces with no extra vertical space to spare.
       FACE_SIZE = 48
-      # EasyRPG's Window_SaveFile lays its four face slots out at
-      # `cx = 92 + i * 56` (Window_Base::DrawFace, 8px of gap past each
-      # 48px cell) -- this screen's own box is a different width, so the
-      # row is anchored to the box's own right edge instead of reusing that
-      # absolute offset, keeping the 56px pitch between slots.
+      # The 56px pitch between face slots (48px cell + 8px gap) -- confirmed
+      # against a genuine RPG_RT.exe under wine: a synthetic save whose title
+      # chunk pointed all four face slots at the same FaceSet sheet at
+      # indices 0-3 showed them at x=96/152/208/264 (logical, i.e. screen
+      # pixels) on the real screen, an exact 56px stride.
       FACE_SPACING = 56
       MAX_SLOT_FACES = 4
 
@@ -374,7 +374,7 @@ class RPG2k
           draw_system_text c, 0, LINE_H, inner_w, LINE_H, name, @skin
           rpg2003 = state.party.respond_to?(:rpg2003?) && state.party.rpg2003?
           draw_level_hp(c, LINE_H * 2, level, hp, rpg2003)
-          draw_slot_faces(c, inner_w, state.party.actors)
+          draw_slot_faces(c, inner_w, state)
         end
         win.contents = c
         win.cursor_rect = if slot_index == @index
@@ -414,20 +414,42 @@ class RPG2k
       end
 
       # Up to `MAX_SLOT_FACES` party face thumbnails, right-anchored within
-      # the slot box, one member per slot in seat order (`actors[0..3]`, the
-      # same per-member order `Game::State#to_lsd` already writes them in).
-      # A member with no FaceSet set (a blank name) simply leaves its slot
-      # empty, matching `#draw_message_face`'s own "blank name -> no face"
-      # rule (`Scene::Map#load_face_bitmap`).
-      def draw_slot_faces(c, inner_w, actors)
-        start_x = inner_w - MAX_SLOT_FACES * FACE_SPACING
-        actors.first(MAX_SLOT_FACES).each_with_index do |actor, i|
-          name = actor.respond_to?(:faceset_name) ? actor.faceset_name : nil
+      # the slot box, at the same 56px pitch in seat order, flush against the
+      # box's own right edge -- the last face's right edge lands exactly on
+      # `inner_w`, with no trailing 56-48=8px gap past it (unlike the gap
+      # between each pair of faces). Confirmed against a genuine RPG_RT.exe
+      # under wine: a synthetic save's four same-sheet faces measured at
+      # x=96/152/208/264 on the real screen, landing the fourth face's right
+      # edge (264+48) exactly on this screen's own 312 = 320-8 content
+      # boundary -- `inner_w - MAX_SLOT_FACES * FACE_SPACING` (this file's
+      # prior formula) instead reserved a phantom fifth gap after the last
+      # face, measurably landing the whole row 8px too far left (x=88 instead
+      # of 96, confirmed against our own engine's screenshot of the same
+      # save before this fix).
+      #
+      # The real screen also draws this row from the save's own title-chunk
+      # snapshot (`Game::State#preview_faces`, see its own citation), not
+      # from whatever the slot's party/actor data says -- so that is tried
+      # first, falling back to deriving from the live party's own members
+      # (`actors[0..3]`, the same per-member order `Game::State#to_lsd`
+      # writes the snapshot in) only when a state never carried one (the
+      # Marshal round-trip path, which loses nothing and so never needs the
+      # snapshot). A blank name -- no FaceSet set, or a snapshot slot the
+      # save left empty -- simply leaves that slot empty, matching
+      # `#draw_message_face`'s own "blank name -> no face" rule
+      # (`Scene::Map#load_face_bitmap`).
+      def draw_slot_faces(c, inner_w, state)
+        pairs = state.respond_to?(:preview_faces) ? state.preview_faces : nil
+        pairs ||= state.party.actors.first(MAX_SLOT_FACES).map do |actor|
+          [actor.respond_to?(:faceset_name) ? actor.faceset_name : nil,
+           actor.respond_to?(:faceset_index) ? actor.faceset_index : 0]
+        end
+        start_x = inner_w - ((MAX_SLOT_FACES - 1) * FACE_SPACING + FACE_SIZE)
+        pairs.first(MAX_SLOT_FACES).each_with_index do |(name, index), i|
           next if name.nil? || name.empty?
           sheet = load_face_bitmap(name)
           next unless sheet
-          index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
-          cell = build_face_cell(sheet, index)
+          cell = build_face_cell(sheet, index || 0)
           c.blt start_x + i * FACE_SPACING, 0, cell, Rect.new(0, 0, FACE_SIZE, FACE_SIZE)
         end
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4186,6 +4186,51 @@ check 'to_lsd/from_lsd leaves an actor untouched by either command exactly ' \
   eq false, restored.battle_commands_changed?
 end
 
+check 'to_lsd/from_lsd round-trips the file-select screen\'s face-thumbnail ' \
+      'snapshot (State#preview_faces), independent of the loaded actors\' own data' do
+  # Confirmed against a genuine RPG_RT.exe under wine: the save/load
+  # file-select screen draws its face row from the save's title chunk (100,
+  # fields 21/22..27/28) verbatim, not from whatever the party/actor data
+  # says once loaded -- a synthetic save whose title chunk pointed at an
+  # unrelated FaceSet showed exactly that FaceSet, even though the save's
+  # own (single-member) party's actor carried no matching data at all. This
+  # loads chunk 108 (SAVE_PARTY_ACTOR) into fresh actors that have never had
+  # #set_faceset called -- as a genuine `.lsd` load always does, since that
+  # chunk has no FaceSet field of its own (see SAVE_PARTY_ACTOR's schema) --
+  # so a `round.preview_faces` that matched party data instead of the title
+  # chunk's own snapshot would prove this regressed back to deriving live.
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
+    2 => FakePlayerRow.new('Ally', '', 0, 3, max_hp: 50, max_mp: 20, atk: 6, def: 5),
+  }
+  db = FakeActorDB.new(players, [1])
+  party = Game::Party.new(db)
+  party.add_actor(2)
+  st = Game::State.new(party, 1, 0, 0)
+  st.party.leader.set_faceset('LeaderFace', 1)
+  st.party.actor_by_id(2).set_faceset('AllyFace', 2)
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq [['LeaderFace', 1], ['AllyFace', 2], nil, nil], round.preview_faces,
+     'both members\' faceset name/index round-trip via the title chunk\'s four ' \
+     'face slots, the unused two staying nil'
+
+  # A save whose party never had a FaceSet at all (e.g. every fixture used
+  # elsewhere in this file) writes an all-blank snapshot, and #from_lsd
+  # leaves State#preview_faces nil for one rather than a row of four nils --
+  # Scene::SaveLoad#draw_slot_faces then falls back to deriving from the
+  # live party, still correct for a state that never had a snapshot to give.
+  no_face_players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  no_face_db = FakeActorDB.new(no_face_players, [1])
+  no_face_st = Game::State.new(Game::Party.new(no_face_db), 1, 0, 0)
+  no_face_round = Game::State.from_lsd(no_face_db, no_face_st.to_lsd)
+  ok no_face_round.preview_faces.nil?,
+     'a party with no FaceSet set writes an all-blank snapshot, read back as nil ' \
+     "(got #{no_face_round.preview_faces.inspect})"
+end
+
 check 'to_lsd/from_lsd round-trips a Change Class back to "no class" (id 0)' do
   actor_curve = []
   3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18617,18 +18617,43 @@ check 'Scene::SaveLoad: an occupied slot draws each party member\'s own face thu
   eq 2, calls.length, 'one face thumbnail blitted per party member'
 
   x0, y0, cell0, rect0 = calls[0]
-  eq [80, 0, 0, 0, 48, 48], [x0, y0, rect0.x, rect0.y, rect0.width, rect0.height],
-     'first member lands at the box\'s own right-anchored start (304 - 4*56)'
+  eq [88, 0, 0, 0, 48, 48], [x0, y0, rect0.x, rect0.y, rect0.width, rect0.height],
+     'first member lands at the box\'s own right-anchored start ' \
+     '(304 - (3*56 + 48), flush with no trailing gap past the last face)'
   eq [[0, 0, 96, 0, 48, 48]],
      cell0.blt_calls.map { |cx, cy, _s, r| [cx, cy, r.x, r.y, r.width, r.height] },
      'cropped straight from Faces1 cell 2 (x=96,y=0), no scaling'
 
   x1, y1, cell1, rect1 = calls[1]
-  eq [136, 0, 0, 0, 48, 48], [x1, y1, rect1.x, rect1.y, rect1.width, rect1.height],
+  eq [144, 0, 0, 0, 48, 48], [x1, y1, rect1.x, rect1.y, rect1.width, rect1.height],
      'second member sits one 56px pitch to the right of the first'
   eq [[0, 0, 48, 48, 48, 48]],
      cell1.blt_calls.map { |cx, cy, _s, r| [cx, cy, r.x, r.y, r.width, r.height] },
      'cropped from Faces2 cell 5 (x=48,y=48), the sheet\'s second row'
+end
+
+check 'Scene::SaveLoad: State#preview_faces, when set, is drawn instead of the live ' \
+      'party\'s own faceset data' do
+  # Confirmed against a genuine RPG_RT.exe under wine (see State#preview_faces'
+  # own citation): the real file-select screen draws this row from the save's
+  # title-chunk snapshot, not from whatever the party/actor data says once
+  # loaded. Deliberately setting the two disagree proves the snapshot wins.
+  st = wrap_menu_state
+  st.party.actors[0].faceset_name = 'ActorFace'
+  st.party.actors[0].faceset_index = 0
+  st.party.leader = st.party.actors.first
+  st.preview_faces = [['SnapshotFace', 3], nil, nil, nil]
+  parent = fake_parent(fake_db)
+  parent.save_states[1] = st
+  scene, = save_load_scene(:load, nil, fake_db, parent: parent)
+  contents = scene.instance_variable_get(:@slot_windows)[0].contents
+  calls = contents.blt_calls
+  eq 1, calls.length, 'one thumbnail, from the snapshot\'s single non-nil slot'
+  cell = calls[0][2]
+  eq [[0, 0, 144, 0, 48, 48]],
+     cell.blt_calls.map { |cx, cy, _s, r| [cx, cy, r.x, r.y, r.width, r.height] },
+     'cropped from SnapshotFace cell 3 (x=144,y=0), not ActorFace -- the ' \
+     'snapshot overrides the live actor\'s own faceset entirely'
 end
 
 check 'Scene::SaveLoad: a member with no FaceSet draws no thumbnail; only the first four ' \


### PR DESCRIPTION
## Summary

- RPG_RT's file-select screen draws each slot's face-thumbnail row from the **save's own title-chunk snapshot** (chunk 100, fields 21-28), never from whatever the loaded party's live actor data says. Confirmed against genuine RPG_RT.exe under wine: a synthetic save whose title chunk pointed all four face fields at an unrelated FaceSet the actual (single-member) party's own actor never carried showed exactly that unrelated FaceSet on the real screen — proving the two are independent.
- `Game::State#to_lsd` already wrote this snapshot at save time; `#from_lsd` never read it back, so `Scene::SaveLoad#draw_slot_faces` re-derived the row from live `state.party.actors` at render time instead — reading the wrong data entirely.
- The same capture also pixel-measured the row's exact position: four faces at logical x=96/152/208/264, the fourth's right edge landing exactly on the box's content edge (312 = 320-8) with **no trailing gap** past the last face. The old `inner_w - MAX_SLOT_FACES * FACE_SPACING` formula reserved a phantom fifth gap, landing the whole row 8px too far left.
- Fixed by adding `Game::State#preview_faces` (read from the title chunk by `.from_lsd`, nil for a Marshal round-trip which loses nothing and needs no snapshot), having `draw_slot_faces` prefer it and fall back to deriving from live party members only when nil, and correcting the right-anchor formula to `inner_w - ((MAX_SLOT_FACES - 1) * FACE_SPACING + FACE_SIZE)`.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine (EasyRPG Player's binary was used only as an established tool to produce byte-real `.lsd` save bytes to edit, per this project's existing `gen-lcf-save-wine.bash` convention, never consulted for behavior).

## Test plan

- New `scripts/rpg2k_logic_check.rb` check: `to_lsd`/`from_lsd` round-trips `preview_faces` independent of loaded actor data; a party with no FaceSet set round-trips to `nil`, not four blank pairs.
- New `scripts/rpg2k_scene_check.rb` check: a deliberately-mismatched `preview_faces` overrides the live party's own faceset data when drawing.
- Corrected x-coordinates in the two pre-existing face-position checks to match the fixed formula.
- Confirmed via `git stash` that all new/updated checks fail against the pre-fix code (2 scene checks + 1 logic check) and pass post-fix.
- All four suites green: `rpg2k_scene_check.rb` (901 checks), `rpg2k_logic_check.rb` (1133 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_