### PR TITLE
Draw the Equip candidate list as a two-column grid

### DIFF
--- a/changelog.d/equip-candidate-remove-conditional.fixed.md
+++ b/changelog.d/equip-candidate-remove-conditional.fixed.md
@@ -1,3 +1,4 @@
-- **Equip screen:** the candidate item list only offers "Remove" when the
-  bag has nothing else that fits the slot, matching RPG_RT — previously it
-  always listed Remove as an extra choice alongside real candidates.
+- **Equip screen:** the candidate item list now draws as a two-column grid
+  with "Remove" always appended as a blank cell after the real candidates,
+  matching RPG_RT — previously every candidate drew in a single column with
+  a literal "(Remove)" row always listed first.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6535,6 +6535,75 @@ The work below is roughly ordered by the critical path to a walkable game
   passing after the fix (904 checks, up from 903; the equip-scene edits
   were index/count corrections to already-passing checks, not new failures
   fixed).
+  ✅ **Follow-up (cycle #129, 2026-08-23): the deferred two-column candidate
+  layout is fixed, and along the way cycle #128's own "Remove is dropped
+  entirely once a real candidate exists" conclusion turned out to be
+  wrong -- Remove is always appended after the real candidates, just drawn
+  blank.** Confirmed against a genuine RPG_RT.exe under wine (Nepheshel, the
+  weapon slot's bag edited directly to hold four unrestricted weapons --
+  ダガー/グラディウス/マンゴーシュ/アサシンダガー, filling a complete 2x2
+  grid): row-major fill (candidate 0 top-left, 1 top-right, 2 second-row
+  left, ...), the same `COLUMN_MAX = 2` shape already ported to
+  `Scene::ItemMenu`/`Scene::SkillMenu`. Column split and row height
+  pixel-measured off the wine framebuffer (640x480, 2x the game's real
+  320x240) confirm the *same* geometry those two already use --
+  `(SCREEN_W - BORDER*2) / COLUMN_MAX` column width, `LINE_H` (16) row
+  height -- not a distinct formula, once the 2x capture scale is accounted
+  for. Cursor navigation matches too: DOWN/UP move a whole row and stop dead
+  at the grid's own top/bottom (two DOWNs from the top-left cell of a full
+  2x2 grid landed on a fifth cell one row below the last full row and
+  stayed there on a third DOWN); RIGHT/LEFT move one cell, crossing a row
+  boundary rather than stopping at it (confirmed directly: LEFT from that
+  fifth cell moved onto the grid's own last *real* candidate, in the row
+  above).
+  That fifth cell is the real finding: with a complete 2x2 grid (4 real
+  candidates, no room left in either drawn row), the cursor could still
+  move one row further down onto a genuinely selectable, blank cell with
+  its own distinct stat-preview delta -- **identical** (870 -> 150 on the
+  Atk row) to the blank trailing cell a separate 2-real-candidate capture
+  (ダガー/グラディウス only, same actor/equipped weapon) reached the same
+  way, proving both are the same computed entry: Remove (id 0), always
+  appended one grid position after the real candidates, just rendered with
+  no text. Cycle #128's own three-data-point comparison (0/1/2 real
+  candidates) never pressed DOWN past the last visibly-populated row, so it
+  read "no third row of text" as "Remove is gone" rather than "Remove is
+  there but blank" -- an easy mistake once the list is a grid rather than a
+  single column, since a short list's trailing Remove cell sits one row
+  below whatever is actually drawn. The candidate *window* itself is also
+  fixed-size, not sized to content -- confirmed by comparing the wine
+  framebuffer's own window border pixels between the 2-candidate and
+  4-candidate captures: pixel-identical top and bottom edges both times,
+  always starting at the same row the slot list itself opens at (`#slot_
+  window_y`, factored out of `#build_slot_window` and reused) and always
+  reaching the bottom of the screen -- six grid rows' worth of interior
+  regardless of how many cells actually hold something. This codebase's own
+  `#build_cand_window` used to size the window tightly to `candidates.size`
+  rows, bottom-anchored, which only happened to look right once the list
+  was long enough to reach that same six-row mark on its own.
+  `EquipMenu#candidates` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) changed
+  from `real.empty? ? [[0, 0]] : real` to `real + [[0, 0]]` (Remove always
+  appended, never omitted, never leading); `#build_cand_window` rewritten
+  for the row-major 2-column grid, the fixed height/position, and to draw
+  nothing for Remove (it used to draw the literal text "(Remove)", which
+  real RPG_RT never shows either); `#refresh_cand_cursor` now places the
+  cursor rect per grid cell; `#update_items`/new `#move_cand_cursor` mirror
+  `Scene::ItemMenu#move_item_cursor` exactly (DOWN/UP by `COLUMN_MAX`,
+  RIGHT/LEFT by 1, both bounded only by the list's absolute ends, no wrap).
+  `scripts/rpg2k_scene_check.rb`'s own candidate-list checks updated
+  throughout: the old wrap-around candidate assertions (wrong for a grid)
+  split out of the slot/actor wrap check into a new dedicated grid-
+  navigation check (column-lock, row-crossing, no wrap, using
+  `wrap_menu_state`'s two real candidates + trailing Remove = three
+  entries); the Remove-inclusion check corrected to assert `real + [Remove]`
+  instead of "real only"; the held-Down auto-repeat check's expected
+  candidate index corrected from 1 to `COLUMN_MAX`; every other candidate
+  check's stale "no Remove alongside real candidates" comment corrected
+  (their actual index assertions were already right, since Remove trailing
+  the real ones does not renumber them). Full suite reconfirmed passing
+  (905 checks, up from 904); the three touched/new checks confirmed to fail
+  against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
+  the fix -- wrong candidates-list contents, wrong candidate count, and an
+  undefined `COLUMN_MAX` constant respectively.
   ✅ **Follow-up (cycle #124, 2026-08-22): `game_over.rb`'s "only Decision
   dismisses the Game Over screen, Cancel does nothing" claim was wrong --
   real RPG_RT.exe accepts Cancel too, identically to Decision. Fixed.**

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -2,10 +2,11 @@ class RPG2k
   module Scene
     # The field equip screen (main menu -> Equip). Shows one party member's five
     # equipment slots and current stats; LEFT/RIGHT cycle the member. Choosing a
-    # slot lists the bag's items that fit it, plus Remove when (and only when)
-    # nothing does; choosing one equips it -- swapping the previously-worn
-    # item back into the bag -- or (choosing Remove) empties the slot. See
-    # #candidates. The bag-aware equip logic is Game::Party#equip_candidates /
+    # slot lists the bag's items that fit it, in a two-column grid, with Remove
+    # always appended after them (drawn as a blank cell -- see #candidates);
+    # choosing one equips it -- swapping the previously-worn item back into the
+    # bag -- or (choosing Remove) empties the slot. See #candidates. The
+    # bag-aware equip logic is Game::Party#equip_candidates /
     # equip_from_bag / unequip_to_bag (host-tested); this is the RGSS UI over it,
     # mirroring Scene::ItemMenu's helpers. A two-handed weapon empties the other
     # hand (Actor#free_two_handed_slot) and a 二刀流 actor's shield slot lists
@@ -20,6 +21,18 @@ class RPG2k
       # (see #build_desc_window) -- the stats/slot/candidate windows below it
       # are all offset down by this much.
       DESC_H = LINE_H + Window::BORDER * 2
+
+      # The candidate list is a two-column grid, not a single stacked column
+      # -- confirmed against genuine RPG_RT under wine with a four-candidate
+      # bag (ダガー/グラディウス/マンゴーシュ/アサシンダガー, none actor-
+      # restricted), which filled row-major (candidate 0 top-left, candidate
+      # 1 top-right, candidate 2 second row left, ...), the same COLUMN_MAX=2
+      # shape already ported to Scene::ItemMenu/Scene::SkillMenu -- see
+      # #candidates and #build_cand_window's own doc comments for the fuller
+      # writeup (row-major layout, always-appended trailing Remove cell,
+      # fixed window height) and #update_items for the cursor-navigation
+      # citation.
+      COLUMN_MAX = 2
 
       # `actor_index` is which party member the screen opens on -- the one
       # `Scene::Menu#enter_actor_selection` preselected from the menu's own
@@ -161,33 +174,58 @@ class RPG2k
         end
       end
 
-      # The slot's fitting bag items -- a leading Remove entry (id 0) is
-      # prepended only when the bag holds nothing that fits, never
-      # alongside real candidates. (A 二刀流 actor's shield slot lists
+      # The slot's fitting bag items, with a trailing Remove entry (id 0)
+      # always appended after them. (A 二刀流 actor's shield slot lists
       # weapons instead of shields, which is why `actor` goes along -- see
-      # Game::Party#equip_candidates.) Confirmed against a genuine RPG_RT.exe
-      # under wine (cycle #128): with the weapon slot's bag empty, opening
-      # the candidate list drew exactly one row, blank-labelled, whose
-      # Decision genuinely unequipped the worn weapon (returning it to the
-      # bag, the slot list's own row going blank) -- so that blank row is a
-      # real, functional Remove, not a placeholder. With one bag weapon
-      # (the item just unequipped), the list drew exactly that one row and
-      # nothing else -- no separate Remove option alongside it. With two
-      # bag weapons, the list drew exactly those two and, again, no Remove
-      # row at all. So real RPG_RT's rule is "Remove exists only when nothing
-      # else does" -- this codebase previously prepended it unconditionally,
-      # making it a genuine third, always-selectable entry alongside every
-      # real one. **Deliberately not addressed here**: with >=2 real
-      # candidates, real RPG_RT lays them out two to a row (a real
-      # discrepancy from this window's own single-item-per-row drawing,
-      # visible in the same wine capture) -- a separate, structurally
-      # distinct layout question, not re-verified in enough detail (exact
-      # column width/wrap behaviour) to fix safely in the same pass; left
-      # as a follow-up.
+      # Game::Party#equip_candidates.)
+      #
+      # Cycle #128 found the Remove-inclusion bug (this codebase used to
+      # *prepend* Remove unconditionally, making it a permanent extra choice
+      # ahead of every real one) but concluded from a 0/1/2-real-candidate
+      # comparison that real RPG_RT *drops* Remove entirely once any real
+      # candidate exists -- because none of those captures ever pressed
+      # DOWN past the last visibly-populated row. **Follow-up (cycle #129):
+      # that conclusion was wrong.** Confirmed against a genuine RPG_RT.exe
+      # under wine with a *four*-candidate bag (ダガー/グラディウス/
+      # マンゴーシュ/アサシンダガー, filling a complete 2x2 grid -- see
+      # COLUMN_MAX): pressing DOWN twice from the top-left cell (column-
+      # locked, landing on row 2's own left cell each time) reached a fifth,
+      # visually blank cell one row below the last full row -- still
+      # genuinely selectable (a cursor box draws around it) and with its own
+      # distinct stat-preview delta, confirmed *identical* (870 -> 150 on
+      # the Atk row, both times) to the blank Remove row a separate 2-real-
+      # candidate capture (ダガー/グラディウス only, same actor/equipped
+      # weapon) reached the same way -- proving both are the same computed
+      # entry (id 0, unequip), not a rendering artifact. Pressing LEFT from
+      # that cell moved the cursor to the *last real* candidate (row 2's own
+      # right cell, アサシンダガー) -- a genuine row-crossing flat-index
+      # move, confirmed by its own distinct stat delta and description text
+      # -- so Remove is a real, ordinary list entry at row-major position
+      # `real.size`, not a separate mode. So the true rule is simply "the
+      # real candidates, plus Remove always appended after them" -- id 0
+      # never has special positioning, and is never omitted; #build_cand_
+      # window draws it as a blank cell (see its own doc comment) which is
+      # why a short list *looks* like it has no Remove option unless the
+      # cursor is actually moved onto it.
       def candidates
         return @candidates if @candidates
         real = @state.party.equip_candidates(@slot_index, actor)
-        @candidates = real.empty? ? [[0, 0]] : real
+        @candidates = real + [[0, 0]]
+      end
+
+      # Cursor movement mirrors Scene::ItemMenu#move_item_cursor exactly --
+      # DOWN/UP move by a whole row (COLUMN_MAX cells) and UP/DOWN off the
+      # grid's own top/bottom is a no-op (confirmed: two DOWNs from the
+      # trailing Remove cell described above left the cursor exactly there,
+      # not wrapping); RIGHT/LEFT move by one cell, bounded only by the
+      # list's own absolute ends, with no row-boundary check -- confirmed by
+      # the LEFT-from-Remove row-crossing move documented on #candidates.
+      def move_cand_cursor(delta)
+        target = @cand_index + delta
+        return if target < 0 || target >= candidates.size
+        @cand_index = target
+        refresh_cand_cursor
+        play_system_se(SFX_CURSOR)
       end
 
       def update_items
@@ -195,15 +233,13 @@ class RPG2k
           play_system_se(SFX_CANCEL)
           leave_items
         elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
-          @cand_index += 1
-          @cand_index %= candidates.size
-          refresh_cand_cursor
-          play_system_se(SFX_CURSOR)
+          move_cand_cursor(COLUMN_MAX)
         elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
-          @cand_index -= 1
-          @cand_index %= candidates.size
-          refresh_cand_cursor
-          play_system_se(SFX_CURSOR)
+          move_cand_cursor(-COLUMN_MAX)
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
+          move_cand_cursor(1)
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
+          move_cand_cursor(-1)
         elsif Input.trigger?(Input::C)
           play_system_se(SFX_DECISION)
           apply_choice
@@ -247,7 +283,7 @@ class RPG2k
       # (e.g. a weapon's "[斬光風龍神]イリスの想いを宿す時の剣"); this scene
       # drew no such banner at all. Tracks whichever item is currently under
       # the cursor: the slot's own equipped item in :slots mode, or the
-      # highlighted candidate in :items mode (blank for the leading Remove
+      # highlighted candidate in :items mode (blank for the trailing Remove
       # entry and for an empty slot, matching there being no item to
       # describe).
       def build_desc_window
@@ -368,11 +404,20 @@ class RPG2k
         end
       end
 
+      # Y (screen-absolute) both the slot list and the candidate grid open
+      # at -- confirmed against genuine RPG_RT under wine: the candidate
+      # window (see #build_cand_window) starts at exactly this same row,
+      # replacing the slot list in place while browsing candidates, not
+      # anchored to the bottom of whatever content it happens to hold.
+      def slot_window_y
+        DESC_H + LINE_H * (1 + STAT_DEFS.size) + Window::BORDER * 2
+      end
+
       def build_slot_window
         @slot_window.dispose if @slot_window
         inner_w = SCREEN_W - Window::BORDER * 2
         h = @slots.size * LINE_H
-        y = DESC_H + LINE_H * (1 + STAT_DEFS.size) + Window::BORDER * 2
+        y = slot_window_y
         @slot_window = Window.new(0, y, SCREEN_W, h + Window::BORDER * 2)
         @slot_window.z = 400
         @slot_window.windowskin = @skin
@@ -454,24 +499,53 @@ class RPG2k
         STAT_POINT_FIELDS.reduce(0) { |s, f| s + stat_field_delta(id, f) }
       end
 
+      # Column width for the candidate grid -- identical formula to
+      # Scene::ItemMenu#item_col_w (see COLUMN_MAX's own doc comment).
+      def cand_col_w
+        (SCREEN_W - Window::BORDER * 2) / COLUMN_MAX
+      end
+
+      # The candidate window is a fixed-size grid, not sized to the
+      # candidate count -- confirmed against genuine RPG_RT under wine: a
+      # 2-real-candidate capture and a 4-real-candidate capture (same actor,
+      # same slot) drew a window with *pixel-identical* top/bottom borders
+      # both times (measured off the wine framebuffer), always starting at
+      # #slot_window_y (replacing the slot list in place) and always
+      # reaching exactly the bottom of the screen -- six grid rows' worth of
+      # interior regardless of how many of those cells a real entry (or the
+      # trailing Remove cell -- see #candidates) actually occupies; the rest
+      # draw as empty background. This codebase used to size the window
+      # tightly to `candidates.size` rows and anchor it to the *bottom* of
+      # the screen, which only happened to look right when the list was
+      # long enough to reach that same six-row mark. **Not independently
+      # re-verified beyond 5 entries** (4 real + Remove, this cycle's own
+      # test bag) whether real RPG_RT scrolls or otherwise handles a
+      # candidate count that would overflow the six-row/twelve-cell grid --
+      # left unaddressed, since #move_cand_cursor's own bound
+      # (`candidates.size`) never lets the cursor reach a cell past the
+      # real content either way, matching every capture actually taken.
       def build_cand_window
         @cand_window.dispose if @cand_window
         rows = candidates
         inner_w = SCREEN_W - Window::BORDER * 2
-        h = rows.size * LINE_H
-        @cand_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
-                                  SCREEN_W, h + Window::BORDER * 2)
+        y = slot_window_y
+        h = SCREEN_H - y - Window::BORDER * 2
+        @cand_window = Window.new(0, y, SCREEN_W, h + Window::BORDER * 2)
         @cand_window.z = 450
         @cand_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
+        col_w = cand_col_w
         rows.each_with_index do |(id, count), i|
-          if id == 0
-            c.draw_text 0, i * LINE_H, inner_w, LINE_H, "(Remove)"
-          else
-            c.draw_text 0, i * LINE_H, inner_w - 40, LINE_H, item_name(id)
-            c.draw_text inner_w - 40, i * LINE_H, 40, LINE_H, ":#{count}"
-          end
+          # Remove (id 0) draws nothing -- confirmed against genuine RPG_RT
+          # under wine, which shows a blank cell there (still a real,
+          # selectable, functional entry; see #candidates), not the literal
+          # "(Remove)" label this codebase used to draw.
+          next if id == 0
+          x = (i % COLUMN_MAX) * col_w
+          yy = (i / COLUMN_MAX) * LINE_H
+          c.draw_text x, yy, col_w - 40, LINE_H, item_name(id)
+          c.draw_text x + col_w - 40, yy, 40, LINE_H, ":#{count}"
         end
         @cand_window.contents = c
         refresh_cand_cursor
@@ -479,8 +553,10 @@ class RPG2k
 
       def refresh_cand_cursor
         return unless @cand_window
-        @cand_window.cursor_rect =
-          Rect.new(0, @cand_index * LINE_H, @cand_window.contents.width, LINE_H)
+        col_w = cand_col_w
+        x = (@cand_index % COLUMN_MAX) * col_w
+        y = (@cand_index / COLUMN_MAX) * LINE_H
+        @cand_window.cursor_rect = Rect.new(x, y, col_w, LINE_H)
         build_stats_window
         refresh_desc
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -20648,7 +20648,7 @@ check 'Scene::Map resumes the saved BGM on Continue even while boarded, ' \
   eq [], RGSS::Audio.bgm_calls, 'nothing was playing at save time, so nothing plays now'
 end
 
-check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around' do
+check 'Scene::EquipMenu: the slot list and actor cursors wrap around' do
   scene = menu_scene(RPG2k::Scene::EquipMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@slot_index), 'starts on the first slot'
   RGSS::Input.triggered = [RGSS::Input::UP]
@@ -20669,47 +20669,98 @@ check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around'
   scene.update
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@actor_index), 'Right from the last actor wraps to the first'
-
-  # The equip-candidate list: the two fitting bag items, no Remove entry
-  # alongside them (real candidates exist, so Remove is left out -- #candidates).
-  scene.instance_variable_set(:@mode, :items)
-  scene.instance_variable_set(:@cand_index, 0)
-  scene.send(:build_cand_window)
-  eq 2, scene.send(:candidates).size, 'just the two candidates, no Remove'
-  RGSS::Input.triggered = [RGSS::Input::UP]
-  scene.update
-  RGSS::Input.reset
-  eq 1, scene.instance_variable_get(:@cand_index), 'Up from the first candidate wraps to the last'
-  RGSS::Input.triggered = [RGSS::Input::DOWN]
-  scene.update
-  RGSS::Input.reset
-  eq 0, scene.instance_variable_get(:@cand_index), 'Down from the last candidate wraps to the first'
 end
 
 # A party whose weapon slot has nothing in the bag that fits it at all --
-# the boundary case #candidates' own Remove-inclusion rule turns on.
+# the boundary case #candidates' own trailing-Remove rule still covers
+# (a list of nothing but Remove).
 class NoCandidateParty < MenuStubParty
   def equip_candidates(_slot, _actor = nil); []; end
 end
 
-# Confirmed against a genuine RPG_RT.exe under wine (cycle #128, Nepheshel):
-# with the weapon slot's bag empty, the candidate list drew exactly one row,
-# blank-labelled, whose Decision genuinely unequipped the worn weapon
-# (returned to the bag, the slot list's own row going blank) -- a real,
-# functional Remove, not a placeholder. With one, then two, real bag
-# weapons, the list drew exactly those and nothing else -- no separate
-# Remove row alongside real candidates, in either count. This codebase used
-# to prepend a Remove entry (id 0) unconditionally, making it a permanent
-# extra choice alongside every real one, which real RPG_RT never shows.
-check 'Scene::EquipMenu: #candidates only includes Remove when the bag has ' \
-      'nothing else that fits' do
+# Confirmed against a genuine RPG_RT.exe under wine. Cycle #128 first found
+# this list's real/Remove membership (with the weapon slot's bag empty, the
+# candidate list drew exactly one row, blank-labelled, whose Decision
+# genuinely unequipped the worn weapon -- a real, functional Remove, not a
+# placeholder) but concluded from captures that never pressed Down past the
+# last visibly-populated row that Remove disappears entirely once any real
+# candidate exists. **Follow-up (cycle #129): that conclusion was wrong.** A
+# four-real-candidate bag (filling a complete 2x2 grid) still had a fifth,
+# selectable cell one row below the last full row, with a stat-preview delta
+# matching (870 -> 150 on the Atk row) a separate 2-real-candidate capture's
+# own trailing blank cell exactly -- both are the same Remove entry (id 0),
+# always appended after the real candidates, just drawn blank (see
+# #build_cand_window). See #candidates' own doc comment for the fuller
+# writeup, including the LEFT-from-Remove row-crossing move that confirmed
+# it is an ordinary list entry, not a separate mode.
+check 'Scene::EquipMenu: #candidates always appends Remove after the real ' \
+      'candidates, never omitting or leading with it' do
   empty_scene = menu_scene(RPG2k::Scene::EquipMenu, Game::State.new(NoCandidateParty.new, 1, 0, 0))
   eq [[0, 0]], empty_scene.send(:candidates),
      'an empty bag: Remove is the sole entry'
 
   full_scene = menu_scene(RPG2k::Scene::EquipMenu, wrap_menu_state)
-  eq [[7, 2], [8, 1]], full_scene.send(:candidates),
-     'a non-empty bag: just the real candidates, no Remove alongside them'
+  eq [[7, 2], [8, 1], [0, 0]], full_scene.send(:candidates),
+     'a non-empty bag: the real candidates, then Remove appended after them'
+end
+
+# The equip-candidate list is a two-column grid, not a wraparound single
+# column -- confirmed against genuine RPG_RT under wine (cycle #129, a
+# four-real-candidate bag): row-major fill, DOWN/UP genuinely column-locked
+# (a whole row, blocked rather than wrapped past either end) and RIGHT/LEFT
+# a flat +-1 bounded only by the list's own absolute ends, crossing a row
+# boundary rather than stopping at it -- the identical shape already ported
+# to Scene::ItemMenu's own item grid (see its ThreeItemWrapParty check).
+# wrap_menu_state's two real candidates plus the always-appended trailing
+# Remove entry (see #candidates) makes three: [0]=id 7 (row 0 col 0),
+# [1]=id 8 (row 0 col 1), [2]=Remove (row 1 col 0) -- enough to exercise
+# every edge this shape has.
+check 'Scene::EquipMenu: the candidate grid is column-locked on Down/Up and ' \
+      'crosses row boundaries on Right/Left, with no wraparound' do
+  scene = menu_scene(RPG2k::Scene::EquipMenu, wrap_menu_state)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :items, scene.instance_variable_get(:@mode), 'Decision on the first slot opens the candidate list'
+  eq 3, scene.send(:candidates).size, 'two real candidates plus the trailing Remove entry'
+  eq 0, scene.instance_variable_get(:@cand_index), 'starts on the first candidate'
+
+  RGSS::Input.triggered = [RGSS::Input::UP]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@cand_index), "Up off the grid's own top is a no-op, not a wrap"
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 2, scene.instance_variable_get(:@cand_index), 'Down moves a whole row, onto Remove (row 1 col 0)'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 2, scene.instance_variable_get(:@cand_index),
+     "Down off the grid's own bottom is a no-op, not a wrap"
+
+  RGSS::Input.triggered = [RGSS::Input::LEFT]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@cand_index),
+     "Left from row 1's only cell flows back into row 0's last cell, not a no-op"
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  eq 2, scene.instance_variable_get(:@cand_index), 'Right flows forward onto Remove the same way'
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  eq 2, scene.instance_variable_get(:@cand_index), "Right off the grid's own end is a no-op"
+
+  RGSS::Input.triggered = [RGSS::Input::UP]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@cand_index), 'Up moves back a whole row onto the first candidate'
 end
 
 # The slot and candidate cursors live on genuine Window_Selectable
@@ -20741,8 +20792,11 @@ check 'Scene::EquipMenu: holding Down auto-repeats the slot and candidate ' \
   RGSS::Input.repeated = [RGSS::Input::DOWN]
   scene.update
   RGSS::Input.reset
-  eq 1, scene.instance_variable_get(:@cand_index),
-     'a held (repeated, not triggered) Down still moves the candidate cursor one step'
+  # A whole row (COLUMN_MAX cells), not one -- the candidate list is a
+  # two-column grid (see COLUMN_MAX's own doc comment), same as the slot
+  # list's own single-column Down being one step.
+  eq RPG2k::Scene::EquipMenu::COLUMN_MAX, scene.instance_variable_get(:@cand_index),
+     'a held (repeated, not triggered) Down still moves the candidate cursor one row'
 end
 
 # Confirmed against RPG_RT's own live source: `Scene_Equip::
@@ -20836,11 +20890,12 @@ check 'Scene::EquipMenu: the candidate list draws only a name and count, no comp
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
   texts = window_texts(scene.instance_variable_get(:@cand_window))
-  # No Remove row (real candidates exist -- #candidates); each candidate row
-  # is exactly two calls -- name, count -- so a summed arrow would show up
-  # as a third.
+  # The trailing Remove entry (see #candidates) draws nothing at all (a
+  # blank cell -- #build_cand_window), so it contributes no text calls
+  # either; each real candidate row is exactly two calls -- name, count --
+  # so a summed arrow would show up as a third.
   eq ['Better', ':1', 'Worse', ':1', 'Same', ':1'], texts,
-     'no arrow glyph anywhere in the candidate list'
+     'no arrow glyph anywhere in the candidate list, and nothing drawn for Remove'
 end
 
 # Confirmed against EasyRPG's actual C++ source, fetched live:
@@ -20891,8 +20946,9 @@ check 'Scene::EquipMenu: the stats window previews each battle stat ' \
   scene = menu_scene(RPG2k::Scene::EquipMenu, state)
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
-  # Real candidates exist, so #candidates leaves Remove out entirely
-  # (see its own comment): [0 Better(id 2), 1 Worse(id 3), 2 Same(id 4)].
+  # Remove is appended after the real candidates (see #candidates), so the
+  # real ones keep their original indices: [0 Better(id 2), 1 Worse(id 3),
+  # 2 Same(id 4), 3 Remove].
   scene.instance_variable_set(:@cand_index, 0) # Better (id 2, atk 15)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
@@ -20940,7 +20996,7 @@ check 'Scene::EquipMenu: both the current and previewed stat are halved by ' \
 
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
-  # Real candidates exist, so #candidates leaves Remove out; Better is index 0.
+  # Remove trails the real candidates (see #candidates); Better is still index 0.
   scene.instance_variable_set(:@cand_index, 0) # Better (id 2, atk 15)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
@@ -20995,8 +21051,8 @@ check 'Scene::EquipMenu: a 両手持ち candidate previews Atk rising and Def ' 
   scene = menu_scene(RPG2k::Scene::EquipMenu, state)
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
-  # The lone real candidate (the Claymore) is index 0 -- no Remove entry
-  # alongside it, since a real candidate exists (see #candidates).
+  # The lone real candidate (the Claymore) is still index 0 -- Remove trails
+  # it, at index 1 (see #candidates).
   scene.instance_variable_set(:@cand_index, 0)
   scene.send(:refresh_cand_cursor)
   texts = window_texts(scene.instance_variable_get(:@stats_window))
@@ -21028,7 +21084,7 @@ check 'Scene::EquipMenu: the stats window\'s preview colour comes from the ' \
   scene.instance_variable_set(:@mode, :items)
   scene.send(:build_cand_window)
 
-  # Real candidates exist, so #candidates leaves Remove out: Better is index 0.
+  # Remove trails the real candidates (see #candidates): Better is still index 0.
   scene.instance_variable_set(:@cand_index, 0) # Better (id 2) -- Atk rises
   scene.send(:refresh_cand_cursor)
   bc = scene.instance_variable_get(:@stats_window).contents.blend_calls || []


### PR DESCRIPTION
## Summary

- Picks up the layout question cycle #128 deliberately deferred, and along the way **corrects cycle #128's own conclusion**: real RPG_RT always appends Remove after the real candidates (rendered as a blank cell), never dropping it once real candidates exist. Cycle #128's three-data-point comparison (0/1/2 real candidates) never pressed DOWN past the last visibly-populated row, so it read "no third row of text" as "Remove is gone" rather than "Remove is there but blank."
- Confirmed against genuine RPG_RT.exe under wine with a 4-candidate bag filling a complete 2×2 grid (weapon slot edited directly): row-major fill, the same `COLUMN_MAX = 2` geometry already ported to `Scene::ItemMenu`/`Scene::SkillMenu` — pixel-measured column width and row height match those two exactly once the wine capture's 2× scale is accounted for. DOWN/UP move a whole row and stop dead at the grid's own top/bottom (two DOWNs from the top-left cell of a full 2×2 grid landed on a fifth, genuinely selectable blank cell one row below the last full row, and stayed there on a third DOWN); RIGHT/LEFT move one cell, crossing row boundaries rather than stopping (confirmed: LEFT from that fifth cell moved onto the last real candidate, one row up).
- That fifth cell's stat-preview delta (870→150 on Atk) was confirmed **identical** to the blank trailing cell a separate 2-real-candidate capture reached the same way — proving both are the same computed Remove entry (id 0), always appended one grid position after the real candidates, just rendered with no text.
- The candidate window is also fixed-size, not sized to content: pixel-identical top/bottom borders between the 2- and 4-candidate captures, always starting where the slot list itself opens and always reaching the bottom of the screen.
- `EquipMenu#candidates` changed from `real.empty? ? [[0,0]] : real` to `real + [[0, 0]]`; `#build_cand_window` rewritten for the 2-column grid, fixed geometry, and drawing nothing for Remove (the literal `"(Remove)"` text is gone too, matching real RPG_RT's blank cell); cursor movement (`#move_cand_cursor`) mirrors `Scene::ItemMenu#move_item_cursor` exactly.
- This investigation consulted no EasyRPG/Player C++ source at any point — all behavioral claims rest solely on genuine RPG_RT.exe output under wine.

## Test plan

- Split the old (wrong, single-column-wrap) candidate cursor assertions out of the slot/actor wrap check into a new dedicated grid-navigation check (column-lock, row-crossing, no wraparound).
- Corrected the Remove-inclusion check to assert `real + [Remove]`; corrected every other candidate-index-dependent check's stale comment (the actual index assertions were already right, since Remove trailing the real candidates doesn't renumber them); corrected the held-Down auto-repeat check's expected index from 1 to `COLUMN_MAX`.
- Confirmed via `git stash` that 3 of 905 checks fail against the pre-fix code and all pass post-fix (905/905).
- All four suites green: `rpg2k_scene_check.rb` (905 checks), `rpg2k_logic_check.rb` (1134 checks), `rpg2k3_battle_row_check.rb` (19 checks), `rpg2k3_battle_gauge_check.rb` (15 checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_