### PR TITLE
Item menu: description banner and item list reflow in target mode

### DIFF
--- a/changelog.d/item-target-confirm-description-reflow.fixed.md
+++ b/changelog.d/item-target-confirm-description-reflow.fixed.md
@@ -1,0 +1,7 @@
+- **Item menu:** the field item menu's description banner and item list now
+  match RPG_RT's real layout when picking a target for an item — both boxes
+  narrow to make room for the right-anchored actor-target panel, the
+  description banner switches to showing the item's own name, and the item
+  grid is replaced by a one-row "held count" box, reverting on Cancel.
+  Previously both boxes stayed full-width and unchanged, left drawn behind
+  the target panel.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,100 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #140, 2026-08-25): closed cycle #132's other open
+  lead on the field Item menu's actor-target-confirm screen -- the item
+  description area on the left visibly "re-flows into two boxes" when
+  entering target mode, flagged but never investigated. It is a real,
+  three-part discrepancy: the description banner and item grid do not just
+  get covered by the (already-fixed, cycle #137/#138) right-anchored target
+  panel, they genuinely narrow to make room for it, and the item grid is
+  replaced outright by a new single-row "held count" box, not merely
+  hidden underneath. Fixed for `Scene::ItemMenu` only -- see below for why
+  `Scene::SkillMenu`'s identical-looking code was deliberately left alone.**
+  Reused the canonical debug save cycle #139 already regenerated and left
+  in place (`data/Nepheshel206beta/Nepheshel206Rbeta/Save01.lsd`, map 12,
+  (40,15), scene cleared, a single 薬草/id-1 medicine x5 in the bag --
+  reconfirmed unchanged by `scripts/lcf_save_check.rb` both before and
+  after this cycle's probes, since nothing here ever wrote to it) rather
+  than regenerating one, since it already sits exactly where cycle #132's
+  own item-target-confirm probe needs to be. Drove genuine RPG_RT.exe under
+  wine (Xvfb 640x480x16, LIBGL_ALWAYS_SOFTWARE=1, matchbox-window-manager,
+  LANG=ja_JP.UTF-8): Continue -> file 1, Escape (field menu), Decision
+  (Item, already selected), Decision (the only item) -> target-confirm
+  screen. Pixel-sampled the capture (640x480, halved for native 320x240):
+  where `Scene::ItemMenu` used to leave the pre-existing full-width
+  description banner and item grid completely untouched behind the new
+  right-anchored target panel, real RPG_RT instead draws two short,
+  narrowed boxes, each `DESC_H` (32px) tall: the description banner at
+  (0, 0) narrows from the full `SCREEN_W` to `SCREEN_W - TARGET_W` (136px,
+  flush against the target panel's own left edge -- border-pattern-
+  measured directly, not inferred) and its text switches from the item's
+  flavour text ("HPを80ポイント程度回復する") to the item's own bare *name*
+  ("薬草"); directly below it, at the item grid's own former top-left
+  corner `(0, DESC_H)`, a second box the same narrowed width and exactly
+  one row tall replaces the grid outright, showing the database's own
+  `possessed_items` term ("所持数") flush left and the bag's actual held
+  count ("5") flush right -- confirmed by a template/border scan finding
+  *two* separate bordered boxes with a real gap between them, not one
+  window whose content changed, and by the area below the second box
+  showing the raw map background (a different, brighter tile colour with
+  no window border pattern at all), proving nothing else is drawn there --
+  the old item grid is gone, not just covered. The measured 136px width
+  and the "term left, count right" row shape independently match
+  `Scene::Map#draw_shop_status`'s own `SHOP_STATUS_W` panel and its
+  `possessed_items`/right-`align`-2-count row (a prior cycle's own
+  citation-heavy doc comment on that method, re-read as pre-existing
+  context here, not re-derived) -- real, recurring RPG_RT UI constants
+  rather than a coincidence of this one screen. Fixed `mruby-rpg2k/mrblib/
+  scene/item_menu.rb`: a new `#left_panel_w` (full `SCREEN_W` in `:items`
+  mode, `SCREEN_W - TARGET_W` in `:target` mode) drives both `#build_desc_
+  window`'s window width and a new `#build_possessed_window` (a one-row
+  box at `(0, DESC_H)` showing `term(:possessed_items, 'Possessed')` left
+  and `@state.party.item_count(@pending_item)` right, `align` 2) that
+  `#build_item_window` now dispatches to whenever `@mode == :target`
+  instead of building the ordinary grid; `#refresh_desc` now shows the
+  pending item's name rather than its description specifically in
+  `:target` mode. `#enter_target_confirm`/`#leave_target_mode` now rebuild
+  both boxes (not just `#refresh_desc`) so the *width* actually changes on
+  the way in and back out, not just the text. Two of the four host-test
+  `MenuStubParty` fixtures this screen's own checks already use had no
+  `item_count` method at all (only real `Game::Party` and a couple of
+  shop-specific stubs did) -- added one to the shared `MenuStubParty` base
+  class, deriving it from the same `[id, count]` pairs `#field_items`
+  already returns, so every existing subclass picked it up for free. New
+  `scripts/rpg2k_scene_check.rb` check (reusing the existing
+  `MedicineItemStubParty` fixture) asserting both boxes' width/position/
+  height in `:items` vs. `:target` mode, the banner's name-vs-description
+  text switch, the held-count box's label/count/right-alignment, and that
+  Cancel reverts both boxes to their full-width `:items` shape -- confirmed
+  to fail against the pre-fix code (a stashed diff of just `item_menu.rb`)
+  before the fix (`expected 136, got 320`, since pre-fix `#build_desc_
+  window` never narrows at all). Full suite reconfirmed passing (917
+  checks, up from 916); `rpg2k_render_check.rb` (41) and `rpg2k_logic_
+  check.rb` (1134) reconfirmed passing unaffected.
+  **Deliberately not touched, and left open:** `Scene::SkillMenu`'s
+  identical-shaped target-confirm screen was *not* given the same fix.
+  This cycle only drove the plain single-target-medicine path through
+  `Scene::ItemMenu`; skills have no "held count" concept at all (a skill
+  is cast, not consumed from a bag), so whatever RPG_RT's analogous
+  left-side reflow shows there -- plausibly an "MP消費"/cost box rather
+  than a "所持数"/count box, but genuinely unverified -- is a different
+  claim this cycle never drove under wine. Applying this fix's own shape
+  there on the strength of one screen's probe would be guessing, not
+  verifying, the same restraint cycle #130's own battle-cursor writeup
+  already established for exactly this situation. Likewise `:teleport_
+  target` mode's own banner (reached from the same item list via a
+  Teleport-invoking special item) was left completely alone -- `#left_
+  panel_w`/`#build_possessed_window` are gated on `@mode == :target`
+  specifically, not "any non-`:items` mode", so that picker's pre-existing,
+  unverified full-width banner is untouched by this fix either way. Also
+  not chased: whether the held-count box's own number stays live if the
+  player uses the item repeatedly without leaving the target screen (see
+  `#apply_item`'s own doc comment -- a successful use never rebuilds
+  either the target panel's HP/MP or this new possessed-count box, so both
+  would go stale together after a use) -- pre-existing behaviour for the
+  target panel's HP/MP already, not a regression this fix introduces, and
+  not independently verified against real RPG_RT this cycle either way.
   ✅ **Follow-up (cycle #139, 2026-08-25): structural investigation into the
   cycle #137/#138 short-synthetic-autostart-page crash, left unchased three
   cycles running. Result: a real, wide-ranging finding that rules out every

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -288,7 +288,12 @@ class RPG2k
         @target_lock = lock
         @target_index = lock ? leader_target_index : 0
         build_target_window
-        refresh_desc
+        # The description banner and item-list box both narrow/change content
+        # for :target mode -- see #left_panel_w and #build_possessed_window.
+        # Both rebuild their own content (including a #refresh_desc call), so
+        # this needs no separate refresh_desc of its own.
+        build_desc_window
+        build_item_window
       end
 
       # The party roster index of the leader -- who a special/use_skill
@@ -586,20 +591,41 @@ class RPG2k
         @item_index = items.size - 1 if @item_index >= items.size
         @item_index = 0 if @item_index < 0
         build_item_window
-        refresh_desc
+        # Back to full width now that :target mode's own narrowed banner is
+        # gone -- see #left_panel_w. Rebuilds rather than a plain
+        # #refresh_desc so the width actually changes back, not just the text.
+        build_desc_window
+      end
+
+      # The description banner and the item-list box below it both run the
+      # full screen width in :items mode, but narrow to leave room for the
+      # right-anchored target panel once :target mode is entered -- confirmed
+      # against genuine RPG_RT.exe under wine (cycle #140): both boxes sit
+      # flush against the target panel's own left edge (`SCREEN_W -
+      # TARGET_W`), not the full screen. Left at the full-width :items
+      # formula for :teleport_target too, matching that mode's own
+      # unchanged, unnarrowed banner (out of scope this cycle -- see
+      # #build_possessed_window's own doc comment).
+      def left_panel_w
+        @mode == :target ? SCREEN_W - TARGET_W : SCREEN_W
       end
 
       # The highlighted item's flavour text, in a one-line banner across the
       # very top of the screen -- confirmed against genuine RPG_RT under
       # wine (e.g. "HPを80ポイント程度回復する" for a healing item), the same
       # gap Scene::EquipMenu had. Tracks the item under the cursor in :items
-      # mode; the :target/:teleport_target pickers keep showing the pending
-      # item's own description, since it is still the one thing on screen a
-      # description could be about.
+      # mode. Once :target mode narrows this banner (see #left_panel_w), real
+      # RPG_RT switches its text too -- confirmed against genuine RPG_RT.exe
+      # under wine (cycle #140): it shows the pending item's own *name*
+      # ("薬草"), not its description, while target mode is open. :teleport_
+      # target is untouched (still the pending item's description) -- that
+      # picker's own banner was not re-examined this cycle, see
+      # #build_possessed_window's own doc comment for why.
       def build_desc_window
         @desc_window.dispose if @desc_window
-        inner_w = SCREEN_W - Window::BORDER * 2
-        @desc_window = Window.new(0, 0, SCREEN_W, DESC_H)
+        w = left_panel_w
+        inner_w = w - Window::BORDER * 2
+        @desc_window = Window.new(0, 0, w, DESC_H)
         @desc_window.z = 400
         @desc_window.windowskin = @skin
         @desc_contents = Bitmap.new(inner_w, LINE_H)
@@ -616,7 +642,13 @@ class RPG2k
                @pending_item
              end
         it = id && id != 0 ? @state.party.db_item(id) : nil
-        text = it ? it.description.to_s : ''
+        text = if it.nil?
+                 ''
+               elsif @mode == :target
+                 it.name.to_s
+               else
+                 it.description.to_s
+               end
         @desc_contents.clear
         @desc_contents.font.color = Color.new(255, 255, 255, 255)
         @desc_contents.draw_text 0, 0, @desc_contents.width, LINE_H, text
@@ -627,8 +659,14 @@ class RPG2k
         (SCREEN_W - Window::BORDER * 2) / COLUMN_MAX
       end
 
+      # The item grid itself in :items mode; a single-row "held count" box in
+      # its place once :target mode is entered -- see #build_possessed_window.
       def build_item_window
         @item_window.dispose if @item_window
+        if @mode == :target
+          build_possessed_window
+          return
+        end
         rows = items
         inner_w = SCREEN_W - Window::BORDER * 2
         grid_rows = [(rows.size / COLUMN_MAX.to_f).ceil, 1].max
@@ -676,6 +714,45 @@ class RPG2k
         y = (@item_index / COLUMN_MAX) * LINE_H
         @item_window.cursor_rect = Rect.new(x, y, item_col_w, LINE_H)
         refresh_desc
+      end
+
+      # The "held count" box that replaces the item grid once :target mode is
+      # entered -- confirmed against genuine RPG_RT.exe under wine (cycle
+      # #140): the item list is not merely covered by the target panel, it is
+      # replaced outright by a second, short box directly under the
+      # (also-narrowed, see #left_panel_w) description banner -- together the
+      # two read as the "narrower, split into two stacked boxes" cycle #132
+      # first flagged as an open lead without investigating. Measured on a
+      # single-target medicine (薬草) with a bag count of 5: the box sits at
+      # the item grid's own top-left corner (`(0, DESC_H)`), is exactly
+      # `DESC_H` tall (one row) regardless of how many items are actually in
+      # the bag -- there is only ever the one pending item to report on here
+      # -- and as wide as the narrowed banner above it. Its one line is the
+      # database's own `possessed_items` term ("所持数"/"Possessed") flush
+      # left, and the held count flush right (`align` 2) -- independently
+      # matching `Scene::Map#draw_shop_status`'s own identical "term left,
+      # count right" row and its own separately-measured `SHOP_STATUS_W ==
+      # 136 == SCREEN_W - TARGET_W` panel width, a real recurring RPG_RT
+      # layout rather than a coincidence of this one screen.
+      #
+      # :teleport_target is deliberately not given the same treatment: this
+      # cycle only drove the plain single-target-medicine path under wine, so
+      # whether the destination-teleport picker's own left column reflows the
+      # same way is unverified and left open for a future cycle -- applying
+      # this same fix there on the strength of this cycle's one probe would
+      # be guessing, not verifying.
+      def build_possessed_window
+        w = left_panel_w
+        inner_w = w - Window::BORDER * 2
+        @item_window = Window.new(0, DESC_H, w, DESC_H)
+        @item_window.z = 400
+        @item_window.windowskin = @skin
+        c = Bitmap.new(inner_w, LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, LINE_H, term(:possessed_items, 'Possessed')
+        count = @pending_item ? @state.party.item_count(@pending_item) : 0
+        c.draw_text 0, 0, inner_w, LINE_H, count.to_s, 2
+        @item_window.contents = c
       end
 
       # The actor-target picker's own geometry -- confirmed against a genuine

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17905,6 +17905,13 @@ class MenuStubParty
                       # that exercises a stat-affecting (halve/double) state
   end
   def field_items(_state = nil); []; end
+  # Mirrors Game::Party#item_count off the same [id, count] pairs #field_items
+  # already returns -- Scene::ItemMenu's target-confirm screen now reads this
+  # for its own "held count" box (cycle #140's #build_possessed_window).
+  def item_count(id)
+    pair = field_items.find { |i, _| i == id }
+    pair ? pair[1] : 0
+  end
   # Every stub item under test here is meant to be usable -- Scene::ItemMenu
   # now consults this to decide whether Decision buzzes-and-stays instead of
   # dispatching, mirroring Game::Party#field_usable?; a stub testing that
@@ -19692,6 +19699,70 @@ check 'Scene::ItemMenu: a successful use stays on the target screen, ' \
   scene.update
   RGSS::Input.reset
   eq :items, scene.instance_variable_get(:@mode)
+end
+
+check 'Scene::ItemMenu: the description banner and item-list box both narrow ' \
+      'and are replaced by a "held count" box once target mode is entered, ' \
+      'and revert on Cancel' do
+  # Confirmed against genuine RPG_RT.exe under wine (cycle #140): cycle
+  # #132 flagged this screen's left side as visibly "re-flowing into two
+  # boxes" without investigating further. It is not a cosmetic overlap of
+  # the pre-existing full-width banner/grid by the (already-fixed)
+  # right-anchored target panel -- both boxes genuinely narrow to
+  # `SCREEN_W - TARGET_W` and the item grid is replaced outright by a
+  # single-row box, not merely covered. See #build_possessed_window's own
+  # doc comment for the measurement.
+  state = Game::State.new(MedicineItemStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::ItemMenu, state)
+  narrow_w = RPG2k::Scene::ItemMenu::SCREEN_W - RPG2k::Scene::ItemMenu::TARGET_W
+
+  desc = scene.instance_variable_get(:@desc_window)
+  item_win = scene.instance_variable_get(:@item_window)
+  eq RPG2k::Scene::ItemMenu::SCREEN_W, desc.width, ':items mode: banner is full width'
+  eq RPG2k::Scene::ItemMenu::SCREEN_W, item_win.width, ':items mode: item grid is full width'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the (only) item -- opens target mode
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+
+  desc = scene.instance_variable_get(:@desc_window)
+  qty = scene.instance_variable_get(:@item_window)
+  eq narrow_w, desc.width, ':target mode: banner narrows to SCREEN_W - TARGET_W'
+  eq 0, desc.x, 'banner stays at the screen\'s left edge'
+  eq 0, desc.y, 'banner stays at the top'
+  eq RPG2k::Scene::ItemMenu::DESC_H, desc.height, 'banner height is unchanged'
+  eq narrow_w, qty.width, ':target mode: the held-count box is the same narrowed width'
+  eq 0, qty.x, 'held-count box stays at the screen\'s left edge'
+  eq RPG2k::Scene::ItemMenu::DESC_H, qty.y, 'held-count box sits where the item grid\'s own top row did'
+  eq RPG2k::Scene::ItemMenu::DESC_H, qty.height,
+     'held-count box is exactly one row tall, not sized to the (irrelevant) item count'
+
+  desc_texts = window_texts(desc)
+  eq ['Potion'], desc_texts, 'the banner shows the pending item\'s own name, not its description'
+  qty_texts = window_texts(qty)
+  ok qty_texts.include?('Possessed'), 'the held-count box labels itself with the possessed_items ' \
+                                       'term (English fallback here, blank in the fixture db)'
+  ok qty_texts.include?('3'), 'and shows the bag\'s actual held count (3, from MedicineItemStubParty)'
+  # The count is right-aligned (Bitmap#draw_text's `align` 2), the same
+  # "label left, count right" row Scene::Map#draw_shop_status already draws
+  # for its own independently-measured SHOP_STATUS_W(136) == this screen's
+  # own narrowed width.
+  count_call = (qty.contents.draw_calls || []).find { |c| c[4] == '3' }
+  ok count_call, 'the count is drawn'
+  eq 2, count_call[5], 'right-aligned (align 2), not flush left beside the label'
+
+  # Cancel reverts both boxes back to their full-width, description-showing
+  # :items shape -- not just a mode-variable flip with stale geometry left
+  # over from target mode.
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  eq :items, scene.instance_variable_get(:@mode)
+  desc = scene.instance_variable_get(:@desc_window)
+  item_win = scene.instance_variable_get(:@item_window)
+  eq RPG2k::Scene::ItemMenu::SCREEN_W, desc.width, 'Cancel: banner is back to full width'
+  eq RPG2k::Scene::ItemMenu::SCREEN_W, item_win.width, 'Cancel: item grid is back to full width'
 end
 
 # A single held item that #field_items now lists (an unequipped weapon,


### PR DESCRIPTION
## Summary

- Closes cycle #132's other open lead on the field Item menu's actor-target-confirm screen: the description banner and item grid don't just sit behind the (already-fixed) right-anchored target panel, they genuinely **narrow** to `SCREEN_W - TARGET_W`, and the item grid is **replaced outright** by a new single-row "held count" box showing the `possessed_items` term and the bag's actual count, right-aligned — not merely covered.
- Confirmed under Wine: the description banner's text also switches from the item's flavour text to its bare name while target mode is open.
- The measured 136px width and "term left, count right" row independently match `Scene::Map#draw_shop_status`'s own `SHOP_STATUS_W` panel, a real recurring RPG_RT layout rather than a coincidence of this one screen.
- Added `#left_panel_w` and `#build_possessed_window` to `Scene::ItemMenu`; `#enter_target_confirm`/`#leave_target_mode` now rebuild both boxes so the width actually changes on the way in and back out, not just the text.
- **Deliberately scoped to `Scene::ItemMenu` only** — `Scene::SkillMenu`'s identical-looking target-confirm screen was not touched, since skills have no "held count" concept and its own analogous reflow (plausibly an MP-cost box) is unverified; applying this fix's shape there would be guessing, not verifying.
- `:teleport_target` mode's own banner is also left untouched — `#left_panel_w`/`#build_possessed_window` are gated specifically on `@mode == :target`.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new check fails against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/item_menu.rb`, rerunning the suite, then `git stash pop`: **1 of 917 checks failed** (`RuntimeError: expected 136, got 320`, since pre-fix `#build_desc_window` never narrows at all).
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 917 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_