### PR TITLE
Shop screen: draw the item-description bar and fix the prompt's own window

### DIFF
--- a/changelog.d/shop-description-and-prompt-bar.fixed.md
+++ b/changelog.d/shop-description-and-prompt-bar.fixed.md
@@ -1,0 +1,9 @@
+- **Shop screen:** now matches RPG_RT's real layout — a full-width bar at
+  the very top shows the highlighted good's own database description, and
+  the shopkeeper's own prompt/greeting line is drawn as its own fixed panel
+  at the screen's bottom message slot rather than merged into the goods
+  list's first row. The goods list itself now docks directly under the
+  description bar with a fixed minimum height, instead of floating
+  bottom-anchored and sized to its own row count. Previously no description
+  bar was drawn at all, and the shopkeeper's line lived inside the list
+  window, both never verified against a real capture.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1643,6 +1643,128 @@ The work below is roughly ordered by the critical path to a walkable game
   offset on Buy and the quantity counter, confirming the rule follows
   `SHOP_PANELS_VISIBLE_ON` rather than being buy-only), confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Follow-up (cycle #144, 2026-08-25): closed the item-description bar
+  half of the three-part gap the entry above flagged and left open, and
+  fixed a second, previously-unflagged defect it exposed along the way --
+  the shopkeeper's own prompt line was drawn merged into the list window's
+  own first row, not as its own separate window the way real RPG_RT draws
+  it. The third piece (a blank, for non-equipment goods, party window
+  between the description bar and the status panel) remains open -- see
+  below for exactly what is and is not covered.** Reached a live Buy/Sell
+  screen with zero synthetic event editing, the same way the entry above
+  did (Nepheshel's own shop NPC, `Map0016.lmu` event 4 -- `--map 16 --at
+  14,11 --facing up --clear-scene` stands the party directly below it) --
+  save-position-only edits, restored to the original bytes (`md5sum`-
+  confirmed) and reconfirmed clean by `scripts/lcf_save_check.rb` after
+  every probe; no `.lmu`/`.ldb` file was touched at all this cycle. Drove
+  genuine RPG_RT.exe under wine (Xvfb 640x480x16, LIBGL_ALWAYS_SOFTWARE=1,
+  matchbox-window-manager, LANG=ja_JP.UTF-8): Continue -> file 1, faced and
+  interacted with the NPC, dismissed its own scripted greeting message,
+  then drove its own scripted Show-Choices menu (this particular NPC scripts
+  Buy/Sell/Cancel itself via Show Choices + two single-mode Open Shop calls,
+  rather than using this engine's native `:command` has_menu screen -- see
+  "not directly verified" below) into a 7-good Buy list, and separately into
+  a 1-good Sell list. Corner-marker pixel scans (native coordinates, the
+  distinctive white/purple `Window::BORDER`-adjacent corner colours, not the
+  body gradient which text-shadow pixels can spuriously match) of both
+  captures found **three** things this codebase drew nothing for or drew
+  wrong:
+  (1) a full-width, one-line window at the very top of the screen (native
+  y=0, height 30 = `SHOP_LINE_H + BORDER*2`, the same one-line-plus-border
+  shape every other shop panel already uses) showing the highlighted good's
+  own database description ("HPを80ポイント程度回復する" for 薬草) -- shown
+  on **both** the Buy and the Sell list (the Sell list's single good, no
+  status/gold column at all per `SHOP_PANELS_VISIBLE_ON`, still got this bar
+  with its own description), not merely absent as the entry above phrased it
+  ("a materially larger layout gap"), but a real, separate, always-full-width
+  window this file drew zero pixels of before now;
+  (2) the shopkeeper's own prompt ("「何をお買い上げになりますか？」" on
+  Buy, its Sell equivalent on Sell) at a **fixed** bottom position, native
+  y=160 height=80 -- exactly the ordinary map message window's own
+  `MSG_WIN_W`/`MSG_WIN_H` fixed shape and bottom slot (ADR 0021), not this
+  file's pre-existing merged-into-the-list's-own-first-row shape (`header`/
+  `offset` in the old `#draw_shop`), which was previously untested against a
+  live capture and turns out to have been wrong the whole time;
+  (3) as a direct consequence of (1)+(2) bracketing it top and bottom, the
+  list window itself is **not** content-sized the way this file drew it (a
+  bottom-anchored box exactly tall enough for its own row count plus the
+  merged header) -- a 7-good Buy list and a 1-good Sell list both left the
+  list window's own bottom border at the *identical* native y (flush against
+  the new prompt bar), direct boundary-case evidence (two clearly different
+  item counts landing on the same edge) that the box has a fixed minimum
+  height, not a dynamic one, for at least this 1..7-good range. Also
+  reconfirmed, precisely, from the same captures: the status/gold panels'
+  own already-correct width/stacking/right-alignment (cycle 2026-08-22,
+  unchanged) now sit at native y=80/y=128 respectively -- not y=6/y=50 as
+  this file hardcoded before the description bar above them existed to push
+  them down.
+  Fixed `mruby-rpg2k/mrblib/scene/map.rb`: new `SHOP_DESC_H` (`SHOP_LINE_H +
+  BORDER*2`), `SHOP_STATUS_Y` (80) and `SHOP_GOLD_Y` (128) constants;
+  `#draw_shop_desc` (new, gated on a new, deliberately *wider* visibility set
+  than the status/gold panels' own `SHOP_PANELS_VISIBLE_ON` --
+  `SHOP_DESC_VISIBLE_ON` includes `:sell`, confirmed live above, while the
+  status/gold panels stay hidden there, unchanged) draws the top bar from a
+  new `Game::Shop#description(id)` (`mruby-rpg2k/mrblib/game.rb`, mirroring
+  `Scene::ItemMenu`'s own `it.description.to_s` pattern); `#draw_shop_prompt`
+  (new) draws the old `#shop_header` text into its own `MSG_WIN_W`x`MSG_WIN_H`
+  window at the screen's fixed bottom slot instead of merging it into
+  `#draw_shop`'s own list bitmap, which lost its `header`/`offset` handling
+  entirely; `#draw_shop` now top-anchors the list at `SHOP_DESC_H` (not
+  bottom-anchored above a bare `6`px margin) with height
+  `[content, #shop_list_min_inner_h].max` (a method, not a constant, purely
+  because it reads `MSG_WIN_H`/`MSG_WIN_W`, declared later in the same file --
+  a class body evaluates top-level constant expressions immediately, in file
+  order, unlike a method body's lazily-resolved constant lookups) so a
+  longer list than this fixed minimum still gets enough room instead of being
+  clipped; `#build_shop_gold_window`/`#draw_shop_status` move to
+  `SHOP_GOLD_Y`/`SHOP_STATUS_Y` instead of the old `6`/`6 + ...` margins;
+  `#close_shop` disposes the two new windows alongside the existing three.
+  **Deliberately not fixed, and left open:** the blank, for non-equipment
+  goods, party window real RPG_RT draws between the description bar and the
+  status panel (native y≈32..80, ~48px) -- this cycle did not attempt it (no
+  equipment-item shop probe was driven, and its content for an equipment good
+  is a wholly separate, unverified question), so that 48px band is left
+  undrawn (raw map background) rather than an empty bordered window the way
+  real RPG_RT shows it; whoever picks this up next should drive a shop
+  selling a weapon/armour item specifically, since a non-equipment probe
+  (this cycle's own 薬草/medicine and the entry above's own item-3/item-5
+  goods) cannot show what that box's *content* for an equippable good looks
+  like, only that it is blank for a consumable. Also not verified: whether
+  the description bar (and the list's new top-anchored position) is correct
+  on the native `:command` has_menu screen specifically -- Nepheshel's own
+  test NPC scripts its own Buy/Sell/Cancel choice menu via Show Choices
+  rather than exercising this engine's native has_menu path at all, so
+  `SHOP_DESC_VISIBLE_ON` excluding `:command` (hiding the bar there) is an
+  inference from the verified Buy/Sell pattern, not a directly-driven result
+  -- flagged with an explicit doc comment and a matching scene-check comment
+  rather than silently presented as verified. Also unverified either way:
+  real RPG_RT's behaviour once a shop's own goods list exceeds the list
+  window's fixed minimum capacity (does it scroll? does the window grow
+  taller, pushing into the now-fixed-position prompt bar below it?) --
+  Nepheshel's own two tested lists (7 goods, 1 good) both fit inside the
+  fixed minimum this fix computed from the gap between the description bar
+  and the prompt bar, so `#shop_list_min_inner_h`'s own `[content, min].max`
+  guard against clipping a longer list is a safety net, not a confirmed
+  behaviour, for any shop with more goods than that. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (the description bar's text/
+  visibility/geometry across the command menu, Buy and Sell; the prompt
+  bar's fixed geometry and the list's new `SHOP_DESC_H` top offset) plus
+  three existing checks updated to read the shopkeeper's line from the new
+  `shop[:prompt]` window instead of the old merged `shop[:window]` row (the
+  greeting/regreeting/per-screen-prompt check, and the buy/sell confirmation-
+  term checks) -- all five confirmed to fail against the pre-fix code (a
+  stashed diff of `game.rb`/`map.rb` only) before the fix: `RuntimeError`s
+  ("the first-visit greeting shows", the two confirmation-term messages, "the
+  buy list shows the highlighted (first) good's own description") and a
+  `NoMethodError: undefined method 'x' for nil` on the prompt-geometry check,
+  since `shop[:prompt]` did not exist pre-fix. Full suite reconfirmed passing
+  (924 checks, up from 922); `rpg2k_render_check.rb` (41) and
+  `rpg2k_logic_check.rb` (1134) reconfirmed passing unaffected. `Save01.lsd`
+  (position/facing only, via `gen-rpg2k-save.rb --map 16 --at 14,11 --facing
+  up --clear-scene`) was the only game-data file touched by any probe this
+  cycle, restored to its original bytes (`md5sum`-confirmed) and the
+  canonical debug save reconfirmed clean by `scripts/lcf_save_check.rb` (map
+  12, (40,15), scene cleared, unchanged) afterward.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8570,6 +8570,14 @@ module Game
       it ? it.name.to_s : ''
     end
 
+    # Database flavour/effect text of item `id` ('' when missing) -- the line
+    # the shop screen's own description bar shows for the highlighted good,
+    # the same field `Scene::ItemMenu`'s description banner already reads.
+    def description(id)
+      it = @db.item[id]
+      it ? it.description.to_s : ''
+    end
+
     # Half the database price — what a sale returns (RPG2000 rounds down).
     def sell_price(id); price(id) / 2; end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5273,7 +5273,8 @@ class RPG2k
         screen = has_menu ? :command : (req[:allow_buy] ? :buy : :sell)
         @shop = { model: model, has_menu: has_menu, screen: screen, index: 0,
                   cmd_index: 0, window: nil, gold: build_shop_gold_window,
-                  status: nil, terms: shop_terms(req[:type]), browsed: false,
+                  status: nil, desc: nil, prompt: nil,
+                  terms: shop_terms(req[:type]), browsed: false,
                   interp: it }
         draw_shop
       end
@@ -5307,15 +5308,19 @@ class RPG2k
         }
       end
 
-      # The line shown above the current screen's selectable rows: the
-      # shopkeeper's greeting on first entering the command menu, the same
-      # shopkeeper asking "anything else?" on returning to it after browsing
-      # (EasyRPG's Window_Shop switches from `shop_greeting` to
-      # `shop_regreeting` once the player has entered Buy or Sell mode -- a
-      # per-visit flag, not a persisted "have I shopped here before"), a
+      # The shopkeeper's own line: a greeting on first entering the command
+      # menu, the same shopkeeper asking "anything else?" on returning to it
+      # after browsing (EasyRPG's Window_Shop switches from `shop_greeting`
+      # to `shop_regreeting` once the player has entered Buy or Sell mode --
+      # a per-visit flag, not a persisted "have I shopped here before"), a
       # prompt on the buy / sell / quantity screens themselves, and the
       # purchased / sold confirmation once a transaction commits. nil for any
-      # other screen, which #draw_shop reads as "no header row".
+      # other screen, which #draw_shop_prompt reads as "hide the prompt bar".
+      # Follow-up (cycle #144, 2026-08-25): this used to be merged into the
+      # list window's own first row (`offset`/`header` in #draw_shop below,
+      # now removed) -- confirmed against genuine RPG_RT.exe under wine that
+      # it is its own separate, full-width window at the screen's bottom
+      # message slot instead; see #draw_shop_prompt.
       def shop_header
         t = @shop[:terms]
         case @shop[:screen]
@@ -5329,6 +5334,25 @@ class RPG2k
         end
       end
 
+      # Height of the one-line item-description bar at the very top of the
+      # screen (#draw_shop_desc) -- the same one-line-plus-border shape every
+      # other shop panel already uses (SHOP_LINE_H + BORDER*2), confirmed
+      # against genuine RPG_RT.exe under wine (cycle #144, see #draw_shop_desc).
+      SHOP_DESC_H = SHOP_LINE_H + Window::BORDER * 2
+
+      # Fixed vertical positions of the right-hand status/gold column,
+      # measured directly (border-corner-marker pixel scan, native
+      # coordinates) against a genuine RPG_RT.exe capture of Nepheshel's own
+      # Map0016 event 4 shop (cycle #144): status at y=80, gold at y=128 --
+      # not y=6 / y=50 as this file used to hardcode before the description
+      # bar above them existed. The 48px gap above the status panel (roughly
+      # y=32..80) is real RPG_RT's own third, always-blank-for-non-equipment-
+      # goods party window, deliberately left undrawn here -- see the
+      # "Follow-up (cycle #144" entry in docs/TODO.md for why, and for the
+      # next cycle that picks it up.
+      SHOP_STATUS_Y = 80
+      SHOP_GOLD_Y = 128
+
       # Docks under the status panel, sharing its own width -- confirmed
       # against genuine RPG_RT.exe under wine: a live shop's right-hand
       # column (border-color pixel scan against a real frame) shows the
@@ -5338,7 +5362,7 @@ class RPG2k
       # / SHOP_LINE_H*2+BORDER*2 shape this stacks below.
       def build_shop_gold_window
         gw = SHOP_STATUS_W
-        win = Window.new(SCREEN_W - gw - 6, 6 + SHOP_LINE_H * 2 + Window::BORDER * 2,
+        win = Window.new(SCREEN_W - gw - 6, SHOP_GOLD_Y,
                          gw, SHOP_LINE_H + Window::BORDER * 2)
         win.z = 300
         win.windowskin = @windowskin
@@ -5376,15 +5400,33 @@ class RPG2k
         end
       end
 
+      # The list's own fixed minimum content height -- confirmed against
+      # genuine RPG_RT.exe under wine (cycle #144): a 7-good Buy list and a
+      # single-good Sell list both left the list window's own bottom border
+      # at the identical native y (flush against the prompt bar below it,
+      # see #draw_shop_prompt), rather than shrinking to fit either list's
+      # actual row count the way this file used to draw it -- direct evidence
+      # the box is a fixed size, not content-sized, for at least this range
+      # (1..7 rows). `[content, SHOP_LIST_MIN_INNER_H].max` keeps a longer
+      # list (more goods than this constant reserves room for) from being
+      # clipped, since real RPG_RT's own behaviour past that point (does it
+      # scroll? does the window itself grow?) was not reachable with any
+      # shop this codebase's own test bed (Nepheshel) ships and is left
+      # unverified -- see the cycle #144 docs/TODO.md entry.
+      #
+      # A method, not a constant, purely because MSG_WIN_H/MSG_WIN_W (the
+      # ordinary map message window's own shape, #draw_shop_prompt reuses
+      # them too) are declared later in this same file -- a class body
+      # evaluates top-level constant expressions immediately at load time, in
+      # file order, unlike a method body's own lazily-resolved constant
+      # lookups.
+      def shop_list_min_inner_h
+        SCREEN_H - SHOP_DESC_H - MSG_WIN_H - Window::BORDER * 2
+      end
+
       def draw_shop
         lines = shop_lines
         @shop[:index] = Game.clamp(@shop[:index], 0, [lines.length - 1, 0].max)
-        # The shopkeeper's line (greeting / regreeting / a buy-sell-quantity
-        # prompt) sits above the selectable rows as one extra line, the same
-        # layout #open_inn_window uses for its own greeting.
-        header = shop_header
-        offset = header ? 1 : 0
-        row_count = lines.length + offset
         # Docks flush to the screen's left edge, not inset 10px -- the same
         # stale anti-pattern ADR 0021 already diagnosed and fixed for the
         # message window ("300px wide, inset 10px" -> "fixed 320x80 at
@@ -5397,26 +5439,109 @@ class RPG2k
         # offset from the screen's right edge.
         win_w = SHOP_PANELS_VISIBLE_ON.include?(@shop[:screen]) ? SCREEN_W - SHOP_STATUS_W - 6 : SCREEN_W
         inner_w = win_w - Window::BORDER * 2
-        inner_h = [row_count, 1].max * SHOP_LINE_H
+        row_h = [lines.length, 1].max * SHOP_LINE_H
+        inner_h = [row_h, shop_list_min_inner_h].max
         @shop[:window].dispose if @shop[:window]
-        win = Window.new(0, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
-                         win_w, inner_h + Window::BORDER * 2)
+        # Top-anchored right below the description bar (#draw_shop_desc), not
+        # bottom-anchored above a 6px screen margin -- confirmed against
+        # genuine RPG_RT.exe under wine (cycle #144): the shopkeeper's own
+        # prompt (formerly this window's own merged first row, now
+        # #draw_shop_prompt's separate bottom bar) never appeared inside this
+        # window at all.
+        win = Window.new(0, SHOP_DESC_H, win_w, inner_h + Window::BORDER * 2)
         win.z = 300
         win.windowskin = @windowskin
         c = Bitmap.new(inner_w, inner_h)
         c.font.color = Color.new(255, 255, 255, 255)
-        c.draw_text 0, 0, inner_w, SHOP_LINE_H, header if header
         lines.each_with_index do |(label, _), i|
-          c.draw_text 0, (i + offset) * SHOP_LINE_H, inner_w, SHOP_LINE_H, label
+          c.draw_text 0, i * SHOP_LINE_H, inner_w, SHOP_LINE_H, label
         end
         win.contents = c
         unless lines.empty?
-          win.cursor_rect =
-            Rect.new(0, (@shop[:index] + offset) * SHOP_LINE_H, inner_w, SHOP_LINE_H)
+          win.cursor_rect = Rect.new(0, @shop[:index] * SHOP_LINE_H, inner_w, SHOP_LINE_H)
         end
         @shop[:window] = win
         draw_shop_gold
         draw_shop_status(lines)
+        draw_shop_desc(lines)
+        draw_shop_prompt
+      end
+
+      # The full-width, one-line item-description bar above the list --
+      # confirmed against genuine RPG_RT.exe under wine (cycle #144, driving
+      # Nepheshel's own Map0016 event 4 shop): shows the highlighted good's
+      # own database description ("HPを80ポイント程度回復する" for 薬草), at
+      # native (0, 0), SCREEN_W wide, SHOP_DESC_H tall -- a real, separate
+      # window this codebase drew nothing for before. Broader than the
+      # status/gold panels' own SHOP_PANELS_VISIBLE_ON (also shown on Sell,
+      # confirmed live -- a single-good Sell list showed the same bar with
+      # the sold item's own description, even though Sell gets no status/gold
+      # column); hidden only on the command menu and whenever the current
+      # screen has no single item to describe (:command, or an empty list),
+      # which was not reachable through this cycle's own test shop (it scripts
+      # its own Buy/Sell/Cancel choice menu rather than using this engine's
+      # native :command screen) and so is inferred, not directly verified --
+      # see the cycle #144 docs/TODO.md entry.
+      SHOP_DESC_VISIBLE_ON = %i[buy sell quantity purchased sold].freeze
+
+      def shop_desc_item_id(lines)
+        return nil unless SHOP_DESC_VISIBLE_ON.include?(@shop[:screen])
+        case @shop[:screen]
+        when :buy, :sell
+          return nil if lines.nil? || lines.empty?
+          lines[@shop[:index]][1]
+        when :quantity, :purchased, :sold
+          @shop[:quantity] && @shop[:quantity][:id]
+        end
+      end
+
+      def draw_shop_desc(lines)
+        id = shop_desc_item_id(lines)
+        if id.nil?
+          @shop[:desc].dispose if @shop[:desc]
+          @shop[:desc] = nil
+          return
+        end
+        win = @shop[:desc]
+        unless win
+          win = Window.new(0, 0, SCREEN_W, SHOP_DESC_H)
+          win.z = 300
+          win.windowskin = @windowskin
+          @shop[:desc] = win
+        end
+        inner_w = SCREEN_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, SHOP_LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, SHOP_LINE_H, @shop[:model].description(id)
+        win.contents = c
+      end
+
+      # The shopkeeper's own prompt/greeting line (#shop_header), now its own
+      # full-width window at the screen's fixed bottom message slot -- reusing
+      # the ordinary map message window's own MSG_WIN_W/MSG_WIN_H shape and
+      # bottom position (ADR 0021), which the shop screen's own capture
+      # (cycle #144) landed on exactly (native y=160, height 80). Replaces the
+      # old "merged into the list window's own first row" shape #draw_shop
+      # used before.
+      def draw_shop_prompt
+        text = shop_header
+        if text.nil?
+          @shop[:prompt].dispose if @shop[:prompt]
+          @shop[:prompt] = nil
+          return
+        end
+        win = @shop[:prompt]
+        unless win
+          win = Window.new(0, SCREEN_H - MSG_WIN_H, MSG_WIN_W, MSG_WIN_H)
+          win.z = 300
+          win.windowskin = @windowskin
+          @shop[:prompt] = win
+        end
+        inner_w = MSG_WIN_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, SHOP_LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, SHOP_LINE_H, text
+        win.contents = c
       end
 
       # The gold and status panels share one visible/hidden set: RPG_RT's
@@ -5481,8 +5606,9 @@ class RPG2k
           # Right-aligned, not the screen's left edge -- confirmed against
           # genuine RPG_RT.exe under wine (see #build_shop_gold_window's own
           # doc comment for the capture this and the gold panel's position
-          # both come from).
-          win = Window.new(SCREEN_W - SHOP_STATUS_W - 6, 6,
+          # both come from). Y is SHOP_STATUS_Y, not the screen's own 6px top
+          # margin -- see that constant's own doc comment (cycle #144).
+          win = Window.new(SCREEN_W - SHOP_STATUS_W - 6, SHOP_STATUS_Y,
                            SHOP_STATUS_W, SHOP_LINE_H * 2 + Window::BORDER * 2)
           win.z = 300
           win.windowskin = @windowskin
@@ -5709,6 +5835,8 @@ class RPG2k
         @shop[:window].dispose if @shop[:window]
         @shop[:gold].dispose if @shop[:gold]
         @shop[:status].dispose if @shop[:status]
+        @shop[:desc].dispose if @shop[:desc]
+        @shop[:prompt].dispose if @shop[:prompt]
         @shop = nil
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15616,8 +15616,13 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
   3.times { scene.update } # the command menu opens (mode 0: buy+sell)
   shop = scene.instance_variable_get(:@shop)
   eq :command, shop[:screen]
+  # Follow-up (cycle #144): the shopkeeper's own line is its own separate
+  # bottom-message-slot window (#draw_shop_prompt), not merged into the list
+  # window's own first row any more -- confirmed against genuine RPG_RT.exe
+  # under wine (docs/TODO.md).
+  ok window_texts(shop[:prompt]).any? { |t| t.include?('いらっしゃいませ！') },
+     'the first-visit greeting shows'
   texts = window_texts(shop[:window])
-  ok texts.any? { |t| t.include?('いらっしゃいませ！') }, 'the first-visit greeting shows'
   ok texts.any? { |t| t.include?('買う') } && texts.any? { |t| t.include?('売る') } &&
      texts.any? { |t| t.include?('やめる') }, 'the command row labels use the database terms'
 
@@ -15626,7 +15631,7 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
   RGSS::Input.triggered = []
   shop = scene.instance_variable_get(:@shop)
   eq :buy, shop[:screen]
-  ok window_texts(shop[:window]).any? { |t| t.include?('何をお求めですか？') },
+  ok window_texts(shop[:prompt]).any? { |t| t.include?('何をお求めですか？') },
      'the buy list shows its own prompt above the goods'
 
   RGSS::Input.triggered = [RGSS::Input::C] # open the quantity counter for the first good
@@ -15634,7 +15639,7 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
   RGSS::Input.triggered = []
   shop = scene.instance_variable_get(:@shop)
   eq :quantity, shop[:screen]
-  ok window_texts(shop[:window]).any? { |t| t.include?('いくつ買いますか？') },
+  ok window_texts(shop[:prompt]).any? { |t| t.include?('いくつ買いますか？') },
      'the quantity screen shows its own prompt'
 
   RGSS::Input.triggered = [RGSS::Input::B] # back to the buy list
@@ -15645,7 +15650,7 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
   RGSS::Input.triggered = []
   shop = scene.instance_variable_get(:@shop)
   eq :command, shop[:screen]
-  ok window_texts(shop[:window]).any? { |t| t.include?('他に何かご入用ですか？') },
+  ok window_texts(shop[:prompt]).any? { |t| t.include?('他に何かご入用ですか？') },
      'having browsed once, the shopkeeper asks "anything else?" rather than greeting again'
 end
 
@@ -15717,7 +15722,7 @@ check 'Open Shop scene: buying shows the shop_purchased confirmation, then retur
 
   shop = scene.instance_variable_get(:@shop)
   eq :purchased, shop[:screen], 'the purchase confirms before the list reappears'
-  ok window_texts(shop[:window]).any? { |t| t.include?('毎度あり！') },
+  ok window_texts(shop[:prompt]).any? { |t| t.include?('毎度あり！') },
      'the confirmation line uses the database shop_purchased term'
 
   # Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) is a bare
@@ -15762,7 +15767,7 @@ check 'Open Shop scene: selling shows the shop_sold confirmation, then returns '
 
   shop = scene.instance_variable_get(:@shop)
   eq :sold, shop[:screen], 'the sale confirms before the list reappears'
-  ok window_texts(shop[:window]).any? { |t| t.include?('毎度！') },
+  ok window_texts(shop[:prompt]).any? { |t| t.include?('毎度！') },
      'the confirmation line uses the database shop_sold term'
 
   # Scene_Shop::vUpdate's Sold case (src/scene_shop.cpp) never reads Input::
@@ -15967,6 +15972,104 @@ check 'Open Shop scene: the gold panel hides on the command menu and the ' \
   shop = scene.instance_variable_get(:@shop)
   eq :quantity, shop[:screen]
   ok shop[:gold].visible, 'the quantity counter shows the gold panel'
+end
+
+# Follow-up (cycle #144, 2026-08-25): a full-width, one-line item-description
+# bar above everything else -- confirmed against genuine RPG_RT.exe under
+# wine (Nepheshel's own Map0016 event 4 shop). This codebase drew nothing at
+# all here before; see docs/TODO.md for the capture this and the two checks
+# below come from.
+check 'Open Shop scene: a description bar above the list shows the highlighted ' \
+      'good\'s own database description, on both the buy and the sell list' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.item[3].description = 'HPを30ポイント回復する'
+  db.item[5].description = 'HPを10ポイント回復する'
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0)] # buy+sell
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  party = ShopStubParty.new(500)
+  party.gain_item(3, 1)
+  state.instance_variable_set(:@party, party)
+  3.times { scene.update } # the command menu opens (mode 0: buy+sell)
+
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  ok shop[:desc].nil?,
+     'the command menu highlights no single good -- no bar (inferred, not directly ' \
+     'reachable through this cycle\'s own real-RPG_RT test shop; see docs/TODO.md)'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Buy
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen]
+  ok window_texts(shop[:desc]).any? { |t| t.include?('HPを30ポイント回復する') },
+     'the buy list shows the highlighted (first) good\'s own description'
+  desc_win = shop[:desc]
+  eq 0, desc_win.x, "the bar is flush to the screen's left edge"
+  eq 0, desc_win.y, "and to the screen's top edge"
+  eq RPG2k::Scene::Map::SCREEN_W, desc_win.width, 'and full screen width -- not ' \
+     'narrowed for the status/gold column the way the list window is'
+  eq RPG2k::Scene::Map::SHOP_DESC_H, desc_win.height
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move to the second good (Herb, id 5)
+  scene.update
+  RGSS::Input.triggered = []
+  ok window_texts(scene.instance_variable_get(:@shop)[:desc])
+       .any? { |t| t.include?('HPを10ポイント回復する') },
+     'the bar tracks the cursor, like the status panel does'
+
+  RGSS::Input.triggered = [RGSS::Input::B] # back to the command menu
+  scene.update
+  RGSS::Input.triggered = []
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move to Sell
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Sell
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :sell, shop[:screen]
+  # Confirmed live: unlike the status/gold panels (SHOP_PANELS_VISIBLE_ON,
+  # hidden on :sell), the description bar showed on a real single-good Sell
+  # list too -- a genuinely wider visibility rule (SHOP_DESC_VISIBLE_ON), not
+  # a copy-paste of the status panel's own gating.
+  ok window_texts(shop[:desc]).any? { |t| t.include?('HPを30ポイント回復する') },
+     'the sell list shows the held good\'s own description too, even though ' \
+     'it gets no status/gold column'
+end
+
+check 'Open Shop scene: the shopkeeper prompt is a fixed 320x80 panel at the ' \
+      'screen\'s bottom message slot, not merged into the list window' do
+  # Follow-up (cycle #144): confirmed against genuine RPG_RT.exe under wine --
+  # reuses the ordinary map message window's own fixed shape/position
+  # (MSG_WIN_W/MSG_WIN_H, ADR 0021), which the shop's own ordinary prompt
+  # bar landed on exactly.
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3], indent: 0)] # buy-only
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # straight to the buy list (buy-only)
+
+  shop = scene.instance_variable_get(:@shop)
+  win = shop[:prompt]
+  map_mod = RPG2k::Scene::Map
+  eq 0, win.x, "the prompt bar is flush to the screen's left edge"
+  eq map_mod::MSG_WIN_W, win.width, "the message window's own fixed width"
+  eq map_mod::SCREEN_H - map_mod::MSG_WIN_H, win.y, 'flush to the bottom edge'
+  eq map_mod::MSG_WIN_H, win.height, "and the message window's own fixed height"
+
+  # The list window itself now sits right below the (hidden-on-:command,
+  # shown-here) description bar instead of floating bottom-anchored above a
+  # 6px screen margin -- also confirmed live.
+  eq map_mod::SHOP_DESC_H, shop[:window].y,
+     'the list docks directly under the description bar'
 end
 
 check 'Enemy Encounter scene: the result window shows the database Victory term' do


### PR DESCRIPTION
## Summary

- Closes the item-description-bar half of a previously-flagged three-part shop layout gap, and fixes a second, previously-unflagged defect found along the way: the shopkeeper's own prompt line was drawn merged into the goods list window's first row, not as its own separate window the way real RPG_RT draws it.
- Confirmed under Wine against Nepheshel's own shop NPC, driving both a 7-good Buy list and a 1-good Sell list:
  - A full-width, one-line window at the very top of the screen shows the highlighted good's own database description — on **both** Buy and Sell (a wider visibility rule than the status/gold panels' own `SHOP_PANELS_VISIBLE_ON`).
  - The shopkeeper's own prompt sits at a **fixed bottom position** matching the ordinary map message window's own `MSG_WIN_W`/`MSG_WIN_H` shape, not merged into the list.
  - As a consequence, the goods list itself has a **fixed minimum height** rather than being sized to its own row count — two clearly different list lengths (7 and 1 goods) both left the list's bottom border at the identical native y.
- Added `Game::Shop#description`, `Scene::Map#draw_shop_desc` and `#draw_shop_prompt`; `#draw_shop` now top-anchors the list under the new description bar instead of bottom-anchoring it above a bare margin.
- **Deliberately left open**: the blank, for non-equipment goods, party window real RPG_RT draws between the description bar and the status panel (no equipment-item shop probe was reachable this cycle), and whether the description bar's visibility rule extends to the native `:command` has_menu screen (Nepheshel's own shop NPC scripts its own Buy/Sell/Cancel menu instead of exercising that code path).

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new/updated checks fail against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/game.rb mruby-rpg2k/mrblib/scene/map.rb`, rerunning the suite, then `git stash pop`: **5 of 924 checks failed** with the exact errors expected (three `RuntimeError`s on the relocated prompt text, one on the missing description bar, one `NoMethodError` on the not-yet-existing prompt window).
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 924 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_