### PR TITLE
rgss: row-copy fast path for opaque blt rows

### DIFF
--- a/changelog.d/bitmap-opaque-row-copy.changed.md
+++ b/changelog.d/bitmap-opaque-row-copy.changed.md
@@ -1,0 +1,14 @@
+- **Bitmap blits of opaque pixels are now row-copied instead of composed
+  pixel by pixel.** `Bitmap#blt` and `#blt_quads` shared one per-pixel loop
+  that re-derived the bytes-per-pixel and redid both bitmaps' bounds checks
+  for every source pixel, even when the whole row was plain opaque colour --
+  which chipset tiles, the map renderer's tile-cache rebuild and animation-
+  step hot path, always are. When both bitmaps share a format, a row whose
+  every alpha byte is 255 is now put down with one `memcpy` (the old opaque
+  branch overwrote the whole pixel anyway), rows with any transparency keep
+  the pixel loop, and the rect is clipped once up front instead of checked
+  per pixel. A 336-tile full-grid rebuild through `#blt_quads` measured
+  ~0.6ms -> ~0.02ms per pass on the host (~30x); charset-shaped blits with
+  transparent margins dropped ~4x from the hoisted clipping alone. This is
+  the "row-copy fast path for opaque chipset pixels" follow-up named by
+  ADR 0058's on-device profiling.

--- a/docs/adr/0058-android-port.md
+++ b/docs/adr/0058-android-port.md
@@ -306,6 +306,28 @@ re-selection now skips events whose condition inputs did not change,
 per-pixel compose cost itself (a row-copy fast path for opaque chipset
 pixels) and the scrolling present path.
 
+**Update (2026-08-26): the per-pixel compose cost got its row-copy fast
+path** — the first of those two remainders. `blt_pixels`, the loop `#blt`
+and `#blt_quads` share (`mruby-rgss/src/lib.cxx`), re-derived the pixel size
+and re-checked both bitmaps' bounds for *every* source pixel, even where the
+old opaque-source branch then overwrote the pixel wholesale — and chipset
+tiles are nothing but opaque rows. Now the rect is clipped once up front
+(the same carry-along clip `bmp_copy_blt` already used), and when both
+bitmaps share a format and the opacity is full, any row whose every alpha
+byte is 255 goes down as one `memcpy`; rows with any transparency keep the
+pixel loop, now bounds-check-free because of the pre-clip. The picture is
+unchanged by construction — a fully-opaque row's memcpy writes exactly what
+the per-pixel overwrite branch wrote — and the mruby-rgss blt parity tests
+plus `scripts/rpg2k_render_check.rb`'s 41 frame checks confirm it. Measured
+on the host with a 336-tile full-grid rebuild through `#blt_quads`
+(21x16 chips, the exact shape of `rebuild_tile_cache`): ~0.6ms → ~0.02ms a
+pass (~30x); charset-shaped blits (transparent margins around an opaque
+core) dropped ~4x from the hoisted clipping alone; blended blts are
+unchanged, as they must be — they never had an overwrite path to shortcut.
+The animation-step `map.layers` spikes above were precisely this loop, so
+the device-side win should track whatever share of them was compose rather
+than dispatch; the scrolling present path is the one named remainder left.
+
 The remaining bullets still hold except where quoted above; "no on-screen
 touch controls yet" is no longer true.
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1837,38 +1837,109 @@ mrb_value bmp_set_pixel(mrb_state* M, V self) {
   return self;
 }
 
+// Composite one source row onto one destination row: `w` pixels from source
+// row `sy` starting at column `sx`, written from destination column `x` on row
+// `y`. The per-pixel body of the old blt_pixels loop, kept verbatim so the
+// fast path below cannot drift from it. Callers pass an already-clipped rect,
+// so no bounds checks -- every pixel lands inside both bitmaps.
+static void blt_row_pixels(Bitmap& dst,
+                           const Bitmap& sb,
+                           mrb_int x,
+                           mrb_int y,
+                           mrb_int sx,
+                           mrb_int sy,
+                           mrb_int w,
+                           int opacity) {
+  for (mrb_int col = 0; col < w; ++col) {
+    int r, g, bl, a;
+    bmp_read(sb, sx + col, sy, r, g, bl, a);
+    const int alpha = a * opacity / 255;
+    if (alpha <= 0)
+      continue;
+    if (alpha >= 255) {
+      bmp_put(dst, x + col, y, r, g, bl, 255);
+      continue;
+    }
+    int dr, dg, db, da;
+    bmp_read(dst, x + col, y, dr, dg, db, da);
+    blend_over(dst, x + col, y, r, g, bl, alpha, dr, dg, db, da);
+  }
+}
+
 // The pixel loop #blt and #blt_quads share: composite src_rect over (x, y)
-// at `opacity`, per-pixel, skipping transparent source pixels and anything
-// outside either bitmap. Kept in one place so the batched form cannot drift
-// from the single-rect one.
+// at `opacity`. Kept in one place so the batched form cannot drift from the
+// single-rect one.
 static void blt_pixels(Bitmap& dst,
                        const Bitmap& sb,
                        mrb_int x,
                        mrb_int y,
                        const Rect& rc,
                        int opacity) {
-  for (mrb_int sy = rc.y; sy < rc.y + rc.height; ++sy) {
-    for (mrb_int sx = rc.x; sx < rc.x + rc.width; ++sx) {
-      if (sx < 0 || sy < 0 || sx >= sb.width || sy >= sb.height)
-        continue;
-      int r, g, bl, a;
-      bmp_read(sb, sx, sy, r, g, bl, a);
-      const int alpha = a * opacity / 255;
-      const mrb_int dx = x + (sx - rc.x);
-      const mrb_int dy = y + (sy - rc.y);
-      if (dx < 0 || dy < 0 || dx >= dst.width || dy >= dst.height)
-        continue;
-      if (alpha <= 0)
-        continue;
-      if (alpha >= 255) {
-        bmp_put(dst, dx, dy, r, g, bl, 255);
-        continue;
-      }
-      int dr, dg, db, da;
-      bmp_read(dst, dx, dy, dr, dg, db, da);
-      blend_over(dst, dx, dy, r, g, bl, alpha, dr, dg, db, da);
-    }
+  mrb_int sx = rc.x, sy = rc.y, w = rc.width, h = rc.height;
+  if (w <= 0 || h <= 0)
+    return;
+  // Clip against both bitmaps up front, carrying the destination along with
+  // the source the way bmp_copy_blt does. The old loop checked every pixel
+  // against both bitmaps instead; iterating only the intersection draws the
+  // same set.
+  if (sx < 0) {
+    w += sx;
+    x -= sx;
+    sx = 0;
   }
+  if (sy < 0) {
+    h += sy;
+    y -= sy;
+    sy = 0;
+  }
+  if (x < 0) {
+    w += x;
+    sx -= x;
+    x = 0;
+  }
+  if (y < 0) {
+    h += y;
+    sy -= y;
+    y = 0;
+  }
+  if (sx + w > sb.width)
+    w = sb.width - sx;
+  if (sy + h > sb.height)
+    h = sb.height - sy;
+  if (x + w > dst.width)
+    w = dst.width - x;
+  if (y + h > dst.height)
+    h = dst.height - y;
+  if (w <= 0 || h <= 0)
+    return;
+
+  // Row-copy fast path. Chipset tiles -- the map renderer's rebuild and
+  // animation-step hot path through #blt_quads -- are fully opaque rows of
+  // plain colour, and for them the per-pixel read/branch/write below is pure
+  // overhead: bmp_read/bmp_put re-derive the bytes-per-pixel and redo the
+  // bounds checks for every pixel. When both bitmaps share a format, a row
+  // whose every alpha byte is 255 is exactly what memcpy puts down (the
+  // opaque branch above overwrites the whole pixel including alpha), so copy
+  // it in one go; rows with any transparency fall back to the pixel loop.
+  if (opacity >= 255 && dst.format == sb.format) {
+    const unsigned bpp = lv_color_format_get_size(dst.format);
+    for (mrb_int row = 0; row < h; ++row) {
+      const uint8_t* s =
+          sb.buffer.data() + ((size_t)(sy + row) * sb.width + sx) * bpp;
+      uint8_t* d =
+          dst.buffer.data() + ((size_t)(y + row) * dst.width + x) * bpp;
+      bool opaque = bpp < 4;
+      for (mrb_int col = 0; !opaque && col < w; ++col)
+        opaque = s[(size_t)col * bpp + 3] == 255;
+      if (opaque)
+        std::memcpy(d, s, (size_t)w * bpp);
+      else
+        blt_row_pixels(dst, sb, x, y + row, sx, sy + row, w, opacity);
+    }
+    return;
+  }
+  for (mrb_int row = 0; row < h; ++row)
+    blt_row_pixels(dst, sb, x, y + row, sx, sy + row, w, opacity);
 }
 
 mrb_value bmp_blt(mrb_state* M, V self) {


### PR DESCRIPTION
## Summary
- `blt_pixels` — the compose loop shared by `Bitmap#blt` and `#blt_quads` (`mruby-rgss/src/lib.cxx`) — now clips the rect once up front and row-`memcpy`s any fully-opaque source row when both bitmaps share a format at full opacity, instead of running per-pixel `bmp_read`/`bmp_put` with per-pixel bounds checks. Rows with transparency keep the pixel loop (bounds-check-free after the pre-clip).
- This is the "row-copy fast path for opaque chipset pixels" follow-up named by ADR 58's on-device profiling; the scrolling present path is the remaining one.

## Why it is safe
A fully-opaque row's `memcpy` writes exactly what the old opaque-source overwrite branch wrote (colour + alpha 255), so the picture is unchanged by construction. Verified with:
- `cmake --build build -t test` — 8/8, including the mruby-rgss blt/`blt_quads`/`copy_blt` parity tests over every alpha
- `scripts/rpg2k_render_check.rb` — 41 frame checks passed
- `scripts/rpg2k_scene_check.rb` — 929 checks passed

## Measured (host, 21x16-tile full-grid rebuild through `#blt_quads`, the exact shape of `Scene::Map#rebuild_tile_cache`)
| workload | before | after |
| --- | ---: | ---: |
| `blt_quads` opaque grid | ~0.6 ms/pass | **~0.02 ms/pass (~30x)** |
| charset-shaped blts (transparent margins) | ~2.2 ms | ~0.5 ms (~4x, hoisted clip) |
| blended blt (opacity 128) | ~0.7 ms | unchanged |

On-device this loop *is* the residual animation-step `map.layers` spike (30-54ms after #1364's batching), so the Android win should track its compose share.

## Labels
`engine:` / `component: rgss` / `type: performance` per `.github/labels.yml` — please add what the diff really carries if the path-based labeler skips them.

Docs: ADR 0058 update paragraph + `changelog.d/bitmap-opaque-row-copy.changed.md`.