### PR TITLE
Fix wasm ccache exhaustion by rotating cache key weekly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1063,17 +1063,30 @@ jobs:
 
       # Same run_id problem as the Emscripten cache above, but ccache's
       # contents legitimately evolve with source changes, so it cannot use a
-      # toolchain-pin key. Keying on the commit instead of the run still
-      # caps growth to one new cache per commit rather than one per
-      # workflow *run* -- re-runs, `issue_comment`/`push`/`pull_request`
-      # firing on the same SHA, and manual workflow_dispatch retries all
-      # collapse onto the same exact-match key instead of each minting a
-      # fresh multi-hundred-MB cache entry.
+      # toolchain-pin key the way that cache does. This used to key on
+      # github.sha instead, capping growth to one new cache per commit rather
+      # than one per workflow *run* -- but on a repo this commit-heavy, "one
+      # per commit" is still a fresh multi-hundred-MB entry on nearly every
+      # push, almost none of which ever gets an exact-match hit again (the
+      # next commit has a different sha), so they just piled up as dead
+      # weight -- flooding github.com/<repo>/actions/caches and evicting the
+      # Nix/RTP/wine/game caches above the same way the old emcc key did.
+      # Rotate on a week instead: every push in the same
+      # ISO week exact-matches the same key (ccache updates locally but the
+      # post-job save step is a no-op on an exact-match restore, since
+      # actions/cache cannot overwrite an existing entry), and
+      # `restore-keys` falls back to the most recent prior week's entry once
+      # the week rolls over. That bounds this to ~52 entries/year while still
+      # refreshing ccache's contents regularly.
+      - name: Cache period
+        id: cache-period
+        run: echo "value=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
       - name: Restore and cache ccache
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/.ccache
-          key: wasm-ccache-${{ github.sha }}
+          key: wasm-ccache-${{ steps.cache-period.outputs.value }}
           restore-keys: wasm-ccache-
 
       # Emscripten builds its system libraries (libc/libc++, and the -fexceptions

--- a/changelog.d/ci-wasm-ccache-cache-exhaustion.fixed.md
+++ b/changelog.d/ci-wasm-ccache-cache-exhaustion.fixed.md
@@ -1,0 +1,8 @@
+- **CI**: the wasm job's ccache cache was keyed on `github.sha`, so nearly
+  every push minted a fresh multi-hundred-MB cache entry that almost never
+  got reused (the next commit has a different sha). On a commit-heavy repo
+  that flooded `github.com/<repo>/actions/caches`, pushing GitHub's
+  10GB-per-repo cap into evicting the still-useful Nix store, RTP, wine
+  prefix and game-data caches to make room. The key now rotates weekly
+  instead, bounding growth to roughly one new entry per week while still
+  refreshing ccache's contents regularly.


### PR DESCRIPTION
## Summary
The wasm job's ccache was being keyed on `github.sha`, causing nearly every push to create a new multi-hundred-MB cache entry that rarely got reused. This exhausted GitHub's 10GB-per-repo cache limit and evicted other critical caches (Nix store, RTP, wine, game data). The cache key now rotates weekly instead, bounding growth while still refreshing ccache regularly.

## Changes
- **Cache key strategy**: Changed from `github.sha`-based keying to ISO week-based keying (`%G-W%V`)
  - Adds a new step that calculates the current ISO week and outputs it as `cache-period`
  - Updates the ccache restore/save action to use the weekly key with fallback to previous weeks
- **Behavior**: 
  - All pushes within the same ISO week hit the same cache key (exact match)
  - When the week rolls over, `restore-keys` falls back to the most recent prior week's entry
  - Bounds cache growth to ~52 entries/year instead of one per commit
  - ccache still updates locally; the post-job save is a no-op on exact-match restores since actions/cache cannot overwrite existing entries

## Implementation Details
The solution leverages `date -u +%G-W%V` to generate a stable weekly identifier that:
- Resets every Sunday (ISO week boundary)
- Provides natural cache reuse within a week
- Gracefully degrades to previous weeks' caches via `restore-keys` fallback
- Prevents cache explosion while maintaining reasonable freshness of compiled artifacts

https://claude.ai/code/session_01CsZ4Ao6CYPMqegRqtSxQbK