### PR TITLE
Shop screen: scroll the goods list past 7 rows instead of growing the window

### DIFF
--- a/changelog.d/shop-goods-list-scrolls.fixed.md
+++ b/changelog.d/shop-goods-list-scrolls.fixed.md
@@ -1,0 +1,5 @@
+- **Shop screen:** a goods list longer than 7 items now scrolls one row at a
+  time as the cursor passes the bottom of the visible page, matching RPG_RT
+  — the list window itself never moves or grows. Previously the window grew
+  to fit every good on screen at once, pushing through the fixed-position
+  prompt bar below it for any shop stocking more than a handful of goods.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1970,6 +1970,96 @@ The work below is roughly ordered by the critical path to a walkable game
   correctness on the native `:command` has_menu screen, and real RPG_RT's
   behaviour once a shop's goods list exceeds the list window's fixed
   minimum capacity).
+  ✅ **Follow-up (cycle #147, 2026-08-25): closed cycle #144's other last-open
+  shop gap -- real RPG_RT's own behaviour once a shop's goods list exceeds
+  the list window's fixed minimum capacity. It scrolls, one row at a time,
+  and the window itself never moves or grows; this codebase's own
+  `#draw_shop` did the opposite (grew the window to fit every good at once,
+  pushing straight through the now-fixed-position prompt bar below it for
+  any shop with more than a handful of goods), now fixed.** Nepheshel's own
+  weapon shop (`Map0015.lmu` event 2, `武器屋の親父` -- the same NPC cycles
+  #145/#146 used) stocks 30 real goods, well past the 7-row list cycle #144
+  measured, and needed no synthetic event editing to reach: `--map 15 --at
+  5,9 --facing up --clear-scene` stands the party at the counter, same as
+  those two cycles.
+  Drove genuine RPG_RT.exe under wine (Xvfb 640x480x16,
+  `LIBGL_ALWAYS_SOFTWARE=1`, matchbox-window-manager, `LANG=ja_JP.UTF-8`)
+  through the NPC's own greeting and Show Choices menu into the live Buy
+  list, then `Down` through the whole 30-good list, screenshotting at every
+  boundary that could distinguish "scrolls" from "grows": the first page
+  (goods 1..7, ダガー/Dagger highlighted), the last row of that page (goods
+  1..7 still, ファルシオン/Falchion highlighted, cursor at row 7 -- still
+  nothing has to move yet), one more `Down` past it (the decisive frame),
+  and the very last (30th) good (サーキュレット/Circlet). At the decisive
+  frame the top good (ダガー) dropped off the list and the newly-revealed
+  8th good (ハンマーヘッド/Hammerhead) appeared at the bottom -- still
+  exactly 7 rows shown, not 8. A raw-pixel column scan (Python/Pillow, not
+  eyeballed) of the list window's own bottom border at native x=50 found it
+  byte-identical across all three of these captures (first page, scrolled
+  page, last good) -- the window's own bottom edge sits at the same
+  screen position regardless of scroll depth or list length, direct
+  boundary-case evidence for "scrolls, fixed size" over "grows to fit"
+  across a 1..30-good range (1-good tested by cycle #144, 7-good by cycle
+  #144, 8..30-good boundary by this cycle).
+  One more finding worth flagging: `shop_list_min_inner_h`'s own 114px
+  native content height has room for an 8th 14px row with 2px to spare by
+  naive division (114 / 14 = 8), but RPG_RT only ever shows 7 -- confirmed
+  by directly cropping the list interior below the 7th row in the
+  unscrolled capture, which shows genuine unused blank space, not a
+  clipped or partial 8th line. So the per-page row count is its own fixed
+  constant, not derivable from the window's own pixel height, which is why
+  the fix adds `SHOP_LIST_ROWS = 7` as a named constant rather than
+  computing it from `shop_list_min_inner_h`.
+  Fixed `mruby-rpg2k/mrblib/scene/map.rb`: new `SHOP_LIST_ROWS` constant
+  (7, see above); `#draw_shop` now tracks `@shop[:scroll]` (the index of
+  the first visible good), nudged by the minimum amount needed to keep
+  `@shop[:index]` (the cursor) inside the visible `SHOP_LIST_ROWS`-row page
+  -- matching every other RPG2000 list window's own "scroll just far enough
+  to reveal the cursor" behaviour rather than snapping to a page boundary --
+  and renders only `lines[@shop[:scroll], SHOP_LIST_ROWS]` instead of every
+  good at once, with the cursor rect offset by the scroll so it still lands
+  on the right row. The window's own height stays `shop_list_min_inner_h`
+  unconditionally now (previously `[row_h, shop_list_min_inner_h].max`,
+  which grew past the minimum for any list longer than it could hold before
+  this fix capped the rendered row count). `#shop_switch` resets
+  `@shop[:scroll]` to 0 alongside `@shop[:index]` on every fresh Buy/Sell
+  browse, so re-entering a list after cancelling out of it (leaving it
+  scrolled deep in) opens back at the top, not mid-scroll. `open_shop`'s
+  initial `@shop` hash gained the `scroll: 0` key for consistency with its
+  siblings. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+  synthetic buy+sell shop with 10 goods, past `SHOP_LIST_ROWS`): asserts
+  the window's `y`/`height` are identical at the first page, the last row
+  of the first page, the decisive one-`Down`-further frame, and the last
+  (10th) good, while the *visible text* changes at each of those points the
+  way the pixel evidence above says it should (goods 1..7, then 2..8 after
+  the scroll, then 4..10 at the end) -- plus the fresh-browse reset,
+  confirmed to fail against the pre-fix code (`git stash` of `map.rb` only)
+  with `RuntimeError: eighth good not yet on screen` (`1 of 927 checks
+  FAILED`) before the fix, since the pre-fix window drew all ten goods on
+  the very first frame. Full suite reconfirmed passing (927 checks, up from
+  926); `rpg2k_render_check.rb` (41) and `rpg2k_logic_check.rb` (1134)
+  reconfirmed passing unaffected. **Not independently verified this
+  cycle**: the fix only against the mruby build (this project's own two-leg
+  verification model, ADR 0021 -- the CRuby scene-check suite plus a live
+  wine capture of the *reference* runtime) -- the mruby build itself could
+  not be exercised this cycle, a pre-existing environment gap unrelated to
+  this change (`mruby-lcf`'s codegen step reads a `$cp932_table` env var
+  that is only set inside this project's nix shell / CI, and this sandbox's
+  plain `cmake --build` has neither), so `--rpg2k_continue`/
+  `--rpg2k_new_game`-style engine-binary confirmation of this specific fix
+  is left to whichever environment has that table available. `Save01.lsd`
+  (position/facing only, via the same `gen-rpg2k-save.rb --map 15 --at 5,9
+  --facing up --clear-scene` recipe cycles #145/#146 used) was the only
+  game-data file touched by any probe this cycle, restored to its original
+  bytes (`md5sum`-confirmed: `3ab5bb01e0914663442e1973dc335596`) and the
+  canonical debug save reconfirmed clean by `scripts/lcf_save_check.rb`
+  (map 12, (40,15), scene cleared, unchanged) afterward.
+  **Still open**: the last remaining gap cycle #144 first flagged --
+  whether the description bar (and the list's own `SHOP_DESC_H`-anchored
+  position) is correct on the native `:command` has_menu screen
+  specifically, which still needs a *synthetic* Open Shop command with the
+  has_menu flag set, since no Nepheshel NPC exercises that path (candidate
+  1 from this cycle's own task list, not attempted this cycle).
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5272,7 +5272,7 @@ class RPG2k
         has_menu = req[:allow_buy] && req[:allow_sell]
         screen = has_menu ? :command : (req[:allow_buy] ? :buy : :sell)
         @shop = { model: model, has_menu: has_menu, screen: screen, index: 0,
-                  cmd_index: 0, window: nil, gold: build_shop_gold_window,
+                  scroll: 0, cmd_index: 0, window: nil, gold: build_shop_gold_window,
                   status: nil, party: nil, desc: nil, prompt: nil,
                   terms: shop_terms(req[:type]), browsed: false,
                   interp: it }
@@ -5400,19 +5400,13 @@ class RPG2k
         end
       end
 
-      # The list's own fixed minimum content height -- confirmed against
+      # The list window's own fixed content height -- confirmed against
       # genuine RPG_RT.exe under wine (cycle #144): a 7-good Buy list and a
       # single-good Sell list both left the list window's own bottom border
       # at the identical native y (flush against the prompt bar below it,
       # see #draw_shop_prompt), rather than shrinking to fit either list's
       # actual row count the way this file used to draw it -- direct evidence
-      # the box is a fixed size, not content-sized, for at least this range
-      # (1..7 rows). `[content, SHOP_LIST_MIN_INNER_H].max` keeps a longer
-      # list (more goods than this constant reserves room for) from being
-      # clipped, since real RPG_RT's own behaviour past that point (does it
-      # scroll? does the window itself grow?) was not reachable with any
-      # shop this codebase's own test bed (Nepheshel) ships and is left
-      # unverified -- see the cycle #144 docs/TODO.md entry.
+      # the box is a fixed size, not content-sized.
       #
       # A method, not a constant, purely because MSG_WIN_H/MSG_WIN_W (the
       # ordinary map message window's own shape, #draw_shop_prompt reuses
@@ -5424,9 +5418,50 @@ class RPG2k
         SCREEN_H - SHOP_DESC_H - MSG_WIN_H - Window::BORDER * 2
       end
 
+      # How many goods the list shows at once before it scrolls -- confirmed
+      # against genuine RPG_RT.exe under wine (cycle #147, closing cycle
+      # #144's own last-open shop question): Nepheshel's own weapon shop
+      # (`Map0015.lmu` event 2, `武器屋の親父`) stocks 30 real goods, well
+      # past the 7-row list cycle #144 measured. Driving its live Buy list
+      # from the first good (ダガー/Dagger) down to the 8th (ハンマーヘッド/
+      # Hammerhead, one `Down` past the 7th) found RPG_RT still shows exactly
+      # 7 rows -- the top row (ダガー) drops off and the new 8th good appears
+      # at the bottom -- **not** an 8-row (or taller) window, even though
+      # `shop_list_min_inner_h`'s own 114px native height has room for an 8th
+      # 14px row with 2px to spare by naive division. A raw-pixel column
+      # scan (Python/Pillow) of the list window's own bottom border (native
+      # x=50, y=152..162, spanning the row just inside the border and the
+      # border itself) came back byte-identical across the
+      # first page (index 0..6), the first scrolled page (index 7, i.e. rows
+      # 2..8) and the very last good (index 29, `Map0015`'s own 30th and
+      # final good, サーキュレット/Circlet) -- the window never moves or
+      # resizes at any of the three; only which 7 goods (and which one is
+      # highlighted) changes. So real RPG_RT reserves room for 7 rows and
+      # leaves the remaining ~16px of the fixed 114px content height
+      # unused rather than fitting an 8th row into it -- a fixed row *count*,
+      # not a derived one, which is why this is its own named constant
+      # instead of `shop_list_min_inner_h / SHOP_LINE_H` (that division
+      # rounds down to 8, one row more than RPG_RT actually shows).
+      SHOP_LIST_ROWS = 7
+
       def draw_shop
         lines = shop_lines
         @shop[:index] = Game.clamp(@shop[:index], 0, [lines.length - 1, 0].max)
+        # Scroll the fixed SHOP_LIST_ROWS-tall window instead of growing it
+        # past that -- confirmed against genuine RPG_RT.exe under wine
+        # (cycle #147, see SHOP_LIST_ROWS' own comment for the full
+        # evidence). `@shop[:scroll]` is the index of the first *visible*
+        # good; nudged by the minimum amount needed to keep the cursor
+        # (`@shop[:index]`) inside the visible page, matching every other
+        # RPG2000 list window's own "scroll just far enough to reveal the
+        # cursor" behaviour rather than snapping to a page boundary.
+        @shop[:scroll] ||= 0
+        @shop[:scroll] = @shop[:index] if @shop[:index] < @shop[:scroll]
+        if @shop[:index] > @shop[:scroll] + SHOP_LIST_ROWS - 1
+          @shop[:scroll] = @shop[:index] - SHOP_LIST_ROWS + 1
+        end
+        @shop[:scroll] = Game.clamp(@shop[:scroll], 0, [lines.length - SHOP_LIST_ROWS, 0].max)
+        visible = lines[@shop[:scroll], SHOP_LIST_ROWS] || []
         # Docks flush to the screen's left edge, not inset 10px -- the same
         # stale anti-pattern ADR 0021 already diagnosed and fixed for the
         # message window ("300px wide, inset 10px" -> "fixed 320x80 at
@@ -5439,8 +5474,15 @@ class RPG2k
         # offset from the screen's right edge.
         win_w = SHOP_PANELS_VISIBLE_ON.include?(@shop[:screen]) ? SCREEN_W - SHOP_STATUS_W - 6 : SCREEN_W
         inner_w = win_w - Window::BORDER * 2
-        row_h = [lines.length, 1].max * SHOP_LINE_H
-        inner_h = [row_h, shop_list_min_inner_h].max
+        # Always the same fixed height -- never content-sized, whether the
+        # list is short (cycle #144's single-good Sell list) or long enough
+        # to scroll (cycle #147's 30-good Buy list): #shop_list_min_inner_h
+        # already exceeds SHOP_LIST_ROWS * SHOP_LINE_H, so this is really
+        # just `shop_list_min_inner_h` now that the row count rendered can
+        # never exceed SHOP_LIST_ROWS -- kept as a `max` for clarity, not
+        # because the two branches still differ.
+        inner_h = [visible.length, 1].max * SHOP_LINE_H
+        inner_h = [inner_h, shop_list_min_inner_h].max
         @shop[:window].dispose if @shop[:window]
         # Top-anchored right below the description bar (#draw_shop_desc), not
         # bottom-anchored above a 6px screen margin -- confirmed against
@@ -5453,12 +5495,13 @@ class RPG2k
         win.windowskin = @windowskin
         c = Bitmap.new(inner_w, inner_h)
         c.font.color = Color.new(255, 255, 255, 255)
-        lines.each_with_index do |(label, _), i|
+        visible.each_with_index do |(label, _), i|
           c.draw_text 0, i * SHOP_LINE_H, inner_w, SHOP_LINE_H, label
         end
         win.contents = c
         unless lines.empty?
-          win.cursor_rect = Rect.new(0, @shop[:index] * SHOP_LINE_H, inner_w, SHOP_LINE_H)
+          cursor_row = @shop[:index] - @shop[:scroll]
+          win.cursor_rect = Rect.new(0, cursor_row * SHOP_LINE_H, inner_w, SHOP_LINE_H)
         end
         @shop[:window] = win
         draw_shop_gold
@@ -5950,6 +5993,13 @@ class RPG2k
         @shop[:cmd_index] = @shop[:index] if @shop[:screen] == :command
         @shop[:screen] = screen
         @shop[:index] = screen == :command ? (@shop[:cmd_index] || 0) : 0
+        # A fresh browse also starts scrolled to the top -- #draw_shop only
+        # ever nudges @shop[:scroll] forward to follow the cursor, so without
+        # this a screen re-entered after scrolling deep into a long list
+        # (e.g. cancelling out of Buy back to the command menu, then back
+        # into Buy) would still open scrolled down instead of showing goods
+        # 1..SHOP_LIST_ROWS the way a fresh Buy/Sell always does.
+        @shop[:scroll] = 0
         draw_shop
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16177,6 +16177,105 @@ check 'Open Shop scene: the equipment party band blits the measured System-' \
   ok scene.instance_variable_get(:@shop)[:party].nil?, 'hidden again for the Potion'
 end
 
+# Follow-up (cycle #147, 2026-08-25): closed cycle #144's other last-open shop
+# gap -- what real RPG_RT does once a shop's own goods list exceeds the list
+# window's fixed minimum capacity. Confirmed against genuine RPG_RT.exe under
+# wine (Nepheshel's own 30-good weapon shop, Map0015 event 2): the window
+# scrolls, one row at a time as the cursor passes its bottom edge, and never
+# grows -- see `Scene::Map::SHOP_LIST_ROWS`'s own doc comment for the full
+# pixel evidence (a corner-marker scan of the list window's own bottom border
+# came back byte-identical at the first page, the first scrolled page, and
+# the very last of the 30 goods).
+check 'Open Shop scene: a goods list past SHOP_LIST_ROWS scrolls, never grows ' \
+      'the list window' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  ids = (20..29).to_a # 10 goods -- past SHOP_LIST_ROWS (7)
+  ids.each_with_index { |id, i| db.item[id] = OpenStruct.new(name: "Sword#{i}", price: 100 + i) }
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, *ids], indent: 0)] # buy+sell
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the command menu opens (mode 0: buy+sell)
+  eq :command, scene.instance_variable_get(:@shop)[:screen]
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Buy (first row)
+  scene.update
+  RGSS::Input.triggered = []
+
+  map_mod = RPG2k::Scene::Map
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen]
+  eq 10, shop[:model].goods.length, 'all ten goods are real, just more than one page shows'
+  win0 = shop[:window]
+  fixed_y, fixed_h = win0.y, win0.height
+  eq map_mod::SHOP_DESC_H, fixed_y
+  texts = window_texts(win0)
+  ok texts.any? { |t| t.include?('Sword0') }, 'first good visible'
+  ok texts.any? { |t| t.include?('Sword6') }, 'seventh good (last of the first page) visible'
+  ok !texts.any? { |t| t.include?('Sword7') }, 'eighth good not yet on screen'
+  eq 0, shop[:scroll], 'scrolled to the top on a fresh browse'
+
+  6.times do # move the cursor down through the first page's own 6 remaining rows
+    RGSS::Input.triggered = [RGSS::Input::DOWN]
+    scene.update
+    RGSS::Input.triggered = []
+  end
+  shop = scene.instance_variable_get(:@shop)
+  eq 6, shop[:index], 'cursor on the seventh good, still the last row of the first page'
+  eq 0, shop[:scroll], 'still no scroll -- the cursor has not yet passed the visible page'
+  win6 = shop[:window]
+  eq fixed_y, win6.y, "the window hasn't moved just from filling its first page"
+  eq fixed_h, win6.height, "...or grown"
+
+  # The decisive boundary: one more Down, past the 7th (last visible) row.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq 7, shop[:index], 'cursor on the eighth good'
+  eq 1, shop[:scroll], 'the window scrolled down exactly one row to follow it'
+  win7 = shop[:window]
+  eq fixed_y, win7.y, 'the window did not move down the screen'
+  eq fixed_h, win7.height, 'the window did not grow -- this is the cycle #144 gap this closes'
+  texts = window_texts(win7)
+  ok !texts.any? { |t| t.include?('Sword0') }, 'the first good scrolled off the top'
+  ok texts.any? { |t| t.include?('Sword7') }, 'the eighth good scrolled onto the bottom'
+
+  # Drive to the very last good (index 9) and confirm the window is still
+  # exactly the same box, with the scroll clamped so the last page is full.
+  2.times do
+    RGSS::Input.triggered = [RGSS::Input::DOWN]
+    scene.update
+    RGSS::Input.triggered = []
+  end
+  shop = scene.instance_variable_get(:@shop)
+  eq 9, shop[:index], 'cursor on the tenth (last) good'
+  eq 3, shop[:scroll], 'scroll clamped to 10 - SHOP_LIST_ROWS, so the last page is full'
+  win_last = shop[:window]
+  eq fixed_y, win_last.y
+  eq fixed_h, win_last.height
+  texts = window_texts(win_last)
+  ok texts.any? { |t| t.include?('Sword9') }, 'the last good is visible'
+  ok texts.any? { |t| t.include?('Sword3') }, 'and the page is full seven rows (goods 4..10)'
+  ok !texts.any? { |t| t.include?('Sword2') }, 'not goods before that -- exactly one page'
+
+  # Cancelling back to the command menu and re-entering Buy resets the scroll
+  # to the top, matching every other RPG2000 list window's own fresh-browse
+  # behaviour (the same rule #shop_switch already applied to @shop[:index]).
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.triggered = []
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Buy again
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen]
+  eq 0, shop[:scroll], 'a fresh browse starts scrolled to the top again'
+  eq 0, shop[:index]
+end
+
 check 'Enemy Encounter scene: the result window shows the database Victory term' do
   ic = Game::Interpreter::Cmd
   db = fake_db


### PR DESCRIPTION
## Summary
- RPG_RT scrolls a shop's goods list one row at a time as the cursor passes the visible page, keeping the list window's own size and position fixed — this codebase instead grew the window to fit every good at once, pushing through the fixed-position prompt bar below it for any shop stocking more than a handful of goods.
- Adds `Scene::Map::SHOP_LIST_ROWS` (7) and `@shop[:scroll]` tracking in `#draw_shop`, reset on every fresh Buy/Sell browse via `#shop_switch`.
- Closes the last open question from cycle #144's shop-screen work (docs/TODO.md).

## Verification
- Confirmed against genuine RPG_RT.exe under wine using Nepheshel's own 30-good weapon shop (`Map0015.lmu` event 2). A raw-pixel column scan of the list window's own bottom border came back byte-identical across the first page, the first scrolled page, and the last of the 30 goods — the window never moves or resizes, only which 7 goods are visible.
- New `scripts/rpg2k_scene_check.rb` check confirmed to fail against pre-fix code (`RuntimeError: eighth good not yet on screen`) via `git stash` of the source fix only, then pass after restoring it.
- All check suites pass: `rpg2k_scene_check.rb` 927/927 (up from 926), `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1134/1134, `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- Not independently verified against the mruby engine binary this cycle — a pre-existing, unrelated environment gap (`mruby-lcf`'s codegen needs `$cp932_table`, only set inside this project's nix shell/CI). Noted in the docs/TODO.md entry.
- No EasyRPG Player source was consulted for this fix.

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 927/927
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1134/1134
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Pre-fix regression proof via `git stash` of `map.rb`


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_