### PR TITLE
Item/Skill menus: fix actor-target-confirm screen layout

### DIFF
--- a/changelog.d/item-skill-target-confirm-layout.fixed.md
+++ b/changelog.d/item-skill-target-confirm-layout.fixed.md
@@ -1,0 +1,6 @@
+- **Item/Skill menus:** the actor-target-confirm screen ("who to use this
+  on") now matches RPG_RT's real layout — a right-anchored panel the full
+  height of the screen, with each party member drawn on three lines (name;
+  level and HP; condition and MP) — previously it was a bottom-anchored bar
+  sized to the party count, with each member squeezed onto two lines (name
+  and condition, then HP and MP together).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,79 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #132, 2026-08-24): the field Item/Skill menus'
+  actor-target-confirm screen ("who to use this on") was a guess this
+  session had never independently re-run against genuine RPG_RT.exe -- a
+  previous cycle's own investigation of this exact screen was discarded
+  entirely (no doc entry, nothing shipped) after it turned out to have
+  secretly consulted EasyRPG source, leaving it untouched territory. Redone
+  here from scratch against the real binary only, and the guess turned out
+  wrong on two separate axes at once: window placement and per-actor row
+  content. Fixed.** `Scene::ItemMenu#build_target_window` (and
+  `Scene::SkillMenu`'s byte-identical copy) drew a *bottom-anchored,
+  full-screen-width* bar sized to `party.size * (LINE_H * 2)`, each actor on
+  two lines (name + condition on the first, "HP x/y  MP x/y" on the
+  second). RPG_RT.exe instead draws a **right-anchored panel the full
+  height of the screen**, sized the same regardless of party size, with
+  each actor on **three** lines -- name alone; level and HP; condition and
+  MP -- and the HP/MP value column starting partway across the row rather
+  than immediately after the label. Measured under wine per ADR 0021's own
+  methodology (Xvfb 640x480x16, LIBGL_ALWAYS_SOFTWARE=1, matchbox-window-
+  manager, LANG=ja_JP.UTF-8) against `data/Nepheshel206beta/
+  Nepheshel206Rbeta/RPG_RT.exe`: a genuine save (`scripts/gen-lcf-save-
+  wine.bash`, then `scripts/gen-rpg2k-save.rb --map 12 --clear-scene` to
+  reposition it off the unskippable bedroom-wakeup map) hand-edited to carry
+  five 薬草 (item 1, a plain single-ally-scope medicine, `db.item[1].scope
+  == 0`) in its inventory chunk (109)'s `item_ids`/`item_counts` fields --
+  Continue, Escape to open the field menu, Decision on Item (already
+  selected), Decision on the (only) item, landing on the target-confirm
+  screen. Pixel-sampled the capture (640x480, so halved for native 320x240
+  coordinates): panel at native (136, 0), 184x240 (`SCREEN_W - TARGET_W` ..
+  `SCREEN_W`, the *full* `SCREEN_H`, not `party.size`-dependent); each row
+  48px (three 16px lines); the label column (name/level/condition) starting
+  56px into the panel's own content area, the value column (HP/MP) at
+  114px; a plain-modulo-wrapping single-row cursor sized to that same
+  content width, not the window's full width, its left edge landing right
+  at the row's own left margin. Fixed `#build_target_window`/
+  `#refresh_target_cursor` in both `item_menu.rb` and `skill_menu.rb`
+  identically (new `TARGET_W`/`TARGET_ROW_H`/`TARGET_LABEL_X`/
+  `TARGET_VALUE_X` constants) to match. Two new `scripts/rpg2k_scene_check
+  .rb` checks -- window geometry (right-anchored, full-height, independent
+  of a 1-actor vs. a 4-actor `FourActorTargetParty` fixture -- RPG2000's own
+  party-membership cap keeps 4 the structural ceiling, and 4 rows at 48px
+  each (192px) comfortably fits the fixed 240px panel with no scrolling,
+  unlike the old per-party-size formula) and per-row content (name on line
+  one, "Lv 5" and "HP 80/120" sharing line two, the condition and "MP
+  10/30" sharing line three, HP/MP both starting at the measured value
+  column) -- both confirmed to fail against the pre-fix code (`NameError:
+  uninitialized constant ...::TARGET_W`, then `target window draws "Lv 5"`
+  once that constant was stubbed back in) before the fix. Full suite
+  reconfirmed passing (908 checks, up from 906).
+  **Left open for a future cycle, boundary cases this investigation could
+  not reach:** (1) RPG_RT reserves a blank gutter to the left of every
+  row's text, of a piece with the cursor highlight -- a plausible but
+  *unconfirmed* explanation is a face-graphic slot this screen does not
+  draw into, since Nepheshel's only reachable test actor (the debug save's
+  solo "デモ用" character, the *sole* actor the save's F9-debug-menu
+  generation flow produces) carries no faceset to test that theory
+  against. (2) The left side of the screen (the item description /
+  quantity area) visibly re-flows too when entering target mode -- narrower,
+  and split into two stacked boxes rather than the ordinary description-bar-
+  plus-item-grid layout -- not investigated or fixed this cycle; scope was
+  kept to the target panel itself. (3) Multi-actor row *stacking* (whether
+  cards butt directly against each other at the measured 48px, and whether
+  a non-selected row's text is laid out identically to the selected one)
+  is this fix's own straight-line extrapolation from the single-actor
+  measurement, not independently confirmed: `inventory` chunk 109's `party`
+  sub-field (`SAVE_INVENTORY` field 1, `int8_array`) would not grow past
+  the save's own saved solo actor no matter how many ids were written into
+  it and read back correctly by this codebase's own parser (`[1]`, `[1,
+  2]`, and `[1, 2, 3, 4]` were all tried) -- genuine RPG_RT kept showing a
+  one-row party regardless, so real party membership is evidently gated by
+  something else this cycle did not identify (not simply "whichever actor
+  ids chunk 109 field 1 lists"). Chasing that mechanism down, or finding
+  another way to reach a genuine multi-member party from a synthetic save,
+  is the natural next step to fully close this screen out.
   ✅ **Follow-up (cycle #131, 2026-08-23): of the four battle cursor spots
   cycle #130 left unverified, `#drive_battle_target` (enemy targeting) turned
   out to have a real bug -- not about key-repeat (that part re-confirmed

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -678,26 +678,64 @@ class RPG2k
         refresh_desc
       end
 
+      # The actor-target picker's own geometry -- confirmed against a genuine
+      # RPG_RT.exe under wine (cycle #132), replacing a guess this class had
+      # never independently re-verified: a *bottom-anchored, full-width* bar
+      # sized to `party.size * (LINE_H * 2)`, two lines per actor (name +
+      # condition on the first, HP/MP on the second). Real RPG_RT instead
+      # draws a **right-anchored panel the full height of the screen**,
+      # sized the same regardless of party size (RPG2000's own party cap
+      # keeps it at 4 members either way, well inside this fixed panel — the
+      # same reasoning #move_battle_target_cursor's own doc comment, cycle
+      # #131, already established for the battle-side target list), with
+      # each actor on **three** lines -- name; level + HP; condition + MP --
+      # not two, and the HP/MP *value* column starting partway across the
+      # row rather than immediately after the label. There is also a blank
+      # gutter to the left of every line, of a piece with the cursor
+      # highlight (see #refresh_target_cursor below): a plausible, but
+      # *not confirmed*, explanation is a face-graphic slot this screen does
+      # not draw into -- Nepheshel's only reachable test actor (the debug
+      # save's solo "デモ用" character) carries no faceset to test that
+      # theory against, and the party field of a hand-edited save
+      # (`inventory` chunk 109's own `party` sub-field) could not be grown
+      # past that one saved actor this cycle (RPG_RT kept showing a solo
+      # party regardless), so the multi-actor stacking below is this
+      # method's own straight-line extrapolation of the confirmed single-row
+      # geometry, not independently confirmed -- see docs/TODO.md's cycle
+      # #132 entry for the full measurement write-up and this as an open
+      # lead. Pixel values measured directly (640x480 wine capture, so
+      # divided by 2 for native 320x240 coordinates): panel at native
+      # (136, 0), 184x240 -- i.e. `SCREEN_W - TARGET_W` .. `SCREEN_W`, full
+      # `SCREEN_H`; each row 48px (three 16px lines); the label column
+      # (name/level/condition) starting 56px into the panel's own content
+      # area, the value column (HP/MP) at 114px.
+      TARGET_W = 184
+      TARGET_ROW_H = LINE_H * 3
+      TARGET_LABEL_X = 56
+      TARGET_VALUE_X = 114
+
       def build_target_window
         @target_window.dispose if @target_window
         party = @state.party.actors
-        inner_w = SCREEN_W - Window::BORDER * 2
-        h = party.size * (LINE_H * 2)
-        @target_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
-                                    SCREEN_W, h + Window::BORDER * 2)
+        inner_w = TARGET_W - Window::BORDER * 2
+        @target_window = Window.new(SCREEN_W - TARGET_W, 0, TARGET_W, SCREEN_H)
         @target_window.z = 450
         @target_window.windowskin = @skin
-        c = Bitmap.new(inner_w, h)
+        c = Bitmap.new(inner_w, SCREEN_H - Window::BORDER * 2)
         c.font.color = Color.new(255, 255, 255, 255)
         party.each_with_index do |a, i|
-          y = i * LINE_H * 2
-          c.draw_text 0, y, inner_w, LINE_H, a.name.to_s
+          y = i * TARGET_ROW_H
+          c.draw_text TARGET_LABEL_X, y, inner_w - TARGET_LABEL_X, LINE_H, a.name.to_s
+          c.draw_text TARGET_LABEL_X, y + LINE_H, TARGET_VALUE_X - TARGET_LABEL_X, LINE_H,
+                      "#{term(:level_short, 'Lv')} #{a.level}"
+          c.draw_text TARGET_VALUE_X, y + LINE_H, inner_w - TARGET_VALUE_X, LINE_H,
+                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}"
           # RPG_RT's target list shows each member's condition (its
           # Window_ActorTarget draws one) -- which is most of the point of the
           # list, since it is where you pick who to use an antidote on.
-          draw_actor_state c, a, 0, y, inner_w, LINE_H, @skin, 2
-          c.draw_text 0, y + LINE_H, inner_w, LINE_H,
-                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
+          draw_actor_state c, a, TARGET_LABEL_X, y + LINE_H * 2,
+                           TARGET_VALUE_X - TARGET_LABEL_X, LINE_H, @skin
+          c.draw_text TARGET_VALUE_X, y + LINE_H * 2, inner_w - TARGET_VALUE_X, LINE_H,
                       "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
         end
         @target_window.contents = c
@@ -713,9 +751,13 @@ class RPG2k
           @target_window.cursor_rect =
             Rect.new(0, 0, @target_window.contents.width, @target_window.contents.height)
         else
+          # Content-width, not window-width, matching the measured single-row
+          # cursor's own left edge (see the geometry comment above) --
+          # `TARGET_LABEL_X - 2` lands the highlight's left edge right at the
+          # measured card border, a couple of pixels ahead of the text itself.
           @target_window.cursor_rect =
-            Rect.new(0, @target_index * LINE_H * 2, @target_window.contents.width,
-                     LINE_H * 2)
+            Rect.new(TARGET_LABEL_X - 2, @target_index * TARGET_ROW_H,
+                     @target_window.contents.width - (TARGET_LABEL_X - 2), TARGET_ROW_H)
         end
       end
 

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -540,26 +540,40 @@ class RPG2k
         refresh_desc
       end
 
+      # See Scene::ItemMenu's identical `TARGET_W`/`TARGET_ROW_H`/
+      # `TARGET_LABEL_X`/`TARGET_VALUE_X` doc comment (cycle #132) for the
+      # full RPG_RT measurement write-up -- this class's own target-confirm
+      # screen shares the exact same geometry (a genuine RPG_RT.exe under
+      # wine draws Scene_Skill's actor-target picker identically to
+      # Scene_Item's), so the constants and both methods below are ported
+      # verbatim from there rather than re-measured independently.
+      TARGET_W = 184
+      TARGET_ROW_H = LINE_H * 3
+      TARGET_LABEL_X = 56
+      TARGET_VALUE_X = 114
+
       def build_target_window
         @target_window.dispose if @target_window
         party = @state.party.actors
-        inner_w = SCREEN_W - Window::BORDER * 2
-        h = party.size * (LINE_H * 2)
-        @target_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
-                                    SCREEN_W, h + Window::BORDER * 2)
+        inner_w = TARGET_W - Window::BORDER * 2
+        @target_window = Window.new(SCREEN_W - TARGET_W, 0, TARGET_W, SCREEN_H)
         @target_window.z = 450
         @target_window.windowskin = @skin
-        c = Bitmap.new(inner_w, h)
+        c = Bitmap.new(inner_w, SCREEN_H - Window::BORDER * 2)
         c.font.color = Color.new(255, 255, 255, 255)
         party.each_with_index do |a, i|
-          y = i * LINE_H * 2
-          c.draw_text 0, y, inner_w, LINE_H, a.name.to_s
+          y = i * TARGET_ROW_H
+          c.draw_text TARGET_LABEL_X, y, inner_w - TARGET_LABEL_X, LINE_H, a.name.to_s
+          c.draw_text TARGET_LABEL_X, y + LINE_H, TARGET_VALUE_X - TARGET_LABEL_X, LINE_H,
+                      "#{term(:level_short, 'Lv')} #{a.level}"
+          c.draw_text TARGET_VALUE_X, y + LINE_H, inner_w - TARGET_VALUE_X, LINE_H,
+                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}"
           # RPG_RT's target list shows each member's condition (its
           # Window_ActorTarget draws one) -- which is most of the point of the
           # list, since it is where you pick who to use an antidote on.
-          draw_actor_state c, a, 0, y, inner_w, LINE_H, @skin, 2
-          c.draw_text 0, y + LINE_H, inner_w, LINE_H,
-                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.display_max_hp}  " \
+          draw_actor_state c, a, TARGET_LABEL_X, y + LINE_H * 2,
+                           TARGET_VALUE_X - TARGET_LABEL_X, LINE_H, @skin
+          c.draw_text TARGET_VALUE_X, y + LINE_H * 2, inner_w - TARGET_VALUE_X, LINE_H,
                       "#{term(:mp_short, 'MP')} #{a.mp}/#{a.display_max_mp}"
         end
         @target_window.contents = c
@@ -569,17 +583,14 @@ class RPG2k
       def refresh_target_cursor
         return unless @target_window
         # A :party lock (an all-ally skill) highlights every row at once --
-        # EasyRPG's own Window_ActorTarget::UpdateCursorRect draws exactly
-        # this for its `index < -10` ("Entire Party") case -- rather than
-        # the single-row rect a :self lock or an ordinary single-ally pick
-        # uses.
+        # see Scene::ItemMenu#refresh_target_cursor's identical comment.
         if @target_lock == :party
           @target_window.cursor_rect =
             Rect.new(0, 0, @target_window.contents.width, @target_window.contents.height)
         else
           @target_window.cursor_rect =
-            Rect.new(0, @target_index * LINE_H * 2, @target_window.contents.width,
-                     LINE_H * 2)
+            Rect.new(TARGET_LABEL_X - 2, @target_index * TARGET_ROW_H,
+                     @target_window.contents.width - (TARGET_LABEL_X - 2), TARGET_ROW_H)
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19104,6 +19104,88 @@ check 'the item / skill target list shows who is afflicted' do
   end
 end
 
+# A four-actor party -- RPG2000's own party-membership cap (see
+# Game::Party#reorder and every battle-side ally list in this codebase) --
+# for the target-confirm panel's own at-capacity boundary case below.
+class FourActorTargetParty < MenuStubParty
+  def initialize
+    super
+    @actors = Array.new(4) { MenuStubActor.new }
+  end
+end
+
+def four_actor_target_state
+  Game::State.new(FourActorTargetParty.new, 1, 0, 0)
+end
+
+check 'the item / skill target-confirm window is a right-anchored, ' \
+      'full-height panel, not a bottom bar sized to the party' do
+  # Confirmed against a genuine RPG_RT.exe under wine (cycle #132): this
+  # window used to be bottom-anchored, full screen width, and sized to
+  # `party.size * (LINE_H * 2)` -- a solo party's window was a short bar
+  # hugging the bottom edge. Real RPG_RT instead draws a *right-anchored*
+  # panel that is the *full height of the screen regardless of party size*
+  # -- confirmed directly for a solo party (the only party size reachable
+  # this cycle -- see Scene::ItemMenu::TARGET_W's own doc comment) and
+  # extrapolated here to a full 4-actor party as this fix's own capacity
+  # boundary: RPG2000 never has more than 4 members to show, and 4 rows of
+  # this panel's own fixed 48px row height (192px) comfortably fits inside
+  # the fixed 240px-tall panel with no scrolling needed, unlike the old
+  # per-party-size formula, which would have kept growing indefinitely.
+  [RPG2k::Scene::ItemMenu, RPG2k::Scene::SkillMenu].each do |klass|
+    [menu_state, four_actor_target_state].each do |st|
+      scene = menu_scene(klass, st)
+      scene.send(:build_target_window)
+      win = scene.instance_variable_get(:@target_window)
+      party_size = st.party.actors.size
+      eq RPG2k::Scene::ItemMenu::SCREEN_W - RPG2k::Scene::ItemMenu::TARGET_W, win.x,
+         "#{klass} (#{party_size} actor(s)) target window's left edge"
+      eq 0, win.y, "#{klass} (#{party_size} actor(s)) target window's top edge"
+      eq RPG2k::Scene::ItemMenu::TARGET_W, win.width,
+         "#{klass} (#{party_size} actor(s)) target window's width"
+      eq RPG2k::Scene::ItemMenu::SCREEN_H, win.height,
+         "#{klass} (#{party_size} actor(s)) target window's height"
+    end
+  end
+end
+
+check 'the item / skill target-confirm screen draws each actor on three ' \
+      'lines (name; level + HP; condition + MP), not two' do
+  # Confirmed against a genuine RPG_RT.exe under wine (cycle #132): the old
+  # layout drew name + condition on one line and "HP x/y  MP x/y" on a
+  # second. Real RPG_RT draws the name alone on the first line, level and
+  # HP on the second, and condition and MP on the third -- see
+  # Scene::ItemMenu::TARGET_W's own doc comment for the measurement.
+  st = menu_state
+  a = st.party.actors.first # MenuStubActor: level 5, hp 80/120, mp 10/30
+  [RPG2k::Scene::ItemMenu, RPG2k::Scene::SkillMenu].each do |klass|
+    scene = menu_scene(klass, st)
+    scene.send(:build_target_window)
+    win = scene.instance_variable_get(:@target_window)
+    calls = ((win.contents.draw_calls || []) + (win.contents.blend_calls || []))
+    row_y = ->(text) { calls.find { |c| c[4].to_s == text }&.at(1) }
+    row_x = ->(text) { calls.find { |c| c[4].to_s == text }&.at(0) }
+    name_y = row_y.call(a.name)
+    lv_y = row_y.call('Lv 5')
+    hp_y = row_y.call('HP 80/120')
+    mp_y = row_y.call('MP 10/30')
+    ok name_y, "#{klass} target window draws the actor's name"
+    ok lv_y, "#{klass} target window draws \"Lv 5\""
+    ok hp_y, "#{klass} target window draws \"HP 80/120\""
+    ok mp_y, "#{klass} target window draws \"MP 10/30\""
+    eq 0, name_y, "#{klass}: the name is alone on the first line"
+    eq RPG2k::Scene::ItemMenu::LINE_H, lv_y, "#{klass}: level is on the second line"
+    eq RPG2k::Scene::ItemMenu::LINE_H, hp_y, "#{klass}: HP shares the second line with level"
+    eq RPG2k::Scene::ItemMenu::LINE_H * 2, mp_y, "#{klass}: MP is on the third line"
+    # The value column (HP/MP) starts partway across the row, not flush
+    # against the label column (level/condition) -- see TARGET_VALUE_X.
+    eq RPG2k::Scene::ItemMenu::TARGET_VALUE_X, row_x.call('HP 80/120'),
+       "#{klass}: HP starts at the value column, not right after \"Lv 5\""
+    eq RPG2k::Scene::ItemMenu::TARGET_VALUE_X, row_x.call('MP 10/30'),
+       "#{klass}: MP starts at the value column, not right after the condition"
+  end
+end
+
 check 'Scene::ItemMenu: the item grid cursor does not wrap, the target cursor does' do
   scene = menu_scene(RPG2k::Scene::ItemMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@item_index), 'starts on the first item'


### PR DESCRIPTION
## Summary

- RPG_RT draws the item/skill target-confirm screen ("who to use this on") as a **right-anchored panel spanning the full screen height**, not a bottom-anchored bar sized to the party count.
- RPG_RT draws each party member on **three lines** (name; level and HP; condition and MP), not two (name + condition, then HP + MP together).
- RPG_RT starts the HP/MP value column partway across the row rather than flush against the label, and the single-row cursor highlight's left edge lands at the panel's own content margin rather than the window's full width.
- These fixes apply identically to `Scene::ItemMenu` and `Scene::SkillMenu`, which share this screen's layout byte-for-byte.

Confirmed directly against genuine `RPG_RT.exe` under Wine (`data/Nepheshel206beta`), per ADR 0021's methodology — pixel-measuring window placement, row height, and label/value column x-offsets from a solo-party save (a hand-edited inventory carrying 5x a single-ally-scope medicine). The four-actor case is this fix's own extrapolation of that single-row measurement: attempts to grow the save's party field to reach a genuine multi-member target list were not honored by real RPG_RT this cycle, so multi-actor row *stacking* is left as an open, unconfirmed lead in `docs/TODO.md`'s new cycle #132 entry, alongside a possible left-side face-graphic gutter and the item-description area's own re-flow in target mode (both out of this cycle's scope).

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the two new `scripts/rpg2k_scene_check.rb` checks (window geometry, per-row content) **fail against the pre-fix source** via `git stash push -- mruby-rpg2k/mrblib/scene/item_menu.rb mruby-rpg2k/mrblib/scene/skill_menu.rb`, rerunning the suite, then `git stash pop`:
  - `NameError: uninitialized constant RPG2k::Scene::ItemMenu::TARGET_W`
  - `RuntimeError: RPG2k::Scene::ItemMenu target window draws "Lv 5"`
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 908 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_