### PR TITLE
ci: add psp-smoke-game, booting a real RPG2k game under PPSSPP-headless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1506,9 +1506,24 @@ jobs:
     #
     # Nepheshel is the same RPG2000 test-bed the desktop `build` job's own
     # "RPG2k real-game boot smoke test" step already downloads and boots, so
-    # no new fixture is introduced. PPSSPP's headless memstick root defaults
-    # to $HOME/.ppsspp; --memstick points it at a directory this job builds
-    # itself so the layout is explicit rather than relying on that default.
+    # no new fixture is introduced.
+    #
+    # Getting the game to where the EBOOT looks for it took one wrong turn
+    # worth recording: a `--memstick=DIR` flag looked right from PPSSPP's own
+    # source (Headless.cpp checks `cmdLineOptions.memStick.has_value()`), but
+    # the first real run showed PPSSPP's arg parser never consuming it as a
+    # flag at all -- it treated the whole `--memstick=...` string as another
+    # positional boot target and tried (and failed) to run it as one,
+    # confirmed by the emulator's own log ("Test init failed for
+    # --memstick=...", right next to the real EBOOT's own "Test timeout").
+    # hrydgard/ppsspp#20552 ("Allow Linux to change memstick directory") backs
+    # this up: as of this writing Linux headless has no working way to
+    # redirect the memstick location at all. What *is* real, quoted straight
+    # from Headless.cpp's own default-path branch (taken whenever no memstick
+    # override applies): non-Windows, non-Android headless runs default
+    # `g_Config.memStickDirectory` to `$HOME/.ppsspp`, creating it if it does
+    # not exist. So instead of trying to redirect it, this job just writes
+    # Nepheshel into that same default location ahead of time.
     #
     # continue-on-error: true for now. `psp-smoke` above used to run the same
     # way while PPSSPP's headless HLE was still catching up (see its own
@@ -1564,11 +1579,14 @@ jobs:
           ./scripts/download-nepheshel.bash
 
       - name: Place Nepheshel at the EBOOT's fixed Memory Stick path
+        # $HOME/.ppsspp is headless's own default memstick root on Linux (see
+        # this job's own top comment) -- created it here ahead of time with
+        # the game already in place, rather than after the emulator creates
+        # it, so there is no race with PPSSPP's own first-run setup.
         run: |
-          memstick="$RUNNER_TEMP/memstick"
+          memstick="$HOME/.ppsspp"
           mkdir -p "$memstick/PSP/GAME/rpg2k"
           cp -r data/Nepheshel206beta/Nepheshel206Rbeta/. "$memstick/PSP/GAME/rpg2k/"
-          echo "memstick=$memstick" >> "$GITHUB_ENV"
 
       - name: Run headless with a real game
         run: |
@@ -1576,9 +1594,8 @@ jobs:
           ls -l "$EBOOT"
           # Longer timeout than psp-smoke's idle-path 15s: a real database
           # and map tree load (RPG_RT.ldb/.lmt) is real work the idle path
-          # never does. --memstick, see the placement step above.
+          # never does.
           ./ppsspp/bin/ppsspp-headless --log --graphics=software --timeout=45 \
-            --memstick="$memstick" \
             "$EBOOT" > "$GITHUB_WORKSPACE/headless-game.log" 2>&1 || true
           echo "=== asserting the EBOOT booted, found the game, and pumped frames ==="
           if grep -q 'RPG2K_PSP_BOOT' "$GITHUB_WORKSPACE/headless-game.log" &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1488,6 +1488,118 @@ jobs:
           path: headless.log
           if-no-files-found: warn
 
+  psp-smoke-game:
+    # Same idea as `psp-smoke`, but with a real RPG2k project placed at the
+    # EBOOT's fixed Memory Stick path (app/psp/main.cxx's kGameDir,
+    # "ms0:/PSP/GAME/rpg2k") instead of nothing. `psp-smoke` above only ever
+    # exercises the idle HAL screen -- no game is ever detected there, so
+    # RPG2K_PSP_GAME_READY never fires and RPG2K_PSP_BRINGUP's scene= is
+    # always "none". This is the first CI job to boot a real game through the
+    # PSP build and capture what docs/adr/0047-psp-memory-budget.md's P1/P1b
+    # actually need: real device memory numbers for "the database and map
+    # tree loaded, Scene::Title built" (GAME_READY) and for steady-state
+    # Title (BRINGUP's scene=RPG2k::Scene::Title). RPG2K_NEW_GAME is
+    # hardcoded false in main.cxx (no command line to carry a real flag on),
+    # so the game never advances past Title on its own -- reaching Map/Menu/
+    # Battle needs either a compile-time toggle or real input scripting,
+    # neither of which exists yet; this job's scope is Title only.
+    #
+    # Nepheshel is the same RPG2000 test-bed the desktop `build` job's own
+    # "RPG2k real-game boot smoke test" step already downloads and boots, so
+    # no new fixture is introduced. PPSSPP's headless memstick root defaults
+    # to $HOME/.ppsspp; --memstick points it at a directory this job builds
+    # itself so the layout is explicit rather than relying on that default.
+    #
+    # continue-on-error: true for now. `psp-smoke` above used to run the same
+    # way while PPSSPP's headless HLE was still catching up (see its own
+    # comment) and was promoted once proven stable; this job is the same
+    # starting point for a real game specifically, which is new ground the
+    # idle path never covered, and Nepheshel's download host has its own
+    # known intermittency (see scripts/download-nepheshel.bash's neighbors'
+    # comments) unrelated to the EBOOT itself. Promote once this has run
+    # green for a while.
+    needs: [psp, psp-smoke]
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+          show-progress: false
+          persist-credentials: false
+
+      - name: Download EBOOT
+        uses: actions/download-artifact@v8
+        with:
+          name: psp-eboot
+          path: eboot
+
+      - uses: nixbuild/nix-quick-install-action@v35
+
+      # Same cache key as `psp-smoke`'s identically-named step, so this job
+      # (which `needs: psp-smoke` and so always starts after it) reuses the
+      # Nix store that step already populated instead of compiling PPSSPP
+      # from source a second time.
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-ppsspp-${{ runner.os }}-${{ hashFiles('flake.*', 'nix/patches/ppsspp-lwmutex-workarea-validate.patch') }}
+          restore-prefixes-first-match: nix-ppsspp-${{ runner.os }}-
+
+      - name: Fetch PPSSPP
+        run: nix build -L --out-link ppsspp '.#ppsspp'
+
+      - name: Download Nepheshel
+        # unar (download-nepheshel.bash's own unpacker) is a devShell package
+        # (flake.nix), and this job never enters the full devShell the way
+        # `nix-develop-export-env.bash` does for the desktop `build` job --
+        # pulling that whole closure in just for one archive tool would be
+        # wasteful here (and a bare `nixpkgs#unar` would resolve against
+        # whatever nixpkgs the ambient Nix registry defaults to, not this
+        # flake's own pinned one), so just apt-get the one package this needs,
+        # the same way the `android` job below installs its one-off `gperf`.
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q unar
+          ./scripts/download-nepheshel.bash
+
+      - name: Place Nepheshel at the EBOOT's fixed Memory Stick path
+        run: |
+          memstick="$RUNNER_TEMP/memstick"
+          mkdir -p "$memstick/PSP/GAME/rpg2k"
+          cp -r data/Nepheshel206beta/Nepheshel206Rbeta/. "$memstick/PSP/GAME/rpg2k/"
+          echo "memstick=$memstick" >> "$GITHUB_ENV"
+
+      - name: Run headless with a real game
+        run: |
+          EBOOT="$GITHUB_WORKSPACE/eboot/EBOOT.PBP"
+          ls -l "$EBOOT"
+          # Longer timeout than psp-smoke's idle-path 15s: a real database
+          # and map tree load (RPG_RT.ldb/.lmt) is real work the idle path
+          # never does. --memstick, see the placement step above.
+          ./ppsspp/bin/ppsspp-headless --log --graphics=software --timeout=45 \
+            --memstick="$memstick" \
+            "$EBOOT" > "$GITHUB_WORKSPACE/headless-game.log" 2>&1 || true
+          echo "=== asserting the EBOOT booted, found the game, and pumped frames ==="
+          if grep -q 'RPG2K_PSP_BOOT' "$GITHUB_WORKSPACE/headless-game.log" &&
+             grep -q 'RPG2K_PSP_GAME_START RPG2k ok' "$GITHUB_WORKSPACE/headless-game.log" &&
+             grep -q 'RPG2K_PSP_BRINGUP' "$GITHUB_WORKSPACE/headless-game.log"; then
+            grep -E 'RPG2K_PSP_[A-Z_]+' "$GITHUB_WORKSPACE/headless-game.log" \
+              | head -20
+          else
+            echo "boot, game-start or bring-up marker missing; last 150 lines:"
+            tail -150 "$GITHUB_WORKSPACE/headless-game.log"
+            exit 1
+          fi
+
+      - name: Upload real-game smoke-test output
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: psp-smoke-game
+          path: headless-game.log
+          if-no-files-found: warn
+
   android:
     # Build the Android debug APK (app/android). Like the Wio/PSP jobs, this is
     # the external check for the port: cross-compiles mruby, LVGL,

--- a/changelog.d/psp-smoke-game-ci-job.added.md
+++ b/changelog.d/psp-smoke-game-ci-job.added.md
@@ -7,7 +7,10 @@
   the title screen", steady-state `RPG2k::Scene::Title`) had no CI run that
   could produce them. The new job places Nepheshel (the same RPG2000
   test-bed the desktop `build` job already downloads) at the EBOOT's fixed
-  Memory Stick path via PPSSPP headless's `--memstick` flag and asserts boot,
+  Memory Stick path (headless's own default memstick root, `$HOME/.ppsspp`,
+  written ahead of the emulator's own first-run setup — a `--memstick=DIR`
+  flag looked right from PPSSPP's source but the first real CI run showed
+  its arg parser never consuming it as a flag at all) and asserts boot,
   game detection and the frame loop the same way `psp-smoke` does. Marked
   `continue-on-error: true` for now, the same starting point `psp-smoke`
   itself used before its own HLE gaps were fixed — this is the first CI run

--- a/changelog.d/psp-smoke-game-ci-job.added.md
+++ b/changelog.d/psp-smoke-game-ci-job.added.md
@@ -1,0 +1,15 @@
+- **CI: a new `psp-smoke-game` job boots a real RPG2k game (Nepheshel) through
+  the PSP EBOOT under PPSSPP-headless.** `psp-smoke` only ever exercises the
+  idle HAL screen (no project at `app/psp/main.cxx`'s fixed `kGameDir`), so
+  `RPG2K_PSP_GAME_READY` never fired and `RPG2K_PSP_BRINGUP`'s `scene=` was
+  always `none` — the real device memory numbers
+  `docs/adr/0047-psp-memory-budget.md`'s P1/P1b need ("memory right before
+  the title screen", steady-state `RPG2k::Scene::Title`) had no CI run that
+  could produce them. The new job places Nepheshel (the same RPG2000
+  test-bed the desktop `build` job already downloads) at the EBOOT's fixed
+  Memory Stick path via PPSSPP headless's `--memstick` flag and asserts boot,
+  game detection and the frame loop the same way `psp-smoke` does. Marked
+  `continue-on-error: true` for now, the same starting point `psp-smoke`
+  itself used before its own HLE gaps were fixed — this is the first CI run
+  to boot a real game on this target, and Nepheshel's download host has its
+  own known intermittency unrelated to the EBOOT.


### PR DESCRIPTION
## Summary

The instrumentation from [#1339](https://github.com/take-cheeze/rpg-maker-clone/pull/1339)/[#1342](https://github.com/take-cheeze/rpg-maker-clone/pull/1342) (scene-tagged heartbeat, `RPG2K_PSP_GAME_READY`, `mrb_open()` bracketing) has been sitting unable to produce most of its own numbers: `psp-smoke` only ever boots the idle HAL screen — no project at `app/psp/main.cxx`'s fixed `kGameDir` — so `RPG2K_PSP_GAME_READY` never fires and `RPG2K_PSP_BRINGUP`'s `scene=` is always `none`. `docs/adr/0047-psp-memory-budget.md`'s P1/P1b explicitly need a real game to measure "memory right before the title screen" and steady-state `Scene::Title` against.

- New `psp-smoke-game` job: places Nepheshel (the same RPG2000 test-bed the desktop `build` job already downloads via `scripts/download-nepheshel.bash`) at the EBOOT's fixed Memory Stick path (`ms0:/PSP/GAME/rpg2k`) using PPSSPP headless's `--memstick` flag, then runs the same EBOOT `psp` already built and asserts boot, game detection (`RPG2K_PSP_GAME_START RPG2k ok`) and the frame loop, echoing every `RPG2K_PSP_*` marker on success — including, for the first time in CI, `RPG2K_PSP_GAME_READY` and a `scene=RPG2k::Scene::Title` heartbeat with real memory numbers.
- Reuses `psp-smoke`'s Nix store cache key for PPSSPP (job `needs: [psp, psp-smoke]`, so it always starts after that cache is populated — no second from-source PPSSPP compile).
- `RPG2K_NEW_GAME` is hardcoded `false` in `main.cxx` (no command line to carry a real flag on), so the game never advances past Title on its own — this job's scope is Title only. Reaching Map/Menu/Battle needs either a compile-time toggle for `RPG2K_NEW_GAME` or real input scripting, neither of which exists yet.
- `continue-on-error: true` for now — the same starting point `psp-smoke` itself used before its HLE gaps were fixed (see its own comment). This is the first CI run to boot a real game on this target, and I could not verify PPSSPP headless's exact `--memstick` behavior outside of actually running it (no local PPSSPP/pspdev toolchain available to me). Nepheshel's download host also has its own known intermittency, unrelated to the EBOOT itself.
- Changelog fragment added.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- [ ] The actual `--memstick` behavior and whether Nepheshel's `Scene::Title` numbers come through — this is exactly what running the job in CI will tell us; I have no way to verify it locally. If it doesn't work as expected, the job's `continue-on-error` means it won't block the PR, and I'll iterate on the actual `headless-game.log` output (uploaded as an artifact, and tailed in the job log on failure).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt


---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_