### PR TITLE
Item/Skill target-confirm screen: draw each actor's face portrait

### DIFF
--- a/changelog.d/item-skill-target-confirm-face.fixed.md
+++ b/changelog.d/item-skill-target-confirm-face.fixed.md
@@ -1,0 +1,5 @@
+- **Item/Skill menus:** the actor-target-confirm screen ("who to use this
+  on") now draws each party member's own 48x48 face portrait, when they
+  have one, matching RPG_RT — the top row's face sits flush at the top of
+  its own row, while every later row's face is pushed further in. Previously
+  no face was ever drawn, leaving a blank gutter on every row.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,81 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #137, 2026-08-25): closed cycle #132's last open
+  lead on the field Item/Skill target-confirm screen -- RPG_RT.exe does draw
+  a real 48x48 face per row when an actor has one (cycle #136 already
+  confirmed this for a non-first row), and row 0's own offset, left
+  unconfirmed by cycle #136, turned out to differ from every later row: row
+  0 draws its face flush at the top of its own row, not pushed 18px in like
+  row 1. Fixed.** Cycle #136's own multi-actor-party recipe reaches row 1
+  with a faceted actor (デモ用 id 15, no native faceset, always party
+  member 0) but never row 0, since a save's live roster always starts with
+  its one saved actor in slot 0. Rather than reorder the party (removing
+  then re-adding the original leader to push a faceted actor into slot 0
+  crashed genuine RPG_RT.exe outright -- see below), gave actor 15 itself a
+  live faceset with a Change Actor Face (event code 10640, `Interpreter#do_
+  change_actor_face`) pointing at the same `FaceSet/face.png` cell 1 actor 2
+  (ファル) already carries natively (`db.player[2].faceset_name/index`),
+  via a synthetic autostart event on a scratch copy of Map0012 (genuine
+  save repositioned with `gen-rpg2k-save.rb --map 12 --at 40,15
+  --clear-scene`, Continue -> file 1, screenshot-verified per keypress).
+  Tested two shapes under wine (Xvfb 640x480x16, LIBGL_ALWAYS_SOFTWARE=1,
+  matchbox-window-manager, LANG=ja_JP.UTF-8): actor 15 alone (a solo party,
+  isolating row 0), and actor 15 plus actor 2 added via cycle #136's own
+  proven-safe add-only Change Party Member (party `[15, 2]`, both rows
+  faceted, visible in the same capture at once). Pixel-sampled both 640x480
+  captures (halved for native 320x240): row 0's face top edge landed at
+  native y ~0 (screen y 2-4), while row 1's landed at native y 66 -- exactly
+  reproducing cycle #136's own independently-measured figure *inside this
+  same frame*, ruling out a capture-to-capture calibration error, and
+  confirmed independent of which row the cursor actually highlighted (moving
+  the cursor from row 0 to row 1 left both faces exactly where they were,
+  ruling out a "draw only the selected row's face" alternative reading).
+  Fixed `#build_target_window` in both `item_menu.rb` and `skill_menu.rb`
+  identically: a new `#draw_target_face` (plus a local `#load_face_bitmap`,
+  neither class having a `@map` to borrow `Scene::Map`'s own copy from,
+  mirroring `Scene::SaveLoad#load_face_bitmap` instead) blits the 48x48
+  `TARGET_FACE_SIZE` cell at `TARGET_FACE_X` (8), `y` for row 0 and `y +
+  TARGET_FACE_Y_EXTRA` (18) for every later row, silently drawing nothing
+  for a blank/missing faceset exactly like every other face-draw call site
+  in this codebase. Two new `scripts/rpg2k_scene_check.rb` checks -- a
+  two-actor, both-faceted party asserting row 0's face at `(8, 0)` and row
+  1's at `(8, TARGET_ROW_H + TARGET_FACE_Y_EXTRA)`, and a faceless-actor
+  party asserting no face blit at all -- the first confirmed to fail against
+  the pre-fix code (a stashed diff of just `item_menu.rb`/`skill_menu.rb`)
+  before the fix (`RuntimeError: expected 2, got 0`, since pre-fix
+  `#build_target_window` never blits a face at all); the second trivially
+  passes either way, since "no face blit" is also what the pre-fix code
+  does, so it only pins the negative case going forward. Full suite
+  reconfirmed passing (915 checks, up from 913).
+  **Left open for a future cycle:** rows 2/3 (the party-cap boundary) are
+  not confirmed to continue row 1's "+18" pattern -- reaching a 3- or
+  4-actor faceted party risked the crash below, so this is this fix's own
+  straight-line extrapolation from row 1 alone, the same shape as cycle
+  #132's original multi-row-stacking caveat before cycle #136 confirmed
+  *that* one. Separately, a genuine and reproducible RPG_RT.exe crash was
+  found and is **not yet understood**: a synthetic autostart page whose
+  command list is short (tried: a bare `Change Party Member` add, and even
+  two bare BlankLines with no actor-related command at all) crashed the
+  genuine binary outright -- not immediately, but on the *next* screen
+  transition (confirmed alive a full 2s after the map settled, dead within
+  0.3s of the following Escape keypress, reproduced across half a dozen
+  separate wine sessions) -- while a *single*-command page (one bare
+  BlankLine) and the long genuine Enemy-Encounter-through-EndBattle tail
+  cycles #130-136 always splice their own probes onto both survived clean.
+  Command *content* is therefore not the trigger; something about a *short*
+  synthetic command list specifically is. This fix's own probes worked
+  around it by keeping every command list at least as long as cycles
+  #130-136's own proven-safe shape (their genuine battle tail, escaped out
+  of via the battle options window's Escape entry rather than fought), but
+  the underlying mechanism is unidentified and worth chasing for its own
+  sake: it means a "short synthetic autostart page" cannot be assumed safe
+  by default in this test-bed, contrary to what cycles #130-136's own
+  successful long-tail recipes might suggest. `Map0012.lmu`/`Map0478.lmu`
+  (read-only, only its already-parsed `event_commands` were reused, never
+  written back)/`Save01.lsd` were edited only as scratch copies for every
+  probe above and restored to their original bytes (byte-identical by
+  `md5sum`) once each wine session was torn down.
   ✅ **Follow-up (cycle #136, 2026-08-24): finished cycle #135's own
   time-boxed-away live Change Party Member technique -- it works cleanly
   against genuine RPG_RT.exe, with no crash, and immediately unblocked

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -692,27 +692,71 @@ class RPG2k
       # not two, and the HP/MP *value* column starting partway across the
       # row rather than immediately after the label. There is also a blank
       # gutter to the left of every line, of a piece with the cursor
-      # highlight (see #refresh_target_cursor below): a plausible, but
-      # *not confirmed*, explanation is a face-graphic slot this screen does
-      # not draw into -- Nepheshel's only reachable test actor (the debug
-      # save's solo "デモ用" character) carries no faceset to test that
-      # theory against, and the party field of a hand-edited save
-      # (`inventory` chunk 109's own `party` sub-field) could not be grown
-      # past that one saved actor this cycle (RPG_RT kept showing a solo
-      # party regardless), so the multi-actor stacking below is this
-      # method's own straight-line extrapolation of the confirmed single-row
-      # geometry, not independently confirmed -- see docs/TODO.md's cycle
-      # #132 entry for the full measurement write-up and this as an open
-      # lead. Pixel values measured directly (640x480 wine capture, so
-      # divided by 2 for native 320x240 coordinates): panel at native
-      # (136, 0), 184x240 -- i.e. `SCREEN_W - TARGET_W` .. `SCREEN_W`, full
-      # `SCREEN_H`; each row 48px (three 16px lines); the label column
-      # (name/level/condition) starting 56px into the panel's own content
-      # area, the value column (HP/MP) at 114px.
+      # highlight (see #refresh_target_cursor below) -- cycle #132 guessed
+      # this might be an undrawn face-graphic slot but could not confirm it
+      # (Nepheshel's only reachable test actor, the debug save's solo
+      # "デモ用" character, carries no faceset); cycle #136 then confirmed
+      # the guess right for a *non-first* row (row 1: actor 2, ファル, drew
+      # its real 48x48 FaceSet/face.png cell 1 at panel-local (8, 66)) but
+      # left row 0's own offset unconfirmed. Settled this cycle (#137, with a
+      # genuine RPG_RT.exe under wine): row 0 draws its face **flush at the
+      # top of its own row** (panel-local (8, 0)), *not* at the same "+18px
+      # into the row" offset row 1 (and, unconfirmed, every later row) uses.
+      # Measured by giving the debug save's own sole actor (15, デモ用, no
+      # native faceset) a live Change Actor Face (event code 10640) onto the
+      # same FaceSet/face.png cell 1 actor 2 already carries, so row 0 could
+      # be tested directly -- both alone and side-by-side with actor 2 (added
+      # to the party without ever removing the original leader, cycle #136's
+      # own proven-safe shape) so both rows' faces were visible in the same
+      # capture at once: row 0's face top edge landed at native y ~0 (screen
+      # y ~2-4 of a 640x480 capture) while row 1's landed at native y 66,
+      # exactly reproducing cycle #136's own figure in the same frame --
+      # ruling out a capture-to-capture calibration error -- and confirmed
+      # independent of which row the cursor was actually highlighting (the
+      # two faces stayed exactly where they were when the cursor moved from
+      # row 0 to row 1, so this is a per-row-index quirk, not a
+      # currently-selected-row one). Rows 2/3 (unreachable without risking
+      # the party-growth crash below) are *not* confirmed to continue the
+      # "+18" pattern past row 1 -- left as this fix's own open lead, the
+      # same shape as cycle #132's original multi-row-stacking caveat.
+      #
+      # Left as a genuine, separate open lead this cycle could not chase
+      # further (out of scope for the face question above): a synthetic
+      # autostart page carrying *only* a Change Party Member and/or Change
+      # Actor Face command or two (a short command list, well short of the
+      # genuine Enemy-Encounter-through-EndBattle tail cycles #130-136's own
+      # probes always spliced onto) crashed genuine RPG_RT.exe outright, but
+      # only on the *next* screen transition (confirmed alive for a full 2s
+      # after the map settled, dead within 0.3s of the following Escape) --
+      # even a page with **no actor-related command at all** (two bare
+      # BlankLines) reproduced it, while a *single*-command page (one
+      # BlankLine) and the long genuine battle-tail-based pages (cycles
+      # #130-136's own recipe, and this cycle's own working recipe) did not.
+      # Command content is therefore not the trigger; something about a
+      # *short* synthetic command list specifically is. Not chased further --
+      # this cycle's own probes worked around it by keeping the spliced
+      # command list exactly as long as cycles #130-136's proven-safe shape
+      # (their full Enemy-Encounter-through-EndBattle tail, escaped out of
+      # rather than fought) -- but it is a real, reproducible crash a future
+      # cycle investigating short synthetic autostart pages should know about
+      # before assuming a short page is automatically safe.
+      #
+      # Pixel values measured directly (640x480 wine capture, so divided by 2
+      # for native 320x240 coordinates): panel at native (136, 0), 184x240 --
+      # i.e. `SCREEN_W - TARGET_W` .. `SCREEN_W`, full `SCREEN_H`; each row
+      # 48px (three 16px lines); the label column (name/level/condition)
+      # starting 56px into the panel's own content area, the value column
+      # (HP/MP) at 114px; the face 48x48 at x=8 (ending exactly where the
+      # label column begins).
       TARGET_W = 184
       TARGET_ROW_H = LINE_H * 3
       TARGET_LABEL_X = 56
       TARGET_VALUE_X = 114
+      TARGET_FACE_X = 8
+      TARGET_FACE_SIZE = 48
+      # The extra push into the row every row *after* the first gets -- see
+      # this method's own citation above for why row 0 is excluded.
+      TARGET_FACE_Y_EXTRA = 18
 
       def build_target_window
         @target_window.dispose if @target_window
@@ -725,6 +769,7 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         party.each_with_index do |a, i|
           y = i * TARGET_ROW_H
+          draw_target_face c, a, i, y
           c.draw_text TARGET_LABEL_X, y, inner_w - TARGET_LABEL_X, LINE_H, a.name.to_s
           c.draw_text TARGET_LABEL_X, y + LINE_H, TARGET_VALUE_X - TARGET_LABEL_X, LINE_H,
                       "#{term(:level_short, 'Lv')} #{a.level}"
@@ -740,6 +785,38 @@ class RPG2k
         end
         @target_window.contents = c
         refresh_target_cursor
+      end
+
+      # Row `row`'s 48x48 face crop, or nothing at all for an actor with no
+      # faceset set (or one that fails to load) -- matching the same "a
+      # missing portrait draws nothing" rule `Scene::Map#load_face_bitmap`/
+      # `#draw_kana_face` and `Scene::Battle#draw_battle_gauge_face` already
+      # use, and `#respond_to?`-guarded the same way for a bare test-fixture
+      # actor with no faceset fields at all. Row 0 draws flush at the row's
+      # own top; every later row is pushed `TARGET_FACE_Y_EXTRA` further in
+      # -- see this class's own citation on `TARGET_FACE_Y_EXTRA` above for
+      # why the two differ.
+      def draw_target_face(c, actor, row, y)
+        return unless actor.respond_to?(:faceset_name)
+        face = load_face_bitmap(actor.faceset_name)
+        return unless face
+        index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
+        src = Rect.new((index % 4) * TARGET_FACE_SIZE, (index / 4) * TARGET_FACE_SIZE,
+                       TARGET_FACE_SIZE, TARGET_FACE_SIZE)
+        face_y = row.zero? ? y : y + TARGET_FACE_Y_EXTRA
+        c.blt TARGET_FACE_X, face_y, face, src
+      end
+
+      # This screen has no `@map` to borrow `#load_face_bitmap` from (unlike
+      # Scene::Battle's own face draw) -- mirrors `Scene::SaveLoad#load_face_
+      # bitmap` exactly, including the colour-key transparency every FaceSet
+      # sheet needs.
+      def load_face_bitmap(name)
+        return nil if name.nil? || name.empty?
+        Bitmap.new "FaceSet/#{name}", true
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] face graphic '#{name}' load failed: #{e.message}"
+        nil
       end
 
       def refresh_target_cursor

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -541,16 +541,20 @@ class RPG2k
       end
 
       # See Scene::ItemMenu's identical `TARGET_W`/`TARGET_ROW_H`/
-      # `TARGET_LABEL_X`/`TARGET_VALUE_X` doc comment (cycle #132) for the
-      # full RPG_RT measurement write-up -- this class's own target-confirm
-      # screen shares the exact same geometry (a genuine RPG_RT.exe under
-      # wine draws Scene_Skill's actor-target picker identically to
-      # Scene_Item's), so the constants and both methods below are ported
-      # verbatim from there rather than re-measured independently.
+      # `TARGET_LABEL_X`/`TARGET_VALUE_X` doc comment (cycle #132, extended
+      # cycle #137 with the face-drawing geometry) for the full RPG_RT
+      # measurement write-up -- this class's own target-confirm screen shares
+      # the exact same geometry (a genuine RPG_RT.exe under wine draws
+      # Scene_Skill's actor-target picker identically to Scene_Item's), so
+      # the constants and methods below are ported verbatim from there rather
+      # than re-measured independently.
       TARGET_W = 184
       TARGET_ROW_H = LINE_H * 3
       TARGET_LABEL_X = 56
       TARGET_VALUE_X = 114
+      TARGET_FACE_X = 8
+      TARGET_FACE_SIZE = 48
+      TARGET_FACE_Y_EXTRA = 18
 
       def build_target_window
         @target_window.dispose if @target_window
@@ -563,6 +567,7 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         party.each_with_index do |a, i|
           y = i * TARGET_ROW_H
+          draw_target_face c, a, i, y
           c.draw_text TARGET_LABEL_X, y, inner_w - TARGET_LABEL_X, LINE_H, a.name.to_s
           c.draw_text TARGET_LABEL_X, y + LINE_H, TARGET_VALUE_X - TARGET_LABEL_X, LINE_H,
                       "#{term(:level_short, 'Lv')} #{a.level}"
@@ -578,6 +583,27 @@ class RPG2k
         end
         @target_window.contents = c
         refresh_target_cursor
+      end
+
+      # See Scene::ItemMenu#draw_target_face's identical comment/citation.
+      def draw_target_face(c, actor, row, y)
+        return unless actor.respond_to?(:faceset_name)
+        face = load_face_bitmap(actor.faceset_name)
+        return unless face
+        index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
+        src = Rect.new((index % 4) * TARGET_FACE_SIZE, (index / 4) * TARGET_FACE_SIZE,
+                       TARGET_FACE_SIZE, TARGET_FACE_SIZE)
+        face_y = row.zero? ? y : y + TARGET_FACE_Y_EXTRA
+        c.blt TARGET_FACE_X, face_y, face, src
+      end
+
+      # See Scene::ItemMenu#load_face_bitmap's identical comment.
+      def load_face_bitmap(name)
+        return nil if name.nil? || name.empty?
+        Bitmap.new "FaceSet/#{name}", true
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] face graphic '#{name}' load failed: #{e.message}"
+        nil
       end
 
       def refresh_target_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19411,6 +19411,67 @@ check 'the item / skill target-confirm screen draws each actor on three ' \
   end
 end
 
+# A party where every member has a real faceset -- for the target-confirm
+# panel's own face-drawing checks below.
+class FacedTargetParty < MenuStubParty
+  def initialize
+    super
+    @actors = Array.new(2) { |i| a = MenuStubActor.new; a.faceset_name = 'face'; a.faceset_index = i; a }
+  end
+end
+
+def faced_target_state
+  Game::State.new(FacedTargetParty.new, 1, 0, 0)
+end
+
+check 'the item / skill target-confirm screen draws a 48x48 face per row, ' \
+      'row 0 flush at the top of its own row but every later row pushed ' \
+      '18px further in' do
+  # Confirmed against a genuine RPG_RT.exe under wine (cycle #137): cycle
+  # #132 left this an open question (a blank gutter to the left of every
+  # row, guessed but not confirmed to be an undrawn face slot) and cycle
+  # #136 confirmed the guess right for a non-first row (row 1's face at
+  # panel-local (8, 66) -- i.e. `1 * TARGET_ROW_H + 18`) but could not reach
+  # a faceted row 0 to settle whether row 0 follows the same "+18" rule.
+  # It does not: row 0's face sits flush at (8, 0), no +18 -- see
+  # Scene::ItemMenu::TARGET_FACE_Y_EXTRA's own doc comment for the full
+  # measurement write-up (a live Change Actor Face onto the debug save's own
+  # sole actor, both alone and side-by-side with a second, natively-faceted
+  # actor so both rows were visible in the same capture at once).
+  [RPG2k::Scene::ItemMenu, RPG2k::Scene::SkillMenu].each do |klass|
+    scene = menu_scene(klass, faced_target_state)
+    scene.send(:build_target_window)
+    win = scene.instance_variable_get(:@target_window)
+    blts = win.contents.blt_calls || []
+    face_blts = blts.select { |c| c[3].is_a?(RGSS::Rect) && c[3].width == 48 && c[3].height == 48 }
+    eq 2, face_blts.size, "#{klass}: one face blit per actor"
+    row0 = face_blts.find { |c| c[3].x.zero? && c[3].y.zero? } # actor 0's own cell (index 0 -> src 0,0)
+    row1 = face_blts.find { |c| c[3].x == 48 && c[3].y.zero? } # actor 1's own cell (index 1 -> src 48,0)
+    ok row0, "#{klass}: row 0's own faceset cell (index 0) was blitted"
+    ok row1, "#{klass}: row 1's own faceset cell (index 1) was blitted"
+    eq RPG2k::Scene::ItemMenu::TARGET_FACE_X, row0[0], "#{klass}: row 0 face x"
+    eq 0, row0[1], "#{klass}: row 0 face is flush at the top of its own row, not pushed in"
+    eq RPG2k::Scene::ItemMenu::TARGET_FACE_X, row1[0], "#{klass}: row 1 face x"
+    eq RPG2k::Scene::ItemMenu::TARGET_ROW_H + RPG2k::Scene::ItemMenu::TARGET_FACE_Y_EXTRA, row1[1],
+       "#{klass}: row 1 face is pushed TARGET_FACE_Y_EXTRA further into its own row"
+  end
+end
+
+check 'the item / skill target-confirm screen draws no face for an actor ' \
+      'with no faceset set' do
+  # MenuStubActor defaults to a blank faceset_name -- matching
+  # Scene::Map#load_face_bitmap's own "blank name -> no face" rule, the same
+  # one the debug save's solo "デモ用" actor exercised for real (cycle #136).
+  [RPG2k::Scene::ItemMenu, RPG2k::Scene::SkillMenu].each do |klass|
+    scene = menu_scene(klass, menu_state)
+    scene.send(:build_target_window)
+    win = scene.instance_variable_get(:@target_window)
+    blts = win.contents.blt_calls || []
+    face_blts = blts.select { |c| c[3].is_a?(RGSS::Rect) && c[3].width == 48 && c[3].height == 48 }
+    eq 0, face_blts.size, "#{klass}: no face blit for a faceless actor"
+  end
+end
+
 check 'Scene::ItemMenu: the item grid cursor does not wrap, the target cursor does' do
   scene = menu_scene(RPG2k::Scene::ItemMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@item_index), 'starts on the first item'


### PR DESCRIPTION
## Summary

- RPG_RT's field Item/Skill target-confirm screen draws a real 48×48 face portrait per row when an actor has one — the top row's face sits flush at the top of its own row, while every later row's face is pushed 18px further in. `Scene::ItemMenu`/`Scene::SkillMenu`'s `#build_target_window` never drew a face at all, leaving a blank gutter cycle #132 had flagged as a plausible but unconfirmed face-graphic slot.
- Closes cycle #132's last open lead: cycle #136 had already confirmed the guess right for a non-first row (row 1), but couldn't reach a faceted row 0 to settle whether it followed the same offset. It doesn't — row 0 is flush, not pushed in.
- Confirmed under Wine using cycle #136's live `Change Party Member` technique: gave the debug save's own sole actor a live faceset via `Change Actor Face` (event code 10640), then compared its row-0 offset against a second, natively-faceted actor's row-1 offset in the same capture — ruling out a capture-to-capture calibration error, and confirmed independent of which row the cursor highlighted.
- Added `#draw_target_face`/`#load_face_bitmap` to both menu classes, matching the "draw nothing for a missing faceset" rule every other face-draw call site in this codebase already uses.
- **Open lead, not chased further:** a genuine, reproducible RPG_RT.exe crash was found as a side effect — a *short* synthetic autostart command list (even two bare BlankLines) crashes the real binary on the *next* screen transition, while a single-command page or the long genuine battle-tail recipe cycles #130-136 use do not. Root cause unidentified; documented in `docs/TODO.md` as a lead for a future cycle.
- Rows 2/3's face offset remains an unconfirmed extrapolation (reaching a 3-/4-actor faceted party risked the crash above).

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new checks against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/item_menu.rb mruby-rpg2k/mrblib/scene/skill_menu.rb`, rerunning the suite, then `git stash pop`: **1 of 915 checks failed** (`RuntimeError: expected 2, got 0`, since pre-fix `#build_target_window` never blits a face at all). The faceless-actor check trivially passes either way since "no face" is also the pre-fix behavior — it only pins the negative case going forward.
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 915 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_