### PR TITLE
Confirm RPG2000 field menu's fixed five-command list against RPG_RT

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6290,6 +6290,52 @@ The work below is roughly ordered by the critical path to a walkable game
   for a multi-actor scenario, not something this cycle chased down further.
   No fix shipped for either open half, per this session's own "no partial
   fix for a narrowly-verified case" rule.
+  ✅ **Follow-up (cycle #122, 2026-08-22): `status_menu.rb`'s solo-party
+  RIGHT/LEFT claim is not merely un-re-run yet — it is structurally
+  unreachable against every genuine RPG_RT ground truth this session has,
+  so it stays permanently unverifiable with current tooling, not a retry
+  target.** Picked back up cycle #121's exact stuck point: navigating a
+  fresh solo-party save (`gen-lcf-save-wine.bash` + `gen-rpg2k-save.rb
+  --map 12 --clear-scene`, party `[1]`) into the field menu under genuine
+  RPG_RT.exe (wine) landed the same way — Down x3 from Item puts the
+  cursor on a row with **no visible text at all**. Stepping through the
+  list one Down at a time (screenshots captured after each) showed this is
+  not a stuck cursor or a missed keypress: the list is exactly **five**
+  rows — Item, Skill, Equip, [blank], a fifth non-blank row — and a fifth
+  Down wraps back to Item, no sixth row to scroll to. A sanity probe on the
+  same save/session (Down x2 to Equip, Return, Return) reached the real
+  Equip screen fine, so Return delivery itself was never the problem.
+  Reading `RPG_RT.ldb` chunk 21 (Term) directly confirmed why: Nepheshel's
+  own `battle_save` term (id 110) is the **empty string**, and `status`
+  (id 118) is too — RPG_RT still draws the Save row, just unlabelled, and
+  there is no Status row to land on at all. The reason: `Scene::Menu::
+  RPG2K_COMMAND_KEYS` (`mruby-rpg2k/mrblib/scene/menu.rb`) is `[:item,
+  :skill, :equip, :save, :end_game]` — RPG2000's field menu is a fixed
+  five-command list with **no Status entry**, full stop; `:status` only
+  ever enters `#build_commands`'s output through `RPG2K3_COMMAND_IDS` when
+  `db.rpg2003?` and the game's own `menu_commands` chunk includes id 5. So
+  for the *only* genuine ground truth this session has (Nepheshel, RPG2000)
+  `Scene::StatusMenu` is never reachable via the field menu at all — the
+  blank row cycle #121 got stuck on **is** Save (with an empty term), not
+  Status. `status_menu.rb`'s own screen only exists for RPG2003, and the
+  one RPG2003 test-bed available (`mtf-meido-action`) has no genuine
+  `RPG_RT.exe`, only EasyRPG's Player.exe, which this session's methodology
+  excludes as ground truth. So there is no available combination of
+  (genuine RPG_RT + a game that actually shows a Status command) to re-run
+  this claim against — closing the loop on why cycle #121 got stuck, not
+  by resolving the navigation, but by showing the target menu row doesn't
+  exist for this game. No code change needed for this specific claim (still
+  correctly un-fixed, pending a real RPG2003 `RPG_RT.exe` becoming
+  available); **what genuinely was EasyRPG-sourced and got fixed instead**:
+  `Scene::Menu::RPG2K_COMMAND_KEYS`'s doc comment (`menu.rb`) and the
+  `scripts/rpg2k_scene_check.rb` check pinning it were both previously
+  cited only to EasyRPG's `Scene_Menu::CreateCommandWindow`; both now cite
+  this cycle's direct RPG_RT confirmation (five rows, wraps at five, Save's
+  own empty term) instead, mirroring the `equip_menu.rb`/
+  `ARROW_BLINK_FRAMES` precedent for re-citing a correct-but-EasyRPG-sourced
+  claim once independently confirmed. The adjacent multi-actor
+  discrete-vs-repeat question from cycle #121 was not chased further this
+  cycle (out of scope once the solo-party half turned out unreachable).
   ✅ **`order.rb` (RPG2003's party-reordering screen) next (2026-08-18) —
   back to needing the fix, both of its cursors this time.** Confirmed
   against EasyRPG Player's actual source: `Scene_Order::vUpdate` (`src/

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -34,11 +34,21 @@ class RPG2k
       LEFT_COLUMN_W = 88
 
       # RPG2000's field menu is a *fixed* five commands with no separate Status
-      # entry -- EasyRPG's `Scene_Menu::CreateCommandWindow`'s `Player::IsRPG2k()`
-      # branch hardcodes exactly Item / Skill / Equipment / Save / Quit
-      # regardless of database content (a per-actor status readout has no
-      # screen of its own in RPG2000; the party list already shown here is
+      # entry regardless of database content (a per-actor status readout has
+      # no screen of its own in RPG2000; the party list already shown here is
       # what stands in for it, and Equip already shows the full stat block).
+      # Independently confirmed against a genuine RPG_RT.exe under wine
+      # (cycle #122): Nepheshel (RPG2000, no `menu_commands` chunk) draws
+      # exactly five command rows for a solo party, wrapping Down from the
+      # fifth back to the first -- Item / Skill / Equip, then a *blank* row
+      # (Nepheshel's own `battle_save` Term, id 110, is the empty string --
+      # confirmed by reading `RPG_RT.ldb` chunk 21 directly -- yet RPG_RT
+      # still draws the row, just with no label, so Save is unconditionally
+      # present, only its text is missing) and a fifth non-blank row (End
+      # Game). No sixth row exists to scroll to. This was previously cited
+      # only to EasyRPG's `Scene_Menu::CreateCommandWindow`'s
+      # `Player::IsRPG2k()` branch (Item/Skill/Equipment/Save/Quit,
+      # unconditional); that reference is now redundant, not load-bearing.
       # RPG2003 replaces this fixed list with the System database's own
       # customizable one -- see RPG2K3_COMMAND_IDS below -- so this constant
       # is the RPG2000 (and RPG2003-without-a-menu_commands-chunk) default.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17829,11 +17829,13 @@ end
 
 check 'Scene::Menu: choosing Item pushes Scene::ItemMenu directly' do
   # RPG2K_COMMAND_KEYS order is Item, Skill, Equip, Save, End Game -- RPG2000
-  # has no Status entry at all (see Scene::Menu's own doc comment, ported from
-  # EasyRPG's Scene_Menu::CreateCommandWindow). Item acts on one confirm,
-  # unlike Skill/Equip/Status below, which hand focus to the party-status
-  # panel first -- confirm Item actually reaches Scene::ItemMenu rather than
-  # falling into the generic "not implemented yet" message.
+  # has no Status entry at all (see Scene::Menu's own doc comment, now
+  # independently confirmed against a genuine RPG_RT.exe under wine, cycle
+  # #122: Nepheshel draws exactly these five rows, wrapping Down from the
+  # fifth back to the first). Item acts on one confirm, unlike Skill/Equip/
+  # Status below, which hand focus to the party-status panel first --
+  # confirm Item actually reaches Scene::ItemMenu rather than falling into
+  # the generic "not implemented yet" message.
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
   scene.instance_variable_set(:@index, 0)
   RGSS::Input.triggered = [RGSS::Input::C]


### PR DESCRIPTION
## Summary

- Picked up cycle #121's stuck point: navigating a solo-party field menu under genuine RPG_RT.exe (wine) to test `status_menu.rb`'s solo-party RIGHT/LEFT no-op claim landed the cursor on a row with no visible text, three Downs from Item.
- Stepping through the list one Down at a time (screenshots after each) showed this isn't a stuck cursor or missed keypress: RPG_RT draws exactly **five** rows for Nepheshel (RPG2000, no `menu_commands` chunk) — Item, Skill, Equip, a blank row, and a fifth non-blank row — wrapping Down from the fifth back to the first. Reading `RPG_RT.ldb` chunk 21 (Term) directly confirmed the blank row is **Save** with an empty `battle_save` term (id 110): RPG_RT still draws the row unconditionally, just unlabelled.
- This closes the loop on cycle #121's stuck point structurally: the row it hit is Save, not Status, and Status simply isn't reachable in RPG2000's field menu at all (`Scene::Menu::RPG2K_COMMAND_KEYS` is a fixed `[:item, :skill, :equip, :save, :end_game]`; `:status` only enters the list for RPG2003 games with a `menu_commands` chunk including id 5).
- `status_menu.rb`'s own solo-party RIGHT/LEFT claim is therefore **structurally unverifiable** with current tooling — it's RPG2003-only reachable, and the one RPG2003 test-bed available has no genuine RPG_RT.exe. Documented as such rather than left as an ambiguous retry target.
- What genuinely was EasyRPG-sourced and got fixed: `RPG2K_COMMAND_KEYS`'s doc comment and its pinning test comment were both previously cited only to EasyRPG's `Scene_Menu::CreateCommandWindow` — both now cite this cycle's direct RPG_RT confirmation instead, mirroring the `equip_menu.rb`/`ARROW_BLINK_FRAMES` re-citation precedent. **No behavioral change** — the existing five-command list was already correct.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine and reading Nepheshel's own database via this project's LCF parser.

## Test plan

- No code change — comment-only fix. Existing regression coverage (`scripts/rpg2k_scene_check.rb`'s "the main command cursor wraps around" check) already pins the five-command, wrap-at-five shape.
- All four suites green: `rpg2k_scene_check.rb` (902 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).
- No changelog fragment — no user-visible behavior changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_