### PR TITLE
PSP: chroot ENOSYS stub fixes the EBOOT link broken by the mruby-dir declaration

### DIFF
--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -209,7 +209,7 @@ rpg2k_add_mruby(
 # earlier HAL-only bring-up did, would double-define every symbol in it
 # (psp_display_create, psp_input_scan, ...) once both this executable and
 # libmruby.a define them.
-add_executable(rpg2k_psp main.cxx)
+add_executable(rpg2k_psp main.cxx psp_missing_syscalls.c)
 
 target_compile_definitions(rpg2k_psp PRIVATE PSP_BUILD LV_CONF_INCLUDE_SIMPLE)
 target_include_directories(rpg2k_psp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/app/psp/psp_missing_syscalls.c
+++ b/app/psp/psp_missing_syscalls.c
@@ -1,0 +1,16 @@
+// libc symbols libmruby.a references that pspsdk's newlib does not provide.
+//
+// mrbgems/hal-posix-dir's mrb_hal_dir_chroot gates the platforms without a
+// chroot(2) on __ANDROID__ / __MSDOS__ but not PSP, so declaring mruby-dir in
+// build_config.rb's rpg_maker_gems pulls dir_hal.o into the EBOOT link and
+// the reference dangles ("undefined reference to `chroot'"). Until upstream
+// mruby's gate learns __PSP__, provide the same ENOSYS answer here that the
+// gate gives those other platforms.
+
+#include <errno.h>
+
+int chroot(const char *path) {
+  (void)path;
+  errno = ENOSYS;
+  return -1;
+}

--- a/changelog.d/psp-chroot-shim.fixed.md
+++ b/changelog.d/psp-chroot-shim.fixed.md
@@ -1,0 +1,6 @@
+- **PSP:** the EBOOT failed to link ("undefined reference to `chroot`") once
+  `mruby-dir` joined the shared gem set and its `hal-posix-dir` object got
+  pulled into the link — upstream mruby's `mrb_hal_dir_chroot` gates the
+  no-`chroot` platforms on `__ANDROID__`/`__MSDOS__` but not `__PSP__`.
+  `app/psp/psp_missing_syscalls.c` provides the same ENOSYS answer the gate
+  gives those platforms, until the upstream gate learns `__PSP__`.


### PR DESCRIPTION
Fixes the `psp` job failure in #1318's CI (run 32681752211) and on master since its merge.

`5aa05b5b` declared `mruby-dir` in `rpg_maker_gems` (mruby 4.0 moved `Dir` out of `mruby-io`). On PSP that pulls `hal-posix-dir`'s `dir_hal.o` into the EBOOT link for the first time, and `mrb_hal_dir_chroot` dangles: its no-`chroot` gate covers `__ANDROID__`/`__MSDOS__` but not `__PSP__`:

```
psp/bin/ld: mruby/psp/lib/libmruby.a(dir_hal.o): dir_hal.c:143: undefined reference to `chroot'
```

`app/psp/psp_missing_syscalls.c` provides the same ENOSYS answer that gate gives the other platforms, following the existing `psp_unwind_fde.cxx` link-shim pattern. The real fix is upstream — `mruby/mruby`'s `mrb_hal_dir_chroot` gate learning `__PSP__` — noted here as a follow-up.

**Verified:** `nix develop .#psp` → `psp-cmake -S app/psp -B build-psp && cmake --build build-psp` links `rpg2k_psp` and creates `EBOOT.PBP` (previously the exact CI failure).