### PR TITLE
ci: make sccache's GHA cache read-only off master pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,17 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       ACTIONS_CACHE_SERVICE_V2: "on"
+      # sccache's GHA backend stores one cache blob per compilation unit, so
+      # every run that's allowed to write can mint a large number of small
+      # cache entries -- on a repo this commit-heavy, doing that on every PR
+      # and manual run (not just the pushes that actually update master)
+      # multiplies fast. Only a push to master grows the shared cache;
+      # every other trigger (pull_request, workflow_dispatch off master)
+      # still reads whatever master already wrote (so a warm sccache is
+      # still faster) but can't write new blobs of its own.
+      SCCACHE_GHA_RW_MODE: >-
+        ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master')
+            && 'READ_WRITE' || 'READ_ONLY' }}
       # Optional: routes the game-archive/asset downloads below through the
       # CORS proxy's R2 cache (cors-proxy/, docs/cors-proxy.md) instead of the
       # origin host, as a fallback for when the "cache test game" step below

--- a/changelog.d/ci-sccache-readonly-non-master.fixed.md
+++ b/changelog.d/ci-sccache-readonly-non-master.fixed.md
@@ -1,0 +1,5 @@
+- **CI**: sccache's GHA cache backend stores one blob per compilation unit,
+  so every pull request and manual run writing to it multiplied cache
+  entries fast. `SCCACHE_GHA_RW_MODE` now only allows writes on a push to
+  `master`; every other trigger still reads master's cache but can no
+  longer add new blobs of its own.


### PR DESCRIPTION
## Summary

Follow-up to #1355 (the wasm-ccache per-commit key fix). sccache's GHA cache backend stores one blob per compilation unit, so every run allowed to write to it can mint a large number of small cache entries — a second, independent source of `actions/caches` growth alongside the one already fixed.

## Change

- `build` job: `SCCACHE_GHA_RW_MODE` is now `READ_WRITE` only when the trigger is a push to `master`, and `READ_ONLY` for every other trigger (pull_request, workflow_dispatch off master).
- Verified against sccache's source (`src/config.rs`): `SCCACHE_GHA_RW_MODE` accepts `READ_ONLY`/`READ_WRITE` and wraps the cache storage in a `ReadOnlyStorage` that rejects `put` but still serves `get`, so PR/manual builds still benefit from whatever master already cached — they just can't add new blobs of their own.
- Other cache steps (Nix store, RTP, wine prefix, game data, Gradle, PlatformIO) are untouched — they already use stable content-hash keys and inherit from master via `restore-keys` without duplicating per branch.
- Added a changelog fragment per the repo's `changelog.d/` convention.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` — YAML parses cleanly
- [ ] CI on this PR exercises the new `READ_ONLY` path (pull_request event); a subsequent push to `master` exercises `READ_WRITE`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CsZ4Ao6CYPMqegRqtSxQbK)_