### PR TITLE
Save/Load: match RPG_RT's real byte layout for tint and picture chunks

### DIFF
--- a/changelog.d/picture-save-continue-chunk-103.fixed.md
+++ b/changelog.d/picture-save-continue-chunk-103.fixed.md
@@ -1,6 +1,7 @@
 - **Saves:** a shown picture (Show Picture) now survives a real
   Save/Continue -- `Game::State#to_lsd` previously never wrote chunk 103
-  at all, matching RPG_RT's `Scene_Save::Prepare`/`Player::LoadSavegame`,
-  which round-trip it unconditionally on every save; a picture up during
-  a cutscene used to silently vanish the instant this engine's own
-  Save/Continue ran.
+  at all, confirmed against genuine RPG_RT.exe to round-trip it
+  unconditionally on every save, holding all 50 picture slots whether
+  or not each one is actually in use; a picture up during a cutscene
+  used to silently vanish the instant this engine's own Save/Continue
+  ran.

--- a/changelog.d/save-chunk-102-103-byte-layout.fixed.md
+++ b/changelog.d/save-chunk-102-103-byte-layout.fixed.md
@@ -1,0 +1,10 @@
+- **Save/Load:** the screen-tint (chunk 102) and shown-pictures (chunk 103)
+  sections of a save file now match RPG_RT's real byte layout: both
+  containers are written on every save regardless of whether a tint or any
+  picture is actually in use, the picture section always carries all 50
+  RPG2000 picture slots (each individually empty when unused), and the
+  tint section's own fields are each omitted independently when at their
+  own default rather than as a single all-or-nothing block. Previously
+  this engine omitted both containers entirely whenever neutral/empty and
+  wrote the picture section as a sparse list of only ever-shown ids,
+  producing saves with a different byte shape than a genuine RPG_RT save.

--- a/changelog.d/screen-tint-save-continue.fixed.md
+++ b/changelog.d/screen-tint-save-continue.fixed.md
@@ -1,5 +1,5 @@
 - **Save/Continue:** a screen tint set by Tint Screen -- whether already
-  settled or still mid-transition -- now survives a real save/load, matching
-  RPG_RT's `Game_Screen::SetSaveData` -- previously the screen silently
+  settled or still mid-transition -- now survives a real save/load,
+  confirmed against genuine RPG_RT.exe -- previously the screen silently
   snapped back to neutral on Continue, and a fade that hadn't finished lost
   its remaining frames instead of resuming exactly where it left off.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2866,6 +2866,152 @@ The work below is roughly ordered by the critical path to a walkable game
   SAVE_SYSTEM beyond 41-44/61/121 (fields 71-140) is still unaudited for
   this same unconditional-write question -- this cycle closed the specific
   cluster cycle #152 flagged, not the whole table.
+  ✅ **Follow-up (cycle #154, 2026-08-25): picked up cycle #153's own
+  closing aside -- the EasyRPG-mislabeled "confirmed against RPG_RT's live
+  source: `Scene_Save::...` (`src/scene_save.cpp`)" comments on
+  `Game::State#to_lsd`'s chunks 102 (screen tint)/103 (pictures)/110
+  (targets), the same mislabeling pattern cycle #125/#126 already fixed
+  elsewhere -- and, unlike those two prior fixes, found the underlying
+  behavioral claim itself was *right* for two of the three (chunks 102/103)
+  while this file's own code had drifted from it, a real, verifiable
+  behavioral gap distinct from the citation problem alone.** Re-derived and
+  tested each claim independently against genuine RPG_RT.exe under wine (no
+  EasyRPG source was consulted at all, for the citation fix or for the
+  underlying claims -- only liblcf's own `generator/csv/fields.csv`-style
+  field ids already in this codebase's own schema.rb, this file's standing
+  narrow exception, and this cycle's own fresh wine captures), reusing
+  cycle #150-153's own `LCF::MapUnit`-based autostart-event injector
+  harness verbatim (`Map0012_orig.lmu`/`Save01_clean.lsd`, re-verified
+  byte-identical this cycle too: `c2fa69a0.../3ab5bb01...`, matching every
+  prior cycle back to #148) under the same Xvfb (640x480x16,
+  `LIBGL_ALWAYS_SOFTWARE=1`, matchbox-window-manager, `LANG=ja_JP.UTF-8`,
+  `WINEARCH=win32`, `WINEPREFIX=~/.wine-nepheshel32`) setup, and cycle
+  #152/#153's own raw-`@data` `LCF::Array1D`/`Array2D` reader technique to
+  inspect genuine Save2.lsd bytes at the *top-level chunk* granularity this
+  time (bypassing not just field defaults but chunk presence itself, so a
+  chunk id's mere existence in the file -- independent of whatever it
+  decodes to -- is directly visible). **Three synthetic autostart
+  scenarios, each independently run once (plus re-using eight further
+  genuine Save2.lsd captures already sitting in this session's own scratch
+  dir from cycles #152/#153's own unrelated probes, none of which ever
+  touched Tint Screen, Show Picture or Set Teleport/Escape Target either,
+  as free additional confirmation of the untouched-baseline shape):** an
+  autostart list that never issues Tint Screen, Show Picture or Set
+  Teleport/Escape Target at all; one issuing a single Tint Screen (11030)
+  with every channel pushed off its own default (100) but `frames=0`
+  (instant, so the transition completes the same frame); and one issuing a
+  single Show Picture (11110) for id 5 only. **Chunk 102 (tint):** every
+  untouched capture (9 total) produced a genuine save with chunk 102
+  *present* as a bare 1-byte, zero-field container -- never an absent
+  chunk, contradicting this file's own prior "omit the whole chunk when
+  neutral" code (which, in an irony the prior comment's own text already
+  half-admitted, cited "unconditional" while implementing the opposite);
+  the instant-tint capture wrote fields 1-4/11-14 (every channel, finish
+  and settled-current alike) present with the changed values while leaving
+  field 15 (`time_left`, still at its own default 0 since the transition
+  had already completed) absent -- i.e. the *container* is unconditional
+  but each *field* is elided independently at its own SAVE_SCREEN-declared
+  default, the identical convention cycle #152/#153 already established
+  for SAVE_SYSTEM's message-config cluster, not the all-or-nothing
+  "omit the whole chunk" shape this file used before. **Chunk 103
+  (pictures):** every untouched capture (9 total) produced a genuine save
+  with chunk 103 *present*, holding exactly `MAX_PICTURE_ID` (50, RPG2000's
+  own Show Picture id ceiling, already a named constant in this codebase)
+  sub-entries, ids 1-50, every one an empty placeholder -- never an absent
+  chunk, and never fewer than 50 ids either; the id-5 capture kept all 50
+  ids present, with only id 5 carrying real field data and every other id
+  (1-4, 6-50) still its own empty placeholder alongside it -- so the whole
+  50-wide slot range is unconditional and only a slot's *own* field
+  presence is sparse, the opposite of this file's prior "omit the id from
+  the array entirely unless a picture has ever been shown there" shape,
+  which also, as a side effect, could never produce more than however many
+  ids had actually been touched. **Chunk 110 (targets):** all 9 untouched
+  captures produced a genuine save with chunk 110 present, holding exactly
+  one entry -- array id 0, the escape-target slot, every one of its own
+  fields individually absent -- which is precisely this file's own
+  existing code already did (array id 0 always written, fields left at
+  their schema defaults when `@escape_target` is nil); this claim, alone
+  of the three, needed only the citation swap, no code change. **Fixed**
+  chunks 102/103 in `Game::State#to_lsd` (`mruby-rpg2k/mrblib/game.rb`) to
+  match: chunk 102 now always builds and assigns its `LCF::Array1D`, with
+  each of its own 9 fields (1-4/11-14/15) written only `if` it differs from
+  `Screen::NEUTRAL`/`0`, instead of the old `unless @screen.tint ==
+  neutral && !tinting?` guard around the whole chunk; chunk 103 now always
+  iterates `1..MAX_PICTURE_ID` and writes one entry per id (populated from
+  `@pictures[id]` when present, an untouched empty `Array1D` otherwise),
+  instead of the old `unless @pictures.empty?` guard iterating only
+  `@pictures`'s own (possibly non-contiguous, always sparse) keys. Chunk
+  110's comment was re-cited to genuine RPG_RT.exe evidence with no code
+  change. `.from_lsd`'s own read side needed no change for either chunk --
+  an absent field already decoded to its schema default before this fix,
+  and still does after it; only the *write* side's shape moved to match
+  genuine RPG_RT.exe. Covered by rewriting the two existing `scripts/
+  rpg2k_logic_check.rb` checks that had asserted the old (now-wrong) "no
+  chunk 102/103 at all when untouched" shape as fact -- `to_lsd writes
+  chunk 103 (shown pictures)...` now also asserts the container is present
+  with all 50 ids for both an empty State and one with a live picture, and
+  the new `to_lsd/from_lsd round-trips a live screen tint transition (chunk
+  102)` block now also asserts the container is present with every field
+  absent for an untouched State, plus the new instant-tint per-field
+  elision case -- confirmed to fail against the pre-fix code (`git stash`
+  of just `game.rb`) with precise, specific errors: `RuntimeError: chunk
+  103 is present even with no pictures ever shown` and `RuntimeError: chunk
+  102 is present even when the tint was never touched`, i.e. exactly the
+  two new assertions, nothing else. `Map0012.lmu`/`Save01.lsd` were
+  restored to their original bytes (byte-identical by `md5sum` against the
+  same `c2fa69a0.../3ab5bb01...` values every prior cycle back to #148
+  recorded) and every scratch `Save02.lsd` this cycle's own probes produced
+  was removed from the game directory (never a tracked fixture) after every
+  run; `git status` on `data/` came back clean. **Whether this is "merely"
+  a save-byte-format difference or a genuine behavioral one is worth being
+  honest about:** `.from_lsd` already treated an absent chunk/field the
+  same as a present-but-default one before this fix, so nothing changes in
+  what this codebase's own Save/Continue round-trips to, and
+  `scripts/compare-nepheshel-save-wine.bash`'s own header already records
+  that genuine RPG_RT.exe tolerates loading a bare engine-written save
+  missing these chunks entirely without incident ("RPG_RT does load those
+  now") -- so no crash or visible gameplay divergence was at stake. The fix
+  is still made on the same basis cycle #152/#153's own field-level fixes
+  were: this project treats an unnecessarily-diverging save-file *shape*
+  from genuine RPG_RT.exe as its own fidelity gap worth closing once
+  concretely identified and verified, not only outright crashes or visibly
+  wrong gameplay. **Two further leads spotted along the way, deliberately
+  left unfixed as out of this cycle's own container-presence scope:**
+  the id-5 Show Picture capture's chunk-103 entry carried a field-2/field-3
+  pair (both decoding to the same x/y value already present at fields 4/5
+  and 31/32) that `LCF::Schema::SAVE_PICTURE` does not model at all --
+  liblcf's own `generator/csv/fields.csv` was not available in this sandbox
+  to identify it properly (no network fetch was attempted to obtain it),
+  so it is flagged here rather than guessed at; and that same capture's
+  fields 33/34/41-44 (zoom/transparency/tone) came back absent despite the
+  slot being fully populated, purely because every value this cycle's own
+  probe happened to choose for them equals that field's own default --
+  suggesting per-value elision may reach *inside* an occupied picture slot
+  too, not only at the chunk-103-container/50-slot level this cycle
+  actually fixed, but not confirmed with a probe that deliberately varies
+  those fields off-default. Full suite reconfirmed passing, unchanged from
+  cycle #153: `scripts/rpg2k_scene_check.rb` (929), `scripts/
+  rpg2k_render_check.rb` (41), `scripts/rpg2k_logic_check.rb` (1137, count
+  unchanged since this cycle only added assertions to two existing checks
+  rather than new check blocks), `scripts/rpg2k3_battle_row_check.rb` (19)
+  and `scripts/rpg2k3_battle_gauge_check.rb` (15). **Left open for a future
+  cycle:** the field-2/3 pair and the possible inside-a-slot elision noted
+  above; fields 51-54 and 71-140 of SAVE_SYSTEM (cycle #152/#153's own open
+  items, untouched this cycle); the crash mystery's own two still-untested
+  threads, unchanged since cycle #151/#152; and every other EasyRPG-style
+  "RPG_RT's live source" citation this file (and others under
+  `mruby-rpg2k/mrblib/`) still carries outside chunks 102/103/104/110's own
+  neighbourhood -- a repo-wide `grep` this cycle ran turned up several dozen
+  more (e.g. around `do_use_item`, `do_change_equipment`,
+  `IsSkillUsable`/`CheckInclude`, enemy AI, move routes), none inspected or
+  re-verified this cycle, each its own genuine-RPG_RT-under-wine
+  verification task the same shape as this one and cycle #125/#126 before
+  it. (One numbering note for whoever picks that up: this cycle's own
+  assignment named "chunks 102/103/104," but the third mislabeled comment
+  actually visible in `to_lsd` next to 102/103 is chunk 110's own, not
+  104's -- chunk 104 (`hero`, the movable position record) carries no
+  EasyRPG-style citation in `to_lsd` at all currently; 102/103/110 is what
+  this cycle actually found and addressed.)
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14717,53 +14717,92 @@ module Game
       end
       save[108] = actors
 
-      # Chunk 102 is the screen tint transition (Tint Screen, 11030) --
-      # confirmed against RPG_RT's live source: `Scene_Save::Save`
-      # (`src/scene_save.cpp`) writes `save.screen = Main_Data::game_screen->
-      # GetSaveData()` unconditionally on every save, and `Player::
-      # LoadSavegame` (`src/player.cpp`) restores it unconditionally on every
-      # load via `Game_Screen::SetSaveData`, a wholesale struct replace (`src/
-      # game_screen.cpp`) -- so a tint mid-transition resumes interpolating
-      # exactly where it left off, not merely snapped to its finish value.
+      # Chunk 102 is the screen tint transition (Tint Screen, 11030) -- its
+      # own container is confirmed unconditional and its own fields
+      # confirmed individually value-elided against genuine RPG_RT.exe under
+      # wine this cycle (not EasyRPG source, correcting a prior comment here
+      # that mislabelled EasyRPG Player's own `src/scene_save.cpp`/`src/
+      # game_screen.cpp` as "RPG_RT's live source"): a synthetic autostart
+      # list that never touches Tint Screen at all still produced a genuine
+      # Save2.lsd with chunk 102 *present* (a bare 1-byte, zero-field
+      # container, not an absent chunk), and a second list issuing one Tint
+      # Screen with every channel pushed off its own SAVE_SCREEN-declared
+      # default (100) but frames=0 (instant, so the transition completes on
+      # the same frame -- time_left settles right back to its own default 0)
+      # wrote fields 1-4/11-14 (every channel, both finish and settled
+      # current) present with the changed values while leaving field 15
+      # (time_left) absent, still sitting at its own default -- i.e. the
+      # container is unconditional but each field is elided independently at
+      # its own default, the exact convention SAVE_SYSTEM's message-config
+      # cluster (fields 41-44) already established, not the all-or-nothing
+      # "omit the whole chunk when neutral" this file previously did (which
+      # never once produced a byte-identical chunk-102 shape to genuine
+      # RPG_RT.exe for the overwhelmingly common "tint never touched" case).
       # Only tint is modelled here (see @screen's own comment above); the
       # shake/flash/fade/weather/battle-animation fields liblcf's SaveScreen
       # also carries are a separate, larger gap this codebase doesn't model
-      # in Game::Screen at all yet, left as a future extension. Only written
-      # when a tint is actually in effect or in flight, the same "omit when
-      # neutral" convention the unplaced-vehicle chunks already follow.
-      unless @screen.tint == [Screen::NEUTRAL] * 4 && !@screen.tinting?
-        scr = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SCREEN })
-        finish, current, frames = @screen.tint_save_data
-        scr[1], scr[2], scr[3], scr[4] = finish
-        scr[11], scr[12], scr[13], scr[14] = current
-        scr[15] = frames
-        save[102] = scr
-      end
+      # in Game::Screen at all yet, left as a future extension.
+      scr = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SCREEN })
+      finish, current, frames = @screen.tint_save_data
+      scr[1] = finish[0] if finish[0] != Screen::NEUTRAL
+      scr[2] = finish[1] if finish[1] != Screen::NEUTRAL
+      scr[3] = finish[2] if finish[2] != Screen::NEUTRAL
+      scr[4] = finish[3] if finish[3] != Screen::NEUTRAL
+      scr[11] = current[0] if current[0] != Screen::NEUTRAL
+      scr[12] = current[1] if current[1] != Screen::NEUTRAL
+      scr[13] = current[2] if current[2] != Screen::NEUTRAL
+      scr[14] = current[3] if current[3] != Screen::NEUTRAL
+      scr[15] = frames if frames != 0
+      save[102] = scr
 
-      # Chunk 103 is every currently-shown picture (Show Picture, 11110) --
-      # confirmed against RPG_RT's live source: `Scene_Save::Prepare`
-      # (`src/scene_save.cpp`) writes `save.pictures = Main_Data::
-      # game_pictures->GetSaveData()` unconditionally on every save, and
-      # `Player::LoadSavegame` (`src/player.cpp`) restores it unconditionally
-      # on every load -- the same chunk `.from_lsd`/`.restore_pictures`
-      # (above) already reads, just never written here. Field mapping is the
-      # exact mirror of `.restore_pictures`' own read (see `SAVE_PICTURE`'s
-      # own comment for why 31/32/etc are finish_*, not current_*): 1 name,
-      # 31/32 finish_x/finish_y, 33 zoom, 34 transparency
-      # (`Game.opacity_to_trans`, the inverse of the live command's own
-      # `#trans_to_opacity`), 41-44 the red/green/blue/saturation tone -- a
-      # picture at rest writes its own live values as both, matching real
-      # RPG_RT's own current-tracks-finish idle sync. `@pictures` only ever
-      # holds currently-shown pictures (#erase_picture deletes the entry
-      # outright), so every entry present is live and belongs in the save.
-      # A picture still mid-Move-Picture (#moving?) additionally writes its
-      # own genuinely-live current_*/time_left fields (4/5/7/8/11-14/51) so a
-      # resumed Continue keeps gliding from exactly where it was, rather than
-      # snapping straight to the move's target the instant the save reloads.
-      unless @pictures.empty?
-        pics = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
-        @pictures.each do |id, p|
-          e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+      # Chunk 103 is every picture slot RPG2000 offers (Show Picture, 11110)
+      # -- its own container and its own 1..MAX_PICTURE_ID (50) slot range are
+      # both confirmed unconditional against genuine RPG_RT.exe under wine
+      # this cycle (not EasyRPG source, correcting a prior comment here that
+      # mislabelled EasyRPG Player's own `src/scene_save.cpp`/`src/
+      # game_pictures.cpp` as "RPG_RT's live source"): a synthetic autostart
+      # list that never issues Show Picture at all still produced a genuine
+      # Save2.lsd with chunk 103 *present*, holding exactly 50 sub-entries
+      # (ids 1-50, RPG2000's own Show Picture id range -- `MAX_PICTURE_ID`
+      # below) every one of them an empty (zero-field) placeholder, not an
+      # absent chunk or a sparse 0-entry array; a second list showing only
+      # picture id 5 produced a save with all 50 ids still present but only
+      # id 5 carrying real field data, every other id (1-4, 6-50) still its
+      # own empty placeholder entry alongside it -- so the whole fixed-size
+      # slot range is unconditional, and only a slot's own field presence is
+      # sparse, the opposite of this file's prior "omit the id from the
+      # array entirely unless a picture has ever been shown there" shape
+      # (which also, as a side effect, only ever emitted however many ids
+      # had been *touched*, never the full 50-wide range genuine RPG_RT.exe
+      # always carries). Field mapping is the exact mirror of
+      # `.restore_pictures`' own read (see `SAVE_PICTURE`'s own comment for
+      # why 31/32/etc are finish_*, not current_*): 1 name, 31/32
+      # finish_x/finish_y, 33 zoom, 34 transparency (`Game.opacity_to_trans`,
+      # the inverse of the live command's own `#trans_to_opacity`), 41-44 the
+      # red/green/blue/saturation tone -- a picture at rest writes its own
+      # live values as both, matching real RPG_RT's own current-tracks-finish
+      # idle sync. `@pictures` only ever holds currently-shown pictures
+      # (#erase_picture deletes the entry outright), so an ordinary shown
+      # picture is a slot with an entry here and an untouched slot is
+      # nil/absent from `@pictures`, both handled below. A picture still
+      # mid-Move-Picture (#moving?) additionally writes its own genuinely-live
+      # current_*/time_left fields (4/5/7/8/11-14/51) so a resumed Continue
+      # keeps gliding from exactly where it was, rather than snapping
+      # straight to the move's target the instant the save reloads. (A
+      # second, narrower gap spotted along the way but left unfixed here,
+      # out of this cycle's own container-presence scope: genuine RPG_RT.exe
+      # also wrote a field 2/3 pair on the live id-5 entry this cycle's own
+      # probe never modelled at all -- and per-value elision may reach
+      # *inside* an occupied slot too, since fields 33/34/41-44 came back
+      # absent in that same probe despite the slot itself being fully
+      # populated, purely because every value this cycle's own probe chose
+      # for them happened to equal each field's own default. Neither was
+      # investigated further; see docs/TODO.md.)
+      pics = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+      (1..MAX_PICTURE_ID).each do |id|
+        p = @pictures[id]
+        e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+        if p
           e[1] = p.name
           if p.moving?
             e[4] = p.x
@@ -14793,10 +14832,10 @@ module Game
             e[43] = p.blue
             e[44] = p.saturation
           end
-          pics[id] = e
         end
-        save[103] = pics
+        pics[id] = e
       end
+      save[103] = pics
 
       inv = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_INVENTORY })
       inv[1] = @party.actors.map { |a| a.id }
@@ -14830,16 +14869,22 @@ module Game
       save[109] = inv
 
       # Chunk 110 is every Set Teleport Target (11810) / Set Escape Target
-      # (11830) destination registered so far -- confirmed against RPG_RT's
-      # live source: `Scene_Save::Prepare`/`Player::LoadSavegame`
-      # (`src/scene_save.cpp`/`src/player.cpp`) round-trip `save.targets` via
-      # `Game_Targets::GetSaveData`/`SetSaveData` (`src/game_targets.cpp`)
-      # unconditionally, every save. `GetSaveData` always writes the escape
-      # target first, at array id 0 (default-constructed/empty when never
-      # set -- RPG_RT carries it regardless), followed by every teleport
-      # target keyed by its own destination map id
-      # (`AddTeleportTarget`'s own `tgt.ID = map_id`) -- the exact shape
-      # mirrored below.
+      # (11830) destination registered so far -- re-confirmed against genuine
+      # RPG_RT.exe under wine this cycle (not EasyRPG source, correcting a
+      # prior comment here that mislabelled EasyRPG Player's own `src/
+      # scene_save.cpp`/`src/player.cpp`/`src/game_targets.cpp` as "RPG_RT's
+      # live source"): eight independent synthetic-autostart wine captures,
+      # none of which ever issued Set Teleport/Escape Target, all produced a
+      # genuine save with chunk 110 *present*, holding exactly one entry --
+      # array id 0, the escape-target slot, with every one of its own fields
+      # individually absent (default-constructed/empty) since no Set Escape
+      # Target had run. That is precisely this code's own existing shape:
+      # array id 0 always written (fields left at their own defaults when
+      # `@escape_target` is nil), followed by one entry per registered
+      # teleport target keyed by its own destination map id
+      # (`AddTeleportTarget`'s own `tgt.ID = map_id`) -- so this claim, unlike
+      # its neighbours in chunks 102/103 below, needed no code change, only
+      # this citation swap.
       targets = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_TARGET })
       esc = @escape_target
       e0 = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_TARGET })
@@ -15272,9 +15317,12 @@ module Game
       end
       # Chunk 102 is the screen tint transition; only #restore_tint's tint
       # sub-fields are modelled here (see #to_lsd's own comment on chunk 102
-      # for why). An absent chunk (a save written before this fix, or one
-      # made while the tint genuinely sat at neutral) leaves the fresh
-      # `Screen.new` neutral defaults in place.
+      # for why, including why the chunk itself is present unconditionally
+      # -- cycle #154). An absent chunk (a save written before this fix, or
+      # by anything else that omits it outright) leaves the fresh
+      # `Screen.new` neutral defaults in place, the same as a present chunk
+      # whose own tint fields are all individually absent at their own
+      # SAVE_SCREEN defaults.
       scr = save[102]
       if scr
         state.screen.restore_tint([scr.tint_finish_red, scr.tint_finish_green,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4630,16 +4630,14 @@ check 'restore_pictures restores zoom, opacity and tone, not just name/position'
 end
 
 check 'to_lsd writes chunk 103 (shown pictures), not just from_lsd reading it' do
-  # Confirmed directly against RPG_RT's live source: `Scene_Save::Prepare`
-  # (`src/scene_save.cpp`) writes `save.pictures = Main_Data::game_pictures->
-  # GetSaveData()` unconditionally on every save, and `Player::LoadSavegame`
-  # (`src/player.cpp`) restores it unconditionally on every load -- so a
-  # picture shown via Show Picture (11110) survives a genuine Save/Continue.
-  # `#to_lsd` never wrote chunk 103 at all (see the "restore_pictures..."
-  # check above, whose own comment used to note this), so any shown picture
-  # silently vanished the instant this engine's own Save/Continue ran, even
-  # though loading a genuine external RPG_RT save with pictures already
-  # worked (that path only ever exercises .from_lsd, never .to_lsd).
+  # Confirmed against genuine RPG_RT.exe under wine, not EasyRPG's source --
+  # so a picture shown via Show Picture (11110) survives a genuine
+  # Save/Continue. `#to_lsd` never wrote chunk 103 at all (see the
+  # "restore_pictures..." check above, whose own comment used to note this),
+  # so any shown picture silently vanished the instant this engine's own
+  # Save/Continue ran, even though loading a genuine external RPG_RT save
+  # with pictures already worked (that path only ever exercises .from_lsd,
+  # never .to_lsd).
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   st.show_picture(3, name: 'backdrop', x: 200, y: 150, zoom: 150,
@@ -4680,11 +4678,37 @@ check 'to_lsd writes chunk 103 (shown pictures), not just from_lsd reading it' d
   eq 20, restored.y
   eq 255, restored.opacity, 'opacity 255 (trans 0) is a fixed point of both conversions'
 
-  # A State with no pictures shown must not gain a stray chunk 103 at all --
-  # the same "absent means nothing to restore" rule chunk 111's own fields
-  # already follow.
+  # Cycle #154: re-verified against genuine RPG_RT.exe under wine (not
+  # EasyRPG source) that chunk 103's own *container* is unconditional and
+  # always carries a fixed 1..MAX_PICTURE_ID (50) slot range -- eight
+  # independent synthetic-autostart wine captures that never issued Show
+  # Picture at all still produced a genuine save with chunk 103 present,
+  # holding exactly 50 entries (ids 1-50), every one an empty placeholder;
+  # a further capture showing only picture id 5 kept all 50 ids present,
+  # with every id but 5 still its own empty placeholder alongside it. A
+  # State with no pictures shown must therefore still write chunk 103, with
+  # every slot present but empty -- not omit the chunk entirely (this
+  # file's own prior claim, sourced from a mislabelled EasyRPG citation and
+  # never actually checked against genuine RPG_RT.exe) and not a sparse
+  # array of only-ever-shown ids either.
   empty_st = Game::State.new(Game::Party.new(db), 1, 0, 0)
-  eq nil, empty_st.to_lsd[103], 'no shown pictures means no chunk 103 at all'
+  empty_saved = empty_st.to_lsd[103]
+  ok !empty_saved.nil?, 'chunk 103 is present even with no pictures ever shown'
+  eq (1..Game::State::MAX_PICTURE_ID).to_a, empty_saved.map { |id, _| id }.sort,
+     'all 50 RPG2000 picture slots are present as their own (empty) entries'
+  raw1 = empty_saved[1].instance_variable_get(:@data)
+  eq [], raw1.each_index.select { |i| raw1[i] },
+     'an untouched slot carries no fields of its own'
+
+  # The same fixed 50-slot range holds around a live picture too: only its
+  # own id gains real field data, every other id (1-2, 4-50) stays its own
+  # empty placeholder rather than being omitted from the array.
+  sparse_check = st.to_lsd[103]
+  eq (1..Game::State::MAX_PICTURE_ID).to_a, sparse_check.map { |id, _| id }.sort,
+     'a State with one shown picture (id 3/4) still carries all 50 slots'
+  raw7 = sparse_check[7].instance_variable_get(:@data)
+  eq [], raw7.each_index.select { |i| raw7[i] },
+     'a slot with no picture of its own stays an empty placeholder alongside the live ones'
 end
 
 check 'to_lsd/from_lsd round-trips a picture still mid-Move-Picture, resuming ' \
@@ -11690,17 +11714,13 @@ check 'to_lsd/from_lsd round-trips Set Teleport Target / Set Escape Target ' \
 end
 
 check 'to_lsd/from_lsd round-trips a live screen tint transition (chunk 102)' do
-  # Confirmed directly against RPG_RT's live source: `Scene_Save::Save`
-  # (`src/scene_save.cpp`) writes `save.screen = Main_Data::game_screen->
-  # GetSaveData()` unconditionally on every save, and `Player::LoadSavegame`
-  # (`src/player.cpp`) restores it unconditionally on every load via
-  # `Game_Screen::SetSaveData` (`src/game_screen.cpp`), a wholesale struct
-  # replace -- so a Tint Screen (11030) transition still in flight when the
-  # game is saved must resume interpolating from exactly where it left off,
-  # not restart or snap to its finish value. #to_lsd/.from_lsd previously
-  # never touched chunk 102 at all -- schema.rb's own comment on SAVE_DATA
-  # flagged it as "left out until confirmed" -- so a real Save/Continue
-  # silently dropped every standing or in-progress tint.
+  # Confirmed against genuine RPG_RT.exe under wine, not EasyRPG's source --
+  # so a Tint Screen (11030) transition still in flight when the game is
+  # saved must resume interpolating from exactly where it left off, not
+  # restart or snap to its finish value. #to_lsd/.from_lsd previously never
+  # touched chunk 102 at all -- schema.rb's own comment on SAVE_DATA flagged
+  # it as "left out until confirmed" -- so a real Save/Continue silently
+  # dropped every standing or in-progress tint.
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   st.screen.tint_to(50, 60, 70, 80, 40) # a transition still 40 frames from done
@@ -11720,16 +11740,41 @@ check 'to_lsd/from_lsd round-trips a live screen tint transition (chunk 102)' do
      'a mid-transition tint must resume with its remaining frame count intact, not restart or settle'
   ok round.screen.tinting?, 'the restored tint must still report itself as in-flight'
 
-  # A tint that had already settled (frames == 0, current == finish) writes
-  # nothing at all -- chunk 102 is omitted entirely, the same "omit when
-  # neutral" convention the unplaced-vehicle chunks already follow -- and a
-  # State that never tinted at all must not invent a tint on round-trip.
+  # Cycle #154: re-verified against genuine RPG_RT.exe under wine (not
+  # EasyRPG source) that chunk 102's own *container* is unconditional --
+  # a synthetic autostart list that never issues Tint Screen at all still
+  # produced a genuine save with chunk 102 present as a bare, zero-field
+  # (1-byte) entry, not an absent chunk (this file's own prior claim,
+  # sourced from a mislabelled EasyRPG citation and never actually checked
+  # against genuine RPG_RT.exe). A State that never tinted at all must
+  # therefore still write chunk 102, with every field individually absent
+  # (at its own SAVE_SCREEN-declared default) rather than the chunk itself
+  # missing, and must not invent a tint on round-trip either way.
   never_tinted = Game::State.new(Game::Party.new(db), 1, 0, 0)
   saved = never_tinted.to_lsd
-  eq nil, saved[102], 'a State that never tinted must not write chunk 102 at all'
+  ok !saved[102].nil?, 'chunk 102 is present even when the tint was never touched'
+  eq [], (1..15).select { |f| saved[102].key?(f) },
+     'a never-touched tint leaves every one of chunk 102\'s own fields absent'
   round2 = Game::State.from_lsd(db, saved)
   eq [100, 100, 100, 100], round2.screen.tint
   eq false, round2.screen.tinting?
+
+  # A further genuine wine capture pushed every tint channel off its own
+  # default with an *instant* (frames=0) Tint Screen, so the transition
+  # settles on the very same frame: fields 1-4/11-14 (every channel, finish
+  # and current alike) came back present with the changed values, but field
+  # 15 (time_left) came back absent, still sitting at its own default 0 --
+  # i.e. each field is elided independently at its own default, not the
+  # whole chunk elided or written as a single all-or-nothing unit.
+  instant_tint = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  instant_tint.screen.tint_to(150, 60, 90, 140, 0) # frames=0: settles immediately
+  scr = instant_tint.to_lsd[102]
+  eq [1, 2, 3, 4, 11, 12, 13, 14], (1..15).select { |f| scr.key?(f) }.sort,
+     'every changed channel (finish and settled current) is present; field 15 (time_left, ' \
+     'still at its own default 0) is not'
+  eq [150, 60, 90, 140], [scr.tint_finish_red, scr.tint_finish_green, scr.tint_finish_blue, scr.tint_finish_sat]
+  eq [150.0, 60.0, 90.0, 140.0],
+     [scr.tint_current_red, scr.tint_current_green, scr.tint_current_blue, scr.tint_current_sat]
 
   # A save written before this landed simply omits chunk 102 entirely;
   # from_lsd must leave the fresh Screen.new neutral defaults alone rather


### PR DESCRIPTION
## Summary
- Two pre-existing comments in `Game::State#to_lsd` cited EasyRPG Player's own C++ source (`Scene_Save::Prepare/Save`, `Player::LoadSavegame`, `Game_Screen`/`Game_Pictures`/`Game_Targets`) mislabeled as "RPG_RT's live source" — the same pattern cycles #125/#126 already found and fixed elsewhere. Independently re-verified each underlying claim against genuine RPG_RT.exe under wine, without consulting EasyRPG source.
- Chunk 110 (Set Teleport/Escape Target) needed only its citation fixed — the existing code already matches genuine RPG_RT.exe.
- Chunks 102 (screen tint) and 103 (shown pictures) needed real fixes:
  - Chunk 102's own container is unconditional, but each of its fields is independently omitted at its own default — not the previous all-or-nothing "omit the whole chunk when neutral."
  - Chunk 103's own container is unconditional and always carries all 50 RPG2000 picture slots, each an empty placeholder when unused — not the previous sparse array of only ever-shown ids.
- Corrected two pre-existing changelog fragments in place (`picture-save-continue-chunk-103.fixed.md`, `screen-tint-save-continue.fixed.md`) that also cited the mislabeled EasyRPG symbol names, per this project's established precedent for correcting prior fragments when disproven.
- A repo-wide grep found several dozen more EasyRPG-style "RPG_RT's live source" citations elsewhere in `mruby-rpg2k/mrblib/` (item/equipment/skill usability, enemy AI, move routes) — flagged in docs/TODO.md for a future cycle, none touched here.

## Verification
- Confirmed via synthetic autostart Tint Screen / Show Picture sequences driven through genuine RPG_RT.exe's own save UI under wine, inspected with a raw chunk-presence reader that bypasses schema defaults.
- New/updated regression checks confirmed to fail against pre-fix code (`git stash` of `game.rb`) with `RuntimeError: chunk 103 is present even with no pictures ever shown` and `RuntimeError: chunk 102 is present even when the tint was never touched`, then pass after restoring — independently re-verified by me as well.
- All check suites pass: `rpg2k_scene_check.rb` 929/929, `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1137/1137, `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- No EasyRPG Player source was consulted for any part of this fix — including while removing the mislabeled citations, the underlying claims were re-derived independently against genuine RPG_RT.exe rather than checked against the source being cited.

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929/929
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1137/1137
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Pre-fix regression proof via `git stash` (independently reproduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_