### PR TITLE
Battle Skill cursor: independently re-verify against genuine RPG_RT.exe

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,73 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #134, 2026-08-24): `#drive_battle_skill`, the one
+  `#drive_battle_item` sibling cycle #133 left unrun, is now independently
+  re-verified against genuine RPG_RT.exe too -- confirmed correct on every
+  list-size boundary tested, no code change needed.** Getting there needed a
+  multi-skill test actor, which the debug save's own file-select screen
+  turned out to name incorrectly: its solo "デモ用" character is chunk 108's
+  actor id **15**, not id 1 -- id 1 (level 1, HP 50, no skills) is just
+  another idle roster row. This was pinned down by cross-referencing the
+  file-select screen's own displayed "LV50 HP600" (SAVE_TITLE hero_level/
+  hero_hp) against chunk 108: id 15 is the only actor row with level 50 and
+  600 HP, everything else in the roster (ids 1-14, 16-49) sits at the
+  generic level-1/40-HP idle default. Confirmed indirectly but repeatably --
+  hand-editing id 15's own chunk 108 field 52 (`skills`, `SAVE_PARTY_ACTOR`)
+  to five different skill lists across five separate wine sessions each
+  changed what the in-battle Skill menu showed exactly as expected, while an
+  earlier attempt at id 1 (this cycle's own first, wrong guess) changed
+  nothing genuine RPG_RT displayed at all. Reused cycles #130/#131/#133's own
+  probe rig: a synthetic autostart Enemy Encounter (troop 103, tail-spliced
+  from Map0478 event 2 page 2's genuine Victory/Escape/EndBattle trailing
+  structure) onto a new event 22 on a scratch copy of Nepheshel's map 12,
+  repositioned debug save (`gen-rpg2k-save.rb --map 12 --at 40,15
+  --clear-scene`), actor 15's skills hand-edited through five list-size
+  boundaries the grid's own 2-column/4-row shape distinguishes: 1 skill
+  (single cell), 2 skills (one full row), 3 skills (odd, a partial second
+  row), 8 skills (an exact 4-row grid, no overflow) and 9 skills (overflow
+  past the grid) -- skill ids 1-9 from Nepheshel's own database, all
+  `type: 0` (ordinary spells), so `Game::Party#battle_skill?` accepts every
+  one regardless of scope. Each case: Continue -> file 1 -> autostart fires
+  straight into the battle options window (this troop shows no "X appeared!"
+  message before it) -> Decision confirms Fight -> Down once (Attack ->
+  Skill) -> Decision opens the skill list, then held Down/Right/Up/Left.
+  Results, all matching this codebase's pre-existing
+  `#move_battle_list_index`/`#battle_list_window` exactly, mirroring
+  `#drive_battle_item`'s own cycle-#133 findings case for case: 1 skill
+  blocked in all four directions (including a 1.2s held Down/Right/Up/Left);
+  2 skills let Right/Left cross the row with Down/Up blocked (no second
+  row); 3 skills let Down reach the partial second row's lone cell, Right
+  off its end blocked (no phantom cell), Up back to row 0; 8 skills
+  auto-repeated through a continuous 1.5s Down hold (row 0 -> 1 -> 2 -> 3
+  within one hold, the same genuine key-repeat cycles #130/#133 already
+  confirmed) then stopped dead at the grid's own last cell on a further
+  hold, neither wrapping nor scrolling; 9 skills scrolled (the previous
+  top-left skill visibly rolled off the top of the window) via a 2.5s Down
+  hold to reveal the 9th skill alone in a fifth, partial row, then blocked
+  there with no wrap and no phantom cell to its right either (checked
+  explicitly, matching the 3-skill case). Since nothing needed fixing,
+  `#drive_battle_skill`'s own comment and `#move_battle_list_index`'s were
+  updated to record the re-verification, mirroring cycle #133's own
+  precedent; two new `scripts/rpg2k_scene_check.rb` checks added
+  (`BattleEightSkillParty`/`BattleNineSkillParty`, mirroring the existing
+  item-side fixtures exactly) for the two boundaries this file had no
+  skill-side coverage for yet, confirmed to fail (alongside the four
+  pre-existing item/skill checks that share this same code) against a
+  deliberately injected modulo-wrap regression in `#move_battle_list_index`
+  before being reverted. Full suite reconfirmed passing (913 checks, up from
+  911). This closes out the six-cursor re-verification cycles #130/#131/#133
+  chipped away at, except `#drive_battle_ally_target`, which remains blocked
+  on cycle #132's own open item (c) -- growing the debug save past its one
+  live actor. That mystery may now be one step closer to solvable: this
+  cycle's own actor-15 finding means a future attempt at it should try
+  writing chunk 109's `party` field (`SAVE_INVENTORY` field 1) as `[15, ...]`
+  rather than `[1, 2, ...]` as cycle #132 tried -- cycle #132's attempts
+  never actually named the save's own live actor in that list at all, so
+  they cannot yet be read as ruling out `party` mattering, only as ruling out
+  those particular wrong ids. `Map0012.lmu`/`Save01.lsd` were edited only as
+  scratch copies for these probes and restored to their original bytes
+  (byte-identical by `md5sum`) once each wine session was torn down.
   ✅ **Follow-up (cycle #133, 2026-08-24): of the three `#drive_battle_skill`/
   `#drive_battle_item`/`#drive_battle_ally_target` battle cursors cycles
   #130/#131 left unrun, `#drive_battle_item`'s key-repeat and grid wrap/

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -1703,17 +1703,65 @@ class RPG2k
       # full row, an odd 3-item partial-second-row, an exact 8-item/4-row
       # grid with no overflow, and a 9-item overflow that scrolls) -- every
       # single case matched this method's pre-existing behaviour exactly, so
-      # no change was needed here. `#drive_battle_skill` was not itself
-      # re-run this cycle, but shares this exact method and
-      # `#battle_list_window` with `#drive_battle_item`, not merely the same
-      # claimed shape -- see that method's own comment for what would be
-      # needed to close it out independently.
+      # no change was needed here. `#drive_battle_skill` is now independently
+      # confirmed too (cycle #134, its own comment has the full writeup) --
+      # the same five boundary cases, all matching this method exactly, on a
+      # hand-edited skill list rather than a hand-edited item list.
       def move_battle_list_index(index, delta, size)
         target = index + delta
         return nil if target.negative? || target >= size
         target
       end
 
+      # Independently re-verified against a genuine RPG_RT.exe under wine
+      # (cycle #134) -- the one piece cycle #133 left unrun of its own
+      # closing note ("`#drive_battle_skill` was not independently re-run
+      # this cycle ... this is not a fresh guess the way the pre-cycle-133
+      # state was"). Gave the debug save's own party leader (chunk 108's
+      # actor id **15** -- not id 1, whose level/HP the SAVE_TITLE hero_
+      # level/hero_hp fields do *not* match; the file-select screen's
+      # "LV50 HP600" only lines up with actor 15's own chunk-108 row, which
+      # is what pins down which roster entry the debug save's solo "デモ用"
+      # character actually is) a hand-edited skills list (chunk 108 field 52,
+      # `SAVE_PARTY_ACTOR#skills`) via five separate wine sessions, one per
+      # list-size boundary this grid's own 2-column/4-row shape distinguishes
+      # -- the same five cases `#drive_battle_item`'s own comment covers, all
+      # drawn from database skill ids 1-9 (all `type: 0`, an ordinary spell,
+      # so `Game::Party#battle_skill?` includes every one regardless of
+      # scope): 1 skill (single cell), 2 skills (one full row), 3 skills (odd,
+      # a partial second row), 8 skills (an exact 4-row grid, no overflow) and
+      # 9 skills (overflow past the grid). Same probe rig as cycles #130/#131/
+      # #133 (a synthetic autostart Enemy Encounter, troop 103, tail-spliced
+      # onto Map0012 from Map0478 event 2 page 2's own genuine Victory/Escape/
+      # EndBattle trailing structure) -- Continue -> file 1 -> autostart fires
+      # straight into the battle options window (no "X appeared!" message this
+      # troop shows) -> Decision confirms Fight -> Down once (Attack -> Skill)
+      # -> Decision opens the skill list, then held Down/Right/Left/Up.
+      # Results, all matching `#move_battle_list_index`/`#battle_list_window`
+      # exactly, the same as `#drive_battle_item`'s own findings: 1 skill
+      # blocked in all four directions across a 1.2s held Down/Right/Up/Left;
+      # 2 skills let Right/Left cross the row with Down/Up blocked (no second
+      # row); 3 skills let Down reach the partial second row's lone cell, with
+      # Right off its end blocked (no phantom cell) and Up returning to row 0;
+      # 8 skills auto-repeated through a continuous 1.5s Down hold (row 0 -> 1
+      # -> 2 -> 3 within that one hold, confirming genuine key-repeat the same
+      # way cycle #130/#133 did) then stopped dead at the grid's own last
+      # cell on a further hold, neither wrapping nor scrolling; 9 skills
+      # scrolled (a genuine pixel scroll, confirmed on-screen -- the previous
+      # top-left skill rolled off the top of the window) via a 2.5s Down hold
+      # to reveal the 9th skill alone in a fifth, partial row, then blocked
+      # there with no wrap and no phantom cell to its right either. Since
+      # nothing needed fixing, this comment and the matching
+      # `scripts/rpg2k_scene_check.rb` checks were updated to record the
+      # re-verification, mirroring cycle #133's own precedent for
+      # `#drive_battle_item`. `#drive_battle_ally_target` remains the one
+      # battle cursor still unverified against genuine RPG_RT -- still
+      # blocked on growing the debug save past its one live actor (cycle
+      # #132's own open item (c); see this cycle's docs/TODO.md entry for
+      # what was and was not learned about that this time around).
+      # `Map0012.lmu`/`Save01.lsd` were edited only as scratch copies for
+      # these probes and restored to their original bytes (byte-identical by
+      # `md5sum`) once each wine session was torn down.
       def drive_battle_skill
         skills = @ui[:skills]
         if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !skills.empty?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12593,6 +12593,89 @@ check 'Enemy Encounter scene: the item grid scrolls to reach a 9th item ' \
                       'phantom cell -- unlike the equip candidate list\'s trailing Remove'
 end
 
+# An exact 4-row/2-column skill grid (8 skills, no overflow), mirroring
+# BattleEightItemParty above -- `#drive_battle_skill` shares
+# `#move_battle_list_index`/`#battle_list_window` with `#drive_battle_item`
+# verbatim, but was never independently exercised at this boundary until
+# cycle #134. Confirmed against a genuine RPG_RT.exe under wine (cycle #134,
+# see `#drive_battle_skill`'s own comment): the cursor stops dead at row 3/
+# col 1, the grid's own last cell, with no wrap back to row 0 and no scroll.
+class BattleEightSkillParty < BattleMagicParty
+  def initialize
+    super()
+    @hero.instance_variable_set(:@skills, (1..8).to_a)
+  end
+  def battle_skills(actor, _caster); actor.skills.map { |sid| [sid, 3] }; end
+  def db_skill(id); OpenStruct.new(name: "Skill#{id}", scope: 0); end
+end
+
+check 'Enemy Encounter scene: the skill grid does not wrap at an exact ' \
+      'full 8-skill/4-row grid' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleEightSkillParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::C)    # open the skill list
+  eq :skill, ui[:phase]
+
+  press_key(scene, RGSS::Input::DOWN)
+  press_key(scene, RGSS::Input::DOWN)
+  press_key(scene, RGSS::Input::DOWN)
+  eq 6, ui[:skill_i], 'three Downs reach row 3, col 0 (index 6) -- the grid\'s last row'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 7, ui[:skill_i], 'Right reaches the grid\'s own last cell (row 3, col 1)'
+
+  press_key(scene, RGSS::Input::DOWN)
+  eq 7, ui[:skill_i], 'Down at the last cell does not wrap back to row 0'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 7, ui[:skill_i], 'Right at the last cell does not wrap either'
+end
+
+# A 9th skill past the exact 8-skill/4-row grid, mirroring
+# BattleNineItemParty above. Confirmed against a genuine RPG_RT.exe under
+# wine (cycle #134): a held Down genuinely scrolls the window to reveal the
+# 9th skill, alone in a fifth, partial row, then blocks there -- no wrap, and
+# (like BattleThreeSkillParty's odd row) no phantom trailing cell to its
+# right either.
+class BattleNineSkillParty < BattleMagicParty
+  def initialize
+    super()
+    @hero.instance_variable_set(:@skills, (1..9).to_a)
+  end
+  def battle_skills(actor, _caster); actor.skills.map { |sid| [sid, 3] }; end
+  def db_skill(id); OpenStruct.new(name: "Skill#{id}", scope: 0); end
+end
+
+check 'Enemy Encounter scene: the skill grid scrolls to reach a 9th skill ' \
+      'past a full 8-cell grid, then blocks with no wrap or phantom cell' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleNineSkillParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::C)    # open the skill list
+  eq :skill, ui[:phase]
+
+  4.times { press_key(scene, RGSS::Input::DOWN) }
+  eq 8, ui[:skill_i], 'four Downs reach the 9th skill (index 8), alone in row 4'
+
+  press_key(scene, RGSS::Input::DOWN)
+  eq 8, ui[:skill_i], 'Down past the 9th skill does not wrap back to row 0'
+
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 8, ui[:skill_i], 'Right off the partial row\'s lone cell does not reach a ' \
+                       'phantom cell -- unlike the equip candidate list\'s trailing Remove'
+end
+
 # `RGSS::Input.repeated` (distinct from `.triggered`) lets this check hold a
 # key across frames without it also reading as a fresh trigger, exercising
 # the `#repeat?` half of `#drive_battle_item`/`#drive_battle_skill`'s own


### PR DESCRIPTION
## Summary

- RPG_RT's battle Skill grid cursor (`#drive_battle_skill`) is now independently re-verified against genuine RPG_RT.exe under Wine — the one piece cycle #133 left unrun of the item/skill grid re-verification, since it shares `#move_battle_list_index`/`#battle_list_window` verbatim with `#drive_battle_item`. **No behavior change**: every list-size boundary tested matched the existing implementation exactly.
- Tested the same five boundaries cycle #133 used on the item side: 1 skill (blocked all directions, incl. a held Down), 2 skills (one full row, Right/Left cross it, Down/Up blocked), 3 skills (odd/partial second row, no phantom trailing cell), an exact 8-skill/4-row grid (auto-repeats across rows on a held Down, then blocks dead at the last cell with no wrap), and a 9-skill overflow (a held Down genuinely scrolls the window to reveal the 9th skill, then blocks with no wrap or phantom cell).
- Getting a multi-skill test actor required identifying that the debug save's real live party member is chunk 108 actor id **15**, not id 1 as prior cycles assumed — pinned down by cross-referencing the file-select screen's displayed "LV50 HP600" against the roster. Recorded in `docs/TODO.md` as a concrete lead for `#drive_battle_ally_target`'s still-blocked multi-actor verification (cycle #132's open item (c)).
- Added two new regression checks (`BattleEightSkillParty`/`BattleNineSkillParty`) mirroring the existing item-grid ones, and updated the relevant code comments to record the re-verification.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new checks catch a regression: temporarily reintroduced a modulo-wrap bug into `#move_battle_list_index`, reran the suite (**6 of 913 checks failed**, including both new skill-grid checks), then reverted.
- All four suites green post-verification:
  - `ruby scripts/rpg2k_scene_check.rb` — 913 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_