### PR TITLE
Independently re-verify Enter Hero Name's Cancel/blank-confirm behavior

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5863,6 +5863,32 @@ The work below is roughly ordered by the critical path to a walkable game
   table cell-for-cell; typing the corrected small-tsu and small-wa cells
   produces the right characters; the hiragana page's own "vu" cell is
   katakana ヴ), confirmed to fail against the pre-fix code before the fix.
+  ✅ **Follow-up (cycle #125, 2026-08-23): the two Cancel/blank-confirm
+  claims above — both cited only to EasyRPG's source, one of them
+  mislabeled "RPG_RT's own live source" at the time — are now independently
+  confirmed against a genuine RPG_RT.exe, no code change needed.** Built a
+  synthetic autostart Enter Hero Name (10740, actor 1 "リト", charset
+  0/hiragana) map event on a copy of Nepheshel's map 12, resumed from a
+  genuine save positioned there, under real RPG_RT.exe/wine. On a name
+  reading "リ" (one kana typed), a single Cancel press erased exactly that
+  character down to empty, matching `#name_input_cancel`'s existing branch;
+  a further Cancel press on the now-empty field left the field and the
+  whole screen visibly unchanged (confirmed by the unchanged screenshot,
+  not inferred from silence) — buzzer-only. Separately, navigating straight
+  to the grid's own 決定 (Confirm) cell with nothing typed and pressing
+  Decision left the screen open with the field refilled to the actor's real
+  name ("リト"), matching `#commit_name_input`'s blank branch exactly — it
+  did not resume the event. Comments on both methods
+  (`mruby-rpg2k/mrblib/scene/map.rb`) updated to record the re-verification
+  and stop mislabeling the EasyRPG citation as RPG_RT's own source.
+  **Side finding, not chased further**: charset `2` ("Latin alphabet",
+  offered per `#drive_name_input`'s own comment "for English-patched
+  games") made real RPG_RT.exe hang on a solid-black screen for 20+ seconds
+  (process alive, screen a constant `(0,0,0)`) where charset `0` on the
+  same map/event worked instantly — a genuine, reproducible divergence, but
+  left uninvestigated since it's unclear whether charset 2 is even a
+  legitimate RPG2000 value versus an RPG2003-only extension, and this
+  environment has no genuine RPG_RT2003.exe to settle that distinction.
 - ✅ **The same "silent embedded widget" family, found once more: Open Shop
   and Show Inn played zero sound effects at all (2026-08-18).** Verified
   against RPG_RT's actual behavior via EasyRPG Player's own C++ source,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6123,6 +6123,19 @@ class RPG2k
       # EasyRPG's Scene_Name::vUpdate Cancel branch exactly (`if
       # (name_window->Get().size() > 0) { ...Cancel...; Erase(); } else {
       # ...Buzzer...; }`).
+      #
+      # Independently re-verified since (cycle #125, 2026-08-23) directly
+      # against a genuine RPG_RT.exe under wine, not just EasyRPG's source --
+      # this whole widget was ported from EasyRPG before this project's own
+      # methodology started requiring that (see docs/TODO.md's own account of
+      # cycle #114). A synthetic autostart Enter Hero Name (10740, actor 1,
+      # charset 0/hiragana) map event on a copy of Nepheshel's map 12,
+      # resumed from a genuine save positioned there: on a name reading "リ"
+      # (one kana typed), a single Cancel press erased exactly that one
+      # character down to empty, matching this method's own branch exactly;
+      # a further Cancel press on the now-empty field left the field and the
+      # whole screen visibly unchanged (buzzer-only, confirmed by the
+      # unchanged screenshot, not just inferred from silence).
       def name_input_cancel
         if @name_ui[:name].empty?
           play_system_se(SFX_BUZZER)
@@ -6137,17 +6150,31 @@ class RPG2k
         @name_ui[:kana] ? draw_kana_name_input : draw_name_input
       end
 
-      # A blank confirm does not close the widget -- confirmed against
-      # RPG_RT's own live source: `Scene_Name::vUpdate`'s DONE branch
-      # (`src/scene_name.cpp`) is `if (name_window->Get().empty()) {
-      # name_window->Set(ToString(actor.GetName())); name_window->Refresh();
-      # } else { actor.SetName(...); Scene::Pop(); }` -- an empty typed name
-      # resets the field back to the actor's current name and leaves the
-      # screen open, rather than resuming the event with an empty string.
-      # This check lives in the single shared `vUpdate` (gated only on
-      # which cell was picked), so it applies identically to every keyboard
-      # page -- the kana grid's own :confirm cell routes through this same
-      # method.
+      # A blank confirm does not close the widget -- originally ported from
+      # EasyRPG's `Scene_Name::vUpdate` DONE branch (`src/scene_name.cpp`,
+      # mislabeled "RPG_RT's own live source" at the time this was written,
+      # before this project's own methodology required checking such claims
+      # against the genuine binary -- see docs/TODO.md's cycle #114 account):
+      # `if (name_window->Get().empty()) { name_window->Set(ToString(actor.
+      # GetName())); name_window->Refresh(); } else { actor.SetName(...);
+      # Scene::Pop(); }` -- an empty typed name resets the field back to the
+      # actor's current name and leaves the screen open, rather than
+      # resuming the event with an empty string. This check lives in the
+      # single shared `vUpdate` (gated only on which cell was picked), so it
+      # applies identically to every keyboard page -- the kana grid's own
+      # :confirm cell routes through this same method.
+      #
+      # Independently re-verified since (cycle #125, 2026-08-23) directly
+      # against a genuine RPG_RT.exe under wine: a synthetic autostart Enter
+      # Hero Name (10740, actor 1 "リト", charset 0/hiragana) map event on a
+      # copy of Nepheshel's map 12, resumed from a genuine save positioned
+      # there. Navigated the cursor straight to the grid's own 決定
+      # (Confirm) cell with no character typed (a single Up wraps from the
+      # top-left cell to the confirm row, then Right x7 reaches Confirm --
+      # both screenshotted to confirm the cursor landed where expected) and
+      # pressed Decision: the screen stayed open and the name field filled
+      # with the actor's real name ("リト"), matching this method's blank
+      # branch exactly -- it did not resume the event or leave the screen.
       def commit_name_input
         ui = @name_ui
         if ui[:name].empty?


### PR DESCRIPTION
## Summary

- Two existing claims in `Scene::Map`'s Enter Hero Name widget (`mruby-rpg2k/mrblib/scene/map.rb`) — Cancel erases one character or buzzes on an already-empty field, and a blank Confirm refills the actor's name and leaves the screen open instead of resuming the event with an empty string — were only ever cited to EasyRPG's `Scene_Name::vUpdate` source, one comment mislabeling it as "RPG_RT's own live source."
- Confirmed against genuine RPG_RT.exe under wine: built a synthetic autostart Enter Hero Name (10740) map event on a copy of Nepheshel's map 12, resumed from a genuine save positioned there. On a name reading "リ", a single Cancel press erased that character down to empty; a further Cancel press on the empty field left the field and screen visibly unchanged (buzzer-only). Navigating to the grid's own 決定 (Confirm) cell with nothing typed and pressing Decision left the screen open with the field refilled to the actor's real name — it did not resume the event.
- **Both existing claims held up — no behavioral change.** Comments rewritten to cite the re-verification and stop mislabeling the EasyRPG citation as RPG_RT's own source.
- Side finding, documented but not chased further: charset 2 ("Latin alphabet") hangs real RPG_RT.exe on a solid-black screen — left uninvestigated since it's unclear whether that's even a legitimate RPG2000 value, and this environment has no genuine RPG_RT2003.exe to settle that.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- No code change — comment-only fix. Existing regression coverage (`scripts/rpg2k_scene_check.rb`'s Enter Hero Name checks for both Cancel and blank-confirm) already covers this behavior.
- All four suites green: `rpg2k_scene_check.rb` (902 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).
- No changelog fragment — no user-visible behavior changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_