### PR TITLE
rgssad: stream/seek instead of loading the whole archive into memory

### DIFF
--- a/changelog.d/rgssad-streaming-reader.fixed.md
+++ b/changelog.d/rgssad-streaming-reader.fixed.md
@@ -1,0 +1,15 @@
+- **`RGSSAD` (the RPG Maker XP/VX/VX Ace encrypted-archive reader) no longer
+  loads the whole archive into memory to open it.** `mruby-rpgxp/mrblib/rgssad.rb`'s
+  `.open(path)` used to `File.read` the entire `Game.rgssad`/`.rgss2a`/`.rgss3a`
+  up front; on the PSP that single `String` came out of the interpreter's
+  fixed 12 MB arena, so any released game's archive at or beyond that size —
+  routine for a real XP/VX release, which can pack tens of MB — couldn't even
+  be opened without exhausting the arena outright. `.open`/`#initialize` now
+  accept a seekable stream (a real `File`, kept open for the archive's
+  lifetime) and read only the header and each version's entry table up
+  front; `#read(name)` seeks to that entry's own offset and decrypts only
+  its own bytes. Opening an archive now costs memory proportional to its
+  entry count, not its total size. The in-memory `.new(String)` form used by
+  tests and by `pack_v1`/`pack_v3`'s own round-trip callers is unchanged
+  (wrapped in a `StringIO` internally). See
+  `docs/adr/0047-psp-memory-budget.md`.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1146,9 +1146,54 @@ the interpreter-linking slice, in this order:
   exact match both ways. What's still a per-release step, not something this
   tool can do for you: excluding the packed archive from a given PSP
   deployment so `open_archive` never reads it (see Finding 2's catch) — the
-  unpacker never touches or deletes the archive itself. A streaming `RGSSAD`
-  reader remains the fallback if Memory Stick space, not RAM, turns out to be
-  the constraint for a release that can't afford the doubled storage.
+  unpacker never touches or deletes the archive itself.
+
+  **Follow-up (2026-08-25) — superseded by P3a below.** This paragraph
+  originally framed a streaming `RGSSAD` reader as a fallback worth building
+  only "if Memory Stick space, not RAM, turns out to be the constraint" —
+  that undersold it: a streaming reader removes Finding 2's actual RAM
+  blocker directly (the whole point of that finding), not just the storage
+  duplication the unpack workaround costs. It has since been built; see P3a.
+- **P3a — done: `RGSSAD` no longer reads the archive whole.**
+  `mruby-rpgxp/mrblib/rgssad.rb`'s `.open(path)` used to be `File.read` — the
+  entire encrypted archive as one `String` before anything was decoded. On
+  the PSP that string is an mruby allocation, meaning it comes out of P2's
+  fixed 12 MB arena: any archive at or beyond arena-size (a released XP/VX
+  game "routinely packs tens of MB", Finding 2) couldn't even be opened
+  without exhausting the arena outright, hitting the corrupting-exhaustion
+  cliff P2's follow-up documented — not a slowdown, a guaranteed failure.
+  `.open`/`#initialize` now accept anything seekable (a real `File`, kept
+  open for the archive's lifetime, or a `StringIO`-wrapped `String` for the
+  in-memory callers — `pack_v1`/`pack_v3`'s own round-trip tests, unchanged)
+  and read only the header plus each version's entry table up front; v1's
+  table is interleaved with entry data in the file, so parsing it means
+  seeking *past* each entry's data block without reading it, while v3's
+  table already sat separately from the data blocks even before this change.
+  `#read(name)` seeks to that entry's own offset and reads only its own
+  bytes, decrypting them the same way as before. Peak memory for opening an
+  archive is now O(entry count) — the `@entries` hash of small offset/size/
+  key records — not O(archive size); a released game's Game.rgssad no
+  longer has to fit in RAM (or the arena) at all to be opened, only each
+  asset has to fit for the moment it is being decoded, same as a loose file
+  always did. Verified three ways, since this rewrites a format parser real
+  games depend on: a standalone byte-for-byte round-trip check covering both
+  archive versions, the `.open(path)` streaming path against `.new(String)`
+  the old in-memory path (including out-of-insertion-order re-reads, to
+  exercise real seeks), an over-`MRB_ARY_LENGTH_MAX` entry, bad-header/
+  version rejection via both entry points, and a truncated-file case; then
+  `scripts/rpgxp_testbed_check.rb` against the real `OpenGame.exe` XP
+  test-bed's actual `Data/*.rxdata` packed both as v1 and v3 and read back
+  through the full `RGSSData` loader (System/Actors/Maps) and a packed
+  `Graphics/` asset, all passing; then `scripts/rpgvx_testbed_check.rb`'s
+  generated VX and VX Ace projects the same way, including the script host
+  actually running the packed project's bundled scripts for real frames.
+  Both CRuby harnesses needed a `require "stringio"` added (`StringIO` is a
+  preloaded mruby gem with no such require, but a CRuby stdlib needing one)
+  — the one portability gap this surfaced. This also fully closes Finding
+  2's RAM half for XP/VX (P3's unpack tool remains useful for the storage-
+  duplication case, now optional rather than the only fix), so the
+  Consequences risk register's "hard-blocking for any future XP/VX PSP
+  target" is resolved rather than merely mitigated.
 - **P4 — corrected; not an LVGL-cache problem.** There is no LVGL image
   cache to bound for RGSS bitmaps (Finding 3) — they live in the plain C
   runtime heap via `Bitmap::buffer`, a third pool `LV_MEM_SIZE` never
@@ -1200,13 +1245,15 @@ the interpreter-linking slice, in this order:
   Decision) rather than soft-blocking, but its *size* is still a placeholder
   awaiting on-device numbers — the BRINGUP heartbeat measures it, so that is a
   measurement follow-up, not an architectural one. P3 (RGSSAD whole-archive
-  loads) is hard-blocking for any future XP/VX PSP target; the
-  tool to close it is done, but running it and excluding the packed archive
-  is still a manual step per release, not something CI or the build enforces
-  — that's the remaining risk, not the unpack logic itself. P4 is a
-  lower-risk follow-up once a title actually renders; P5 is now measured
-  rather than guessed, leaving only the same "needs a real game" caveat P2's
-  arena size has.
+  loads) is **resolved, not just mitigated, as of P3a**: `RGSSAD` no longer
+  reads a packed archive whole, so a released XP/VX game no longer needs the
+  unpack-and-exclude-the-archive deployment step to fit the PSP's RAM (P3's
+  unpack tool is still useful for the separate, much lower-stakes case of
+  wanting to avoid the archive's storage footprint on the Memory Stick, but
+  is no longer the only thing standing between a packed release and a
+  guaranteed arena-exhaustion crash). P4 is a lower-risk follow-up once a
+  title actually renders; P5 is now measured rather than guessed, leaving
+  only the same "needs a real game" caveat P2's arena size has.
 - Follow-up: once P1's real numbers exist, replace this ADR's estimates with
   measured figures (a memory budget table, as ADR 0007 has for the Wio
   Terminal) — either as an amendment here or a superseding ADR.

--- a/mruby-rpgxp/mrblib/rgssad.rb
+++ b/mruby-rpgxp/mrblib/rgssad.rb
@@ -35,6 +35,12 @@
 # data). Decrypted bytes are assembled by packing bounded chunks with
 # `Array#pack("C*")` (mruby-pack) and joining them, so no single Array grows past
 # mruby's array-length cap on large entries.
+#
+# .open (below) never reads the archive whole: it opens a seekable stream and
+# only reads the header plus each version's entry table, then seeks straight to
+# an entry's own bytes when #read asks for it by name. See docs/adr/0047-psp-
+# memory-budget.md Finding 2 for why that matters -- a released game routinely
+# packs this file past the size of the PSP's entire RAM budget by itself.
 
 class RPGXP
   class RGSSAD
@@ -57,8 +63,16 @@ class RPGXP
       nil
     end
 
+    # Opens the archive for streaming, seekable reads (see #initialize) rather
+    # than reading the whole file up front: a released XP/VX game routinely
+    # packs tens of MB into this single file, comfortably larger than the
+    # PSP's entire ~24 MB budget by itself (docs/adr/0047-psp-memory-budget.md,
+    # Finding 2), so the old `File.read` here was a hard memory-budget
+    # blocker for any archive bigger than what was left of RAM. The `File`
+    # stays open for the archive object's lifetime (the same lifetime the
+    # whole-buffer version kept its String alive for).
     def self.open(path)
-      new(File.open(path, "rb") { |f| f.read })
+      new(File.open(path, "rb"))
     end
 
     # Build a version-1 archive from `files`, a list of [name, bytes] pairs (name
@@ -195,11 +209,20 @@ class RPGXP
       bytes
     end
 
-    # `data` is the raw archive bytes.
+    # `data` is either a `String` of the whole archive (wrapped in a
+    # `StringIO` below -- how the tests and pack_v1/pack_v3's own round-trip
+    # callers use this) or an IO-like object already open for reading (what
+    # .open above passes: a real `File`, read on demand instead of slurped
+    # whole up front). Either way, only the header and each version's entry
+    # table are read here; entry *data* is read lazily by #read via a seek,
+    # so opening the archive no longer requires it to fit in RAM all at once
+    # (see .open's comment above).
     def initialize(data)
-      @data = data
-      raise "not an RGSSAD archive (bad header)" unless header_ok?
-      @version = @data.getbyte(7)
+      @io = data.is_a?(String) ? StringIO.new(data) : data
+      @io.seek(0)
+      header = @io.read(8)
+      raise "not an RGSSAD archive (bad header)" unless header_ok?(header)
+      @version = header.getbyte(7)
       @entries = {}
       case @version
       when 1
@@ -225,20 +248,25 @@ class RPGXP
     end
 
     # Decrypted bytes for one entry, or nil when it is not in the archive. `name`
-    # may be given with '/' or '\' separators.
+    # may be given with '/' or '\' separators. Seeks to the entry's own offset
+    # and reads only its own bytes -- the archive is never loaded whole (see
+    # #initialize).
     def read(name)
       e = @entries[normalize(name)]
       return nil unless e
-      decrypt_data(@data[e[:offset], e[:size]], e[:key])
+      @io.seek(e[:offset])
+      bytes = @io.read(e[:size])
+      return nil if bytes.nil?
+      decrypt_data(bytes, e[:key])
     end
 
     private
 
-    def header_ok?
-      return false if @data.bytesize < 8
+    def header_ok?(header)
+      return false if header.nil? || header.bytesize < 8
       i = 0
       while i < 7
-        return false unless @data.getbyte(i) == HEADER.getbyte(i)
+        return false unless header.getbyte(i) == HEADER.getbyte(i)
         i += 1
       end
       true
@@ -254,83 +282,103 @@ class RPGXP
       (key / POW[n]) % 256
     end
 
-    # Read a 32-bit little-endian integer at `i`, de-obfuscated with `key`.
-    def read_int(i, key)
+    # De-obfuscate an already-read 4-byte little-endian integer with `key`.
+    def decrypt_int(bytes, key)
       v = 0
       b = 0
       while b < 4
-        v += (@data.getbyte(i + b) ^ key_byte(key, b)) * POW[b]
+        v += (bytes.getbyte(b) ^ key_byte(key, b)) * POW[b]
         b += 1
       end
       v
     end
 
-    # Read a plain (un-obfuscated) 32-bit little-endian integer at `i`.
-    def read_plain_int(i)
+    # An already-read, plain (un-obfuscated) 4-byte little-endian integer.
+    def plain_int(bytes)
       v = 0
       b = 0
       while b < 4
-        v += @data.getbyte(i + b) * POW[b]
+        v += bytes.getbyte(b) * POW[b]
         b += 1
       end
       v
     end
 
+    # Walks the archive sequentially from just after the 8-byte header,
+    # reading only each entry's own name-length/name/size fields and then
+    # seeking past its data block (never reading the data itself -- that
+    # only happens lazily, per entry, in #read). A short/missing read at any
+    # point (a truncated or otherwise malformed tail) stops enumeration the
+    # same way running off the end of a bounds-checked buffer used to.
     def parse_v1
       key = START_KEY
-      i = 8
-      len = @data.bytesize
-      while i + 4 <= len
-        nlen = read_int(i, key)
+      loop do
+        len_bytes = @io.read(4)
+        break if len_bytes.nil? || len_bytes.bytesize < 4
+        nlen = decrypt_int(len_bytes, key)
         key = advance(key)
-        i += 4
-        break if nlen <= 0 || i + nlen + 4 > len
+        break if nlen <= 0
 
+        name_enc = @io.read(nlen)
+        break if name_enc.nil? || name_enc.bytesize < nlen
         name_bytes = []
         j = 0
         while j < nlen
-          name_bytes << (@data.getbyte(i + j) ^ key_byte(key, 0))
+          name_bytes << (name_enc.getbyte(j) ^ key_byte(key, 0))
           key = advance(key)
           j += 1
         end
-        i += nlen
 
-        size = read_int(i, key)
+        size_bytes = @io.read(4)
+        break if size_bytes.nil? || size_bytes.bytesize < 4
+        size = decrypt_int(size_bytes, key)
         key = advance(key)
-        i += 4
-        break if size < 0 || i + size > len
+        break if size < 0
 
-        @entries[name_bytes.pack("C*")] = { offset: i, size: size, key: key }
-        i += size
+        offset = @io.pos
+        @entries[name_bytes.pack("C*")] = { offset: offset, size: size, key: key }
+        @io.seek(offset + size) # skip the data block itself -- see #read
       end
     end
 
     # Parse the v3 (`.rgss3a`) entry table. The base key comes from the plaintext
     # header seed and stays fixed while walking the records; each record carries
     # its data's absolute offset, size and per-file key, so unlike v1 the records
-    # live together up front and the data blocks follow. Terminated by a record
-    # whose offset field decrypts to 0.
+    # live together up front and the data blocks follow -- meaning this table was
+    # already cheap to read without touching the data even before streaming.
+    # Terminated by a record whose offset field decrypts to 0.
     def parse_v3
-      key = (read_plain_int(8) * 9 + 3) % MASK
-      i = 12
-      len = @data.bytesize
-      while i + 16 <= len
-        offset = read_int(i, key)
+      seed_bytes = @io.read(4)
+      return if seed_bytes.nil? || seed_bytes.bytesize < 4
+      key = (plain_int(seed_bytes) * 9 + 3) % MASK
+      loop do
+        offset_bytes = @io.read(4)
+        break if offset_bytes.nil? || offset_bytes.bytesize < 4
+        offset = decrypt_int(offset_bytes, key)
         break if offset == 0 # terminator record
-        size = read_int(i + 4, key)
-        file_key = read_int(i + 8, key)
-        nlen = read_int(i + 12, key)
-        i += 16
-        break if nlen <= 0 || i + nlen > len
 
+        size_bytes = @io.read(4)
+        break if size_bytes.nil? || size_bytes.bytesize < 4
+        size = decrypt_int(size_bytes, key)
+
+        fkey_bytes = @io.read(4)
+        break if fkey_bytes.nil? || fkey_bytes.bytesize < 4
+        file_key = decrypt_int(fkey_bytes, key)
+
+        nlen_bytes = @io.read(4)
+        break if nlen_bytes.nil? || nlen_bytes.bytesize < 4
+        nlen = decrypt_int(nlen_bytes, key)
+        break if nlen <= 0
+
+        name_enc = @io.read(nlen)
+        break if name_enc.nil? || name_enc.bytesize < nlen
         name_bytes = []
         j = 0
         while j < nlen
-          name_bytes << (@data.getbyte(i + j) ^ key_byte(key, j % 4))
+          name_bytes << (name_enc.getbyte(j) ^ key_byte(key, j % 4))
           j += 1
         end
-        i += nlen
-        next if offset < 0 || offset + size > len
+        next if offset < 0
 
         @entries[name_bytes.pack("C*")] = { offset: offset, size: size, key: file_key }
       end

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -36,6 +36,10 @@
 require "tmpdir"
 require "fileutils"
 require "zlib"
+# rgssad.rb's #initialize wraps a String argument in StringIO (see its own
+# comment) to stream/seek over it the same way it does a real File -- a
+# preloaded mruby gem there, needing this explicit CRuby stdlib require here.
+require "stringio"
 
 # --- RGSS value-type shims (native classes in the real build) --------------
 

--- a/scripts/rpgxp_testbed_check.rb
+++ b/scripts/rpgxp_testbed_check.rb
@@ -66,6 +66,10 @@ module Audio
   def self.se_play(*); end
 end
 class RPGXP; end
+# rgssad.rb's #initialize wraps a String argument in StringIO (see its own
+# comment) to stream/seek over it the same way it does a real File -- a
+# preloaded mruby gem there, needing this explicit CRuby stdlib require here.
+require "stringio"
 load File.join(mrblib, "rgssad.rb")
 require "tmpdir"
 


### PR DESCRIPTION
## Summary

`RGSSAD` (`mruby-rpgxp/mrblib/rgssad.rb`, shared by XP/VX/VX Ace) is the reader for a released game's encrypted `Game.rgssad`/`.rgss2a`/`.rgss3a`. `.open(path)` used to `File.read` the whole archive into a single `String` before decoding anything. On the PSP that string is an mruby allocation, so it comes out of the interpreter's fixed 12 MB arena (`docs/adr/0047-psp-memory-budget.md`'s P2) — meaning any released XP/VX game whose packed archive reaches that size (routine for a real release: "tens of MB" per that ADR's Finding 2) couldn't even be *opened* without exhausting the arena outright and hitting the corrupting-exhaustion failure path the ADR's P2 follow-up already documented. This was flagged in that ADR's own risk register as "hard-blocking for any future XP/VX PSP target."

- `.open`/`#initialize` now accept anything seekable — a real `File` (kept open for the archive's lifetime) or a `StringIO`-wrapped `String` for the in-memory callers (`pack_v1`/`pack_v3`'s own round-trip tests, unchanged) — and read only the header plus each version's entry table up front. v1's table is interleaved with entry data in the file, so parsing it now means seeking *past* each entry's data block instead of reading it; v3's table was already separate from the data.
- `#read(name)` seeks to that entry's own offset and reads/decrypts only its own bytes.
- Peak memory for *opening* an archive is now O(entry count), not O(archive size) — a released game's `Game.rgssad` no longer needs to fit in RAM (or the 12 MB arena) at all to be opened.
- `docs/adr/0047-psp-memory-budget.md` updated (a new P3a, and Finding 2/the risk register corrected to say this is resolved, not just mitigated) plus a changelog fragment.

## Test plan

Verified three ways, since this rewrites a format parser real games depend on:

- [x] A standalone round-trip/edge-case script: both archive versions, `.open(path)` (streaming) vs `.new(String)` (in-memory) parity including out-of-insertion-order re-reads (exercises real seeks), an entry over `MRB_ARY_LENGTH_MAX`, bad-header/unsupported-version rejection via both entry points, and a truncated file — all pass.
- [x] `ruby scripts/rpgxp_testbed_check.rb` against the real `OpenGame.exe` XP test-bed's actual `Data/*.rxdata`, packed as both v1 and v3, read back through the full `RGSSData` loader (System/Actors/Maps) and a packed `Graphics/` asset — passes both ways.
- [x] `ruby scripts/rpgvx_testbed_check.rb`'s generated VX and VX Ace projects, packed and read back the same way, including the script host actually running the packed project's bundled scripts for real frames — passes both ways.
- [x] `ruby scripts/rgss_cruby_test_check.rb` (mruby-rgss's own CRuby-portable suite) still passes.
- [x] Rebuilt the `host` mruby target (`rake -f 3rd/mruby/Rakefile MRUBY_TARGET=host`) — the changed mrblib compiles and links clean.
- [x] `pre-commit run trailing-whitespace`/`end-of-file-fixer`/`check-added-large-files` on the changed files; `ruby -c` on all three.
- Surfaced one real portability gap along the way: `StringIO` is a preloaded mruby gem (no `require` even exists in that build) but a CRuby stdlib needing an explicit `require`. Fixed by adding `require "stringio"` to the two CRuby harness scripts above, not to `rgssad.rb` itself.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt


---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_