### PR TITLE
psp: attribute the BRINGUP heartbeat to a scene, bracket mrb_open()'s cost

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1464,8 +1464,16 @@ jobs:
           # would have passed a build that never pumped a frame.
           if grep -q 'RPG2K_PSP_BOOT' "$GITHUB_WORKSPACE/headless.log" &&
              grep -q 'RPG2K_PSP_BRINGUP' "$GITHUB_WORKSPACE/headless.log"; then
-            grep -E 'RPG2K_PSP_(BOOT|BRINGUP)' "$GITHUB_WORKSPACE/headless.log" \
-              | head -5
+            # Every RPG2K_PSP_* marker, not just BOOT/BRINGUP: the
+            # PRE_MRUBY_OPEN/MRUBY_OPEN pair (mrb_open()'s own memory/timing
+            # cost, docs/adr/0047-psp-memory-budget.md) and GAME_START/
+            # GAME_READY/GAME_STOP are otherwise only visible by pulling the
+            # `psp-smoke` artifact's full headless.log, which needs GitHub API
+            # access this job's own log does not. -10 covers every one-shot
+            # marker (there are at most a handful) plus a few BRINGUP
+            # heartbeats.
+            grep -E 'RPG2K_PSP_[A-Z_]+' "$GITHUB_WORKSPACE/headless.log" \
+              | head -10
           else
             echo "boot or bring-up marker missing from the emulator log; last 100 lines:"
             tail -100 "$GITHUB_WORKSPACE/headless.log"

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -57,6 +57,7 @@
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/error.h>
+#include <mruby/string.h>
 #include <mruby/variable.h>
 #include <pspiofilemgr.h>
 #include <pspkernel.h>
@@ -113,6 +114,14 @@ class StrBuf {
   void str(const char* s) {
     while (*s && len_ + 1 < cap_)
       buf_[len_++] = *s++;
+  }
+
+  // Length-bounded variant for bytes that aren't a NUL-terminated C string --
+  // an mruby String's RSTRING_PTR/RSTRING_LEN, which mruby happens to
+  // NUL-terminate internally but which this call does not rely on.
+  void str(const char* s, size_t n) {
+    for (size_t i = 0; i < n && len_ + 1 < cap_; ++i)
+      buf_[len_++] = s[i];
   }
 
   void uint(unsigned v) {
@@ -458,6 +467,81 @@ void show_keys(uint64_t mask) {
   lv_label_set_text(g_status_label, sb.c_str());
 }
 
+// Appends " t_us=N free=N maxfree=N lvgl_used=N lvgl_max=N stack_free=N
+// stack_used_max=N arena_used=N" -- the figure tail every RPG2K_PSP_*
+// diagnostic marker in this file carries (see the BRINGUP heartbeat below for
+// what each field means; ADR 0047 is the budget these exist to measure
+// against). t_us is sceKernelGetSystemTimeLow() -- microseconds on the
+// console's own free-running clock (the same source mruby-rgss/src/psp.cxx's
+// LVGL tick callback uses), not wall-clock time or time-since-process-start:
+// subtract one marker's t_us from a later one's to get an elapsed duration
+// between them (mrb_open cost, load-to-title-screen cost, ...) without this
+// file needing to know or care what "now" means beyond that. stack_used_max
+// is a parameter rather than recomputed here because only the periodic
+// heartbeat tracks a running maximum across many samples -- a one-shot
+// marker's own high-water mark is just its single sample (see
+// append_mem_snapshot below, which fills that in for one-shot callers).
+void append_mem_fields(StrBuf& sb, int stack_free, unsigned stack_used_max) {
+  lv_mem_monitor_t mon;
+  lv_mem_monitor(&mon);
+  sb.str(" t_us=");
+  sb.uint(static_cast<unsigned>(sceKernelGetSystemTimeLow()));
+  sb.str(" free=");
+  sb.uint(static_cast<unsigned>(sceKernelTotalFreeMemSize()));
+  sb.str(" maxfree=");
+  sb.uint(static_cast<unsigned>(sceKernelMaxFreeMemSize()));
+  sb.str(" lvgl_used=");
+  sb.uint(static_cast<unsigned>(mon.total_size - mon.free_size));
+  sb.str(" lvgl_max=");
+  sb.uint(static_cast<unsigned>(mon.max_used));
+  sb.str(" stack_free=");
+  sb.sint(stack_free);
+  sb.str(" stack_used_max=");
+  sb.uint(stack_used_max);
+  sb.str(" arena_used=");
+  sb.uint(static_cast<unsigned>(mrb_arena_used()));
+}
+
+// Convenience for a one-shot marker (as opposed to the periodic BRINGUP
+// heartbeat, which tracks stack_used_max across many samples itself): samples
+// the main thread's stack once and reports that single sample as its own
+// high-water mark, since there is no earlier history to compare it against.
+void append_mem_snapshot(StrBuf& sb) {
+  const int stack_free = sceKernelGetThreadStackFreeSize(0);
+  const unsigned stack_used =
+      (stack_free >= 0 && static_cast<unsigned>(stack_free) <= kMainStackBytes)
+          ? kMainStackBytes - static_cast<unsigned>(stack_free)
+          : 0;
+  append_mem_fields(sb, stack_free, stack_used);
+}
+
+// Appends the active scene's class name ("RPG2k::Scene::Title",
+// "RPG2k::Scene::Map", ... for RPG2k; a project's own bundled script classes
+// for XP/VX, whatever they happen to be named) via each maker's
+// RPG2k#current_scene_name/RPGXP#current_scene_name/
+// RPGVX#current_scene_name (mruby-rpg2k, mruby-rpgxp, mruby-rpgvx mrblib) --
+// added alongside this file's own scene-agnostic markers so the BRINGUP
+// heartbeat can attribute its memory numbers to what the player was actually
+// looking at, not just a frame count. Appends "none" for no game running or
+// (defensively) the call itself raising -- a diagnostic marker must never be
+// the thing that aborts the frame loop. RSTRING_PTR/RSTRING_LEN are read and
+// copied out here, synchronously, rather than a raw pointer being handed back
+// to the caller -- mruby's GC gives no lifetime guarantee once the string
+// value itself is no longer reachable from this scope.
+void append_scene_name(StrBuf& sb, mrb_state* M, mrb_value game_obj) {
+  const mrb_value name = mrb_funcall(M, game_obj, "current_scene_name", 0);
+  if (M->exc) {
+    M->exc = nullptr;
+    sb.str("none");
+    return;
+  }
+  if (!mrb_string_p(name)) {
+    sb.str("none");
+    return;
+  }
+  sb.str(RSTRING_PTR(name), static_cast<size_t>(RSTRING_LEN(name)));
+}
+
 }  // namespace
 
 // Wires RGSS::_display (mruby-rgss/src/lib.cxx's get_display) to the LVGL
@@ -510,15 +594,34 @@ int main(void) {
   psp_input_init();
   build_ui();
 
+  // Baseline for "how much did mrb_open() itself cost": everything up to
+  // here (the HAL, LVGL, the display and its widgets) is already live, but no
+  // mruby allocation -- core VM state, the symbol table, or any gem's classes
+  // -- has happened yet, so arena_used is always 0 at this marker. Subtract
+  // this from RPG2K_PSP_MRUBY_OPEN's own free= (or add up arena_used, which
+  // is the more direct number: mrb_open() links every gem's mrblib in, the
+  // same "full gembox, no game loaded yet" state ADR 0047's Finding 1
+  // host-proxy measurement estimated at ~1.2-1.4 MB before a device number
+  // existed for it) to get mrb_open()'s real device cost.
+  {
+    char buf[256];
+    StrBuf sb(buf, sizeof(buf));
+    sb.str("RPG2K_PSP_PRE_MRUBY_OPEN");
+    append_mem_snapshot(sb);
+    sb.str("\n");
+    psp_write(buf, sb.length());
+  }
+
   // Open the interpreter and report whether it succeeded. `M` is kept alive
   // (never mrb_close()d) for the rest of the process, the same as every other
   // target's entry point.
   mrb_state* const M = mrb_open();
   {
-    char buf[48];
+    char buf[256];
     StrBuf sb(buf, sizeof(buf));
     sb.str("RPG2K_PSP_MRUBY_OPEN ");
     sb.str(M ? "ok" : "FAILED");
+    append_mem_snapshot(sb);
     sb.str("\n");
     psp_write(buf, sb.length());
   }
@@ -604,6 +707,23 @@ int main(void) {
     sb.str(game_start_result);
     sb.str("\n");
     psp_write(buf, sb.length());
+
+    // One-shot snapshot, only on a successful construction: the game object
+    // (database, map tree, and -- for RPG2k -- Scene::Title) is fully built,
+    // but the frame loop below has not run even once, so nothing has been
+    // drawn or updated yet. This is "memory right before the title screen"
+    // (docs/adr/0047-psp-memory-budget.md): everything the load itself cost,
+    // with none of the per-frame steady-state drift the BRINGUP heartbeat
+    // measures afterward.
+    if (have_game) {
+      char rbuf[256];
+      StrBuf rb(rbuf, sizeof(rbuf));
+      rb.str("RPG2K_PSP_GAME_READY ");
+      rb.str(game_info->class_name);
+      append_mem_snapshot(rb);
+      rb.str("\n");
+      psp_write(rbuf, rb.length());
+    }
   }
 
   // The loop runs ~200 iterations/second (5 ms delay); emit a heartbeat line
@@ -650,8 +770,6 @@ int main(void) {
       lv_timer_handler();
     }
     if (frame % 200 == 0) {
-      lv_mem_monitor_t mon;
-      lv_mem_monitor(&mon);
       // ADR 0047's P5. sceKernelGetThreadStackFreeSize scans the low (deep)
       // end of the thread's stack for the 0xFF fill pspsdk leaves there at
       // creation and reports how much of it is still untouched. Because a
@@ -670,24 +788,16 @@ int main(void) {
         if (used > stack_used_max)
           stack_used_max = used;
       }
-      char buf[192];
+      char buf[256];
       StrBuf sb(buf, sizeof(buf));
       sb.str("RPG2K_PSP_BRINGUP frame=");
       sb.uint(frame);
-      sb.str(" free=");
-      sb.uint(static_cast<unsigned>(sceKernelTotalFreeMemSize()));
-      sb.str(" maxfree=");
-      sb.uint(static_cast<unsigned>(sceKernelMaxFreeMemSize()));
-      sb.str(" lvgl_used=");
-      sb.uint(static_cast<unsigned>(mon.total_size - mon.free_size));
-      sb.str(" lvgl_max=");
-      sb.uint(static_cast<unsigned>(mon.max_used));
-      sb.str(" stack_free=");
-      sb.sint(stack_free);
-      sb.str(" stack_used_max=");
-      sb.uint(stack_used_max);
-      sb.str(" arena_used=");
-      sb.uint(static_cast<unsigned>(mrb_arena_used()));
+      sb.str(" scene=");
+      if (have_game)
+        append_scene_name(sb, M, game_obj);
+      else
+        sb.str("none");
+      append_mem_fields(sb, stack_free, stack_used_max);
       sb.str("\n");
       psp_write(buf, sb.length());
     }

--- a/changelog.d/psp-scene-memory-heartbeat.added.md
+++ b/changelog.d/psp-scene-memory-heartbeat.added.md
@@ -1,0 +1,18 @@
+- **PSP: the bring-up heartbeat now attributes memory to a scene, and two new
+  markers isolate `mrb_open()`'s own cost.** `app/psp/main.cxx`'s
+  `RPG2K_PSP_BRINGUP` heartbeat carries a `scene=` field (e.g.
+  `RPG2k::Scene::Title`) via a new `#current_scene_name` on `RPG2k`, `RPGXP`
+  and `RPGVX` (mruby-rpg2k, mruby-rpgxp, mruby-rpgvx mrblib), so a memory
+  snapshot can be attributed to what the player was looking at instead of
+  just a frame count. Two new one-shot markers bracket interpreter startup:
+  `RPG2K_PSP_PRE_MRUBY_OPEN` (right before `mrb_open()`, LVGL/display already
+  live) and the existing `RPG2K_PSP_MRUBY_OPEN` now also carries the same
+  memory figures, isolating what opening the interpreter (and defining every
+  gem's classes) costs on its own. A third, `RPG2K_PSP_GAME_READY`, fires
+  once a game's database/map-tree load and (for RPG2k) `Scene::Title`
+  construction finish, before the frame loop has run even once -- "memory
+  right before the title screen." Every marker with these figures now also
+  carries `t_us=` (`sceKernelGetSystemTimeLow()`), so any two markers'
+  timestamps subtract into an elapsed duration (`mrb_open()` cost,
+  load-to-title-screen cost, ...) without new profiling code. See
+  `docs/adr/0047-psp-memory-budget.md`.

--- a/changelog.d/psp-smoke-echo-all-markers.changed.md
+++ b/changelog.d/psp-smoke-echo-all-markers.changed.md
@@ -1,0 +1,9 @@
+- **CI: the `psp-smoke` job now echoes every `RPG2K_PSP_*` marker, not just
+  `BOOT`/`BRINGUP`.** The new `RPG2K_PSP_PRE_MRUBY_OPEN`/`RPG2K_PSP_MRUBY_OPEN`
+  (`mrb_open()`'s own memory/timing cost) and `GAME_START`/`GAME_READY`/
+  `GAME_STOP` markers were already written to `headless.log`, but the job's
+  own printed output only ever grepped `BOOT`/`BRINGUP` — seeing the others
+  meant pulling the full `psp-smoke` artifact, which needs direct GitHub API/
+  blob-storage access the job log itself does not. `.github/workflows/build.yml`
+  now greps `RPG2K_PSP_[A-Z_]+` (still gated on `BOOT`/`BRINGUP` both being
+  present, unchanged). See `docs/adr/0047-psp-memory-budget.md`.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -938,6 +938,36 @@ the interpreter-linking slice, in this order:
       would force the same one-time pthread/TLS bootstrap to happen in a
       controlled spot instead of wherever the first real exception happens
       to land.
+- **P1b — done, the BRINGUP heartbeat now attributes memory to a scene and
+  isolates `mrb_open()`'s own cost (2026-08-25).** The heartbeat could
+  already show *that* memory usage changed over a run, but not what caused
+  it -- no marker knew which scene was on screen, and `mrb_open()`'s own
+  footprint (Finding 1's ~1.2-1.4 MB host-proxy estimate) was folded into
+  whatever ran after it with no device-measured split. `RPG2K_PSP_BRINGUP`
+  now carries `scene=` (`RPG2k::Scene::Title`, `RPG2k::Scene::Map`, ... for
+  RPG2k; a project's own bundled script classes for XP/VX) via a new
+  `#current_scene_name` on `RPG2k`/`RPGXP`/`RPGVX` (mruby-rpg2k,
+  mruby-rpgxp, mruby-rpgvx mrblib -- RPG2k reads its own `@scenes` stack, XP/
+  VX delegate to `ScriptHost.current_scene`, already used by the desktop
+  cross-runtime probes for the same RGSS/RGSS2 `$scene` vs. RGSS3
+  `SceneManager.scene` split). Two new markers bracket `mrb_open()`:
+  `RPG2K_PSP_PRE_MRUBY_OPEN` (LVGL/display already live, no mruby allocation
+  yet -- `arena_used` is always 0 here) and the existing
+  `RPG2K_PSP_MRUBY_OPEN`, which now also carries the same figures, so the two
+  bracket exactly what opening the interpreter and defining every gem's
+  classes costs. `RPG2K_PSP_GAME_READY` fires once on successful game
+  construction, before the frame loop's first iteration -- "memory right
+  before the title screen," none of the per-frame steady-state drift the
+  periodic heartbeat measures afterward. Every marker with these figures now
+  also carries `t_us=` (`sceKernelGetSystemTimeLow()`, the same free-running
+  clock `mruby-rgss/src/psp.cxx`'s LVGL tick callback already uses), so any
+  two markers' timestamps subtract into an elapsed duration -- `mrb_open()`
+  cost, load-to-title-screen cost, or any other interval -- without new
+  profiling code. Still needs a real game at `kGameDir` to produce anything
+  beyond the idle path's own numbers (CI's `psp-smoke` job has none, same gap
+  P1's own "measure a real game" follow-up flagged); the `mrb_open()`-bracket
+  markers are the one pair that already fire on the idle path today, since
+  they run before `kGameDir` is even consulted.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -544,6 +544,19 @@ class RPG2k
   # answers a question, unlike the plain `test_play` value above.
   def hide_title?; @hide_title; end
 
+  # The active scene's class name ("RPG2k::Scene::Title", "RPG2k::Scene::Map",
+  # ... -- Class#name always returns the fully-qualified path), or
+  # "none" if the stack is somehow empty (never true after #initialize, which
+  # pushes Scene::Title before returning). Exposed so a native caller with no
+  # other window into this object's state can tag a diagnostic snapshot with
+  # what the player was looking at -- the PSP bring-up heartbeat
+  # (app/psp/main.cxx) uses this to attribute its per-second memory numbers to
+  # a scene instead of just a frame count; see
+  # docs/adr/0047-psp-memory-budget.md.
+  def current_scene_name
+    @scenes.empty? ? "none" : @scenes.last.class.name
+  end
+
   # RPG_RT.exe (and the RPG2000/2003 editor's own Test Play button) is launched
   # with bare positional words instead of --flag=value ones, e.g.
   # `Game.exe TestPlay HideTitle Window`. None of those look like a flag, so

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -134,6 +134,14 @@ class RPGVX
 
   attr_reader :db, :edition, :title
 
+  # The active scene's class name -- see RPGXP#current_scene_name
+  # (mruby-rpgxp/mrblib/lib.rb) for what this means and why; VX / VX Ace
+  # shares that engine's ScriptHost wholesale (@use_script_host above).
+  def current_scene_name
+    scene = RPGXP::ScriptHost.enabled? ? RPGXP::ScriptHost.current_scene : nil
+    scene ? scene.class.name : "none"
+  end
+
   # The edition's display name, for logs ("RPG Maker VX Ace").
   def maker_name
     @edition ? self.class.edition_name(@edition) : "RPG Maker VX"

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -65,6 +65,20 @@ class RPGXP
 
   attr_reader :db, :title
 
+  # The active scene's class name, mirroring RPG2k#current_scene_name
+  # (mruby-rpg2k/mrblib/main.rb) -- see there for why a native caller wants
+  # this. Unlike RPG2k's own @scenes stack, this engine runs the game's own
+  # bundled scripts (see the class comment above), so "the active scene" is
+  # whatever *they* publish -- ScriptHost.current_scene already resolves that
+  # across both real conventions (RGSS/RGSS2's `$scene`, RGSS3's
+  # `SceneManager.scene`; script_host.rb). "none" covers the script host being
+  # disabled, a project shipping no scripts, or the host simply not having
+  # reported a scene yet.
+  def current_scene_name
+    scene = ScriptHost.enabled? ? ScriptHost.current_scene : nil
+    scene ? scene.class.name : "none"
+  end
+
   # One frame of the game: one resume of the host's Fiber, which runs the
   # scripts' own loop up to their next Graphics.update. Both the desktop
   # `loop { main_loop }` and the web per-frame `emscripten_set_main_loop`


### PR DESCRIPTION
## Summary

- `RPG2K_PSP_BRINGUP` (the per-second PSP bring-up heartbeat, `app/psp/main.cxx`) now carries a `scene=` field via a new `#current_scene_name` on `RPG2k`/`RPGXP`/`RPGVX` (`mruby-rpg2k`, `mruby-rpgxp`, `mruby-rpgvx` mrblib) — RPG2k reads its own `@scenes` stack, XP/VX delegate to the existing `ScriptHost.current_scene` (already used by the desktop cross-runtime probes). This lets the heartbeat's memory numbers be attributed to what the player was actually looking at, not just a frame count.
- Two new markers bracket `mrb_open()`: `RPG2K_PSP_PRE_MRUBY_OPEN` (LVGL/display already live, no mruby allocation yet) and the existing `RPG2K_PSP_MRUBY_OPEN`, which now also carries the same memory figures — isolating what opening the interpreter (and defining every gem's classes) costs on its own, replacing ADR 0047 Finding 1's host-proxy estimate with a real device number once CI runs.
- `RPG2K_PSP_GAME_READY` fires once on successful game construction, before the frame loop has run even once — "memory right before the title screen" (the database/map-tree load and, for RPG2k, `Scene::Title` construction are done, but nothing has been drawn or updated yet).
- Every marker carrying these figures now also carries `t_us=` (`sceKernelGetSystemTimeLow()`, the same clock `mruby-rgss/src/psp.cxx`'s LVGL tick callback uses), so any two markers' timestamps subtract into an elapsed duration (`mrb_open()` cost, load-to-title-screen cost, ...).
- `docs/adr/0047-psp-memory-budget.md` and a changelog fragment updated to record this.

## Test plan

- [x] Rebuilt the `host` mruby target (`rake -f 3rd/mruby/Rakefile MRUBY_TARGET=host`, includes `mruby-rgss`/`mruby-rpg2k`/`mruby-rpgxp`/`mruby-rpgvx`) — compiles and links clean.
- [x] `pre-commit run clang-format` / `trailing-whitespace` / `end-of-file-fixer` / `check-added-large-files` on the changed files.
- [ ] Actual `psp` cross-build and `psp-smoke` device numbers (needs the `psp-gcc` pspdev toolchain, not available in this environment) — left to CI's `psp`/`psp-smoke` jobs. The `RPG2K_PSP_PRE_MRUBY_OPEN`/`RPG2K_PSP_MRUBY_OPEN` pair already fires on `psp-smoke`'s existing idle path (no game needed), so real `mrb_open()` numbers should be pullable straight from this PR's CI log. `RPG2K_PSP_GAME_READY` and a non-`none` `scene=` still need a real game placed at `kGameDir`, which `psp-smoke` doesn't do yet — a separate follow-up.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt


---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_