### PR TITLE
Draw Save/Load Lv/HP from the title-chunk snapshot too

### DIFF
--- a/changelog.d/save-load-level-hp-snapshot.fixed.md
+++ b/changelog.d/save-load-level-hp-snapshot.fixed.md
@@ -1,0 +1,4 @@
+- **Save/Load screen:** the Lv/HP line now draws from the save's own
+  title-chunk snapshot (taken at save time), matching RPG_RT — previously
+  it re-derived level/HP from the currently-loaded leader's live data,
+  the same class of bug already fixed for the face-thumbnail row.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5136,6 +5136,35 @@ The work below is roughly ordered by the critical path to a walkable game
   party with no FaceSet set round-trips to `nil`, not four blank pairs), plus
   corrected x-coordinates in the two pre-existing position checks — all
   confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (cycle #120): the same live-vs-snapshot gap existed for the
+  file-select screen's Lv/HP line, not just its face row.** The face-thumbnail
+  fix above flagged this as worth checking; it was. Confirmed against a
+  genuine RPG_RT.exe under wine: a synthetic Save01.lsd whose title chunk
+  (chunk 100, fields 12/13, `hero_level`/`hero_hp`) was edited to 7/321 while
+  leaving the leader's own live actor entry (chunk 108) at its real 50/600
+  showed **"LV 7  HP 321"** on the real file-select screen — proving
+  `Window_SaveFile` draws this pair from the title chunk directly too, never
+  from any Actor object, the same architecture as the face row.
+  `Scene::SaveLoad#draw_slot_box` (`mruby-rpg2k/mrblib/scene/save_load.rb`)
+  was still reading `state.party.leader.level`/`.hp` (the live actor) for
+  this line. `Game::State#to_lsd` already wrote `hero_level`/`hero_hp` from
+  the leader's own level/hp at save time; `#from_lsd` never read them back.
+  Fixed by adding `Game::State#preview_level`/`#preview_hp`
+  (`mruby-rpg2k/mrblib/game.rb`), populated by `.from_lsd` from the title
+  chunk's fields 12/13 (nil for a state that never carried one, e.g. a
+  Marshal round-trip), and having `draw_slot_box` prefer them, falling back
+  to the live leader's own level/hp only when nil — the same snapshot-first,
+  live-fallback shape `draw_slot_faces` already uses. (The leader's *name*
+  needed no equivalent snapshot: the promotion fix directly below already
+  guarantees `party.leader.name` agrees with `title.hero_name` one way or
+  another, but there is no equivalent stat-sync step for level/hp, so this
+  build should not have implicitly relied on one either.) Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (`to_lsd`/`from_lsd` round-trips the
+  snapshot, staying independent of a subsequent live mutation to the same
+  actor) and a new `scripts/rpg2k_scene_check.rb` check (a deliberately-
+  mismatched `preview_level`/`preview_hp` overrides the live leader's own
+  level/hp in the drawn text) — both confirmed to fail against the pre-fix
+  code before the fix.
   ✅ **Continue could resume with the wrong actor leading the party.**
   Found by comparing against a genuine `RPG_RT.exe` under wine on a real
   Nepheshel save: chunk 109's party list (field 1) named actor 1 ("リト"),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14049,6 +14049,22 @@ module Game
     # per-actor chunk, which has no FaceSet fields at all) and so needs no
     # separate snapshot.
     attr_accessor :preview_faces
+    # The file-select screen's own level/HP snapshot (title chunk 100, fields
+    # 12/13, `hero_level`/`hero_hp`) -- nil for a state that never carried one
+    # (a Marshal round-trip, or a state built directly rather than loaded from
+    # a genuine `.lsd`). Confirmed against a genuine RPG_RT.exe under wine
+    # exactly like `#preview_faces` above: a synthetic save whose title chunk
+    # was edited to a level/HP the party leader's own live actor data (chunk
+    # 108) never carried (7/321 against a live 50/600) showed precisely the
+    # edited 7/321 on the real file-select screen, proving `Window_SaveFile`
+    # draws this pair from the title chunk directly, never from any Actor
+    # object. `#to_lsd` already writes this snapshot from the leader's own
+    # level/hp at save time (see its own comment); only the read side was
+    # missing. `Scene::SaveLoad#draw_level_hp` reads this when present,
+    # falling back to the live leader's own level/hp only when it is nil --
+    # correct for the Marshal round-trip path, which is not lossy and so
+    # needs no separate snapshot.
+    attr_accessor :preview_level, :preview_hp
     # Teleport / Escape skill destinations registered by Set Teleport Target
     # (11810) and Set Escape Target (11830). `teleport_targets` is a hash keyed
     # by map id → `{ x:, y:, switch_id: }`; `escape_target` is nil or one such
@@ -15192,6 +15208,16 @@ module Game
           name && !name.empty? ? [name, index] : nil
         end
         state.preview_faces = faces if faces.any?
+        # The level/HP pair the file-select screen actually draws -- see
+        # State#preview_level/#preview_hp. Independently nil-checked (unlike
+        # the name promotion above, which already guarantees party.leader.name
+        # matches title.hero_name one way or another) because there is no
+        # equivalent stat-sync step for level/hp: the promoted leader's own
+        # chunk-108 entry happens to agree in every genuine save this codebase
+        # has seen, but RPG_RT itself never reads that entry for this screen
+        # at all, so this build should not either.
+        state.preview_level = title.hero_level unless title.hero_level.nil?
+        state.preview_hp = title.hero_hp unless title.hero_hp.nil?
       end
       # Chunk 102 is the screen tint transition; only #restore_tint's tint
       # sub-fields are modelled here (see #to_lsd's own comment on chunk 102

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -369,8 +369,15 @@ class RPG2k
         if state
           leader = state.party.leader
           name = leader ? leader.name.to_s : ''
-          level = leader ? leader.level : 0
-          hp = leader ? leader.hp : 0
+          # The title-chunk snapshot (`State#preview_level`/`#preview_hp`,
+          # see its own citation) when the save carries one, falling back to
+          # the live leader's own level/hp only for a state that never had a
+          # snapshot to read (the Marshal round-trip path) -- the same
+          # snapshot-first, live-fallback shape `#draw_slot_faces` already
+          # uses for the face row below.
+          has_preview = state.respond_to?(:preview_level) && !state.preview_level.nil?
+          level = has_preview ? state.preview_level : (leader ? leader.level : 0)
+          hp = has_preview ? state.preview_hp : (leader ? leader.hp : 0)
           draw_system_text c, 0, LINE_H, inner_w, LINE_H, name, @skin
           rpg2003 = state.party.respond_to?(:rpg2003?) && state.party.rpg2003?
           draw_level_hp(c, LINE_H * 2, level, hp, rpg2003)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4231,6 +4231,37 @@ check 'to_lsd/from_lsd round-trips the file-select screen\'s face-thumbnail ' \
      "(got #{no_face_round.preview_faces.inspect})"
 end
 
+check 'to_lsd/from_lsd round-trips the file-select screen\'s level/HP snapshot ' \
+      '(State#preview_level/#preview_hp), independent of the loaded actor\'s own data' do
+  # Confirmed against a genuine RPG_RT.exe under wine: a synthetic save whose
+  # title chunk (100, fields 12/13) was edited to a level/HP (7/321) the
+  # party leader's own live actor data (chunk 108) never carried (50/600)
+  # showed exactly 7/321 on the real file-select screen -- Window_SaveFile
+  # draws this pair from the title chunk directly, never from any Actor
+  # object. #to_lsd already writes hero_level/hero_hp from the leader's own
+  # level/hp at save time; this proves #from_lsd reads them back into their
+  # own snapshot fields rather than leaving the screen to re-derive from
+  # whatever the loaded actor says.
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 12, max_hp: 250, max_mp: 30,
+                                     atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.leader.hp = 111
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq 12, round.preview_level, 'the leader\'s level round-trips via the title chunk'
+  eq 111, round.preview_hp, 'the leader\'s (non-max) hp round-trips via the title chunk'
+
+  # The snapshot has to stay independent of the loaded actor once read back --
+  # mutating the live actor afterwards (as further gameplay in a resumed game
+  # would) must not retroactively change what the title chunk itself cached,
+  # or a subsequent file-select redraw of an *unrelated* slot sharing this
+  # State object would show the wrong number.
+  round.party.leader.hp = 1
+  eq 111, round.preview_hp,
+     'the preview snapshot does not alias the live actor\'s own hp'
+end
+
 check 'to_lsd/from_lsd round-trips a Change Class back to "no class" (id 0)' do
   actor_curve = []
   3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18656,6 +18656,28 @@ check 'Scene::SaveLoad: State#preview_faces, when set, is drawn instead of the l
      'snapshot overrides the live actor\'s own faceset entirely'
 end
 
+check 'Scene::SaveLoad: State#preview_level/#preview_hp, when set, are drawn instead of ' \
+      'the live leader\'s own level/hp' do
+  # Confirmed against a genuine RPG_RT.exe under wine (see State#preview_level's
+  # own citation): the real file-select screen draws Lv/HP from the save's
+  # title-chunk snapshot, not from whatever the leader's live actor data says
+  # once loaded. Deliberately setting the two to disagree proves the snapshot
+  # wins, the same shape the sibling preview_faces check above already proves
+  # for the face row.
+  st = menu_state
+  st.party.leader = st.party.actors.first # live: Lv5, 80 HP (MenuStubActor)
+  st.preview_level = 42
+  st.preview_hp = 777
+  parent = fake_parent(fake_db)
+  parent.save_states[1] = st
+  scene, = save_load_scene(:load, nil, fake_db, parent: parent)
+  texts = window_texts(scene.instance_variable_get(:@slot_windows)[0])
+  ok texts.include?('42'), 'the level drawn is the snapshot\'s 42, not the live actor\'s 5'
+  ok texts.include?('777'), 'the HP drawn is the snapshot\'s 777, not the live actor\'s 80'
+  ok !texts.any? { |t| t == ' 5' }, 'the live actor\'s own level does not leak through'
+  ok !texts.any? { |t| t == ' 80' }, 'the live actor\'s own hp does not leak through'
+end
+
 check 'Scene::SaveLoad: a member with no FaceSet draws no thumbnail; only the first four ' \
       'members ever draw one' do
   st = wrap_menu_state


### PR DESCRIPTION
## Summary

- Direct follow-up to the cycle #119 face-thumbnail fix's own note that other file-select-screen displays might have the same live-vs-snapshot gap. RPG_RT's file-select screen draws the Lv/HP line from the save's own title-chunk snapshot (chunk 100, fields 12/13, `hero_level`/`hero_hp`), not from the loaded party leader's live actor data (chunk 108).
- Confirmed against genuine RPG_RT.exe under wine: a synthetic save whose title chunk was edited to 7/321 while leaving the leader's own live actor entry untouched at its real 50/600 showed **"LV 7  HP 321"** on the real file-select screen — proving `Window_SaveFile` draws this pair from the title chunk directly, never from any Actor object.
- `Scene::SaveLoad#draw_slot_box` was still reading `state.party.leader.level`/`.hp` — live actor data. `Game::State#to_lsd` already wrote `hero_level`/`hero_hp` from the leader's own level/hp at save time; `#from_lsd` never read them back.
- Fixed by adding `Game::State#preview_level`/`#preview_hp`, populated by `.from_lsd` from the title chunk (nil for a Marshal round-trip, which needs no separate snapshot), and having `draw_slot_box` prefer them — the same snapshot-first, live-fallback shape `draw_slot_faces` already uses from #119.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- New `scripts/rpg2k_logic_check.rb` check: `to_lsd`/`from_lsd` round-trips the snapshot, and confirms it stays independent of a subsequent live mutation to the same actor object.
- New `scripts/rpg2k_scene_check.rb` check: a deliberately-mismatched `preview_level`/`preview_hp` overrides the live leader's own level/hp in the drawn text.
- Confirmed via `git stash` that both new checks fail against the pre-fix code and pass post-fix.
- All four suites green: `rpg2k_scene_check.rb` (902 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_