### PR TITLE
Save/Load: bgm_stopping now round-trips through Save/Continue

### DIFF
--- a/changelog.d/bgm-stopping-save-roundtrip.fixed.md
+++ b/changelog.d/bgm-stopping-save-roundtrip.fixed.md
@@ -1,0 +1,8 @@
+- **Save/Load:** the `bgm_stopping` flag a Fade Out BGM sets (forcing the
+  next same-name Play BGM/Play Memorized BGM to restart from the top
+  instead of silently continuing) now survives a Save/Continue, matching
+  liblcf's `SaveSystem` field 61 (`music_stopping`). Previously the flag was
+  session-only and silently reset to "not stopping" on every load, so a
+  game that faded a track out, saved, and continued wrongly resumed the old
+  in-place-volume-adjust behaviour on the very next same-name Play BGM
+  instead of restarting it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2624,6 +2624,126 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k3_battle_row_check.rb` (19) and `scripts/
   rpg2k3_battle_gauge_check.rb` (15) -- all unchanged from cycle #150, since
   no production code was touched this cycle.
+  ✅ **Follow-up (cycle #152, 2026-08-25): gave the autostart-crash mystery
+  one last look for a genuinely new angle per this file's own task brief,
+  found none within a reasonable effort, and pivoted to candidate 2 -- a
+  real, fixable behavioral gap this cycle actually lands with a code fix
+  and regression coverage, closing a "left for later" note from an earlier
+  (2026-08-21) BGM cluster fix: `Game::State#bgm_stopping` (RPG_RT's own
+  `music_stopping` flag, set true by Fade Out BGM and forcing the next
+  same-name Play BGM/Play Memorized BGM to restart rather than silently
+  continue) was session-only -- liblcf's `SaveSystem` field 61
+  (`generator/csv/fields.csv`, `0x3D`) was never modelled in `schema.rb`'s
+  `SAVE_SYSTEM`, so the flag silently reset to `false` on every Save/
+  Continue.** On the crash mystery itself: re-read cycle #150/#151's own
+  entries in full first; both of this file's own suggested untested
+  threads (a non-autostart trigger for the >=2-command list; whether the
+  field menu differs from battle/teleport/save because of a surface
+  resolution/mode difference) would need either a new player-triggered,
+  non-autostart list-completion harness or a pixel-format trace comparison
+  neither of which looked reachable as a clean, decisive result inside this
+  cycle's own time budget after the schema investigation below turned up a
+  genuine fixable gap instead -- left for a future cycle exactly as framed,
+  not abandoned. **Confirmed directly against a genuine RPG_RT.exe save
+  under wine that field 61 is real and is written conditionally, not
+  merely inferred from liblcf's field list (used here only for the field
+  id/type, per this file's own standing exception).** Reused cycle #150/
+  #151's own `LCF::MapUnit`-based injector design (fresh scratch dir this
+  session, `Map0012_orig.lmu`/`Save01_clean.lsd` re-copied from cycle
+  #150's own saved copies and re-verified byte-identical: `c2fa69a0...`/
+  `3ab5bb01...`, matching every prior cycle back to #148) to build a single
+  autostart event -- genuine content commands throughout (Play BGM ->
+  Wait -> [Fade Out BGM -> Wait] -> [Play BGM -> Wait] -> Open Save Menu),
+  never a bare no-op list, so per cycle #151's own "appending any further
+  command suppresses the count-4 signature" finding this was not expected
+  to (and did not) interact with the crash mystery at all -- then drove the
+  real save UI under Xvfb (640x480x16, `LIBGL_ALWAYS_SOFTWARE=1`,
+  matchbox-window-manager, `LANG=ja_JP.UTF-8`, `WINEARCH=win32`,
+  `WINEPREFIX=~/.wine-nepheshel32`) down to the empty File 2 slot
+  (`xdotool` Down + Return -- confirmed by screenshot that an empty slot
+  saves and returns to the map on a single Return, no yes/no confirm,
+  unlike overwriting an occupied one) to produce a genuine `Save02.lsd`,
+  copied out and inspected field-by-field with this project's own
+  `LCF::Array1D` reader (`key?`/raw `@data` access, bypassing the schema so
+  an undeclared field's mere presence -- not just its decoded value -- is
+  visible). **Three scenarios, each independently run once:** no Fade Out
+  BGM ever issued (field 61 absent -- matches the shipped `Save01.lsd`
+  fixture itself, also checked and also absent); Play BGM then Fade Out BGM
+  then a wait long enough for the fade to finish, then save (field 61
+  present, exactly one byte, value `1`); the same, then a further Play BGM
+  of the identical track before saving, clearing the flag back to `false`
+  per this codebase's own already-existing `#play_audio` logic (field 61
+  absent again, not present-as-`0`). This pins both the field's genuine
+  on-disk presence (settling "is this really persisted at all, or does
+  liblcf's field list merely document an in-memory-only RPG_RT struct" in
+  the affirmative) and RPG_RT's own write convention for it: present only
+  while true, the same "omit at false" pattern field 41
+  (`message_transparent`) already empirically shows in the shipped save
+  (also spot-checked this cycle), not the unconditional-write convention
+  fields 121-124 use -- so this is not a uniform per-type rule but a
+  genuinely per-field fact, worth recording since a future field-61-shaped
+  gap elsewhere in this table cannot be assumed either way without its own
+  check. **A methodology aside, timeboxed and not chased further:** an
+  extraneous, otherwise-idle second Return keypress sent immediately after
+  a successful save-and-return-to-map was found to reliably kill genuine
+  RPG_RT.exe outright in this cycle's own harness (reproduced once,
+  `ps`-confirmed real process death, not merely `alive` returning false
+  once) -- interesting and possibly related to this file's own broader
+  crash-mystery territory, but a single further keypress on the map with
+  nothing to interact with is a different precondition shape than anything
+  the mystery's own existing writeups cover, so this is flagged rather than
+  investigated; the fix that mattered for this cycle's own probe was simply
+  not sending that second keypress, which every real run below already
+  does. **Fixed** by adding `61 => { name: :bgm_stopping, type: :bool,
+  default: false }` to `SAVE_SYSTEM` (`mruby-lcf/mrblib/schema.rb`), a
+  conditional `sys[61] = true if @bgm_stopping` in `Game::State#to_lsd` and
+  `state.bgm_stopping = sys.bgm_stopping ? true : false` in `.from_lsd`
+  (both `mruby-rpg2k/mrblib/game.rb`) -- the `?true:false`/absent-default
+  round trip mirroring this same file's own `message_transparent`/
+  `teleport_allowed`-style boolean fields already in this table. Covered by
+  two new `scripts/rpg2k_logic_check.rb` checks: a direct `to_lsd`/
+  `from_lsd` round-trip asserting field 61's physical presence (`key?(61)`)
+  tracks `bgm_stopping` exactly (present+true / absent+false, both
+  directions), and a behavioral check that starts a fresh `Game::
+  Interpreter` on a *newly* `Game::State.from_lsd`-built state (not the
+  same live objects the original Fade Out BGM ran on, matching a real
+  Continue) and confirms a same-name Play BGM issued after that load still
+  restarts the track (two `:bgm` log entries) rather than only adjusting
+  volume in place -- both confirmed to fail against the pre-fix code
+  (`git stash` of just `schema.rb`/`game.rb`): the round-trip check never
+  ran (pre-fix `SAVE_SYSTEM` has no `:bgm_stopping` accessor at all, so
+  `.from_lsd`'s own new read line would raise `NoMethodError`/`TypeError`
+  reaching into an unindexed field -- avoided here by stashing the read
+  line along with the schema, so the check instead demonstrates the
+  behavioral gap directly), and the behavioral check failed with a precise,
+  specific `RuntimeError: expected ["town", "town"], got ["town"]` --
+  exactly the silently-wrong "resumed the fade's leftover state instead of
+  restarting" symptom this fix closes. `Map0012.lmu`/`Save01.lsd` were
+  restored to their original bytes (byte-identical by `md5sum` against the
+  same `c2fa69a0.../3ab5bb01...` values every prior cycle back to #148
+  recorded) and the scratch `Save02.lsd` this cycle's own probes produced
+  was removed from the game directory (never a tracked fixture) after
+  every run; `git status` on `data/` came back clean. No EasyRPG source was
+  consulted for any claim in this cycle, and no web search was used either
+  -- the only outside reference was liblcf's own `generator/csv/fields.csv`
+  field id/type for field 61, this file's own standing narrow exception,
+  and every behavioral claim (the field's genuine presence, its value, and
+  its write-only-when-true convention) traces to this cycle's own genuine
+  RPG_RT.exe wine captures and this codebase's own pre-fix/post-fix test
+  runs. Full suite reconfirmed passing, `scripts/rpg2k_logic_check.rb` up
+  by 2: `scripts/rpg2k_scene_check.rb` (929), `scripts/
+  rpg2k_render_check.rb` (41), `scripts/rpg2k_logic_check.rb` (1136),
+  `scripts/rpg2k3_battle_row_check.rb` (19) and `scripts/
+  rpg2k3_battle_gauge_check.rb` (15). **Left open for a future cycle:** the
+  crash mystery's own two still-untested threads (see above, unchanged from
+  cycle #151's own framing); the "extraneous Return kills RPG_RT" aside
+  just above, which might or might not be the same underlying mechanism as
+  the mystery proper; and whether any *other* SAVE_SYSTEM field this table
+  already declares actually follows the "unconditional write" convention
+  its own `to_lsd` code assumes rather than the "omit at false/default"
+  convention field 41 and now field 61 both empirically show -- this cycle
+  only spot-checked 41/61/121, not an exhaustive field-by-field audit of
+  the whole table.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1503,6 +1503,21 @@ module LCF
       # transparency), not a player-visibility override -- see SAVE_MOVABLE's
       # field 24 for where Set Transparent Flag's state actually lives, and
       # why it was wrongly modelled here before.
+      # liblcf's `SaveSystem.music_stopping` (`generator/csv/fields.csv`,
+      # `0x3D`/61) -- see `Game::State#bgm_stopping`'s own doc comment in
+      # game.rb for what the flag means. Confirmed present in a genuine
+      # RPG_RT.exe save under wine only while the flag is actually true: a
+      # synthetic autostart list (Play BGM -> Fade Out BGM -> wait out the
+      # fade -> Open Save Menu) saved with chunk 101 carrying this field as
+      # a single 0x01 byte, while the identical list with no Fade Out BGM at
+      # all, and a third variant that faded out and then re-issued Play BGM
+      # of the same track before saving (clearing the flag back to false --
+      # `#play_audio`'s own `@state.bgm_stopping = false` on every BgmPlay,
+      # restart or not), both omitted field 61 entirely -- so real RPG_RT
+      # writes this field only when true, the same "false is simply absent"
+      # convention field 41 (`message_transparent`) already follows here,
+      # not the unconditional-write convention fields 121-124 use.
+      61 => { name: :bgm_stopping, type: :bool, default: false },
       # Overridden BGM/SE playback state. An empty file name means "use the
       # database value".
       71 => { name: :title_bgm, type: :Array1D, elements: BGM },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14008,6 +14008,12 @@ module Game
     # ordinary same-name replay. Cleared unconditionally at the end of every
     # `BgmPlay` call, restart or not (`data.music_stopping = false;`), which
     # `#play_audio`'s `:bgm` branch and `#do_play_memorized_bgm` both mirror.
+    # Round-trips through Save/Continue as liblcf's SaveSystem field 61 (see
+    # `#to_lsd`/`.from_lsd`'s own field-61 comments and SAVE_SYSTEM in
+    # schema.rb for the genuine-RPG_RT wine evidence this cycle gathered for
+    # it) -- a save taken mid-fade and reloaded now correctly forces the next
+    # same-name Play BGM to restart, matching real RPG_RT rather than
+    # silently resetting to "not stopping" on every load.
     attr_accessor :bgm_stopping
     # Whether the party leader's map sprite is hidden, toggled by the Set
     # Transparent Flag / Change Player Visibility (11310) event command. Defaults
@@ -14594,6 +14600,13 @@ module Game
       sys[52] = mc.face_index || 0
       sys[53] = mc.face_right ? 1 : 0
       sys[54] = mc.face_flipped ? true : false
+      # liblcf's `music_stopping` (field 61) -- written only when true,
+      # confirmed against a genuine RPG_RT.exe save under wine (see
+      # SAVE_SYSTEM's own comment in schema.rb): a fresh Fade Out BGM
+      # produces a save with this field present as a single 0x01 byte, while
+      # both a save taken with no fade ever issued and one taken after a
+      # later Play BGM cleared the flag back to false both omit it entirely.
+      sys[61] = true if @bgm_stopping
       sys[75] = bgm_chunk(@current_bgm) if @current_bgm
       sys[78] = bgm_chunk(@memorized_bgm) if @memorized_bgm
       # Change System BGM (10660) / Change System SFX (10670) overrides, one
@@ -15142,6 +15155,10 @@ module Game
       mc.face_index = sys.face_index || 0
       mc.face_right = (sys.face_right_position || 0) != 0
       mc.face_flipped = sys.face_flip ? true : false
+      # An absent field 61 (the schema's own default) means "not stopping",
+      # matching a genuine save that never wrote the field at all -- see
+      # SAVE_SYSTEM's own comment in schema.rb.
+      state.bgm_stopping = sys.bgm_stopping ? true : false
       # Overridden BGM playback state; an empty file name means "none".
       state.current_bgm = bgm_from_chunk(sys.current_bgm)
       state.memorized_bgm = bgm_from_chunk(sys.stored_bgm)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4370,6 +4370,66 @@ check 'to_lsd/from_lsd round-trips the current and memorized BGM\'s balance, ' \
   eq 60, round.memorized_bgm[:balance], 'and its balance round-trips too'
 end
 
+check 'to_lsd/from_lsd round-trips bgm_stopping (liblcf SaveSystem field ' \
+      '61), present only while it is actually true' do
+  # Cycle #152: confirmed against a genuine RPG_RT.exe save under wine that
+  # field 61 ("music_stopping") is written only while the flag is true --
+  # see SAVE_SYSTEM's own comment in schema.rb for the three-scenario
+  # evidence (no fade ever issued / mid-fade / faded-then-replayed, gathered
+  # via a synthetic autostart Play BGM -> Fade Out BGM -> Open Save Menu
+  # list driven through the real save UI).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.bgm_stopping = true
+  saved = st.to_lsd
+  eq true, saved[101].key?(61),
+     'field 61 is physically present when bgm_stopping is true, matching ' \
+     'the genuine mid-fade save gathered this cycle'
+  round = Game::State.from_lsd(db, saved)
+  eq true, round.bgm_stopping, 'bgm_stopping itself round-trips true'
+
+  st2 = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  saved2 = st2.to_lsd
+  eq false, saved2[101].key?(61),
+     'field 61 is omitted entirely when bgm_stopping is false (the default), ' \
+     'matching both the never-faded and the faded-then-replayed genuine saves'
+  round2 = Game::State.from_lsd(db, saved2)
+  eq false, round2.bgm_stopping, 'an absent field reads back as "not stopping"'
+end
+
+check 'a Fade Out BGM followed by a Save/Continue boundary still forces the ' \
+      'next same-file Play BGM to restart, not silently adjust volume in place' do
+  # The behavioural point of the round-trip above: pre-fix, bgm_stopping was
+  # session-only (never written by #to_lsd nor read by .from_lsd), so it
+  # silently reset to false on every load -- a game that faded a track out,
+  # saved, and continued would then wrongly skip the restart on the very
+  # next same-name Play BGM, unlike genuine RPG_RT (whose `music_stopping`
+  # flag is part of the persisted SaveSystem chunk).
+  RGSS::Audio.log = []
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::FADEOUT_BGM, [400]),
+  ])
+  it.update
+  eq true, st.bgm_stopping, 'sanity: the Fade Out BGM set the in-memory flag before any save'
+
+  # A brand new State/Interpreter built from the saved bytes, exactly as a
+  # real Continue does -- not the same live objects the fade ran on.
+  loaded = Game::State.from_lsd(db, st.to_lsd)
+  it2 = Game::Interpreter.new(loaded)
+  it2.start([FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town')])
+  it2.update
+  names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
+  eq %w[town town], names,
+     'the post-load Play BGM of the same track restarted it -- pre-fix this ' \
+     'stayed at a single entry, since bgm_stopping silently reset to false ' \
+     'across the save/load boundary'
+end
+
 check 'to_lsd/from_lsd round-trips both Timer Operation countdowns' do
   # docs/TODO.md used to call the game timer the one field the .lsd export
   # "cannot yet carry", guessing it would need "a documented chunk id" of its


### PR DESCRIPTION
## Summary
- Fade Out BGM sets `Game::State#bgm_stopping`, forcing the next same-name Play BGM/Play Memorized BGM to restart from the top instead of silently continuing — already correctly modeled in-session. But this flag was never wired into the save format: `mruby-lcf`'s `SAVE_SYSTEM` schema never declared liblcf field 61 (`music_stopping`), so `to_lsd`/`from_lsd` silently dropped it, resetting to "not stopping" on every Save/Continue.
- Adds field 61 to `SAVE_SYSTEM`; `to_lsd` writes it only when true, `from_lsd` reads an absent field back as false.

## Verification
- Confirmed against genuine RPG_RT.exe under wine via a synthetic autostart Play BGM → Fade Out BGM → Open Save Menu sequence: a mid-fade save writes field 61 as a single `0x01` byte, while both a never-faded save and a faded-then-replayed save omit it entirely — pinning both the field's existence and its "present only while true" write convention (matching field 41, not the unconditional-write convention fields 121–124 use).
- Two new regression checks confirmed to fail against pre-fix code (`git stash` of `schema.rb`+`game.rb`) with exactly the claimed errors, then pass after restoring — independently re-verified by me as well.
- All check suites pass: `rpg2k_scene_check.rb` 929/929, `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1136/1136 (up from 1134), `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- No EasyRPG Player source was consulted; the only outside reference was liblcf's `generator/csv/fields.csv` for field 61's id/type, the project's own narrow documented exception.

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929/929
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1136/1136
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Pre-fix regression proof via `git stash` (independently reproduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_