### PR TITLE
Save/Load: identify SAVE_PICTURE's show_x/y field, fix byte layout

### DIFF
--- a/changelog.d/save-picture-show-position-and-byte-layout.fixed.md
+++ b/changelog.d/save-picture-show-position-and-byte-layout.fixed.md
@@ -1,0 +1,9 @@
+- **Save/Load:** a shown picture's save-file record now matches RPG_RT's
+  real byte layout: it carries the position last given to Show Picture
+  (distinct from its current and target position while a Move Picture is
+  in flight) alongside its live position, and its zoom/transparency/tone
+  values are each written only when off their own default rather than
+  always present or, for a picture at rest, missing its live values
+  entirely. Previously this codebase modeled neither the shown position
+  nor a resting picture's live zoom/transparency/tone at all, producing
+  saves with a different byte shape than a genuine RPG_RT save.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3012,6 +3012,174 @@ The work below is roughly ordered by the critical path to a walkable game
   104's -- chunk 104 (`hero`, the movable position record) carries no
   EasyRPG-style citation in `to_lsd` at all currently; 102/103/110 is what
   this cycle actually found and addressed.)
+  ✅ **Follow-up (cycle #155, 2026-08-25): picked up candidate 1, the two
+  loose ends cycle #154 explicitly left open on chunk 103 (pictures) --
+  the undeclared field 2/3 pair on a live picture entry, and whether
+  per-value elision reaches *inside* an occupied slot for fields 33/34/
+  41-44. Both resolved with new, controlled genuine-RPG_RT.exe-under-wine
+  evidence, and a third, larger gap found along the way: `Game::State
+  #to_lsd` was writing chunk 103's own current_x/y/zoom/transparency/tone
+  (fields 4/5/7/8/11-14) only while `Game::Picture#moving?`, but genuine
+  RPG_RT.exe writes them unconditionally, on every shown picture, moving or
+  not.** Reused cycle #148-154's own `LCF::MapUnit`-based autostart-event
+  injector design (a fresh scratch harness this session, since a prior
+  session's own scratch dir does not persist across cycles; `Map0012.lmu`/
+  `Save01.lsd` copied to scratch first and re-verified byte-identical
+  against every prior cycle's own recorded values back to #148: `c2fa69a0
+  .../3ab5bb01...`) and cycle #152's own genuine-in-game-Save-menu capture
+  technique (an autostart list ending in Open Save Menu, `xdotool` Down +
+  Return onto the empty File 2 slot, no confirm dialog) under the same Xvfb
+  (640x480x16, `LIBGL_ALWAYS_SOFTWARE=1`, matchbox-window-manager,
+  `LANG=ja_JP.UTF-8`, `WINEARCH=win32`, `WINEPREFIX=~/.wine-nepheshel32`)
+  setup every prior wine cycle has used, plus cycle #152/#153's own raw
+  `LCF::Array1D` `key?`/`@data` field-presence reader (bypassing schema
+  defaults entirely) to inspect the resulting genuine `Save02.lsd` byte for
+  byte. One methodology snag hit and fixed along the way, noted for whoever
+  extends this harness next: the very first Show Picture probe named a
+  picture file (`"picture"`) that does not exist in Nepheshel's own
+  `Picture/` folder, and genuine RPG_RT.exe silently hung on the map
+  forever rather than opening the autostart's own trailing Open Save Menu
+  command or drawing anything -- switching to a real asset already shipped
+  with the game (`black.png`) fixed it outright; this was never chased
+  further as its own investigation (a missing-asset hang is a plausible,
+  low-priority engine quirk, not a save-format fidelity gap), but is worth
+  either testbed authors or a future cycle knowing about. **Four scenarios,
+  each independently driven once:** a picture shown at (111,77) with
+  zoom/transparency/tone all left at their own default (100/0/100,100,100,
+  100); the identical command except all six pushed off their own default
+  (133/25/140,60,180,50); the off-default show immediately followed by a
+  Move Picture to (222,188) over 5.0s (frames=300 @ 60fps) with a 3.0s Wait
+  (180 frames) before the autostart's own Open Save Menu, so the move was
+  genuinely still in flight when the genuine save was written; and a
+  control autostart that never touches a picture at all (reconfirming cycle
+  #154's own "50 empty placeholder slots" finding still holds, unchanged).
+  **Field 2/3:** present in every one of the three picture-touching
+  captures, always an 8-byte IEEE-754 double (same wire type as 4/5/31/32,
+  confirmed by directly inspecting the raw bytes rather than assuming a
+  type, the same discipline the task brief itself asked for). At rest, 2/3
+  equalled 4/5 and 31/32 exactly (111.0/77.0), reproducing cycle #154's own
+  original, undecidable observation. The decisive capture was the
+  still-moving one: current_x/y (4/5) read the genuinely interpolated
+  177.6/143.6 (a clean 60%-of-the-way point between 111,77 and 222,188 over
+  the 180-of-300 elapsed frames, cross-checked arithmetically, not merely
+  eyeballed) and finish_x/y (31/32) read the move's own target 222.0/188.0
+  -- while field 2/3 stayed at 111.0/77.0, tracking *neither* value, but
+  the position the picture was originally shown at and left untouched by
+  the intervening Move Picture entirely. No liblcf field name was available
+  to confirm this against (this file's own standing exception covers using
+  `generator/csv/fields.csv` for a field id/type already known, not
+  fetching it fresh over the network, which this sandbox still cannot do
+  per cycle #154's own note) -- named `show_x`/`show_y` here strictly by
+  the behavior actually observed, documented as such in `SAVE_PICTURE`'s
+  own comment rather than claimed as RPG_RT's or liblcf's own internal
+  name. **Fields 33/34/41-44 (and their current_* counterparts 7/8/11-14):**
+  the default-valued capture wrote chunk 103's entry with *only* fields
+  [1,2,3,4,5,31,32] present -- zoom/transparency/tone (current and finish
+  alike) all six absent -- while the identical command with all six pushed
+  off-default wrote all of [7,8,11,12,13,14,33,34,41,42,43,44] present too,
+  carrying the exact values given. Same picture, same name, same position,
+  same "never moved" state, only the six visual values changed between the
+  two runs -- decisively confirming genuine per-field elision-at-default
+  (the same convention already established for SAVE_SCREEN's tint fields,
+  cycle #154, and SAVE_SYSTEM's message-config cluster, cycle #152/#153)
+  and ruling out cycle #154's own flagged alternative ("the probe's values
+  merely happened to equal each default"). **The unrelated, larger gap
+  found along the way:** the off-default-but-never-moved capture's fields
+  7/8/11-14 (current_zoom/transparency/tone) were present with the exact
+  same values as their 33/34/41-44 (finish) counterparts, even though this
+  picture was never put through Move Picture at all -- meaning genuine
+  RPG_RT.exe writes current_* unconditionally on every shown picture, not
+  only while a move is in flight, contradicting this file's own prior
+  `Game::Picture#moving?`-gated write (inherited from cycle #150's original
+  chunk-103 fix, which only ever had a *moving* sample save to work from).
+  **Fixed** three things in `mruby-rpg2k/mrblib/game.rb` and
+  `mruby-lcf/mrblib/schema.rb`: (1) `SAVE_PICTURE` gained `2 => :show_x` /
+  `3 => :show_y` (type `:double`, default `0.0`, matching its position
+  siblings) and explicit `default:` values on 31-34/41-44 (previously
+  undefaulted, decoding to `nil` on an absent field -- harmless in practice
+  since `Game::Picture.new`'s own `opts[:x] || default` fallbacks already
+  covered `nil`, but now consistent with every other field here); (2)
+  `Game::Picture` gained a `show_x`/`show_y` reader pair, set at
+  construction from `opts[:show_x] || @x` (so the live Show Picture command
+  path, which never passes `show_x` explicitly, naturally records its own
+  shown position, and `#move_to` never touches it, matching the evidence
+  exactly); (3) `Game::State#to_lsd`'s chunk 103 write collapsed the old
+  `if p.moving? / else` branch into one unconditional block that writes
+  `show_x`/`show_y` (2/3) and `current_x`/`current_y` (4/5) always, elides
+  `current_zoom`/`current_transparency`/`current_tone_*` (7/8/11-14) and
+  `zoom`/`transparency`/`tone_*` (33/34/41-44) independently at their own
+  default (reading from `p.finish_*` while moving, from `p.x`/`p.zoom`/etc.
+  directly at rest, matching the already-established "current tracks finish
+  at idle" sync), and writes `time_left` (51) only while still moving --
+  simpler code than the branch it replaced, not just more correct.
+  `Game::State.restore_pictures` (the read side) gained a `show_x:
+  pic.key?(2) ? pic.show_x : nil` / `show_y:` pair passed through to
+  `Game::Picture.new`, gated on `key?` rather than the value alone so an
+  old save with no field 2/3 at all falls back to the shown position
+  (through `Picture.new`'s own fallback) instead of wrongly restoring a
+  literal `(0.0, 0.0)` from the schema's new default. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks: one asserting the exact raw
+  present-field-id list for a same-position picture at its own defaults
+  vs. off them (`[1,2,3,4,5,31,32]` vs. the full eighteen-field list,
+  mirroring the genuine-RPG_RT A/B pair above byte for byte) plus the
+  round-trip of the off-default values through `.from_lsd`; the other
+  building the exact moving-picture scenario above in miniature (Show
+  Picture, Move Picture, 180 simulated `#update` frames, then `to_lsd`) and
+  asserting `show_x`/`show_y` stay at the original position while current/
+  finish read the interpolated/target values respectively, survive a
+  `.from_lsd` round-trip, reset on a fresh Show Picture for the same id,
+  and fall back correctly from a legacy entry with no field 2/3 at all --
+  confirmed to fail against the pre-fix code (`git stash` of just
+  `schema.rb`/`game.rb`) with two precise, specific errors: `RuntimeError:
+  expected [1, 2, 3, 4, 5, 31, 32], got [1, 31, 32, 33, 34, 41, 42, 43, 44]`
+  (exactly the old unconditional-finish/no-current-at-rest shape) and
+  `TypeError: no implicit conversion from nil to integer` (`show_x`/
+  `show_y` not existing pre-fix at all, `LCF::Array1D#[]` raising the
+  instant the new check asked for a schema field id the old table never
+  declared). `Map0012.lmu`/`Save01.lsd` were restored to their original
+  bytes (byte-identical by `md5sum` against the same `c2fa69a0.../
+  3ab5bb01...` values every prior cycle back to #148 recorded) and every
+  scratch `Save02.lsd` this cycle's probes produced was removed from the
+  game directory afterward; `git status` on `data/` came back clean. No
+  EasyRPG source was consulted for any claim in this cycle (the field 2/3
+  identification was deliberately behavioral, per the task brief's own
+  instruction, precisely because liblcf's own field list was unreachable
+  without a network fetch this sandbox still does not have) and no web
+  search was used either. This cycle also built the mruby engine binary
+  from source (per this file's own standing note that this sandbox
+  supports it: fetched and hash-verified the two Unicode tables `scripts/
+  native-build-without-nix.bash` pins, exported `$cp932_table`/
+  `$jis0208_table`, `cmake --build build --target rpg_maker_clone`) and
+  confirmed both that the build succeeds with these changes (mruby's own
+  stricter parser compiling `game.rb`/`schema.rb` cleanly is a real, if
+  weak, second check beyond CRuby's own more permissive one) and that
+  `--rpg2k_continue` on the Nepheshel test-bed still boots straight to the
+  map with no crash. Full suite reconfirmed passing, `scripts/
+  rpg2k_logic_check.rb` up by 2: `scripts/rpg2k_scene_check.rb` (929),
+  `scripts/rpg2k_render_check.rb` (41), `scripts/rpg2k_logic_check.rb`
+  (1139), `scripts/rpg2k3_battle_row_check.rb` (19) and `scripts/
+  rpg2k3_battle_gauge_check.rb` (15). **Left open for a future cycle:**
+  whether genuine RPG_RT.exe ever *reads* field 2/3 back for anything
+  beyond round-tripping it through Save/Continue (this cycle only
+  established what it writes and named it behaviorally; no test loaded an
+  edited save with show_x/y deliberately different from current/finish
+  under genuine RPG_RT.exe to see whether anything visible depends on it --
+  plausibly nothing does, matching chunk 110's own escape-target precedent,
+  but unconfirmed either way); whether current_* and finish_* are truly
+  elided *independently* of each other (every scenario this cycle ran kept
+  them equal, since only an at-rest or a same-valued moving picture was
+  tested -- a picture whose current copy sits exactly on a default while
+  its finish copy does not, or vice versa, was never captured); field 9
+  (`visible`) of `SAVE_PICTURE`, never written by this codebase at all and
+  untouched again this cycle, still an open question distinct from
+  everything above; fields 51-54/71-140 of SAVE_SYSTEM (cycle #152/#153's
+  own open items, untouched again); the crash mystery's own two still-
+  untested threads (unchanged since cycle #151/#152); the missing-Picture-
+  asset hang noted above, its own small mystery never chased; and every
+  other EasyRPG-style "RPG_RT's live source" citation cycle #154's own
+  repo-wide grep turned up outside chunks 102/103/110's own neighbourhood
+  (item/equipment/skill usability, enemy AI, move routes -- candidate 2,
+  not attempted this cycle either).
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1209,14 +1209,41 @@ module LCF
     # resumed under real RPG_RT as a picture visibly still gliding from the
     # current position toward the finish one -- not sitting statically at
     # either.
+    #
+    # Field 2/3 -- cycle #154 spotted genuine RPG_RT.exe writing an
+    # undeclared pair here (on a picture at rest, decoding to the same x/y as
+    # 4/5 and 31/32, so left unidentified) and cycle #155 pinned it down with
+    # a follow-up experiment: Show Picture at (111,77), then Move Picture to
+    # (222,188) over 5.0s with a 3.0s Wait before saving (so the move is
+    # genuinely still in flight, current_x/y at 4/5 reading the interpolated
+    # 177.6/143.6 and finish_x/y at 31/32 reading the target 222/188, both
+    # confirmed against this same save) -- field 2/3 stayed at 111.0/77.0
+    # throughout, tracking *neither* current nor finish, but the position the
+    # picture was originally shown at and never touched by the move at all.
+    # No liblcf field name could be consulted for this pair (this file's own
+    # standing narrow exception did not extend to a name never seen without
+    # network access to `generator/csv/fields.csv`), so `show_x`/`show_y`
+    # names it by the behavior actually observed: the argument of the last
+    # Show Picture call for this id, holding steady across any number of
+    # subsequent Move Picture calls, reset only by a fresh Show Picture.
+    # Whether genuine RPG_RT ever *reads* this pair back for anything beyond
+    # round-tripping it through Save/Continue is not established either way
+    # -- see docs/TODO.md.
     SAVE_PICTURE = {
       1 => { name: :name, type: :string },              # ピクチャグラフィックのファイル名
-      # The picture's genuinely live position/zoom/transparency/tone, only
-      # meaningful while a move is still in flight (time_left > 0) -- see
-      # this table's own comment above. Defaults match a fresh Game::Picture
-      # so an old save written before these fields existed (or a picture
-      # that has never moved, time_left always 0) restores identically to
-      # before: #restore_pictures only ever reads these when time_left > 0.
+      2 => { name: :show_x, type: :double, default: 0.0 },
+      3 => { name: :show_y, type: :double, default: 0.0 },
+      # The picture's genuinely live position/zoom/transparency/tone -- see
+      # this table's own comment above for how 4/5 were told apart from
+      # 31/32. Confirmed unconditional (present whenever a picture is shown
+      # at all, not only while a move is in flight) by cycle #155: a picture
+      # shown and never moved still wrote 4/5/7/8/11-14 with the exact same
+      # values as 31-34/41-44, matching real RPG_RT's own current-tracks-
+      # finish idle sync already noted above -- see Game::State#to_lsd's own
+      # comment for the fix this corrected (the old code wrote these only
+      # while Game::Picture#moving?). Defaults match a fresh Game::Picture so
+      # an old save written before these fields existed restores identically
+      # to before.
       4 => { name: :current_x, type: :double, default: 0.0 },
       5 => { name: :current_y, type: :double, default: 0.0 },
       7 => { name: :current_zoom, type: :double, default: 100.0 },
@@ -1228,17 +1255,33 @@ module LCF
       9 => { name: :visible, type: :bool, default: false }, # 表示するか (0 非表示 / 1 表示)
       # The picture's resting/target position -- see this table's own
       # comment above for why these are named finish_*, not current_*.
-      31 => { name: :finish_x, type: :double },         # 表示位置Ｘ (中心)
-      32 => { name: :finish_y, type: :double },         # 表示位置Ｙ (中心)
-      33 => { name: :zoom, type: :int },                # 拡大率
-      34 => { name: :transparency, type: :int },        # 透明度
-      41 => { name: :tone_red, type: :int },            # 色調：赤(R)
-      42 => { name: :tone_green, type: :int },          # 色調：緑(G)
-      43 => { name: :tone_blue, type: :int },           # 色調：青(B)
-      44 => { name: :tone_saturation, type: :int },     # 色調：彩度(S)
+      31 => { name: :finish_x, type: :double, default: 0.0 }, # 表示位置Ｘ (中心)
+      32 => { name: :finish_y, type: :double, default: 0.0 }, # 表示位置Ｙ (中心)
+      # Zoom/transparency/tone (both the current_* set above and this
+      # finish_* set) are each elided independently at their own default --
+      # confirmed by cycle #155's own controlled pair of genuine RPG_RT.exe
+      # captures, identical in every other respect (same name, same
+      # position, same "never moved" state): one issuing Show Picture with
+      # every one of these six values left at its own default (zoom 100,
+      # transparency 0, tone 100/100/100/100) wrote fields 7/8/11-14/33/34/
+      # 41-44 *absent*; the other issuing the identical command with every
+      # one of the six pushed off its own default (zoom 133, transparency
+      # 25, tone 140/60/180/50) wrote every one of those fields *present*
+      # with the exact values given -- ruling out the alternative reading
+      # cycle #154 flagged ("every value that cycle's own probe chose merely
+      # happened to equal the default") in favour of genuine per-field
+      # elision, the same convention already established for SAVE_SCREEN's
+      # own tint fields (cycle #154) and SAVE_SYSTEM's message-config
+      # cluster (cycle #152/#153).
+      33 => { name: :zoom, type: :int, default: 100 },        # 拡大率
+      34 => { name: :transparency, type: :int, default: 0 },  # 透明度
+      41 => { name: :tone_red, type: :int, default: 100 },        # 色調：赤(R)
+      42 => { name: :tone_green, type: :int, default: 100 },      # 色調：緑(G)
+      43 => { name: :tone_blue, type: :int, default: 100 },       # 色調：青(B)
+      44 => { name: :tone_saturation, type: :int, default: 100 }, # 色調：彩度(S)
       # How many frames remain in an in-flight Move Picture; 0 (the default,
       # covering both a still picture and an old save missing this field
-      # entirely) means fields 4/5/7/8/11-14 above are not consulted at all.
+      # entirely) means #restore_pictures does not start a fresh move on load.
       51 => { name: :time_left, type: :int, default: 0 },
     }
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8441,6 +8441,13 @@ module Game
   class Picture
     attr_reader :id, :name, :fixed_to_map, :use_transparent_color
 
+    # The position given to the most recent Show Picture call for this id --
+    # `.lsd` chunk 103's own field 2/3, identified behaviorally by cycle #155
+    # (see SAVE_PICTURE's own comment for the experiment): unlike `#x`/`#y`
+    # below, a Move Picture (`#move_to`) never touches these, only a fresh
+    # `Picture.new` (i.e. another Show Picture on this same id) does.
+    attr_reader :show_x, :show_y
+
     # Every interpolated field is truncated to a whole number here (matching
     # EasyRPG's own `int x = data.current_x;`, `sprite_picture.cpp`) but held
     # at full float precision internally between frames -- see #step's own
@@ -8474,6 +8481,15 @@ module Game
       @name = opts[:name] || ''
       @x = opts[:x] || 0
       @y = opts[:y] || 0
+      # Defaults to the shown position itself: the live Show Picture command
+      # (#do_show_picture) never passes these explicitly, so an ordinary
+      # fresh show records its own x/y as-shown, exactly matching genuine
+      # RPG_RT. #restore_pictures passes the saved field 2/3 explicitly, for
+      # a save whose picture was already mid-Move-Picture when written (so
+      # `x`/`y` above hold the live *current* position, not the original
+      # show position, which is what these must restore to instead).
+      @show_x = opts[:show_x] || @x
+      @show_y = opts[:show_y] || @y
       @zoom = opts[:zoom] || 100
       @opacity = opts[:opacity] || 255
       @red = opts[:red] || 100
@@ -14758,7 +14774,7 @@ module Game
       # Chunk 103 is every picture slot RPG2000 offers (Show Picture, 11110)
       # -- its own container and its own 1..MAX_PICTURE_ID (50) slot range are
       # both confirmed unconditional against genuine RPG_RT.exe under wine
-      # this cycle (not EasyRPG source, correcting a prior comment here that
+      # (cycle #154; not EasyRPG source, correcting a prior comment here that
       # mislabelled EasyRPG Player's own `src/scene_save.cpp`/`src/
       # game_pictures.cpp` as "RPG_RT's live source"): a synthetic autostart
       # list that never issues Show Picture at all still produced a genuine
@@ -14774,64 +14790,67 @@ module Game
       # array entirely unless a picture has ever been shown there" shape
       # (which also, as a side effect, only ever emitted however many ids
       # had been *touched*, never the full 50-wide range genuine RPG_RT.exe
-      # always carries). Field mapping is the exact mirror of
-      # `.restore_pictures`' own read (see `SAVE_PICTURE`'s own comment for
-      # why 31/32/etc are finish_*, not current_*): 1 name, 31/32
-      # finish_x/finish_y, 33 zoom, 34 transparency (`Game.opacity_to_trans`,
-      # the inverse of the live command's own `#trans_to_opacity`), 41-44 the
-      # red/green/blue/saturation tone -- a picture at rest writes its own
-      # live values as both, matching real RPG_RT's own current-tracks-finish
-      # idle sync. `@pictures` only ever holds currently-shown pictures
+      # always carries). `@pictures` only ever holds currently-shown pictures
       # (#erase_picture deletes the entry outright), so an ordinary shown
       # picture is a slot with an entry here and an untouched slot is
-      # nil/absent from `@pictures`, both handled below. A picture still
-      # mid-Move-Picture (#moving?) additionally writes its own genuinely-live
-      # current_*/time_left fields (4/5/7/8/11-14/51) so a resumed Continue
-      # keeps gliding from exactly where it was, rather than snapping
-      # straight to the move's target the instant the save reloads. (A
-      # second, narrower gap spotted along the way but left unfixed here,
-      # out of this cycle's own container-presence scope: genuine RPG_RT.exe
-      # also wrote a field 2/3 pair on the live id-5 entry this cycle's own
-      # probe never modelled at all -- and per-value elision may reach
-      # *inside* an occupied slot too, since fields 33/34/41-44 came back
-      # absent in that same probe despite the slot itself being fully
-      # populated, purely because every value this cycle's own probe chose
-      # for them happened to equal each field's own default. Neither was
-      # investigated further; see docs/TODO.md.)
+      # nil/absent from `@pictures`, both handled below.
+      #
+      # Field mapping is the exact mirror of `.restore_pictures`' own read
+      # (see `SAVE_PICTURE`'s own comment for the full evidence behind each
+      # field): 1 name; 2/3 show_x/show_y (the position last given to Show
+      # Picture, untouched by any Move Picture since); 4/5/7/8/11-14 the
+      # genuinely live current position/zoom/transparency/tone; 31/32
+      # finish_x/finish_y (the move's target, equal to current at rest);
+      # 33/34/41-44 the finish zoom/transparency/tone; 51 the in-flight
+      # move's own remaining-frames counter. Cycle #155 confirmed against
+      # genuine RPG_RT.exe under wine that 4/5/7/8/11-14 are written whether
+      # or not a move is actually in flight (a picture shown and never moved
+      # still carries them, equal to their own 31-34/41-44 counterparts,
+      # matching real RPG_RT's own current-tracks-finish idle sync already
+      # noted above) -- fixing a prior version of this method that wrote
+      # them only while `Game::Picture#moving?`, silently dropping the
+      # "genuinely live" current_* value on every picture at rest. Cycle
+      # #155 also confirmed zoom/transparency/tone (both the current_* and
+      # finish_* copies) are each elided independently at their own default
+      # -- see SAVE_PICTURE's own comment for the controlled genuine-RPG_RT
+      # A/B pair that pinned this down, ruling out cycle #154's own
+      # "probe just happened to pick default values" alternative reading.
       pics = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
       (1..MAX_PICTURE_ID).each do |id|
         p = @pictures[id]
         e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
         if p
           e[1] = p.name
-          if p.moving?
-            e[4] = p.x
-            e[5] = p.y
-            e[7] = p.zoom
-            e[8] = Game.opacity_to_trans(p.opacity)
-            e[11] = p.red
-            e[12] = p.green
-            e[13] = p.blue
-            e[14] = p.saturation
-            e[31] = p.finish_x
-            e[32] = p.finish_y
-            e[33] = p.finish_zoom
-            e[34] = Game.opacity_to_trans(p.finish_opacity)
-            e[41] = p.finish_red
-            e[42] = p.finish_green
-            e[43] = p.finish_blue
-            e[44] = p.finish_saturation
-            e[51] = p.frames_left
-          else
-            e[31] = p.x
-            e[32] = p.y
-            e[33] = p.zoom
-            e[34] = Game.opacity_to_trans(p.opacity)
-            e[41] = p.red
-            e[42] = p.green
-            e[43] = p.blue
-            e[44] = p.saturation
-          end
+          e[2] = p.show_x
+          e[3] = p.show_y
+          e[4] = p.x
+          e[5] = p.y
+          e[7] = p.zoom if p.zoom != 100
+          cur_trans = Game.opacity_to_trans(p.opacity)
+          e[8] = cur_trans if cur_trans != 0
+          e[11] = p.red if p.red != 100
+          e[12] = p.green if p.green != 100
+          e[13] = p.blue if p.blue != 100
+          e[14] = p.saturation if p.saturation != 100
+          moving = p.moving?
+          fx = moving ? p.finish_x : p.x
+          fy = moving ? p.finish_y : p.y
+          fzoom = moving ? p.finish_zoom : p.zoom
+          fopacity = moving ? p.finish_opacity : p.opacity
+          fred = moving ? p.finish_red : p.red
+          fgreen = moving ? p.finish_green : p.green
+          fblue = moving ? p.finish_blue : p.blue
+          fsat = moving ? p.finish_saturation : p.saturation
+          e[31] = fx
+          e[32] = fy
+          e[33] = fzoom if fzoom != 100
+          fin_trans = Game.opacity_to_trans(fopacity)
+          e[34] = fin_trans if fin_trans != 0
+          e[41] = fred if fred != 100
+          e[42] = fgreen if fgreen != 100
+          e[43] = fblue if fblue != 100
+          e[44] = fsat if fsat != 100
+          e[51] = p.frames_left if moving
         end
         pics[id] = e
       end
@@ -15450,6 +15469,14 @@ module Game
     # fresh `Game::Picture` starts at, so a save written before this landed
     # (missing all of fields 4/5/7/8/11-14/51) reads time_left as 0 and
     # restores identically to before -- unaffected by this change.
+    #
+    # Field 2/3 (show_x/show_y, see SAVE_PICTURE's own comment for how cycle
+    # #155 identified them) are passed through explicitly rather than via
+    # `Game::Picture.new`'s own "defaults to the shown position" fallback --
+    # `pic.key?` (not `pic.show_x` alone) gates it, since the schema default
+    # of 0.0 would otherwise look like a real, present value of (0,0) for a
+    # save written before this field was modelled, wrongly overriding the
+    # fallback for exactly the legacy saves it exists to cover.
     def self.restore_pictures(state, pictures)
       return unless pictures
       pictures.each do |id, pic|
@@ -15462,6 +15489,8 @@ module Game
         state.show_picture(id, name: name,
                                x: ((moving ? pic.current_x : pic.finish_x) || 0).to_i,
                                y: ((moving ? pic.current_y : pic.finish_y) || 0).to_i,
+                               show_x: pic.key?(2) ? pic.show_x : nil,
+                               show_y: pic.key?(3) ? pic.show_y : nil,
                                zoom: moving ? pic.current_zoom : pic.zoom,
                                opacity: transparency ? Game.trans_to_opacity(transparency) : nil,
                                red: moving ? pic.current_tone_red : pic.tone_red,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4762,6 +4762,123 @@ check 'to_lsd/from_lsd round-trips a picture still mid-Move-Picture, resuming ' 
   ok !still_round.pictures[6].moving?, 'a picture never moved restores at rest'
 end
 
+check 'to_lsd writes chunk 103\'s current_x/y/zoom/etc unconditionally (not ' \
+      'only while moving), eliding zoom/transparency/tone independently at ' \
+      'their own default' do
+  # Cycle #155: confirmed against genuine RPG_RT.exe under wine (not EasyRPG
+  # source) with a controlled pair of synthetic-autostart captures, identical
+  # in every other respect (same picture id/name/position, never moved) --
+  # one issuing Show Picture with zoom/transparency/tone all left at their
+  # own default (100/0/100,100,100,100) produced a save whose chunk 103 raw
+  # field ids present were exactly [1,2,3,4,5,31,32] (fields 7/8/11-14/33/34/
+  # 41-44 all absent); the other, identical except every one of those six
+  # values pushed off its own default (133/25/140,60,180,50), produced a
+  # save with every one of fields 7,8,11,12,13,14,31,32,33,34,41,42,43,44
+  # present carrying the exact values given. This rules out cycle #154's own
+  # "the probe just happened to choose default values" alternative reading
+  # of its own field-33/34/41-44-absent finding, and additionally shows
+  # current_* (4/5/7/8/11-14) are written even though this picture was never
+  # put through a Move Picture at all -- the prior version of this method
+  # only ever wrote those fields when `Game::Picture#moving?`, so an
+  # ordinary still picture's own current_zoom/current_transparency/
+  # current_tone_* silently never round-tripped through Save/Continue.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+
+  st.show_picture(8, name: 'black', x: 111, y: 77) # every visual param at default
+  at_default = st.to_lsd[103][8]
+  raw = at_default.instance_variable_get(:@data)
+  present = (0...raw.size).select { |i| raw[i] }
+  eq [1, 2, 3, 4, 5, 31, 32], present,
+     'zoom/transparency/tone are all absent when every one sits at its own default'
+  eq 111.0, at_default.current_x
+  eq 77.0, at_default.current_y
+
+  st.show_picture(9, name: 'black', x: 111, y: 77,
+                  zoom: 133, opacity: Game.trans_to_opacity(25),
+                  red: 140, green: 60, blue: 180, saturation: 50)
+  off_default = st.to_lsd[103][9]
+  raw2 = off_default.instance_variable_get(:@data)
+  present2 = (0...raw2.size).select { |i| raw2[i] }
+  eq [1, 2, 3, 4, 5, 7, 8, 11, 12, 13, 14, 31, 32, 33, 34, 41, 42, 43, 44], present2,
+     'zoom/transparency/tone are all present (current and finish alike) once ' \
+     'every one is off its own default, though the picture was never moved'
+  eq 133.0, off_default.current_zoom
+  # 26, not 25: the same pre-existing opacity/transparency round-trip
+  # precision gap the "to_lsd writes chunk 103..." check above already notes
+  # (Game.trans_to_opacity(25) == 191, then Game.opacity_to_trans(191) ==
+  # 26) -- unrelated to and unaffected by this check's own fix.
+  eq 26, off_default.transparency
+  eq 133, off_default.zoom
+  eq 140, off_default.tone_red
+  eq 60, off_default.tone_green
+  eq 180, off_default.tone_blue
+  eq 50, off_default.tone_saturation
+
+  # Round-trips correctly too: a fresh Game::State built from this save
+  # restores the exact same off-default values, not Picture's own defaults.
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.pictures[9]
+  eq 133, restored.zoom
+  eq 140, restored.red
+  eq 60, restored.green
+  eq 180, restored.blue
+  eq 50, restored.saturation
+end
+
+check 'to_lsd/from_lsd round-trips chunk 103\'s show_x/show_y (field 2/3), ' \
+      'the position last given to Show Picture, untouched by Move Picture' do
+  # Cycle #155: field 2/3 was an undeclared pair cycle #154 spotted genuine
+  # RPG_RT.exe writing on a live picture entry but could not identify (its
+  # own probe only ever exercised a picture at rest, where current/finish/
+  # show all coincide). A follow-up genuine-RPG_RT.exe wine capture --
+  # Show Picture at (111,77), then Move Picture to (222,188) over 5.0s with
+  # a 3.0s Wait before saving (so the move was genuinely still in flight) --
+  # found field 2/3 held steady at 111.0/77.0 throughout: not the live
+  # current position (177.6/143.6, the correct 60%-of-the-way interpolation)
+  # and not the move's finish target (222/188) either, but the position the
+  # picture was originally shown at.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+
+  st.show_picture(10, name: 'banner', x: 111, y: 77)
+  st.move_picture(10, 222, 188, 100, 255, 100, 100, 100, 100, 300) # 5.0s @ 60fps
+  180.times { st.pictures[10].update } # 3.0s elapsed, still 120 frames left
+
+  saved = st.to_lsd[103][10]
+  eq 120, saved.time_left, 'sanity: the move is genuinely still in flight'
+  eq 111.0, saved.show_x, 'show_x stays the original Show Picture position...'
+  eq 77.0, saved.show_y, '...not the live current position...'
+  ok (saved.current_x.to_i - 177).abs <= 1, '...which has moved on (~177.6)'
+  eq 222, saved.finish_x.to_i, '...nor the move\'s own finish target'
+  eq 188, saved.finish_y.to_i
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  restored = round.pictures[10]
+  eq 111.0, restored.show_x, 'show_x survives a full to_lsd/from_lsd round-trip'
+  eq 77.0, restored.show_y
+
+  # A fresh Show Picture on the same id resets show_x/show_y to the new
+  # position -- it is "the last Show Picture call", not a permanent origin.
+  st.show_picture(10, name: 'banner', x: 5, y: 9)
+  eq 5, st.pictures[10].show_x
+  eq 9, st.pictures[10].show_y
+
+  # A save written before this field existed (no field 2/3 at all) must not
+  # restore show_x/show_y as (0,0) -- it should fall back to the picture's
+  # own shown position, matching this codebase's behavior before field 2/3
+  # was modelled at all.
+  legacy = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+  legacy[1] = 'old'
+  legacy[31] = 40.0
+  legacy[32] = 60.0
+  legacy_pics = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+  legacy_pics[11] = legacy
+  Game::State.restore_pictures(st, legacy_pics)
+  eq 40, st.pictures[11].show_x, 'no field 2/3 at all falls back to the shown position'
+  eq 60, st.pictures[11].show_y
+end
+
 # -- the permanent actor roster (Game::Actors) --------------------------------
 #
 # Nepheshel drives its whole party mechanic through Change Party Member: it adds


### PR DESCRIPTION
## Summary
Closes the two loose ends cycle #154 explicitly left open on chunk 103 (shown pictures):
- Field 2/3 was an undeclared pair genuine RPG_RT.exe writes on a picture entry that cycle #154 spotted but couldn't identify (its own probe only exercised a picture at rest, where every position field coincides). Pinned down here with a picture shown then mid-Move: the pair holds the position originally given to Show Picture, untouched by any subsequent Move Picture — named `show_x`/`show_y` behaviorally, since this sandbox has no network access to confirm liblcf's actual field name.
- Fields 33/34/41-44 (zoom/transparency/tone, current and finish alike) are each elided independently at their own default — confirmed via a controlled genuine RPG_RT.exe A/B pair, ruling out cycle #154's own "the probe just happened to pick default values" alternative reading.
- A third gap found along the way: `current_x/y/zoom/transparency/tone` were previously written only while `Game::Picture#moving?`, but genuine RPG_RT writes them unconditionally for any shown picture, elided per-field at default like everything else in this cluster.

## Verification
- Confirmed via synthetic Show Picture / Move Picture sequences driven through genuine RPG_RT.exe's own save UI under wine, using a raw field reader that bypasses schema defaults.
- Two new regression checks confirmed to fail against pre-fix code (`git stash` of `schema.rb`+`game.rb`) with `RuntimeError: expected [1, 2, 3, 4, 5, 31, 32], got [1, 31, 32, 33, 34, 41, 42, 43, 44]` and `TypeError: no implicit conversion from nil to integer`, then pass after restoring — independently re-verified by me as well.
- All check suites pass: `rpg2k_scene_check.rb` 929/929, `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1139/1139 (up from 1137), `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- No EasyRPG Player source was consulted for this fix (the field 2/3 name could not be confirmed against liblcf's `generator/csv/fields.csv` either, since this sandbox has no network access — named behaviorally instead and documented as such rather than claimed as an authoritative name).

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929/929
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1139/1139
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Pre-fix regression proof via `git stash` (independently reproduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_