### PR TITLE
Batch each tile's blits into one Bitmap#blt_quads dispatch

### DIFF
--- a/app/android/README.md
+++ b/app/android/README.md
@@ -101,9 +101,11 @@ Nepheshel — title screen 22 → 60fps, map scenes 14 → 40-45fps, overworld
 
 What remains is mruby game-logic speed on a low-end CPU (the interpreter and
 event bookkeeping are the biggest single block of a standing-still frame),
-plus two known follow-ups: the tile-animation step still re-blits every
-autotile cell on autotile-heavy maps (~50ms spikes), and walking across a
-panorama map re-tiles it every frame (~20ms) on top of the scrolling present.
+plus two known follow-ups: the tile-animation step's per-pixel compose
+(~30-54ms spikes on autotile-heavy maps, down from ~57-86ms once the step
+batched its blits through `Bitmap#blt_quads` — a row-copy fast path for
+opaque chipset pixels is the next cut), and walking across a panorama map
+re-tiling it every frame (~20ms) on top of the scrolling present.
 
 ## Launcher icon
 

--- a/changelog.d/bitmap-blt-quads.added.md
+++ b/changelog.d/bitmap-blt-quads.added.md
@@ -1,0 +1,11 @@
+- **`Bitmap#blt_quads(x, y, src, quads)`** batches a whole tile's source
+  rects into one native dispatch: each `quads` element
+  `[qdx, qdy, sx, sy, w, h]` composites exactly as an individual full-opacity
+  `#blt` would (the pixel loop is shared with `#blt`, so the two cannot
+  drift; the mruby-rgss test asserts pixel equality per quad, including a
+  clipped quad and partial-alpha blending). The map renderer's `draw_tile`
+  now issues one call per tile instead of one dispatch plus a `Rect`
+  allocation per sub-quad — and animation steps redraw every animated cell,
+  so this was the renderer's hottest mruby path. On the Android test device
+  the intro map's animation-step `map.layers` spikes dropped from ~57-86ms
+  to 30-54ms (cluster ~37-41ms), with fps at 42-45 on the same scene.

--- a/docs/adr/0058-android-port.md
+++ b/docs/adr/0058-android-port.md
@@ -298,9 +298,13 @@ that follow it; the panorama memcpy-copies instead of blending; the native
 `opacity=`/`x=`/`y=`/`visible=` setters skip the style set on an equal
 value. Measured: intro map 14 → 40-45fps, overworld 26fps standing, battle
 53-59fps, `gfx.lvgl` 22 → ~2.5ms on a static frame. The floor is now mruby
-game logic on the device's CPU; known follow-ups are C-side quad batching
-for animation-step spikes on autotile-heavy maps and the scrolling present
-path.
+game logic on the device's CPU; the C-side quad batching follow-up has since
+landed (`Bitmap#blt_quads`, one native dispatch for a whole tile's quads:
+animation-step `map.layers` spikes ~57-86 → 30-54ms, and event-page
+re-selection now skips events whose condition inputs did not change,
+`map.refresh_pages` 5.5 → 0.9ms on the town map); what remains is the
+per-pixel compose cost itself (a row-copy fast path for opaque chipset
+pixels) and the scrolling present path.
 
 The remaining bullets still hold except where quoted above; "no on-screen
 touch controls yet" is no longer true.

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1837,20 +1837,16 @@ mrb_value bmp_set_pixel(mrb_state* M, V self) {
   return self;
 }
 
-mrb_value bmp_blt(mrb_state* M, V self) {
-  mrb_int x, y;
-  Bitmap* src;
-  V srect;
-  mrb_int opacity = 255;
-  mrb_get_args(M, "iido|i", &x, &y, &src, &DataType<Bitmap>::data_type, &srect,
-               &opacity);
-  Bitmap& dst = bmp_self(M, self);
-  Bitmap& sb = bmp_require(M, src);
-  Rect& rc = DataType<Rect>::get(M, srect);
-  if (opacity < 0)
-    opacity = 0;
-  if (opacity > 255)
-    opacity = 255;
+// The pixel loop #blt and #blt_quads share: composite src_rect over (x, y)
+// at `opacity`, per-pixel, skipping transparent source pixels and anything
+// outside either bitmap. Kept in one place so the batched form cannot drift
+// from the single-rect one.
+static void blt_pixels(Bitmap& dst,
+                       const Bitmap& sb,
+                       mrb_int x,
+                       mrb_int y,
+                       const Rect& rc,
+                       int opacity) {
   for (mrb_int sy = rc.y; sy < rc.y + rc.height; ++sy) {
     for (mrb_int sx = rc.x; sx < rc.x + rc.width; ++sx) {
       if (sx < 0 || sy < 0 || sx >= sb.width || sy >= sb.height)
@@ -1872,6 +1868,70 @@ mrb_value bmp_blt(mrb_state* M, V self) {
       bmp_read(dst, dx, dy, dr, dg, db, da);
       blend_over(dst, dx, dy, r, g, bl, alpha, dr, dg, db, da);
     }
+  }
+}
+
+mrb_value bmp_blt(mrb_state* M, V self) {
+  mrb_int x, y;
+  Bitmap* src;
+  V srect;
+  mrb_int opacity = 255;
+  mrb_get_args(M, "iido|i", &x, &y, &src, &DataType<Bitmap>::data_type, &srect,
+               &opacity);
+  Bitmap& dst = bmp_self(M, self);
+  Bitmap& sb = bmp_require(M, src);
+  Rect& rc = DataType<Rect>::get(M, srect);
+  if (opacity < 0)
+    opacity = 0;
+  if (opacity > 255)
+    opacity = 255;
+  blt_pixels(dst, sb, x, y, rc, opacity);
+  dst.dirty = true;
+  return self;
+}
+
+// Bitmap#blt_quads(x, y, src, quads) -- #blt for a batch of source rects in
+// one dispatch. Each element of `quads` is [qdx, qdy, sx, sy, w, h]: the
+// rect src[sx,sy,w,h] composited at (x+qdx, y+qdy) with full opacity,
+// exactly as an individual #blt call would draw it.
+//
+// It exists because that batching shape is the map renderer's tile hot
+// path. Drawing one chip means several #blt calls (ChipsetLayout#quads),
+// and every animation step re-draws every animated cell on the map -- on
+// the RPG2000 testbed's water-heavy overworld that is hundreds of mruby
+// dispatches plus a Rect allocation apiece, which measured as ~45-60ms
+// spikes once per animation step. One dispatch and no Rect objects turns
+// the spike back into the per-pixel work itself.
+mrb_value bmp_blt_quads(mrb_state* M, V self) {
+  mrb_int x, y;
+  Bitmap* src;
+  V quads_v;
+  // "A" both fetches the batch and enforces that it is an Array.
+  mrb_get_args(M, "iidA", &x, &y, &src, &DataType<Bitmap>::data_type, &quads_v);
+  Bitmap& dst = bmp_self(M, self);
+  Bitmap& sb = bmp_require(M, src);
+  Rect rc;
+  const mrb_int n = RARRAY_LEN(quads_v);
+  for (mrb_int i = 0; i < n; ++i) {
+    V qv = mrb_ary_ref(M, quads_v, i);
+    if (!mrb_array_p(qv) || RARRAY_LEN(qv) != 6)
+      mrb_raisef(
+          M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "RGSSError"),
+          "blt_quads: each quad must be [qdx, qdy, sx, sy, w, h] (%S)", qv);
+    V nums[6];
+    for (int j = 0; j < 6; ++j) {
+      nums[j] = mrb_ary_ref(M, qv, j);
+      if (!mrb_integer_p(nums[j]))
+        mrb_raisef(
+            M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "RGSSError"),
+            "blt_quads: each quad element must be an Integer (%S)", qv);
+    }
+    rc.x = mrb_integer(nums[2]);
+    rc.y = mrb_integer(nums[3]);
+    rc.width = mrb_integer(nums[4]);
+    rc.height = mrb_integer(nums[5]);
+    blt_pixels(dst, sb, x + mrb_integer(nums[0]), y + mrb_integer(nums[1]), rc,
+               255);
   }
   dst.dirty = true;
   return self;
@@ -6691,6 +6751,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "blt_quads", bmp_blt_quads, MRB_ARGS_REQ(4));
   mrb_define_method(M, bmp, "copy_blt", bmp_copy_blt, MRB_ARGS_REQ(4));
   mrb_define_method(M, bmp, "tone_blt", bmp_tone_blt, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "stretch_blt", bmp_stretch_blt,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -615,6 +615,60 @@ assert "RGSS::Bitmap blt" do
   assert_equal 0.0, dst.get_pixel(0, 0).alpha # untouched
 end
 
+assert "RGSS::Bitmap blt_quads matches per-quad blt" do
+  # The batched form is the map renderer's tile path; it must lay down the
+  # exact same pixels as calling #blt once per quad. A quad clipped by both
+  # bitmaps' edges and a partial-alpha source cover the interesting cases
+  # (the batch draws at full opacity only -- #blt's optional opacity stays
+  # single-rect).
+  mk = lambda do |a|
+    s = RGSS::Bitmap.new(3, 3)
+    s.fill_rect(0, 0, 2, 2, RGSS::Color.new(10, 200, 30, a))
+    s.fill_rect(2, 2, 1, 1, RGSS::Color.new(255, 0, 0, 128))
+    s
+  end
+
+  src = mk.call(160)
+  want = RGSS::Bitmap.new(6, 6)
+  want.blt(1, 1, src, RGSS::Rect.new(0, 0, 2, 2))          # plain quad
+  want.blt(4, 0, src, RGSS::Rect.new(2, 2, 1, 1))          # second chip piece
+  want.blt(-1, 4, src, RGSS::Rect.new(1, 1, 2, 2))         # clipped by dst+src
+
+  got = RGSS::Bitmap.new(6, 6)
+  got.blt_quads(
+    1, 1, src,
+    [[0, 0, 0, 0, 2, 2], [3, -1, 2, 2, 1, 1], [-2, 3, 1, 1, 2, 2]]
+  )
+
+  6.times do |y|
+    6.times do |x|
+      w, g = want.get_pixel(x, y), got.get_pixel(x, y)
+      assert_equal w.alpha, g.alpha, "alpha at #{x},#{y}"
+      next if w.alpha == 0.0
+      assert_equal w.red, g.red, "red at #{x},#{y}"
+      assert_equal w.green, g.green, "green at #{x},#{y}"
+      assert_equal w.blue, g.blue, "blue at #{x},#{y}"
+    end
+  end
+
+  # A partial-alpha source over an existing destination still blends in the
+  # batch, same as #blt.
+  base_w = RGSS::Bitmap.new(4, 4)
+  base_g = RGSS::Bitmap.new(4, 4)
+  under = RGSS::Color.new(0, 0, 255, 255)
+  base_w.fill_rect(0, 0, 4, 4, under)
+  base_g.fill_rect(0, 0, 4, 4, under)
+  faint = mk.call(64)
+  base_w.blt(0, 0, faint, RGSS::Rect.new(0, 0, 2, 2))
+  base_g.blt_quads(0, 0, faint, [[0, 0, 0, 0, 2, 2]])
+  4.times do |y|
+    4.times do |x|
+      assert_equal base_w.get_pixel(x, y).green, base_g.get_pixel(x, y).green,
+                   "blend at #{x},#{y}"
+    end
+  end
+end
+
 assert "RGSS::Bitmap copy_blt matches blt onto a cleared destination" do
   # The justification for #copy_blt is that onto a *cleared* destination it
   # shows the same picture as #blt -- that is what lets the map renderer swap

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -10080,9 +10080,13 @@ class RPG2k
       # chip is a single 16x16 copy; an autotile is assembled from four 8x8
       # quarters. Empty/out-of-range ids draw nothing (id 0 is transparent).
       def draw_tile bmp, id, dx, dy, abf, cf
-        Game::ChipsetLayout.quads(id, abf, cf).each do |qdx, qdy, sx, sy, w, h|
-          bmp.blt dx + qdx, dy + qdy, @chipset_bmp, Rect.new(sx, sy, w, h)
-        end
+        # One native dispatch for the whole chip instead of a dispatch (and
+        # a Rect allocation) per sub-quad -- see Bitmap#blt_quads in
+        # mruby-rgss/src/lib.cxx. Animation steps redraw every animated cell,
+        # so this is the map renderer's hottest mruby path.
+        qs = Game::ChipsetLayout.quads(id, abf, cf)
+        return if qs.empty?
+        bmp.blt_quads dx, dy, @chipset_bmp, qs
       end
 
       # Which CharSet bitmap + index currently draw the player: ordinarily the

--- a/scripts/rgss_cruby_compat.rb
+++ b/scripts/rgss_cruby_compat.rb
@@ -1083,6 +1083,17 @@ module RGSS
       self
     end
 
+    # The batched form of #blt (see Bitmap#blt_quads in mruby-rgss/src/
+    # lib.cxx): each [qdx, qdy, sx, sy, w, h] quad composites exactly as an
+    # individual full-opacity #blt would. The CRuby harness has no native
+    # dispatch to save, so it simply fans back out to #blt.
+    def blt_quads(x, y, src, quads)
+      quads.each do |qdx, qdy, sx, sy, w, h|
+        blt(x + qdx, y + qdy, src, Rect.new(sx, sy, w, h))
+      end
+      self
+    end
+
     def copy_blt(x, y, src, srect)
       bmp_require!
       src.bmp_require!

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -77,6 +77,15 @@ module RGSS
     # only that drawing happened.
     def blt(*a); (@blt_calls ||= []) << a; end
     attr_reader :blt_calls
+    # Bitmap#blt_quads batches several #blt source rects into one native
+    # dispatch (see Bitmap#blt_quads in mruby-rgss/src/lib.cxx). The stub
+    # expands it back to per-quad #blt calls, so checks counting or
+    # inspecting tile draws see the same shape whichever path drew them.
+    def blt_quads(x, y, src, quads)
+      quads.each do |qdx, qdy, sx, sy, w, h|
+        blt(x + qdx, y + qdy, src, Rect.new(sx, sy, w, h))
+      end
+    end
     def clear_blt_calls; @blt_calls = []; end
     # The non-blending copy the map renderer moves its cached tile grid with
     # (see Bitmap#copy_blt in mruby-rgss/src/lib.cxx). Recorded apart from


### PR DESCRIPTION
## What

`Bitmap#blt_quads(x, y, src, quads)` (mruby-rgss): composites a batch of source rects in one native dispatch. Each `quads` element `[qdx, qdy, sx, sy, w, h]` draws exactly as an individual full-opacity `#blt` would — the pixel loop is factored out (`blt_pixels`) and shared by both methods, so the batched form cannot drift from the single-rect one. Malformed batches raise rather than skip.

`Scene::Map#draw_tile` now issues **one** `blt_quads` call per tile instead of one `#blt` dispatch *plus* one `Rect` allocation per sub-quad (`ChipsetLayout.quads`). Animation steps redraw every animated cell on the map, so this was the map renderer's hottest mruby path — hundreds of dispatches and allocations every ~6-24 frames.

The scene-check harness stub expands `blt_quads` back to per-quad `#blt` calls, so checks counting or inspecting tile draws see the same shape whichever path drew them.

## Why

Follow-up from the on-device profiling: after #1358's compose skip and #1363's page-refresh dirty index, the remaining render-side spike was the animation step. Measured on the C330 test device:

| metric (intro map) | before | after |
|---|---|---|
| `map.layers` anim-step spikes | ~57-86ms | 30-54ms (cluster ~37-41ms), 291 spikes / 6973 frames, p50 unchanged at 0.33ms |
| fps | 40-45 | 42-45 |

The residual spike is the per-pixel compose cost itself (accessor-based read/write per pixel); a row-copy fast path for opaque chipset pixels is the natural next cut, noted in the ADR.

## Testing

- [x] New mruby-rgss test asserts `blt_quads` is pixel-identical to per-quad `blt` (plain quad, clipped quad, partial-alpha blend over an existing destination)
- [x] `ctest -R "mruby_test|render_probe"` passes
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929 checks; `rpg2k_logic_check.rb` — 1139 checks
- [x] On-device (C330): intro map boots clean at 42-45fps, no new logcat errors