### PR TITLE
ci(psp): reach Scene::Map in psp-smoke-game, not just Title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1498,11 +1498,16 @@ jobs:
     # PSP build and capture what docs/adr/0047-psp-memory-budget.md's P1/P1b
     # actually need: real device memory numbers for "the database and map
     # tree loaded, Scene::Title built" (GAME_READY) and for steady-state
-    # Title (BRINGUP's scene=RPG2k::Scene::Title). RPG2K_NEW_GAME is
-    # hardcoded false in main.cxx (no command line to carry a real flag on),
-    # so the game never advances past Title on its own -- reaching Map/Menu/
-    # Battle needs either a compile-time toggle or real input scripting,
-    # neither of which exists yet; this job's scope is Title only.
+    # Title (BRINGUP's scene=RPG2k::Scene::Title). This job also drops a
+    # `.psp_ci_new_game` marker file next to Nepheshel's own data --
+    # app/psp/main.cxx checks for it and, only when present, sets
+    # RPG2K_NEW_GAME true instead of its normal hardcoded false, which makes
+    # Scene::Title auto-select "New Game" with no input needed (the same
+    # mechanism src/main.cxx's own --rpg2k_new_game already drives on
+    # desktop). That reaches Scene::Map for real numbers too, not just
+    # Title -- Menu/Battle still need either a compile-time RPG2K_NEW_GAME
+    # replacement (a specific map/troop id, say) or real input scripting,
+    # neither of which exists yet, so this job's scope stops at Map.
     #
     # Nepheshel is the same RPG2000 test-bed the desktop `build` job's own
     # "RPG2k real-game boot smoke test" step already downloads and boots, so
@@ -1585,8 +1590,14 @@ jobs:
         # it, so there is no race with PPSSPP's own first-run setup.
         run: |
           memstick="$HOME/.ppsspp"
-          mkdir -p "$memstick/PSP/GAME/rpg2k"
-          cp -r data/Nepheshel206beta/Nepheshel206Rbeta/. "$memstick/PSP/GAME/rpg2k/"
+          gamedir="$memstick/PSP/GAME/rpg2k"
+          mkdir -p "$gamedir"
+          cp -r data/Nepheshel206beta/Nepheshel206Rbeta/. "$gamedir/"
+          # app/psp/main.cxx's own opt-in: only this marker's presence flips
+          # RPG2K_NEW_GAME true, so Scene::Title auto-selects New Game and
+          # this run reaches Scene::Map instead of sitting on the title
+          # screen -- see this job's own top comment.
+          touch "$gamedir/.psp_ci_new_game"
 
       - name: Run headless with a real game
         run: |
@@ -1601,8 +1612,13 @@ jobs:
           if grep -q 'RPG2K_PSP_BOOT' "$GITHUB_WORKSPACE/headless-game.log" &&
              grep -q 'RPG2K_PSP_GAME_START RPG2k ok' "$GITHUB_WORKSPACE/headless-game.log" &&
              grep -q 'RPG2K_PSP_BRINGUP' "$GITHUB_WORKSPACE/headless-game.log"; then
-            grep -E 'RPG2K_PSP_[A-Z_]+' "$GITHUB_WORKSPACE/headless-game.log" \
-              | head -20
+            # 30, not 20: the .psp_ci_new_game marker (see this job's own top
+            # comment) makes Title auto-select New Game, which adds the
+            # [RPG2k-MAP] transition line and a run of BRINGUP heartbeats
+            # tagged scene=RPG2k::Scene::Map worth seeing in the job's own
+            # log, not just the uploaded artifact.
+            grep -E 'RPG2K_PSP_[A-Z_]+|\[RPG2k-MAP\]' "$GITHUB_WORKSPACE/headless-game.log" \
+              | head -30
           else
             echo "boot, game-start or bring-up marker missing; last 150 lines:"
             tail -150 "$GITHUB_WORKSPACE/headless-game.log"

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -662,8 +662,24 @@ int main(void) {
     // here doesn't reliably unwind on this target -- see ADR 0047's bug-10
     // follow-up finding -- so leaving these undefined crashes instead of
     // being caught.
+    //
+    // RPG2K_NEW_GAME is the one exception: it is driven by whether a
+    // `.psp_ci_new_game` marker file sits next to the project's own data at
+    // kGameDir, not always false like the other three. Scene::Title's
+    // auto_select? (mruby-rpg2k/mrblib/scene/title.rb) reads it to
+    // auto-pick "New Game" with no input needed, the same mechanism
+    // src/main.cxx's own --rpg2k_new_game already drives on desktop for
+    // scripts/compare-nepheshel-wine.bash -- this just gives the PSP target
+    // a way to opt in without a command line. A real release's own game
+    // folder never carries this file (nothing in the editor or this
+    // codebase's own packaging ever writes it), so every real player still
+    // lands on an ordinary title screen; only CI's psp-smoke-game job
+    // creates it, to reach Scene::Map for ADR 0047's per-scene memory
+    // numbers instead of measuring the idle title screen forever.
+    const bool ci_new_game = path_exists(kGameDir, ".psp_ci_new_game");
     mrb_const_set(M, mrb_obj_value(M->object_class),
-                  mrb_intern_lit(M, "RPG2K_NEW_GAME"), mrb_false_value());
+                  mrb_intern_lit(M, "RPG2K_NEW_GAME"),
+                  mrb_bool_value(ci_new_game));
     mrb_const_set(M, mrb_obj_value(M->object_class),
                   mrb_intern_lit(M, "RPG2K_CONTINUE"), mrb_false_value());
     mrb_const_set(M, mrb_obj_value(M->object_class),

--- a/changelog.d/psp-smoke-game-reach-map-scene.added.md
+++ b/changelog.d/psp-smoke-game-reach-map-scene.added.md
@@ -1,0 +1,12 @@
+- **`psp-smoke-game` CI now reaches `RPG2k::Scene::Map`, not just Title.**
+  `app/psp/main.cxx` checks for a `.psp_ci_new_game` marker file next to the
+  project's own data at `kGameDir` and, only when present, sets
+  `RPG2K_NEW_GAME` true instead of its usual hardcoded false -- the same
+  mechanism `src/main.cxx`'s desktop-only `--rpg2k_new_game` flag already
+  drives, now reachable on the PSP target with no command line. A real
+  release's own game folder never carries the marker (nothing in the editor
+  or this codebase's packaging writes it), so every real player still lands
+  on an ordinary title screen; only the `psp-smoke-game` CI job creates it,
+  so `docs/adr/0047-psp-memory-budget.md`'s per-scene memory numbers can
+  cover a loaded map and party, not just the idle title screen. See the
+  ADR for the measured figures once this job has run.


### PR DESCRIPTION
## Summary

Continuing `docs/adr/0047-psp-memory-budget.md`'s per-scene memory work: `psp-smoke-game` ([#1346](https://github.com/take-cheeze/rpg-maker-clone/pull/1346)) has only ever measured the idle title screen — `RPG2K_NEW_GAME` was hardcoded `false` in `main.cxx` (no command line to carry a real flag on), so `Scene::Title` never advances on its own.

`mruby-rpg2k/mrblib/scene/title.rb` already has exactly the mechanism this needs: `Scene::Title#auto_select?` reads `RPG2K_NEW_GAME` to auto-pick "New Game" with no input, the same thing `src/main.cxx`'s own `--rpg2k_new_game` flag already drives for `scripts/compare-nepheshel-wine.bash` on desktop. This wires it up for the PSP target:

- `app/psp/main.cxx` checks for a `.psp_ci_new_game` marker file next to the project's own data at `kGameDir` and, only when present, sets `RPG2K_NEW_GAME` true instead of its usual hardcoded `false`. A real release's own game folder never carries this file (nothing in the editor or this codebase's packaging writes it), so every real player still sees an ordinary title screen — this is an opt-in test hook, not a behavior change for released games.
- `.github/workflows/build.yml`'s `psp-smoke-game` job creates the marker file after placing Nepheshel, so its run now reaches `Scene::Map` (party built, map loaded) instead of sitting on Title.
- Widened the job's own grep pattern to also surface the `[RPG2k-MAP]` transition line and more `BRINGUP` heartbeats in the job's own log, **without** changing its pass/fail assertions (still just `BOOT`/`GAME_START`/`BRINGUP`) — this is a data-gathering change, not a stricter gate. `continue-on-error: true` stays as-is.
- Changelog fragment added.

Once this job runs, I'll pull its real numbers (`scene=RPG2k::Scene::Map` memory figures) and record them in the ADR, the same pattern used for [#1349](https://github.com/take-cheeze/rpg-maker-clone/pull/1349)/[#1351](https://github.com/take-cheeze/rpg-maker-clone/pull/1351).

## Test plan

- [x] `clang-format -n app/psp/main.cxx` — no diff.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-yaml, clang-format) — all passed.
- [ ] No local PSP/pspdev toolchain available to build or run this — this PR's own CI run is the first real verification, same as every other PSP change in this session. Watching for it.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_