### PR TITLE
docs: verify current_scene_name .to_s fix against a real psp-smoke-game run

### DIFF
--- a/changelog.d/psp-scene-name-fix-verified.changed.md
+++ b/changelog.d/psp-scene-name-fix-verified.changed.md
@@ -1,0 +1,7 @@
+- **Verified the `current_scene_name` `.to_s` fix ([#1349](https://github.com/take-cheeze/rpg-maker-clone/pull/1349))
+  against a real `psp-smoke-game` CI run.** Every `RPG2K_PSP_BRINGUP`
+  heartbeat now reads `scene=RPG2k::Scene::Title` where it previously always
+  read `scene=none`, confirming the per-scene memory attribution documented
+  in `docs/adr/0047-psp-memory-budget.md`'s P1b actually works on real
+  device output. No code change -- this fragment records the CI-confirmed
+  result.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1036,8 +1036,15 @@ the interpreter-linking slice, in this order:
   `mruby-rpgvx/mrblib/lib.rb`): `Module#to_s` (`mrb_mod_to_s`, core mruby,
   `3rd/mruby/src/class.c`) resolves through the identical `mrb_class_path`
   machinery and returns the same qualified name for a named class, with no
-  extra gem. Not yet re-verified against a fresh `psp-smoke-game` run with
-  the fix in place -- follow-up.
+  extra gem. Verified against a fresh `psp-smoke-game` run with the fix in
+  place ([#1349](https://github.com/take-cheeze/rpg-maker-clone/pull/1349),
+  2026-08-25): every `RPG2K_PSP_BRINGUP` heartbeat now reads
+  `scene=RPG2k::Scene::Title`, from `frame=0` (`t_us=1280186`) through
+  `frame=600` (`t_us=11310745`) -- the same run's other figures are
+  unchanged (`arena_used` still 4,391,744 B at `GAME_READY`, drifting
+  4,393,856 -> 4,935,696 -> 4,465,040 B across the four heartbeats, the same
+  GC sawtooth the pre-fix run already showed), confirming the `.to_s` switch
+  fixed only the name lookup and nothing else about the frame loop.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none


### PR DESCRIPTION
## Summary

Follow-up to [#1349](https://github.com/take-cheeze/rpg-maker-clone/pull/1349) (the `current_scene_name` `.to_s` fix). That PR's own `psp-smoke-game` CI run confirms the fix: every `RPG2K_PSP_BRINGUP` heartbeat now reads `scene=RPG2k::Scene::Title` (frames 0/200/400/600) instead of the previous `scene=none`, with the rest of the run's memory figures (`arena_used` still 4,391,744 B at `GAME_READY`) unchanged from the pre-fix run — confirming the `.to_s` switch fixed only the name lookup and nothing else about the frame loop.

- Updates `docs/adr/0047-psp-memory-budget.md`'s P1b follow-up paragraph from "not yet re-verified" to the actual confirmed device output.
- Changelog fragment added.
- No code change — this PR only records the CI-confirmed result.

## Test plan

- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer) — passed on the changed files.
- [x] Data quoted directly from [PR #1349's own `psp-smoke-game` job log](https://github.com/take-cheeze/rpg-maker-clone/actions/runs/32838363609/job/97775631728), not re-derived.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_