### PR TITLE
lcf/rpgvx: cache event/move-command decodes, unblock VX's lazy tables

### DIFF
--- a/changelog.d/lcf-array1d-cache-event-commands.changed.md
+++ b/changelog.d/lcf-array1d-cache-event-commands.changed.md
@@ -1,0 +1,18 @@
+- **LCF: event/move-route command lists are decoded once and kept, like
+  nested tables already were.** `LCF::Array1D#[]` only cached nested
+  `Array1D`/`Array2D` values -- a `:event` chunk (an RPG2000 event page's
+  own command list) or `:move_commands` chunk (a Move Route's) re-parsed
+  and rebuilt one object per command from scratch on every single read,
+  same as the container types used to before that caching existed. Unlike
+  a one-off Scene::Map entry cost, this one recurs: `Scene::Map#build_event`
+  redecodes every active event's command list on every page-flip (a
+  switch-gated dialogue is a routine RPG2000 idiom, not a one-time
+  transition), and `Scene::Base::EventResolver#map_event_commands`
+  redecodes on every Call Event to a map page -- its sibling
+  `#common_event_commands` already got equivalent caching in #1360. Now
+  cached the same way as `Array1D`/`Array2D`, dropped by the existing
+  `#[]=`/`#delete` write paths like any other cached decode. Verified:
+  `scripts/rpg2k_scene_check.rb` (929 checks) and
+  `scripts/rpg2k_logic_check.rb` (1139 checks) both pass unchanged, plus a
+  standalone script confirming identity-cached reads and correct
+  cache-drop on write.

--- a/changelog.d/rpgvx-lazy-database-tables.changed.md
+++ b/changelog.d/rpgvx-lazy-database-tables.changed.md
@@ -1,0 +1,17 @@
+- **RPGVX/VX Ace: database tables load lazily instead of all eleven eagerly
+  at open, closing the gap #1367 left for XP's own loader.** `RPGVX::RGSSData`
+  used to `Marshal.load` every `Data/*.rvdata(2)` table unconditionally the
+  instant the database opened -- Troops/Enemies/Animations (often the
+  largest files in a real project) go untouched by any session that never
+  opens a battle. This was left eager in #1367 because the boot-time
+  `[RGSS2-DB]` summary log read each table's cache slot directly to report
+  an exact record count, which would have either forced every table to load
+  anyway or silently degraded the log to reporting nothing. Now unblocked:
+  `#summary` reports a not-yet-loaded table's on-disk byte size instead of
+  a record count (a loose file's own size, or the packed archive entry's
+  already-parsed header size via `RPGXP::RGSSAD#entry_size`, a new small
+  accessor -- neither needs a read, decrypt, or `Marshal.load`), and a
+  table actually touched later still gets an exact count once it's cached.
+  Verified against `scripts/rpgvx_testbed_check.rb`'s generated VX and VX
+  Ace projects (both loose and packed), including the archive-entry-size
+  path.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -493,16 +493,26 @@ module LCF
     # a :Array1D / :Array2D chunk re-parses its *whole* table on every read, and
     # the runtime asks for the same one over and over -- building a party alone
     # reads `db.item` thirty times (Game::Actor#equip_bonus, six stats over five
-    # equipment slots), which cost 7.7 seconds on Nepheshel's database. Only the
-    # container types are cached: they are read-only to callers (Array1D exposes
-    # no field writers), where a scalar or String decode is cheap and handing out
-    # the same mutable object would change what a caller can do with it. The two
-    # writers below, #[]= and #delete, drop the cached decode with the bytes.
+    # equipment slots), which cost 7.7 seconds on Nepheshel's database. The same
+    # applies to :event/:move_commands chunks (an RPG2000 event page's own
+    # command list, or a Move Route's): each decode builds one EventCommand (or
+    # move-command Hash) object per entry from scratch, and both
+    # Scene::Map#build_event and Scene::Base::EventResolver#map_event_commands
+    # (mruby-rpg2k) re-read the same page's #event_commands on every page-flip
+    # (a switch-gated dialogue is a routine RPG2000 idiom, not a one-off) or
+    # Call Event, not just once. Cached the same way as the container types:
+    # read-only to callers (Array1D exposes no field writers, and nothing in
+    # this codebase mutates a decoded EventCommand/move-command list in place),
+    # where a scalar or String decode is cheap and handing out the same mutable
+    # object would change what a caller can do with it. The two writers below,
+    # #[]= and #delete, drop the cached decode with the bytes.
     def [] idx
       cached = @decoded && @decoded[idx]
       return cached if cached
-      value = LCF.to_rb @data[idx], @schema[:elements][idx]
-      if value.is_a?(Array1D) || value.is_a?(Array2D)
+      elem = @schema[:elements][idx]
+      value = LCF.to_rb @data[idx], elem
+      if value.is_a?(Array1D) || value.is_a?(Array2D) ||
+         elem[:type] == :event || elem[:type] == :move_commands
         @decoded ||= {}
         @decoded[idx] = value
       end

--- a/mruby-rpgvx/mrblib/rgss_data.rb
+++ b/mruby-rpgvx/mrblib/rgss_data.rb
@@ -49,14 +49,23 @@ class RPGVX
       @system = load_data("System")
       @map_infos = load_data("MapInfos")
       @cache = {}
-      ARRAY_FILES.each { |name, file| @cache[name] = load_data(file) }
-      EDITION_FILES[@edition].each { |name, file| @cache[name] = load_data(file) }
     end
 
     attr_reader :system, :map_infos, :game_dir, :edition, :ext
 
-    ALL_FILES.each do |name|
-      define_method(name) { @cache[name] }
+    # Each table loads lazily, on first access to its reader, the same as
+    # RPGXP::RGSSData (mruby-rpgxp/mrblib/rgss_data.rb) -- a session that
+    # never opens a battle never needs Troops/Enemies/Animations, often the
+    # largest files in this group. #summary below reports each table without
+    # forcing this load, so the boot-time census stays accurate without
+    # undoing the laziness the instant the game starts.
+    ARRAY_FILES.each { |name, file| define_method(name) { @cache[name] ||= load_data(file) } }
+    (EDITION_FILES[:vx].keys + EDITION_FILES[:vxace].keys).each do |name|
+      file = (EDITION_FILES[:vx][name] || EDITION_FILES[:vxace][name])
+      define_method(name) do
+        next nil unless EDITION_FILES[@edition][name]
+        @cache[name] ||= load_data(file)
+      end
     end
 
     # Load one map (Data/MapNNN.rvdata(2)) by id. Maps are big, so they are not
@@ -90,12 +99,25 @@ class RPGVX
       @edition == :vxace
     end
 
-    # A one-line census of what loaded, for the boot log.
+    # A one-line census of what's available, for the boot log. Deliberately
+    # does not force a table to load just to report it -- a table already
+    # touched (because something read it) gets an exact record count; one
+    # still lazy gets its on-disk byte size instead (a loose file's #size, or
+    # the packed archive entry's already-parsed header size -- RGSSAD only
+    # reads entry headers at open, never decrypts until #read), so this
+    # boot-time log stays cheap without undoing the laziness the readers
+    # above provide the instant the game starts.
     def summary
       counts = ALL_FILES.map do |name|
+        file = ARRAY_FILES[name] || EDITION_FILES[@edition][name]
+        next nil unless file
         table = @cache[name]
-        next nil unless table
-        "#{name}=#{table.compact.size}"
+        if table
+          "#{name}=#{table.compact.size}"
+        else
+          size = table_byte_size(file)
+          size && "#{name}~#{size}B"
+        end
       end
       counts = counts.compact
       counts.unshift "maps=#{(@map_infos || {}).size}"
@@ -168,6 +190,16 @@ class RPGVX
     # before the archive, matching RGSS.
     def load_data(base)
       read_object("Data/#{base}#{@ext}")
+    end
+
+    # Byte size of a not-yet-loaded Data/ entry by base name, without reading
+    # or decrypting it -- #summary's cheap stand-in for a record count. A
+    # loose file's own #size, or the packed archive entry's already-parsed
+    # header size; nil if neither has it (a genuinely missing table).
+    def table_byte_size(base)
+      path = data_path(base)
+      return File.size(path) if File.exist?(path)
+      @archive && @archive.entry_size("Data/#{base}#{@ext}")
     end
   end
 end

--- a/mruby-rpgxp/mrblib/rgssad.rb
+++ b/mruby-rpgxp/mrblib/rgssad.rb
@@ -247,6 +247,16 @@ class RPGXP
       @entries.key?(normalize(name))
     end
 
+    # An entry's decoded byte size without reading or decrypting it -- the
+    # archive's own header already carries this per entry (see #initialize),
+    # so this is a plain Hash lookup, not I/O. nil when the entry is absent.
+    # Lets a caller report on a packed entry (e.g. a database-table census)
+    # without paying for a full read+decrypt+Marshal.load just to size it.
+    def entry_size(name)
+      e = @entries[normalize(name)]
+      e && e[:size]
+    end
+
     # Decrypted bytes for one entry, or nil when it is not in the archive. `name`
     # may be given with '/' or '\' separators. Seeks to the entry's own offset
     # and reads only its own bytes -- the archive is never loaded whole (see


### PR DESCRIPTION
## Summary

Continues the memory-reduction work from #1360/#1367 with two more real fixes in the same territory.

### 1. LCF event/move-command decodes are now cached (RPG2k)

`LCF::Array1D#[]` only cached nested `Array1D`/`Array2D` values — a `:event` chunk (an event page's own command list) or `:move_commands` chunk (a Move Route's) re-parsed and rebuilt one object per command from scratch on **every single read**. Unlike a one-off `Scene::Map` entry cost, this one recurs: `Scene::Map#build_event` redecodes every active event's command list on every page-flip (switch-gated dialogue is a routine RPG2000 idiom, not a one-time transition), and `EventResolver#map_event_commands` redecodes on every Call Event to a map page — its sibling `#common_event_commands` already got equivalent caching in #1360. Now cached the same way as the container types; confirmed nothing in this codebase mutates a decoded command list in place, so this is safe.

### 2. RPGVX/VX Ace's database tables are finally lazy too

#1367 deliberately left `RPGVX::RGSSData` eager: its boot-time `[RGSS2-DB]` summary log read each table's cache slot directly for an exact record count, so making the readers lazy would have either forced every table to load anyway (no benefit) or silently degraded the log to reporting nothing. Unblocked by having `#summary` report a not-yet-loaded table's **on-disk byte size** instead of a record count — a loose file's own size, or the packed archive entry's already-parsed header size (`RPGXP::RGSSAD#entry_size`, a small new accessor mirroring `#include?`, needing no read or decrypt) — so the boot log stays cheap and accurate, and the readers can finally be lazy the same as XP's sibling loader.

## Change

- `mruby-lcf/mrblib/lcf.rb`: `Array1D#[]` also caches `:event`/`:move_commands` decodes.
- `mruby-rpgxp/mrblib/rgssad.rb`: new `RGSSAD#entry_size(name)` — an archive entry's byte size without reading/decrypting it.
- `mruby-rpgvx/mrblib/rgss_data.rb`: `RGSSData`'s table readers are lazy; `#summary` reports byte size for not-yet-loaded tables.
- Changelog fragments for both.

## Test plan

- [x] `scripts/rpg2k_scene_check.rb` — 929 checks pass.
- [x] `scripts/rpg2k_logic_check.rb` — 1139 checks pass.
- [x] Standalone verification of `Array1D`'s event-command caching (same object across repeat reads, correctly invalidated on write).
- [x] `scripts/rpgxp_testbed_check.rb` and `scripts/rpgxp_script_host_check.rb` against the real OpenGame.exe XP test-bed.
- [x] `scripts/rpgvx_testbed_check.rb`'s generated VX and VX Ace projects (both loose and packed) — confirms the byte-size summary format at boot and exact counts once a table is actually touched, including the archive-entry-size path.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer) — all passed on changed files.
- [ ] CI's own `psp-smoke-game` run — pending.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_