### PR TITLE
Only offer Remove in the Equip candidate list when nothing else fits

### DIFF
--- a/changelog.d/equip-candidate-remove-conditional.fixed.md
+++ b/changelog.d/equip-candidate-remove-conditional.fixed.md
@@ -1,0 +1,3 @@
+- **Equip screen:** the candidate item list only offers "Remove" when the
+  bag has nothing else that fits the slot, matching RPG_RT — previously it
+  always listed Remove as an extra choice alongside real candidates.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6481,6 +6481,60 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (`expected 14, got 0` for the Down case)
   before the fix. Full suite reconfirmed passing after the fix (903
   checks).
+  ✅ **Follow-up (cycle #128, 2026-08-23): `equip_menu.rb`'s candidate item
+  list always prepended a "(Remove)" entry (id 0) ahead of the bag's real
+  candidates -- real RPG_RT.exe only offers Remove when the bag has
+  *nothing else* that fits the slot, never alongside a real candidate.
+  Fixed.** Investigated as a sibling of #127's wrap-vs-clamp hunt (a
+  hand-rolled list outside the generic clamp-list convention `item_menu.rb`/
+  `skill_menu.rb` already use) -- the slot list itself (Weapon/Shield/
+  Armor/Helmet/Accessory, DOWN/UP) turned out fine: a genuine RPG_RT.exe
+  under wine (Nepheshel, a repositioned real save, Menu -> Equip) showed Up
+  from the first slot landing on the last and Down from the last landing on
+  the first, both directions, matching this codebase's own existing
+  `@slot_index %= @slots.size` exactly -- confirmed correct, no change
+  needed there. Continuing into the *candidate* item list (choosing a slot
+  opens the bag's fitting items) surfaced the real bug instead: with the
+  weapon slot's bag empty (edited into the save directly, the established
+  `LCF::Array1D`/reassign-to-parent technique), the candidate list drew
+  *one* row, blank-labelled, and pressing Decision on it genuinely
+  unequipped the worn weapon -- the slot list's own row went blank and the
+  weapon reappeared in the bag, confirming this blank row is a real,
+  functional Remove, not a placeholder. Adding two ownable weapons to the
+  bag (ids with no actor_set restriction, so any actor can wear them) and
+  reopening the same list showed *exactly* those two rows and nothing else
+  -- no Remove alongside them. Removing the equipped weapon (leaving one
+  real bag item, the one just unequipped) showed *exactly* that one row,
+  again with no separate Remove option. All three data points (0, 1, 2 real
+  candidates) agree: Remove is the sole entry when the bag has nothing that
+  fits, and is dropped entirely the moment it does. `EquipMenu#candidates`
+  (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) used to be `[[0, 0]] +
+  @state.party.equip_candidates(...)` unconditionally, making Remove a
+  permanent extra choice next to every real one; fixed to prepend it only
+  when the real list is empty (`real.empty? ? [[0, 0]] : real`). **Side
+  finding, not fixed this cycle, a structurally distinct and less-verified
+  question left for a follow-up**: with two or more real candidates, real
+  RPG_RT laid them out two to a row (`ダガー` and `グラディウス` side by
+  side, half-width each, in the same wine capture that found the bug
+  above), where this codebase's own `#build_cand_window` still draws one
+  full-width row per item -- a real layout mismatch, but its exact geometry
+  (column width scaling, wrap-to-a-second-row behaviour) was not
+  characterised precisely enough this cycle to fix safely alongside the
+  Remove-inclusion rule, since both live in the same method and a rushed
+  layout change risked getting the interaction between them wrong.
+  `scripts/rpg2k_scene_check.rb`'s existing candidate-list checks (which
+  all assumed the old unconditional-Remove shape) updated throughout to the
+  corrected indices/sizes -- the wrap check's own "3 rows" became "2 rows,
+  no Remove" (`WrapMenuParty`'s bag is never empty), the comparison-glyph
+  check dropped `'(Remove)'` from its expected draw-call list, and every
+  `@cand_index` set to skip past a no-longer-existing leading Remove row
+  (the per-stat-preview, halved-by-state, two-handed-forced-unequip and
+  preview-colour checks) shifted down by one -- plus a new dedicated check
+  (`#candidates only includes Remove when the bag has nothing else that
+  fits`) pinning both boundary cases directly. Full suite reconfirmed
+  passing after the fix (904 checks, up from 903; the equip-scene edits
+  were index/count corrections to already-passing checks, not new failures
+  fixed).
   ✅ **Follow-up (cycle #124, 2026-08-22): `game_over.rb`'s "only Decision
   dismisses the Game Over screen, Cancel does nothing" claim was wrong --
   real RPG_RT.exe accepts Cancel too, identically to Decision. Fixed.**

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -2,9 +2,10 @@ class RPG2k
   module Scene
     # The field equip screen (main menu -> Equip). Shows one party member's five
     # equipment slots and current stats; LEFT/RIGHT cycle the member. Choosing a
-    # slot lists the bag's items that fit it (plus Remove); choosing one equips it
-    # -- swapping the previously-worn item back into the bag -- or empties the
-    # slot. The bag-aware equip logic is Game::Party#equip_candidates /
+    # slot lists the bag's items that fit it, plus Remove when (and only when)
+    # nothing does; choosing one equips it -- swapping the previously-worn
+    # item back into the bag -- or (choosing Remove) empties the slot. See
+    # #candidates. The bag-aware equip logic is Game::Party#equip_candidates /
     # equip_from_bag / unequip_to_bag (host-tested); this is the RGSS UI over it,
     # mirroring Scene::ItemMenu's helpers. A two-handed weapon empties the other
     # hand (Actor#free_two_handed_slot) and a 二刀流 actor's shield slot lists
@@ -160,11 +161,33 @@ class RPG2k
         end
       end
 
+      # The slot's fitting bag items -- a leading Remove entry (id 0) is
+      # prepended only when the bag holds nothing that fits, never
+      # alongside real candidates. (A 二刀流 actor's shield slot lists
+      # weapons instead of shields, which is why `actor` goes along -- see
+      # Game::Party#equip_candidates.) Confirmed against a genuine RPG_RT.exe
+      # under wine (cycle #128): with the weapon slot's bag empty, opening
+      # the candidate list drew exactly one row, blank-labelled, whose
+      # Decision genuinely unequipped the worn weapon (returning it to the
+      # bag, the slot list's own row going blank) -- so that blank row is a
+      # real, functional Remove, not a placeholder. With one bag weapon
+      # (the item just unequipped), the list drew exactly that one row and
+      # nothing else -- no separate Remove option alongside it. With two
+      # bag weapons, the list drew exactly those two and, again, no Remove
+      # row at all. So real RPG_RT's rule is "Remove exists only when nothing
+      # else does" -- this codebase previously prepended it unconditionally,
+      # making it a genuine third, always-selectable entry alongside every
+      # real one. **Deliberately not addressed here**: with >=2 real
+      # candidates, real RPG_RT lays them out two to a row (a real
+      # discrepancy from this window's own single-item-per-row drawing,
+      # visible in the same wine capture) -- a separate, structurally
+      # distinct layout question, not re-verified in enough detail (exact
+      # column width/wrap behaviour) to fix safely in the same pass; left
+      # as a follow-up.
       def candidates
-        # The slot's fitting bag items, with a leading Remove entry (id 0). A
-        # 二刀流 actor's shield slot lists weapons instead of shields, which is
-        # why `actor` goes along -- see Game::Party#equip_candidates.
-        @candidates ||= [[0, 0]] + @state.party.equip_candidates(@slot_index, actor)
+        return @candidates if @candidates
+        real = @state.party.equip_candidates(@slot_index, actor)
+        @candidates = real.empty? ? [[0, 0]] : real
       end
 
       def update_items

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -20670,19 +20670,46 @@ check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around'
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@actor_index), 'Right from the last actor wraps to the first'
 
-  # The equip-candidate list (Remove + the two fitting bag items = 3 rows).
+  # The equip-candidate list: the two fitting bag items, no Remove entry
+  # alongside them (real candidates exist, so Remove is left out -- #candidates).
   scene.instance_variable_set(:@mode, :items)
   scene.instance_variable_set(:@cand_index, 0)
   scene.send(:build_cand_window)
-  eq 3, scene.send(:candidates).size, 'Remove plus the two candidates'
+  eq 2, scene.send(:candidates).size, 'just the two candidates, no Remove'
   RGSS::Input.triggered = [RGSS::Input::UP]
   scene.update
   RGSS::Input.reset
-  eq 2, scene.instance_variable_get(:@cand_index), 'Up from the first candidate wraps to the last'
+  eq 1, scene.instance_variable_get(:@cand_index), 'Up from the first candidate wraps to the last'
   RGSS::Input.triggered = [RGSS::Input::DOWN]
   scene.update
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@cand_index), 'Down from the last candidate wraps to the first'
+end
+
+# A party whose weapon slot has nothing in the bag that fits it at all --
+# the boundary case #candidates' own Remove-inclusion rule turns on.
+class NoCandidateParty < MenuStubParty
+  def equip_candidates(_slot, _actor = nil); []; end
+end
+
+# Confirmed against a genuine RPG_RT.exe under wine (cycle #128, Nepheshel):
+# with the weapon slot's bag empty, the candidate list drew exactly one row,
+# blank-labelled, whose Decision genuinely unequipped the worn weapon
+# (returned to the bag, the slot list's own row going blank) -- a real,
+# functional Remove, not a placeholder. With one, then two, real bag
+# weapons, the list drew exactly those and nothing else -- no separate
+# Remove row alongside real candidates, in either count. This codebase used
+# to prepend a Remove entry (id 0) unconditionally, making it a permanent
+# extra choice alongside every real one, which real RPG_RT never shows.
+check 'Scene::EquipMenu: #candidates only includes Remove when the bag has ' \
+      'nothing else that fits' do
+  empty_scene = menu_scene(RPG2k::Scene::EquipMenu, Game::State.new(NoCandidateParty.new, 1, 0, 0))
+  eq [[0, 0]], empty_scene.send(:candidates),
+     'an empty bag: Remove is the sole entry'
+
+  full_scene = menu_scene(RPG2k::Scene::EquipMenu, wrap_menu_state)
+  eq [[7, 2], [8, 1]], full_scene.send(:candidates),
+     'a non-empty bag: just the real candidates, no Remove alongside them'
 end
 
 # The slot and candidate cursors live on genuine Window_Selectable
@@ -20809,9 +20836,10 @@ check 'Scene::EquipMenu: the candidate list draws only a name and count, no comp
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
   texts = window_texts(scene.instance_variable_get(:@cand_window))
-  # Row 0 is "(Remove)" (one call); each candidate row after it is exactly
-  # two calls -- name, count -- so a summed arrow would show up as a third.
-  eq ['(Remove)', 'Better', ':1', 'Worse', ':1', 'Same', ':1'], texts,
+  # No Remove row (real candidates exist -- #candidates); each candidate row
+  # is exactly two calls -- name, count -- so a summed arrow would show up
+  # as a third.
+  eq ['Better', ':1', 'Worse', ':1', 'Same', ':1'], texts,
      'no arrow glyph anywhere in the candidate list'
 end
 
@@ -20863,19 +20891,19 @@ check 'Scene::EquipMenu: the stats window previews each battle stat ' \
   scene = menu_scene(RPG2k::Scene::EquipMenu, state)
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
-  # #candidates leads with a "(Remove)" entry (id 0), so index 1 is the
-  # first real candidate: [0 Remove, 1 Better(id 2), 2 Worse(id 3), 3 Same(id 4)].
-  scene.instance_variable_set(:@cand_index, 1) # Better (id 2, atk 15)
+  # Real candidates exist, so #candidates leaves Remove out entirely
+  # (see its own comment): [0 Better(id 2), 1 Worse(id 3), 2 Same(id 4)].
+  scene.instance_variable_set(:@cand_index, 0) # Better (id 2, atk 15)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
   ok texts.include?('25'), 'Better\'s own delta (15 - 10 = +5) applied on top: 20 + 5 = 25'
 
-  scene.instance_variable_set(:@cand_index, 2) # Worse (id 3, atk 5)
+  scene.instance_variable_set(:@cand_index, 1) # Worse (id 3, atk 5)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
   ok texts.include?('15'), 'Worse\'s own delta (5 - 10 = -5) applied: 20 - 5 = 15'
 
-  scene.instance_variable_set(:@cand_index, 3) # Same (id 4, atk 10)
+  scene.instance_variable_set(:@cand_index, 2) # Same (id 4, atk 10)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
   ok texts.include?('20'), 'no delta (10 - 10 = 0): the new value equals the old one (20)'
@@ -20912,7 +20940,8 @@ check 'Scene::EquipMenu: both the current and previewed stat are halved by ' \
 
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
-  scene.instance_variable_set(:@cand_index, 1) # Better (id 2, atk 15)
+  # Real candidates exist, so #candidates leaves Remove out; Better is index 0.
+  scene.instance_variable_set(:@cand_index, 0) # Better (id 2, atk 15)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
   # base+equip: 20 + (15 - 10) = 25, then halved: 12 (25 / 2 truncated)
@@ -20966,8 +20995,9 @@ check 'Scene::EquipMenu: a 両手持ち candidate previews Atk rising and Def ' 
   scene = menu_scene(RPG2k::Scene::EquipMenu, state)
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
-  # #candidates leads with a "(Remove)" entry (id 0); the Claymore is index 1.
-  scene.instance_variable_set(:@cand_index, 1)
+  # The lone real candidate (the Claymore) is index 0 -- no Remove entry
+  # alongside it, since a real candidate exists (see #candidates).
+  scene.instance_variable_set(:@cand_index, 0)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
   ok texts.include?('40'),
@@ -20998,14 +21028,15 @@ check 'Scene::EquipMenu: the stats window\'s preview colour comes from the ' \
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
 
-  scene.instance_variable_set(:@cand_index, 1) # Better (id 2) -- Atk rises
+  # Real candidates exist, so #candidates leaves Remove out: Better is index 0.
+  scene.instance_variable_set(:@cand_index, 0) # Better (id 2) -- Atk rises
   scene.send(:refresh_cand_cursor)
   bc = scene.instance_variable_get(:@stats_window).contents.blend_calls || []
   # swatch cell (idx % 10 * 16, idx / 10 * 16 + 48) -- see Game::MessagePalette.
   ok bc.any? { |call| call[6] == 32 && call[7] == 48 },
      'a rising stat blends from swatch index 2 (32, 48)'
 
-  scene.instance_variable_set(:@cand_index, 2) # Worse (id 3) -- Atk falls
+  scene.instance_variable_set(:@cand_index, 1) # Worse (id 3) -- Atk falls
   scene.send(:refresh_cand_cursor)
   bc = scene.instance_variable_get(:@stats_window).contents.blend_calls || []
   ok bc.any? { |call| call[6] == 48 && call[7] == 48 },


### PR DESCRIPTION
## Summary

- `EquipMenu#candidates` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) unconditionally prepended a "Remove" entry (id 0) ahead of the bag's real fitting candidates, making it a permanent extra choice next to every real one.
- Confirmed against genuine RPG_RT.exe under wine, testing three data points via direct save-inventory edits: with the weapon slot's bag empty, the candidate list drew exactly one row (blank-labelled, whose Decision genuinely unequipped the worn weapon — a real, functional Remove, not a placeholder). With one real bag weapon, the list drew exactly that one row, no Remove alongside it. With two, exactly those two, again no Remove. **Real RPG_RT's rule: Remove is the sole entry when the bag has nothing else that fits, and is dropped entirely the moment a real candidate exists.**
- Fixed by prepending Remove only when the real candidate list is empty.
- Investigated as a sibling to cycle #127's wrap-vs-clamp hunt on hand-rolled lists: the Equip screen's *slot* list (Weapon/Shield/Armor/Helmet/Accessory) was separately confirmed to wrap correctly already — no change needed there.
- **Deliberately deferred, not fixed here**: with 2+ real candidates, real RPG_RT lays them out two items per row (confirmed in the same wine capture), while this codebase's `#build_cand_window` still draws one full-width row per item — a real, distinct layout discrepancy whose exact geometry wasn't characterized precisely enough to change safely in the same pass as the Remove-inclusion fix. Documented in `docs/TODO.md` as a follow-up.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check pinning both boundary cases directly (`#candidates only includes Remove when the bag has nothing else that fits`).
- Updated every pre-existing equip-candidate check that assumed the old unconditional-Remove shape (wrap-check size/indices, comparison-glyph draw-call list, four `@cand_index` offsets across stat-preview/halved-by-state/two-handed/preview-color checks).
- Confirmed via `git stash` that 6 of 904 checks fail against the pre-fix code and all pass post-fix (904/904).
- All four suites green: `rpg2k_scene_check.rb` (904 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_