### PR TITLE
psp: repoint tail calls in psp-fixup-imports, and build MinSizeRel

### DIFF
--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -21,28 +21,26 @@ project(rpg2k_psp C CXX ASM)
 # -O2 -g -DNDEBUG while the `psp` CI job, which runs in a bare pspdev container
 # with no such variable, got an empty build type and therefore no optimisation
 # flags at all. Two different builds of the same commit, neither declared
-# anywhere, and the difference is not cosmetic: at -O2 this EBOOT halts on
-# LVGL's TLSF assert (`!block_is_free(block)` in lv_tlsf_realloc,
-# 3rd/lvgl/src/stdlib/builtin/lv_tlsf.c:1215) during display setup, while the
-# unoptimised build boots to completion. Confirmed by building in the *same*
-# container both ways: only the flag changed, and only the -O2 build asserts.
+# anywhere, which is how an optimisation-dependent failure went unnoticed.
 #
-# So this is deliberately the unoptimised build, plus -g: it is the only
-# configuration proven to reach RPG2K_PSP_MRUBY_OPEN and a running
-# RPG2K_PSP_BRINGUP heartbeat, and while the port is still in bring-up (ADR
-# 0047's P1 is about measuring this target at all) accurate line info and absent
-# inlining are worth more than code size. The cost is measured and affordable:
-# unoptimised .text is ~260 KB larger, against a boot that reports 782 KB heap
-# free, a 256 KB LVGL pool running at 1.4%, and a 256 KB main stack at 6.4%. -g
-# adds no RAM cost -- debug sections are not in a PT_LOAD.
+# MinSizeRel (-Os -DNDEBUG) is the right default for this target: the whole
+# EBOOT is loaded into the console's ~24 MB at launch, so every byte of .text is
+# live RAM, and -Os buys 373 KB against Debug and 118 KB against -O2 here
+# (2095840 / 2477972 / 2217032 bytes of .text respectively), with no behavioural
+# difference measured -- all three reach RPG2K_PSP_GAME_START and hold a
+# RPG2K_PSP_BRINGUP heartbeat.
 #
-# Provisional. Once the -O2 failure is root-caused, MinSizeRel (-Os -DNDEBUG) is
-# the better long-term answer for a target whose whole image is RAM-resident at
-# launch. Override deliberately with -DRPG2K_PSP_BUILD_TYPE=<type>; setting
+# This was pinned to Debug for a while because -O2 halted on LVGL's TLSF assert.
+# That turned out not to be an optimisation bug at all: bug 11 in
+# app/psp/README.md, psp-fixup-imports not repointing tail-call `j`
+# instructions. Optimisation simply emits more tail calls, so it hit more
+# mis-dispatched stubs. With the fix, -O2 and -Os both boot cleanly.
+#
+# Override deliberately with -DRPG2K_PSP_BUILD_TYPE=<type>; setting
 # CMAKE_BUILD_TYPE directly (or via the environment) is intentionally ignored,
 # since that ambient behaviour is the bug this pin exists to prevent.
 set(RPG2K_PSP_BUILD_TYPE
-    "Debug"
+    "MinSizeRel"
     CACHE STRING "Optimisation level for the PSP EBOOT")
 set(CMAKE_BUILD_TYPE
     "${RPG2K_PSP_BUILD_TYPE}"

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -349,7 +349,47 @@ pinned, and the cost is measured and small: unoptimised `.text` is ~260 KB
 larger, against a boot reporting 782 KB heap free, a 256 KB LVGL pool running
 at 1.4%, and a 256 KB main stack at 6.4%.
 
-### Open: a failed file operation on every frame
+### Bug 11: psp-fixup-imports did not repoint tail calls
+
+`psp-fixup-imports` reorders import stubs and repoints the call sites that
+target them, but the patched tool scanned only for `jal`. MIPS has a second
+direct jump, `j`, which the compiler emits for a **tail call** -- any function
+whose last act is calling the import. LVGL's delay hook in
+`mruby-rgss/src/psp.cxx` is exactly that:
+
+```c
+void delay_cb(uint32_t ms) { sceKernelDelayThread(ms * 1000); }
+```
+
+It compiles to a bare `j sceKernelDelayThread` with no `jal` anywhere. This
+EBOOT has **49 such sites against 1642 `jal`s**, and every one was left
+pointing at its pre-reorder address, silently invoking whichever import the
+regroup left sitting there.
+
+The symptom was hard to read because it is layout-dependent. `delay_cb`'s tail
+call landed on `sceIoRemove` in one build and `sceIoDread` in another, so
+LVGL's once-per-frame *timing* call surfaced as a once-per-frame *filesystem*
+syscall with nonsense arguments -- `a0 = 0x4a38`, the 19000us delay
+reinterpreted as a path pointer -- and moved to a different, sometimes fatal,
+syscall whenever unrelated code shifted the binary. Which is also why adding a
+few lines of diagnostics to the guest could turn a working boot into an
+emulator crash, and why this looked for a long time like layout-sensitive
+memory corruption. Nothing was corrupt: the call simply went somewhere else.
+
+What finally identified it was reading the guest's registers at the bad
+syscall rather than reasoning from the call graph. `_unlink` sets `a0 = sp`
+before calling `sceIoRemove`; the live `a0` was `0x00004a38` while `sp` was
+`0x09fbf9a0`, which proved the call never came through `_unlink` at all,
+despite `_unlink` being the only static `jal` to that stub.
+
+Fixed by accepting `MIPS_OP_J` alongside `MIPS_OP_JAL` in
+`patches/psp-fixup-imports-jal-relocation-aware.patch`; the rewrite already
+preserves the opcode field, so a `j` stays a `j`. Verified: `delay_cb`'s tail
+call now resolves to `sceKernelDelayThread`, the per-frame bogus `sceIoRemove`
+and `sceIoDread` calls drop to zero, and 212623 real delays are issued across
+a 1066-heartbeat run.
+
+### Superseded: the "failed file operation on every frame"
 
 With the two PPSSPP patches above in, the EBOOT boots to Nepheshel's title
 screen and holds it, but the frame loop performs one failed file operation per
@@ -366,10 +406,10 @@ frame -- tens of thousands per run. Its identity changed when
   `_unlink_r` -> `_unlink` -> `sceIoRemove`, and `_unlink` passes the stack
   buffer `__path_absolute` filled in.
 
-Both are "a file operation with a bad argument, every frame". What has *not*
-been established is whether they are the same underlying call: the two
-observations come from builds that differ in both the emulator and the guest
-binary, so the change cannot be attributed to either on this evidence.
+Both were the same thing, and neither was a file operation: bug 11 above.
+The earlier caution about not attributing the change to either the emulator
+or the guest was right to be cautious and wrong about the cause -- it was the
+stub layout moving under an unrepointed tail call.
 
 Two things make it worth chasing rather than ignoring. `mrb_sys_fail` raises
 when the HAL call fails, and mruby here is built with the C++ exception ABI --

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -310,12 +310,16 @@ with no such variable, got an empty build type and no optimisation at all --
 two undeclared, different builds of the same commit, which is how an
 `-O2`-only failure went unnoticed.
 
-At `-O2` the EBOOT halts on LVGL's TLSF assert
-(`!block_is_free(block)` in `lv_tlsf_realloc`) during `lv_init()`, before
-anything here has touched LVGL's pool. Unoptimised it boots to completion.
-Confirmed by building in the *same* container both ways, so the environment
-is not the variable -- only the flag is. **Open.** Eliminated so far, each by
-measurement:
+At `-O2` the EBOOT used to halt on LVGL's TLSF assert
+(`!block_is_free(block)` in `lv_tlsf_realloc`) during `lv_init()`.
+**Resolved:** that was never an optimisation bug. It was bug 11 below --
+`psp-fixup-imports` not repointing tail-call `j` instructions -- and
+optimisation merely emits more tail calls, so it hit more mis-dispatched
+stubs. With that fixed, `-O2` and `-Os` both boot to
+`RPG2K_PSP_GAME_START` and hold a heartbeat, and the pin is now
+`MinSizeRel`: every byte of `.text` is live RAM on this target, and `-Os`
+saves 373 KB against `Debug`. The candidates ruled out along the way, each
+by measurement, are kept because the eliminations are still sound:
 
 - **The draw buffers.** `psp_display_create` reports its post-condition
   (`RPG2K_PSP_DRAWBUF`); both pointers are non-null and both sizes exact at

--- a/changelog.d/psp-build-type-minsizerel.changed.md
+++ b/changelog.d/psp-build-type-minsizerel.changed.md
@@ -1,0 +1,11 @@
+- **The PSP EBOOT now builds `MinSizeRel` instead of `Debug`.** The pin was
+  `Debug` because `-O2` halted on LVGL's TLSF assert, and the comment said it
+  was provisional pending a root cause. That cause turned out not to be
+  optimisation at all — it was `psp-fixup-imports` leaving tail-call `j`
+  instructions pointing at pre-reorder import stubs, and optimisation merely
+  emits more tail calls, so it hit more of them. With that fixed, `Debug`,
+  `RelWithDebInfo` and `MinSizeRel` all reach `RPG2K_PSP_GAME_START` and hold a
+  `RPG2K_PSP_BRINGUP` heartbeat with identical memory telemetry. `-Os` is the
+  right default here because the whole EBOOT is loaded into the console's
+  ~24 MB at launch, so every byte of `.text` is live RAM: 2,095,840 bytes
+  against `Debug`'s 2,477,972 and `-O2`'s 2,217,032 — 373 KB back.

--- a/changelog.d/psp-fixup-imports-tail-calls.fixed.md
+++ b/changelog.d/psp-fixup-imports-tail-calls.fixed.md
@@ -1,0 +1,20 @@
+- **`psp-fixup-imports` now repoints tail calls, not just `jal`.** The patched
+  tool reorders import stubs and rewrites the call sites that target them, but
+  scanned only for `jal`. MIPS also has `j`, which the compiler emits for a
+  tail call — any function whose last act is calling the import, such as LVGL's
+  delay hook `void delay_cb(uint32_t ms) { sceKernelDelayThread(ms * 1000); }`,
+  which compiles to a bare `j` with no `jal` anywhere. This EBOOT has 49 such
+  sites against 1642 `jal`s, and all 49 were left aimed at pre-reorder
+  addresses, silently invoking whichever import the regroup left there. Because
+  the stub table moves with the binary, the same tail call landed on
+  `sceIoRemove` in one build and `sceIoDread` in another: LVGL's once-per-frame
+  *timing* call surfaced as a once-per-frame *filesystem* syscall with the
+  19000μs delay reinterpreted as a path pointer, and could land somewhere fatal
+  whenever unrelated code shifted the layout — which is why adding a few lines
+  of diagnostics could turn a working boot into an emulator crash, and why this
+  looked like layout-sensitive memory corruption for so long. Nothing was
+  corrupt; the call went elsewhere. Fixed by accepting `MIPS_OP_J` alongside
+  `MIPS_OP_JAL` — the rewrite already preserves the opcode field. Verified:
+  `delay_cb` now resolves to `sceKernelDelayThread`, the per-frame bogus
+  `sceIoRemove`/`sceIoDread` calls drop to zero, and 212623 real delays are
+  issued across a 1066-heartbeat run.

--- a/patches/psp-fixup-imports-jal-relocation-aware.patch
+++ b/patches/psp-fixup-imports-jal-relocation-aware.patch
@@ -71,9 +71,31 @@ about this fix is specific to this project's binary, but applied locally
 here in the meantime the same way this repo's own PPSSPP patches are
 (nix/patches/).
 
+Update: the original version of this patch repointed only `jal`. MIPS has a
+second direct jump, `j`, and the compiler emits it for a *tail call* -- any
+function whose last act is calling the import. LVGL's delay hook here,
+`void delay_cb(uint32_t ms) { sceKernelDelayThread(ms * 1000); }`, compiles
+to a bare `j sceKernelDelayThread` with no `jal` anywhere. This project's
+own EBOOT has 49 such sites against 1642 `jal`s, and every one of them was
+left pointing at its pre-reorder address, silently invoking whichever
+import the regroup left sitting there.
+
+The symptom was hard to read because it is layout-dependent. delay_cb's
+tail call landed on sceIoRemove in one build and sceIoDread in another, so
+LVGL's once-per-frame *timing* call surfaced as a once-per-frame
+*filesystem* syscall with nonsense arguments -- the millisecond count
+(0x4a38, 19000us) reinterpreted as a path pointer -- and moved to a
+different, sometimes fatal, syscall whenever unrelated code shifted the
+binary. That is also why adding a few lines of diagnostics to the guest
+could turn a working boot into an emulator crash, and why the failure
+appeared to be memory corruption: nothing was corrupt, the call simply went
+somewhere else. Fixed by accepting MIPS_OP_J alongside MIPS_OP_JAL. The
+rewrite already preserves the instruction's opcode field, so a `j` stays a
+`j`.
+
 --- a/tools/psp-fixup-imports.c
 +++ b/tools/psp-fixup-imports.c
-@@ -648,6 +648,105 @@
+@@ -648,6 +648,113 @@
  #define MIPS_JR_31 0x03e00008
  #define MIPS_NOP   0x0
 
@@ -98,6 +120,7 @@ here in the meantime the same way this repo's own PPSSPP patches are
 +}
 +
 +#define MIPS_OP_JAL 0x3
++#define MIPS_OP_J   0x2
 +
 +/* Every function's own trampoline slot in g_stubtext (.sceStub.text) sits at
 + * a FIXED address, g_stubtext->iAddr + originalIndex*8 -- every `jal` in the
@@ -108,7 +131,14 @@ here in the meantime the same way this repo's own PPSSPP patches are
 + * that function's real, callable address -- so every one of those `jal`s
 + * has to be repointed at the function's new slot to match, or callers
 + * silently invoke whichever *other* function the reordering left sitting at
-+ * the address they still target. remap[i] gives the new address for the
++ * the address they still target. Both forms of the direct jump matter:
++ * `jal` for an ordinary call, and `j` for a tail call, which the compiler
++ * emits whenever the import is the last thing a function does -- a plain
++ * `void wrapper(x) { sce_thing(x); }` compiles to `j sce_thing` with no
++ * `jal` anywhere. Missing those leaves a working-looking binary whose tail
++ * calls land on whichever stub the reorder happens to leave at the old
++ * address, which is layout-dependent and therefore moves with unrelated
++ * changes. remap[i] gives the new address for the
 + * function that used to sit at slot i; scanRewriteJal patches every `jal`
 + * in every SHF_EXECINSTR section (.text/.init/.fini -- real code only,
 + * never a data section a stray matching bit pattern could show up in) whose
@@ -143,7 +173,7 @@ here in the meantime the same way this repo's own PPSSPP patches are
 +			unsigned int target;
 +			int i;
 +
-+			if(op != MIPS_OP_JAL)
++			if((op != MIPS_OP_JAL) && (op != MIPS_OP_J))
 +			{
 +				continue;
 +			}
@@ -179,7 +209,7 @@ here in the meantime the same way this repo's own PPSSPP patches are
  int fixup_imports(void)
  {
  	unsigned int *pText;
-@@ -671,6 +770,113 @@
+@@ -671,6 +778,113 @@
  		fprintf(stderr, "Import count %d\n", count);
  	}
 


### PR DESCRIPTION
Root-causes the layout-sensitive failures the PSP port has been chasing, and unblocks optimised builds. Follow-up to #1277 and #1287.

## The bug: `psp-fixup-imports` never repointed tail calls

The patched tool reorders import stubs and rewrites the call sites targeting them — but scanned only for `jal`. MIPS has a second direct jump, `j`, which the compiler emits for a **tail call**: any function whose last act is calling the import. LVGL's delay hook is exactly that:

```c
void delay_cb(uint32_t ms) { sceKernelDelayThread(ms * 1000); }
```

It compiles to a bare `j sceKernelDelayThread`, with **no `jal` anywhere**. This EBOOT has **49 such sites against 1642 `jal`s**, and every one was left pointing at its pre-reorder address, silently invoking whichever import the regroup left sitting there.

```
88abb18:  j  8a61014 <sceKernelDelayThread>   <- stale objdump label
          PPSSPP binds 08a61014 = sceIoRemove
          real sceKernelDelayThread = 08a6107c
```

## Why it presented as memory corruption

The stub table moves with the binary, so the same tail call landed on `sceIoRemove` in one build and `sceIoDread` in another. LVGL's once-per-frame *timing* call therefore surfaced as a once-per-frame *filesystem* syscall with nonsense arguments — `a0 = 0x4a38`, the 19000μs delay reinterpreted as a path pointer — and could land somewhere fatal whenever unrelated code shifted the layout.

This one gap accounts for every symptom the port has been chasing:

| symptom | actual cause |
|---|---|
| per-frame `sceIoDread` with `0xDEADBEEF` args | `delay_cb`'s tail call landing on `sceIoDread` |
| per-frame `sceIoRemove` with an unreadable path | same call, different build, different stub |
| 60k `File.delete`s with no Ruby caller anywhere | never a `File.delete` |
| adding 15 lines of diagnostics → deterministic emulator crash | layout shift moved the landing somewhere fatal |
| `-O2` halting on LVGL's TLSF assert | optimisation emits *more* tail calls |
| "layout-sensitive memory corruption" | nothing corrupt; the call went elsewhere |

## How it was found

By reading the guest's registers at the bad syscall rather than reasoning from the call graph. `_unlink` sets `a0 = sp` before calling `sceIoRemove`; the live values were `a0 = 0x00004a38` against `sp = 0x09fbf9a0`, proving the call never came through `_unlink` — despite `_unlink` being the only static `jal` to that stub. A static call graph cannot see a mis-targeted tail call, which is why several passes of disassembly missed it.

Fixed by accepting `MIPS_OP_J` alongside `MIPS_OP_JAL`; the rewrite already preserves the opcode field, so a `j` stays a `j`. The patch was regenerated against the pinned pspsdk rather than hand-edited.

## Second commit: `MinSizeRel`

The build type was pinned to `Debug` because `-O2` was broken, with a comment saying it was provisional pending a root cause. That cause is above, and it was never an optimisation defect. All three build types now boot to `RPG2K_PSP_GAME_START` and hold a heartbeat with identical memory telemetry:

```
Debug           2477972 bytes .text
RelWithDebInfo  2217032
MinSizeRel      2095840   <- 373 KB back against Debug
```

`-Os` is the right default for a target whose whole image is RAM-resident at launch. The pin's comment is rewritten to record the real cause rather than implying an optimisation defect that never existed, and the README's `-O2` section is marked resolved — keeping the eliminated candidates, since those eliminations are still sound.

## Verification

```
delay_cb tail call -> 08a610e4
PPSSPP: Importing sceKernelDelayThread : 08a610e4     ✓

per-frame bogus syscalls:  sceIoRemove 0   sceIoDread 0
real sceKernelDelayThread calls: 212623
```

- **native, `nix develop`** (where `CMAKE_BUILD_TYPE=RelWithDebInfo` is in the environment): cache reads `MinSizeRel`, 1166 heartbeats
- **container `-O2`**: 1848 heartbeats, no TLSF assert
- **container `-Os`**: 1782 heartbeats

Documented as bug 11 in `app/psp/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZpTj3DY5Wy8kv4kAcPnK7