### PR TITLE
Clamp the battle enemy-target cursor when a troop overflows the target window

### DIFF
--- a/changelog.d/battle-target-cursor-overflow-clamp.fixed.md
+++ b/changelog.d/battle-target-cursor-overflow-clamp.fixed.md
@@ -1,0 +1,6 @@
+- **Battle screen:** the enemy-target cursor now stops at the last visible
+  row instead of wrapping around once a troop has more living members than
+  the four-row target window can show at once, matching RPG_RT — previously
+  it wrapped modulo the full living-member count, letting the cursor reach
+  and scroll past members the target list never actually scrolls to on real
+  RPG_RT.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,53 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #131, 2026-08-23): of the four battle cursor spots
+  cycle #130 left unverified, `#drive_battle_target` (enemy targeting) turned
+  out to have a real bug -- not about key-repeat (that part re-confirmed
+  fine), but about wrap-vs-clamp at the list boundary once a troop has more
+  living members than the window's own four visible rows. Fixed.** Built two
+  more synthetic autostart Enemy Encounters on copies of Nepheshel's map 12
+  (same tail-splice pattern as #130's probe, swapping only the troop id
+  param on the copied 10710 command): a 6-Killer-Bee troop (id 16) and, for
+  the exact-boundary control, a 3-Blood-Bat troop (id 5) and a 4-Zombie troop
+  (id 37). Since every member of a wild troop shares one on-screen name, the
+  cursor's real target couldn't be read off the text list alone -- instead
+  each probe attacked-to-kill from a known cursor position and read the
+  troop's own member x/y off the .ldb (`enemy_group[id].members`) to see
+  *which* sprite actually died, an unambiguous per-member signal. Results:
+  on the 6-Bee troop, holding/tapping Down from row 1 stops dead at row 4 and
+  never reaches members 5/6 (confirmed by attacking from there: the 4th
+  member died, not the 5th/6th) -- no scroll, no wrap either, even across 8
+  discrete taps and a 2.5s hold well past where auto-repeat would have
+  cycled through the rest; Up from row 1 is symmetric (member 1 died after
+  3 Up taps, never member 6). On the 3-Bat and 4-Zombie troops (both fitting
+  the 4-row window with no overflow), the *opposite* holds: Up from row 1
+  wraps to the last row (member 3 died) and Down from the last row of an
+  exactly-4 troop wraps back to row 1 (row 1 stayed highlighted after a 4th
+  Down tap) -- ordinary modulo wrap, matching this method's own pre-existing
+  code. So the bug was specifically the overflow case: `drive_battle_target`
+  wrapped `@ui[:target_i]` modulo the *full* living-foe count regardless,
+  which both let the cursor reach members past row 4 (via `battle_list_
+  window`'s scrolling, which real RPG_RT's enemy-target list does not do at
+  all) and wrapped it back to row 1 from the true last member instead of
+  stopping at row 4. Fixed by splitting `#drive_battle_target`'s Down/Up into
+  a new `#move_battle_target_cursor(delta, foes_count)`: plain modulo wrap
+  when `foes_count <= BATTLE_VISIBLE_ROWS` (unchanged), blocked at either end
+  with no wrap at all once it overflows -- the same block-not-wrap shape
+  `#move_battle_list_index` already uses for the Item/Skill grids.
+  `#drive_battle_ally_target`'s identical-shaped modulo needed no matching
+  change: RPG2000's own party cap keeps `allies.length` at 4 or fewer always,
+  so it can never hit the overflow case this fixes. `#drive_battle_skill`/
+  `#drive_battle_item` were not re-examined this cycle (they already use the
+  correct block-not-wrap `#move_battle_list_index`, not this method's old
+  modulo). New `scripts/rpg2k_scene_check.rb` check (a 6-Slime fixture troop,
+  `enemy_group[5]`) asserting Down from row 1 stops at row 4 rather than
+  reaching row 5 or wrapping, confirmed to fail against the pre-fix code
+  (a stashed diff of just `battle.rb`) before the fix -- `expected 3, got 4`.
+  Full suite reconfirmed passing (906 checks, up from 905).
+  `Map0012.lmu`/`Save01.lsd` were edited only as scratch copies for these
+  probes and restored to their original bytes (byte-identical by `md5sum`)
+  once each wine session was torn down.
   ✅ **Follow-up (cycle #130, 2026-08-23): `battle.rb`'s battle-scene
   key-repeat claim -- the whole reason every one of its six cursor spots
   gained `|| Input.repeat?(...)` back on 2026-08-18 -- is now independently

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1568,19 +1568,36 @@ class RPG2k
       end
 
       # Enemy target-selection menu: pick which living enemy the Attack (or an
-      # enemy-scope Skill) hits.
+      # enemy-scope Skill) hits. When there are more living foes than the
+      # window's own BATTLE_VISIBLE_ROWS (4), Down/Up is clamped to rows 1..4
+      # -- blocked, not wrapped, at either end, the same shape
+      # `#move_battle_list_index` already uses for the battle Item/Skill
+      # grids -- instead of this method's own pre-existing plain modulo wrap,
+      # which stays exactly as it was for a troop of 4 or fewer (see
+      # #move_battle_target_cursor). Confirmed against a genuine RPG_RT.exe
+      # (cycle #131): on a troop of 6 (member x/y positions read straight off
+      # the .ldb, each individually killed to identify which one the cursor
+      # actually had, since every member of a wild troop shares one on-screen
+      # name), Down held/tapped repeatedly from row 1 stops dead at row 4 and
+      # *never* reaches members 5/6 -- no scroll, no wrap-around back to row 1
+      # either, even after 8 discrete taps and a 2.5s hold well past the
+      # point auto-repeat would have cycled through the rest. Up from row 1
+      # is symmetric: it never reaches member 6. A same-shape probe on a
+      # troop of exactly 4 (which fits the window with no overflow) shows the
+      # opposite: Down from row 4 *does* wrap back to row 1 -- and a troop of
+      # 3 confirms Up from row 1 wraps to row 3. So only the overflow case
+      # (more living foes than the window's 4 visible rows) needed a fix:
+      # real RPG_RT cannot select past the 4 rows it first draws at all, it
+      # does not scroll this particular list the way the Item/Skill grids do.
+      # `#drive_battle_ally_target`'s identical-shaped modulo needs no
+      # matching change -- RPG2000's own party cap keeps `allies.length` at 4
+      # or fewer always, so it can never hit the overflow case this fixes.
       def drive_battle_target
         foes = living_foes
         if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !foes.empty?
-          @ui[:target_i] += 1
-          @ui[:target_i] %= foes.length
-          draw_battle_target
-          play_system_se(SFX_CURSOR)
+          move_battle_target_cursor(1, foes.length)
         elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !foes.empty?
-          @ui[:target_i] -= 1
-          @ui[:target_i] %= foes.length
-          draw_battle_target
-          play_system_se(SFX_CURSOR)
+          move_battle_target_cursor(-1, foes.length)
         elsif Input.trigger?(Input::C)
           play_system_se(SFX_DECISION)
           target = foes[@ui[:target_i]]
@@ -1608,6 +1625,24 @@ class RPG2k
             draw_battle_command
           end
         end
+      end
+
+      # Move the enemy-target cursor by `delta` (+-1) over `foes_count` living
+      # foes: a plain modulo wrap when they all fit in the window
+      # (`foes_count <= BATTLE_VISIBLE_ROWS`, this method's own pre-existing
+      # behaviour, unchanged), blocked at either end with no wrap at all once
+      # `foes_count` overflows it -- see #drive_battle_target's own comment
+      # for the cycle #131 evidence behind the split.
+      def move_battle_target_cursor(delta, foes_count)
+        if foes_count > BATTLE_VISIBLE_ROWS
+          target = @ui[:target_i] + delta
+          return if target.negative? || target >= BATTLE_VISIBLE_ROWS
+          @ui[:target_i] = target
+        else
+          @ui[:target_i] = (@ui[:target_i] + delta) % foes_count
+        end
+        draw_battle_target
+        play_system_se(SFX_CURSOR)
       end
 
       def pending_kind; @ui[:pending] && @ui[:pending][:kind]; end
@@ -3131,9 +3166,13 @@ class RPG2k
       # from the options window, so the status window's footprint here is
       # always its command-phase one (#battle_status_x's `0`).
       BATTLE_TARGET_W = 136
-      # How many rows show at once before a longer list (an 8-monster troop, a
-      # long skill list) scrolls: the panel's fixed 64px content area (80 minus
-      # the 8px border on each side) divided by the 16px row height.
+      # How many rows fit at once: the panel's fixed 64px content area (80
+      # minus the 8px border on each side) divided by the 16px row height. A
+      # longer Item/Skill list scrolls past this, keeping the cursor's row in
+      # view (`#move_battle_list_index`); the enemy-target list does not --
+      # see #drive_battle_target's own comment (cycle #131) -- a troop with
+      # more living members than this cannot have the extra ones targeted by
+      # the player's cursor at all, real RPG_RT included.
       BATTLE_VISIBLE_ROWS = 4
       # The battle Item/Skill lists are a two-column grid, not a single
       # stacked column -- confirmed against RPG_RT's own live source:
@@ -3488,9 +3527,11 @@ class RPG2k
       # caller except #draw_battle_item/#draw_battle_skill, see
       # `BATTLE_LIST_COLUMN_MAX`) lays `labels` out row-major across that many
       # columns instead of one; a list longer than `BATTLE_VISIBLE_ROWS`
-      # *rows* scrolls, keeping `sel`'s own row in view, the way
-      # `Window_Selectable`'s own scrolling does for an oversized troop or
-      # skill list.
+      # *rows* scrolls, keeping `sel`'s own row in view, for a long Item/Skill
+      # list. The enemy-target list never actually sends a `sel` past
+      # `BATTLE_VISIBLE_ROWS - 1` any more (#drive_battle_target caps it), so
+      # this scrolls it in principle only -- real RPG_RT does not scroll that
+      # particular list at all, see that method's own comment.
       # `idxs`, parallel to `labels`, is an optional windowskin swatch index
       # per row (0 enabled / 3 disabled, `Scene::Base#draw_system_text`'s own
       # convention) -- nil (every caller except #draw_battle_item/

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -554,6 +554,18 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
         pages: nil),
       4 => OpenStruct.new(name: 'Red Slimes', members: {
         1 => OpenStruct.new(enemy_id: 5, x: 100, y: 80, invisible: false) },
+        pages: nil),
+      # Six Slimes -- one more than the enemy-target window's own
+      # BATTLE_VISIBLE_ROWS (4) -- for the cycle #131 overflow-clamp check.
+      # Its own lone extra rows keep it from disturbing the two-Slime troop's
+      # assertions above.
+      5 => OpenStruct.new(name: 'Many Slimes', members: {
+        1 => OpenStruct.new(enemy_id: 2, x: 40, y: 80, invisible: false),
+        2 => OpenStruct.new(enemy_id: 2, x: 90, y: 80, invisible: false),
+        3 => OpenStruct.new(enemy_id: 2, x: 140, y: 80, invisible: false),
+        4 => OpenStruct.new(enemy_id: 2, x: 190, y: 80, invisible: false),
+        5 => OpenStruct.new(enemy_id: 2, x: 240, y: 80, invisible: false),
+        6 => OpenStruct.new(enemy_id: 2, x: 290, y: 80, invisible: false) },
         pages: nil) },
     # A drawable battle animation (id 8): four frames, with a screen flash timing
     # on frame 1. (Id 7 is intentionally absent so that test exercises the
@@ -12095,6 +12107,39 @@ check 'Enemy Encounter scene: the command and target cursors wrap around' do
   eq 1, ui[:target_i], 'Up from the first foe wraps to the last (2 Slimes)'
   press_key(scene, RGSS::Input::DOWN)
   eq 0, ui[:target_i], 'Down from the last foe wraps to the first'
+end
+
+# A troop with more living members than the enemy-target window's own
+# BATTLE_VISIBLE_ROWS (4) is a genuinely different case from the 2-Slime wrap
+# check above -- confirmed against a real RPG_RT.exe (cycle #131, see
+# #drive_battle_target's own comment): the cursor cannot advance past row 4 at
+# all when a troop overflows the window, and does not wrap back to row 1
+# either, unlike the small (<= 4) case just above.
+check 'Enemy Encounter scene: the target cursor is clamped, not wrapped, ' \
+      'when a troop overflows the 4-row window' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, troop_id: 5) # 6 Slimes
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::C) # open the enemy target list (6 Slimes)
+  eq :target, ui[:phase]
+  eq 0, ui[:target_i], 'starts on the first foe'
+
+  4.times { press_key(scene, RGSS::Input::DOWN) }
+  eq 3, ui[:target_i],
+     'Down stops dead at row 4 (the last visible row) -- it does not reach ' \
+     'the 5th/6th Slime, and does not wrap back to row 1 either'
+
+  press_key(scene, RGSS::Input::UP)
+  press_key(scene, RGSS::Input::UP)
+  press_key(scene, RGSS::Input::UP)
+  press_key(scene, RGSS::Input::UP)
+  eq 0, ui[:target_i],
+     'Up from row 4 comes back to row 1 the ordinary way, then stops dead ' \
+     'there -- it does not wrap forward to the 6th Slime'
 end
 
 check 'Enemy Encounter scene: the command menu is drawn Attack / Skill / Defend / Item' do


### PR DESCRIPTION
## Summary
- RPG_RT's enemy-target cursor stops at the last visible row instead of wrapping once a troop has more living members than the four-row target window can show at once — this codebase previously wrapped `@ui[:target_i]` modulo the full living-member count, letting the cursor reach and scroll past rows RPG_RT's own target list never actually scrolls to.
- Verified against genuine RPG_RT.exe (Nepheshel) with three synthetic Enemy Encounters: a 6-Killer-Bee troop confirmed the cursor blocks at row 4 with no scroll and no wrap even under a sustained hold; a 3-Blood-Bat troop and an exactly-4-Zombie troop (both fitting the window with no overflow) confirmed ordinary modulo wrap still applies in that case. Since every troop member shares one on-screen name, each probe attacked to kill from a known cursor position and cross-checked the troop's own member x/y in the `.ldb` against which sprite actually died, giving an unambiguous per-member signal.
- `#drive_battle_target`'s Down/Up now delegate to a new `#move_battle_target_cursor(delta, foes_count)`, mirroring the existing block-not-wrap shape `#move_battle_list_index` already uses for the Item/Skill grids. `#drive_battle_ally_target` needed no matching change since RPG2000's own 4-member party cap means it can never hit the overflow case.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check (6-Slime fixture troop) confirmed to **fail** against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/battle.rb` (`expected 3, got 4`), then confirmed to pass after `git stash pop`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 906 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvVVCj619TThxYzb5CbavC)_