### PR TITLE
Battle ally-target cursor: Right/Left are dead input, not Down/Up aliases

### DIFF
--- a/changelog.d/battle-ally-target-right-left-cursor.fixed.md
+++ b/changelog.d/battle-ally-target-right-left-cursor.fixed.md
@@ -1,4 +1,7 @@
-- **Battle ally-target selection:** Right/Left now move the cursor exactly
-  like Down/Up when choosing which ally to heal or use an item on, matching
-  RPG_RT -- previously they did nothing at all. Covered by a new
-  `scripts/rpg2k_scene_check.rb` check.
+- **Battle ally-target selection:** Right/Left are dead input when choosing
+  which ally to heal or use an item on -- only Down/Up move the cursor,
+  matching RPG_RT. An earlier fix here (based on a since-disproven source
+  citation) had instead made Right/Left move the cursor like Down/Up;
+  independently re-verified against genuine RPG_RT.exe under Wine with a
+  real multi-member party and found wrong, so this fragment has been
+  corrected in place to describe the current, verified behavior.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,98 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #136, 2026-08-24): finished cycle #135's own
+  time-boxed-away live Change Party Member technique -- it works cleanly
+  against genuine RPG_RT.exe, with no crash, and immediately unblocked
+  `#drive_battle_ally_target`'s verification, which turned up a real bug,
+  fixed.** Recipe (exactly cycle #135's own recommended one): place a
+  genuine save on Map0012 via `gen-rpg2k-save.rb --map 12 --at 40,15
+  --clear-scene`, inject a synthetic autostart event (trigger 3) carrying
+  live `Change Party Member` commands (event code 10330, `[0, 0, <actor
+  id>]`, `Interpreter#do_change_party`) prepended onto Map0478 event 2 page
+  2's own genuine Enemy-Encounter-through-EndBattle trailing structure
+  (troop 103, codes 10710/20710/20711/20713/0, tail-spliced verbatim as
+  cycles #130-134 did), then drive EasyRPG's title screen to **Continue**
+  (not New Game) -- screenshot-verifying the highlighted entry after every
+  single keypress rather than assuming a fixed press count, exactly as
+  cycle #135 flagged as the fix for its own flaky title-cursor navigation.
+  That navigation (Down once, Return, Return) turned out reliable every
+  time once screenshot-verified (four separate wine sessions, no misfire),
+  so the flakiness cycle #135 hit was evidently this session's own
+  drive-without-checking, not a genuine timing hazard in the recipe. The
+  autostart fired the moment each save loaded and genuinely grew the live
+  party in memory -- confirmed both in the field menu (Escape from the map)
+  and in battle, across four separate wine sessions building 1/2/2/4-member
+  parties (デモ用 solo; デモ用+ファル (actor 2); デモ用+ファル again, for
+  the Right/Left probe below; デモ用+ファル+ティララ+ディーヴァ (actors
+  2/3/4)) -- no crash in any of them, unlike every hand-edited-`party`-field
+  attempt cycles #132/#135 tried. This is a strictly better technique than
+  raw save-byte editing: it lets genuine RPG_RT.exe itself decide what a
+  live "add" does, rather than guessing byte layouts it then crashes on.
+  Side finding, not investigated further this cycle: with a real 2-member
+  party, the field Item target-confirm screen (`Scene::ItemMenu
+  #build_target_window`, cycle #132's own fix) drew actor 2's (ファル's)
+  own real 48x48 faceset image in the row's left gutter -- template-matched
+  pixel-exact against `FaceSet/face.png` cell index 1 (`db.player[2]
+  .faceset_name/index`) at native panel-local coordinates (8, 66), i.e. 18px
+  below row 1's own top (`TARGET_ROW_H * 1 == 48`) and extending 18px past
+  its bottom -- while actor 15 (`デモ用`)'s row 0, which has no faceset
+  assigned (`faceset_name == ''`), drew nothing there, exactly matching the
+  current code's blank gutter and confirming cycle #132's own open question
+  (1) was on the right track without quite landing it: the blank gutter
+  is real evidence of "no face configured for this one test actor", not
+  evidence there is no face slot at all -- RPG_RT does draw one when an
+  actor has a face. **Not fixed this cycle** (`#build_target_window` still
+  draws no face): the measured vertical offset (+18px into the row, +18px
+  past it) was only ever observed on a non-first row, so whether row 0's
+  own face (were `デモ用` given one) would sit at the same "+18" offset,
+  or instead be clipped/repositioned by the window's own top border, is
+  still unconfirmed and would need a test actor with both a real faceset
+  and the row-0 slot to settle safely -- left as a concrete, well-measured
+  lead for whichever cycle picks up cycle #132's open item (1) next. Cycle
+  #132's open item (3) (multi-actor row **stacking**) is however now
+  positively confirmed, separately from the face question: gridlines drawn
+  every `TARGET_ROW_H` (48 native px) onto the 2-actor wine capture landed
+  exactly on both rows' own text baselines, with no extra gap between them
+  -- `#build_target_window`'s straight-line extrapolation of one uniform
+  48px-tall row per actor, cards butting directly against each other, was
+  the right guess.
+  With a genuine multi-actor party finally reachable, immediately used it
+  (per this file's own standing instruction to cycles that crack this) to
+  verify `#drive_battle_ally_target`, the last of the six battle cursors
+  cycles #130/#131/#133/#134 left unverified -- and it was wrong. The
+  method's own prior comment claimed Right/Left move this cursor exactly
+  like Down/Up (cited, by a cycle that predates the strict no-EasyRPG-source
+  rule, to `Window_BattleStatus::Update`'s `IsRepeated(RIGHT)`/`(LEFT)`
+  gates). Tested via Continue -> file 1 -> autostart -> confirm Fight ->
+  Down x3 to Item -> Decision on 薬草 (item 1, single-ally scope, already in
+  the debug inventory) -> ally-target screen, at both the 2-ally and 4-ally
+  boundaries: Down/Up wrap exactly as this method already computed (2
+  allies: 0->1->0 on Down, Up from 0 reaches 1; 4 allies: a plain Down x4
+  visits every row in order before wrapping, Up from row 0 wraps straight
+  to row 3) -- but Right and Left, tested individually from *every* row at
+  both party sizes (row 0 and row 1 at size 2; row 0 and row 3 at size 4),
+  left the cursor exactly where it started, every single time, with a full
+  settle wait after each isolated press. (A first *batched* Right/Up/Left
+  sequence briefly looked like Right worked -- screenshotted mid-sequence,
+  it showed the wrong row -- but re-isolating each key one at a time and
+  re-checking after a full settle wait proved that was ordinary frame lag
+  in the capture, not a real cursor move; the isolated, settled reads are
+  the ones this fix relies on.) Fixed `#drive_battle_ally_target`
+  (`mruby-rpg2k/mrblib/scene/battle.rb`) to drop the Right/Left arms
+  entirely -- only Down/Up (trigger or repeat) move `@ui[:ally_i]` now.
+  `scripts/rpg2k_scene_check.rb`'s existing "Right/Left move the ally
+  target cursor exactly like Down/Up" check was inverted in place (now
+  "Right/Left are dead input on the ally target cursor", asserting a no-op
+  from both the first and last row of a 2-member party) rather than left
+  alongside a new, contradicting one, since its old premise was simply
+  wrong, not merely incomplete. Confirmed to fail against the pre-fix code
+  (a stashed diff of just `battle.rb`) before the fix, 1 of 913 checks; full
+  suite reconfirmed passing after (913 checks, same count -- an existing
+  check was corrected in place, not added to). `Map0012.lmu`/`Save01.lsd`
+  were edited only as scratch copies for every probe above and restored to
+  their original bytes (byte-identical by `md5sum`) once each wine session
+  was torn down.
   ✅ **Follow-up (cycle #135, 2026-08-24): chased cycle #134's own suggested
   next step for growing the debug save's party past its one live actor --
   writing chunk 109's `party` field (`SAVE_INVENTORY` field 1) as `[15,

--- a/mruby-rpg2k/mrblib/scene/battle.rb
+++ b/mruby-rpg2k/mrblib/scene/battle.rb
@@ -2049,26 +2049,51 @@ class RPG2k
 
       # -- Ally target (heal skill / medicine) --------------------------------
 
-      # Right/Left move the ally-target cursor exactly like Down/Up --
-      # confirmed against RPG_RT's own live source: `Window_BattleStatus::
-      # Update` (`src/window_battlestatus.cpp`), the window that drives this
-      # cursor (`Scene_Battle::status_window`, active during ally-target
-      # selection), gates its "next ally" step on `IsRepeated(DOWN) ||
-      # IsRepeated(RIGHT) || IsTriggered(SCROLL_DOWN)` and its "previous
-      # ally" step on the Up/Left/SCROLL_UP mirror -- deliberately
-      # bypassing the generic `Window_Selectable::Update` cursor logic
-      # ("skipped on purpose (breaks up/down-logic)", the function's own
-      # comment) to fold Right/Left into the same single up/down axis.
+      # Only Down/Up move the ally-target cursor -- Right/Left are dead input
+      # here, not folded onto the same axis.
+      #
+      # Independently re-verified (cycle #136, 2026-08-24), overturning a
+      # prior cycle's own claim (which had secretly cited EasyRPG source,
+      # since removed) that Right/Left mirror Down/Up. Confirmed against
+      # genuine RPG_RT.exe under wine (Nepheshel), using a technique cycle
+      # #135 had time-boxed away from and this cycle finished: a synthetic
+      # autostart event on a scratch copy of Map0012, carrying live `Change
+      # Party Member` (event code 10330, `[0, 0, <actor id>]`) commands
+      # prepended onto Map0478 event 2 page 2's own genuine Enemy-Encounter-
+      # through-EndBattle trailing structure (troop 103, codes 10710/20710/
+      # 20711/20713/0, tail-spliced verbatim as cycles #130-134 did) --
+      # letting the genuine runtime itself grow the live party in memory
+      # before battle starts, rather than hand-editing a save's `party`
+      # field (confirmed a dead end by cycle #135: it crashes RPG_RT.exe
+      # outright). This produced real, undamaged 2- and 4-member parties
+      # (デモ用+ファル; デモ用+ファル+ティララ+ディーヴァ) with no crash --
+      # unblocking this check and cycle #132's own open multi-actor
+      # question in the field target-confirm screen (see that entry's own
+      # follow-up below). Tested via Continue -> file 1 -> autostart ->
+      # confirm Fight -> Down x3 to Item -> Decision on 薬草 (single-ally
+      # scope) -> ally-target screen, screenshot-verified after every single
+      # keypress (never assuming a fixed press count, matching cycle #135's
+      # own recommended fix for its title-cursor flakiness): with 2 allies,
+      # Down/Up wrap correctly (0->1->0, and Up from 0 reaches 1) exactly as
+      # this method already computed, but Right and Left from *either* row
+      # left the cursor on the same row every single time -- rechecked with
+      # a full settle wait after each individual press once a first batched
+      # sequence looked ambiguous (proved to be simple frame lag, not a real
+      # movement, once isolated one key at a time). With 4 allies the same
+      # holds at both boundaries: Right from row 0 and row 3 both no-op,
+      # Left from row 0 no-ops (does not reach row 3 the way Up correctly
+      # does), and a plain Down x4 visits all four rows in order before
+      # wrapping, Up from row 0 wraps straight to row 3. Fixed by dropping
+      # the Right/Left arms entirely -- Down/Up (trigger or repeat) are the
+      # only inputs that move `@ui[:ally_i]`.
       def drive_battle_ally_target
         allies = battle_ally_targets
-        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN) ||
-            Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)) && !allies.empty?
+        if (Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)) && !allies.empty?
           @ui[:ally_i] += 1
           @ui[:ally_i] %= allies.length
           draw_battle_ally_target
           play_system_se(SFX_CURSOR)
-        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP) ||
-               Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)) && !allies.empty?
+        elsif (Input.trigger?(Input::UP) || Input.repeat?(Input::UP)) && !allies.empty?
           @ui[:ally_i] -= 1
           @ui[:ally_i] %= allies.length
           draw_battle_ally_target

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12785,15 +12785,19 @@ check 'Enemy Encounter scene: the ally target cursor wraps around' do
   eq 0, ui[:ally_i], 'Down from the last ally wraps to the first'
 end
 
-check 'Enemy Encounter scene: Right/Left move the ally target cursor exactly ' \
-      'like Down/Up' do
-  # Confirmed against RPG_RT's own live source: `Window_BattleStatus::Update`
-  # (src/window_battlestatus.cpp) -- the window driving this cursor while
-  # ally-target selection is active -- gates its "next ally" step on
-  # `IsRepeated(DOWN) || IsRepeated(RIGHT) || IsTriggered(SCROLL_DOWN)` and
-  # its "previous ally" step on the Up/Left/SCROLL_UP mirror, deliberately
-  # skipping the generic Window_Selectable cursor logic to fold Right/Left
-  # onto the same up/down axis.
+check 'Enemy Encounter scene: Right/Left are dead input on the ally target cursor' do
+  # Overturns this check's own prior claim ("Right/Left move the cursor
+  # exactly like Down/Up", sourced from a since-removed EasyRPG-source
+  # citation). Independently re-verified against genuine RPG_RT.exe under
+  # wine (cycle #136, 2026-08-24, Nepheshel): a real 2-member party (デモ用
+  # + ファル, grown in-memory by a live synthetic `Change Party Member`
+  # autostart event rather than a hand-edited save) showed Right from either
+  # row and Left from either row leaving the cursor exactly where it started,
+  # every time, while Down/Up still wrap correctly -- reconfirmed again at 4
+  # members (デモ用/ファル/ティララ/ディーヴァ): Right no-ops at both the
+  # first and last row, Left no-ops at the first row (does not reach the
+  # last row the way Up correctly does). See docs/TODO.md's cycle #136 entry
+  # for the full wine transcript.
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic)
@@ -12808,9 +12812,15 @@ check 'Enemy Encounter scene: Right/Left move the ally target cursor exactly ' \
   press_key(scene, RGSS::Input::C)    # choose the Potion -> ally target
   eq 0, ui[:ally_i], 'starts on the first ally'
   press_key(scene, RGSS::Input::LEFT)
-  eq 1, ui[:ally_i], 'Left from the first ally wraps to the last, same as Up'
+  eq 0, ui[:ally_i], 'Left from the first ally is a no-op, unlike Up'
   press_key(scene, RGSS::Input::RIGHT)
-  eq 0, ui[:ally_i], 'Right from the last ally wraps to the first, same as Down'
+  eq 0, ui[:ally_i], 'Right from the first ally is also a no-op, unlike Down'
+  press_key(scene, RGSS::Input::DOWN)
+  eq 1, ui[:ally_i], 'Down still moves the cursor normally'
+  press_key(scene, RGSS::Input::RIGHT)
+  eq 1, ui[:ally_i], 'Right from the last ally is a no-op, unlike Down'
+  press_key(scene, RGSS::Input::LEFT)
+  eq 1, ui[:ally_i], 'Left from the last ally is also a no-op, unlike Up'
 end
 
 # Two actors (distinct ids) with an item_usable_by? that restricts the


### PR DESCRIPTION
## Summary

- Finished cycle #135's time-boxed-away live `Change Party Member` technique: a synthetic autostart event carrying live `Change Party Member` commands (event code 10330) reliably grows the party to a real 2- or 4-member group in genuine RPG_RT.exe, with no crash — unlike hand-editing a save's `party` field directly, which cycle #135 found crashes the real binary outright. This is a durable new technique for future multi-actor verification work.
- With a genuine multi-actor party finally reachable, verified `#drive_battle_ally_target` (the last of the six battle cursors independently re-checked across cycles #130/#131/#133/#134/#136) — and found it wrong. Its Right/Left arms, based on a stale citation from a cycle that predates this project's strict no-EasyRPG-source-consultation rule, treated Right/Left as aliases for Down/Up.
- Tested at both the 2-ally and 4-ally boundaries: Down/Up wrap correctly (matches existing code), but Right/Left are **dead input on every row at both party sizes** in genuine RPG_RT.exe. Removed the Right/Left arms from `#drive_battle_ally_target`.
- **Bonus finding, documented but not fixed:** with a real multi-member party, the field Item target-confirm screen (cycle #132's own fix) was observed to draw a real 48×48 faceset in a non-first row's gutter when an actor has one — confirming cycle #132's open question about the blank gutter (no face configured for that one test actor, not "no face slot exists"), and separately confirming cycle #132's row-stacking extrapolation was correct. Left as a well-measured lead in `docs/TODO.md` since the row-0 vertical offset is still unconfirmed.
- Inverted the existing regression check in place (its old premise was simply wrong, not incomplete) and corrected the `battle-ally-target-right-left-cursor.fixed.md` changelog fragment in place to match, since it described the now-disproven behavior.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the check fails against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/battle.rb`, rerunning the suite, then `git stash pop`: **1 of 913 checks failed** (`Left from the first ally is a no-op, unlike Up`).
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 913 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_