### PR TITLE
Battle Item cursor: independently re-verify against genuine RPG_RT.exe

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,62 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #133, 2026-08-24): of the three `#drive_battle_skill`/
+  `#drive_battle_item`/`#drive_battle_ally_target` battle cursors cycles
+  #130/#131 left unrun, `#drive_battle_item`'s key-repeat and grid wrap/
+  clamp behaviour is now independently re-verified against genuine
+  RPG_RT.exe -- confirmed correct on every list-size boundary tested, no
+  code change needed.** Built a synthetic autostart Enemy Encounter (troop
+  103, the same probe cycles #130/#131 used) by tail-splicing Map0478 event
+  2 page 2's own Enemy-Encounter-through-EndBattle command block (codes
+  10710/20710/20711/20713/0, troop id left unchanged) onto a new event 22 on
+  a scratch copy of Nepheshel's map 12, autostart-triggered. Repositioned
+  the debug save onto it (`gen-rpg2k-save.rb --map 12 --at 40,15
+  --clear-scene`) and hand-edited its inventory chunk (109)'s `item_ids`/
+  `item_counts`/`item_count` fields through five separate wine sessions, one
+  per list-size boundary the battle Item grid's own 2-column/4-row shape
+  distinguishes: 1 item (single cell), 2 items (one full row), 3 items (odd,
+  a partial second row), 8 items (an exact 4-row grid, no overflow) and 9
+  items (overflow past the grid). Every scenario: Continue -> file 1 ->
+  autostart fires -> dismiss the "X appeared!" message -> confirm Fight ->
+  Down x3 to Item -> Decision opens the item list, then held/tapped
+  Down/Up/Right/Left. Results, all matching this codebase's pre-existing
+  `#move_battle_list_index`/`#drive_battle_item` exactly: 1 item blocked in
+  all four directions (including a 1.2s held Down); 2 items let Right/Left
+  cross the row with Down/Up blocked (no second row); 3 items let Down reach
+  the partial second row's lone cell with Right off its end *not* reaching a
+  phantom cell -- unlike the equip candidate list's trailing Remove entry
+  (cycle #129), that finding does not generalise here; 8 items auto-repeated
+  through a continuous 1.5s Down hold (row 0 -> 1 -> 2 -> 3 within one hold,
+  confirming genuine key-repeat the same way cycle #130 did for the
+  options/command cursors) then stopped dead at the grid's own last cell,
+  neither wrapping nor scrolling; 9 items scrolled (a genuine pixel scroll,
+  confirmed on-screen -- the window's small down-arrow scroll indicator was
+  visible before the hold) via a 2.5s Down hold to reveal the 9th item alone
+  in a fifth, partial row -- unlike the enemy-target list, which cycle #131
+  found does *not* scroll and hard-caps instead -- then blocked there the
+  same way the 3-item case did, no wrap, no phantom cell. Since nothing
+  needed fixing, comments in `battle.rb` (`#move_battle_list_index`,
+  `#drive_battle_item`) and the matching `scripts/rpg2k_scene_check.rb`
+  citation were updated to record the re-verification, mirroring the
+  precedent cycle #130 set for a "confirmed correct" outcome; three new
+  checks added (an exact-8-item no-wrap check, a 9-item scroll-and-block
+  check, and a held-Down repeat check for the item/skill grids, two of the
+  six battle cursors cycle #130's own repeat check did not cover) --
+  confirmed to catch a regression (a deliberately injected modulo-wrap bug
+  in `#move_battle_list_index` failed 4 of 911 checks, including both new
+  grid checks) before being reverted. Full suite reconfirmed passing (911
+  checks, up from 908). `#drive_battle_skill` was not independently re-run
+  this cycle (it shares `#move_battle_list_index`/`#battle_list_window`
+  with `#drive_battle_item` exactly, not merely the same claimed shape, so
+  this is not a fresh guess the way the pre-cycle-133 state was) and
+  `#drive_battle_ally_target` remains untouched -- Nepheshel's debug save
+  still cannot be grown past its one solo actor (cycle #132's own open item
+  (c)), so its wrap/clamp behaviour past a single ally is still
+  unverifiable against the genuine binary; both are left for a future
+  cycle. `Map0012.lmu`/`Save01.lsd` were edited only as scratch copies for
+  these probes and restored to their original bytes (byte-identical by
+  `md5sum`) once each wine session was torn down.
   ✅ **Follow-up (cycle #132, 2026-08-24): the field Item/Skill menus'
   actor-target-confirm screen ("who to use this on") was a guess this
   session had never independently re-run against genuine RPG_RT.exe -- a

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1692,15 +1692,22 @@ class RPG2k
 
       # Move a battle Item/Skill list cursor by `delta` cells (a row for
       # +-BATTLE_LIST_COLUMN_MAX, a column for +-1), left in place if the
-      # target cell is off the grid -- confirmed against RPG_RT's own live
-      # source: `Window_Selectable::Update` (`src/window_selectable.cpp`)
-      # bounds Down/Up by `index < item_max - column_max`/`index >=
-      # column_max` (blocked rather than wrapped past either end, genuinely
-      # column-locked) and Right/Left by the flat `index < item_max -
-      # 1`/`index > 0` (no row-boundary term at all) -- the identical
-      # mechanism `Scene::ItemMenu#move_item_cursor` already uses for the
-      # field item/skill grid, which never propagated to battle's own
-      # Item/Skill lists.
+      # target cell is off the grid -- originally only cited to EasyRPG's
+      # `Window_Selectable::Update` (`src/window_selectable.cpp`), the same
+      # column-locked-Down/Up, flat-Right/Left shape `Scene::ItemMenu#
+      # move_item_cursor` already uses for the field item/skill grid. Now
+      # independently confirmed against a genuine RPG_RT.exe under wine
+      # (cycle #133, `#drive_battle_item`'s own comment has the full
+      # writeup): `#drive_battle_item` specifically, at every list-size
+      # boundary this method's own shape distinguishes (1 item, 2 items/one
+      # full row, an odd 3-item partial-second-row, an exact 8-item/4-row
+      # grid with no overflow, and a 9-item overflow that scrolls) -- every
+      # single case matched this method's pre-existing behaviour exactly, so
+      # no change was needed here. `#drive_battle_skill` was not itself
+      # re-run this cycle, but shares this exact method and
+      # `#battle_list_window` with `#drive_battle_item`, not merely the same
+      # claimed shape -- see that method's own comment for what would be
+      # needed to close it out independently.
       def move_battle_list_index(index, delta, size)
         target = index + delta
         return nil if target.negative? || target >= size
@@ -1876,6 +1883,36 @@ class RPG2k
         draw_battle_item
       end
 
+      # Independently re-verified against a genuine RPG_RT.exe under wine
+      # (cycle #133), companion work to cycle #130's re-verification of
+      # `#drive_battle_command`/`#drive_battle_options` and cycle #131's fix
+      # to `#drive_battle_target` -- this one was the first of the three
+      # `#drive_battle_skill`/`#drive_battle_item`/`#drive_battle_ally_target`
+      # cursors those two cycles left unrun. A synthetic autostart Enemy
+      # Encounter (troop 103, the same probe cycles #130/#131 used, tail-
+      # spliced onto a copy of Nepheshel's map 12) with the debug save's
+      # inventory chunk (109) hand-edited to hold exactly 1/2/3/8/9 held
+      # items -- every list-size case this grid's own shape distinguishes:
+      # a single cell (blocked in all four directions, including a 1.2s held
+      # Down); one full row (Right/Left cross it, Down/Up blocked -- no
+      # second row exists); an odd 3-item list (Down reaches the partial
+      # second row's lone cell, Right off the end of it does *not* reach a
+      # hidden/phantom cell the way the equip candidate list's trailing
+      # Remove entry does -- cycle #129's own finding does not generalise
+      # here); an exact 8-item/4-row grid with no overflow (a continuous
+      # 1.5s Down hold auto-repeats row 0 -> row 1 -> row 2 -> row 3 within
+      # one hold, confirming genuine key-repeat same as cycle #130's own
+      # finding, then stops dead at row 3/col 1, the grid's own last cell --
+      # neither wrapping to row 0 nor scrolling for lack of anywhere to
+      # scroll to); and a 9-item overflow (a 2.5s Down hold reaches the 9th
+      # item alone in a fifth, partial row -- the window genuinely *does*
+      # scroll to reveal it, unlike the enemy-target list cycle #131 found
+      # does not scroll at all -- then blocks there with no wrap and no
+      # phantom trailing cell, exactly mirroring the 3-item case). Every one
+      # of these matched `#move_battle_list_index`'s pre-existing behaviour
+      # exactly, so this method needed no change -- confirmed correct, not
+      # merely inherited from a shared code shape, the same outcome cycle
+      # #130 reached for the options/command cursors.
       def drive_battle_item
         items = @ui[:items]
         if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !items.empty?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12414,14 +12414,16 @@ class BattleThreeSkillParty < BattleMagicParty
   def db_skill(id); OpenStruct.new(name: "Skill#{id}", scope: 0); end
 end
 
-# The battle Item/Skill lists are a genuine two-column grid -- confirmed
-# against RPG_RT's own live source: `Window_Item`/`Window_Skill`
-# (`src/window_item.cpp`/`src/window_skill.cpp`) both set `column_max = 2`,
-# and `Window_BattleSkill` inherits that unchanged. `Window_Selectable::
-# Update`'s own Down/Up are genuinely column-locked (`index < item_max -
-# column_max`, blocked rather than wrapped) while Right/Left are a flat
-# `index +- 1` bounded only by the list's absolute ends, no row-boundary
-# term -- the identical shape the field item/skill grid already has.
+# The battle Item/Skill lists are a genuine two-column grid -- originally
+# only cited to EasyRPG's `Window_Item`/`Window_Skill`
+# (`src/window_item.cpp`/`src/window_skill.cpp`, both setting
+# `column_max = 2`) and `Window_Selectable::Update`'s column-locked Down/Up
+# vs. flat Right/Left. Now independently confirmed for the item side against
+# a genuine RPG_RT.exe under wine (cycle #133) -- see `#drive_battle_item`'s
+# own comment (`mruby-rpg2k/mrblib/scene/battle.rb`) for the full writeup,
+# including the 1/2/8/9-item boundary cases the checks just below and further
+# down this file (the exact-8-item grid, the 9-item scroll-to-overflow, and
+# the held-Down repeat) pin that this one check alone did not cover.
 check 'Enemy Encounter scene: the skill list cursor is a column-locked ' \
       'two-column grid, not a single wrapping column' do
   ic = Game::Interpreter::Cmd
@@ -12501,6 +12503,136 @@ check 'Enemy Encounter scene: the item list cursor is a column-locked ' \
 
   press_key(scene, RGSS::Input::LEFT)
   eq 0, ui[:item_i], 'Left moves back to column 0'
+end
+
+# An exact 4-row/2-column grid (8 items, no overflow) -- the boundary
+# BattleThreeItemParty's odd 3-item list cannot reach: its own last cell has
+# a full row above it, unlike the partial-row case. Confirmed against a
+# genuine RPG_RT.exe under wine (cycle #133, see #drive_battle_item's own
+# comment): the cursor stops dead at row 3/col 1, the grid's own last cell,
+# with no wrap back to row 0 and no scroll (there is nowhere left to scroll
+# to -- all 4 rows are already on screen).
+class BattleEightItemParty < BattleMagicParty
+  def initialize
+    super()
+    @items = (1..8).to_h { |id| [id, 1] }
+  end
+  def db_item(id); OpenStruct.new(name: "Item#{id}"); end
+end
+
+check 'Enemy Encounter scene: the item grid does not wrap at an exact ' \
+      'full 8-item/4-row grid' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleEightItemParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  eq :item, ui[:phase]
+
+  press_key(scene, RGSS::Input::DOWN)
+  press_key(scene, RGSS::Input::DOWN)
+  press_key(scene, RGSS::Input::DOWN)
+  eq 6, ui[:item_i], 'three Downs reach row 3, col 0 (index 6) -- the grid\'s last row'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 7, ui[:item_i], 'Right reaches the grid\'s own last cell (row 3, col 1)'
+
+  press_key(scene, RGSS::Input::DOWN)
+  eq 7, ui[:item_i], 'Down at the last cell does not wrap back to row 0'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 7, ui[:item_i], 'Right at the last cell does not wrap either'
+end
+
+# A 9th item past the exact 8-item/4-row grid -- the case
+# BattleEightItemParty cannot reach: this list overflows the window's own
+# BATTLE_VISIBLE_ROWS, so #battle_list_window has to scroll (unlike the
+# enemy-target list, which cycle #131 found does *not* scroll and instead
+# hard-caps at its own visible rows). Confirmed against a genuine RPG_RT.exe
+# under wine (cycle #133): a held Down genuinely scrolls the window to reveal
+# the 9th item, alone in a fifth, partial row, then blocks there -- no wrap,
+# and (like BattleThreeItemParty's odd row) no phantom trailing cell to its
+# right either.
+class BattleNineItemParty < BattleMagicParty
+  def initialize
+    super()
+    @items = (1..9).to_h { |id| [id, 1] }
+  end
+  def db_item(id); OpenStruct.new(name: "Item#{id}"); end
+end
+
+check 'Enemy Encounter scene: the item grid scrolls to reach a 9th item ' \
+      'past a full 8-cell grid, then blocks with no wrap or phantom cell' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleNineItemParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  eq :item, ui[:phase]
+
+  4.times { press_key(scene, RGSS::Input::DOWN) }
+  eq 8, ui[:item_i], 'four Downs reach the 9th item (index 8), alone in row 4'
+
+  press_key(scene, RGSS::Input::DOWN)
+  eq 8, ui[:item_i], 'Down past the 9th item does not wrap back to row 0'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 8, ui[:item_i], 'Right off the partial row\'s lone cell does not reach a ' \
+                      'phantom cell -- unlike the equip candidate list\'s trailing Remove'
+end
+
+# `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold a
+# key across frames without it also reading as a fresh trigger, exercising
+# the `#repeat?` half of `#drive_battle_item`/`#drive_battle_skill`'s own
+# gate on its own -- the two of the six battle cursors cycle #130's own
+# held-Down check (further up this file) did not cover. Confirmed against a
+# genuine RPG_RT.exe under wine (cycle #133, see #drive_battle_item's own
+# comment): a single continuous hold advanced the item grid's cursor through
+# multiple rows within one hold, exactly like the options/command/enemy-
+# target cursors cycle #130 already confirmed.
+check 'Enemy Encounter scene: holding Down auto-repeats the battle item ' \
+      'and skill grid cursors too' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleThreeItemParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN) # Defend -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  eq :item, ui[:phase]
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN] # held, but not a fresh trigger
+  scene.update
+  RGSS::Input.reset
+  eq 2, ui[:item_i], 'a held (repeated, not triggered) Down still moves the item grid cursor'
+
+  scene2 = new_scene({ 1 => event(2, 2, auto) })
+  scene2.instance_variable_get(:@state).instance_variable_set(:@party, BattleThreeSkillParty.new)
+  ui2 = battle_to_command(scene2)
+  press_key(scene2, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene2, RGSS::Input::C)    # open the skill list
+  eq :skill, ui2[:phase]
+
+  RGSS::Input.repeated = [RGSS::Input::DOWN]
+  scene2.update
+  RGSS::Input.reset
+  eq 2, ui2[:skill_i], 'a held (repeated, not triggered) Down still moves the skill grid cursor'
 end
 
 # A single held item that #battle_items now lists (a field-only medicine,


### PR DESCRIPTION
## Summary

- RPG_RT's battle Item grid cursor (`#drive_battle_item`/`#move_battle_list_index`) is now independently re-verified against genuine RPG_RT.exe under Wine — the companion cursor cycles #130/#131 left unrun alongside `#drive_battle_skill` and `#drive_battle_ally_target`. **No behavior change**: every list-size boundary tested matched the existing implementation exactly.
- Tested boundaries: 1 item (blocked all directions, incl. a held Down), 2 items (one full row, Right/Left cross it, Down/Up blocked), 3 items (odd/partial second row, no phantom trailing cell — cycle #129's equip-candidate-list finding does not generalize here), an exact 8-item/4-row grid (auto-repeats across rows on a held Down, then blocks dead at the last cell with no wrap), and a 9-item overflow (a held Down genuinely scrolls the window to reveal the 9th item, then blocks with no wrap or phantom cell).
- `#drive_battle_skill` shares this exact method/window code with `#drive_battle_item` (not merely the same claimed shape), so this strongly implies it too is correct, but it was not independently exercised this cycle. `#drive_battle_ally_target` remains unverifiable — the debug save cannot be grown past a solo actor (open item from cycle #132).
- Added three new regression checks (exact-grid no-wrap, overflow scroll-and-block, held-Down repeat for the item/skill grids) and updated the relevant code comments to record the re-verification, replacing an EasyRPG-source citation with the Wine confirmation.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new checks catch a regression: temporarily reintroduced a modulo-wrap bug into `#move_battle_list_index`, reran the suite (**4 of 911 checks failed**, including both new grid checks), then reverted.
- All four suites green post-verification:
  - `ruby scripts/rpg2k_scene_check.rb` — 911 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_