### PR TITLE
ci: promote psp-smoke to a required check, asserting both markers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1389,15 +1389,17 @@ jobs:
     # that from a from-source PPSSPP compile on every run into a one-time cost,
     # replacing the hand-rolled tree cache PPSSPP used to be built from.
     #
-    # NON-BLOCKING (continue-on-error): PPSSPP's headless HLE only partially
-    # implements pspsdk's libc stdio (printf/strlen resolve to firmware stubs),
-    # which the EBOOT's markers lean on, so capture can be flaky under the
-    # emulator even though the EBOOT builds and boots. The required gate is the
-    # `psp` build; this job stays informational (its log is uploaded) until the
-    # emulator path is solid.
+    # BLOCKING: this used to run with continue-on-error while PPSSPP's headless
+    # HLE only partially implemented pspsdk's libc stdio (printf/strlen
+    # resolved to firmware stubs), which the EBOOT's markers lean on, making
+    # capture flaky even when the EBOOT itself booted fine. The ten-bug trail
+    # in app/psp/README.md (five of them PPSSPP HLE/interpreter bugs, patched
+    # in nix/patches/ and applied via this flake's own `packages.ppsspp`) fixed
+    # that, and the frame loop now runs for the whole timeout window (thousands
+    # of BRINGUP heartbeats per run), so the job asserts both markers and
+    # gates the build alongside `psp`.
     needs: psp
     runs-on: ubuntu-24.04
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1454,14 +1456,18 @@ jobs:
           # (the markers, or the tail when they are missing) are echoed here.
           ./ppsspp/bin/ppsspp-headless --log --graphics=software --timeout=15 \
             "$EBOOT" > "$GITHUB_WORKSPACE/headless.log" 2>&1 || true
-          echo "=== asserting the EBOOT booted (and ideally pumped frames) ==="
+          echo "=== asserting the EBOOT booted and pumped frames ==="
           # RPG2K_PSP_BOOT proves it booted with output captured; RPG2K_PSP_BRINGUP
-          # (the per-second heartbeat) additionally proves the frame loop runs.
-          if grep -qE 'RPG2K_PSP_(BOOT|BRINGUP)' "$GITHUB_WORKSPACE/headless.log"; then
+          # (the per-second heartbeat) additionally proves the frame loop runs --
+          # required separately, because BRINGUP was unreachable for weeks while
+          # the boot crashed before the first heartbeat, so a BOOT-only grep
+          # would have passed a build that never pumped a frame.
+          if grep -q 'RPG2K_PSP_BOOT' "$GITHUB_WORKSPACE/headless.log" &&
+             grep -q 'RPG2K_PSP_BRINGUP' "$GITHUB_WORKSPACE/headless.log"; then
             grep -E 'RPG2K_PSP_(BOOT|BRINGUP)' "$GITHUB_WORKSPACE/headless.log" \
               | head -5
           else
-            echo "no bring-up marker in the emulator log; last 100 lines:"
+            echo "boot or bring-up marker missing from the emulator log; last 100 lines:"
             tail -100 "$GITHUB_WORKSPACE/headless.log"
             exit 1
           fi

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -110,14 +110,16 @@ already a high-water mark (P5). All of them are real numbers for
 [ADR 0047](../../docs/adr/0047-psp-memory-budget.md)'s P1, captured from the
 `psp-smoke` log rather than estimated, and now against a real game's usage
 once one is deployed to `kGameDir` instead of just the idle HAL's. CI's
-`psp-smoke` job boots the EBOOT under PPSSPP headless and checks that a
-marker appears, so a regression that links but fails to boot is caught
+`psp-smoke` job boots the EBOOT under PPSSPP headless and checks that both
+the boot marker and a frame-loop heartbeat appear, so a regression that
+links but fails to boot — or boots but never pumps a frame — is caught
 automatically; it has no project at `kGameDir`, so it only ever exercises the
-idle path (`RPG2K_PSP_GAME_START none not_found`). The job is currently
-**non-blocking** (the required build gate is the `psp` job) — a holdover
-from when the EBOOT did not boot to completion under PPSSPP-headless; now
-that it does (see below), promoting `psp-smoke` to a required check is
-worth revisiting. Ten independent bugs were found and root-caused
+idle path (`RPG2K_PSP_GAME_START none not_found`). The job is a
+**required** check alongside `psp`: it ran with continue-on-error as a
+holdover from when the EBOOT did not boot to completion under
+PPSSPP-headless, but boot completes now (see below) and the frame loop
+pumps thousands of heartbeats per run, so it gates like every other job.
+Ten independent bugs were found and root-caused
 chasing that boot-to-completion goal; eight of them fixed, the remaining
 one (pspsdk's own upstream bug) no longer reachable — **boot now
 completes**:

--- a/changelog.d/psp-smoke-required-check.changed.md
+++ b/changelog.d/psp-smoke-required-check.changed.md
@@ -1,0 +1,7 @@
+- **CI:** the `psp-smoke` job (boots the PSP EBOOT under this flake's patched
+  PPSSPP-headless) is now a required check instead of running with
+  `continue-on-error`, and its assertion now requires *both* markers:
+  `RPG2K_PSP_BOOT` (booted, output captured) and `RPG2K_PSP_BRINGUP` (the
+  frame loop pumps). A BOOT-only grep would have stayed green through the
+  weeks the boot crashed before its first heartbeat; BRINGUP now flows at
+  thousands per run.


### PR DESCRIPTION
## What

- Drops `continue-on-error: true` from the `psp-smoke` job so it gates alongside `psp`.
- Tightens its assertion: requires `RPG2K_PSP_BOOT` **and** `RPG2K_PSP_BRINGUP` separately (the old grep accepted either).
- Updates the `app/psp/README.md` passage that still described the job as non-blocking.

## Why now

`BRINGUP` — the per-second frame-loop heartbeat — was unreachable for weeks while the boot crashed before its first heartbeat, so a BOOT-only grep proved almost nothing; that is why the job ran non-blocking in the first place. Since #1304/#1307 the frame loop runs for the whole timeout window (~7000 BRINGUP heartbeats per CI run), and #1312 removed the one crash a real game could still hit. Requiring BRINGUP now means: booted, output captured, *and* frames pumping.

## Labels

`engine:` psp · `platform:` ci · `type:` ci-infra