### PR TITLE
Independently re-verify Save/Load most-recent-slot cursor default

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6336,6 +6336,51 @@ The work below is roughly ordered by the critical path to a walkable game
   claim once independently confirmed. The adjacent multi-actor
   discrete-vs-repeat question from cycle #121 was not chased further this
   cycle (out of scope once the solo-party half turned out unreachable).
+  ✅ **Follow-up (cycle #123, 2026-08-22): `save_load.rb`'s "the file-select
+  cursor opens on whichever slot was saved most recently" claim is now
+  independently confirmed against a genuine RPG_RT.exe, not just EasyRPG's
+  source -- confirmed correct, no code change.** `#initial_index`/
+  `#slot_timestamp` (`mruby-rpg2k/mrblib/scene/save_load.rb`) were fixed
+  back on 2026-08-20 (see the ✅ bullet further down this file, "This screen
+  always opened with the cursor on slot 1...") but cited only EasyRPG's
+  `Scene_File::Start` (`src/scene_file.cpp`), never re-run against real
+  RPG_RT -- exactly the kind of claim this session's methodology treats as
+  worth re-checking on its own. Wrote two title-only `Save<N>.lsd` siblings
+  directly into Nepheshel's own game dir (chunk 100 field 1, `timestamp`,
+  the only field that differs between them; built from a genuine
+  `gen-lcf-save-wine.bash` base save so both round-trip cleanly), then
+  booted real RPG_RT.exe under wine fresh and drove Title -> Down -> Return
+  (Continue) into the file-select screen with neither slot's Return pressed
+  (so no map load, no drift risk). With slot 2 given the larger timestamp,
+  the cursor landed on File 2, not File 1; swapping which slot carried the
+  larger timestamp (re-running with the values exchanged) moved the cursor
+  to File 1 instead -- ruling out "just the highest-numbered occupied slot"
+  as a competing explanation for the first result, since the cursor
+  tracked the timestamp field specifically, through a swap, not slot
+  position. No fix needed. Comments on `#initial_index`
+  (`save_load.rb`) and the matching `scripts/rpg2k_scene_check.rb` check
+  updated to record the re-verification rather than just citing EasyRPG,
+  mirroring the `ARROW_BLINK_FRAMES`/`equip_menu.rb` precedent; the
+  existing check (two title-only `.lsd` siblings with explicit timestamps,
+  asserting `@index`/`@top` land on the newer one, plus a no-saves-at-all
+  case) already covered this and needed no changes, confirmed still passing
+  (902 checks). One dead end chased first and abandoned per this session's
+  own time-boxing rule: an attempt to verify a *different*, adjacent
+  EasyRPG-sourced claim in this same investigation -- `Scene::Menu`'s
+  disabled-Save "buzzer only, no message" branch (`menu.rb`), via an
+  injected autostart Change Save Access (11930) map event -- reproducibly
+  **crashed genuine RPG_RT.exe itself** the instant Escape was pressed to
+  open the field menu afterward (confirmed reproducible twice; confirmed,
+  by a control run with a neutral injected event instead, that it is
+  specific to this command, not "any new event id on this map"; confirmed,
+  by a further control run, that plain movement after the same event runs
+  fine and only opening the menu triggers it). Since this project's own
+  event-command encoder (`LCF.encode_event_commands`) is a generic,
+  already-proven-correct codec shared by every other command (including
+  the ones exercised in this same probe), and this is a real crash in the
+  genuine reference runtime rather than a difference in rendered output,
+  there was no actionable code fix to extract from it -- reported here
+  rather than chased further, and not left as a partially-verified claim.
   ✅ **`order.rb` (RPG2003's party-reordering screen) next (2026-08-18) —
   back to needing the fix, both of its cursors this time.** Confirmed
   against EasyRPG Player's actual source: `Scene_Order::vUpdate` (`src/

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -159,17 +159,23 @@ class RPG2k
       # first slot. `#update` passes `allow_wrap:` true only for the frame a
       # direction is freshly pressed, matching that split exactly.
       # RPG_RT opens this screen with the cursor already on whichever slot
-      # was saved most recently, not always slot 1 -- confirmed against
-      # EasyRPG's own live source: `Scene_File::Start` (`src/scene_file.cpp`)
-      # sets `index = latest_slot; top_index = std::max(0, index - 2);`,
-      # where `latest_slot`/`latest_time` (`UpdateLatestTimestamp`) track
-      # whichever populated slot's `title.timestamp` (chunk 100 field 1) is
-      # the largest, defaulting to slot 0 when no save has one at all.
-      # `Game::State#to_lsd` already writes that exact field into each
-      # slot's exported `Save<N>.lsd` sibling (`title[1] = timestamp.to_f`,
-      # defaulting to the real save-time "now") -- reading it back here is
-      # the same genuine on-disk field RPG_RT itself reads, not a
-      # filesystem-mtime proxy.
+      # was saved most recently, not always slot 1 -- independently
+      # confirmed against a genuine RPG_RT.exe under wine (cycle #123), not
+      # just EasyRPG's source (`Scene_File::Start`, `src/scene_file.cpp`,
+      # whose `index = latest_slot; ...` shape this was originally, and
+      # still correctly, ported from). Two title-only `Save<N>.lsd` siblings
+      # written directly into Nepheshel's game dir, differing only in chunk
+      # 100 field 1 (`title.timestamp`): with slot 2 given the larger value,
+      # a fresh RPG_RT.exe boot -> Continue landed the cursor on File 2, not
+      # File 1; swapping which slot carried the larger timestamp swapped
+      # which slot the cursor landed on too (File 1 the second time) --
+      # ruling out "just the highest-numbered occupied slot" as an
+      # alternative explanation for the first result. `Game::State#to_lsd`
+      # already writes that exact field into each slot's exported
+      # `Save<N>.lsd` sibling (`title[1] = timestamp.to_f`, defaulting to
+      # the real save-time "now") -- reading it back here is the same
+      # genuine on-disk field RPG_RT itself reads, not a filesystem-mtime
+      # proxy.
       def initial_index
         best = 0
         best_time = -Float::INFINITY

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18479,10 +18479,15 @@ def write_title_only_lsd(path, timestamp)
   save.save_to(path)
 end
 
-# Confirmed against RPG_RT's own live source: `Scene_File::Start`
-# (`src/scene_file.cpp`) sets `index = latest_slot; top_index = std::max(0,
-# index - 2);`, tracking whichever populated slot's `title.timestamp` is
-# the largest -- not always slot 1.
+# Independently confirmed against a genuine RPG_RT.exe under wine (cycle
+# #123): two title-only Save<N>.lsd siblings differing only in timestamp,
+# dropped into Nepheshel's own game dir, landed the file-select cursor on
+# whichever slot held the larger one -- and swapping which slot had the
+# larger timestamp swapped which slot the cursor landed on, ruling out "just
+# the highest-numbered occupied slot". Originally ported from EasyRPG's
+# `Scene_File::Start` (`src/scene_file.cpp`, `index = latest_slot;
+# top_index = std::max(0, index - 2);`, tracking whichever populated slot's
+# `title.timestamp` is the largest) -- not always slot 1.
 check 'Scene::SaveLoad opens with the cursor on the most-recently-saved ' \
       'slot, not always the first one' do
   Dir.mktmpdir('rpg2k-save-recency') do |dir|


### PR DESCRIPTION
## Summary

- `Scene::SaveLoad#initial_index`'s existing behavior (the file-select cursor opens on whichever slot has the largest title-chunk `timestamp`, not always slot 1) was only ever cited to EasyRPG's `Scene_File::Start`, never independently re-run against real RPG_RT.
- Confirmed against genuine RPG_RT.exe under wine: two title-only `Save<N>.lsd` siblings differing only in timestamp, dropped into Nepheshel's own game dir. With slot 2 given the larger timestamp, a fresh boot → Continue landed the cursor on File 2; swapping which slot carried the larger timestamp moved the cursor to File 1 instead — ruling out "just the highest-numbered occupied slot" as a coincidental alternative explanation, since the cursor tracked the timestamp field specifically through the swap.
- **No behavioral change** — the existing implementation was already correct. Comments rewritten to cite the re-verification instead of EasyRPG source, mirroring the `ARROW_BLINK_FRAMES`/`equip_menu.rb` precedent.
- A separate dead end was investigated and abandoned: an attempt to verify `Scene::Menu`'s disabled-Save "buzzer only, no message" branch via an injected autostart Change Save Access (11930) map event reproducibly **crashed genuine RPG_RT.exe itself** on menu open (confirmed reproducible, and specific to this command via control runs). Since this is a crash in the reference runtime rather than an observable rendering difference, and this project's event-command encoder is a generic, already-proven codec, there was nothing actionable to extract — documented in `docs/TODO.md`, no fix shipped.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- No code change — comment-only fix. Existing regression coverage (`scripts/rpg2k_scene_check.rb`'s "opens with the cursor on the most-recently-saved slot" check) already covers this behavior.
- All four suites green: `rpg2k_scene_check.rb` (902 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).
- No changelog fragment — no user-visible behavior changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_