### PR TITLE
flake: derive the psp devShell from packages.build

### DIFF
--- a/changelog.d/nix-psp-devshell-inherits-build.changed.md
+++ b/changelog.d/nix-psp-devshell-inherits-build.changed.md
@@ -1,0 +1,6 @@
+- **PSP devshell** now derives from the `build` package via `overrideAttrs`
+  instead of re-listing its host tools, so anything added to the native build
+  environment (including the gperf/bison pair mruby's lexer regeneration
+  needs) reaches `nix develop .#psp` without a second list drifting out of
+  sync. Only the PSP-specific additions (`pspdev`, `pkg-config`, PPSSPP) are
+  declared in the shell itself.

--- a/flake.nix
+++ b/flake.nix
@@ -372,43 +372,39 @@
           # patched psp-fixup-imports app/psp/CMakeLists.txt insists on ships
           # inside it.
           #
-          # Host tools mirror what the psp CI job's container gets from apk
-          # plus what mruby's host half needs on a nix machine (the gperf/
-          # bison trap from PSP-HANDOFF.md's environment notes applies here
-          # too: without them, a stale direnv shell fails in mruby's lexer
-          # regeneration and leaves a zero-byte lex.def behind).
+          # The shell *is* packages.build, overrideAttrs'd like
+          # devShells.default above, rather than a fresh mkShell re-listing
+          # the host tools: every addition to the package build's
+          # environment (cmake/ninja/ruby/autoconf/automake/pre-commit, the
+          # gperf/bison pair mruby's lexer regeneration needs on a nix
+          # machine -- the trap PSP-HANDOFF.md's environment notes describe,
+          # where a stale direnv shell fails mid-regeneration and leaves a
+          # zero-byte lex.def behind) reaches PSP builds without a second
+          # copy of the list drifting out of sync. Only what PSP work adds
+          # beyond the native baseline lives here.
           #
           # Linux-only: packages.pspdev is an x86_64-linux tarball and
           # packages.ppsspp is Linux-only anyway. On darwin, use the default
           # devshell plus upstream's macOS release tarball by hand.
-          psp = pkgs.mkShell {
-            packages =
-              with pkgs;
-              [
+          psp = self.packages.${system}.build.overrideAttrs (old: {
+            nativeBuildInputs =
+              old.nativeBuildInputs
+              ++ [
                 self.packages.${system}.pspdev
-                cmake
-                ninja
-                ruby
-                bison
-                gperf
-                git
-                autoconf
-                automake
-                pkg-config
-                pre-commit
+                pkgs.pkg-config
               ]
               ++ nixpkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
                 self.packages.${system}.ppsspp
               ];
             PSPDEV = "${self.packages.${system}.pspdev}";
             CMAKE_BUILD_TYPE = "MinSizeRel";
-            shellHook = ''
+            shellHook = old.shellHook + ''
               echo "psp shell: PSPDEV=$PSPDEV"
               "$PSPDEV/bin/psp-gcc" --version | head -1
               echo "build:  psp-cmake -S app/psp -B build-psp && cmake --build build-psp"
               echo "run:    ppsspp-headless --log --graphics=software build-psp/EBOOT.PBP"
             '';
-          };
+          });
         }
       );
     };


### PR DESCRIPTION
## Summary
- `devShells.psp` is now `packages.build.overrideAttrs` (the pattern `devShells.default` already uses) instead of a standalone `pkgs.mkShell` that re-listed the host tools.
- The shell inherits the native build environment wholesale — cmake, ninja, ruby, autoconf/automake, pre-commit, the gperf/bison pair mruby's lexer regeneration needs (the PSP-HANDOFF.md trap), plus the mesa llvmpipe hook and `CTEST_PARALLEL_LEVEL` — so future additions to the build env reach PSP work without a second list drifting out of sync.
- Only PSP-specific additions remain in the shell: `pspdev`, `pkg-config`, PPSSPP (Linux-only), `PSPDEV`, `CMAKE_BUILD_TYPE=MinSizeRel`, and the banner appended to the inherited `shellHook`.

Verified by evaluating `.#devShells.x86_64-linux.psp`: all inherited tools plus pspdev/pkg-config/ppsspp resolve; `pre-commit` (nixfmt) passes.

Trade-off note: entering the shell now also pulls the build derivation's SDL2/mesa/emscripten closure.

## Labels
- component:build, platform:psp, type:refactor