### PR TITLE
Shop screen: the native command menu draws its choices in the prompt window

### DIFF
--- a/changelog.d/shop-command-menu-blank-list.fixed.md
+++ b/changelog.d/shop-command-menu-blank-list.fixed.md
@@ -1,0 +1,8 @@
+- **Shop screen:** the native Buy/Sell/Leave command menu (shown when an
+  Open Shop event allows both buying and selling) now matches RPG_RT's real
+  layout — the description bar and goods-list window are still drawn, but
+  both stay blank, and the Buy/Sell/Leave choices themselves render merged
+  into the bottom prompt window below the shopkeeper's greeting, the same
+  way this codebase's own Inn Accept/Cancel prompt already works.
+  Previously the command choices were drawn into the goods-list window
+  itself, a screen real RPG_RT never puts them on.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2060,6 +2060,184 @@ The work below is roughly ordered by the critical path to a walkable game
   specifically, which still needs a *synthetic* Open Shop command with the
   has_menu flag set, since no Nepheshel NPC exercises that path (candidate
   1 from this cycle's own task list, not attempted this cycle).
+  ✅ **Follow-up (cycle #148, 2026-08-25): closed the last remaining shop
+  gap cycle #144 first flagged and cycles #145-147 each left untouched --
+  the native `:command` has_menu screen (Buy/Sell/Leave choice menu, shown
+  when an Open Shop command allows both buying and selling). No Nepheshel
+  NPC exercises this path (every real shop NPC in the game scripts its own
+  Buy/Sell/Cancel via Show Choices instead, per cycle #144's own finding),
+  so this needed a genuinely *synthetic* Open Shop command -- built via a
+  new, reusable technique (LCF map-file injection with the CRuby-loadable
+  `mruby-lcf/mrblib` schema itself, not a scratch reimplementation): a
+  scratch Ruby script (`LCF::MapUnit`, `LCF::Array1D`/`Array2D` built via
+  their own from-scratch constructors, `LCF::Schema::MAP_UNIT`/`MAP_EVENT`/
+  `MAP_EVENT_PAGE`) that adds one brand-new event (id 90, previously unused)
+  to a copy of `Map0012.lmu` -- an unconditional, trigger-3 (autostart)
+  single page whose own event-command list is a single synthetic Open Shop
+  command (10720, `mode=0` so `allow_buy && allow_sell`, `type=0`, goods
+  `[3, 5]` -- real Nepheshel item ids, the same params shape
+  `scripts/rpg2k_scene_check.rb`'s own synthetic buy+sell checks already
+  use) followed by the **genuine** 89-command event-command list copied
+  verbatim off `Map0478.lmu` event 2 page 2 (the same real "long tail"
+  cycles #130-147 have repeatedly spliced their own synthetic autostart
+  probes onto, to sidestep the still-unexplained short-synthetic-page crash
+  tracked since cycle #135/#137/#139/#143 -- kept unchanged as a length/
+  safety margin here too, though this cycle's own probe never needed to run
+  past the Open Shop command it suspends on). Verified round-trip-safe
+  before touching genuine game data: every one of Map0012's 21 pre-existing
+  events re-serialised byte-identical (`to_lcf` compared entry-by-entry)
+  after adding the new one, the modified file re-parses and re-saves
+  idempotently, and `scripts/lcf_testbed_check.rb` re-confirmed all 543
+  maps (11363 events, up from 11362) still parse cleanly. `Map0012.lmu` was
+  the only game-data file edited (byte-diffed against a fresh backup, not
+  assumed); `Save01.lsd` was untouched this cycle -- the canonical debug
+  save already sits on map 12 (40,15), scene cleared (confirmed via
+  `scripts/lcf_save_check.rb` before touching anything), which is exactly
+  where an autostart event needs the party to be. Both restored to their
+  original bytes after every probe (`md5sum`-confirmed against the values
+  cycle #147 itself recorded: `c2fa69a0...` / `3ab5bb01...`), and
+  `scripts/lcf_testbed_check.rb`/`scripts/lcf_save_check.rb` reconfirmed
+  clean afterward.
+  Drove genuine RPG_RT.exe under wine (Xvfb 640x480x16,
+  `LIBGL_ALWAYS_SOFTWARE=1`, matchbox-window-manager, `LANG=ja_JP.UTF-8`,
+  `xdotool windowfocus` per cycle #146's own methodology note) through
+  Continue -> file 1 -> the autostart's own Open Shop command, landing
+  directly on the `:command` screen (no NPC interaction needed -- autostart
+  fires the instant the map loads). A raw-pixel border-color column scan
+  (Python/Pillow, not eyeballed, native x=4) found **three** real, separate
+  bordered windows stacked top to bottom -- not two windows plus a hidden
+  gap, the shape this codebase's own code assumed going in: the description
+  bar (native y=0..~31, matching `SHOP_DESC_H`), the goods-list window
+  (native y=~32..~154, matching the existing `SHOP_DESC_H`-anchored
+  position and `shop_list_min_inner_h` geometry), and the bottom prompt
+  window (native y=~154..~234, matching the existing `MSG_WIN_H`-anchored
+  position) -- all three at *exactly* the same native geometry cycles
+  #144-147 already measured for the Buy/Sell screens, confirming the extra
+  command menu shifts nothing. Two of those three, however, turned out
+  **blank** rather than absent: a pixel-color scan of the description bar's
+  own interior found only smooth background-gradient colours (18 distinct
+  shades, each a large contiguous run -- zero glyph-coloured pixels), and
+  the goods-list window's interior was identically blank -- confirmed
+  across all three command rows in turn (Buy/Sell/Leave each screenshotted
+  highlighted, by pressing `Down` and re-capturing) that neither window
+  ever gains content on this screen, not merely on its first frame. This
+  falsifies cycle #144's own inference (guessed, never tested: "hidden only
+  on the command menu") for the description bar -- it is *shown*, just with
+  no text -- and reveals a genuine, previously-unknown defect in how this
+  codebase drew the goods-list window on `:command`: the current code drew
+  the Buy/Sell/Leave labels *into* that list window (`draw_shop`'s own
+  `visible`/cursor-rect handling, driven by `shop_lines`), a screen real
+  RPG_RT never puts them on at all.
+  Where real RPG_RT actually draws them, a glyph-row pixel scan of the
+  bottom prompt window found decisively: merged directly beneath the
+  greeting/regreeting line, inside the *same* `MSG_WIN_W x MSG_WIN_H`
+  window -- the greeting text plus three selectable rows (visible,
+  cursor-highlighted, and confirmed live to move with `Down`/track the
+  correct row and to persist the regreeting-vs-greeting distinction cycle
+  #144 already modelled) at a measured **16-native-pixel** row pitch, not
+  the shop list's own 14px `SHOP_LINE_H`/`INN_LINE_H` -- i.e. this is built
+  from the ordinary *message* window's own `MSG_LINE_H` text metric, not
+  the shop list's. This is the exact same "message text with a choice list
+  attached directly beneath it" shape this codebase's own Show Inn prompt
+  already implements for its own Accept/Cancel pair
+  (`#open_inn_window`/`#set_inn_cursor`), and the same shape Nepheshel's own
+  choice-scripted shop NPCs build by hand via Show Message + Show Choices
+  (cycle #144's own finding) -- strong, convergent evidence that RPG_RT's
+  native has_menu screen is not a bespoke "shop command window" at all, but
+  literally the same message-plus-attached-choice-list primitive reused.
+  Backed out of the command menu (`B`) to confirm the regreeting swap and
+  cursor persistence (cycle #144/#146's own already-modelled behaviour)
+  still held with the fix's own new rendering path, then advanced into Buy
+  (`z`, not `Return` -- cycle #145's own keyboard-binding finding, `Return`
+  still confirmed inert on this map/build) to directly re-confirm the
+  ordinary Buy list (goods 3/5, real descriptions and prices) renders
+  exactly as cycles #144-147 already established, with the extra command
+  menu in front changing nothing about it.
+  Fixed `mruby-rpg2k/mrblib/scene/map.rb`: `draw_shop`'s list-window content
+  is now `[]` (blank, no cursor) whenever `@shop[:screen] == :command`,
+  instead of `shop_lines`' own three command rows -- the cursor-rect guard
+  changed from `unless lines.empty?` to `unless visible.empty?` so it stays
+  suppressed on `:command` without disturbing any other screen (`visible`
+  and `lines` coincide there already). `SHOP_DESC_VISIBLE_ON` now includes
+  `:command`, and `draw_shop_desc` no longer treats a `nil` id as "dispose
+  the window" -- it always builds/keeps the window open once the shop is,
+  drawing the highlighted good's description when there is one and an empty
+  string otherwise, so the description bar is visible-but-blank on
+  `:command` (confirmed) and, by the same now-unified rule, on an empty
+  Buy/Sell list too (an extension by inference -- that specific case is
+  still not reachable through any known genuine shop and remains untested
+  either way, flagged in the method's own doc comment same as before).
+  `draw_shop_prompt` now dispatches to a new `#draw_shop_command_prompt` on
+  `:command`, which draws the greeting/regreeting line plus the three
+  command rows (from `shop_lines`, reusing its existing terms/ordering
+  unchanged) into the one prompt window at `MSG_LINE_H` spacing, with
+  `cursor_rect` at row `1 + @shop[:index]` (offset by the one greeting
+  line, mirroring `#set_inn_cursor`'s identical "greeting lines then choice
+  rows" offset pattern) -- every other screen's `#draw_shop_prompt` path is
+  untouched. Covered by three changes to `scripts/rpg2k_scene_check.rb`:
+  the existing "description bar" check's own `:command` assertion flipped
+  from "window is nil" to "window exists, draws only an empty string"; the
+  existing "shopkeeper terms" check's own command-row-labels assertion
+  moved from reading `shop[:window]` to reading `shop[:prompt]` (plus a new
+  assertion that `shop[:window]` draws nothing at all on `:command`); and a
+  new check driving the command cursor through all three rows, asserting
+  the prompt window's own fixed geometry, `MSG_LINE_H`-spaced `cursor_rect`
+  position at each row, and that the list window's `cursor_rect` stays at
+  its all-zero default throughout -- all three confirmed to fail against
+  the pre-fix code (`git stash` of `map.rb` only) with exactly these
+  errors: `RuntimeError: the command row labels use the database terms, in
+  the prompt window`, `RuntimeError: expected 16, got 0 (row 0 (Buy)
+  selected...)`, and `RuntimeError: the description bar is a real window on
+  the command menu too, just blank -- not hidden` (`3 of 928 checks
+  FAILED`) -- not a vacuous pass on either side. Full suite reconfirmed
+  passing (928 checks, up from 927); `rpg2k_render_check.rb` (41),
+  `rpg2k_logic_check.rb` (1134), `rpg2k3_battle_row_check.rb` (19) and
+  `rpg2k3_battle_gauge_check.rb` (15) all reconfirmed passing unaffected.
+  **Also independently verified against the mruby build itself this
+  cycle** -- the environment gap prior cycles kept hitting
+  (`mruby-lcf`'s codegen step reading `$cp932_table`/`$jis0208_table` from
+  outside the nix shell/CI) turned out avoidable without nix after all: the
+  two Unicode mapping tables the flake fetches are the same two files
+  `scripts/native-build-without-nix.bash` already downloads and pins by
+  hash for exactly this situation, so fetching them by hand and exporting
+  the two env vars let `cmake --build build --target rpg_maker_clone` (this
+  session's pre-existing, partially-configured `build/` directory) complete
+  cleanly. Ran the resulting `./build/rpg_maker_clone --game_dir ...
+  --test_play --rpg2k_continue` under its own headless Xvfb/matchbox
+  session against the *same* injected Map0012/Save01, and screenshot-
+  compared its own `:command` screen against the genuine RPG_RT.exe capture
+  above: a border-color column scan (the same native x=4 scan used against
+  the genuine capture) landed on matching window boundaries at every edge
+  (within 1-4px of jitter, consistent with ADR 0021's own already-documented
+  RGB565-quantisation floor), and pressing `Down` on the mruby build's own
+  window reproduced the identical cursor-moves-to-Sell frame, layout-for-
+  layout, that the genuine capture showed. This is the first cycle able to
+  close the loop with all three legs (CRuby scene-check, genuine RPG_RT.exe
+  under wine, and this project's own compiled engine binary) in one pass
+  rather than leaving the mruby leg as a standing gap; worth flagging to
+  future cycles that this build path is available in this kind of sandboxed
+  environment without nix.
+  No EasyRPG source was consulted for any part of this cycle's
+  investigation or fix -- every claim above traces to either the genuine
+  RPG_RT.exe wine captures or this project's own prior, already-verified
+  code/comments (the Show Inn prompt, cycles #144-147's own shop-geometry
+  findings). The pre-existing `drive_shop_command` doc comment citing
+  EasyRPG's `Window_Shop::Update`/`Scene_Shop::UpdateCommandSelection` for
+  Decision/Cancel dispatch predates this project's strict no-EasyRPG-source
+  rule (flagged as such already, same as several other shop-code comments
+  cycle #145 already noted) and was left alone -- this cycle's own fix
+  touches rendering only, not that dispatch logic, so nothing here depended
+  on it either way.
+  **Still open**: whether a shop whose description bar/list/prompt windows
+  interact with the still-unreproduced equipment-party-band icon (cycles
+  #145/#146) on the `:command` screen itself -- not applicable, since the
+  party band is gated on a highlighted *good*, which `:command` never has,
+  but not independently re-confirmed live this cycle since no equipment
+  good was probed here; the empty-Buy/Sell-list description-bar inference
+  above (extended from the `:command` finding, not independently tested);
+  and the long-deferred short-synthetic-autostart-page crash (candidate 2)
+  and Enter Hero Name charset-2 hang (candidate 3) from this cycle's own
+  task list, neither attempted this cycle.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5461,7 +5461,18 @@ class RPG2k
           @shop[:scroll] = @shop[:index] - SHOP_LIST_ROWS + 1
         end
         @shop[:scroll] = Game.clamp(@shop[:scroll], 0, [lines.length - SHOP_LIST_ROWS, 0].max)
-        visible = lines[@shop[:scroll], SHOP_LIST_ROWS] || []
+        # The command menu's own Buy/Sell/Leave rows are never drawn into
+        # this list window -- confirmed against genuine RPG_RT.exe under
+        # wine (cycle #148, a synthetic mode=0 Open Shop command spliced
+        # onto Map0012 via a new autostart event): on the native :command
+        # has_menu screen this window is a real, bordered window at its
+        # usual position/size (same border-pixel geometry as every other
+        # screen, confirmed by a column scan) but always empty -- no text,
+        # no cursor -- across all three command rows in turn (Buy/Sell/Leave
+        # each screenshotted highlighted in turn showed the identical blank
+        # window). The actual choice list renders merged into the bottom
+        # prompt window instead -- see #draw_shop_command_prompt.
+        visible = @shop[:screen] == :command ? [] : (lines[@shop[:scroll], SHOP_LIST_ROWS] || [])
         # Docks flush to the screen's left edge, not inset 10px -- the same
         # stale anti-pattern ADR 0021 already diagnosed and fixed for the
         # message window ("300px wide, inset 10px" -> "fixed 320x80 at
@@ -5499,7 +5510,7 @@ class RPG2k
           c.draw_text 0, i * SHOP_LINE_H, inner_w, SHOP_LINE_H, label
         end
         win.contents = c
-        unless lines.empty?
+        unless visible.empty?
           cursor_row = @shop[:index] - @shop[:scroll]
           win.cursor_rect = Rect.new(0, cursor_row * SHOP_LINE_H, inner_w, SHOP_LINE_H)
         end
@@ -5520,13 +5531,26 @@ class RPG2k
       # status/gold panels' own SHOP_PANELS_VISIBLE_ON (also shown on Sell,
       # confirmed live -- a single-good Sell list showed the same bar with
       # the sold item's own description, even though Sell gets no status/gold
-      # column); hidden only on the command menu and whenever the current
-      # screen has no single item to describe (:command, or an empty list),
-      # which was not reachable through this cycle's own test shop (it scripts
-      # its own Buy/Sell/Cancel choice menu rather than using this engine's
-      # native :command screen) and so is inferred, not directly verified --
-      # see the cycle #144 docs/TODO.md entry.
-      SHOP_DESC_VISIBLE_ON = %i[buy sell quantity purchased sold].freeze
+      # column).
+      #
+      # Follow-up (cycle #148, 2026-08-25): the command menu is *not* a
+      # fourth hidden case after all -- confirmed against genuine RPG_RT.exe
+      # under wine (a synthetic mode=0 Open Shop command, allow_buy and
+      # allow_sell both set, spliced onto a new autostart event on Map0012):
+      # the native :command has_menu screen shows this exact window too, at
+      # the identical position, still bordered -- a raw-pixel scan of its
+      # interior found nothing but the background gradient (no glyph-colour
+      # pixels at all), i.e. present but blank, not disposed. Cycle #144's
+      # own guess that it hides on :command was an unverified inference and
+      # turned out wrong; #shop_desc_item_id already returned nil there
+      # (correctly -- no single good is ever highlighted on the command
+      # menu), so the fix is only in #draw_shop_desc no longer treating a nil
+      # id as "hide the window" -- it draws blank text instead, extending the
+      # same "always shown, blank without an id" reading to the other nil-id
+      # case (an empty Buy/Sell list) by inference, since that case is still
+      # not directly reachable through any known genuine shop and was never
+      # independently verified either way before or after this fix.
+      SHOP_DESC_VISIBLE_ON = %i[command buy sell quantity purchased sold].freeze
 
       def shop_desc_item_id(lines)
         return nil unless SHOP_DESC_VISIBLE_ON.include?(@shop[:screen])
@@ -5541,11 +5565,6 @@ class RPG2k
 
       def draw_shop_desc(lines)
         id = shop_desc_item_id(lines)
-        if id.nil?
-          @shop[:desc].dispose if @shop[:desc]
-          @shop[:desc] = nil
-          return
-        end
         win = @shop[:desc]
         unless win
           win = Window.new(0, 0, SCREEN_W, SHOP_DESC_H)
@@ -5556,7 +5575,7 @@ class RPG2k
         inner_w = SCREEN_W - Window::BORDER * 2
         c = Bitmap.new(inner_w, SHOP_LINE_H)
         c.font.color = Color.new(255, 255, 255, 255)
-        c.draw_text 0, 0, inner_w, SHOP_LINE_H, @shop[:model].description(id)
+        c.draw_text 0, 0, inner_w, SHOP_LINE_H, id ? @shop[:model].description(id) : ''
         win.contents = c
       end
 
@@ -5567,7 +5586,11 @@ class RPG2k
       # (cycle #144) landed on exactly (native y=160, height 80). Replaces the
       # old "merged into the list window's own first row" shape #draw_shop
       # used before.
+      #
+      # The command menu draws differently in this same window -- see
+      # #draw_shop_command_prompt.
       def draw_shop_prompt
+        return draw_shop_command_prompt if @shop[:screen] == :command
         text = shop_header
         if text.nil?
           @shop[:prompt].dispose if @shop[:prompt]
@@ -5586,6 +5609,47 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         c.draw_text 0, 0, inner_w, SHOP_LINE_H, text
         win.contents = c
+      end
+
+      # The native :command has_menu screen's greeting/regreeting line and its
+      # Buy/Sell/Leave choices, merged into one window -- confirmed against
+      # genuine RPG_RT.exe under wine (cycle #148, see #draw_shop's own
+      # citation for the full setup): the three choice rows are *not* drawn
+      # into the main list window (#draw_shop leaves it blank on :command)
+      # but directly below the greeting text, inside this same
+      # MSG_WIN_W x MSG_WIN_H bottom window -- the same "message text with a
+      # choice list attached directly beneath it" shape this codebase's own
+      # Show Inn prompt already uses for its own Accept/Cancel pair
+      # (#open_inn_window / #set_inn_cursor), and the same shape Nepheshel's
+      # own choice-scripted shop NPCs use when *they* build a Buy/Sell/Cancel
+      # menu by hand via Show Message + Show Choices (docs/TODO.md's own
+      # cycle #144 entry) -- real RPG_RT's native has_menu screen turns out to
+      # be built from that identical primitive, not a bespoke command window.
+      #
+      # Row spacing is MSG_LINE_H (16 native), not SHOP_LINE_H/INN_LINE_H (14)
+      # -- measured directly off the wine capture (a glyph-row pixel scan of
+      # the four text rows landed on a 16px-native pitch, matching this
+      # window's own ordinary message-line metric, not the shop list's own
+      # compressed one), which makes sense once this is understood to be the
+      # message window's own text renderer rather than the shop list's.
+      def draw_shop_command_prompt
+        rows = shop_lines
+        text_lines = [shop_header] + rows.map { |label, _| label }
+        win = @shop[:prompt]
+        unless win
+          win = Window.new(0, SCREEN_H - MSG_WIN_H, MSG_WIN_W, MSG_WIN_H)
+          win.z = 300
+          win.windowskin = @windowskin
+          @shop[:prompt] = win
+        end
+        inner_w = MSG_WIN_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, text_lines.length * MSG_LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        text_lines.each_with_index do |line, i|
+          c.draw_text 0, i * MSG_LINE_H, inner_w, MSG_LINE_H, line
+        end
+        win.contents = c
+        win.cursor_rect = Rect.new(0, (1 + @shop[:index]) * MSG_LINE_H, inner_w, MSG_LINE_H)
       end
 
       # The gold and status panels share one visible/hidden set: RPG_RT's

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15620,11 +15620,21 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
   # bottom-message-slot window (#draw_shop_prompt), not merged into the list
   # window's own first row any more -- confirmed against genuine RPG_RT.exe
   # under wine (docs/TODO.md).
-  ok window_texts(shop[:prompt]).any? { |t| t.include?('いらっしゃいませ！') },
+  #
+  # Follow-up (cycle #148): the command menu's own Buy/Sell/Leave row labels
+  # turn out to belong in *this* window too, merged directly below the
+  # greeting line -- not in the list window (#draw_shop_command_prompt) --
+  # confirmed against genuine RPG_RT.exe under wine (a synthetic mode=0 Open
+  # Shop command, docs/TODO.md). The list window (shop[:window]) draws no
+  # text at all on the command menu.
+  prompt_texts = window_texts(shop[:prompt])
+  ok prompt_texts.any? { |t| t.include?('いらっしゃいませ！') },
      'the first-visit greeting shows'
-  texts = window_texts(shop[:window])
-  ok texts.any? { |t| t.include?('買う') } && texts.any? { |t| t.include?('売る') } &&
-     texts.any? { |t| t.include?('やめる') }, 'the command row labels use the database terms'
+  ok prompt_texts.any? { |t| t.include?('買う') } && prompt_texts.any? { |t| t.include?('売る') } &&
+     prompt_texts.any? { |t| t.include?('やめる') },
+     'the command row labels use the database terms, in the prompt window'
+  ok window_texts(shop[:window]).all?(&:empty?),
+     'the list window itself draws none of the command labels'
 
   RGSS::Input.triggered = [RGSS::Input::C] # choose Buy
   scene.update
@@ -15652,6 +15662,58 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
   eq :command, shop[:screen]
   ok window_texts(shop[:prompt]).any? { |t| t.include?('他に何かご入用ですか？') },
      'having browsed once, the shopkeeper asks "anything else?" rather than greeting again'
+end
+
+# Follow-up (cycle #148, 2026-08-25): closes the last-open shop gap cycle
+# #144 first flagged and cycles #145-147 each left untouched -- whether the
+# description bar and the list's own SHOP_DESC_H-anchored geometry hold on
+# the native :command has_menu screen. They do (same window, same position,
+# on every screen), but the command menu's own Buy/Sell/Leave choices turn
+# out to live in the *prompt* window instead of the list -- see
+# #draw_shop_command_prompt's own citation for the full wine evidence
+# (a synthetic mode=0 Open Shop command spliced onto a new autostart event
+# on Map0012, screenshotted through Buy/Sell/Leave highlighted in turn).
+check 'Open Shop scene: the command menu\'s own cursor lives in the prompt ' \
+      'window, at MSG_LINE_H spacing below the greeting -- not in the list' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0)]
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db = fake_db), state)
+  state.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the command menu opens (mode 0: buy+sell)
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+
+  win = shop[:prompt]
+  eq 0, win.x, "the prompt window is the ordinary bottom message slot"
+  eq RPG2k::Scene::Map::SCREEN_H - RPG2k::Scene::Map::MSG_WIN_H, win.y
+  eq RPG2k::Scene::Map::MSG_WIN_W, win.width
+  eq RPG2k::Scene::Map::MSG_WIN_H, win.height
+  msg_line_h = RPG2k::Scene::Map::MSG_LINE_H
+  eq 1 * msg_line_h, win.cursor_rect.y,
+     'row 0 (Buy) selected -- cursor sits one MSG_LINE_H row below the greeting'
+  eq msg_line_h, win.cursor_rect.height
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move onto Sell
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  win = shop[:prompt]
+  eq 2 * msg_line_h, win.cursor_rect.y, 'row 1 (Sell) selected -- two rows down'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move onto Leave
+  scene.update
+  RGSS::Input.triggered = []
+  win = scene.instance_variable_get(:@shop)[:prompt]
+  eq 3 * msg_line_h, win.cursor_rect.y, 'row 2 (Leave) selected -- three rows down'
+
+  # The list window (goods box) never gets a cursor on the command menu --
+  # SHOP_LIST_ROWS' own boundary-case machinery has nothing to scroll here.
+  list_win = scene.instance_variable_get(:@shop)[:window]
+  eq 0, list_win.cursor_rect.width,
+     'the list window carries no cursor rect while on the command menu'
 end
 
 # Confirmed against EasyRPG's actual C++ source: `Window_Shop`
@@ -15997,9 +16059,15 @@ check 'Open Shop scene: a description bar above the list shows the highlighted '
 
   shop = scene.instance_variable_get(:@shop)
   eq :command, shop[:screen]
-  ok shop[:desc].nil?,
-     'the command menu highlights no single good -- no bar (inferred, not directly ' \
-     'reachable through this cycle\'s own real-RPG_RT test shop; see docs/TODO.md)'
+  # Follow-up (cycle #148): confirmed against genuine RPG_RT.exe under wine --
+  # the command menu still shows this window (same position/size as every
+  # other shop screen), just with no text in it, since no single good is
+  # ever highlighted there; it is not hidden/disposed the way cycle #144's
+  # own inference guessed. See docs/TODO.md.
+  ok !shop[:desc].nil?, 'the description bar is a real window on the ' \
+     'command menu too, just blank -- not hidden'
+  ok window_texts(shop[:desc]).all?(&:empty?),
+     'and it draws no text while the command menu has no single good to describe'
 
   RGSS::Input.triggered = [RGSS::Input::C] # choose Buy
   scene.update


### PR DESCRIPTION
## Summary
- RPG_RT's native Buy/Sell/Leave command menu (shown when an Open Shop event allows both buying and selling) still draws the description bar and goods-list window, but leaves both blank — the three choices render merged into the bottom prompt window below the shopkeeper's greeting instead, the same "message plus attached choice list" shape this codebase's own Inn Accept/Cancel prompt already uses.
- Closes the last open question from cycle #144's shop-screen work (docs/TODO.md).
- `SHOP_DESC_VISIBLE_ON` now includes `:command`; `draw_shop_desc` no longer disposes the window on a `nil` id, drawing blank text instead; `draw_shop` leaves the list window's visible rows empty on `:command`; a new `#draw_shop_command_prompt` handles the merged greeting+choices render.

## Verification
- Confirmed against genuine RPG_RT.exe under wine via a synthetic `mode=0` Open Shop command spliced onto a new autostart event on a copy of `Map0012.lmu` (no Nepheshel NPC exercises this path — every real shop NPC scripts its own Buy/Sell/Cancel via Show Choices instead). A raw-pixel scan found the description bar and list window both blank across all three command rows, and the choice rows at a 16px-native `MSG_LINE_H` pitch inside the prompt window, not the list's own compressed `SHOP_LINE_H`.
- Also cross-checked against this project's own compiled mruby engine binary this cycle — first cycle able to close the loop with all three legs (CRuby scene-check, genuine RPG_RT.exe under wine, and the compiled engine binary) in one pass.
- New regression checks confirmed to fail against pre-fix code (`git stash` of `map.rb` only) with exactly the claimed errors, then pass after restoring: `3 of 928 checks FAILED` → `928 checks passed`.
- All check suites pass: `rpg2k_scene_check.rb` 928/928 (up from 927), `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1134/1134, `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- Game data (`Map0012.lmu`, `Save01.lsd`) confirmed clean/unmodified in the final diff.
- No EasyRPG Player source was consulted for this fix. (Note: an unrelated pre-existing comment on `#drive_shop_command`, from a different workstream/branch merged earlier, already cites EasyRPG source for dispatch logic this fix doesn't touch — flagged as legacy debt, not introduced or relied upon here.)

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 928/928
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1134/1134
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Pre-fix regression proof via `git stash` of `map.rb`


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_