### PR TITLE
Independently re-verify Equip menu solo-party RIGHT/LEFT no-op

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6255,6 +6255,41 @@ The work below is roughly ordered by the critical path to a walkable game
   Right/Left neither move `@actor_index` nor play the cursor SE),
   confirmed to fail against the pre-fix code (`expected [], got
   [["Cursor1", ...]]`).
+  ✅ **Follow-up (cycle #121, 2026-08-22): `equip_menu.rb`'s solo-party
+  RIGHT/LEFT no-op, above, was independently re-verified against a genuine
+  RPG_RT.exe under wine — confirmed correct, no code change.** Every bullet
+  in this whole cluster (this one, `status_menu.rb`'s twin below, and the
+  discrete-vs-repeat finding further up) was checked only against EasyRPG
+  Player's own C++ source, never against real RPG_RT, exactly the kind of
+  claim this session's later methodology treats as worth re-checking on its
+  own. Built a synthetic single-actor `Save01.lsd` (デモ用, the existing
+  debug save already used for the file-select-screen investigations)
+  repositioned to a plain already-explored map (`gen-rpg2k-save.rb --map 12
+  --clear-scene`, avoiding the bedroom map's long unskippable narrative) and
+  drove genuine RPG_RT.exe under wine into `Scene_Equip` (Menu -> Equip):
+  with this solo-actor party, a single RIGHT tap immediately followed by a
+  single LEFT tap left the captured frame **pixel-identical** (`compare
+  -fuzz 5%`, 0 differing pixels) to a matched pair of idle frames sampled
+  the same distance apart with no key pressed at all — the only pixel
+  movement anywhere in the whole sequence, on every frame pair regardless of
+  input, was the windowskin's own constant cursor-blink noise floor (a
+  steady 3200px), never a rebuilt panel or a moved actor. Comment on
+  `Scene::EquipMenu#update_slots` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`)
+  updated to record the re-verification rather than just citing EasyRPG,
+  mirroring the `ARROW_BLINK_FRAMES` precedent. **Left open, not chased
+  further this cycle**: (a) `status_menu.rb`'s identical claim was not
+  re-run against real RPG_RT — menu navigation landed on an unexpectedly
+  blank-labelled command row this cycle's time budget didn't resolve; (b)
+  the separate, adjacent discrete-vs-repeat claim (does RIGHT/LEFT actually
+  auto-repeat when held, vs. switching once per tap?) needs a **multi**-
+  actor party to observe at all, and every attempt to add a second party
+  member to this exact debug save's chunk 109 party list (even one, e.g.
+  `[15, 1]`, both ids already carrying a chunk 108 record) crashed genuine
+  RPG_RT outright on the very next map load — a real, if narrow, limitation
+  of this specific test save worth remembering before reaching for it again
+  for a multi-actor scenario, not something this cycle chased down further.
+  No fix shipped for either open half, per this session's own "no partial
+  fix for a narrowly-verified case" rule.
   ✅ **`order.rb` (RPG2003's party-reordering screen) next (2026-08-18) —
   back to needing the fix, both of its cursors this time.** Confirmed
   against EasyRPG Player's actual source: `Scene_Order::vUpdate` (`src/

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -118,11 +118,20 @@ class RPG2k
           @slot_index %= @slots.size
           refresh_slot_cursor
           play_system_se(SFX_CURSOR)
-        # A solo party leaves RIGHT/LEFT silent no-ops -- confirmed against
-        # RPG_RT's own live source: `Scene_Equip::UpdateEquipSelection`
-        # (`src/scene_equip.cpp`) gates both branches on `actors.size() >
-        # 1`, not just the trigger itself, so a lone hero's Equip screen
-        # plays no cursor SE and rebuilds nothing on either key.
+        # A solo party leaves RIGHT/LEFT silent no-ops -- this was only ever
+        # cited to EasyRPG's own live source (`Scene_Equip::
+        # UpdateEquipSelection`, `src/scene_equip.cpp`, gating both branches
+        # on `actors.size() > 1`), the exact kind of claim this session's
+        # methodology treats as worth re-checking on its own. Independently
+        # re-verified since (cycle #121) against a genuine RPG_RT.exe under
+        # wine: with a solo-actor party on the real Equip screen, a single
+        # RIGHT tap followed by a single LEFT tap left the captured frame
+        # pixel-identical (0 differing pixels, `compare -fuzz 5%`) to a pair
+        # of idle frames sampled the same distance apart with no key pressed
+        # at all -- the only pixel movement anywhere in the sequence was the
+        # windowskin's own constant cursor-blink noise floor (a steady 3200
+        # px, present between every frame pair regardless of input), not a
+        # rebuilt screen or a moved actor. Confirmed correct; no code change.
         elsif party.size > 1 && Input.trigger?(Input::RIGHT)
           @actor_index += 1
           @actor_index %= party.size


### PR DESCRIPTION
## Summary

- `Scene::EquipMenu#update_slots`'s existing `party.size > 1` gate on RIGHT/LEFT actor-switching was only ever cited to EasyRPG's C++ source (`Scene_Equip::UpdateEquipSelection`), never actually checked against real RPG_RT.
- Confirmed against genuine RPG_RT.exe under wine: with a solo-actor party on the real Equip screen, a captured frame after a RIGHT tap followed by a LEFT tap was pixel-identical (`compare -fuzz 5%`, 0 differing pixels) to a matched pair of idle frames sampled the same distance apart with no key pressed at all — the only pixel movement anywhere in the sequence, regardless of input, was the windowskin's constant cursor-blink noise floor.
- **No behavioral change** — the existing implementation was already correct. Comment rewritten to cite the re-verification instead of EasyRPG source, mirroring the `ARROW_BLINK_FRAMES` precedent from cycle #116.
- Two related claims in the same cluster are documented as explicitly left open, not chased down this cycle: `status_menu.rb`'s identical twin claim, and the separate discrete-vs-repeat question (needs a multi-actor party the available debug save couldn't safely provide — every attempt to add a second party member crashed genuine RPG_RT on the next map load).
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- No code change — comment-only fix. Existing regression coverage (`scripts/rpg2k_scene_check.rb`'s "a solo party leaves Right/Left as silent no-ops" check) already covers this behavior.
- All four suites green: `rpg2k_scene_check.rb` (902 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).
- No changelog fragment — no user-visible behavior changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_