### PR TITLE
psp: trim unused stb_image format decoders

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -328,6 +328,15 @@ if psp
       # behaviour change.
       t.defines << 'MRB_HEAP_PAGE_SIZE=256'
       t.defines << 'KHASH_INITIAL_SIZE=16'
+      # stb_image's FILE*-based stbi_load(path, ...) is only ever called by
+      # mruby-mvjs's mvcanvas.cxx (MV/MZ's Image loader); this cross-build
+      # excludes mvjs (include_mvjs: false below) and mruby-rgss's own loader
+      # always reads bytes itself and decodes via stbi_load_from_memory (see
+      # bmp_decode_into, mruby-rgss/src/lib.cxx), so the stdio path is dead
+      # code here. Dropping it removes newlib's stdio-backed stb decode path
+      # (and the buffered-FILE state it pulls in) from the one PT_LOAD-mapped
+      # EBOOT that would otherwise carry it unused.
+      t.defines << 'STBI_NO_STDIO'
     end
     conf.linker.flags += cpu_flags
 

--- a/changelog.d/psp-stb-image-format-trim.changed.md
+++ b/changelog.d/psp-stb-image-format-trim.changed.md
@@ -1,0 +1,14 @@
+- **PSP/desktop/wasm/wio: stb_image no longer compiles in decoders the engine
+  never calls.** The asset search this engine performs only ever tries
+  `.png`, `.jpg`/`.jpeg`, `.bmp` (via stb) and `.xyz` (a custom decoder, not
+  stb's) — `mruby-rgss/src/lib.cxx` now defines `STBI_NO_GIF`/`STBI_NO_PSD`/
+  `STBI_NO_TGA`/`STBI_NO_HDR`/`STBI_NO_PIC`/`STBI_NO_PNM` before including
+  `stb_image.h`, so those six unreachable format decoders are no longer
+  linked into any target. Measured on a host build: `lib.o`'s `.text` shrinks
+  by ~37 KB. The PSP cross-build also adds `STBI_NO_STDIO`, dropping stb's
+  `FILE*`-based `stbi_load(path, ...)` path — dead code there since that
+  build excludes `mruby-mvjs` (the only caller) and `mruby-rgss`'s own
+  loader always decodes via `stbi_load_from_memory`. On the PSP every
+  PT_LOAD segment of the EBOOT is mapped into RAM at launch, so this is live
+  RAM there, not just file size; desktop/wasm/wio shrink by the same unused
+  decoders for free. See `docs/adr/0047-psp-memory-budget.md`.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1051,6 +1051,33 @@ the interpreter-linking slice, in this order:
     `MRB_NO_METHOD_CACHE`, which would cost dispatch speed), shrinking GC heap
     page granularity and the initial khash bucket counts with no behaviour
     change.
+  - **Follow-up (2026-08-25), the same lever applied to stb_image.** The
+    asset search this engine performs only ever tries `.png`, `.jpg`/`.jpeg`,
+    `.bmp` (via stb — see docs/adr/0025's XP RTP finding) and `.xyz` (a
+    custom decoder in `lib.cxx`, not stb's); stb's other format decoders
+    (GIF, PSD, TGA, HDR, PIC, PNM) were being compiled in with no caller
+    anywhere in the codebase (confirmed by grep for every format-specific
+    `stbi__*` symbol). `mruby-rgss/src/lib.cxx` now defines `STBI_NO_GIF`/
+    `STBI_NO_PSD`/`STBI_NO_TGA`/`STBI_NO_HDR`/`STBI_NO_PIC`/`STBI_NO_PNM`
+    ahead of `#include <stb_image.h>`, universally (every target links the
+    same `lib.cxx`). Host-side proxy measurement (same caveat as Finding 1 —
+    not a device number): `lib.o`'s `.text` falls from 422,046 B to
+    384,968 B, ~37 KB, on an x86-64 `-O3` build; the PSP's 32-bit MIPS
+    `.text` for the same removed code is plausibly smaller but not zero. The
+    `psp` cross-build additionally defines `STBI_NO_STDIO` (`build_config.rb`),
+    dropping stb's `FILE*`-based `stbi_load(path, ...)`/`stbi_load_from_file`
+    family: the only caller in this codebase is `mruby-mvjs/src/mvcanvas.cxx`
+    (MV/MZ's `Image` loader), and the `psp` cross-build already excludes
+    `mruby-mvjs` (`include_mvjs: false`, ADR 0010) — `mruby-rgss`'s own
+    `bmp_decode_into` always reads bytes itself first and decodes via
+    `stbi_load_from_memory`/`stbi_info_from_memory`, neither of which is
+    guarded by `STBI_NO_STDIO` in the vendored stb fork. Confirmed safe for
+    the shared TU by building the `host` mruby target (which does link
+    `mruby-mvjs`) with only the six format defines and without
+    `STBI_NO_STDIO`: `mvcanvas.cxx`'s `stbi_load` call still resolves and
+    `libmruby.a` links clean. Not yet re-measured against a `psp`
+    cross-build (no `psp-gcc` toolchain in this pass); the reasoning is the
+    same PT_LOAD-resident-code argument as the rest of P6, not a new one.
 - **P3 — done (the tool; the deployment step itself is still per-release).**
   `scripts/rgssad_unpack.rb` unpacks a `Game.rgssad`/`.rgss2a`/`.rgss3a`
   (desktop-side, reusing the existing `RPGXP::RGSSAD` reader rather than

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -40,6 +40,24 @@
 
 #include <iostream>
 
+// The asset search this engine actually performs only ever tries .png,
+// .jpg/.jpeg, .bmp (via stb, all three formats an RPG Maker XP/VX RTP mixes —
+// see docs/adr/0025-rpgxp-cross-runtime-testing.md) and .xyz (the custom
+// decoder below, not stb's). None of stb's other format decoders — GIF, PSD,
+// TGA, HDR, PIC, PNM — are reachable from any loader in this codebase
+// (confirmed by grep: no stbi__gif/psd/tga/hdr/pic/pnm-specific symbol is
+// referenced anywhere). Compiling them in cost real bytes for nothing: on the
+// PSP every PT_LOAD segment of the EBOOT is mapped into RAM at launch (see
+// docs/adr/0047-psp-memory-budget.md's uni-algo trim for the same reasoning),
+// so this is live RAM there, not just file/flash size, and it shrinks the
+// desktop/wasm/wio/android binaries for free the same way that trim did.
+#define STBI_NO_GIF
+#define STBI_NO_PSD
+#define STBI_NO_TGA
+#define STBI_NO_HDR
+#define STBI_NO_PIC
+#define STBI_NO_PNM
+
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 


### PR DESCRIPTION
## Summary

- The asset search this engine performs only ever tries `.png`, `.jpg`/`.jpeg`, `.bmp` (via stb — see `docs/adr/0025-rpgxp-cross-runtime-testing.md`'s XP RTP finding) and `.xyz` (a custom decoder in `mruby-rgss/src/lib.cxx`, not stb's). stb's GIF/PSD/TGA/HDR/PIC/PNM decoders had no caller anywhere in the codebase but were being compiled into every target regardless — `mruby-rgss/src/lib.cxx` now defines `STBI_NO_GIF`/`STBI_NO_PSD`/`STBI_NO_TGA`/`STBI_NO_HDR`/`STBI_NO_PIC`/`STBI_NO_PNM` ahead of `stb_image.h`'s implementation include.
- The `psp` mruby cross-build also defines `STBI_NO_STDIO` (`build_config.rb`), dropping stb's `FILE*`-based `stbi_load(path, ...)` path: its only caller, `mruby-mvjs`'s `Image` loader, is already excluded from that build (`include_mvjs: false`), and `mruby-rgss`'s own `Bitmap` loader always decodes via `stbi_load_from_memory`.
- On the PSP every `PT_LOAD` segment of the EBOOT is mapped into RAM at launch, so this is live memory there, not just file size — the same reasoning `docs/adr/0047-psp-memory-budget.md`'s P6 already used for the uni-algo table trim. Desktop/wasm/wio shrink by the same unused decoders for free.
- Host-side proxy measurement (not a device number): `lib.o`'s `.text` falls from 422,046 B to 384,968 B (~37 KB) on an `-O3` host build.
- `docs/adr/0047-psp-memory-budget.md` and a changelog fragment updated to record this.

## Test plan

- [x] Rebuilt the `host` mruby target (`rake -f 3rd/mruby/Rakefile MRUBY_TARGET=host`, includes `mruby-mvjs`) before and after the change — links clean both ways, confirming the universal format-decoder removal doesn't break `mvcanvas.cxx`'s `stbi_load` call, and confirming `STBI_NO_STDIO` (only applied to the `psp` cross-build) is correctly scoped and doesn't affect the host/desktop build.
- [x] `pre-commit run clang-format` / `trailing-whitespace` / `end-of-file-fixer` / `check-added-large-files` on the changed files.
- [ ] Actual `psp` cross-build (needs the `psp-gcc` pspdev toolchain, not available in this environment) — left to CI's `psp` job.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt


---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_