### PR TITLE
Item/Skill menus: Teleport destination picker removes the banner outright

### DIFF
--- a/changelog.d/item-skill-teleport-target-removes-banner.fixed.md
+++ b/changelog.d/item-skill-teleport-target-removes-banner.fixed.md
@@ -1,0 +1,6 @@
+- **Item/Skill menus:** picking a Teleport-type item or skill's destination
+  now matches RPG_RT's real layout — the description banner and item/skill
+  grid are removed outright, leaving bare map background above the
+  destination list, and are rebuilt full-width on Cancel. Previously both
+  boxes stayed on screen at full width, unchanged, behind the destination
+  list.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6604,6 +6604,102 @@ The work below is roughly ordered by the critical path to a walkable game
   against the pre-fix code (a stashed diff of just `equip_menu.rb`) before
   the fix -- wrong candidates-list contents, wrong candidate count, and an
   undefined `COLUMN_MAX` constant respectively.
+  ✅ **Follow-up (cycle #142, 2026-08-25): closed the `:teleport_target`
+  lead cycles #140 and #141 both explicitly left open ("that picker's own
+  banner was not re-examined this cycle") on `Scene::ItemMenu` and
+  `Scene::SkillMenu` alike. Real RPG_RT does not narrow the description
+  banner/item-or-skill grid the way `:target` mode does, and does not merely
+  leave them alone either (the guess both prior cycles flagged as
+  "plausibly... but genuinely unverified") -- it removes them outright,
+  leaving bare map background above the destination picker's own full-width,
+  bottom-anchored box.** Nepheshel's own database ships zero Escape/Teleport-
+  type skills or items (confirmed by dumping every one of its 306 skill rows
+  and cross-checking all 14 type-9 special items' `skill_id`s: every real
+  skill in this game is type 0 Normal or type 3 Switch, the latter only for
+  scripted summon/boss-intro skills, never Teleport(1)/Escape(2)) -- so this
+  needed a hand-edited scratch skill row and save, not existing content.
+  Picked an unused, blank-named skill slot (id 129, confirmed unreferenced by
+  any item's `skill_id`) in a scratch copy of `RPG_RT.ldb`, gave it a name/
+  description and `type = 1` (`SKILL_TELEPORT`), and hand-edited a scratch
+  copy of the canonical debug save (`Save01.lsd`) to learn it. **This
+  surfaced a real save-format footgun worth recording for future cycles
+  independent of the banner finding itself:** `SAVE_PARTY_ACTOR`'s field 52
+  (`skills`, the raw uint16 id array) is not self-describing -- genuine
+  RPG_RT reads exactly `skill_size` (field 51) entries from it and ignores
+  the rest, the same size-then-array pairing already documented for field
+  81/82 (`state_size`/`states`). Setting field 52 alone (to `[129]`, or even
+  to a *known-good, previously-validated* id like 32 alone) left the skill
+  genuinely absent under genuine RPG_RT -- rendered as an empty list with
+  only a bare cursor box, indistinguishable at a glance from "the skill's own
+  name failed to render" (which is what this looked like at first, and cost
+  three dead-end wine boots chasing an encoding/rendering theory before the
+  actual cause -- a missing size field -- was found by controlling for list
+  length with a single already-known-good skill id). `gen-rpg2k-save.rb`/
+  cycle #141's own recipe never hit this because 3 is also what cycle #141
+  set field 51 to alongside it, just not called out in that cycle's own
+  writeup; this engine's own `Game::Actor#to_lsd` (`mruby-rpg2k/mrblib/
+  game.rb`) already writes both fields together correctly, so this is a
+  hand-editing gotcha for future save probes, not a production bug. Also
+  registered 1 and then 3 teleport destinations directly in the save's own
+  chunk 110 (`SAVE_TARGET`, `map_id`/`x`/`y` per entry) and enabled
+  `SAVE_SYSTEM` field 121 (`teleport_allowed`) the same way, sidestepping any
+  need for a synthetic autostart map event (and its own unrelated,
+  still-unexplained crash risk, cycles #137-140) entirely -- save-only edits
+  are sufficient to reach and probe this screen. Drove genuine RPG_RT.exe
+  under wine (Xvfb 640x480x16, LIBGL_ALWAYS_SOFTWARE=1, matchbox-window-
+  manager, LANG=ja_JP.UTF-8) on the resulting save: Continue -> file 1,
+  Escape (field menu), Down (Skill), Decision, Decision (solo actor row) ->
+  the single-entry skill list (now showing correctly, "MP cost" box format
+  confirming the field-51 fix already) -> Decision on the Teleport skill.
+  Both the description banner and the skill grid vanished completely --
+  pixel-sampled the capture and found a flat, uniform map-floor colour with
+  no window border/gradient pattern anywhere across the entire top two-
+  thirds of the screen (native y 0-152 of 240), directly above the
+  destination list's own box, which runs the full `SCREEN_W` (not `SCREEN_W
+  - TARGET_W`, ruling out a `:target`-style narrow) anchored to the screen's
+  bottom edge (`SCREEN_H - h - BORDER*2`, matching `Window_Teleport`'s
+  already-ported geometry). Repeated with exactly 1 registered destination
+  (a single left-aligned entry, no second column) and 3 (two rows, a blank
+  second cell in the incomplete last row) -- both boundary cases showed the
+  identical bare band above the list, ruling out "the banner narrows to make
+  room and I mismeasured" as an alternative explanation at either end.
+  Cancelling out of the picker (confirmed live at both destination counts)
+  restored the ordinary full-width, description/grid-showing `:skills` shape
+  exactly, with no stale narrowed geometry left over. Repeated the identical
+  probe through `Scene::ItemMenu`, repointing a real type-9 special item
+  (id 25, 毒針玉) at the same synthetic skill 129 instead of its real skill
+  88 and giving the save a single held copy of it -- pixel-identical result:
+  banner and item grid both gone, same bottom-anchored full-width
+  destination box, Cancel restores the full-width `:items` shape. Fixed
+  `mruby-rpg2k/mrblib/scene/skill_menu.rb` and `item_menu.rb` identically: a
+  new `#enter_teleport_target` (called from `#choose_skill`/`#choose_item`'s
+  own Teleport branch in place of the old `build_teleport_window;
+  refresh_desc` pair) disposes `@desc_window` and `@skill_window`/
+  `@item_window` outright before building the destination list, and
+  `#leave_teleport_target` now calls `#build_desc_window`/`#build_skill_
+  window`/`#build_item_window` (full rebuild, matching `:skills`/`:items`
+  mode's own full-width formula since `left_panel_w` is never touched by
+  `:teleport_target`) instead of a bare `#refresh_desc` that never actually
+  existed to refresh once the fix removes the windows it would have
+  refreshed. Updated the stale doc comments on `#left_panel_w`, `#build_
+  desc_window`/`#refresh_desc`, and `#build_mp_cost_window`/`#build_
+  possessed_window` in both files that previously described this picker as
+  "unverified"/"deliberately not touched" -- `left_panel_w`'s own `:target`-
+  only branch is now correctly documented as never reached in
+  `:teleport_target` mode at all, rather than silently returning the (now
+  irrelevant) full-width case for it. New `scripts/rpg2k_scene_check.rb`
+  checks on both screens (reusing the existing `EscapeTeleportItemStubParty`/
+  `EscapeTeleportStubParty` fixtures) asserting `@desc_window`/`@item_window`
+  (`@skill_window` for the Skill screen) become `nil` on entering
+  `:teleport_target` and are rebuilt at the screen's own full width on
+  Cancel; both confirmed to fail against the pre-fix code (a stashed diff of
+  just the two production files) with `RuntimeError: the description banner
+  is disposed outright, not narrowed`. Full suite reconfirmed passing (921
+  checks, up from 919); `rpg2k_render_check.rb` (41) and `rpg2k_logic_
+  check.rb` (1134) reconfirmed passing unaffected. All edited game-data files
+  (`RPG_RT.ldb`, `Save01.lsd`) restored to their original bytes and
+  re-confirmed byte-identical by `md5sum`, and the canonical debug save
+  reconfirmed clean by `scripts/lcf_save_check.rb`, after every probe.
   ✅ **Follow-up (cycle #141, 2026-08-25): closed the lead cycle #140 left open
   on its own doc comment -- `Scene::SkillMenu`'s target-confirm screen gets
   the identical description-banner-narrows/skill-list-replaced reflow cycle

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -222,8 +222,7 @@ class RPG2k
           @pending_item = id
           @mode = :teleport_target
           @teleport_index = 0
-          build_teleport_window
-          refresh_desc
+          enter_teleport_target
         elsif sk
           if sk.type == Game::Party::SKILL_SWITCH
             # A switch skill has no target and no confirmation message either
@@ -436,6 +435,39 @@ class RPG2k
         play_system_se(SFX_CURSOR)
       end
 
+      # :teleport_target's own left side -- unlike :target mode (which
+      # narrows the description banner/item grid to make room for a
+      # right-anchored panel, cycle #140), the destination picker removes
+      # both entirely, leaving raw map background where they used to be --
+      # confirmed against genuine RPG_RT.exe under wine (cycle #142, closing
+      # the lead cycles #140/#141 both explicitly left open): a real type-9
+      # special item repointed at a synthetic Teleport-type skill (Nepheshel's
+      # own database has no Escape/Teleport-type skill or item to begin with
+      # -- see docs/TODO.md's own cycle #142 entry for the full recipe, and
+      # Scene::SkillMenu's identical #enter_teleport_target for the shared
+      # citation) opened onto a solid map-coloured band across the whole top
+      # two-thirds of the screen, no window border/gradient anywhere in it,
+      # directly above the destination list's own full-width, bottom-anchored
+      # box -- not the banner/grid merely covered (the destination box does
+      # not span that height) nor narrowed (its own box runs the full
+      # `SCREEN_W`, not `SCREEN_W - TARGET_W`). Tested at both ends of the
+      # registered-destination-count boundary this cycle could reach (1 and 3
+      # targets); both left the same bare band above the list. Cancelling out
+      # (confirmed live, both counts) restores the ordinary full-width
+      # `:items` banner and grid exactly, which #leave_teleport_target's own
+      # rebuild (mirroring #enter_teleport_target) now matches.
+      def enter_teleport_target
+        if @desc_window
+          @desc_window.dispose
+          @desc_window = nil
+        end
+        if @item_window
+          @item_window.dispose
+          @item_window = nil
+        end
+        build_teleport_window
+      end
+
       def leave_teleport_target
         @pending_item = nil
         @mode = :items
@@ -443,7 +475,8 @@ class RPG2k
           @teleport_window.dispose
           @teleport_window = nil
         end
-        refresh_desc
+        build_desc_window
+        build_item_window
       end
 
       # The registered teleport destinations as `[map_id, name]` pairs,
@@ -602,10 +635,12 @@ class RPG2k
       # right-anchored target panel once :target mode is entered -- confirmed
       # against genuine RPG_RT.exe under wine (cycle #140): both boxes sit
       # flush against the target panel's own left edge (`SCREEN_W -
-      # TARGET_W`), not the full screen. Left at the full-width :items
-      # formula for :teleport_target too, matching that mode's own
-      # unchanged, unnarrowed banner (out of scope this cycle -- see
-      # #build_possessed_window's own doc comment).
+      # TARGET_W`), not the full screen. :teleport_target never reaches this
+      # formula at all -- #enter_teleport_target disposes both windows
+      # outright rather than narrowing them (cycle #142; see its own doc
+      # comment), so `@mode == :teleport_target` never calls #build_desc_
+      # window/#build_item_window in the first place. Left branchless (only
+      # :target narrows) rather than adding a dead :teleport_target case.
       def left_panel_w
         @mode == :target ? SCREEN_W - TARGET_W : SCREEN_W
       end
@@ -617,10 +652,10 @@ class RPG2k
       # mode. Once :target mode narrows this banner (see #left_panel_w), real
       # RPG_RT switches its text too -- confirmed against genuine RPG_RT.exe
       # under wine (cycle #140): it shows the pending item's own *name*
-      # ("薬草"), not its description, while target mode is open. :teleport_
-      # target is untouched (still the pending item's description) -- that
-      # picker's own banner was not re-examined this cycle, see
-      # #build_possessed_window's own doc comment for why.
+      # ("薬草"), not its description, while target mode is open. This method
+      # is never reached in :teleport_target mode at all (see
+      # #enter_teleport_target, cycle #142) since that mode disposes
+      # `@desc_window` outright rather than refreshing its text.
       def build_desc_window
         @desc_window.dispose if @desc_window
         w = left_panel_w
@@ -735,12 +770,11 @@ class RPG2k
       # 136 == SCREEN_W - TARGET_W` panel width, a real recurring RPG_RT
       # layout rather than a coincidence of this one screen.
       #
-      # :teleport_target is deliberately not given the same treatment: this
-      # cycle only drove the plain single-target-medicine path under wine, so
-      # whether the destination-teleport picker's own left column reflows the
-      # same way is unverified and left open for a future cycle -- applying
-      # this same fix there on the strength of this cycle's one probe would
-      # be guessing, not verifying.
+      # :teleport_target does not get a possessed-count box of its own at
+      # all -- confirmed against genuine RPG_RT.exe under wine (cycle #142):
+      # unlike :target, the destination picker does not narrow-and-replace
+      # the left column, it removes it outright (see #enter_teleport_
+      # target's own doc comment).
       def build_possessed_window
         w = left_panel_w
         inner_w = w - Window::BORDER * 2

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -190,8 +190,7 @@ class RPG2k
           @pending_skill = sid
           @mode = :teleport_target
           @teleport_index = 0
-          build_teleport_window
-          refresh_desc
+          enter_teleport_target
         else
           @pending_skill = sid
           enter_target_confirm(sk && sk.scope == 2 ? :self : sk && sk.scope == 4 ? :party : nil)
@@ -438,6 +437,39 @@ class RPG2k
         @parent.pop_to_map
       end
 
+      # :teleport_target's own left side -- unlike :target mode (which
+      # narrows the description banner/skill grid to make room for a
+      # right-anchored panel, cycles #140/#141), the destination picker
+      # removes both entirely, leaving raw map background where they used
+      # to be -- confirmed against genuine RPG_RT.exe under wine (cycle
+      # #142, closing the lead cycles #140/#141 both explicitly left open):
+      # driving a synthetic Teleport-type skill (Set Teleport Target /
+      # Change Teleport Access have no existing exerciser in Nepheshel's own
+      # database, so this needed a scratch skill row and a hand-edited save
+      # -- see docs/TODO.md's own cycle #142 entry for the full recipe) into
+      # this screen showed a solid map-coloured band across the whole top
+      # two-thirds of the screen, with no window border/gradient anywhere in
+      # it, directly above the destination list's own full-width, bottom-
+      # anchored box -- not the banner/grid merely covered (the destination
+      # box does not span that height) nor narrowed (its own box runs the
+      # full `SCREEN_W`, not `SCREEN_W - TARGET_W`). Tested at both ends of
+      # the registered-destination-count boundary this cycle could reach (1
+      # and 3 targets); both left the same bare band above the list.
+      # Cancelling out (confirmed live, both counts) restores the ordinary
+      # full-width :skills banner and grid exactly, which #leave_teleport_
+      # target's own rebuild (mirroring #enter_teleport_target) now matches.
+      def enter_teleport_target
+        if @desc_window
+          @desc_window.dispose
+          @desc_window = nil
+        end
+        if @skill_window
+          @skill_window.dispose
+          @skill_window = nil
+        end
+        build_teleport_window
+      end
+
       def leave_teleport_target
         @pending_skill = nil
         @mode = :skills
@@ -445,7 +477,8 @@ class RPG2k
           @teleport_window.dispose
           @teleport_window = nil
         end
-        refresh_desc
+        build_desc_window
+        build_skill_window
       end
 
       # After a successful cast, drop back to the skill list and rebuild it (SP
@@ -465,13 +498,12 @@ class RPG2k
       # panel's own left edge (`SCREEN_W - TARGET_W`), not the full screen --
       # pixel-sampled at the identical native x (136, the border pattern
       # starting right where the target panel's own left edge does) as the
-      # already-fixed Item screen. Left at the full-width :skills formula for
-      # :teleport_target too, matching that mode's own unchanged, unnarrowed
-      # banner -- this cycle only drove the ordinary self/single-ally/
-      # all-ally target-confirm path under wine, not the Teleport picker, so
-      # extending this there would be guessing, not verifying (the same
-      # restraint Scene::ItemMenu#left_panel_w's own doc comment already
-      # takes for its own Teleport picker).
+      # already-fixed Item screen. :teleport_target never reaches this
+      # formula at all -- #enter_teleport_target disposes both windows
+      # outright rather than narrowing them (cycle #142; see its own doc
+      # comment), so `@mode == :teleport_target` never calls #build_desc_
+      # window/#build_skill_window in the first place. Left branchless (only
+      # :target narrows) rather than adding a dead :teleport_target case.
       def left_panel_w
         @mode == :target ? SCREEN_W - TARGET_W : SCREEN_W
       end
@@ -488,9 +520,10 @@ class RPG2k
       # (scope 3), self-locked (scope 2) and all-ally-locked (scope 4) skill
       # alike -- all three tested, since #enter_target_confirm's own lock
       # argument only changes cursor behaviour, not (as this fix confirms)
-      # whether the reflow happens. :teleport_target is untouched (still the
-      # pending skill's description) -- that picker's own banner was not
-      # re-examined this cycle, see #left_panel_w's own doc comment for why.
+      # whether the reflow happens. This method is never reached in
+      # :teleport_target mode at all (see #enter_teleport_target, cycle
+      # #142) since that mode disposes `@desc_window` outright rather than
+      # refreshing its text.
       def build_desc_window
         @desc_window.dispose if @desc_window
         w = left_panel_w
@@ -603,8 +636,11 @@ class RPG2k
       # status`, a real recurring RPG_RT layout rather than a coincidence of
       # one screen.
       #
-      # :teleport_target is deliberately not given the same treatment -- see
-      # #left_panel_w's own doc comment for why.
+      # :teleport_target does not get an MP-cost box of its own at all --
+      # confirmed against genuine RPG_RT.exe under wine (cycle #142): unlike
+      # :target, the destination picker does not narrow-and-replace the left
+      # column, it removes it outright (see #enter_teleport_target's own doc
+      # comment).
       def build_mp_cost_window
         w = left_panel_w
         inner_w = w - Window::BORDER * 2

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -20229,6 +20229,51 @@ check 'Scene::ItemMenu: cancelling the Teleport destination list returns to the 
   ok !parent.pop_to_map_called
 end
 
+check 'Scene::ItemMenu: the description banner and item grid are removed ' \
+      'outright (not narrowed, not covered) once the Teleport destination ' \
+      'picker opens, and rebuilt full-width on Cancel' do
+  # Confirmed against genuine RPG_RT.exe under wine (cycle #142), closing
+  # the lead cycles #140/#141 both explicitly left open ("that picker's own
+  # banner was not re-examined this cycle"). Unlike :target mode (which
+  # narrows both boxes to make room for a right-anchored panel), the
+  # destination picker disposes them outright: driving a synthetic
+  # Teleport-invoking special item into this screen showed a solid
+  # map-coloured band with no window border/gradient anywhere in the whole
+  # top two-thirds of the screen, above the destination list's own
+  # full-width, bottom-anchored box -- tested at both ends of the
+  # registered-destination-count boundary reached (1 and 3 targets).
+  parent = fake_parent(fake_db)
+  state = escape_teleport_item_state
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  ok scene.instance_variable_get(:@desc_window), ':items mode: banner exists'
+  ok scene.instance_variable_get(:@item_window), ':items mode: item grid exists'
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the Teleport item
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  eq :teleport_target, scene.instance_variable_get(:@mode)
+  ok scene.instance_variable_get(:@desc_window).nil?,
+     'the description banner is disposed outright, not narrowed'
+  ok scene.instance_variable_get(:@item_window).nil?,
+     'the item grid is disposed outright, not narrowed or covered'
+  ok scene.instance_variable_get(:@teleport_window), 'only the destination list itself remains'
+
+  RGSS::Input.triggered = [RGSS::Input::B]           # Cancel back to the item list
+  scene.update
+  RGSS::Input.reset
+  eq :items, scene.instance_variable_get(:@mode)
+  desc = scene.instance_variable_get(:@desc_window)
+  item_win = scene.instance_variable_get(:@item_window)
+  ok desc, 'the banner is rebuilt on Cancel'
+  ok item_win, 'the item grid is rebuilt on Cancel'
+  eq RPG2k::Scene::ItemMenu::SCREEN_W, desc.width, 'rebuilt banner is full width, not left narrowed'
+  eq RPG2k::Scene::ItemMenu::SCREEN_W, item_win.width, 'rebuilt item grid is full width, not left narrowed'
+  ok scene.instance_variable_get(:@teleport_window).nil?, 'the destination list itself is gone'
+end
+
 check 'Scene::SkillMenu: the skill grid cursor does not wrap, caster is fixed, ' \
       'the target cursor does wrap' do
   scene = menu_scene(RPG2k::Scene::SkillMenu, wrap_menu_state)
@@ -20525,6 +20570,53 @@ check 'Scene::SkillMenu: cancelling the destination list returns to the skill li
   eq :skills, scene.instance_variable_get(:@mode)
   ok state.pending_teleport.nil?
   ok !parent.pop_to_map_called
+end
+
+check 'Scene::SkillMenu: the description banner and skill grid are removed ' \
+      'outright (not narrowed, not covered) once the Teleport destination ' \
+      'picker opens, and rebuilt full-width on Cancel' do
+  # Confirmed against genuine RPG_RT.exe under wine (cycle #142), closing
+  # the lead cycles #140/#141 both explicitly left open ("that picker's own
+  # banner was not re-examined this cycle"). Unlike :target mode (which
+  # narrows both boxes to make room for a right-anchored panel), the
+  # destination picker disposes them outright: driving a synthetic Teleport-
+  # type skill into this screen (Nepheshel's own database has no Escape/
+  # Teleport-type skill to begin with -- see docs/TODO.md's own cycle #142
+  # entry for the full recipe) showed a solid map-coloured band with no
+  # window border/gradient anywhere in the whole top two-thirds of the
+  # screen, above the destination list's own full-width, bottom-anchored
+  # box -- tested at both ends of the registered-destination-count boundary
+  # reached (1 and 3 targets).
+  parent = fake_parent(fake_db)
+  state = escape_teleport_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  ok scene.instance_variable_get(:@desc_window), ':skills mode: banner exists'
+  ok scene.instance_variable_get(:@skill_window), ':skills mode: skill grid exists'
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto Teleport
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  eq :teleport_target, scene.instance_variable_get(:@mode)
+  ok scene.instance_variable_get(:@desc_window).nil?,
+     'the description banner is disposed outright, not narrowed'
+  ok scene.instance_variable_get(:@skill_window).nil?,
+     'the skill grid is disposed outright, not narrowed or covered'
+  ok scene.instance_variable_get(:@teleport_window), 'only the destination list itself remains'
+
+  RGSS::Input.triggered = [RGSS::Input::B]           # Cancel back to the skill list
+  scene.update
+  RGSS::Input.reset
+  eq :skills, scene.instance_variable_get(:@mode)
+  desc = scene.instance_variable_get(:@desc_window)
+  skill_win = scene.instance_variable_get(:@skill_window)
+  ok desc, 'the banner is rebuilt on Cancel'
+  ok skill_win, 'the skill grid is rebuilt on Cancel'
+  eq RPG2k::Scene::SkillMenu::SCREEN_W, desc.width, 'rebuilt banner is full width, not left narrowed'
+  eq RPG2k::Scene::SkillMenu::SCREEN_W, skill_win.width, 'rebuilt skill grid is full width, not left narrowed'
+  ok scene.instance_variable_get(:@teleport_window).nil?, 'the destination list itself is gone'
 end
 
 # A single-target skill (scope != 2/4, so the target cursor is not locked)


### PR DESCRIPTION
## Summary

- Closes the `:teleport_target` lead cycles #140 and #141 both explicitly left open. Real RPG_RT does not narrow the description banner/item-or-skill grid the way `:target` mode does, and does not leave them alone either — it removes them outright, leaving bare map background above the destination picker's own full-width, bottom-anchored box.
- Nepheshel's own database ships zero Teleport/Escape-type skills or items, so verifying this needed a hand-edited scratch skill row and save. That surfaced a real save-format footgun worth documenting: `SAVE_PARTY_ACTOR`'s `skills` field (52) is not self-describing — genuine RPG_RT reads exactly `skill_size` (field 51) entries and ignores the rest, the same size-then-array pairing as `state_size`/`states`. Setting field 52 alone left the skill genuinely absent, rendered indistinguishable from a text-rendering failure at a glance — documented for future save probes.
- Tested at both ends of the registered-destination-count boundary (1 and 3 targets) on both `Scene::ItemMenu` and `Scene::SkillMenu`; Cancel restores the full-width banner/grid exactly at both counts.
- Added `#enter_teleport_target` to both menu classes, disposing `@desc_window` and `@item_window`/`@skill_window` before building the destination list; `#leave_teleport_target` now does a full rebuild instead of a bare `refresh_desc` that no longer has anything to refresh.
- Updated stale doc comments across both files that previously described this picker as "unverified"/"deliberately not touched" from cycles #140/#141.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new checks fail against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/item_menu.rb mruby-rpg2k/mrblib/scene/skill_menu.rb`, rerunning the suite, then `git stash pop`: **2 of 921 checks failed** (`RuntimeError: the description banner is disposed outright, not narrowed`) on both screens.
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 921 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_