### PR TITLE
psp: size the mruby arena at 12 MB, measured against a real game

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -454,14 +454,16 @@ The pieces below are scaffolded but **not** part of the EBOOT yet:
   runtime project loader, since the PSP EBOOT has no command line and no
   way to be told a different location after it starts.
 - **Validating ADR 0047's P2 numbers.** The mruby/LVGL allocator split itself
-  is decided and wired (mruby's whole heap lives in its own 8 MB arena, see
+  is decided and wired (mruby's whole heap lives in its own fixed arena, see
   `main.cxx`'s `mrb_basic_alloc_func` — LVGL's pool only aligns to 4 bytes on
   32-bit, too weak for mruby's word boxing, so sharing it is not an option
-  the way it is on desktop). What still needs a real game running at
-  `kGameDir` is confirming the arena size is right: the `RPG2K_PSP_BRINGUP`
-  heartbeat reports free RAM and LVGL's pool high-water mark, and the
-  mruby arena's own usage is the gap between `sceKernelTotalFreeMemSize` and
-  those two, once a title actually runs on hardware or an emulator.
+  the way it is on desktop). The size is now game-validated: Nepheshel's
+  New Game pins the arena at ~12.0 MB steady-state under PPSSPP-headless
+  (the title screen alone sits at ~4.3 MB), so the arena is 12 MB — 8 MB
+  exhausted mid-map-load and the failed-allocation unwind corrupted VM state
+  (see ADR 0047's P2 follow-up), and 16 MB starves the shared newlib heap.
+  The `RPG2K_PSP_BRINGUP` heartbeat now reports the arena's own occupancy as
+  `arena_used=` directly, next to free RAM and LVGL's pool high-water mark.
 - **Accelerated rendering.** The bring-up flushes with a CPU `memcpy` into the
   framebuffer. Moving the blit onto the `sceGu` GPU is a later optimisation,
   and the natural place to also do real scaling (above) instead of clipping.
@@ -474,11 +476,14 @@ fit inside the PSP's ~24 MB of RAM still needs a real game run on real
 hardware or an emulator with a Memory Stick image, not just CI's `psp-smoke`.
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)
 works through that, including the P2 allocator split, which is now decided and
-wired: mruby's entire heap lives in a fixed 8 MB arena of its own
+wired: mruby's entire heap lives in a fixed 12 MB arena of its own
 (`main.cxx`'s `mrb_basic_alloc_func`) rather than sharing LVGL's pool (whose
 TLSF only 4-byte-aligns on 32-bit — too weak for mruby's word boxing) or
 growing unbounded on plain malloc, so the interpreter OOMs into a catchable
-`NoMemoryError` instead of colliding with the decoded-bitmap heap. `lv_conf.h`'s
+`NoMemoryError` instead of colliding with the decoded-bitmap heap. The size
+is measured, not guessed: Nepheshel's New Game pins steady-state usage at
+~12.0 MB (8 MB exhausted and corrupted mid-map; see ADR 0047's P2 follow-up),
+while 16 MB takes RAM the decoded-bitmap/newlib heap needs. `lv_conf.h`'s
 `LV_MEM_SIZE` therefore covers only LVGL's own widgets and internals, and the
 decoded bitmaps stay in a third, uncapped pool as before. That pool is 256 KB,
 cut down from an original 4 MB once P2 established what is actually left for
@@ -508,8 +513,8 @@ PSP every PT_LOAD segment of the EBOOT is mapped into RAM at launch, so a
 read-only table is live memory, not just file size. The
 `RPG2K_PSP_BRINGUP` heartbeat is the place to read the
 result: `free`/`maxfree` from `sceKernelTotalFreeMemSize` are the device's real
-free RAM, `lvgl_used`/`lvgl_max` are LVGL's pool, and the mruby arena's usage is
-the gap between them once a game is actually running.
+free RAM, `lvgl_used`/`lvgl_max` are LVGL's pool, and `arena_used=` is the
+mruby arena's occupancy once a game is actually running.
 
 For a packed RPG Maker XP/VX/VX Ace title,
 [`scripts/rgssad_unpack.rb`](../../scripts/rgssad_unpack.rb) unpacks

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -165,14 +165,22 @@ lv_obj_t* g_status_label = nullptr;
 //
 // This is a first-fit free-list allocator with splitting and coalescing; every
 // block is 16-byte aligned (enough for the 8-byte RVALUE alignment mruby's
-// word boxing needs on 32-bit). The size should be validated against a real
-// game on-device -- the BRINGUP heartbeat below already reports free RAM --
-// but 8 MB is generous: the rpg2k+lcf+rgss mrblib costs ~1.4 MB of class
-// definitions on a 64-bit host (roughly half on the PSP's 32-bit MIPS), and a
-// real LCF database (Nepheshel's 1.3 MB .ldb) plus the maps and scene objects
-// fit well inside, while still leaving most of the ~24 MB for the LVGL pool,
-// the draw buffers and the decoded-bitmap heap.
-constexpr size_t kMrbArenaSize = 8u * 1024u * 1024u;
+// word boxing needs on 32-bit). The size is validated against a real game
+// (Nepheshel, New Game) under PPSSPP-headless: at 8 MB the arena fills to its
+// last byte during the first map load and the failed-allocation recovery paths
+// (mrb_realloc_simple's full-GC-and-retry, then a NoMemoryError raise that
+// itself has to unwind through cipop's env-unshare allocation) corrupt the VM
+// callinfo chain -- frames pointing into freed memory and even onto the native
+// C stack -- which aborts inside catch_handler_find on the very next raise.
+// At 12 MB the same scenario runs millions of frames with steady-state usage
+// pinned at ~12.0 MB (mruby grows to fill capacity and GCs under pressure;
+// one transient exhaustion per 3 minutes, recovered cleanly by the GC retry),
+// while 16 MB starves the newlib/sbrk heap that decoded bitmaps and the C++
+// exception machinery share (std::bad_alloc during map play). So 12 MB is the
+// measured working size on this ~24 MB target: the heartbeat below reports the
+// arena's own occupancy (arena_used) alongside the system figures, for the day
+// a game outgrows it.
+constexpr size_t kMrbArenaSize = 12u * 1024u * 1024u;
 alignas(16) uint8_t g_mrb_arena[kMrbArenaSize];
 
 constexpr size_t kMrbAlign = 16;
@@ -184,6 +192,17 @@ static_assert(sizeof(MrbBlock) <= kMrbAlign,
               "block header must fit one alignment unit");
 
 MrbBlock* g_mrb_free = nullptr;
+
+void mrb_arena_init();
+
+// Live bytes (payload + headers) currently handed out, for the heartbeat.
+size_t mrb_arena_used() {
+  mrb_arena_init();
+  size_t free_bytes = 0;
+  for (MrbBlock* b = g_mrb_free; b; b = b->next)
+    free_bytes += kMrbAlign + b->size;
+  return kMrbArenaSize - free_bytes;
+}
 
 size_t mrb_align_up(size_t n) {
   return (n + kMrbAlign - 1) & ~(kMrbAlign - 1);
@@ -667,6 +686,8 @@ int main(void) {
       sb.sint(stack_free);
       sb.str(" stack_used_max=");
       sb.uint(stack_used_max);
+      sb.str(" arena_used=");
+      sb.uint(static_cast<unsigned>(mrb_arena_used()));
       sb.str("\n");
       psp_write(buf, sb.length());
     }

--- a/changelog.d/psp-mruby-arena-12mb.fixed.md
+++ b/changelog.d/psp-mruby-arena-12mb.fixed.md
@@ -1,0 +1,11 @@
+- **PSP:** size the mruby arena at 12 MB instead of 8 MB. Nepheshel's
+  New Game filled the old arena to its last byte during the first map load,
+  and the failed-allocation recovery path corrupted the VM callinfo chain
+  (frames left pointing into freed memory), aborting inside mruby's
+  `catch_handler_find` on the next raise. The new size is measured, not
+  guessed: 12 MB runs millions of New Game frames under PPSSPP-headless with
+  steady-state occupancy of ~12.0 MB and one cleanly-recovered transient
+  exhaustion per few minutes, while 16 MB starves the shared newlib heap
+  (`std::bad_alloc`). The per-second `RPG2K_PSP_BRINGUP` heartbeat now also
+  reports `arena_used=` so the next game to outgrow it shows up in numbers
+  rather than as a crash.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -958,6 +958,38 @@ the interpreter-linking slice, in this order:
   LVGL only) instead of describing the un-taken shared-pool option. The 8 MB
   figure is a generous placeholder to be validated against a real game
   on-device, exactly as the BRINGUP heartbeat (P1) measures.
+
+  **Follow-up (2026-08-23, the validation P2 asked for): 8 MB was not
+  generous — it was too small, and exhausting it corrupted rather than
+  degraded.** Nepheshel's New Game fills the arena to its last byte during
+  the first map load; the title screen alone sits at ~4.3 MB, which is why
+  weeks of title-screen bring-up never saw this. What happens at exhaustion
+  is *not* the clean catchable `NoMemoryError` this section promised:
+  `mrb_realloc_simple`'s recovery path runs `mrb_full_gc` and retries, and
+  when even that fails the resulting raise has to unwind through
+  `cipop`'s env-unshare allocation and friends — allocation failures inside
+  that unwind leave the callinfo chain pointing into freed memory (observed:
+  frames in the just-freed old ci array after a growth realloc moved it, and
+  eventually an entry whose address sits on the native C stack), and the next
+  raise aborts inside `catch_handler_find`'s pc-range assert. Diagnosed by
+  dumping the walk's frames from inside mruby (`[vm] raw @=` traces), then
+  bisected by swapping the arena for plain malloc — the crash vanished — and
+  confirmed by usage instrumentation (`RPG2K_PSP_ARENA_OOM used=8388480`,
+  i.e. 100% full, fired *before* any corruption). The allocator's own logic
+  is sound: it survives millions of randomized alloc/free/reload ops with
+  integrity checks on host, and guarded runs on target show every pointer
+  arriving in-range with the free list ordered right up to exhaustion.
+  Resolution: arena sized to **12 MB** (measured working size — millions of
+  New Game frames, steady-state occupancy pinned at ~12.0 MB because mruby
+  grows to fill capacity and GCs under pressure, one transient exhaustion per
+  few minutes recovered cleanly by the GC retry). 16 MB boots but starves the
+  newlib/sbrk heap decoded bitmaps and `__cxa_allocate_exception` share
+  (`std::bad_alloc` mid-map), so the ceiling is real. The heartbeat now
+  reports `arena_used=` alongside the system figures so the next game to
+  outgrow the arena shows up as a number instead of a crash. Known sharp
+  edge left open on purpose: a game that genuinely exhausts 12 MB will hit
+  the same corrupting-unwind cliff until the failure paths are hardened —
+  treat `arena_used` approaching capacity as the early warning.
 - **P2a — `LV_MEM_SIZE` cut from 4 MB to 256 KB.** Once P2 moved mruby onto
   its own arena, checked what is actually left for LVGL's pool to cover:
   decoded bitmaps bypass it (Finding 3), the LVGL partial-render draw buffers


### PR DESCRIPTION
## What

Bumps the PSP build's fixed mruby arena from 8 MB to **12 MB**, adds an `arena_used=` field to the per-second `RPG2K_PSP_BRINGUP` heartbeat, and records the measurement in ADR 0047's P2 section (the on-device validation that section asked for).

## Why: the "New Game aborts" crash from PSP-HANDOFF.md, root-caused

Nepheshel's New Game filled the old 8 MB arena to its last byte during the first map load (the title screen alone sits at ~4.3 MB, which is why weeks of title-only bring-up never saw it). Exhaustion itself is survivable — `mrb_realloc_simple` runs a full GC and retries — but when even the retry fails, the resulting raise unwinds through allocation-performing paths (`cipop`'s env-unshare), and failing allocations there leave the callinfo chain pointing into freed memory (observed: frames in the just-freed old ci array after a growth realloc moved it; eventually an entry whose address is on the native C stack). The next raise aborts inside mruby's `catch_handler_find` pc-range assert after a burst of near-null reads.

Diagnostic trail (full version in the ADR):

- dumped the exception walk's frames from instrumented `vm.c`: walk descends through valid frames into garbage ones
- swapped the arena for plain malloc → crash gone, game runs millions of frames
- usage instrumentation: `ARENA_OOM used=8388480` (=100% full) fires *before* any corruption
- allocator logic exonerated: survives millions of randomized host fuzz ops with integrity checks; guarded target runs show all pointers in-range and free list ordered right up to exhaustion
- 10 MB still dies; 12 MB clean for minutes with one transient OOM recovered by the GC retry; 16 MB boots but starves the newlib heap decoded bitmaps and `__cxa_allocate_exception` share → `std::bad_alloc`

## Verification

- `ppsspp-headless --timeout=180`, Nepheshel New Game (via the local `RPG2K_NEW_GAME` repro flag, not committed): **8,054,200 frames, zero assertions / bad accesses / bad_alloc**
- idle/title boot unchanged: 1280 heartbeats over 40 s, `arena_used=4504752`
- `pre-commit run` clean; native ctest suite unchanged (only pre-existing `error_dump` failure, identical on clean master)

## Labels

`engine:` psp runtime · `component:` memory · `type:` bug+docs