### PR TITLE
Sort changelog fragments by git commit date instead of filename

### DIFF
--- a/changelog.d/mruby-enum-ext.fixed.md
+++ b/changelog.d/mruby-enum-ext.fixed.md
@@ -1,5 +1,5 @@
-Added `mruby-enum-ext` to the engine's gem set so `Enumerable#sort_by` (and
-`min_by` / `max_by` / `group_by`) work in the built engine. These are absent
-from the default mruby gem set, so code that called `Array#sort_by` — the
-RPG2000 battle turn-order and message-pacing paths — raised `NoMethodError` and
-aborted the native binary at runtime, even though the CRuby host checks passed.
+- Added `mruby-enum-ext` to the engine's gem set so `Enumerable#sort_by` (and
+  `min_by` / `max_by` / `group_by`) work in the built engine. These are absent
+  from the default mruby gem set, so code that called `Array#sort_by` — the
+  RPG2000 battle turn-order and message-pacing paths — raised `NoMethodError` and
+  aborted the native binary at runtime, even though the CRuby host checks passed.

--- a/changelog.d/rpg2k-choice-system-sfx.added.md
+++ b/changelog.d/rpg2k-choice-system-sfx.added.md
@@ -1,5 +1,5 @@
-The map choice window now plays the RPG2000 system sounds: the cursor sound
-as the selection moves between options and the decision sound when a choice is
-confirmed. Each resolves a Change System SFX (10670) override held on the game
-state before falling back to the database's own sound, so events that swap the
-system sounds are honoured.
+- The map choice window now plays the RPG2000 system sounds: the cursor sound
+  as the selection moves between options and the decision sound when a choice is
+  confirmed. Each resolves a Change System SFX (10670) override held on the game
+  state before falling back to the database's own sound, so events that swap the
+  system sounds are honoured.

--- a/changelog.d/rpg2k-item-field-occasion.added.md
+++ b/changelog.d/rpg2k-item-field-occasion.added.md
@@ -1,4 +1,4 @@
-The field item menu now honours an item's "usable in field" occasion: a
-medicine or switch item flagged battle-only (`occasion_field` off) no longer
-appears in the field item list, mirroring how the battle item list already
-hides field-only items. Skill books and seeds remain field-only as before.
+- The field item menu now honours an item's "usable in field" occasion: a
+  medicine or switch item flagged battle-only (`occasion_field` off) no longer
+  appears in the field item list, mirroring how the battle item list already
+  hides field-only items. Skill books and seeds remain field-only as before.

--- a/changelog.d/rpg2k-message-auto-position.added.md
+++ b/changelog.d/rpg2k-message-auto-position.added.md
@@ -1,5 +1,5 @@
-The message window now moves away from the hero when it is not position-fixed
-(RPG2000's default): if the hero stands in the lower half of the screen the
-window jumps to the top, otherwise it sits at the bottom, so talking to
-something near a map's bottom edge no longer covers it. A position-fixed
-message still honours its configured top/middle/bottom slot.
+- The message window now moves away from the hero when it is not position-fixed
+  (RPG2000's default): if the hero stands in the lower half of the screen the
+  window jumps to the top, otherwise it sits at the bottom, so talking to
+  something near a map's bottom edge no longer covers it. A position-fixed
+  message still honours its configured top/middle/bottom slot.

--- a/changelog.d/rpg2k-message-gold-window.added.md
+++ b/changelog.d/rpg2k-message-gold-window.added.md
@@ -1,4 +1,4 @@
-A message containing `\$` now shows the party's gold in a small window
-alongside the text (RPG2000's money display), which closes together with the
-message. `Game::Message.scan` flags the code and `Scene::Map` builds and tears
-down the gold window with the message.
+- A message containing `\$` now shows the party's gold in a small window
+  alongside the text (RPG2000's money display), which closes together with the
+  message. `Game::Message.scan` flags the code and `Scene::Map` builds and tears
+  down the gold window with the message.

--- a/changelog.d/rpg2k-message-instant-span.added.md
+++ b/changelog.d/rpg2k-message-instant-span.added.md
@@ -1,5 +1,5 @@
-Message text between `\>` and `\<` now reveals instantly instead of typing out
-character by character (RPG2000's instant-display span). `Game::Message.scan`
-records the spans and `Game::TextReveal` collapses each one in a single frame,
-while still stopping at any `\!` / `\.` / `\|` pause that falls inside the span.
-An unclosed `\>` runs to the end of the line.
+- Message text between `\>` and `\<` now reveals instantly instead of typing out
+  character by character (RPG2000's instant-display span). `Game::Message.scan`
+  records the spans and `Game::TextReveal` collapses each one in a single frame,
+  while still stopping at any `\!` / `\.` / `\|` pause that falls inside the span.
+  An unclosed `\>` runs to the end of the line.

--- a/changelog.d/rpg2k-message-pacing-codes.added.md
+++ b/changelog.d/rpg2k-message-pacing-codes.added.md
@@ -1,6 +1,6 @@
-Message pacing control codes now act instead of being silently dropped:
-`\!` holds the typewriter until a button is pressed, `\.` and `\|` pause it for
-a quarter- and a full second, and `\^` closes the window once the text finishes
-without waiting for a keypress. `\_` inserts a space. `Game::Message.scan`
-surfaces these positions (counting the expanded length of `\v` / `\n`) and
-`Game::TextReveal` halts at each pause until it is released.
+- Message pacing control codes now act instead of being silently dropped:
+  `\!` holds the typewriter until a button is pressed, `\.` and `\|` pause it for
+  a quarter- and a full second, and `\^` closes the window once the text finishes
+  without waiting for a keypress. `\_` inserts a space. `Game::Message.scan`
+  surfaces these positions (counting the expanded length of `\v` / `\n`) and
+  `Game::TextReveal` halts at each pause until it is released.

--- a/changelog.d/rpg2k-play-counters.added.md
+++ b/changelog.d/rpg2k-play-counters.added.md
@@ -1,5 +1,5 @@
-The RPG2000 play counters now advance and are readable through the Control
-Variables "Other" operand: the **save count** bumps on each save, and the
-**battle / win / defeat / escape counts** bump when an Enemy Encounter starts
-and resolves. All five persist in the save (and default to 0 in an older save),
-so events keyed on how many battles were fought or won now work.
+- The RPG2000 play counters now advance and are readable through the Control
+  Variables "Other" operand: the **save count** bumps on each save, and the
+  **battle / win / defeat / escape counts** bump when an Enemy Encounter starts
+  and resolves. All five persist in the save (and default to 0 in an older save),
+  so events keyed on how many battles were fought or won now work.

--- a/changelog.d/rpg2k-switch-item.added.md
+++ b/changelog.d/rpg2k-switch-item.added.md
@@ -1,4 +1,4 @@
-Switch items (item type 9) can now be used from the field item menu: using one
-turns on the game switch it names and consumes one from the bag.
-`Game::Party#use_switch_item` consumes the item and returns the switch id, and
-the item menu sets it — so events gated on that switch fire.
+- Switch items (item type 9) can now be used from the field item menu: using one
+  turns on the game switch it names and consumes one from the bag.
+  `Game::Party#use_switch_item` consumes the item and returns the switch id, and
+  the item menu sets it — so events gated on that switch fire.

--- a/changelog.d/rpg2k-timer-display.added.md
+++ b/changelog.d/rpg2k-timer-display.added.md
@@ -1,5 +1,5 @@
-The game timer is now drawn on the map. The Timer Operation command's start
-carries RPG2000's "show timer" flag, and while set `Scene::Map` shows a small
-top-centre window counting down as `M:SS` (independent of whether the timer is
-still running, so a stopped timer stays on screen frozen). The visibility flag
-round-trips through the save.
+- The game timer is now drawn on the map. The Timer Operation command's start
+  carries RPG2000's "show timer" flag, and while set `Scene::Map` shows a small
+  top-centre window counting down as `M:SS` (independent of whether the timer is
+  still running, so a stopped timer stays on screen frozen). The visibility flag
+  round-trips through the save.

--- a/changelog.d/rpg2k-weather-render.added.md
+++ b/changelog.d/rpg2k-weather-render.added.md
@@ -1,5 +1,5 @@
-`Scene::Map` now renders the map weather effect (Change Weather / 11070): a
-screen-sized overlay draws animated rain streaks or drifting snow, with the
-particle count scaling to the weather strength, so the type/strength already
-held on `Game::State` become visible on the map instead of only round-tripping
-through the save.
+- `Scene::Map` now renders the map weather effect (Change Weather / 11070): a
+  screen-sized overlay draws animated rain streaks or drifting snow, with the
+  particle count scaling to the weather strength, so the type/strength already
+  held on `Game::State` become visible on the map instead of only round-tripping
+  through the save.

--- a/scripts/build_changelog.rb
+++ b/scripts/build_changelog.rb
@@ -36,12 +36,38 @@ HEADINGS = {
   "security" => "Security",
 }.freeze
 
+# The time each fragment was first added to the repo, keyed by absolute path:
+# the `git log` commit date it was introduced in, so entries render in the
+# order changes actually landed instead of alphabetically by slug. A fragment
+# with no git history yet (freshly created, uncommitted) falls back to its
+# file mtime, so it sorts after everything already committed.
+def fragment_added_at(paths)
+  log = `git -C #{ROOT} log --reverse --diff-filter=A --name-only --format=@@%ct -- #{FRAGMENT_DIR}`
+  added = {}
+  timestamp = nil
+  log.each_line do |line|
+    line = line.chomp
+    if line.start_with?("@@")
+      timestamp = line[2..].to_i
+    elsif !line.empty?
+      path = File.join(ROOT, line)
+      added[path] ||= timestamp
+    end
+  end
+  paths.to_h { |p| [p, added[p] || File.mtime(p).to_i] }
+end
+
 # A fragment file is `<slug>.<category>.md`. Returns [category, path] pairs
-# grouped by category, in canonical order, each list sorted by filename so the
-# output is deterministic regardless of filesystem order.
+# grouped by category, in canonical order, each list sorted by the date it was
+# added (oldest first, ties broken by filename) so the output is deterministic
+# and reflects when changes actually landed.
 def load_fragments
+  paths = Dir.glob(File.join(FRAGMENT_DIR, "*.*.md"))
+  added_at = fragment_added_at(paths)
+  paths = paths.sort_by { |p| [added_at[p], File.basename(p)] }
+
   grouped = Hash.new { |h, k| h[k] = [] }
-  Dir.glob(File.join(FRAGMENT_DIR, "*.md")).sort.each do |path|
+  paths.each do |path|
     name = File.basename(path, ".md")
     category = name.split(".").last
     unless CATEGORIES.include?(category)


### PR DESCRIPTION
## Summary
Updated the changelog build script to sort fragments by the date they were added to the repository (via git commit history) rather than alphabetically by filename. This ensures the generated changelog reflects the actual chronological order in which changes landed.

## Key Changes
- Added `fragment_added_at()` function that queries git history to determine when each fragment file was first committed, falling back to file modification time for uncommitted files
- Modified `load_fragments()` to sort fragments by `[commit_date, filename]` instead of just filename, ensuring deterministic output that respects landing order
- Updated changelog fragment files to use consistent markdown list formatting (added leading `- ` and indentation for multi-line entries)

## Implementation Details
- The git query uses `git log --reverse --diff-filter=A` to find the original commit that added each file, extracting the commit timestamp (`%ct`)
- Fragments with no git history yet (freshly created, uncommitted) fall back to their file `mtime`, ensuring they sort after all committed entries
- The sorting is stable: when multiple fragments have the same commit timestamp, they're ordered by filename for determinism
- All changelog entries were reformatted to use proper markdown list syntax for consistency

https://claude.ai/code/session_01K7xZmkrsomQdxPXJmovFiQ