### PR TITLE
Item/Skill target-confirm screen: rows are pitched 58px, not 48px

### DIFF
--- a/changelog.d/item-skill-target-confirm-face.fixed.md
+++ b/changelog.d/item-skill-target-confirm-face.fixed.md
@@ -1,5 +1,10 @@
 - **Item/Skill menus:** the actor-target-confirm screen ("who to use this
   on") now draws each party member's own 48x48 face portrait, when they
-  have one, matching RPG_RT — the top row's face sits flush at the top of
-  its own row, while every later row's face is pushed further in. Previously
-  no face was ever drawn, leaving a blank gutter on every row.
+  have one, matching RPG_RT — every row's face sits flush at its own row's
+  top, with successive rows pitched 58px apart. Previously no face was ever
+  drawn, leaving a blank gutter on every row. (An earlier version of this
+  fix, based on measuring only two rows, special-cased the top row as
+  flush and pushed every later row in by a flat 18px; independently
+  re-verified against genuine RPG_RT.exe with a full four-member party and
+  found wrong past the second row, so this fragment has been corrected in
+  place.)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6679,6 +6679,98 @@ The work below is roughly ordered by the critical path to a walkable game
   written back)/`Save01.lsd` were edited only as scratch copies for every
   probe above and restored to their original bytes (byte-identical by
   `md5sum`) once each wine session was torn down.
+  ✅ **Follow-up (cycle #138, 2026-08-25): closed cycle #137's own open lead
+  on the field Item/Skill target-confirm screen's rows 2/3 -- and in doing so
+  found cycle #137's own "row 0 flush, every later row pushed a flat +18px"
+  model was itself wrong past row 1. RPG_RT.exe does not pack these rows
+  edge-to-edge at the 48px row height at all: it pitches them 58px apart (a
+  10px gap between rows), and that 58px pitch is uniform starting at row 0 --
+  there is no row-0 special case. Fixed.** Cycle #137's own two-row
+  measurement (row 0 at native y 0, row 1 at native y 66) cannot actually
+  distinguish its own model from this one, since `48*1 + 18 == 58*1 + 0` --
+  the two formulas only diverge from row 2 onward, which cycle #137 could not
+  yet reach. Reached this cycle with a real 4-actor faceted party: デモ用
+  (id 15, the debug save's own live actor, normally faceless) given actor 2's
+  own face via a live Change Actor Face (event code 10640, cell 1 of
+  `FaceSet/face.png`) so row 0 could be tested with a face too, plus ファル/
+  ティララ/ディーヴァ (ids 2/3/4, each already carrying a real native
+  faceset at cells 1/2/3) added via cycle #136's proven-safe Change Party
+  Member technique -- all four via one synthetic autostart event on a
+  scratch copy of Map0012 whose command list is the live Change Actor Face
+  plus three Change Party Member commands prepended onto Map0478 event 2
+  page 2's own genuine Enemy-Encounter-through-EndBattle tail (troop 103,
+  codes 10710/20710/20711/20713/0, tail-spliced verbatim as cycles #130-137
+  did), keeping the spliced list at least as long as that proven-safe shape
+  throughout -- deliberately the same "long synthetic list" workaround
+  cycle #137 flagged, since the short-list crash below remains unexplained
+  and this fix had no need to poke at it. Tested under wine (Xvfb
+  640x480x16, LIBGL_ALWAYS_SOFTWARE=1, matchbox-window-manager,
+  LANG=ja_JP.UTF-8): Continue -> file 1 -> autostart fired (party grew to
+  4 with no crash, reproducing cycle #136's own finding) -> the battle the
+  spliced Enemy Encounter opens presented a party-wide 戦う/オート/逃げる
+  tactics menu this time (not the per-actor 攻撃/特殊技能/防御/アイテム menu
+  cycles #130-137's battle-side probes saw -- ESC from the per-actor menu
+  reliably surfaced it) -> 逃げる (Escape) selected, ending the battle
+  cleanly back on the map, no crash -- then the field menu -> アイテム ->
+  薬草 opened the actual target-confirm screen with all four rows visible
+  and faceted at once. All four faces template-matched pixel-exact against
+  genuine `FaceSet/face.png`'s own cells (`compare -metric RMSE
+  -subimage-search`, RMSE ~0 on every match) at content-local y = 0, 58,
+  116, 174 -- exactly `58 * row`, no row-0 exception -- cross-confirmed two
+  independent ways: the selection cursor's own top border (detected by its
+  distinct windowskin colour, unrelated to face content) landed on the
+  identical four values, and an overlaid gridline at those four values
+  visually lined up with every row's face *and* name-text top in the same
+  capture. Boundary cases checked: row 0 (the previously-disputed one, now
+  measured directly with a real face rather than inferred), row 1 (cycle
+  #137's own reproduced control value), and rows 2/3 (the party-cap
+  boundary this fix was chasing, both landing exactly on the `58 * row`
+  line with no drift). Sanity check: 4 rows at this pitch top out at
+  content-local y `58 * 3 + 48 == 222`, two pixels inside
+  `#build_target_window`'s own `SCREEN_H - Window::BORDER * 2 == 224`-tall
+  content bitmap with no room to spare -- a good sign 58 is the real
+  constant and not a coincidental near-fit. Fixed `#build_target_window`,
+  `#draw_target_face` and `#refresh_target_cursor` in both `item_menu.rb`
+  and `skill_menu.rb` identically: replaced `TARGET_FACE_Y_EXTRA`'s
+  row-zero-exception model with a single `TARGET_ROW_PITCH = 58` used for
+  every row's own position (face, text, and the selection cursor's y) while
+  `TARGET_ROW_H` (48, unchanged) stays only the row's own content height --
+  used for the cursor rectangle's height and the three text lines' internal
+  offsets, which do not move. `scripts/rpg2k_scene_check.rb`'s own
+  two-actor face check was widened to a full four-actor `FacedTargetParty`
+  and rewritten to assert `i * TARGET_ROW_PITCH` for every row 0-3 instead
+  of the old row-0-vs-row-1 special case; a new check pins the cursor
+  rectangle's y at the same `TARGET_ROW_PITCH` stride while its height
+  stays `TARGET_ROW_H`. Both confirmed to fail against the pre-fix code (a
+  stashed diff of just `item_menu.rb`/`skill_menu.rb`) before the fix --
+  both checks reference the new `TARGET_ROW_PITCH` constant directly in
+  their own assertions, so both raise the same `NameError:
+  uninitialized constant RPG2k::Scene::ItemMenu::TARGET_ROW_PITCH`
+  against pre-fix code that has not yet defined it, 2 of 916 checks;
+  full suite reconfirmed passing after (916 checks, up from 915).
+  `scripts/rpg2k_render_check.rb` (41 checks) and `scripts/
+  rpg2k_logic_check.rb` (1134 checks) reconfirmed passing unaffected.
+  `Map0012.lmu`/`Map0478.lmu` (read-only, only its already-parsed
+  `event_commands` were reused, never written back)/`Save01.lsd` were
+  edited only as scratch copies for every probe above and restored to their
+  original bytes (byte-identical by `md5sum`) once the wine session was
+  torn down; `scripts/lcf_testbed_check.rb` reconfirmed 1099 maps/22858
+  events (back to its pre-probe count) parse cleanly afterward.
+  **Not chased this cycle:** cycle #137's own separately-flagged short-list
+  autostart crash remains completely unexplained -- this fix's own probe
+  reused the exact same long-list workaround rather than poking at the
+  boundary, so it adds no new data point either way (it is simply one more
+  confirmation the long-list shape stays safe, this time at 4 added
+  Change-Party-Member/Change-Actor-Face commands deep rather than 1). One
+  incidental observation for whoever does chase it: this cycle's battle
+  encounter surfaced the party-wide 戦う/オート/逃げる tactics menu on
+  entry, where cycle #136's own otherwise-identical recipe (same troop 103,
+  same tail) went straight to the per-actor 攻撃/特殊技能/防御/アイテム
+  menu instead -- both are genuine RPG_RT battle-command screens (ESC from
+  the per-actor menu reaches the tactics one either way), so this is
+  probably just an existing per-troop or per-save setting rather than
+  anything this cycle's own event edits caused, but it was not investigated
+  and is worth a note in case a future cycle finds it significant.
   ✅ **Follow-up (cycle #136, 2026-08-24): finished cycle #135's own
   time-boxed-away live Change Party Member technique -- it works cleanly
   against genuine RPG_RT.exe, with no crash, and immediately unblocked

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -743,20 +743,60 @@ class RPG2k
       #
       # Pixel values measured directly (640x480 wine capture, so divided by 2
       # for native 320x240 coordinates): panel at native (136, 0), 184x240 --
-      # i.e. `SCREEN_W - TARGET_W` .. `SCREEN_W`, full `SCREEN_H`; each row
-      # 48px (three 16px lines); the label column (name/level/condition)
-      # starting 56px into the panel's own content area, the value column
-      # (HP/MP) at 114px; the face 48x48 at x=8 (ending exactly where the
-      # label column begins).
+      # i.e. `SCREEN_W - TARGET_W` .. `SCREEN_W`, full `SCREEN_H`; each row's
+      # own *content* (face + its three 16px text lines) is 48px tall, but
+      # successive rows are pitched 58px apart, not 48 -- see
+      # `TARGET_ROW_PITCH` below for the citation. The label column
+      # (name/level/condition) starts 56px into the panel's own content area,
+      # the value column (HP/MP) at 114px; the face 48x48 at x=8 (ending
+      # exactly where the label column begins).
       TARGET_W = 184
       TARGET_ROW_H = LINE_H * 3
+      # Follow-up (cycle #138, 2026-08-25): RPG_RT does *not* pack these rows
+      # edge-to-edge at the 48px `TARGET_ROW_H` cycle #132 measured from a
+      # single visible row -- it leaves a 10px gap between them, so
+      # consecutive rows are 58px apart, and that 58px pitch applies to
+      # *every* row, row 0 included. This supersedes cycle #137's own
+      # `TARGET_FACE_Y_EXTRA` model (a flush row 0 plus a flat "+18" pushed
+      # into every later row), which was a curve-fit to exactly two data
+      # points (row 0 and row 1) that happens to be indistinguishable from
+      # this one at row 1 -- `48*1 + 18 == 58*1 + 0` -- and only diverges
+      # from row 2 onward, which cycle #137 could not yet reach. Confirmed
+      # against genuine RPG_RT.exe under wine (Xvfb 640x480x16,
+      # LIBGL_ALWAYS_SOFTWARE=1, matchbox-window-manager, LANG=ja_JP.UTF-8)
+      # with a real 4-actor faceted party (デモ用 id 15 given actor 2's own
+      # face via a live Change Actor Face, event code 10640, so row 0 could
+      # be tested with a face too; ファル/ティララ/ディーヴァ, ids 2/3/4,
+      # added via cycle #136's proven-safe Change Party Member technique) --
+      # grown via a synthetic autostart event on a scratch copy of Map0012
+      # whose command list is a live Change Actor Face plus three Change
+      # Party Member commands prepended onto Map0478 event 2 page 2's own
+      # genuine Enemy-Encounter-through-EndBattle tail (troop 103, escaped
+      # out of via the battle options window's Escape entry), keeping the
+      # spliced list at least as long as cycles #130-137's own proven-safe
+      # shape throughout. All four faces template-matched pixel-exact
+      # against `FaceSet/face.png`'s own cells (`compare -subimage-search`,
+      # RMSE ~0) at content-local y = 0, 58, 116, 174 -- i.e. `58 * row`
+      # exactly, no row-0 exception -- cross-confirmed by the selection
+      # cursor's own top border (independently detected by its windowskin
+      # colour) landing on the identical four values. This also resolves
+      # cycle #137's own "row 0 face top edge landed at native y ~0" reading
+      # as measurement slop, not a real flush-top special case: it was a
+      # manual "screen y 2-4" estimate against a 640x480 capture, 8px off
+      # the true value found here (screen y 16) -- the automated
+      # template-match this cycle used is precise to the pixel and was
+      # cross-checked two independent ways (face content and cursor border)
+      # on two separate captures, so it supersedes that earlier estimate.
+      # Bare arithmetic check: 4 rows at this 58px pitch top out at
+      # content-local y `58 * 3 + 48 == 222`, two pixels inside this
+      # method's own `SCREEN_H - Window::BORDER * 2 == 224`-tall content
+      # bitmap with no room to spare -- a good sign this is the real
+      # constant and not a coincidental near-fit.
+      TARGET_ROW_PITCH = 58
       TARGET_LABEL_X = 56
       TARGET_VALUE_X = 114
       TARGET_FACE_X = 8
       TARGET_FACE_SIZE = 48
-      # The extra push into the row every row *after* the first gets -- see
-      # this method's own citation above for why row 0 is excluded.
-      TARGET_FACE_Y_EXTRA = 18
 
       def build_target_window
         @target_window.dispose if @target_window
@@ -768,8 +808,8 @@ class RPG2k
         c = Bitmap.new(inner_w, SCREEN_H - Window::BORDER * 2)
         c.font.color = Color.new(255, 255, 255, 255)
         party.each_with_index do |a, i|
-          y = i * TARGET_ROW_H
-          draw_target_face c, a, i, y
+          y = i * TARGET_ROW_PITCH
+          draw_target_face c, a, y
           c.draw_text TARGET_LABEL_X, y, inner_w - TARGET_LABEL_X, LINE_H, a.name.to_s
           c.draw_text TARGET_LABEL_X, y + LINE_H, TARGET_VALUE_X - TARGET_LABEL_X, LINE_H,
                       "#{term(:level_short, 'Lv')} #{a.level}"
@@ -792,19 +832,17 @@ class RPG2k
       # missing portrait draws nothing" rule `Scene::Map#load_face_bitmap`/
       # `#draw_kana_face` and `Scene::Battle#draw_battle_gauge_face` already
       # use, and `#respond_to?`-guarded the same way for a bare test-fixture
-      # actor with no faceset fields at all. Row 0 draws flush at the row's
-      # own top; every later row is pushed `TARGET_FACE_Y_EXTRA` further in
-      # -- see this class's own citation on `TARGET_FACE_Y_EXTRA` above for
-      # why the two differ.
-      def draw_target_face(c, actor, row, y)
+      # actor with no faceset fields at all. Flush at the row's own top for
+      # every row, row 0 included -- see `TARGET_ROW_PITCH`'s own citation
+      # above for why an earlier cycle once thought row 0 was special.
+      def draw_target_face(c, actor, y)
         return unless actor.respond_to?(:faceset_name)
         face = load_face_bitmap(actor.faceset_name)
         return unless face
         index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
         src = Rect.new((index % 4) * TARGET_FACE_SIZE, (index / 4) * TARGET_FACE_SIZE,
                        TARGET_FACE_SIZE, TARGET_FACE_SIZE)
-        face_y = row.zero? ? y : y + TARGET_FACE_Y_EXTRA
-        c.blt TARGET_FACE_X, face_y, face, src
+        c.blt TARGET_FACE_X, y, face, src
       end
 
       # This screen has no `@map` to borrow `#load_face_bitmap` from (unlike
@@ -832,8 +870,13 @@ class RPG2k
           # cursor's own left edge (see the geometry comment above) --
           # `TARGET_LABEL_X - 2` lands the highlight's left edge right at the
           # measured card border, a couple of pixels ahead of the text itself.
+          # The box's own *height* stays `TARGET_ROW_H` (48px, matching the
+          # row's own content) even though rows are pitched 58px apart --
+          # confirmed cycle #138: the cursor border measured 48px tall at
+          # every row, leaving the same 10px gap below it that separates the
+          # rows themselves (see `TARGET_ROW_PITCH`'s own citation).
           @target_window.cursor_rect =
-            Rect.new(TARGET_LABEL_X - 2, @target_index * TARGET_ROW_H,
+            Rect.new(TARGET_LABEL_X - 2, @target_index * TARGET_ROW_PITCH,
                      @target_window.contents.width - (TARGET_LABEL_X - 2), TARGET_ROW_H)
         end
       end

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -541,8 +541,9 @@ class RPG2k
       end
 
       # See Scene::ItemMenu's identical `TARGET_W`/`TARGET_ROW_H`/
-      # `TARGET_LABEL_X`/`TARGET_VALUE_X` doc comment (cycle #132, extended
-      # cycle #137 with the face-drawing geometry) for the full RPG_RT
+      # `TARGET_ROW_PITCH`/`TARGET_LABEL_X`/`TARGET_VALUE_X` doc comment
+      # (cycle #132, extended cycle #137 with the face-drawing geometry and
+      # cycle #138 with the real 58px row pitch) for the full RPG_RT
       # measurement write-up -- this class's own target-confirm screen shares
       # the exact same geometry (a genuine RPG_RT.exe under wine draws
       # Scene_Skill's actor-target picker identically to Scene_Item's), so
@@ -550,11 +551,11 @@ class RPG2k
       # than re-measured independently.
       TARGET_W = 184
       TARGET_ROW_H = LINE_H * 3
+      TARGET_ROW_PITCH = 58
       TARGET_LABEL_X = 56
       TARGET_VALUE_X = 114
       TARGET_FACE_X = 8
       TARGET_FACE_SIZE = 48
-      TARGET_FACE_Y_EXTRA = 18
 
       def build_target_window
         @target_window.dispose if @target_window
@@ -566,8 +567,8 @@ class RPG2k
         c = Bitmap.new(inner_w, SCREEN_H - Window::BORDER * 2)
         c.font.color = Color.new(255, 255, 255, 255)
         party.each_with_index do |a, i|
-          y = i * TARGET_ROW_H
-          draw_target_face c, a, i, y
+          y = i * TARGET_ROW_PITCH
+          draw_target_face c, a, y
           c.draw_text TARGET_LABEL_X, y, inner_w - TARGET_LABEL_X, LINE_H, a.name.to_s
           c.draw_text TARGET_LABEL_X, y + LINE_H, TARGET_VALUE_X - TARGET_LABEL_X, LINE_H,
                       "#{term(:level_short, 'Lv')} #{a.level}"
@@ -586,15 +587,14 @@ class RPG2k
       end
 
       # See Scene::ItemMenu#draw_target_face's identical comment/citation.
-      def draw_target_face(c, actor, row, y)
+      def draw_target_face(c, actor, y)
         return unless actor.respond_to?(:faceset_name)
         face = load_face_bitmap(actor.faceset_name)
         return unless face
         index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
         src = Rect.new((index % 4) * TARGET_FACE_SIZE, (index / 4) * TARGET_FACE_SIZE,
                        TARGET_FACE_SIZE, TARGET_FACE_SIZE)
-        face_y = row.zero? ? y : y + TARGET_FACE_Y_EXTRA
-        c.blt TARGET_FACE_X, face_y, face, src
+        c.blt TARGET_FACE_X, y, face, src
       end
 
       # See Scene::ItemMenu#load_face_bitmap's identical comment.
@@ -615,7 +615,7 @@ class RPG2k
             Rect.new(0, 0, @target_window.contents.width, @target_window.contents.height)
         else
           @target_window.cursor_rect =
-            Rect.new(TARGET_LABEL_X - 2, @target_index * TARGET_ROW_H,
+            Rect.new(TARGET_LABEL_X - 2, @target_index * TARGET_ROW_PITCH,
                      @target_window.contents.width - (TARGET_LABEL_X - 2), TARGET_ROW_H)
         end
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -19411,12 +19411,13 @@ check 'the item / skill target-confirm screen draws each actor on three ' \
   end
 end
 
-# A party where every member has a real faceset -- for the target-confirm
-# panel's own face-drawing checks below.
+# A full 4-actor party where every member has a real faceset -- for the
+# target-confirm panel's own face-drawing checks below, including the
+# party-cap boundary rows (2/3) cycle #138 finally reached.
 class FacedTargetParty < MenuStubParty
   def initialize
     super
-    @actors = Array.new(2) { |i| a = MenuStubActor.new; a.faceset_name = 'face'; a.faceset_index = i; a }
+    @actors = Array.new(4) { |i| a = MenuStubActor.new; a.faceset_name = 'face'; a.faceset_index = i; a }
   end
 end
 
@@ -19425,35 +19426,62 @@ def faced_target_state
 end
 
 check 'the item / skill target-confirm screen draws a 48x48 face per row, ' \
-      'row 0 flush at the top of its own row but every later row pushed ' \
-      '18px further in' do
-  # Confirmed against a genuine RPG_RT.exe under wine (cycle #137): cycle
-  # #132 left this an open question (a blank gutter to the left of every
-  # row, guessed but not confirmed to be an undrawn face slot) and cycle
-  # #136 confirmed the guess right for a non-first row (row 1's face at
-  # panel-local (8, 66) -- i.e. `1 * TARGET_ROW_H + 18`) but could not reach
-  # a faceted row 0 to settle whether row 0 follows the same "+18" rule.
-  # It does not: row 0's face sits flush at (8, 0), no +18 -- see
-  # Scene::ItemMenu::TARGET_FACE_Y_EXTRA's own doc comment for the full
-  # measurement write-up (a live Change Actor Face onto the debug save's own
-  # sole actor, both alone and side-by-side with a second, natively-faceted
-  # actor so both rows were visible in the same capture at once).
+      'every row (0 through 3) flush at its own row top, rows pitched ' \
+      '58px apart rather than packed at the 48px row height' do
+  # Confirmed against a genuine RPG_RT.exe under wine (cycle #138, closing
+  # cycle #137's own open lead): cycle #132 left this an open question (a
+  # blank gutter to the left of every row, guessed but not confirmed to be
+  # an undrawn face slot); cycle #136 confirmed the guess right for a
+  # non-first row; cycle #137 reached row 0 too but, with only two rows ever
+  # visible at once, fit a "row 0 flush, every later row pushed +18" model
+  # that a two-point measurement cannot distinguish from this cycle's own
+  # (`48*1 + 18 == 58*1 + 0`) -- and mis-measured row 0 itself by eye as
+  # "~0" when it is really 8. Cycle #138 finally reached a real 4-actor
+  # faceted party (row 0 given a face via a live Change Actor Face) and
+  # found the true rule: no row is special-cased at all -- every row's face
+  # sits flush at `row * TARGET_ROW_PITCH` (58px), confirmed pixel-exact by
+  # template-matching all four rows against genuine `FaceSet/face.png` cells
+  # and cross-checked against the selection cursor's own top border. See
+  # `TARGET_ROW_PITCH`'s own doc comment for the full measurement write-up.
   [RPG2k::Scene::ItemMenu, RPG2k::Scene::SkillMenu].each do |klass|
     scene = menu_scene(klass, faced_target_state)
     scene.send(:build_target_window)
     win = scene.instance_variable_get(:@target_window)
     blts = win.contents.blt_calls || []
     face_blts = blts.select { |c| c[3].is_a?(RGSS::Rect) && c[3].width == 48 && c[3].height == 48 }
-    eq 2, face_blts.size, "#{klass}: one face blit per actor"
-    row0 = face_blts.find { |c| c[3].x.zero? && c[3].y.zero? } # actor 0's own cell (index 0 -> src 0,0)
-    row1 = face_blts.find { |c| c[3].x == 48 && c[3].y.zero? } # actor 1's own cell (index 1 -> src 48,0)
-    ok row0, "#{klass}: row 0's own faceset cell (index 0) was blitted"
-    ok row1, "#{klass}: row 1's own faceset cell (index 1) was blitted"
-    eq RPG2k::Scene::ItemMenu::TARGET_FACE_X, row0[0], "#{klass}: row 0 face x"
-    eq 0, row0[1], "#{klass}: row 0 face is flush at the top of its own row, not pushed in"
-    eq RPG2k::Scene::ItemMenu::TARGET_FACE_X, row1[0], "#{klass}: row 1 face x"
-    eq RPG2k::Scene::ItemMenu::TARGET_ROW_H + RPG2k::Scene::ItemMenu::TARGET_FACE_Y_EXTRA, row1[1],
-       "#{klass}: row 1 face is pushed TARGET_FACE_Y_EXTRA further into its own row"
+    eq 4, face_blts.size, "#{klass}: one face blit per actor"
+    (0..3).each do |i|
+      row = face_blts.find { |c| c[3].x == i * 48 && c[3].y.zero? } # actor i's own cell (index i -> src i*48,0)
+      ok row, "#{klass}: row #{i}'s own faceset cell (index #{i}) was blitted"
+      eq RPG2k::Scene::ItemMenu::TARGET_FACE_X, row[0], "#{klass}: row #{i} face x"
+      eq i * RPG2k::Scene::ItemMenu::TARGET_ROW_PITCH, row[1],
+         "#{klass}: row #{i} face is flush at i * TARGET_ROW_PITCH, no special-casing"
+    end
+  end
+end
+
+check 'the item / skill target-confirm screen\'s selection cursor is ' \
+      'pitched 58px per row (TARGET_ROW_PITCH), not the 48px row height' do
+  # Same cycle #138 measurement as the face check above, applied to
+  # `refresh_target_cursor`: the cursor's own box stayed the row's 48px
+  # content height (`TARGET_ROW_H`, confirmed unchanged -- the wine capture's
+  # cursor border was 48px tall at every row) but its *position* must follow
+  # the same 58px pitch as the face/text it highlights, not the old 48px
+  # `TARGET_ROW_H` stride, or it drifts out of alignment with its own row by
+  # row 2 (a 20px miss) and row 3 (a 30px miss).
+  [RPG2k::Scene::ItemMenu, RPG2k::Scene::SkillMenu].each do |klass|
+    scene = menu_scene(klass, faced_target_state)
+    scene.send(:build_target_window)
+    win = scene.instance_variable_get(:@target_window)
+    (0..3).each do |i|
+      scene.instance_variable_set(:@target_index, i)
+      scene.send(:refresh_target_cursor)
+      rect = win.cursor_rect
+      eq i * RPG2k::Scene::ItemMenu::TARGET_ROW_PITCH, rect.y,
+         "#{klass}: row #{i} cursor y follows TARGET_ROW_PITCH"
+      eq RPG2k::Scene::ItemMenu::TARGET_ROW_H, rect.height,
+         "#{klass}: row #{i} cursor height stays the row's own 48px content height"
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

- Cycle #137 fixed the item/skill target-confirm screen to draw a face portrait per row, fitting a "row 0 flush, every later row pushed +18px" model from a two-row measurement. That model is mathematically indistinguishable from a uniform 58px-per-row pitch at row 1 (`48+18 == 58+0`) and only diverges from row 2 onward, which cycle #137 could not yet reach.
- Reached a real 4-actor faceted party this cycle and found the true rule: RPG_RT does not special-case row 0 at all. Every row's face, text, and selection cursor sit at a uniform **58px pitch** (a 10px gap between each row's 48px content), confirmed pixel-exact by template-matching all four rows against genuine `FaceSet/face.png` cells and cross-checked against the selection cursor's own top border.
- Replaced `TARGET_FACE_Y_EXTRA`'s row-zero-exception model with a single `TARGET_ROW_PITCH = 58` constant used uniformly for face, text, and cursor y positions; `TARGET_ROW_H` (48) stays only the row's own content height.
- Widened the regression check to a full 4-actor party covering all four rows, and added a cursor-pitch check.
- Corrected the `item-skill-target-confirm-face.fixed.md` changelog fragment in place, since it described the now-disproven row-0-special-case model.
- **Open lead, not chased this cycle:** cycle #137's separately-flagged short-autostart-list crash remains completely unexplained; this fix reused the same proven-safe long-list workaround rather than probing the boundary.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new checks fail against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/item_menu.rb mruby-rpg2k/mrblib/scene/skill_menu.rb`, rerunning the suite, then `git stash pop`: **2 of 916 checks failed**, both `NameError: uninitialized constant RPG2k::Scene::ItemMenu::TARGET_ROW_PITCH`.
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 916 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_