### PR TITLE
psp/mruby: P1c arena-size experiment + hardened NoMemoryError recovery

### DIFF
--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -197,21 +197,23 @@ lv_obj_t* g_status_label = nullptr;
 // (docs/adr/0047-psp-memory-budget.md's P1c) drives Nepheshel through a real
 // New Game into map 371, and `ppsspp-headless` segfaults deterministically
 // (byte-identical across three separate runs) once arena_used climbs to
-// 11,887,824 B -- 94.5% of the old 12 MB ceiling, with the OS-level
-// `sceKernelTotalFreeMemSize` figure (`free=` in the heartbeat) sitting
-// unchanged at 782,336 B (~764 KiB) throughout every marker of every run,
-// proving that headroom was never touched by anything else and is free to
-// give to the arena. 12.5 MB is a first experiment, not a re-validated
-// figure: it spends 512 KiB of that ~764 KiB margin (leaving ~250 KiB for
-// the newlib/sbrk heap decoded bitmaps and the C++ exception machinery
-// still need, per the 16 MB finding above) to see whether Nepheshel's
-// specific session fits inside it, or whether the ceiling just moves and the
-// same cliff waits further out -- exactly the open question P1c's own
-// follow-up (3) raised. Either result is useful: surviving confirms this
-// session was purely capacity-bound; crashing again (later, at a
-// correspondingly higher arena_used) strengthens the case for hardening the
-// failure paths themselves rather than keeps chasing the size.
-constexpr size_t kMrbArenaSize = 12u * 1024u * 1024u + 512u * 1024u;
+// 11,887,824 B -- 94.5% of the 12 MB ceiling. Tried spending 512 KiB of the
+// ~764 KiB of untouched OS-level headroom every heartbeat's `free=782336`
+// figure showed (12.5 MB, see PR #1357) to see whether the ceiling was the
+// real problem: it was not. The same run reached one heartbeat further
+// (arena_used 12,976,496 B at frame=400, 99.0% of the *new* 12.5 MB
+// ceiling) and then crashed the same way -- the cliff tracks whatever
+// ceiling is in force almost exactly (94.5% then 99.0%, both right before
+// the crash, on two different sizes), which is about as clean a
+// confirmation as one experiment can give that this is genuine capacity
+// exhaustion hitting the corrupting-unwind cliff above, not an unrelated
+// PPSSPP HLE gap. Reverted to 12 MB: 12.5 MB bought nothing (a bigger map,
+// a real XP/VX project, or just more play time would hit the same wall
+// further out regardless of size) while permanently spending headroom the
+// newlib/sbrk heap may need. The actual fix is hardening the unwind path
+// itself, not raising this number -- out of scope for a PSP-port change;
+// see the ADR's P1c for the full trail.
+constexpr size_t kMrbArenaSize = 12u * 1024u * 1024u;
 alignas(16) uint8_t g_mrb_arena[kMrbArenaSize];
 
 constexpr size_t kMrbAlign = 16;

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -185,11 +185,33 @@ lv_obj_t* g_status_label = nullptr;
 // pinned at ~12.0 MB (mruby grows to fill capacity and GCs under pressure;
 // one transient exhaustion per 3 minutes, recovered cleanly by the GC retry),
 // while 16 MB starves the newlib/sbrk heap that decoded bitmaps and the C++
-// exception machinery share (std::bad_alloc during map play). So 12 MB is the
-// measured working size on this ~24 MB target: the heartbeat below reports the
-// arena's own occupancy (arena_used) alongside the system figures, for the day
-// a game outgrows it.
-constexpr size_t kMrbArenaSize = 12u * 1024u * 1024u;
+// exception machinery share (std::bad_alloc during map play). So 12 MB was
+// the measured working size on this ~24 MB target -- with a known sharp edge
+// left open on purpose, this same comment already warned: "a game that
+// genuinely exhausts 12 MB will hit the same corrupting-unwind cliff until
+// the failure paths are hardened." The heartbeat below reports the arena's
+// own occupancy (arena_used) alongside the system figures precisely to catch
+// that day arriving.
+//
+// It arrived under CI: `psp-smoke-game`'s `.psp_ci_new_game` marker
+// (docs/adr/0047-psp-memory-budget.md's P1c) drives Nepheshel through a real
+// New Game into map 371, and `ppsspp-headless` segfaults deterministically
+// (byte-identical across three separate runs) once arena_used climbs to
+// 11,887,824 B -- 94.5% of the old 12 MB ceiling, with the OS-level
+// `sceKernelTotalFreeMemSize` figure (`free=` in the heartbeat) sitting
+// unchanged at 782,336 B (~764 KiB) throughout every marker of every run,
+// proving that headroom was never touched by anything else and is free to
+// give to the arena. 12.5 MB is a first experiment, not a re-validated
+// figure: it spends 512 KiB of that ~764 KiB margin (leaving ~250 KiB for
+// the newlib/sbrk heap decoded bitmaps and the C++ exception machinery
+// still need, per the 16 MB finding above) to see whether Nepheshel's
+// specific session fits inside it, or whether the ceiling just moves and the
+// same cliff waits further out -- exactly the open question P1c's own
+// follow-up (3) raised. Either result is useful: surviving confirms this
+// session was purely capacity-bound; crashing again (later, at a
+// correspondingly higher arena_used) strengthens the case for hardening the
+// failure paths themselves rather than keeps chasing the size.
+constexpr size_t kMrbArenaSize = 12u * 1024u * 1024u + 512u * 1024u;
 alignas(16) uint8_t g_mrb_arena[kMrbArenaSize];
 
 constexpr size_t kMrbAlign = 16;

--- a/changelog.d/mruby-nomemoryerror-reentrant-alloc.fixed.md
+++ b/changelog.d/mruby-nomemoryerror-reentrant-alloc.fixed.md
@@ -1,0 +1,18 @@
+- **Vendored mruby: hardened two real gaps in `NoMemoryError` recovery.**
+  Found chasing `docs/adr/0047-psp-memory-budget.md`'s P1c (a real
+  `ppsspp-headless` segfault once the PSP's fixed mruby arena runs near
+  full), via a host-native repro built against this project's own exact
+  arena allocator. (1) The pre-allocated `NoMemoryError`/
+  `SystemStackError`/arena-overflow singleton exceptions were never
+  actually frozen, so raising one could still trigger a second, avoidable
+  allocation (backtrace capture) at exactly the moment there was no room
+  left -- now frozen, matching how `src/print.c`/`src/backtrace.c` already
+  special-case them when printing. (2) `mrb_open()` could not tell
+  `mrb_core_init_abort()`'s deliberate `mrb->exc = NULL` apart from genuine
+  success, so an allocation failure early enough in bootstrap let it
+  proceed into gem init on a half-initialized state instead of failing
+  cleanly -- now also checks `mrb->c == NULL`. Both are real, verified
+  fixes to upstream mruby's own logic (patched in place via
+  `patches/mruby-nomemoryerror-reentrant-alloc.patch`, this submodule
+  having no fork of its own to carry them on); the repro did not reproduce
+  P1c's exact crash signature, so P1c itself remains open.

--- a/changelog.d/psp-mruby-arena-12-5mb-experiment.changed.md
+++ b/changelog.d/psp-mruby-arena-12-5mb-experiment.changed.md
@@ -1,0 +1,13 @@
+- **PSP mruby arena bumped from 12 MB to 12.5 MB, as an experiment.**
+  `psp-smoke-game`'s `.psp_ci_new_game` marker (docs/adr/0047-psp-memory-budget.md's
+  P1c) drove Nepheshel into a real New Game and reproduced -- deterministically,
+  across three separate CI runs -- a `ppsspp-headless` segfault once
+  `arena_used` climbed to 94.5% of the old 12 MB ceiling. That ceiling was
+  already flagged, in the commit that originally sized it, as a known sharp
+  edge left open on purpose: exhausting it hits a corrupting-unwind failure
+  path in mruby's own `NoMemoryError` recovery, not a clean catchable error.
+  This spends 512 KiB of the ~764 KiB of OS-level headroom every heartbeat's
+  `free=` figure has shown sitting untouched throughout every run so far, to
+  see whether Nepheshel's specific session fits inside the larger ceiling or
+  the same cliff just waits further out. Not yet re-validated against a
+  fresh `psp-smoke-game` run -- follow-up.

--- a/changelog.d/psp-mruby-arena-12-5mb-experiment.changed.md
+++ b/changelog.d/psp-mruby-arena-12-5mb-experiment.changed.md
@@ -1,13 +1,17 @@
-- **PSP mruby arena bumped from 12 MB to 12.5 MB, as an experiment.**
-  `psp-smoke-game`'s `.psp_ci_new_game` marker (docs/adr/0047-psp-memory-budget.md's
-  P1c) drove Nepheshel into a real New Game and reproduced -- deterministically,
-  across three separate CI runs -- a `ppsspp-headless` segfault once
-  `arena_used` climbed to 94.5% of the old 12 MB ceiling. That ceiling was
-  already flagged, in the commit that originally sized it, as a known sharp
-  edge left open on purpose: exhausting it hits a corrupting-unwind failure
-  path in mruby's own `NoMemoryError` recovery, not a clean catchable error.
-  This spends 512 KiB of the ~764 KiB of OS-level headroom every heartbeat's
-  `free=` figure has shown sitting untouched throughout every run so far, to
-  see whether Nepheshel's specific session fits inside the larger ceiling or
-  the same cliff just waits further out. Not yet re-validated against a
-  fresh `psp-smoke-game` run -- follow-up.
+- **PSP mruby arena: tried 12.5 MB, confirmed it doesn't fix the `Scene::Map`
+  crash, reverted to 12 MB.** `psp-smoke-game`'s `.psp_ci_new_game` marker
+  (`docs/adr/0047-psp-memory-budget.md`'s P1c) drives Nepheshel into a real
+  New Game and reproduces -- deterministically, across three separate CI
+  runs -- a `ppsspp-headless` segfault once `arena_used` climbs to 94.5% of
+  the 12 MB ceiling. Bumping the arena to 12.5 MB (spending 512 KiB of the
+  ~764 KiB of OS-level headroom every heartbeat's `free=` figure has shown
+  sitting untouched) didn't help: the same run reached one heartbeat
+  further before crashing the same way, at 99.0% of the *new* ceiling --
+  the cliff tracks whatever ceiling is in force almost exactly, confirming
+  this is genuine capacity exhaustion hitting a known, already-documented
+  corrupting-unwind failure path in mruby's own `NoMemoryError` recovery
+  (not a clean catchable error, and not an unrelated PPSSPP HLE gap).
+  Reverted to 12 MB since the bump bought nothing but permanently spent
+  headroom the newlib/sbrk heap may need. The real fix is hardening that
+  unwind path itself, not raising the arena size further -- out of scope
+  for a PSP-port change; see the ADR's P1c for the full trail.

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -129,6 +129,25 @@ function(rpg2k_add_mruby)
   set(mruby_defined_keyword_patch
       "${ARG_REPO_ROOT}/patches/mruby-defined-keyword.patch")
 
+  # Vendored mruby's own out-of-memory recovery has two real gaps
+  # (patches/mruby-nomemoryerror-reentrant-alloc.patch's own preamble has the
+  # full trail, including a host-native repro harness built against this
+  # project's own exact PSP arena allocator): the pre-allocated
+  # NoMemoryError/SystemStackError/arena-overflow singletons were never
+  # actually frozen, so raising one of them can still trigger a second,
+  # avoidable allocation (a backtrace capture) at exactly the moment there is
+  # no room left; and mrb_open() cannot tell mrb_core_init_abort()'s
+  # deliberate mrb->exc=NULL apart from genuine success, so an allocation
+  # failure early enough in bootstrap lets it proceed into gem init on a
+  # half-initialized state instead of failing cleanly. Found chasing P1c
+  # (docs/adr/0047-psp-memory-budget.md), though the repro did not reproduce
+  # P1c's own exact crash signature -- these are real, independently
+  # verified fixes, not a confirmed fix for P1c itself. Same patch-in-place
+  # treatment as the other mruby patches above, for the same reason (no fork
+  # of upstream mruby/mruby this project controls).
+  set(mruby_nomem_patch
+      "${ARG_REPO_ROOT}/patches/mruby-nomemoryerror-reentrant-alloc.patch")
+
   # Point mruby's rake at the vendored mgem-list (the mgem index) via symlinks
   # in its repos/ dir so it resolves gems locally instead of cloning from
   # GitHub. Both repos/host and repos/<TARGET_NAME> are linked: a cross build
@@ -147,6 +166,8 @@ function(rpg2k_add_mruby)
             "${mruby_dollar_bang_patch}"
     COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
             "${mruby_defined_keyword_patch}"
+    COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
+            "${mruby_nomem_patch}"
     COMMAND
       mkdir -p ${mruby_build_dir}/repos/host
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME} && ln -sfn
@@ -157,7 +178,7 @@ function(rpg2k_add_mruby)
     WORKING_DIRECTORY "${mruby_prefix}"
     DEPENDS "${ARG_REPO_ROOT}/build_config.rb" "${mruby_colon3_patch}"
             "${mruby_dollar_bang_patch}" "${mruby_defined_keyword_patch}"
-            ${mrb_files})
+            "${mruby_nomem_patch}" ${mrb_files})
   add_custom_target(mruby_build DEPENDS "${libmruby_a}")
   add_dependencies(mruby mruby_build)
 

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -133,18 +133,18 @@ function(rpg2k_add_mruby)
   # (patches/mruby-nomemoryerror-reentrant-alloc.patch's own preamble has the
   # full trail, including a host-native repro harness built against this
   # project's own exact PSP arena allocator): the pre-allocated
-  # NoMemoryError/SystemStackError/arena-overflow singletons were never
-  # actually frozen, so raising one of them can still trigger a second,
-  # avoidable allocation (a backtrace capture) at exactly the moment there is
-  # no room left; and mrb_open() cannot tell mrb_core_init_abort()'s
-  # deliberate mrb->exc=NULL apart from genuine success, so an allocation
-  # failure early enough in bootstrap lets it proceed into gem init on a
-  # half-initialized state instead of failing cleanly. Found chasing P1c
+  # NoMemoryError/SystemStackError/arena-overflow singletons were never actually
+  # frozen, so raising one of them can still trigger a second, avoidable
+  # allocation (a backtrace capture) at exactly the moment there is no room
+  # left; and mrb_open() cannot tell mrb_core_init_abort()'s deliberate
+  # mrb->exc=NULL apart from genuine success, so an allocation failure early
+  # enough in bootstrap lets it proceed into gem init on a half-initialized
+  # state instead of failing cleanly. Found chasing P1c
   # (docs/adr/0047-psp-memory-budget.md), though the repro did not reproduce
-  # P1c's own exact crash signature -- these are real, independently
-  # verified fixes, not a confirmed fix for P1c itself. Same patch-in-place
-  # treatment as the other mruby patches above, for the same reason (no fork
-  # of upstream mruby/mruby this project controls).
+  # P1c's own exact crash signature -- these are real, independently verified
+  # fixes, not a confirmed fix for P1c itself. Same patch-in-place treatment as
+  # the other mruby patches above, for the same reason (no fork of upstream
+  # mruby/mruby this project controls).
   set(mruby_nomem_patch
       "${ARG_REPO_ROOT}/patches/mruby-nomemoryerror-reentrant-alloc.patch")
 

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1118,6 +1118,34 @@ the interpreter-linking slice, in this order:
   landing at the same point in execution every time, which strengthens
   (without yet confirming) the arena-exhaustion hypothesis over an
   intermittent/unrelated one. Follow-ups (2) and (3) remain not started.
+
+  **Follow-up (3), partly resolved: this is P2's own already-documented
+  sharp edge, not a new mystery.** P2's follow-up below records, from the
+  original 8 MB -> 12 MB investigation: *"Known sharp edge left open on
+  purpose: a game that genuinely exhausts 12 MB will hit the same
+  corrupting-unwind cliff until the failure paths are hardened -- treat
+  `arena_used` approaching capacity as the early warning."* That is exactly
+  what happened here: `arena_used` reached 94.5% of the 12 MB ceiling
+  (11,887,824 / 12,582,912 B) at the last heartbeat before the crash. This
+  does not by itself prove the crash *is* that same corrupting-unwind path
+  (still no backtrace confirming it), but it means the PPSSPP-HLE-gap
+  alternative this entry originally weighed equally is now the less likely
+  one -- the exact failure this project already root-caused and chose not
+  to fully fix is sitting right at the scene of this crash too.
+
+  **Experiment (2026-08-25): `kMrbArenaSize` bumped from 12 MB to
+  12.5 MB** (`app/psp/main.cxx`),
+  spending 512 KiB of the ~764 KiB of OS-level headroom every heartbeat's
+  unchanged `free=782336` figure shows sitting untouched throughout every
+  run so far (proof nothing else needs it yet). This is deliberately framed
+  as an experiment, not a re-validated figure: either Nepheshel's session
+  fits inside the larger ceiling (confirming this specific crash was purely
+  capacity-bound), or it crashes again later at a correspondingly higher
+  `arena_used` (confirming the ceiling was never really the fix, and the
+  failure paths P2 already flagged need to be hardened instead of chasing
+  the size further -- there is only about 250 KiB of headroom margin left
+  after this bump before touching what the 16 MB finding already showed the
+  newlib/sbrk heap needs). See that PR for the result once CI runs.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none
@@ -1357,15 +1385,17 @@ the interpreter-linking slice, in this order:
   mruby embedded tuning knobs, and the uni-algo table trim), and P5's
   explicit main-thread stack size plus its heartbeat fields. The three sizing
   numbers that still depend on a real database and map actually being loaded
-  are the mruby arena's 8 MB, LVGL's 256 KB, and the stack's 256 KB, all
-  three of which the heartbeat is now in place to validate.
+  are the mruby arena's size (8 MB originally, revised to 12 MB and now
+  12.5 MB — see P2's follow-ups and P1c), LVGL's 256 KB, and the stack's
+  256 KB, all three of which the heartbeat is now in place to validate.
 - ADR 0010's "the full gem set should fit" is narrowed: it holds for gem
   *code* size, but says nothing about per-title asset memory, which Finding 2
   shows can exceed the entire 24 MB budget for an RGSSAD-packed game even
   though the Wio Terminal's port needed the same warning at a much smaller
   scale.
-- **Risk register:** P2 is now decided (a bounded 8 MB mruby arena, see the
-  Decision) rather than soft-blocking, but its *size* is still a placeholder
+- **Risk register:** P2 is now decided (a bounded mruby arena, currently
+  12.5 MB — see the Decision, its follow-ups, and P1c) rather than
+  soft-blocking, but its *size* is still a placeholder
   awaiting on-device numbers — the BRINGUP heartbeat measures it, so that is a
   measurement follow-up, not an architectural one. P3 (RGSSAD whole-archive
   loads) is **resolved, not just mitigated, as of P3a**: `RGSSAD` no longer

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1145,7 +1145,42 @@ the interpreter-linking slice, in this order:
   failure paths P2 already flagged need to be hardened instead of chasing
   the size further -- there is only about 250 KiB of headroom margin left
   after this bump before touching what the 16 MB finding already showed the
-  newlib/sbrk heap needs). See that PR for the result once CI runs.
+  newlib/sbrk heap needs).
+
+  **Result (2026-08-25): the bump didn't help -- the same cliff, just
+  moved.** `psp-smoke-game`'s run against 12.5 MB reached one heartbeat
+  further than every 12 MB run before it (a new `frame=400` line that never
+  appeared at 12 MB) before segfaulting the same way:
+
+  ```
+  RPG2K_PSP_BRINGUP frame=200 scene=RPG2k::Scene::Map t_us=18729969  arena_used=11887824  (94.5% of the old 12 MB ceiling)
+  RPG2K_PSP_BRINGUP frame=400 scene=RPG2k::Scene::Map t_us=31535888  arena_used=12976496  (99.0% of the new 12.5 MB ceiling)
+  Segmentation fault (core dumped)
+  ```
+
+  `arena_used` tracks each ceiling almost exactly regardless of which
+  ceiling is in force -- 94.5% then 99.0%, both right before the crash, on
+  two different arena sizes -- which is about as clean a confirmation as a
+  single data point can give that this is genuine capacity exhaustion, not
+  an unrelated PPSSPP HLE gap coincidentally triggered by Map-scene code.
+  `free=782336` stayed unchanged again, confirming the extra 512 KiB came
+  only from the untouched OS-level headroom this experiment was designed to
+  spend, nothing else.
+
+  **Conclusion: sizing is not the fix.** With only ~131 KB left before the
+  new 12.5 MB ceiling and ~250 KB of total headroom before risking the
+  newlib/sbrk starvation the original 16 MB test already ruled out, there
+  is no more room to keep raising the number -- this map's session would
+  need a substantially larger arena than this ~24 MB target can spare to
+  outrun its own growth, and a *bigger* Nepheshel map, a real XP/VX project,
+  or simply more play time would just hit the same wall further out
+  regardless of size. The actual fix is what P2's own follow-up already
+  named: harden the `NoMemoryError` unwind path itself (the corrupting
+  interaction between `mrb_realloc_simple`'s failed-retry raise and
+  `cipop`'s env-unshare allocation) so exhaustion degrades to a real
+  catchable error the game can act on, instead of corrupting the VM's
+  callinfo chain. That is mruby-VM-internals work, not a PSP-port change --
+  out of scope for a same-session follow-up here.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none
@@ -1385,17 +1420,19 @@ the interpreter-linking slice, in this order:
   mruby embedded tuning knobs, and the uni-algo table trim), and P5's
   explicit main-thread stack size plus its heartbeat fields. The three sizing
   numbers that still depend on a real database and map actually being loaded
-  are the mruby arena's size (8 MB originally, revised to 12 MB and now
-  12.5 MB — see P2's follow-ups and P1c), LVGL's 256 KB, and the stack's
-  256 KB, all three of which the heartbeat is now in place to validate.
+  are the mruby arena's size (8 MB originally, revised to 12 MB, a 12.5 MB
+  experiment tried and reverted — see P2's follow-ups and P1c), LVGL's
+  256 KB, and the stack's 256 KB, all three of which the heartbeat is now
+  in place to validate.
 - ADR 0010's "the full gem set should fit" is narrowed: it holds for gem
   *code* size, but says nothing about per-title asset memory, which Finding 2
   shows can exceed the entire 24 MB budget for an RGSSAD-packed game even
   though the Wio Terminal's port needed the same warning at a much smaller
   scale.
-- **Risk register:** P2 is now decided (a bounded mruby arena, currently
-  12.5 MB — see the Decision, its follow-ups, and P1c) rather than
-  soft-blocking, but its *size* is still a placeholder
+- **Risk register:** P2 is now decided (a bounded mruby arena, 12 MB after a
+  12.5 MB experiment was tried and reverted — see the Decision, its
+  follow-ups, and P1c) rather than soft-blocking, but its *size* is still a
+  placeholder
   awaiting on-device numbers — the BRINGUP heartbeat measures it, so that is a
   measurement follow-up, not an architectural one. P3 (RGSSAD whole-archive
   loads) is **resolved, not just mitigated, as of P3a**: `RGSSAD` no longer

--- a/patches/mruby-nomemoryerror-reentrant-alloc.patch
+++ b/patches/mruby-nomemoryerror-reentrant-alloc.patch
@@ -1,0 +1,133 @@
+mruby bug: raising `NoMemoryError` is not itself allocation-free, and a
+second allocation failure while raising the first corrupts more than it
+should. Two separate gaps, found chasing docs/adr/0047-psp-memory-budget.md's
+P1c (a real `ppsspp-headless` segfault, deterministic across three separate
+CI runs, once the PSP's fixed mruby arena climbed to ~95% full mid-map-load)
+and confirmed with a standalone host-native repro: a tiny C++ harness
+(`app/psp/main.cxx`'s exact fixed first-fit arena allocator, just
+parameterized smaller) driving precompiled mruby bytecode (matching the PSP
+target exactly -- it never parses/compiles Ruby at runtime, only executes
+gem_init-linked bytecode) under a shrunk arena, with `gdb` attached directly
+(the PSP target itself gives no such access -- `ppsspp-headless` runs the
+EBOOT under MIPS emulation with no debugger hook this project has). That
+repro reproduced a real, confirmable class of bug (below); it did not,
+despite substantial effort across several allocation patterns (deep
+recursion, flat live-object accumulation, closures forcing real
+env-unshare traffic, and a Fiber-driven loop mirroring RGSS's own script-host
+architecture, ADR 0023), reproduce the *exact* segfault signature P1c saw.
+This patch is the real, verified fix for what the repro did confirm; P1c's
+own crash may or may not be the same root cause and remains open.
+
+1. `mrb->nomem_err`/`mrb->stack_err`/`mrb->arena_err` are pre-allocated
+   singleton exception objects, created once in `mrb_init_exception`
+   specifically so raising them never needs a fresh allocation -- the whole
+   point of pre-allocating them. But `mrb_exc_set` (src/error.c) captures a
+   backtrace for any exception it is given unless
+   `!mrb->gc.out_of_memory && !mrb_frozen_p(mrb->exc)` is false, and neither
+   of these three objects was ever actually frozen, so the frozen half of
+   that guard never protected them. The `out_of_memory` half is not
+   reliable either: `mrb_realloc` (src/gc.c) sets `mrb->gc.out_of_memory =
+   TRUE` right before raising on failure, but resets it back to `FALSE` the
+   next time *any* allocation succeeds -- and between the original raise and
+   `mrb_exc_set` actually running, several allocations (call-frame/GC
+   bookkeeping) can succeed. So `mrb_keep_backtrace` (src/backtrace.c) often
+   runs anyway for `nomem_err`, allocating a backtrace object at exactly the
+   moment there is the least room to spare -- a second, avoidable
+   allocation failure stacked on the first. (`src/print.c` and
+   `src/backtrace.c` already special-case `nomem_err` to skip the normal
+   message-formatting/lookup path when *printing* it, for the same
+   underlying reason -- this patch closes the one remaining gap, at the
+   point the exception is first set rather than where it is later printed.)
+
+   Confirmed via the repro: with a small Fiber-driven live-object workload,
+   `gdb` (`break mrb_raise_nomemory`, `bt`) showed the real chain --
+   `mrb_realloc` fails building a string, raises `nomem_err`; `mrb_exc_set`
+   -> `mrb_keep_backtrace` -> `packed_backtrace` -> `mrb_obj_alloc` fails
+   *again* allocating the backtrace object itself. Freezing the three
+   singletons (this patch) removes that second failure from the trace
+   entirely -- confirmed by re-running the same repro afterward.
+
+   Fix: freeze all three singletons right after creation. `mrb_frozen_p`
+   only gates high-level Ruby-visible mutation (ivar/backtrace setters);
+   direct C-level bookkeeping on them (`clear_error_object` in src/gc.c,
+   called during GC sweep to null out their `iv`/`mesg`/`backtrace` fields)
+   writes the struct fields directly and is unaffected by the frozen bit,
+   so this does not interfere with their own lifecycle management.
+
+2. `mrb_open_core` (src/state.c) can fail before `mrb->nomem_err` exists to
+   raise it through normally -- `init_gc_and_core` calls `mrb_malloc` for
+   `mrb->c` itself (the root `mrb_context`) before `mrb_init_core` has run
+   far enough to create any exception objects at all. `mrb_raise_nomemory`
+   handles that specific case via `mrb_core_init_abort`, which *deliberately*
+   sets `mrb->exc = NULL` before throwing (there being no valid exception
+   object this early to expose) and unwinds back to `mrb_open_core`'s own
+   `mrb_core_init_protect` guard.
+
+   `mrb_open_core` itself handles this correctly -- it checks
+   `mrb_core_init_protect`'s return code directly and returns early on
+   failure, never relying on `mrb->exc`. But its caller, `mrb_open`, has no
+   way to see that return code -- it can only inspect the `mrb_state` it
+   gets back, via `if (mrb == NULL || mrb->exc)`. Since
+   `mrb_core_init_abort` sets `mrb->exc` to NULL specifically, that check
+   cannot tell "abort fired" apart from "core init genuinely succeeded" --
+   both leave `mrb->exc` NULL. `mrb_open` then proceeds into
+   `mrb_init_mrbgems` on a state whose `mrb->c` (and `mrb->root_c`,
+   `mrb->jmp`, `mrb->top_self`) were never set, corrupting further from
+   there -- confirmed via the repro under `gdb`: `mrb->c` reads back as a
+   literal `NULL` pointer, `root_c`/`jmp` as small-integer garbage, at a
+   segfault several frames into gem bootstrap trying to dereference through
+   it.
+
+   Fix: `mrb_open` also treats `mrb->c == NULL` as failure.
+   `init_gc_and_core` sets `mrb->c` unconditionally, immediately before
+   calling `mrb_init_core` -- the one field guaranteed NULL after this
+   specific abort path and non-NULL after a real success, unlike `mrb->exc`.
+
+Neither gap is PSP-specific -- both are reachable on any target whose
+allocator can run genuinely out of memory (this project's PSP arena is the
+one that actually exercises it, being the only fixed/bounded allocator any
+target here uses; the Wio Terminal's own even-tighter budget, ADR 0007,
+could plausibly hit the second one too, though it has not been observed
+there). Real, not vendor-specific: verified directly against this
+project's own mruby 4.0.0 checkout, and the underlying gaps read as
+present in current upstream mruby/mruby too (both files' relevant logic is
+unchanged there as of this writing). This submodule tracks upstream
+mruby/mruby directly (no fork this project controls to carry the fix on),
+so it is patched in place here instead, the same treatment
+patches/mruby-colon3-assign-setmcnst.patch and its neighbors already use.
+
+--- a/src/error.c
++++ b/src/error.c
+@@ -927,10 +927,13 @@ mrb_init_exception(mrb_state *mrb)
+   mrb_define_class_id(mrb, MRB_SYM(NoMatchingPatternError), E_STANDARD_ERROR);                         /* pattern matching */
+   struct RClass *stack_error = mrb_define_class_id(mrb, MRB_SYM(SystemStackError), exception);
+   mrb->stack_err = mrb_obj_ptr(mrb_exc_new_lit(mrb, stack_error, "stack level too deep"));
++  mrb->stack_err->frozen = 1;
+
+   struct RClass *nomem_error = mrb_define_class_id(mrb, MRB_SYM(NoMemoryError), exception);
+   mrb->nomem_err = mrb_obj_ptr(mrb_exc_new_lit(mrb, nomem_error, "Out of memory"));
++  mrb->nomem_err->frozen = 1;
+ #ifdef MRB_GC_FIXED_ARENA
+   mrb->arena_err = mrb_obj_ptr(mrb_exc_new_lit(mrb, nomem_error, "arena overflow error"));
++  mrb->arena_err->frozen = 1;
+ #endif
+ }
+--- a/src/state.c
++++ b/src/state.c
+@@ -78,7 +78,15 @@ mrb_open(void)
+ {
+   mrb_state *mrb = mrb_open_core();
+
+-  if (mrb == NULL || mrb->exc) {
++  /* mrb->c == NULL: mrb_core_init_abort() fired during init_gc_and_core
++   * (an allocation failed before mrb->nomem_err existed to raise it
++   * through normally) and deliberately clears mrb->exc when it does, since
++   * there is no valid exception object this early to expose -- so mrb->exc
++   * alone cannot distinguish that abort from a genuinely successful init.
++   * mrb->c can: init_gc_and_core sets it unconditionally on success, right
++   * before calling mrb_init_core, so it is the one field guaranteed to
++   * still be NULL after this abort path and non-NULL after a real one. */
++  if (mrb == NULL || mrb->exc || mrb->c == NULL) {
+     /* Either allocation failed or core init failed */
+     return mrb;
+   }


### PR DESCRIPTION
## Summary

Follow-up to [#1352](https://github.com/take-cheeze/rpg-maker-clone/pull/1352)/[#1354](https://github.com/take-cheeze/rpg-maker-clone/pull/1354) (P1c's `Scene::Map` crash), now covering both halves of that investigation: the arena-size experiment, and a first real hardening pass on mruby's own `NoMemoryError` recovery that the experiment's conclusion pointed to.

### Part 1: arena-size experiment (confirmed not the fix)

`psp-smoke-game`'s `.psp_ci_new_game` marker drives Nepheshel through a real New Game into map 371, and `ppsspp-headless` segfaults deterministically once `arena_used` climbs to 94.5% of the 12 MB `g_mrb_arena` ceiling. Bumped `kMrbArenaSize` to 12.5 MB to test whether more headroom helps — it didn't; the same run reached one heartbeat further before crashing the same way, at 99.0% of the *new* ceiling:

```
frame=200  arena_used=11,887,824  (94.5% of the old 12 MB ceiling)
frame=400  arena_used=12,976,496  (99.0% of the new 12.5 MB ceiling)
Segmentation fault (core dumped)
```

`arena_used` tracks whatever ceiling is in force almost exactly — genuine capacity exhaustion, not an unrelated PPSSPP HLE gap. **Reverted to 12 MB** since the bump bought nothing but permanently spent OS-level headroom the newlib/sbrk heap may still need.

### Part 2: hardened two real gaps in mruby's `NoMemoryError` recovery

Sizing isn't the fix; the real fix is hardening mruby's own OOM unwind path. Built a host-native repro (a tiny harness reusing `app/psp/main.cxx`'s exact fixed first-fit arena allocator, driving precompiled mruby bytecode under a shrunk arena, with `gdb` attached directly) and found two real, confirmable bugs, independent of anything PSP-specific:

1. `mrb->nomem_err`/`stack_err`/`arena_err` are pre-allocated singletons meant to make raising them allocation-free, but were never actually frozen, so a second allocation (backtrace capture) could still fail while raising the first — right when there's the least room to spare.
2. `mrb_open()`'s failure check (`mrb == NULL || mrb->exc`) can't distinguish `mrb_core_init_abort()`'s deliberate `mrb->exc = NULL` from genuine success, letting it proceed into gem init on a half-initialized state when the very first bootstrap allocation fails.

Both fixes are verified via the repro (before/after `gdb` traces); `patches/mruby-nomemoryerror-reentrant-alloc.patch`'s own preamble has the full trail. **Honesty check:** despite substantial effort across several allocation patterns (deep recursion, flat live-object accumulation, closures forcing real env-unshare, a Fiber-driven loop mirroring RGSS's own script-host architecture per ADR 0023), the repro did **not** reproduce P1c's own exact crash signature. These are real, independently-useful hardening fixes to upstream mruby's OOM logic — not a confirmed fix for P1c itself, which remains open.

## Change

- `app/psp/main.cxx`: `kMrbArenaSize` unchanged at 12 MB in the final diff (tried 12.5 MB, confirmed it doesn't help, reverted) — comment rewritten with the full experiment and result.
- `docs/adr/0047-psp-memory-budget.md`: P1c's experiment paragraph records the full result; stale "8 MB"/"12.5 MB" mentions in the Consequences/Risk register fixed to match.
- `patches/mruby-nomemoryerror-reentrant-alloc.patch` (new): freezes the three OOM singleton exceptions; makes `mrb_open()` also check `mrb->c == NULL`.
- `cmake/build-mruby.cmake`: wires the new patch into the build, same pattern as the three existing mruby patches.
- Changelog fragments for both parts.

## Test plan

- [x] `clang-format -n app/psp/main.cxx` — no diff.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer) — all passed on changed files.
- [x] This PR's own `psp-smoke-game` run (12.5 MB) produced the arena-size result documented above.
- [x] `patches/mruby-nomemoryerror-reentrant-alloc.patch` applies cleanly and idempotently via `scripts/apply_mruby_patch.bash` against a pristine `3rd/mruby` checkout.
- [x] Both mruby fixes verified against the host-native repro (before/after `gdb` traces show the specific reentrant-allocation call chain eliminated).
- [ ] CI (this push): full matrix including `psp`/`psp-smoke`/`psp-smoke-game` with the new mruby patch applied.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_