### PR TITLE
docs: seed_boosts' points2-not-points1 claim re-verified against genuine RPG_RT.exe

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3303,6 +3303,93 @@ The work below is roughly ordered by the critical path to a walkable game
   again); the missing-Picture-asset hang (cycle #155's own open item,
   untouched again); and whether field 9 (`visible`) of `SAVE_PICTURE`
   (cycle #155's own open item) is ever written by genuine RPG_RT.exe.
+  ✅ **Follow-up (cycle #157, 2026-08-26): picked up cycle #156's own named
+  leftover item, the `seed_boosts` comment** (`mruby-rpg2k/mrblib/game.rb`,
+  a few lines above cycle #156's own fix) -- it honestly said "confirmed
+  against EasyRPG's Game_Actor seed handling" rather than misattributing the
+  claim to RPG_RT (so it was a citation-only problem, not the
+  RPG_RT-mislabeled-as-EasyRPG pattern #125/#126/#154/#156 kept finding), but
+  had never been independently re-verified against the genuine engine. The
+  underlying claim: a Seed-type item's (database type 8) one-time permanent
+  stat boost reads `max_hp_points`/`max_sp_points` and the `atk_points2`/
+  `def_points2`/`spi_points2`/`agi_points2` field set -- distinct from the
+  structurally near-identical `atk_points1`/`def_points1`/`spi_points1`/
+  `agi_points1` fields that carry *equipment* bonuses (`EQUIP_BONUS_FIELD`,
+  read only while an item is worn). **Independently re-verified directly
+  against genuine RPG_RT.exe under wine** (no EasyRPG source consulted for
+  this claim, or at all this cycle). **Method:** reused cycles #148-156's own
+  raw-field save/database editing infrastructure (`mruby-lcf`'s own
+  `LCF::Database`/`LCF::SaveData` classes, loaded standalone the same way
+  cycle #154-156's own scratch scripts did) rather than any synthetic
+  autostart map event, again sidestepping the still-open autostart-crash
+  mystery entirely. Nepheshel206beta's own item 403 (a real shipped "seed",
+  赤いドロップ/Red Drop, `atk_points2`=2 in the unmodified database, one of a
+  clean six-item family 401-406 the game's own designer built, one per
+  `seed_boosts` stat) was duplicated into a second `RPG_RT.ldb` with
+  `atk_points1` additionally set to a large, unmistakable 77 (`atk_points2`
+  left at its original 2) -- a field a Seed item never otherwise touches,
+  since Seeds are never equipped. A `Save01.lsd` giving the save's live
+  leader (デモ用, LV50 -- confirmed, per cycle #156's own finding, to be
+  actor 15's data despite chunk109's `party` field nominally saying `[1]`;
+  left completely untouched here too, editing only the item-inventory
+  arrays, matching cycle #156's own crash-avoidance workaround) exactly 1x
+  item 403 was built once and reused unmodified across both runs. Two
+  side-by-side genuine RPG_RT.exe boots (Xvfb 640x480x16, matchbox,
+  `LANG=ja_JP.UTF-8`, `LIBGL_ALWAYS_SOFTWARE=1`, `xdotool`-driven, `xwd`+
+  ImageMagick screenshots) -- one with the unmodified item 403, one with the
+  `atk_points1`=77 variant -- each: loaded File 1, opened the field 装備
+  (Equip) screen to read the leader's own 攻撃力 (ATK) stat line *before*
+  (870 in both runs, confirming the LDB edit changed nothing about the
+  equip-time display, as expected since a type-8 item is never equipped),
+  backed out to the map, opened the field アイテム (Item) menu, used item 403
+  on the leader (confirmed consumed: held count 1 -> 0 in both runs, ruling
+  out "the item silently failed to apply at all" as an alternative
+  explanation for a null result), then reopened Equip and read ATK *after*.
+  **Result: identical in both runs** -- ATK rose from 870 to exactly 872
+  (+2, matching `atk_points2`) whether or not `atk_points1` carried 77; the
+  item's displayed name and flavour-text description were also byte-for-byte
+  identical between runs, evidence the edited database parsed correctly and
+  wasn't silently rejected/defaulted. This directly confirms genuine
+  RPG_RT.exe's Seed-consumption code reads only the points2 field set,
+  exactly matching the pre-existing (if mis-cited) `Game::Actor#seed_boosts`
+  implementation -- **no behavioral code changed**, only the comment's
+  citation. Also **strengthened the matching pre-existing regression check**
+  in `scripts/rpg2k_logic_check.rb` ("a seed permanently raises the target
+  stats (points2 set...)"): the fixture item now also carries `atk: 999`
+  (`atk_points1`) alongside the existing `atk2: 5` (`atk_points2`), and the
+  assertion documents that only the +5 must land. Proved this actually
+  catches a regression: temporarily changing `seed_boosts` to read
+  `atk_points1`/`def_points1`/`spi_points1`/`agi_points1` instead of the
+  `*_points2` set (`git diff` reverted after) made the check fail with a
+  precise, specific error (`RuntimeError: expected 15, got 999`) before
+  restoring the original fields brought the suite back to green. Full suite
+  reconfirmed passing, unchanged from cycle #156 (a citation fix plus
+  strengthening one pre-existing check in place touches no check count):
+  `scripts/rpg2k_scene_check.rb` (929), `scripts/rpg2k_render_check.rb` (41),
+  `scripts/rpg2k_logic_check.rb` (1139), `scripts/rpg2k3_battle_row_check.rb`
+  (19) and `scripts/rpg2k3_battle_gauge_check.rb` (15). `RPG_RT.ldb`/
+  `Save01.lsd` were restored to their original bytes after every run (each
+  driver script backs up and restores them automatically on exit, `trap
+  cleanup EXIT`) and reconfirmed byte-identical by `md5sum` against the same
+  `a738d3b9.../3ab5bb01...` values recorded since cycle #148; `git status` on
+  `data/` came back clean. No EasyRPG source was consulted for any claim
+  this cycle, and no web search was used either. **Left open for a future
+  cycle:** every EasyRPG-style citation cycle #154's own repo-wide grep
+  turned up that no cycle has yet touched (`do_change_equipment`,
+  `Window_Skill::CheckInclude`/`Algo::IsSkillUsable`'s own field-skill-menu
+  logic, `EnemyAi::IsActionValid`, `Game_Event::MoveTypeRandom`/
+  `MoveTypeCycle`, `CalcNormalAttackAutoBattleTargetRank`, `Window_ShopSell`,
+  and more -- see cycle #154's own list); the autostart-crash mystery; the
+  party-roster-field crash; fields 51-54/71-140 of SAVE_SYSTEM; the
+  missing-Picture-asset hang; and whether `SAVE_PICTURE` field 9 (`visible`)
+  is ever written -- none of these five were touched again this cycle. One
+  new, small, genuinely fresh observation worth flagging for whoever next
+  investigates the party-roster-field crash: this cycle's own `Save01.lsd`
+  edits (item-inventory arrays only, chunk109 fields 11-14, `party` at field
+  1 never touched) never crashed or misbehaved across many repeated
+  boots -- consistent with cycle #156's own conclusion that the fragility is
+  specific to writing chunk109 field 1 itself, not inventory edits in
+  general.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4774,8 +4774,21 @@ module Game
     # The six permanent stat boosts a seed grants, in Actor::STAT_NAMES order
     # (max HP, max SP, attack, defence, spirit, agility). RPG2000 seeds use the
     # item's max_hp_points / max_sp_points and the *_points2 stat set -- distinct
-    # from the *_points1 fields that carry equipment bonuses -- confirmed against
-    # EasyRPG's Game_Actor seed handling.
+    # from the *_points1 fields that carry equipment bonuses. Confirmed
+    # directly against genuine RPG_RT.exe under wine (cycle #157, replacing a
+    # former citation to "EasyRPG's Game_Actor seed handling" that was never
+    # itself independently checked): Nepheshel206beta's own item 403 (a real
+    # shipped "seed", 赤いドロップ/Red Drop, atk_points2=2) was duplicated with
+    # atk_points1 additionally set to 77 on a second copy of the database, then
+    # used from the field Item menu on the save's live leader in two
+    # side-by-side genuine runs, ATK read via the Equip screen both times: the
+    # unmodified item raised ATK 870 -> 872 (+2); the atk_points1=77 variant
+    # raised it 870 -> 872 too, the identical +2, not +77 or +79, while the
+    # item's name/description and its held count (1 -> 0 both runs) stayed
+    # exactly the same, ruling out "the edit was silently ignored" as an
+    # alternative explanation. See the matching regression check in
+    # scripts/rpg2k_logic_check.rb ("a seed permanently raises the target
+    # stats (points2 set, not points1)...") for the full write-up.
     def seed_boosts(it)
       [it.max_hp_points || 0, it.max_sp_points || 0,
        it.atk_points2 || 0, it.def_points2 || 0,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7390,14 +7390,34 @@ check 'a skill book does nothing on a downed actor -- unlike Medicine, ' \
   eq 1, st.party.item_count(8)                 # not consumed
 end
 
-check 'a seed permanently raises the target stats (points2 set) and is consumed' do
-  st = item_party({ 9 => fake_item(type: 8, mhp: 50, atk2: 5) })
+check 'a seed permanently raises the target stats (points2 set, not points1) ' \
+      'and is consumed' do
+  # atk: (atk_points1, the *equip*-bonus field EQUIP_BONUS_FIELD reads for a
+  # worn weapon/shield/armour/helmet/accessory) is set here to a large,
+  # unmistakable 999 alongside atk2: 5 (atk_points2, the seed-boost field) --
+  # confirmed directly against genuine RPG_RT.exe under wine (cycle #157):
+  # item 403 in Nepheshel206beta's own database (an actual shipped "seed" --
+  # 赤いドロップ/Red Drop, atk_points2=2 in the unmodified data) was edited to
+  # add atk_points1=77 on a duplicate database, then used from the field Item
+  # menu on the save's live leader (デモ用, LV50) in two side-by-side genuine
+  # runs read via the Equip screen's own 攻撃力 stat line: unmodified item
+  # (atk_points1 absent) raised ATK from 870 to 872 (+2, matching
+  # atk_points2); the atk_points1=77 variant raised it from 870 to 872 too --
+  # the identical +2, not +77 or +79 -- while the item's name, description
+  # and on-use consumption (held count 1 -> 0 in both runs, ruling out "the
+  # item silently failed to apply" as an alternative explanation) were
+  # unchanged, so the LDB edit demonstrably parsed and the seed path
+  # demonstrably ran; RPG_RT.exe's own Seed-consumption code reads only the
+  # points2 field set, exactly like Game::Actor#seed_boosts already does.
+  # (Replaces the former citation to "EasyRPG's Game_Actor seed handling",
+  # which was never independently checked against the genuine engine.)
+  st = item_party({ 9 => fake_item(type: 8, mhp: 50, atk: 999, atk2: 5) })
   st.party.gain_item(9, 2)
   hero = st.party.leader                        # max_hp 100, atk 10
   eq true, st.party.item_effective?(9, hero)
   eq [hero], st.party.use_item(9, hero)
   eq 150, hero.max_hp                           # +50 base max HP
-  eq 15, hero.atk                               # +5 base attack (atk_points2)
+  eq 15, hero.atk, 'atk_points2 (+5) applies; atk_points1 (999) must not'
   eq 1, st.party.item_count(9)                  # one seed consumed
 end
 


### PR DESCRIPTION
## Summary
- A comment on `Game::Actor#seed_boosts` cited "EasyRPG's `Game_Actor` seed handling" — an honest citation, not the RPG_RT-mislabeled-as-EasyRPG pattern cycles #125/#126/#154/#156 found elsewhere, but one that had never itself been independently checked against the genuine engine.
- Confirmed directly: duplicated a real shipped Nepheshel206beta seed item with `atk_points1` additionally set to 77 (alongside its real `atk_points2`=2) on a second copy of the database, then used it from the field Item menu on the same save's leader in two side-by-side genuine RPG_RT.exe runs, reading ATK via the Equip screen. Both the unmodified item and the `atk_points1`=77 variant raised ATK by the identical +2 — not +77 or +79 — while item consumption (held count 1→0 both runs) and its name/description stayed identical, ruling out "the edit was silently ignored" as an alternative explanation.
- **The implementation was already correct; only the citation needed fixing.** Strengthened the existing regression check to also set `atk_points1` to a large, unmistakable value, so a future regression that swapped points1/points2 would be caught.

## Verification
- No EasyRPG Player source was consulted for this claim. No web search was used.
- Regression check strengthened and confirmed to catch a deliberately injected regression (temporarily swapping `atk_points2` for `atk_points1` in the implementation) with `RuntimeError: expected 15, got 999`, then restored — independently re-verified by me as well.
- All check suites pass: `rpg2k_scene_check.rb` 929/929, `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1139/1139, `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- No changelog fragment — docs-only, no user-visible behavior changed.

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929/929
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1139/1139
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Regression proof via deliberately injected bug (independently reproduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_