### PR TITLE
Accept Cancel on the Game Over screen, same as Decision

### DIFF
--- a/changelog.d/game-over-cancel-dismisses.fixed.md
+++ b/changelog.d/game-over-cancel-dismisses.fixed.md
@@ -1,0 +1,4 @@
+- **Game Over screen:** Cancel now dismisses the screen and returns to the
+  title, same as Decision, matching RPG_RT — previously only Decision
+  worked, the one screen in this codebase that didn't accept Cancel like
+  every other message/choice/menu window does.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6381,6 +6381,47 @@ The work below is roughly ordered by the critical path to a walkable game
   genuine reference runtime rather than a difference in rendered output,
   there was no actionable code fix to extract from it -- reported here
   rather than chased further, and not left as a partially-verified claim.
+  ✅ **Follow-up (cycle #124, 2026-08-22): `game_over.rb`'s "only Decision
+  dismisses the Game Over screen, Cancel does nothing" claim was wrong --
+  real RPG_RT.exe accepts Cancel too, identically to Decision. Fixed.**
+  This was a literal, explicitly-labelled port of EasyRPG's
+  `Scene_Gameover::vUpdate` (src/scene_gameover.cpp), which checks only
+  `Input::IsTriggered(Input::DECISION)` -- exactly the kind of never-
+  re-run-against-real-RPG_RT claim this session's methodology treats as
+  worth checking. Built a synthetic autostart Game Over (12420) map event
+  (the same injection pattern as the `ARROW_BLINK_FRAMES` probe: a bare
+  `{code: 12420}` command list terminated by the mandatory `code 10`
+  BlankLine) on a copy of Nepheshel's map 12, resumed from a genuine save
+  positioned there. Real RPG_RT dropped straight into the Game Over screen
+  as expected. A single, cleanly-isolated Escape press -- sent well after
+  the screen had visibly settled, ruling out the picture's own brief
+  opening fade as a confound -- faded straight to the title screen,
+  pixel-for-pixel the same transition a single Return press produces from
+  the same starting point. **One dead end chased first and ruled out
+  before trusting this result**: an earlier, hastier pair of attempts
+  (two Escape presses in quick succession, both taken right as the screen
+  first appeared) gave inconsistent results run to run -- sometimes
+  reaching the title within ~3s, sometimes not -- which briefly looked
+  like "Cancel needs two presses". Controls ruled that out on both sides:
+  no key at all left the screen static and unchanging for a full 10s (no
+  auto-timeout), and even a *single* Decision press taken right as the
+  screen first appeared also failed to dismiss it within several seconds
+  -- so the flakiness was an artifact of pressing right at scene entry
+  (plausibly a brief window-focus race in this project's own wine test
+  harness immediately after the map-to-Game-Over scene transition, not
+  necessarily a real RPG_RT input lock -- left unresolved, since nailing
+  that down further wasn't needed once testing a single well-timed press
+  of each key gave a clean, unambiguous, reproducible answer for the
+  actual question). Fixed `Scene::GameOver#update`
+  (`mruby-rpg2k/mrblib/scene/game_over.rb`) to also accept
+  `Input.trigger?(Input::B)` (Cancel), matching every other message/
+  choice/menu window in this engine, all of which already accept Cancel.
+  The pre-existing `scripts/rpg2k_scene_check.rb` check that pinned the
+  old (wrong) claim -- "the Cancel button does not dismiss the Game Over
+  screen -- only Decision does" -- is now "the Cancel button dismisses
+  the Game Over screen, same as Decision", asserting both keys return to
+  title from a fresh screen; confirmed to fail against the pre-fix code
+  (`Cancel dismisses this screen too` raised).
   ✅ **`order.rb` (RPG2003's party-reordering screen) next (2026-08-18) —
   back to needing the fix, both of its cursors this time.** Confirmed
   against EasyRPG Player's actual source: `Scene_Order::vUpdate` (`src/

--- a/mruby-rpg2k/mrblib/scene/game_over.rb
+++ b/mruby-rpg2k/mrblib/scene/game_over.rb
@@ -33,28 +33,30 @@ class RPG2k
         play_gameover_bgm
       end
 
-      # A literal port of EasyRPG's `Scene_Gameover::vUpdate`
-      # (src/scene_gameover.cpp): `if (Input::IsTriggered(Input::DECISION))
-      # { Scene::ReturnToTitleScene(); }` -- the whole method, no Cancel
-      # anywhere in the file (unlike the message/choice/menu windows this
-      # screen otherwise resembles, Cancel does not also dismiss it) and no
-      # arming/pending state of any kind. An earlier version here required a
-      # key-released frame before arming, on the theory that the key which
-      # dismissed the battle-defeat result could otherwise skip this screen
-      # in the same frame -- but `RPG2k#show_game_over` swaps `@scenes`
-      # without ever calling `.update` on the new scene itself, so this
-      # screen's first real `#update` always lands on the *next*
-      # `#main_loop` iteration, by which point that iteration's own
-      # `Input.update` has already cleared the old trigger (`@triggered` is
-      # reset at the top of every `Input.update` call, and only a genuine
-      # new key-down event sets it again) -- the scenario the arming gate
-      # defended against cannot occur through this engine's actual update
-      # loop, and the gate itself introduced a real divergence: a player
-      # merely still *holding* Cancel (which does nothing here) when this
-      # screen appears had a fresh Decision press silently ignored until
-      # they let go, something real RPG_RT never does.
+      # Confirmed directly against a genuine RPG_RT.exe under wine (not just
+      # EasyRPG's source, which this was originally ported from and which
+      # claims only Decision dismisses this screen -- `Scene_Gameover::
+      # vUpdate`, src/scene_gameover.cpp): **Cancel dismisses the Game Over
+      # screen too, identically to Decision.** A synthetic autostart Game
+      # Over (12420) map event dropped real RPG_RT.exe onto this screen with
+      # nothing else animating; a single, cleanly-isolated Escape press
+      # (sent well after the screen had settled, ruling out the picture's
+      # own brief opening fade as a confound) faded straight to the title
+      # screen -- pixel-for-pixel the same transition a single Return press
+      # produces from the same starting state. So this screen behaves like
+      # every other message/choice/menu window in offering Cancel as a
+      # second way to back out, not the one exception EasyRPG's source
+      # claimed.
+      #
+      # No arming/pending state of any kind (matching this screen's
+      # pre-existing reasoning for Decision, which still holds): `RPG2k#
+      # show_game_over` swaps `@scenes` without calling `.update` on the new
+      # scene itself, so this screen's first real `#update` always lands on
+      # the *next* `#main_loop` iteration, by which point that iteration's
+      # own `Input.update` has already reset stale triggers from the
+      # previous scene.
       def update
-        return unless Input.trigger?(Input::C)
+        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
         parent.return_to_title
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8057,23 +8057,31 @@ check "Game Over's very first #update already honours a Decision trigger " \
   Input.reset
 end
 
-# Verified against EasyRPG Player's actual C++ source rather than assumed
-# from this screen's own resemblance to a message/choice/menu window (every
-# one of which does accept Cancel): `Scene_Gameover::vUpdate`
-# (src/scene_gameover.cpp) checks only `Input::IsTriggered(Input::DECISION)`
-# -- there is no reference to `Input::CANCEL` anywhere in the file. Pressing
-# Cancel on the real Game Over screen does nothing at all.
-check 'the Cancel button does not dismiss the Game Over screen -- only Decision does' do
+# Confirmed against a genuine RPG_RT.exe under wine (2026-08-22): a
+# synthetic autostart Game Over (12420) map event put both a Decision press
+# and, independently, a Cancel press to the real Game Over screen (each
+# sent well after the screen had settled, past its own opening picture
+# fade), and both alike faded straight to the title screen. This screen
+# behaves like every other message/choice/menu window in this engine
+# (every one of which accepts Cancel as well as Decision) -- unlike what
+# EasyRPG's `Scene_Gameover::vUpdate` (src/scene_gameover.cpp) does, which
+# checks only `Input::IsTriggered(Input::DECISION)`. This check used to
+# pin the EasyRPG-sourced claim ("Cancel does nothing here"); it now pins
+# the confirmed opposite.
+check 'the Cancel button dismisses the Game Over screen, same as Decision' do
   parent = fake_parent(fake_db)
   Input.reset
   scene = RPG2k::Scene::GameOver.new(parent)
   Input.triggered = [Input::B]
   scene.update
-  ok !parent.returned_to_title, 'Cancel is not a dismiss trigger for this screen'
+  ok parent.returned_to_title, 'Cancel dismisses this screen too'
   Input.reset
+
+  parent2 = fake_parent(fake_db)
+  scene2 = RPG2k::Scene::GameOver.new(parent2)
   Input.triggered = [Input::C]
-  scene.update
-  ok parent.returned_to_title, 'Decision still dismisses it, right after'
+  scene2.update
+  ok parent2.returned_to_title, 'Decision still dismisses it too'
   Input.reset
 end
 


### PR DESCRIPTION
## Summary

- `Scene::GameOver#update` (`mruby-rpg2k/mrblib/scene/game_over.rb`) was a literal port of EasyRPG's `Scene_Gameover::vUpdate`, whose comment explicitly claimed only Decision dismisses the screen — "no Cancel anywhere in the file... Cancel does not also dismiss it." Never independently checked against real RPG_RT.
- Confirmed against genuine RPG_RT.exe under wine: a synthetic autostart Game Over (12420) map event dropped real RPG_RT.exe onto this screen with nothing else animating. A single, cleanly-isolated Escape press — sent well after the screen had settled, ruling out its own opening picture fade as a confound — faded straight to the title screen, pixel-for-pixel the same transition a single Return press produces. This screen behaves like every other message/choice/menu window in this engine (all of which already accept Cancel), not the one exception EasyRPG's source claimed.
- An earlier, hastier repro attempt (two rapid Escape presses right at scene entry) gave flaky, inconsistent results — ruled out via controls (no-key-at-all held static; a single Decision press right at entry also failed to dismiss within several seconds) as an artifact of pressing right at the map→GameOver scene transition, not a genuine RPG_RT input-gating difference. Documented honestly in `docs/TODO.md` rather than glossed over.
- Fixed the guard to `Input.trigger?(Input::C) || Input.trigger?(Input::B)`. Comment rewritten to cite the re-verification instead of EasyRPG source.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- Rewrote the pre-existing `scripts/rpg2k_scene_check.rb` check that pinned the old (wrong) claim to assert both Cancel and Decision independently return to title from a fresh screen.
- Confirmed via `git stash` that the rewritten check fails against the pre-fix code and passes post-fix (902/902).
- All four suites green: `rpg2k_scene_check.rb` (902 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_