### PR TITLE
Clamp the Save/Load file-select cursor instead of wrapping

### DIFF
--- a/changelog.d/save-load-cursor-no-wrap.fixed.md
+++ b/changelog.d/save-load-cursor-no-wrap.fixed.md
@@ -1,0 +1,4 @@
+- **Save/Load screen:** the file-select cursor now clamps at the first and
+  last slot instead of wrapping around, matching RPG_RT — previously a
+  fresh key tap wrapped past either end (a held key already clamped
+  correctly), but real RPG_RT never wraps this list at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6445,6 +6445,42 @@ The work below is roughly ordered by the critical path to a walkable game
   reassigning `save[101] = sys` before serialising, not investigated further
   as a library defect since no runtime call site was found using the
   lossy pattern.
+  ✅ **Follow-up (cycle #127, 2026-08-23): the file-select list's own
+  "a fresh tap wraps past the first/last slot, a held key just stops there"
+  claim was wrong on the wrap half -- real RPG_RT never wraps this list at
+  either end, tap or hold alike. Fixed.** That claim (added in the
+  2026-08-19 follow-up above) was cited only to EasyRPG's `Scene_File::
+  vUpdate` -- the exact class of claim this session's methodology treats as
+  worth re-checking on its own, and never independently re-verified since.
+  Booted a genuine RPG_RT.exe under wine fresh (Title -> Down -> Return,
+  landing on the file-select screen with the cursor on File 1, no map load
+  needed) and drove it directly: a single Up tap from File 1 left the
+  captured frame pixel-identical to the one before it (still File 1, no
+  scroll) -- confirmed the input pipeline itself was live by then tapping
+  Down three times and watching the list scroll/advance normally. Walked
+  Down to File 15 (`MAX_SAVE_SLOTS`, the last slot) with 14 taps, then
+  tapped Down once more: frame unchanged, still File 15, no wrap to File 1;
+  a further ~1.5s hold of Down there, and a matching hold of Up back at
+  File 1, both likewise left the frame unchanged. All four probes (tap-Up-
+  at-first, tap-Down-at-last, hold-Down-at-last, hold-Up-at-first) agree:
+  this list simply clamps at both ends and never wraps, contradicting the
+  "a fresh tap wraps, a hold does not" shape entirely -- not a narrower
+  refinement of it. Fixed by dropping the `allow_wrap:` parameter from
+  `#move_selection` (`mruby-rpg2k/mrblib/scene/save_load.rb`) entirely: it
+  now clamps unconditionally (`return if target < 0 || target >=
+  SLOT_COUNT`), matching the bounded, no-wrap shape every other list in
+  this codebase already uses (e.g. `Scene::ItemMenu#move_item_cursor`'s
+  identical `return if target < 0 || target >= items.size`) rather than
+  singling this screen out with wrap-then-un-wrap logic. `#update`'s and
+  `#move_selection`'s own comments updated to record the finding and drop
+  the EasyRPG citation. `scripts/rpg2k_scene_check.rb`'s four wrap-adjacent
+  checks updated to match: the two held-key checks were already asserting
+  the (unchanged) correct behaviour and needed only their citation comment
+  swapped, while the two fresh-tap checks (which asserted the now-wrong
+  wrap) were rewritten to assert clamping instead, confirmed to fail
+  against the pre-fix code (`expected 14, got 0` for the Down case)
+  before the fix. Full suite reconfirmed passing after the fix (903
+  checks).
   ✅ **Follow-up (cycle #124, 2026-08-22): `game_over.rb`'s "only Decision
   dismisses the Game Over screen, Cancel does nothing" claim was wrong --
   real RPG_RT.exe accepts Cancel too, identically to Decision. Fixed.**

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -121,25 +121,31 @@ class RPG2k
           play_system_se(SFX_CANCEL)
           @parent.pop
         # Holding Down/Up auto-repeats the cursor after the initial delay, not
-        # just a single step per tap. `Window_SaveFile` (`src/window_savefile.cpp`)
-        # is a plain `Window_Base`, not a `Window_Selectable` -- real RPG_RT's
-        # own `Scene_File::vUpdate` (`src/scene_file.cpp`) hand-rolls this
-        # list's index/scroll logic itself, entirely separate from
-        # `Window_Selectable`'s generic cursor machinery every item/skill/
-        # message list goes through (correcting this comment's own earlier,
-        # mistaken citation). Its repeat timing still genuinely matches this
-        # build's own `Input.repeat?`: EasyRPG's `start_repeat_time = 23`/
-        # `repeat_time = 4` (`src/input.cpp`) first fires once `press_time`
-        # reaches 24 and every 4 frames after, exactly the 24-then-every-4
-        # timing `Input.repeat?` documents (`mruby-rgss/mrblib/lib.rb`),
-        # already measured against genuine RPG_RT.exe. `#move_selection`'s
-        # own comment covers the one real nuance `vUpdate` adds on top of
-        # that timing: a *held* Down/Up does not wrap past the last/first
-        # slot, only a fresh tap does.
+        # just a single step per tap. `Window_SaveFile` is a plain
+        # `Window_Base`, not a `Window_Selectable` -- real RPG_RT's own
+        # `Scene_File::vUpdate` hand-rolls this list's index/scroll logic
+        # itself, entirely separate from `Window_Selectable`'s generic cursor
+        # machinery every item/skill/message list goes through.
+        #
+        # This list never wraps past the first/last slot at all, on a tap or a
+        # held key alike -- independently confirmed against a genuine
+        # RPG_RT.exe under wine (cycle #127): from the file-select screen's
+        # opening cursor (File 1), a single Up tap left the captured frame
+        # unchanged (still File 1, no scroll); walking Down to File 15 (the
+        # last of MAX_SAVE_SLOTS) and tapping Down once more likewise left the
+        # frame unchanged, as did a full ~1.5s hold of Down there and of Up
+        # back at File 1. This replaces an earlier claim -- cited only to
+        # EasyRPG's own `Scene_File::vUpdate` (`index = (index + 1) %
+        # file_windows.size()` unconditionally on a fresh trigger, gated on
+        # `index < max_index` only on a bare repeat) -- that a fresh tap
+        # wraps around while a held key stops at the boundary; real RPG_RT
+        # does neither, matching this list's own siblings instead (e.g.
+        # `Scene::ItemMenu#move_item_cursor`'s identical bounded, no-wrap
+        # `return if target < 0 || target >= size`).
         elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
-          move_selection(1, allow_wrap: Input.trigger?(Input::DOWN))
+          move_selection(1)
         elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
-          move_selection(-1, allow_wrap: Input.trigger?(Input::UP))
+          move_selection(-1)
         elsif Input.trigger?(Input::C)
           confirm_selection
         end
@@ -147,17 +153,6 @@ class RPG2k
 
       private
 
-      # Move the slot cursor by `delta`, wrapping past the first/last slot
-      # only when `allow_wrap` is true. Confirmed against RPG_RT's own live
-      # source: `Scene_File::vUpdate` (`src/scene_file.cpp`) advances
-      # `index = (index + 1) % file_windows.size()` unconditionally on a
-      # fresh `IsTriggered(DOWN)` (so a tap at the last slot always wraps to
-      # the first), but on a bare `IsRepeated(DOWN)` (the key still held past
-      # the auto-repeat threshold) that same advance is gated on `index <
-      # max_index` -- a sustained hold simply stops moving at the last slot
-      # rather than cycling back around, the mirror image for Up at the
-      # first slot. `#update` passes `allow_wrap:` true only for the frame a
-      # direction is freshly pressed, matching that split exactly.
       # RPG_RT opens this screen with the cursor already on whichever slot
       # was saved most recently, not always slot 1 -- independently
       # confirmed against a genuine RPG_RT.exe under wine (cycle #123), not
@@ -201,10 +196,13 @@ class RPG2k
         nil
       end
 
-      def move_selection(delta, allow_wrap:)
+      # Move the slot cursor by `delta`, clamped at the first/last slot -- see
+      # #update's own citation for why this never wraps, on a tap or a held
+      # key alike.
+      def move_selection(delta)
         target = @index + delta
-        return if (target == SLOT_COUNT || target == -1) && !allow_wrap
-        @index = target % SLOT_COUNT
+        return if target < 0 || target >= SLOT_COUNT
+        @index = target
         @top = @index if @index < @top
         @top = @index - VISIBLE_SLOTS + 1 if @index >= @top + VISIBLE_SLOTS
         refresh_slot_windows

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -18760,19 +18760,21 @@ check 'Scene::SaveLoad :load mode: confirming an occupied slot resumes it' do
   eq [1], parent.continue_calls, 'RPG2k#continue_game was called for the confirmed slot'
 end
 
-check 'Scene::SaveLoad: Down/Up move and wrap across all MAX_SAVE_SLOTS' do
+check 'Scene::SaveLoad: Down/Up move the cursor and clamp, never wrap, at ' \
+      'either end of MAX_SAVE_SLOTS' do
   scene, = save_load_scene(:load)
-  RPG2k::MAX_SAVE_SLOTS.times do
+  (RPG2k::MAX_SAVE_SLOTS + 3).times do
     RGSS::Input.triggered = [RGSS::Input::DOWN]
     scene.update
     RGSS::Input.reset
   end
-  eq 0, scene.instance_variable_get(:@index), 'DOWN pressed MAX_SAVE_SLOTS times wraps back to 0'
+  eq RPG2k::MAX_SAVE_SLOTS - 1, scene.instance_variable_get(:@index),
+     'DOWN pressed past the last slot clamps there instead of wrapping to 0'
   RGSS::Input.triggered = [RGSS::Input::UP]
   scene.update
   RGSS::Input.reset
-  eq RPG2k::MAX_SAVE_SLOTS - 1, scene.instance_variable_get(:@index),
-     'UP from slot 1 wraps to the last slot'
+  eq RPG2k::MAX_SAVE_SLOTS - 2, scene.instance_variable_get(:@index),
+     'UP from the last slot moves up by one, same as any other slot'
 end
 
 # EasyRPG's Window_Selectable::Update (src/window_selectable.cpp) falls
@@ -18792,17 +18794,14 @@ check 'Scene::SaveLoad: holding Down auto-repeats the cursor, not just a ' \
      'a held (repeated, not triggered) Down still moves the cursor one slot'
 end
 
-# Confirmed directly against RPG_RT's live source: `Scene_File::vUpdate`
-# (`src/scene_file.cpp`) advances the index unconditionally on a fresh
-# `IsTriggered(DOWN)` -- a tap at the last slot always wraps to the first --
-# but a bare `IsRepeated(DOWN)` (the key already auto-repeating) gates that
-# same advance on `index < max_index`: a sustained hold simply stops at the
-# last slot rather than cycling back around, only wrapping once the player
-# releases and presses again. The mirror case holds for Up at the first
-# slot. `Window_SaveFile` is a plain `Window_Base`, not a `Window_Selectable`
-# -- this nuance is `Scene_File`'s own, not the generic list-cursor machinery
-# every other menu's `#repeat?` wiring goes through.
-check 'Scene::SaveLoad: a held (not freshly tapped) Down does not wrap past ' \
+# This list never wraps at either end, on a tap or a held key alike --
+# independently confirmed against a genuine RPG_RT.exe under wine (cycle
+# #127); see Scene::SaveLoad#update's own citation for the frame-by-frame
+# evidence. `Window_SaveFile` is a plain `Window_Base`, not a
+# `Window_Selectable` -- this list's index/scroll logic is `Scene_File`'s
+# own, not the generic list-cursor machinery every other menu's `#repeat?`
+# wiring goes through.
+check 'Scene::SaveLoad: a held (not freshly tapped) Down does not move past ' \
       'the last slot' do
   scene, = save_load_scene(:load)
   scene.instance_variable_set(:@index, RPG2k::MAX_SAVE_SLOTS - 1)
@@ -18813,7 +18812,7 @@ check 'Scene::SaveLoad: a held (not freshly tapped) Down does not wrap past ' \
      'a held Down at the last slot stays put instead of wrapping to the first'
 end
 
-check 'Scene::SaveLoad: a held (not freshly tapped) Up does not wrap past ' \
+check 'Scene::SaveLoad: a held (not freshly tapped) Up does not move past ' \
       'the first slot' do
   scene, = save_load_scene(:load)
   RGSS::Input.repeated = [RGSS::Input::UP] # held, but not a fresh trigger
@@ -18823,14 +18822,27 @@ check 'Scene::SaveLoad: a held (not freshly tapped) Up does not wrap past ' \
      'a held Up at the first slot stays put instead of wrapping to the last'
 end
 
-check 'Scene::SaveLoad: a fresh tap of Down still wraps past the last slot' do
+check 'Scene::SaveLoad: a fresh tap of Down at the last slot does not wrap ' \
+      'either' do
   scene, = save_load_scene(:load)
   scene.instance_variable_set(:@index, RPG2k::MAX_SAVE_SLOTS - 1)
   RGSS::Input.triggered = [RGSS::Input::DOWN] # a fresh tap, not merely held
   scene.update
   RGSS::Input.reset
+  eq RPG2k::MAX_SAVE_SLOTS - 1, scene.instance_variable_get(:@index),
+     'a fresh tap at the last slot stays put too -- this list never wraps, ' \
+     'tap or hold alike'
+end
+
+check 'Scene::SaveLoad: a fresh tap of Up at the first slot does not wrap ' \
+      'either' do
+  scene, = save_load_scene(:load)
+  RGSS::Input.triggered = [RGSS::Input::UP] # a fresh tap, not merely held
+  scene.update
+  RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@index),
-     'unlike a held repeat, a fresh tap at the last slot does wrap to the first'
+     'a fresh tap at the first slot stays put too -- this list never wraps, ' \
+     'tap or hold alike'
 end
 
 check 'Scene::SaveLoad: cancelling (B) pops back without touching the parent app' do


### PR DESCRIPTION
## Summary

- The Save/Load file-select cursor's existing shape ("a fresh tap wraps past the first/last slot, a held key just clamps there") was cited only to EasyRPG's `Scene_File::vUpdate`, never independently re-verified — the exact class of stale claim this session's methodology treats as worth re-checking.
- Confirmed against genuine RPG_RT.exe under wine: booted fresh to the file-select screen (cursor on File 1). A single Up tap from File 1 left the frame unchanged (no wrap). Walking Down to File 15 (the last slot) and tapping Down once more also left the frame unchanged. A ~1.5s hold of Down at File 15, and of Up at File 1, both likewise left the frame unchanged. All four probes (tap and hold, at both boundaries) agree: **this list simply clamps at both ends and never wraps** — contradicting the "tap wraps, hold clamps" claim entirely, not refining it.
- Fixed by dropping the `allow_wrap:` parameter from `#move_selection` (`mruby-rpg2k/mrblib/scene/save_load.rb`) entirely — it now clamps unconditionally, matching the bounded, no-wrap shape every other list cursor in this codebase already uses (e.g. `Scene::ItemMenu#move_item_cursor`).
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- Rewrote the two fresh-tap checks in `scripts/rpg2k_scene_check.rb` that had asserted wrapping to assert clamping instead; updated the two held-key checks' citation comments (their assertions were already correct).
- Confirmed via `git stash` that 3 of 903 checks fail against the pre-fix code and all pass post-fix (903/903).
- All four suites green: `rpg2k_scene_check.rb` (903 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_