### PR TITLE
Skill menu: description banner and skill list reflow in target mode

### DIFF
--- a/changelog.d/skill-target-confirm-mp-cost-reflow.fixed.md
+++ b/changelog.d/skill-target-confirm-mp-cost-reflow.fixed.md
@@ -1,0 +1,7 @@
+- **Skill menu:** the field skill menu's description banner and skill list
+  now match RPG_RT's real layout when picking a target for a skill — both
+  boxes narrow to make room for the right-anchored actor-target panel, the
+  description banner switches to showing the skill's own name, and the
+  skill list is replaced by a one-row "MP cost" box, reverting on Cancel.
+  Previously both boxes stayed full-width and unchanged, left drawn behind
+  the target panel.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,125 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #141, 2026-08-25): closed the lead cycle #140 left open
+  on its own doc comment -- `Scene::SkillMenu`'s target-confirm screen gets
+  the identical description-banner-narrows/skill-list-replaced reflow cycle
+  #140 fixed for `Scene::ItemMenu`, with an "MP cost" box in place of the
+  item screen's "held count" one, resolving cycle #140's own guess ("plausibly
+  an MP消費/cost box... but genuinely unverified") in the affirmative.**
+  Getting a live probe needed a skill on the debug save's actor at all: actor
+  15 (デモ用)'s own database row (`RPG_RT.ldb` chunk 11/`player`, field 63/
+  `skills`, the `LEARNING` table) carries zero entries, and the canonical save
+  itself (chunk 108/`actors`, field 52/`skills`) had never been given any
+  either -- contrary to this file's own now-corrected assumption that the
+  debug actor already had "at least one skill". Hand-edited the save's own
+  chunk 108 field 52 across two separate wine sessions (restored to the
+  original bytes, confirmed byte-identical by `md5sum` and re-checked clean
+  by `scripts/lcf_save_check.rb`, after each) to give actor 15 three of
+  Nepheshel's own field-usable heal skills spanning every scope this screen's
+  own `#enter_target_confirm` treats differently: id 32 マーフェ (scope 3,
+  single-ally, no lock, 4 MP), id 21 再生能力 (scope 2, self-locked, 20 MP),
+  and id 35 エレクマーシャ (scope 4, all-ally-locked, 30 MP) -- following the
+  same `LCF::SaveData`/`Array2D`/`Array1D` reassign-before-`to_lcf` recipe
+  this file's own standing instructions describe (mutating the nested
+  `Array1D` in place and never reassigning it into its parent silently drops
+  the edit). Drove genuine RPG_RT.exe under wine (Xvfb 640x480x16,
+  LIBGL_ALWAYS_SOFTWARE=1, matchbox-window-manager, LANG=ja_JP.UTF-8) on the
+  canonical debug save (map 12, (40,15), scene cleared): Continue -> file 1,
+  Escape (field menu), Down (特殊技能/Skill, second of three commands under
+  this game's own menu customisation), Decision, Decision (the solo actor
+  selection row) -> the skill list (caster name/MP header line, then a
+  1-2-column grid, both full width) -> Decision on each of the three skills
+  in turn. All three landed on the identical reflow cycle #140 already found
+  on the Item screen: the description banner (top, `DESC_H` tall) narrows
+  from `SCREEN_W` to `SCREEN_W - TARGET_W` (border-pattern-measured at the
+  same native x=136 the already-fixed Item screen uses) and its text switches
+  from the skill's description to its bare name ("マーフェ"/"再生能力"/
+  "エレクマーシャ"); directly below, at the skill window's own former
+  top-left corner `(0, DESC_H)`, a second box the same narrowed width and
+  exactly one row tall replaces the *entire* skill window outright (caster-
+  name/MP header line included, not just the grid), showing the database's
+  own `mp_cost` term ("消費ＭＰ"/confirmed present in Nepheshel's own term
+  chunk 21, byte-for-byte the same string genuine RPG_RT drew) flush left and
+  the cast skill's own cost flush right ("4"/"20"/"30", matching each skill's
+  `sp_cost` exactly) -- confirmed by the same "raw map background below the
+  second box, no third window" check cycle #140 used to prove the old skill
+  list is gone, not merely covered. The reflow, and the box's own content,
+  were identical across all three scopes/locks tested -- `#enter_target_
+  confirm`'s `lock` argument (`nil`/`:self`/`:party`) only ever changed the
+  right-anchored target panel's cursor behaviour (already fixed, cycles
+  #132/#137/#138), never whether this left-side reflow happens, closing the
+  boundary-case gap cycle #140's own doc comment flagged ("this cycle only
+  drove the plain single-target-medicine path"). Cancel reverted both boxes
+  to their full-width, description/grid-showing `:skills` shape in every
+  case, tested directly (not just inferred from the mode variable). Fixed
+  `mruby-rpg2k/mrblib/scene/skill_menu.rb` mirroring `item_menu.rb`'s own
+  cycle #140 shape exactly: a new `#left_panel_w` (full `SCREEN_W` in
+  `:skills` mode, `SCREEN_W - TARGET_W` in `:target` mode) drives both
+  `#build_desc_window`'s window width and a new `#build_mp_cost_window` (a
+  one-row box at `(0, DESC_H)` showing `term(:mp_cost, 'MP Cost')` left and
+  `@state.party.skill_cost(sk, caster)` right, `align` 2) that `#build_skill_
+  window` now dispatches to whenever `@mode == :target` instead of building
+  the ordinary header+grid; `#refresh_desc` now shows the pending skill's
+  name rather than its description specifically in `:target` mode.
+  `#enter_target_confirm`/`leave_target` now rebuild both boxes (not just
+  `#refresh_desc`) so the *width* actually changes on the way in and back
+  out, not just the text. `MenuStubParty` (the shared scene-check fixture
+  base class) gained a `#skill_cost` mirroring the `[id, cost]` pairs
+  `#field_skills` already returns -- the identical shape cycle #140 already
+  added `#item_count` there for -- so every existing `SkillMenu`-exercising
+  fixture in `scripts/rpg2k_scene_check.rb` picked it up for free (a stub's
+  `db_skill` row answers `nil` for the `id` field it never set, which simply
+  misses every pair and falls back to cost 0 rather than raising; a check
+  that cares about the shown cost sets `id:` explicitly, as the two new/
+  extended fixtures below do). New checks: a `NormalTargetSkillStubParty`-
+  based check (given an explicit `id:` on its stub skill row) asserting both
+  boxes' width/position/height in `:skills` vs. `:target` mode, the banner's
+  name-vs-description text switch, the MP-cost box's label/cost/right-
+  alignment, and that Cancel reverts both boxes to their full-width `:skills`
+  shape; a second check on the existing `SelfAllySkillStubParty` (now also
+  carrying explicit `id:` fields, plus named `SELF_COST`/`PARTY_COST`
+  constants replacing the two bare literals its `#field_skills` used to
+  return) confirming the MP-cost box's *value* tracks whichever of its
+  self-scope or all-ally-scope skill was actually chosen. A third,
+  pre-existing check (the one asserting the old, now-wrong claim that "the
+  pending skill's own description is still shown while picking a target")
+  was corrected to assert the name instead, matching the fix. All three
+  confirmed to fail against the pre-fix code (a stashed diff of just
+  `skill_menu.rb`) before the fix: `expected 136, got 320` on the width
+  assertion, a buzzer-shaped "MP-cost box shows the self-scope skill's own
+  cost" failure (the box did not exist pre-fix), and the description-vs-name
+  mismatch on the third, 3 of 919 checks. Full suite reconfirmed passing (919
+  checks, up from 917); `rpg2k_render_check.rb` (41) and `rpg2k_logic_
+  check.rb` (1134) reconfirmed passing unaffected. `:teleport_target` mode's
+  own banner (reached from the same skill list via a Teleport-type skill) was
+  left completely alone, matching cycle #140's own identical restraint on the
+  Item screen's Teleport picker -- `#left_panel_w`/`#build_mp_cost_window`
+  are gated on `@mode == :target` specifically, not "any non-`:skills` mode",
+  so that picker's pre-existing, unverified full-width banner is untouched by
+  this fix either way; this cycle only drove the ordinary self/single-ally/
+  all-ally target-confirm path under wine, not the Teleport picker, so
+  extending this there would be guessing, not verifying. Also not chased:
+  the same "does the box's own number go stale after a use without leaving
+  the target screen" question cycle #140 left open for the Item screen's
+  held-count box applies identically here (a successful cast never rebuilds
+  either the target panel's HP/MP or this new MP-cost box) -- pre-existing
+  behaviour, not a regression this fix introduces, and not independently
+  verified against real RPG_RT this cycle either way. Attempted a full
+  engine build (`cmake --build build`) to additionally sanity-check the
+  change under mruby proper (per ADR 0021's own mruby/CRuby-divergence
+  warning) rather than CRuby alone; it failed on an unrelated, pre-existing
+  environment gap (`mruby-lcf/cp932_to_unicode.rb` needs a `cp932_table` env
+  var pointing at a system WCTABLE file this sandbox does not have, needed by
+  a completely different mrbgem than the one touched here) before reaching
+  either `mruby-rpg2k` gem, so it could not be used this cycle either way --
+  flagging it for whoever next needs a real engine build in this same
+  sandbox. Compiled `skill_menu.rb` directly through the project's own
+  prebuilt `mrbc` (`build/mruby/host/mrbc/bin/mrbc`) instead, which the fix
+  passes clean -- not a full substitute for an actual mruby VM run, but it
+  does rule out a syntax-level mruby/CRuby gap, and every new construct here
+  (ternaries, string interpolation, `Window.new`/`Bitmap.new`/`draw_text`) is
+  copied verbatim from patterns `item_menu.rb` already ships in production.
   ✅ **Follow-up (cycle #140, 2026-08-25): closed cycle #132's other open
   lead on the field Item menu's actor-target-confirm screen -- the item
   description area on the left visibly "re-flows into two boxes" when

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -218,7 +218,12 @@ class RPG2k
         @target_lock = lock
         @target_index = lock == :self ? @caster_index : 0
         build_target_window
-        refresh_desc
+        # The description banner and skill-list box both narrow/change content
+        # for :target mode -- see #left_panel_w and #build_mp_cost_window.
+        # Both rebuild their own content (including a #refresh_desc call), so
+        # this needs no separate refresh_desc of its own.
+        build_desc_window
+        build_skill_window
       end
 
       def update_target
@@ -337,7 +342,10 @@ class RPG2k
         @skill_index = skills.size - 1 if @skill_index >= skills.size
         @skill_index = 0 if @skill_index < 0
         build_skill_window
-        refresh_desc
+        # Back to full width now that :target mode's own narrowed banner is
+        # gone -- see #left_panel_w. Rebuilds rather than a plain
+        # #refresh_desc so the width actually changes back, not just the text.
+        build_desc_window
       end
 
       # The destination list is a two-column grid too, not a single stacked
@@ -448,17 +456,46 @@ class RPG2k
         (SCREEN_W - Window::BORDER * 2) / COLUMN_MAX
       end
 
+      # The description banner and the skill-list box below it both run the
+      # full screen width in :skills mode, but narrow to leave room for the
+      # right-anchored target panel once :target mode is entered -- confirmed
+      # against genuine RPG_RT.exe under wine (cycle #141), closing the lead
+      # cycle #140 deliberately left open when it fixed this same reflow for
+      # Scene::ItemMenu but not here: both boxes sit flush against the target
+      # panel's own left edge (`SCREEN_W - TARGET_W`), not the full screen --
+      # pixel-sampled at the identical native x (136, the border pattern
+      # starting right where the target panel's own left edge does) as the
+      # already-fixed Item screen. Left at the full-width :skills formula for
+      # :teleport_target too, matching that mode's own unchanged, unnarrowed
+      # banner -- this cycle only drove the ordinary self/single-ally/
+      # all-ally target-confirm path under wine, not the Teleport picker, so
+      # extending this there would be guessing, not verifying (the same
+      # restraint Scene::ItemMenu#left_panel_w's own doc comment already
+      # takes for its own Teleport picker).
+      def left_panel_w
+        @mode == :target ? SCREEN_W - TARGET_W : SCREEN_W
+      end
+
       # The highlighted skill's flavour text, in a one-line banner across the
       # very top of the screen -- see Scene::ItemMenu#build_desc_window,
       # which this mirrors exactly (the same gap, in the Skill screen
-      # instead). Tracks the skill under the cursor in :skills mode; the
-      # :target/:teleport_target pickers keep showing the pending skill's own
-      # description, since it is still the one thing on screen a description
-      # could be about.
+      # instead). Tracks the skill under the cursor in :skills mode. Once
+      # :target mode narrows this banner (see #left_panel_w), real RPG_RT
+      # switches its text too -- confirmed against genuine RPG_RT.exe under
+      # wine (cycle #141), the same swap cycle #140 already found on the Item
+      # screen: it shows the pending skill's own *name* (e.g. "マーフェ"),
+      # not its description, while target mode is open, for a single-ally
+      # (scope 3), self-locked (scope 2) and all-ally-locked (scope 4) skill
+      # alike -- all three tested, since #enter_target_confirm's own lock
+      # argument only changes cursor behaviour, not (as this fix confirms)
+      # whether the reflow happens. :teleport_target is untouched (still the
+      # pending skill's description) -- that picker's own banner was not
+      # re-examined this cycle, see #left_panel_w's own doc comment for why.
       def build_desc_window
         @desc_window.dispose if @desc_window
-        inner_w = SCREEN_W - Window::BORDER * 2
-        @desc_window = Window.new(0, 0, SCREEN_W, DESC_H)
+        w = left_panel_w
+        inner_w = w - Window::BORDER * 2
+        @desc_window = Window.new(0, 0, w, DESC_H)
         @desc_window.z = 400
         @desc_window.windowskin = @skin
         @desc_contents = Bitmap.new(inner_w, LINE_H)
@@ -475,14 +512,27 @@ class RPG2k
                 @pending_skill
               end
         sk = sid ? @state.party.db_skill(sid) : nil
-        text = sk ? sk.description.to_s : ''
+        text = if sk.nil?
+                 ''
+               elsif @mode == :target
+                 sk.name.to_s
+               else
+                 sk.description.to_s
+               end
         @desc_contents.clear
         @desc_contents.font.color = Color.new(255, 255, 255, 255)
         @desc_contents.draw_text 0, 0, @desc_contents.width, LINE_H, text
       end
 
+      # The skill grid (plus its caster-name/MP header line) in :skills mode;
+      # a single-row "MP cost" box in its place once :target mode is entered
+      # -- see #build_mp_cost_window.
       def build_skill_window
         @skill_window.dispose if @skill_window
+        if @mode == :target
+          build_mp_cost_window
+          return
+        end
         rows = skills
         inner_w = SCREEN_W - Window::BORDER * 2
         head_h = LINE_H
@@ -527,6 +577,47 @@ class RPG2k
         end
         @skill_window.contents = c
         refresh_skill_cursor
+      end
+
+      # The "MP cost" box that replaces the skill grid (and its caster-name/
+      # MP header line) once :target mode is entered -- confirmed against
+      # genuine RPG_RT.exe under wine (cycle #141): the skill list is not
+      # merely covered by the target panel, it is replaced outright by a
+      # second, short box directly under the (also-narrowed, see
+      # #left_panel_w) description banner -- the same "narrower, split into
+      # two stacked boxes" shape cycle #140 already fixed for Scene::ItemMenu,
+      # but with the database's own `mp_cost` term ("消費ＭＰ"/"MP Cost")
+      # rather than `possessed_items`, since a skill is cast, not consumed
+      # from a bag -- resolving the guess cycle #140's own doc comment left
+      # open ("plausibly an MP消費/cost box... but genuinely unverified").
+      # Measured on a single-ally heal (マーフェ, 4 MP) and re-confirmed on a
+      # self-locked heal (再生能力, 20 MP) and an all-ally-locked heal
+      # (エレクマーシャ, 30 MP): the box sits at the skill window's own
+      # former top-left corner (`(0, DESC_H)`), is exactly `DESC_H` tall (one
+      # row) and as wide as the narrowed banner above it, regardless of scope
+      # or lock. Its one line is `term(:mp_cost, 'MP Cost')` flush left and
+      # the pending skill's own cost (`Game::Party#skill_cost`, the same value
+      # the ordinary grid row already shows) flush right (`align` 2) -- the
+      # identical "term left, value right" row shape as
+      # Scene::ItemMenu#build_possessed_window and `Scene::Map#draw_shop_
+      # status`, a real recurring RPG_RT layout rather than a coincidence of
+      # one screen.
+      #
+      # :teleport_target is deliberately not given the same treatment -- see
+      # #left_panel_w's own doc comment for why.
+      def build_mp_cost_window
+        w = left_panel_w
+        inner_w = w - Window::BORDER * 2
+        @skill_window = Window.new(0, DESC_H, w, DESC_H)
+        @skill_window.z = 400
+        @skill_window.windowskin = @skin
+        c = Bitmap.new(inner_w, LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, LINE_H, term(:mp_cost, 'MP Cost')
+        sk = @pending_skill ? @state.party.db_skill(@pending_skill) : nil
+        cost = sk ? @state.party.skill_cost(sk, caster) : 0
+        c.draw_text 0, 0, inner_w, LINE_H, cost.to_s, 2
+        @skill_window.contents = c
       end
 
       def refresh_skill_cursor

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17918,6 +17918,19 @@ class MenuStubParty
   # specific disabled path overrides this.
   def field_usable?(_id, _state = nil); true; end
   def field_skills(_actor, _state = nil); []; end
+  # Mirrors Game::Party#skill_cost off the same [id, cost] pairs #field_skills
+  # already returns -- Scene::SkillMenu's target-confirm screen now reads this
+  # for its own "MP cost" box (cycle #141's #build_mp_cost_window), the same
+  # shape as #item_count just above for Scene::ItemMenu's "held count" box.
+  # Real Game::Party#skill_cost takes the skill row itself, not a bare id, so
+  # this looks the row up by its own `id` -- every existing db_skill stub's
+  # OpenStruct answers `nil` for a field it never set, which simply misses
+  # every pair here and falls back to 0 rather than raising; a check that
+  # cares about the shown cost sets `id:` on its stub row to match.
+  def skill_cost(sk, caster)
+    pair = field_skills(caster).find { |i, _| i == sk.id }
+    pair ? pair[1] : 0
+  end
   def reorder(new_order); @actors = new_order.map { |i| @actors[i] }; end
   # Mirrors Game::Party#stat_mode/#adjust_stat/#effective_atk (etc, see
   # game.rb) -- Scene::StatusMenu/Scene::EquipMenu now read an actor's
@@ -20524,7 +20537,7 @@ class NormalTargetSkillStubParty < WrapMenuParty
   def field_skills(_actor, _state = nil); [[SKILL_ID, 5]]; end
   def db_skill(id)
     return nil unless id == SKILL_ID
-    OpenStruct.new(name: 'Heal', type: Game::Party::SKILL_NORMAL, scope: 3,
+    OpenStruct.new(id: SKILL_ID, name: 'Heal', type: Game::Party::SKILL_NORMAL, scope: 3,
                    animation_id: ANIMATION_ID)
   end
   def cast_skill(caster, sid, target = nil, _free = false)
@@ -20611,6 +20624,72 @@ check "Scene::SkillMenu: an animation's own success SE skips past a " \
      'real sound plays instead'
 end
 
+check 'Scene::SkillMenu: the description banner and skill-list box both ' \
+      'narrow and are replaced by an "MP cost" box once target mode is ' \
+      'entered, and revert on Cancel' do
+  # Confirmed against genuine RPG_RT.exe under wine (cycle #141): cycle #140
+  # fixed this identical reflow for Scene::ItemMenu but deliberately left
+  # Scene::SkillMenu alone, since a skill has no "held count" concept -- its
+  # own doc comment guessed the analogous box here might show "an MP消費/
+  # cost box... but genuinely unverified". It does: not a cosmetic overlap
+  # of the pre-existing full-width banner/grid by the (already-shared)
+  # right-anchored target panel, both boxes genuinely narrow to `SCREEN_W -
+  # TARGET_W` and the skill grid (plus its caster-name/MP header line) is
+  # replaced outright by a single-row "MP cost" box, not merely covered.
+  # See #build_mp_cost_window's own doc comment for the pixel measurement.
+  state = Game::State.new(NormalTargetSkillStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::SkillMenu, state)
+  narrow_w = RPG2k::Scene::SkillMenu::SCREEN_W - RPG2k::Scene::SkillMenu::TARGET_W
+
+  desc = scene.instance_variable_get(:@desc_window)
+  skill_win = scene.instance_variable_get(:@skill_window)
+  eq RPG2k::Scene::SkillMenu::SCREEN_W, desc.width, ':skills mode: banner is full width'
+  eq RPG2k::Scene::SkillMenu::SCREEN_W, skill_win.width, ':skills mode: skill grid is full width'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the (only) skill -- opens target mode
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+
+  desc = scene.instance_variable_get(:@desc_window)
+  cost_win = scene.instance_variable_get(:@skill_window)
+  eq narrow_w, desc.width, ':target mode: banner narrows to SCREEN_W - TARGET_W'
+  eq 0, desc.x, 'banner stays at the screen\'s left edge'
+  eq 0, desc.y, 'banner stays at the top'
+  eq RPG2k::Scene::SkillMenu::DESC_H, desc.height, 'banner height is unchanged'
+  eq narrow_w, cost_win.width, ':target mode: the MP-cost box is the same narrowed width'
+  eq 0, cost_win.x, 'MP-cost box stays at the screen\'s left edge'
+  eq RPG2k::Scene::SkillMenu::DESC_H, cost_win.y, 'MP-cost box sits where the skill grid\'s own top row did'
+  eq RPG2k::Scene::SkillMenu::DESC_H, cost_win.height,
+     'MP-cost box is exactly one row tall, not sized to the (irrelevant) skill count'
+
+  desc_texts = window_texts(desc)
+  eq ['Heal'], desc_texts, 'the banner shows the pending skill\'s own name, not its description'
+  cost_texts = window_texts(cost_win)
+  ok cost_texts.include?('MP Cost'), 'the MP-cost box labels itself with the mp_cost term ' \
+                                      '(English fallback here, blank in the fixture db)'
+  ok cost_texts.include?('5'), 'and shows the pending skill\'s own cost (5, from ' \
+                                'NormalTargetSkillStubParty\'s #field_skills)'
+  # Right-aligned (Bitmap#draw_text's `align` 2), the same "label left, value
+  # right" row Scene::ItemMenu#build_possessed_window already draws for its
+  # own held-count box.
+  cost_call = (cost_win.contents.draw_calls || []).find { |c| c[4] == '5' }
+  ok cost_call, 'the cost is drawn'
+  eq 2, cost_call[5], 'right-aligned (align 2), not flush left beside the label'
+
+  # Cancel reverts both boxes back to their full-width, description-showing
+  # :skills shape -- not just a mode-variable flip with stale geometry left
+  # over from target mode.
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  eq :skills, scene.instance_variable_get(:@mode)
+  desc = scene.instance_variable_get(:@desc_window)
+  skill_win = scene.instance_variable_get(:@skill_window)
+  eq RPG2k::Scene::SkillMenu::SCREEN_W, desc.width, 'Cancel: banner is back to full width'
+  eq RPG2k::Scene::SkillMenu::SCREEN_W, skill_win.width, 'Cancel: skill grid is back to full width'
+end
+
 # Confirmed against EasyRPG's actual C++ source:
 # `Game_Character::MoveTypeCustomCommand`'s `Code::play_sound_effect` case
 # (`src/game_character.cpp`) -- `if (move_command.parameter_string !=
@@ -20659,6 +20738,8 @@ end
 class SelfAllySkillStubParty < MenuStubParty
   SELF_SID = 70
   PARTY_SID = 71
+  SELF_COST = 5
+  PARTY_COST = 3
 
   attr_reader :cast_skill_calls
 
@@ -20668,12 +20749,14 @@ class SelfAllySkillStubParty < MenuStubParty
     @cast_skill_calls = []
   end
 
-  def field_skills(_actor, _state = nil); [[SELF_SID, 5], [PARTY_SID, 3]]; end
+  def field_skills(_actor, _state = nil); [[SELF_SID, SELF_COST], [PARTY_SID, PARTY_COST]]; end
 
+  # `id:` set on both rows so MenuStubParty#skill_cost (cycle #141) can find
+  # them by the same key #build_mp_cost_window looks up.
   def db_skill(id)
     case id
-    when SELF_SID  then OpenStruct.new(name: 'Guard Up', type: Game::Party::SKILL_NORMAL, scope: 2)
-    when PARTY_SID then OpenStruct.new(name: 'Heal All', type: Game::Party::SKILL_NORMAL, scope: 4)
+    when SELF_SID  then OpenStruct.new(id: SELF_SID, name: 'Guard Up', type: Game::Party::SKILL_NORMAL, scope: 2)
+    when PARTY_SID then OpenStruct.new(id: PARTY_SID, name: 'Heal All', type: Game::Party::SKILL_NORMAL, scope: 4)
     end
   end
 
@@ -20743,6 +20826,38 @@ check 'Scene::SkillMenu: cancelling a self-scope skill\'s target-confirm screen 
   RGSS::Input.reset
   eq :skills, scene.instance_variable_get(:@mode)
   ok state.party.cast_skill_calls.empty?, 'nothing was cast'
+end
+
+check 'Scene::SkillMenu: the "MP cost" box shows the right cost for a ' \
+      'self-locked or all-ally-locked skill too, not just a single-ally one' do
+  # Cycle #141's own wine probe confirmed the reflow happens regardless of
+  # scope/lock (a self-scope heal and an all-ally-scope heal both showed the
+  # narrowed banner and MP-cost box exactly like the single-ally case) --
+  # this pins that the box's own *cost value* tracks whichever skill was
+  # actually chosen, not just the first one ever cast.
+  state = Game::State.new(SelfAllySkillStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::SkillMenu, state)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the self-scope skill (index 0)
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+  cost_win = scene.instance_variable_get(:@skill_window)
+  ok window_texts(cost_win).include?(SelfAllySkillStubParty::SELF_COST.to_s),
+     'the MP-cost box shows the self-scope skill\'s own cost'
+
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::RIGHT] # move to the all-ally skill (index 1)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+  cost_win = scene.instance_variable_get(:@skill_window)
+  ok window_texts(cost_win).include?(SelfAllySkillStubParty::PARTY_COST.to_s),
+     'the MP-cost box shows the all-ally skill\'s own cost'
 end
 
 # A party exposing a real #can_cast?, to prove Scene::SkillMenu now gates
@@ -20983,7 +21098,7 @@ end
 # mruby-rpg2k (confirmed with scripts/rpg2k_field_audit.rb against a real
 # game's database), so the Skill screen showed no flavour text at all.
 check 'Scene::SkillMenu: the description banner shows the highlighted skill\'s own text, ' \
-      'follows the cursor, and keeps the pending skill\'s text in target mode' do
+      'follows the cursor, and switches to the pending skill\'s name in target mode' do
   scene = menu_scene(RPG2k::Scene::SkillMenu, wrap_menu_state)
   ok window_texts(scene.instance_variable_get(:@desc_window)).include?('Description of skill 10.'),
      'starts on the first skill (id 10)'
@@ -20998,8 +21113,15 @@ check 'Scene::SkillMenu: the description banner shows the highlighted skill\'s o
   scene.update
   RGSS::Input.reset
   eq :target, scene.instance_variable_get(:@mode)
-  ok window_texts(scene.instance_variable_get(:@desc_window)).include?('Description of skill 11.'),
-     'the pending skill\'s own description is still shown while picking a target'
+  # Once :target mode narrows this banner (see #left_panel_w), real RPG_RT
+  # switches its text too -- confirmed against genuine RPG_RT.exe under wine
+  # (cycle #141), the same swap cycle #140 already found on the Item screen:
+  # it shows the pending skill's own *name* ("Skill11"), not its
+  # description, while target mode is open.
+  desc_texts = window_texts(scene.instance_variable_get(:@desc_window))
+  ok desc_texts.include?('Skill11'), 'the banner switches to the pending skill\'s own name'
+  ok !desc_texts.include?('Description of skill 11.'),
+     'not its description, which the old (unnarrowed) banner used to keep showing'
 end
 
 check 'Scene::Map: a pending teleport queued by the field skill menu is applied' do


### PR DESCRIPTION
## Summary

- Closes the lead cycle #140 left open on its own doc comment: fixes `Scene::SkillMenu`'s target-confirm screen with the identical description-banner-narrows/list-replaced reflow cycle #140 fixed for `Scene::ItemMenu`, with an **"MP cost" box** in place of the item screen's "held count" one — resolving cycle #140's own guess ("plausibly an MP cost box... but genuinely unverified") in the affirmative.
- Confirmed under Wine across all three scopes/locks this screen's own `#enter_target_confirm` treats differently (single-ally, self-locked, all-ally-locked): the reflow and the box's own content are identical regardless of scope or lock.
- The description banner narrows to `SCREEN_W - TARGET_W` and switches from description to the skill's own name; the entire skill window (caster-name/MP header plus grid) is replaced outright by a one-row box showing the database's own `mp_cost` term and the skill's own cost, right-aligned.
- Added `#left_panel_w` and `#build_mp_cost_window` to `Scene::SkillMenu`, mirroring `item_menu.rb`'s cycle #140 shape exactly.
- Corrected a pre-existing check that asserted the old, now-wrong claim that the banner keeps showing the pending skill's description in target mode.
- Deliberately left `:teleport_target`'s own banner untouched, matching cycle #140's identical restraint on the Item screen.
- Attempted a full mruby engine build for an additional sanity check; it failed on an unrelated, pre-existing environment gap (`mruby-lcf/cp932_to_unicode.rb` needs a `cp932_table` env var this sandbox lacks) before reaching either affected gem — flagged in `docs/TODO.md` for whoever next needs a real engine build here. Compiled the changed file through the project's prebuilt `mrbc` instead, which passes clean.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new/corrected checks fail against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/skill_menu.rb`, rerunning the suite, then `git stash pop`: **3 of 919 checks failed** (width assertion `expected 136, got 320`; the MP-cost-box-didn't-exist failure; and the description-vs-name mismatch).
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 919 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_