### PR TITLE
ci(psp): record Scene::Map's real numbers and a real emulator crash (P1c)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1606,8 +1606,25 @@ jobs:
           # Longer timeout than psp-smoke's idle-path 15s: a real database
           # and map tree load (RPG_RT.ldb/.lmt) is real work the idle path
           # never does.
+          # $status, not `|| true` on the invocation itself: a signal-killed
+          # exit (128 + signal number -- 139 for the SIGSEGV docs/adr/0047-
+          # psp-memory-budget.md's P1c hit) must not be silently absorbed
+          # the way it was there -- that run segfaulted partway through
+          # Scene::Map and still reported success because only the marker-
+          # presence asserts below gated the job, with nothing checking
+          # whether the emulator itself survived. Checked as "$status" -ge
+          # 128, not "$status" -ne 0: a plain --timeout completion (this
+          # EBOOT never calls the syscall a real Headless.cpp test-success
+          # exit would want) is expected to exit nonzero on its own and
+          # must not be flagged as if it were a crash.
+          set +e
           ./ppsspp/bin/ppsspp-headless --log --graphics=software --timeout=45 \
-            "$EBOOT" > "$GITHUB_WORKSPACE/headless-game.log" 2>&1 || true
+            "$EBOOT" > "$GITHUB_WORKSPACE/headless-game.log" 2>&1
+          status=$?
+          set -e
+          if [ "$status" -ge 128 ]; then
+            echo "::warning::ppsspp-headless was killed by signal $((status - 128)) (exit $status) -- see docs/adr/0047-psp-memory-budget.md's P1c"
+          fi
           echo "=== asserting the EBOOT booted, found the game, and pumped frames ==="
           if grep -q 'RPG2K_PSP_BOOT' "$GITHUB_WORKSPACE/headless-game.log" &&
              grep -q 'RPG2K_PSP_GAME_START RPG2k ok' "$GITHUB_WORKSPACE/headless-game.log" &&

--- a/changelog.d/psp-smoke-game-crash-detection.added.md
+++ b/changelog.d/psp-smoke-game-crash-detection.added.md
@@ -1,0 +1,13 @@
+- **`psp-smoke-game` now flags an emulator crash instead of silently
+  swallowing it.** The first CI run to reach `Scene::Map` (via the new
+  `.psp_ci_new_game` marker) surfaced a real `ppsspp-headless` segfault
+  partway through the run -- but the job still reported success, since
+  only the marker-presence assertions gated it and `|| true` on the
+  emulator invocation absorbed the crash along with the ordinary case of
+  a clean `--timeout`. The invocation now checks its own exit status: a
+  signal-killed exit (128+signal, e.g. 139 for `SIGSEGV`) prints a
+  `::warning::` annotation naming the signal, while a plain nonzero exit
+  from a clean timeout (expected, not a crash) stays silent. Job pass/fail
+  is unchanged -- this only makes a real crash visible in the job's own
+  log instead of requiring someone to notice by reading raw output. See
+  `docs/adr/0047-psp-memory-budget.md`'s P1c for the numbers.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1101,6 +1101,23 @@ the interpreter-linking slice, in this order:
   data point or unusually heavy; (3) root-cause the crash itself before
   treating the 12 MB arena figure (P2) as validated for anything beyond an
   idle title screen.
+
+  Follow-up (1) shipped in
+  [#1354](https://github.com/take-cheeze/rpg-maker-clone/pull/1354): the
+  emulator invocation now checks its own exit status and prints a
+  `::warning::` for a signal-killed exit (128+signal) rather than relying
+  on someone to read raw output. Its own CI run confirmed the warning fires
+  correctly (`ppsspp-headless was killed by signal 11 (exit 139)`) -- and,
+  more importantly, reproduced the *exact same crash*: identical `t_us`
+  timestamps and identical `arena_used` figures at every marker
+  (`GAME_READY` 4,391,744; `BRINGUP frame=0` 10,762,352 at `t_us=5726062`;
+  `BRINGUP frame=200` 11,887,824 at `t_us=18729969`) across two independent
+  CI runs on two different commits. `ppsspp-headless`'s emulated clock is
+  deterministic, so byte-identical figures across separate runs mean this
+  is not a timing-dependent flake -- it is a fully reproducible failure
+  landing at the same point in execution every time, which strengthens
+  (without yet confirming) the arena-exhaustion hypothesis over an
+  intermittent/unrelated one. Follow-ups (2) and (3) remain not started.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1045,6 +1045,62 @@ the interpreter-linking slice, in this order:
   4,393,856 -> 4,935,696 -> 4,465,040 B across the four heartbeats, the same
   GC sawtooth the pre-fix run already showed), confirming the `.to_s` switch
   fixed only the name lookup and nothing else about the frame loop.
+
+  **P1c — open risk found: `Scene::Map` approaches the 12 MB arena ceiling,
+  and the emulator crashed shortly after reaching it (2026-08-25,
+  [#1352](https://github.com/take-cheeze/rpg-maker-clone/pull/1352)).**
+  `.psp_ci_new_game` (a marker file `app/psp/main.cxx` checks for next to
+  the project's own data, opt-in only -- a real release's game folder never
+  carries it) makes `Scene::Title` auto-select New Game the same way
+  `src/main.cxx`'s desktop-only `--rpg2k_new_game` flag already does, so
+  `psp-smoke-game` now reaches `Scene::Map` instead of stopping at Title.
+  The run:
+
+  ```
+  RPG2K_PSP_GAME_READY RPG2k t_us=1248338 ... arena_used=4391744
+  [RPG2k-MAP] map=371 x=10 y=7
+  RPG2K_PSP_BRINGUP frame=0   scene=RPG2k::Scene::Map t_us=5726062  lvgl_used=5640 lvgl_max=7096 stack_used_max=17600 arena_used=10762352
+  RPG2K_PSP_BRINGUP frame=200 scene=RPG2k::Scene::Map t_us=18729969 lvgl_used=6876 lvgl_max=7448 stack_used_max=17600 arena_used=11887824
+  Segmentation fault (core dumped)
+  ```
+
+  Two things worth separating. First, the real numbers: entering
+  `Scene::Map` (party built, `RPG_RT.lmt` map 371 loaded, chipset/panorama
+  decoded) jumped `arena_used` from 4,391,744 B (Title, unchanged from
+  P1b) to 10,762,352 B at the very first Map frame -- **+6.37 MB**, more
+  than 11x Title's own footprint -- and it kept climbing to 11,887,824 B by
+  frame 200 (~13 s later), leaving only about 113 KB of the 12 MB arena
+  (`kMrbArenaSize`, `app/psp/main.cxx`) unused. `lvgl_used`/`lvgl_max` also
+  jumped (2208/2208 at Title -> 6876/7448 at Map frame=200) as the map's
+  tileset/panorama bitmaps decode into LVGL's own pool, and
+  `stack_used_max` roughly doubled (3356 B post-`mrb_open()` -> 17600 B),
+  consistent with the deeper call chains map rendering and the event
+  interpreter add over gem registration alone.
+
+  Second, and separately: `ppsspp-headless` itself segfaulted (`core
+  dumped`) sometime between the `frame=200` heartbeat and `frame=400`'s
+  (which never appears), ending the run early. `psp-smoke-game`'s own
+  `|| true` after the emulator invocation exists so its *assertions* can
+  still run against whatever log exists rather than the step aborting
+  outright, and those assertions (`RPG2K_PSP_BOOT`/`GAME_START`/`BRINGUP`
+  all present) technically still passed, so the job reported success with
+  the crash sitting silently in the log -- not caught by anything, just
+  found by reading the raw output this once. Whether the crash is caused
+  by arena pressure (the fixed 12 MB `g_mrb_arena` running out, and
+  `mrb_basic_alloc_func`'s override doing something unsafe on exhaustion
+  rather than a clean `mrb_full_gc`-then-fail) or is an unrelated PPSSPP
+  HLE gap that Map-scene code is simply the first thing in this project to
+  trip (a syscall or GPU command Title never issues) is **not yet
+  determined** -- both are plausible from this one data point, and telling
+  them apart needs either a core-dump backtrace or a smaller repro, neither
+  attempted yet. Follow-up, not yet started: (1) make `psp-smoke-game`
+  itself detect and loudly flag a crash (grep the log for `Segmentation
+  fault`/`core dumped`, or check the emulator's own exit code before `||
+  true` discards it) so this stops requiring a human to notice by reading
+  raw output; (2) determine whether Nepheshel's map 371 is a representative
+  data point or unusually heavy; (3) root-cause the crash itself before
+  treating the 12 MB arena figure (P2) as validated for anything beyond an
+  idle title screen.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none


### PR DESCRIPTION
## Summary

Follow-up to [#1352](https://github.com/take-cheeze/rpg-maker-clone/pull/1352). Its own `psp-smoke-game` run reached `Scene::Map` for the first time and produced real numbers worth recording — plus a real problem worth not hiding:

- `arena_used` jumped from 4,391,744 B (Title, unchanged from prior runs) to **10,762,352 B at the very first Map frame**, climbing to **11,887,824 B by frame 200** — within ~113 KB of the 12 MB `g_mrb_arena` ceiling.
- `ppsspp-headless` itself **segfaulted** (`core dumped`) shortly after — but the job still reported success, since `|| true` on the emulator invocation absorbed the crash the same way it absorbs an ordinary clean `--timeout`, and only marker-presence assertions (`BOOT`/`GAME_START`/`BRINGUP`) gated pass/fail.

This PR:

- Records the real numbers and the crash as an explicitly **open, undetermined** risk in `docs/adr/0047-psp-memory-budget.md`'s new **P1c** — whether the crash is arena exhaustion or an unrelated PPSSPP HLE gap that Map-scene code is simply the first thing to trip isn't known yet, and I'm not guessing at it without a backtrace or a smaller repro.
- Makes the job itself **surface** a crash instead of silently swallowing it: the emulator invocation now checks its own exit status and prints a `::warning::` specifically for a signal-killed exit (128+signal — 139 for `SIGSEGV`), while a plain nonzero exit from an ordinary `--timeout` completion (expected, not a crash) stays silent. Job pass/fail is unchanged — this is visibility, not a stricter gate; `continue-on-error: true` stays as-is until the crash itself is understood.
- Changelog fragment added.

## Why this matters

This flips the framing of the memory work: earlier PRs in this series were about *shrinking* PSP memory use. This finding suggests the opposite risk in the other direction — a real map (Nepheshel's map 371) may leave very little headroom in the 12 MB mruby arena, and the emulator crashed shortly after. I'm not proposing a fix here (increasing the arena, chasing a PPSSPP-specific bug, or something else) because I don't yet know which of those, if any, is the right one — that's exactly what P1c's follow-up items call out as not yet started.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-yaml) — all passed.
- [ ] The crash-detection logic itself (does a `SIGSEGV` really print the warning, does a clean timeout really stay silent) can only be verified by this PR's own CI run reproducing (or not reproducing) the same crash — watching for it.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_