### PR TITLE
fix: current_scene_name always returned "none" (Class#name needs mruby-class-ext)

### DIFF
--- a/changelog.d/psp-scene-name-classname-fix.fixed.md
+++ b/changelog.d/psp-scene-name-classname-fix.fixed.md
@@ -1,0 +1,11 @@
+- **`#current_scene_name` (`RPG2k`/`RPGXP`/`RPGVX`) always reported `"none"`.**
+  It read `.class.name`, but `Class#name`/`Module#name` lives in the
+  `mruby-class-ext` gem, which `build_config.rb` never includes -- so the call
+  raised `NoMethodError` every time, silently caught by `app/psp/main.cxx`'s
+  `append_scene_name` (a diagnostic marker must never crash the frame loop)
+  and reported as `"none"`. Confirmed by the first real-game CI run
+  (`psp-smoke-game`, Nepheshel): `RPG2K_PSP_BRINGUP`'s `scene=` stayed `none`
+  for 600 frames despite the game actually running. Fixed by switching to
+  `.class.to_s`, which resolves through the same `mrb_class_path` machinery
+  but is core mruby (`Module#to_s` / `mrb_mod_to_s`), needing no extra gem.
+  See `docs/adr/0047-psp-memory-budget.md`'s P1b follow-up.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -995,6 +995,49 @@ the interpreter-linking slice, in this order:
   `stack_used_max` 1800 -> 3356 B: `mrb_open()`'s own call depth (gem
   registration is recursive) peaks noticeably higher than the idle loop's own
   ~1.8 KB baseline, but nowhere near the 256 KB stack budget (P5).
+
+  **First real-game run, `psp-smoke-game`'s CI job (2026-08-25, Nepheshel
+  under PPSSPP-headless) — "memory right before the title screen":**
+
+  ```
+  RPG2K_PSP_GAME_START RPG2k ok
+  RPG2K_PSP_GAME_READY RPG2k t_us=1239419 free=782336 maxfree=524288 lvgl_used=3788 lvgl_max=3788 stack_free=245160 stack_used_max=16984 arena_used=4391744
+  ```
+
+  `arena_used` 563,648 B right after `mrb_open()` (idle path, no game) ->
+  4,391,744 B (~4.19 MiB) once `RPG2k.new` finishes constructing the game
+  object (database, map tree, `Scene::Title`) -- so loading a real project's
+  own data (Nepheshel's `.ldb`/`.lmt` plus every asset `Scene::Title#initialize`
+  touches) costs roughly 3.6 MiB more than the interpreter's own bootstrap
+  alone, on top of a fixed 12 MB arena (P2). `t_us=1239419` vs.
+  `RPG2K_PSP_MRUBY_OPEN`'s `t_us=109126` on the same idle-path run puts
+  main-to-game-ready around 1.1 s, most of it disk I/O against the emulated
+  Memory Stick rather than CPU work. `stack_used_max` jumps to 16,984 B --
+  still comfortably inside the 256 KB budget, but an order of magnitude
+  deeper than `mrb_open()`'s own 3,356 B peak, since constructing a game
+  recurses through the RGSS/RPG2k class hierarchy far more than gem
+  registration alone does.
+
+  This same run's `RPG2K_PSP_BRINGUP` heartbeats all read `scene=none`,
+  including at `frame=600` (several seconds into a running game) -- not
+  because the scene stack was ever actually empty (RPG2k#main_loop calls
+  `@scenes.last.update` every frame with no rescue around it, so an empty
+  stack would have crashed the loop outright, and no `RPG2K_PSP_GAME_STOP`
+  marker appears), but because `#current_scene_name`'s `@scenes.last.class.
+  name` raised `NoMethodError` every single call: `Class#name`/`Module#name`
+  lives in the `mruby-class-ext` gem (`3rd/mruby/mrbgems/mruby-class-ext/src/
+  class.c`'s `mod_name`), which `build_config.rb`'s `rpg_maker_gems` never
+  includes, and `app/psp/main.cxx`'s `append_scene_name` deliberately
+  swallows any exception from the call into `"none"` (a diagnostic marker
+  must never abort the frame loop) -- so the bug read as "scene is always
+  none" instead of surfacing as a crash or a build error. Fixed by having
+  `current_scene_name` call `.to_s` instead of `.name` in all three
+  implementations (`mruby-rpg2k/mrblib/main.rb`, `mruby-rpgxp/mrblib/lib.rb`,
+  `mruby-rpgvx/mrblib/lib.rb`): `Module#to_s` (`mrb_mod_to_s`, core mruby,
+  `3rd/mruby/src/class.c`) resolves through the identical `mrb_class_path`
+  machinery and returns the same qualified name for a named class, with no
+  extra gem. Not yet re-verified against a fresh `psp-smoke-game` run with
+  the fix in place -- follow-up.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -553,8 +553,15 @@ class RPG2k
   # (app/psp/main.cxx) uses this to attribute its per-second memory numbers to
   # a scene instead of just a frame count; see
   # docs/adr/0047-psp-memory-budget.md.
+  # `.to_s`, not `.name`: `Class#name` lives in the mruby-class-ext gem, which
+  # this project's build_config.rb never pulls in, so it raises NoMethodError
+  # here (confirmed by a real psp-smoke-game CI run -- every heartbeat read
+  # back "none" despite the scene stack never actually being empty). Core
+  # mruby's `Module#to_s` (3rd/mruby/src/class.c's mrb_mod_to_s) resolves
+  # through the identical mrb_class_path machinery and returns the same
+  # qualified name ("RPG2k::Scene::Title") for free.
   def current_scene_name
-    @scenes.empty? ? "none" : @scenes.last.class.name
+    @scenes.empty? ? "none" : @scenes.last.class.to_s
   end
 
   # RPG_RT.exe (and the RPG2000/2003 editor's own Test Play button) is launched

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -137,9 +137,12 @@ class RPGVX
   # The active scene's class name -- see RPGXP#current_scene_name
   # (mruby-rpgxp/mrblib/lib.rb) for what this means and why; VX / VX Ace
   # shares that engine's ScriptHost wholesale (@use_script_host above).
+  # `.to_s`, not `.name` -- see RPG2k#current_scene_name's comment
+  # (mruby-rpg2k/mrblib/main.rb) for why: `Class#name` needs the
+  # mruby-class-ext gem, which this build never includes.
   def current_scene_name
     scene = RPGXP::ScriptHost.enabled? ? RPGXP::ScriptHost.current_scene : nil
-    scene ? scene.class.name : "none"
+    scene ? scene.class.to_s : "none"
   end
 
   # The edition's display name, for logs ("RPG Maker VX Ace").

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -74,9 +74,12 @@ class RPGXP
   # `SceneManager.scene`; script_host.rb). "none" covers the script host being
   # disabled, a project shipping no scripts, or the host simply not having
   # reported a scene yet.
+  # `.to_s`, not `.name` -- see RPG2k#current_scene_name's comment
+  # (mruby-rpg2k/mrblib/main.rb) for why: `Class#name` needs the
+  # mruby-class-ext gem, which this build never includes.
   def current_scene_name
     scene = ScriptHost.enabled? ? ScriptHost.current_scene : nil
-    scene ? scene.class.name : "none"
+    scene ? scene.class.to_s : "none"
   end
 
   # One frame of the game: one resume of the host's Fiber, which runs the


### PR DESCRIPTION
## Summary

[#1346](https://github.com/take-cheeze/rpg-maker-clone/pull/1346)'s new `psp-smoke-game` CI job (booting real Nepheshel data through the PSP EBOOT under PPSSPP-headless) produced its first real numbers — and exposed a real bug the idle-path `psp-smoke` job could never catch: `RPG2K_PSP_BRINGUP`'s `scene=` stayed `none` for all 600+ frames of a genuinely running game.

- **Root cause:** `#current_scene_name` (added in [#1339](https://github.com/take-cheeze/rpg-maker-clone/pull/1339)/[#1342](https://github.com/take-cheeze/rpg-maker-clone/pull/1342)) called `.class.name`, but `Class#name`/`Module#name` lives in the `mruby-class-ext` gem — which `build_config.rb`'s `rpg_maker_gems` never includes. The call raised `NoMethodError` every single time, silently caught by `app/psp/main.cxx`'s `append_scene_name` (a diagnostic marker must never crash the frame loop) and reported as `"none"` — so the bug read as "scene is always none" rather than surfacing as a crash or build error. Confirmed not a stack-emptiness issue: `RPG2k#main_loop` calls `@scenes.last.update` every frame with no rescue, so an actually-empty stack would have crashed the loop outright (no `RPG2K_PSP_GAME_STOP` marker ever appeared).
- **Fix:** switch `current_scene_name` to `.class.to_s` in all three implementations (`mruby-rpg2k`, `mruby-rpgxp`, `mruby-rpgvx`). `Module#to_s` (`mrb_mod_to_s`, `3rd/mruby/src/class.c`) is core mruby and resolves through the identical `mrb_class_path` machinery, returning the same qualified name (`"RPG2k::Scene::Title"`) for a named class — no extra gem needed. Verified identical under CRuby too.
- Records `psp-smoke-game`'s first successful real-game numbers in `docs/adr/0047-psp-memory-budget.md` (P1b follow-up): `RPG2K_PSP_GAME_READY`'s `arena_used` went from 563,648 B (right after `mrb_open()` alone, idle path) to 4,391,744 B (~4.19 MiB) once Nepheshel's own database/map tree/`Scene::Title` finished constructing — the device-measured "memory right before the title screen" figure the ADR's P1/P1b needed a real game to produce.
- Changelog fragment added.

## Test plan

- [x] `ruby -c` on all three edited files — syntax OK.
- [x] Verified `.to_s` gives the identical qualified name to `.name` for a nested class under CRuby (`RPG2k::Scene::Title.to_s == RPG2k::Scene::Title.name`).
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-yaml, large-files) — all passed on the changed files.
- [ ] Not yet re-verified against a fresh `psp-smoke-game` CI run with the fix in place — that's this PR's own CI run, which I'll check once it completes; expecting `scene=RPG2k::Scene::Title` in the `BRINGUP` heartbeat where it previously read `none`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_