### PR TITLE
Shop screen: draw the equipment party window's own icon

### DIFF
--- a/changelog.d/shop-equipment-party-window.fixed.md
+++ b/changelog.d/shop-equipment-party-window.fixed.md
@@ -1,5 +1,5 @@
 - **Shop screen:** a third panel between the description bar and the status
-  panel now shows a bordered window whenever the highlighted good is
-  equipment (a weapon, shield, armor, helmet, or accessory), matching
-  RPG_RT — previously this band was always left blank. The icon RPG_RT
-  itself draws inside that window is not yet reproduced.
+  panel now shows a bordered window with a small icon whenever the
+  highlighted good is equipment (a weapon, shield, armor, helmet, or
+  accessory), matching RPG_RT — previously this band was always left
+  blank.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1879,6 +1879,97 @@ The work below is roughly ordered by the critical path to a walkable game
   command since no Nepheshel NPC exercises that path -- and real RPG_RT's
   behaviour once a shop's goods list exceeds the list window's fixed minimum
   capacity).
+  ✅ **Follow-up (cycle #146, 2026-08-25): identified and reproduced cycle
+  #145's own last-open lead -- the equipment party band's icon -- via asset
+  forensics against Nepheshel's own System graphic, exactly the technique
+  cycle #145's own entry suggested trying next instead of another
+  behavioural probe.** Nepheshel's own `System/システム.png` (the game's
+  windowskin) turned out to ship a genuinely corrupt IDAT stream: a strict
+  `Zlib::Inflate` rejects it outright ("invalid distance too far back", 0
+  bytes decoded, confirmed both through CRuby's `zlib` directly and through
+  `convert`/PIL, all three agreeing) even though every PNG chunk's own CRC
+  still matches the file's bytes exactly (so this is not transfer/checkout
+  corruption -- the deflate stream itself has a back-reference before the
+  start of its own output, a known old-RPG-Maker-era "buggy windowskin PNG"
+  shape). It decoded cleanly through this project's *own* tolerant inflater
+  instead -- `RGSS::Bitmap#bmp_decode_into` / `#inflate_tolerant` in
+  `scripts/rgss_cruby_compat.rb`, a pure-Ruby port of `src/lib.cxx`'s
+  `png_tol::inflate_tolerant`, already written for exactly this "RPG Maker
+  windowskins" case per its own pre-existing doc comment, just never
+  previously exercised on this particular file -- which recovered all
+  160x80 pixels and exposed an 8x8-celled icon grid at System-graphic
+  (128..160, 0..32) this codebase had never read before, including four
+  visually-identical downward "droplet" icons at y=16..24.
+  Drove genuine RPG_RT.exe under wine (Xvfb, `LIBGL_ALWAYS_SOFTWARE=1`,
+  matchbox-window-manager, `LANG=ja_JP.UTF-8`) to the same live weapon-shop
+  Buy list cycle #145 reached (Nepheshel's own Map0015 event 2, `--map 15
+  --at 5,9 --facing up --clear-scene`) and read the captured screenshot's
+  raw pixels directly with a small Python script (not eyeballed): the
+  mystery band's icon is a byte-for-byte match, modulo the wine capture's
+  own RGB565 quantisation (ADR 0021's own noted floor, ±1-3 per channel
+  here), for the System graphic's first droplet cell at (128, 16), 8x8,
+  scaled 2x by the capture pipeline itself -- Xvfb runs the reference at
+  640x480 while RPG2000's own native resolution is `SCREEN_W x SCREEN_H`
+  (320x240), confirmed independently by every other landmark measured in
+  the same capture (a border-pixel scan of the description-bar and status-
+  panel dividers this cycle re-measured lands on the *existing*
+  `SHOP_DESC_H`=30 / `SHOP_STATUS_Y`=80 / `SHOP_GOLD_Y`=128 constants once
+  halved, reconfirming those cycle #144 constants rather than contradicting
+  them). Confirmed fixed, not per-item, and now with *position* pinned down
+  too, not just content: the identical crop (0 differing pixels between the
+  two captures) reappeared at the identical position for both the
+  first-highlighted 150G ダガー/Dagger and, after moving the cursor down
+  four rows, the 800G ブロードソード/Broad Sword.
+  **Methodology finding worth flagging alongside cycle #145's own wine
+  keyboard-binding note**: reaching the live Buy list this cycle needed
+  several `z` presses in a row with no visible change in between (the
+  shopkeeper's own greeting message, then its Show Choices menu, each
+  needing its own confirm) before the Buy list actually opened -- a single
+  `z` (or a `Down`/`Up` sanity check in between, while a message or choice
+  menu was still up and legitimately ignoring movement) can look
+  indistinguishable from broken input if the intermediate screens are not
+  captured too. `xdotool windowactivate` also silently no-ops on this
+  matchbox setup once RPG_RT recreates its window after a save load (no
+  `_NET_ACTIVE_WINDOW` support, confirmed by `xdotool`'s own
+  `XGetWindowProperty[_NET_ACTIVE_WINDOW] failed` stderr) -- `xdotool
+  windowfocus`, which sets input focus directly (`XSetInputFocus`) rather
+  than going through EWMH, is what actually got keys delivered again after
+  that point; re-querying the window id after every load/reload rather than
+  reusing one from an earlier boot also mattered, since RPG_RT hands out a
+  new window id on each fresh launch.
+  Fixed `mruby-rpg2k/mrblib/scene/map.rb`: `SHOP_PARTY_ICON_SRC` (`Rect.new
+  (128, 16, 8, 8)`, the measured System-graphic cell) and
+  `SHOP_PARTY_ICON_OFFSET` (`[22, 22]`, the icon's measured native offset
+  from the party window's own interior origin); `#draw_shop_party` now
+  blits the icon from `@windowskin` onto the window's own `contents` once,
+  at window creation, instead of leaving the window permanently
+  contentless (the icon is static -- confirmed above -- so unlike the
+  status/gold panels' own per-frame text redraw this needs no repaint while
+  the window stays open). Covered by a new `scripts/rpg2k_scene_check.rb`
+  check asserting the exact single `blt` call (offset, source bitmap
+  identity and source rect), confirmed to fail against the pre-fix code (a
+  `git stash` of `map.rb` only) with `1 of 926 checks FAILED` before the
+  fix. Full suite reconfirmed passing (926 checks, up from 925, matching
+  the one new check added); `rpg2k_render_check.rb` (41) and
+  `rpg2k_logic_check.rb` (1134) reconfirmed passing unaffected. `Save01.lsd`
+  (position/facing only, via the same `gen-rpg2k-save.rb --map 15 --at 5,9
+  --facing up --clear-scene` recipe cycle #145 used) was the only game-data
+  file touched by any probe this cycle, restored to its original bytes
+  (`md5sum`-confirmed) and the canonical debug save reconfirmed clean by
+  `scripts/lcf_save_check.rb` (map 12, (40,15), scene cleared, unchanged)
+  afterward; the Nbeta sibling copy was never touched.
+  **Deliberately still open**: what this specific icon *represents*
+  semantically (its neighbours in the same 8x8 grid -- the pink triangles
+  at y=0..8 and the glyphs at y=24..32 -- were not identified either, and
+  this project deliberately does not consult EasyRPG source to name them);
+  whether a multi-member party shows more than one copy of it (this cycle's
+  save still carried only the same single live party member cycle #145
+  tested with, for the same reason -- growing it risks cycle #135's own
+  documented party-field crash); and the two gaps cycle #144 first left
+  open and neither #145 nor this cycle touched (the description bar's
+  correctness on the native `:command` has_menu screen, and real RPG_RT's
+  behaviour once a shop's goods list exceeds the list window's fixed
+  minimum capacity).
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5643,10 +5643,9 @@ class RPG2k
       # for a non-equipment good (medicine, confirmed again this cycle) the
       # band is blank, matching cycle #144's own finding exactly.
       #
-      # **The icon itself is deliberately not reproduced here** -- its exact
-      # pixels were not identified with the confidence this codebase's other
-      # fixes require. What was ruled out, each confirmed live against
-      # genuine RPG_RT.exe under wine rather than assumed:
+      # Cycle #145 left the icon itself unreproduced. What it ruled out, each
+      # confirmed live against genuine RPG_RT.exe under wine rather than
+      # assumed:
       #   - **not a per-item stat comparator**: pixel-identical across a
       #     97x price/stat range (150G ダガー/Dagger through 1400G
       #     バスタードソード/Bastard Sword through 4500G プレートメイル/Plate
@@ -5663,11 +5662,74 @@ class RPG2k
       #     icon here, since growing the test party risked cycle #135's own
       #     documented party-field crash and was out of scope for this
       #     cycle's time-box).
-      # See the cycle #145 docs/TODO.md entry for the full evidence and
-      # exactly what a future cycle would need to identify the icon itself
-      # (most likely: a windowskin/system-graphic asset dump and a pixel-
-      # for-pixel crop compare, not a further behavioural probe).
+      #
+      # Follow-up (cycle #146, 2026-08-25): identified the icon itself via
+      # asset forensics, exactly the "windowskin/system-graphic asset dump
+      # and a pixel-for-pixel crop compare" cycle #145 suggested as the next
+      # step. Nepheshel's own System graphic (`System/システム.png`) ships a
+      # genuinely corrupt IDAT stream -- a strict `Zlib::Inflate` rejects it
+      # outright ("invalid distance too far back", 0 bytes decoded even
+      # through raw deflate with the zlib header stripped), confirmed by hand
+      # against the file's own bytes (every PNG chunk CRC still matches, so
+      # this is not transfer corruption -- the deflate stream itself has a
+      # back-reference before the start of output, RPG Maker's own
+      # historically-known "buggy windowskin PNG" shape). Decoded cleanly
+      # instead through this project's *own* tolerant inflater
+      # (`RGSS::Bitmap#bmp_decode_into` in `scripts/rgss_cruby_compat.rb`, a
+      # pure-Ruby port of `src/lib.cxx`'s `png_tol::inflate_tolerant` --
+      # already written for exactly this "RPG Maker windowskins" case per its
+      # own doc comment, just never previously exercised on this particular
+      # file), which recovered all 160x80 pixels and exposed an 8x8-celled
+      # icon grid at System-graphic (128..160, 0..32) this codebase had never
+      # read before, including four visually-identical downward "droplet"
+      # icons at y=16..24.
+      #
+      # Drove genuine RPG_RT.exe under wine to the same live weapon-shop Buy
+      # list cycle #145 reached (Map0015 event 2, `--map 15 --at 5,9
+      # --facing up --clear-scene`) and read the captured screenshot's raw
+      # pixels directly (not eyeballed): the mystery band's icon is a
+      # byte-for-byte match, modulo the wine capture's own RGB565
+      # quantisation (ADR 0021's own noted floor, ±1-3 per channel here), for
+      # the System graphic's first droplet cell at (128, 16), 8x8, scaled 2x
+      # by the capture pipeline itself -- Xvfb runs the reference at 640x480
+      # while RPG2000's native resolution is SCREEN_W x SCREEN_H (320x240);
+      # confirmed independently by every other landmark measured in the same
+      # capture (the description-bar/status-panel border dividers this cycle
+      # re-measured land on the *existing* SHOP_DESC_H=30 / SHOP_STATUS_Y=80
+      # / SHOP_GOLD_Y=128 constants once halved, reconfirming those cycle
+      # #144 constants rather than contradicting them). Confirmed fixed, not
+      # per-item: the identical crop (0 differing pixels) reappeared at the
+      # identical position for both the first-highlighted 150G ダガー/Dagger
+      # and, after moving the cursor down four rows, the 800G
+      # ブロードソード/Broad Sword -- extending cycle #145's own
+      # "pixel-identical across every stat tier" finding to *position* too,
+      # not just content. Native draw position: interior offset (22, 22)
+      # from the party window's own top-left interior corner (the icon's own
+      # absolute native pixel position, halved from the capture, measured
+      # against the window's already-established origin -- `SCREEN_W -
+      # SHOP_STATUS_W - 6 + Window::BORDER`, `SHOP_DESC_H + Window::BORDER`).
+      #
+      # Fixed: `#draw_shop_party` now blits `SHOP_PARTY_ICON_SRC` (the
+      # measured 8x8 System-graphic cell) from `@windowskin` onto the
+      # window's own contents at `SHOP_PARTY_ICON_OFFSET`, once at window
+      # creation (the icon is static -- confirmed above -- so unlike the
+      # status/gold panels' own per-frame text redraw, this needs no repaint
+      # while the window stays open). Still open for a future cycle: what
+      # this specific icon *represents* semantically (its neighbours in the
+      # same 8x8 grid -- the pink triangles at y=0..8 and the glyphs at
+      # y=24..32 -- were not identified either, and this project deliberately
+      # does not consult EasyRPG source to name them) and whether a
+      # multi-member party shows more than one copy of it -- this cycle's
+      # save still carried only the same single live party member cycle #145
+      # tested with, for the same reason (growing it risks cycle #135's
+      # documented party-field crash).
       SHOP_PARTY_H = SHOP_STATUS_Y - SHOP_DESC_H
+
+      # The equipment-good icon's own source cell in the System graphic, and
+      # its draw offset inside the party window's interior -- see the cycle
+      # #146 doc comment above for the pixel-scan evidence behind both.
+      SHOP_PARTY_ICON_SRC = Rect.new(128, 16, 8, 8)
+      SHOP_PARTY_ICON_OFFSET = [22, 22].freeze
 
       def draw_shop_party(lines)
         id = shop_status_item_id(lines)
@@ -5682,6 +5744,13 @@ class RPG2k
                            SHOP_STATUS_W, SHOP_PARTY_H)
           win.z = 300
           win.windowskin = @windowskin
+          if @windowskin
+            c = Bitmap.new(SHOP_STATUS_W - Window::BORDER * 2,
+                           SHOP_PARTY_H - Window::BORDER * 2)
+            ox, oy = SHOP_PARTY_ICON_OFFSET
+            c.blt ox, oy, @windowskin, SHOP_PARTY_ICON_SRC
+            win.contents = c
+          end
           win
         end
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16122,6 +16122,61 @@ check 'Open Shop scene: the mystery band above the status panel is a window, ' \
      'the band hides again once a non-equipment good is highlighted'
 end
 
+# Follow-up (cycle #146, 2026-08-25): closed cycle #145's own last-open shop
+# gap -- identified the mystery band's icon itself via asset forensics (a
+# windowskin dump decoded through this project's own tolerant PNG inflater,
+# and a pixel-for-pixel crop compare against a fresh genuine RPG_RT.exe
+# capture of the same Map0015 weapon shop) and reproduced it. See
+# `Scene::Map#draw_shop_party`'s own doc comment for the full evidence.
+check 'Open Shop scene: the equipment party band blits the measured System-' \
+      'graphic droplet icon at its measured offset' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.item[3].type = 6 # Potion -- ordinary consumable, not equipment
+  db.item[11] = OpenStruct.new(name: 'Short Sword', price: 200, type: 1) # weapon
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3, 11], indent: 0)] # buy-only
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  skin = Bitmap.new('System/skin', true)
+  scene.instance_variable_set(:@windowskin, skin)
+  state.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # straight to the buy list (buy-only)
+
+  shop = scene.instance_variable_get(:@shop)
+  ok shop[:party].nil?, 'the first good (a Potion) is not equipment -- no band, no blit'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move to the Short Sword
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  win = shop[:party]
+  map_mod = RPG2k::Scene::Map
+  ok win.contents, 'the equipment band now has drawn contents, not a bare frame'
+  calls = win.contents.blt_calls
+  ok calls && calls.size == 1, 'exactly one icon blit, once at window creation'
+  ox, oy, src, rect = calls.first
+  eq 22, ox, "the icon's measured interior x offset"
+  eq 22, oy, "the icon's measured interior y offset"
+  eq skin.object_id, src.object_id, 'blitted from the live windowskin'
+  eq map_mod::SHOP_PARTY_ICON_SRC, rect, 'from the measured 8x8 System-graphic cell'
+  eq 128, rect.x, "the droplet icon's own x in the System graphic"
+  eq 16, rect.y, "the droplet icon's own y in the System graphic"
+  eq 8, rect.width, 'an 8x8 cell'
+  eq 8, rect.height, 'an 8x8 cell'
+
+  # Re-hiding and re-showing the band (a different equipment good) must not
+  # blit again onto the same contents bitmap -- the icon is static, so this
+  # would either be a silent no-op duplicate or, worse, a sign the offset
+  # depends on which good is highlighted, which the live capture (identical
+  # crop for both a 150G dagger and an 800G broad sword) ruled out.
+  RGSS::Input.triggered = [RGSS::Input::UP] # back to the Potion -- band hides
+  scene.update
+  RGSS::Input.triggered = []
+  ok scene.instance_variable_get(:@shop)[:party].nil?, 'hidden again for the Potion'
+end
+
 check 'Enemy Encounter scene: the result window shows the database Victory term' do
   ic = Game::Interpreter::Cmd
   db = fake_db


### PR DESCRIPTION
## Summary

- Closes cycle #145's own last-open lead: identified the equipment party band's icon via asset forensics against Nepheshel's own System graphic instead of further behavioral probing.
- Nepheshel's `System/システム.png` ships a genuinely corrupt IDAT stream (every chunk CRC matches, but the deflate stream itself has a back-reference before its own output start — a known old-RPG-Maker "buggy windowskin PNG" shape a strict zlib inflater rejects outright). Decoded cleanly through this project's own pre-existing tolerant inflater (`RGSS::Bitmap#inflate_tolerant` in `scripts/rgss_cruby_compat.rb`, already written for exactly this case but never exercised on this file), exposing an 8x8-celled icon grid never read before.
- Drove genuine RPG_RT.exe under Wine to the same live weapon-shop Buy list cycle #145 reached and found the mystery band's icon is a byte-for-byte match (modulo RGB565 quantization) for the System graphic's droplet cell at (128, 16), confirmed at the identical position across two different highlighted goods four rows apart.
- Added `SHOP_PARTY_ICON_SRC`/`SHOP_PARTY_ICON_OFFSET` constants; `#draw_shop_party` now blits the icon from `@windowskin` once at window creation, since it's static.
- Corrected the cycle #145 changelog fragment in place, since it explicitly noted the icon as not yet reproduced.
- **Deliberately still open**: what the icon semantically represents (its grid neighbors are unidentified), whether a multi-member party shows more than one copy, and two gaps cycle #144 first flagged (has_menu description-bar correctness, shop-list overflow behavior).
- Also documented a methodology finding for future wine-driving cycles: `xdotool windowactivate` silently no-ops on this sandbox's matchbox setup after RPG_RT recreates its window post-save-load — `xdotool windowfocus` is what actually restores key delivery.

No EasyRPG source was consulted at any point during this investigation.

## Test plan

- Confirmed the new check fails against the pre-fix code via `git stash push -- mruby-rpg2k/mrblib/scene/map.rb`, rerunning the suite, then `git stash pop`: **1 of 926 checks failed** (`RuntimeError: the equipment band now has drawn contents, not a bare frame`).
- All four suites green post-fix:
  - `ruby scripts/rpg2k_scene_check.rb` — 926 checks passed
  - `ruby scripts/rpg2k_logic_check.rb` — 1134 checks passed
  - `ruby scripts/rpg2k3_battle_row_check.rb` — 19 checks, 0 failures
  - `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15 checks, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_