### PR TITLE
Save/Load: message-window config fields omitted from saves at default

### DIFF
--- a/changelog.d/save-message-config-omit-at-default.fixed.md
+++ b/changelog.d/save-message-config-omit-at-default.fixed.md
@@ -1,0 +1,7 @@
+- **Save/Load:** the message-window options set by Change Message Options
+  (transparency, position, whether the window is pinned, whether events
+  keep running behind it) are now written to the save file only when they
+  differ from their own default, matching RPG_RT's real save format.
+  Previously every save carried explicit values for all four settings even
+  when the player never changed any of them, producing save bytes real
+  RPG_RT.exe never writes.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2744,6 +2744,128 @@ The work below is roughly ordered by the critical path to a walkable game
   convention field 41 and now field 61 both empirically show -- this cycle
   only spot-checked 41/61/121, not an exhaustive field-by-field audit of
   the whole table.
+  ✅ **Follow-up (cycle #153, 2026-08-25): picked up cycle #152's own closing
+  question -- whether any other SAVE_SYSTEM field this codebase's own
+  `to_lsd` writes unconditionally actually follows real RPG_RT.exe's
+  "present only when different from the declared default" convention
+  (fields 41/61/121 were only spot-checked, not the whole table) -- and
+  found and fixed a second genuine instance: SAVE_SYSTEM fields 42/43/44
+  (`message_position`/`message_prevent_overlap`/`message_continue_events`),
+  the rest of the message-window-config cluster field 41
+  (`message_transparent`) belongs to, were *also* written unconditionally
+  by `Game::State#to_lsd`, every one of them, on every single save this
+  codebase ever produced -- not spot-checked at all by cycle #152, which
+  only tested field 41 itself.** Reused cycle #150/#151/#152's own
+  `LCF::MapUnit`-based injector design (fresh scratch dir this session,
+  `Map0012_orig.lmu`/`Save01_clean.lsd` re-copied from cycle #150's own
+  saved copies and re-verified byte-identical: `c2fa69a0.../3ab5bb01...`,
+  matching every prior cycle back to #148) to build a single autostart event
+  around Change Message Options (10120, this codebase's own
+  `Cmd::MESSAGE_OPTIONS`) followed by Open Save Menu (11910), then drove the
+  real save UI under the same Xvfb (640x480x16, `LIBGL_ALWAYS_SOFTWARE=1`,
+  matchbox-window-manager, `LANG=ja_JP.UTF-8`, `WINEARCH=win32`,
+  `WINEPREFIX=~/.wine-nepheshel32`) setup down to the empty File 2 slot to
+  produce genuine `Save02.lsd` files, inspected field-by-field with this
+  project's own `LCF::Array1D` raw-`@data` reader (bypassing the schema, so
+  a field's mere physical presence is visible independent of its decoded
+  value) -- the same technique cycle #152 established. **A methodology
+  stumble worth recording for the next cycle attempting a similarly "instant"
+  autostart list:** the first attempt used an autostart list of exactly one
+  command (bare Open Save Menu, no Wait first) and genuine RPG_RT.exe never
+  opened the Save Menu at all -- confirmed alive throughout (`ps`, high CPU)
+  but stuck on the map indefinitely, with the injected event itself
+  independently confirmed correctly encoded (re-read back via a direct
+  `LCF::MapUnit` decode: right position, trigger=3/autostart, the exact
+  single command expected). Adding a 20-frame Wait before Open Save Menu
+  (the same duration cycle #152's own injector already used) fixed it
+  immediately and every mode reached the Save Menu reliably after that; this
+  was not chased further as its own mystery (a command list whose *entire*
+  effect completes on the very first renderable frame is not a shape a real
+  player-triggered Open Save Menu ever takes anyway, so it is flagged here
+  rather than folded into the separate autostart-crash-mystery writeups
+  above, which are specifically about >=2-*content*-command lists surviving
+  to a *later* surface-creating transition, a different shape entirely) --
+  every real probe below already includes the Wait, so it did not affect
+  any result. **Four scenarios, each independently run once, all via Change
+  Message Options' own four params (transparent/position/fixed-vs-auto/
+  continue-events):** never issued at all (fields 41-44 all absent, the
+  known baseline both `Save01_clean.lsd` itself and cycle #152's own spot
+  check already showed for field 41); issued with every param reproducing
+  the exact default state -- transparent=0, position=2/bottom, param2=1
+  (auto, i.e. `position_fixed=false`, `Game::MessageConfig`'s own
+  constructor default per direct inspection of `mruby-rpg2k/mrblib/game.rb`)
+  and continue=0 (all four fields still absent, identical to never issuing
+  the command -- this **caught a self-inflicted mistake before it reached
+  the fix**: the first pass at this scenario used param2=0, which actually
+  requests `position_fixed=true`, silently testing a *changed* field 43
+  while believing it tested the default; cross-checking the constructor's
+  own default before trusting the result caught this); issued with every
+  param different from default -- transparent=1, position=0/top, param2=0
+  (fixed, differing from the false default) and continue=1 (all four
+  fields present: 41=`[1]`, 42=`[0]`, 43=`[0]`, 44=`[1]`, matching the
+  changed values exactly); and the same changed call followed by a further
+  Change Message Options putting every param back to the exact default
+  (all four fields absent again, not present-holding-the-default-value) --
+  pinning the same per-value, not per-touch, "omit at default" convention
+  cycle #152 already established for field 61, now confirmed across this
+  entire four-field cluster rather than field 41 alone. **Fixed** by
+  changing the four unconditional `sys[41..44] = ...` assignments in
+  `Game::State#to_lsd` (`mruby-rpg2k/mrblib/game.rb`) to conditional writes
+  guarded on each field's own away-from-default test (`if mc.transparent`;
+  `if mc.position != MessageConfig::POS_BOTTOM`; `if mc.position_fixed`,
+  since field 43 stores the *inverse* of that flag; `if
+  mc.continue_events`) -- `.from_lsd`'s own read side already handled an
+  absent field correctly via the schema's declared defaults (`sys.
+  message_transparent || 0`, etc.) and needed no change. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check asserting all four fields are absent
+  on a freshly-constructed state, present once every one of the four
+  `MessageConfig` values is pushed away from its own default (round-tripping
+  back to the same changed values through a fresh `Game::State.from_lsd`),
+  and absent again once every value is reset back to the exact default --
+  confirmed to fail against the pre-fix code (`git stash` of just
+  `schema.rb`/`game.rb`) with a precise, specific error: `RuntimeError:
+  expected false, got true (field 41 is absent on a freshly-constructed
+  state ...)`, i.e. the very first assertion, since pre-fix `to_lsd` wrote
+  field 41 (and 42-44) on every state regardless of value. `Map0012.lmu`/
+  `Save01.lsd` were restored to their original bytes (byte-identical by
+  `md5sum` against the same `c2fa69a0.../3ab5bb01...` values every prior
+  cycle back to #148 recorded) and every scratch `Save02.lsd` this cycle's
+  own probes produced was removed from the game directory (never a tracked
+  fixture) after every run; `git status` on `data/` came back clean. No
+  EasyRPG source was consulted for any claim in this cycle, and no web
+  search was used either -- the only outside reference was liblcf's own
+  `generator/csv/fields.csv` field id/type for fields 41-44 (already in this
+  table from a prior cycle, not newly added here), this file's own standing
+  narrow exception, and every behavioral claim (the fields' genuine
+  per-value presence convention) traces to this cycle's own genuine
+  RPG_RT.exe wine captures and this codebase's own pre-fix/post-fix test
+  runs. **Aside (not chased, out of scope for this fix):** while reading
+  `to_lsd` for this audit, several of its own surrounding comments
+  ("confirmed against RPG_RT's live source: `Scene_Save::Prepare`
+  (`src/scene_save.cpp`) ...") are, on inspection, EasyRPG Player's actual
+  C++ source file names mislabeled "RPG_RT's live source" -- the same
+  pre-existing mislabeling this file's own cycle #125/#126 entries already
+  found and fixed elsewhere (Enter Hero Name, save-confirm), evidently not
+  yet swept from every occurrence. This task's own standing instruction
+  limits the "known legacy debt, leave alone" exception to shop-code
+  comments specifically, so these are flagged here rather than either
+  silently left or fixed outside this cycle's actual scope (chunks 102/103/
+  104 in `to_lsd`, unrelated to the SAVE_SYSTEM audit this cycle actually
+  did) -- worth a dedicated future cycle to re-verify each against genuine
+  RPG_RT.exe the way #125/#126 did, not assumed wrong just because the
+  citation style matches a known-bad pattern. Full suite reconfirmed
+  passing, `scripts/rpg2k_logic_check.rb` up by 1: `scripts/
+  rpg2k_scene_check.rb` (929), `scripts/rpg2k_render_check.rb` (41),
+  `scripts/rpg2k_logic_check.rb` (1137), `scripts/rpg2k3_battle_row_check.rb`
+  (19) and `scripts/rpg2k3_battle_gauge_check.rb` (15). **Left open for a
+  future cycle:** fields 51-54 (Change Face Graphic's own save-system
+  cluster) were not checked and may show the same pattern, by analogy but
+  not yet confirmed; the crash mystery's own two still-untested threads are
+  unchanged from cycle #151/#152's own framing; the "extraneous Return kills
+  RPG_RT" aside from cycle #152 is unchanged too; and the rest of
+  SAVE_SYSTEM beyond 41-44/61/121 (fields 71-140) is still unaudited for
+  this same unconditional-write question -- this cycle closed the specific
+  cluster cycle #152 flagged, not the whole table.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1488,7 +1488,19 @@ module LCF
       32 => { name: :switches, type: :bool_array },
       33 => { name: :variable_size, type: :int, default: 0 },
       34 => { name: :variables, type: :int32_array },
-      # 0 = normal, 1 = transparent.
+      # 0 = normal, 1 = transparent. Confirmed against a genuine RPG_RT.exe
+      # save under wine (cycle #153): fields 41-44, all set together by
+      # Change Message Options (10120), are each written only when they
+      # differ from the default given here -- a synthetic autostart Change
+      # Message Options call that reproduces the exact default state (and,
+      # separately, a call that changes every field then a further call that
+      # resets them all back) leaves the corresponding field(s) absent
+      # exactly as if the command had never run at all, while any field
+      # actually left different from its default is present with that
+      # value. This is a per-value comparison at save time, not an
+      # ever-touched flag -- the same convention already confirmed for field
+      # 61 (`bgm_stopping`, see that field's own comment below), now spot
+      # checked across this whole cluster too rather than field 41 alone.
       41 => { name: :message_transparent, type: :int, default: 0 },
       # 0 = top, 1 = middle, 2 = bottom.
       42 => { name: :message_position, type: :int, default: 2 },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14590,12 +14590,28 @@ module Game
       sys[34] = variables
       # Message-window configuration (field 41 transparency is 0/1, 43 is the
       # inverse of our "pinned" flag: prevent-overlap true == not position_fixed,
-      # 53 face side is 0 left / 1 right).
+      # 53 face side is 0 left / 1 right). Fields 41-44 are each written only
+      # when they differ from SAVE_SYSTEM's own declared default for that
+      # field (message_transparent false/0, message_position 2/bottom,
+      # message_prevent_overlap true i.e. position_fixed false,
+      # message_continue_events false) -- confirmed against a genuine
+      # RPG_RT.exe save under wine this cycle: a synthetic autostart Change
+      # Message Options (10120) call whose four params reproduce the exact
+      # default state left every one of 41-44 absent (identical to never
+      # issuing the command at all), the same call with all four params
+      # changed away from default wrote all four fields present with the
+      # changed values, and a further Change Message Options call putting
+      # every param back to the default left all four absent again -- the
+      # same value-based (not "ever touched") "omit at default" convention
+      # field 61 (`bgm_stopping`) already established, now confirmed to
+      # extend across this whole message-config field cluster too, not just
+      # field 41 alone as cycle #152's own single-value spot check left
+      # open.
       mc = @message_config
-      sys[41] = mc.transparent ? 1 : 0
-      sys[42] = mc.position
-      sys[43] = mc.position_fixed ? false : true
-      sys[44] = mc.continue_events ? true : false
+      sys[41] = 1 if mc.transparent
+      sys[42] = mc.position if mc.position != MessageConfig::POS_BOTTOM
+      sys[43] = false if mc.position_fixed
+      sys[44] = true if mc.continue_events
       sys[51] = mc.face_name || ''
       sys[52] = mc.face_index || 0
       sys[53] = mc.face_right ? 1 : 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4398,6 +4398,67 @@ check 'to_lsd/from_lsd round-trips bgm_stopping (liblcf SaveSystem field ' \
   eq false, round2.bgm_stopping, 'an absent field reads back as "not stopping"'
 end
 
+check 'to_lsd omits SAVE_SYSTEM fields 41-44 (message-window config) when ' \
+      'each one sits at its own schema default, matching genuine RPG_RT.exe' do
+  # Cycle #153: confirmed against a genuine RPG_RT.exe save under wine that
+  # this whole cluster -- all four set together by Change Message Options
+  # (10120) -- follows the exact same "present only when different from the
+  # declared default" convention field 61 already established, not the
+  # unconditional write this codebase's own #to_lsd had before this fix
+  # (every prior save this engine produced carried explicit 0/false-valued
+  # 41-44 bytes a genuine RPG_RT.exe save never does). Evidence: a synthetic
+  # autostart Change Message Options call whose four params reproduce the
+  # exact default state (transparent=0, position=2/bottom, param2=1 i.e.
+  # position_fixed=false, continue=0) left fields 41-44 all absent,
+  # identical to never issuing the command at all; the same call with every
+  # param changed away from default (transparent=1, position=0/top,
+  # param2=0 i.e. position_fixed=true, continue=1) wrote all four fields
+  # present with the changed values (41=1, 42=0, 43=0, 44=1); and a further
+  # Change Message Options call resetting every param back to the default
+  # left all four absent again -- a per-value comparison at save time, not
+  # an ever-touched flag.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  saved = st.to_lsd[101]
+  [41, 42, 43, 44].each do |id|
+    eq false, saved.key?(id),
+       "field #{id} is absent on a freshly-constructed state (message " \
+       'config untouched, matching its own schema default)'
+  end
+
+  st2 = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  mc = st2.message_config
+  mc.transparent = true
+  mc.position = Game::MessageConfig::POS_TOP
+  mc.position_fixed = true
+  mc.continue_events = true
+  saved2 = st2.to_lsd[101]
+  eq true, saved2.key?(41), 'field 41 present once transparent differs from its default (false)'
+  eq true, saved2.key?(42), 'field 42 present once position differs from its default (bottom)'
+  eq true, saved2.key?(43), 'field 43 present once position_fixed differs from its default (false)'
+  eq true, saved2.key?(44), 'field 44 present once continue_events differs from its default (false)'
+  round2 = Game::State.from_lsd(db, st2.to_lsd)
+  eq true, round2.message_config.transparent, 'transparent itself round-trips true'
+  eq Game::MessageConfig::POS_TOP, round2.message_config.position, 'position round-trips top'
+  eq true, round2.message_config.position_fixed, 'position_fixed round-trips true'
+  eq true, round2.message_config.continue_events, 'continue_events round-trips true'
+
+  # Changed, then reset back to the exact default -- mirrors this cycle's
+  # own "changed_then_reset" genuine-RPG_RT probe: the fields go absent
+  # again, not "present, but re-holding the default value".
+  mc.transparent = false
+  mc.position = Game::MessageConfig::POS_BOTTOM
+  mc.position_fixed = false
+  mc.continue_events = false
+  saved3 = st2.to_lsd[101]
+  [41, 42, 43, 44].each do |id|
+    eq false, saved3.key?(id),
+       "field #{id} is absent again once every message-config value is put " \
+       'back to its default, not left present holding the default value'
+  end
+end
+
 check 'a Fade Out BGM followed by a Save/Continue boundary still forces the ' \
       'next same-file Play BGM to restart, not silently adjust volume in place' do
   # The behavioural point of the round-trip above: pre-fix, bgm_stopping was


### PR DESCRIPTION
## Summary
- Change Message Options (10120) sets four independent settings (transparency, position, whether the window is pinned, whether events keep running behind it) — liblcf `SaveSystem` fields 41-44. `#to_lsd` wrote all four unconditionally on every save; genuine RPG_RT.exe omits each one whenever it sits at its own default, the same convention cycle #152 established for field 61 (`bgm_stopping`), now confirmed across this whole cluster too rather than field 41 alone.
- `#from_lsd` needed no change: its accessors already fall back to the schema's declared default when a field is absent.
- Also flags (but doesn't touch, out of scope) a newly-noticed instance of pre-existing comments elsewhere in `to_lsd` mislabeling EasyRPG Player's own C++ source as "RPG_RT's live source" — the same legacy-debt pattern cycles #125/#126 already found and fixed elsewhere, worth a dedicated future cycle.

## Verification
- Confirmed against genuine RPG_RT.exe under wine via a synthetic autostart Change Message Options sequence: a call reproducing the exact default state left fields 41-44 all absent (identical to never issuing the command at all), the same call with every param changed wrote all four fields present with the changed values, and a further call resetting every param back to default left all four absent again — a per-value comparison at save time, not an ever-touched flag.
- New regression check confirmed to fail against pre-fix code (`git stash` of `game.rb`) with `RuntimeError: expected false, got true`, then pass after restoring — independently re-verified by me as well.
- All check suites pass: `rpg2k_scene_check.rb` 929/929, `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1137/1137 (up from 1136), `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- No EasyRPG Player source was consulted for this fix; the only outside reference was liblcf's `generator/csv/fields.csv`, the project's own narrow documented exception.

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929/929
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1137/1137
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Pre-fix regression proof via `git stash` (independently reproduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_