### PR TITLE
Save/Load: Erase Picture keeps its stale position/zoom/tone fields

### DIFF
--- a/changelog.d/erase-picture-save-residual-fields.fixed.md
+++ b/changelog.d/erase-picture-save-residual-fields.fixed.md
@@ -1,0 +1,6 @@
+- **Save/Load:** an Erase Picture'd id now matches RPG_RT's real save-file
+  behavior -- the picture stops drawing and can't be moved, but its saved
+  position, zoom, opacity and tone keep the exact values it held at the
+  moment of erasure, with only its name recorded as absent. Previously
+  erasing a picture also dropped these fields entirely, indistinguishable
+  from an id that had never been shown at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3538,6 +3538,148 @@ The work below is roughly ordered by the critical path to a walkable game
   yet touched (`do_change_equipment`, `Window_Skill::CheckInclude`/`Algo::
   IsSkillUsable`, `EnemyAi::IsActionValid`, `Game_Event::MoveTypeRandom`/
   `MoveTypeCycle`, `CalcNormalAttackAutoBattleTargetRank`, `Window_ShopSell`).
+  ✅ **Follow-up (cycle #159, 2026-08-26): picked up candidate 1 (unblocking
+  the "Open Save Menu crashes genuine RPG_RT.exe" finding cycle #158 left
+  behind), then pivoted to candidate 2 (`SAVE_PICTURE` field 9) once that
+  unblocked it -- landing a real fix on a *different*, freshly-discovered
+  chunk 103 gap along the way: an Erase Picture'd id's own genuine save entry
+  is not the fully field-less placeholder this codebase's own `#to_lsd`
+  wrote for it.** **Candidate 1, resolved as "not reproducible," unblocking
+  2/3 for whoever needs the write path next:** reused cycle #155's own
+  scratch `LCF::MapUnit` injector (`inject_picture_probe.rb`) and wine driver
+  (`drive_picture_probe.bash`, both scratch-only) unchanged, on the identical
+  byte-for-byte fixture cycle #158 reported crashing on (`Map0012.lmu` md5
+  `c2fa69a0...`, `Save01.lsd` md5 `3ab5bb01...`, chunk 101 field 123
+  `save_allowed` independently reconfirmed `false` by direct raw-field read,
+  same as cycle #158 found) -- and it never crashed, five independent times
+  in a row: the exact `baseline` scenario (Show Picture never touched, Open
+  Save Menu, confirm the empty File 2 slot) twice, a `moving` scenario
+  (picture mid-Move-Picture when saved) once, and a new variant confirming
+  onto the *occupied* File 1 slot (overwrite, `Return` then a second `Return`
+  for the "already used" confirm dialog) once -- every run produced a
+  genuine, structurally valid `Save0N.lsd` (`lcf_save_check.rb` parsed every
+  chunk cleanly; the overwrite variant's `save_count`/`frame` fields visibly
+  advanced past the source save's own, ruling out "the overwrite silently
+  did nothing" as an alternative explanation). Since this is the same
+  fixture, same `save_allowed=false` state, and the same event-command
+  technique cycle #158 reported failing identically five times, the most
+  likely explanation is a session-local environmental artifact in cycle
+  #158's own run (a stale wine prefix lock, a leftover process from an
+  earlier crash, or similar) rather than a genuine, reproducible RPG_RT.exe
+  behavior tied to `save_allowed` -- documented here rather than chased
+  further, since the task at hand is a *positive* capture, not a crash
+  post-mortem; whoever next hits a save-menu-confirm crash on this fixture
+  should suspect their own session state before re-blaming `save_allowed`.
+  **Candidate 2, decisively resolved with new genuine-RPG_RT.exe evidence,
+  though not the way it was framed:** built a new scenario in the same
+  injector/driver pair -- autostart: Show Picture id 5 off every visual
+  default, Wait 1.0s, Erase Picture 5, Open Save Menu, confirm File 2 --
+  and inspected the resulting genuine `Save02.lsd` chunk 103 id 5 with
+  cycle #155's own raw `LCF::Array1D` `key?`/`@data` field-presence reader.
+  **Result:** field 1 (`name`) absent, but fields 2/3 (`show_x`/`show_y`),
+  4/5/7/8/11-14 (`current_*`), and 31/32/33/34/41-44 (`finish_*`) *all still
+  present*, carrying the exact pre-erase values (111.0/77.0 show position,
+  133/25/140/60/180/50 zoom/transparency/tone) -- decisively distinct from a
+  same-save control id (6, never shown at all), whose raw field list was
+  empty, `[]`, reconfirming cycle #154's own "fully field-less placeholder"
+  finding is unchanged for a genuinely untouched slot. Field 9 (`visible`)
+  itself was absent in this capture too, same as every other genuine
+  capture cycles #154/#155/#159 have now tried (never-touched, at-rest
+  shown, off-default shown, mid-move, and now erased) -- five distinct
+  capture shapes across three cycles have never once observed it present,
+  documented as such in `SAVE_PICTURE`'s own schema comment
+  (`mruby-lcf/mrblib/schema.rb`) rather than claimed as definitively dead,
+  since RPG2003's own picture flag set was never tried. **The real,
+  previously-unknown gap this surfaced:** this codebase's own
+  `Game::State#erase_picture` deleted the `Picture` object outright, so
+  `#to_lsd` wrote a fully field-less placeholder for any erased id --
+  silently losing every one of the stale fields genuine RPG_RT.exe keeps.
+  **Fixed** (`mruby-rpg2k/mrblib/game.rb`): `Game::State#erase_picture` now
+  calls a new `Picture#erase!` (clears a dedicated `@shown` flag, halts any
+  in-flight move by zeroing `@frames`, but leaves name/position/zoom/tone
+  otherwise untouched) instead of deleting the hash entry; `#to_lsd` gates
+  field 1 on the new `Picture#shown?` instead of writing it unconditionally;
+  `Game::State#move_picture` also now gates on `#shown?` rather than mere
+  hash presence, so Move Picture on an erased id stays the no-op it already
+  was for a never-shown one. A dedicated `@shown` flag was used rather than
+  clearing `@name` on erase (the more literal reading of "field 1 goes
+  absent") because several pre-existing `rpg2k_scene_check.rb` fixtures
+  build a `Game::Picture.new` directly with no `:name` at all, purely to
+  seed a position for a Move/Erase Picture check, and must still read as
+  currently shown; `Scene::Map#draw_pictures` (`mruby-rpg2k/mrblib/
+  scene/map.rb`) was updated to gate drawing on `#shown?` explicitly for the
+  same reason, rather than continuing to rely on `Scene::Map#picture_src`'s
+  own nil/empty-name guard as an incidental "erased picture never draws"
+  mechanism. **Whether a picture still mid-Move-Picture at the exact instant
+  of Erase Picture freezes at its live interpolated position (this fix's own
+  choice, since RPG_RT's event thread is single-stepped so nothing else
+  could be advancing the move) or keeps gliding toward its old target was
+  not tested this cycle** -- flagged in `Picture#erase!`'s own comment as
+  the conservative, not-invented-evidence reading; likewise
+  `Game::State#erase_all_pictures` (the automatic all-pictures clear on an
+  ordinary map transfer) was deliberately left as a full hash reset, not
+  converted to a per-id soft-erase, since only the explicit Erase Picture
+  command was ever tested against genuine RPG_RT.exe. **New coverage in
+  `scripts/rpg2k_logic_check.rb`:** the pre-existing "Erase Picture removes
+  the picture" check was rewritten to assert the new `#shown?`-based
+  semantics (the `Picture` object itself is `not nil`, `#shown?` is false,
+  `#name` is unchanged, Move Picture on it is still a no-op) instead of hash
+  deletion; a new check drives Show Picture then Erase Picture through
+  `Game::State` directly and asserts `#to_lsd`'s chunk 103 output against
+  the exact field list/values this cycle's own genuine capture recorded,
+  with a same-state never-touched control id proving the field-less
+  placeholder path is unchanged. One pre-existing `rpg2k_scene_check.rb`
+  check ("Show/Move/Erase Picture from an independently-running parallel
+  process...") also needed its own final assertion updated from
+  `!st3.pictures.key?(1)` to `st3.pictures.key?(1) && !st3.pictures[1]
+  .shown?`, since hash presence no longer implies "currently shown" --
+  this is not a new regression test, just keeping a real pre-existing
+  behavioral check aligned with the new (evidence-driven) internal
+  representation; the behavior it verifies (an erased picture does not
+  draw) is unchanged and still covered. **Proved the fix and both updated
+  checks actually catch the regression:** `git stash` of just
+  `mruby-rpg2k/mrblib/{game.rb,scene/map.rb}` reverted to pre-fix code and
+  reran both suites -- `rpg2k_logic_check.rb` failed its own two picture
+  checks with precise, specific errors (`NoMethodError: undefined method
+  'shown?' for an instance of Game::Picture`, then, after fixing just that
+  one, `RuntimeError: field 2 (show_x) is still present after erase`) and
+  `rpg2k_scene_check.rb` failed its own updated check the same way
+  (`NoMethodError: undefined method 'shown?'`) -- before `git stash pop`
+  restored the fix and all three passed again. Full suite reconfirmed
+  passing, `scripts/rpg2k_logic_check.rb` up by 1 (the one new check;
+  the rewritten "Erase Picture..." check replaces its old self 1-for-1):
+  `scripts/rpg2k_scene_check.rb` (929), `scripts/rpg2k_render_check.rb`
+  (41), `scripts/rpg2k_logic_check.rb` (1141), `scripts/
+  rpg2k3_battle_row_check.rb` (19) and `scripts/rpg2k3_battle_gauge_check.rb`
+  (15); `scripts/rpg2k_save_load_check.rb`'s own 3 pre-existing failures
+  (an unmodelled BGM `balance` field and a `show_x`/`show_y` `nil`-vs-absent
+  mismatch, both unrelated to pictures-on-erase) were independently
+  reconfirmed present identically before and after this cycle's own changes,
+  ruling this cycle out as their cause. This cycle also built the mruby
+  engine binary from source (`cmake --build build --target rpg_maker_clone`)
+  twice, once mid-cycle and once after the final `@shown`-flag redesign, and
+  confirmed both link and compile cleanly. Every scratch game directory,
+  injected `.lmu`, and edited `Save0N.lsd` this cycle's probes produced
+  lived entirely under this session's own scratch dir, never inside `data/`;
+  the two live fixtures the wine driver copies into `data/` on each run
+  (`Save01.lsd`, `Map0012.lmu`) were restored to their exact original bytes
+  and reconfirmed byte-identical by `md5sum` against the same `c2fa69a0.../
+  3ab5bb01...` values every prior cycle back to #148 recorded; `git status`
+  on `data/` came back clean. No EasyRPG source was consulted for any claim
+  this cycle, and no web search was used either. **Left open for a future
+  cycle:** whether `SAVE_PICTURE` field 9 (`visible`) is *ever* written by
+  genuine RPG_RT.exe remains unconfirmed (five capture shapes now say no;
+  RPG2003's own picture-flag commands were never tried); whether a picture
+  still mid-move at the instant of Erase Picture freezes or keeps gliding;
+  whether `Game::State#erase_all_pictures`'s automatic map-transfer clear
+  should carry the same per-id residual-field behavior as an explicit Erase
+  Picture (untested, deliberately left as a full reset); `SAVE_PICTURE`'s
+  own still-missing `fixed_to_map`/`use_transparent_color` fields (cycle
+  #155/#158); fields 51-54/71-140 of `SAVE_SYSTEM`, now genuinely unblocked
+  again by this cycle's own candidate-1 finding; the party-roster-field
+  crash; the autostart-crash mystery; the missing-Picture-asset hang; and
+  every EasyRPG-style citation cycle #154's own repo-wide grep turned up
+  that no cycle has yet touched (see cycle #154's own list, unchanged).
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1252,7 +1252,24 @@ module LCF
       12 => { name: :current_tone_green, type: :double, default: 100.0 },
       13 => { name: :current_tone_blue, type: :double, default: 100.0 },
       14 => { name: :current_tone_saturation, type: :double, default: 100.0 },
-      9 => { name: :visible, type: :bool, default: false }, # 表示するか (0 非表示 / 1 表示)
+      # 表示するか (0 非表示 / 1 表示) -- a name inferred from the field id's
+      # own position in this table (between the current_* and finish_*
+      # clusters), never confirmed against a genuine RPG_RT.exe capture that
+      # actually carries it. Cycle #159 looked for it in the one new scenario
+      # this cycle's own genuine-wine evidence could reach (a picture shown
+      # then Erase Picture'd, then saved) and still did not find it present
+      # -- an erased id's own chunk 103 entry keeps every other field
+      # (2/3/4/5/7/8/11-14/31/32/33/34/41-44) but field 9 stayed absent there
+      # too, the same as every other capture cycles #154/#155 already tried
+      # (a never-touched slot, an at-rest shown picture, one pushed off every
+      # visual default, and one mid-Move-Picture). Five distinct genuine
+      # capture shapes across three cycles have now never once observed this
+      # field present -- consistent with it being unused by any ordinary
+      # RPG2000 Show/Move/Erase Picture sequence, though still not proof no
+      # scenario ever writes it (RPG2003's own picture flag set, e.g., was
+      # never tried). Left as `default: false` (matching a picture that was
+      # never shown) since nothing in this codebase reads or writes it.
+      9 => { name: :visible, type: :bool, default: false },
       # The picture's resting/target position -- see this table's own
       # comment above for why these are named finish_*, not current_*.
       31 => { name: :finish_x, type: :double, default: 0.0 }, # 表示位置Ｘ (中心)

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8554,9 +8554,21 @@ module Game
     def frames_left; @frames; end
     def saturation; @saturation.to_i; end
 
+    # Whether this id is currently on screen -- false once #erase! has run.
+    # A distinct flag rather than "name non-empty": a fresh `Picture.new`
+    # with no `:name` (as several pre-existing scene-check fixtures build one
+    # directly, skipping Show Picture, purely to seed a position for a Move/
+    # Erase Picture check) must still read as shown -- only an *explicit*
+    # #erase! turns this false. An id that has never been shown at all has no
+    # `Picture` object in `Game::State#pictures` to begin with (see
+    # `#erase_picture`'s own comment), so this predicate only ever needs to
+    # distinguish "currently shown" from "was shown, now erased".
+    def shown?; @shown; end
+
     def initialize(id, opts = {})
       @id = id
       @name = opts[:name] || ''
+      @shown = true
       @x = opts[:x] || 0
       @y = opts[:y] || 0
       # Defaults to the shown position itself: the live Show Picture command
@@ -8589,6 +8601,39 @@ module Game
     end
 
     def moving?; @frames > 0; end
+
+    # Erase Picture (11130): turns #shown? false (so nothing draws --
+    # `Scene::Map#draw_pictures` gates on it explicitly, since the name
+    # itself is deliberately left alone here, see below) and halts any
+    # in-flight move, but otherwise leaves name/position/zoom/tone exactly as
+    # they stood at the moment of erasure -- confirmed against genuine
+    # RPG_RT.exe under wine (cycle #159): a Show Picture immediately followed
+    # by Erase Picture, then an Open Save Menu, produced a genuine `.lsd`
+    # chunk 103 entry with field 1 (name) *absent* but fields
+    # 2/3/4/5/7/8/11-14/31/32/33/34/41-44 all still *present*, carrying the
+    # exact values the picture held before erasure -- decisively distinct
+    # from an id that was never shown at all, which cycle #154 already
+    # established writes as a fully field-less placeholder (every one of
+    # those fields absent, not merely zero). `#to_lsd` reads `#shown?`, not
+    # `#name`, to decide whether to write field 1 -- `@name` itself is left
+    # untouched here (rather than cleared) because several pre-existing
+    # scene-check fixtures build a `Picture.new` directly with no `:name` at
+    # all, purely to seed a position, and must still read as shown; clearing
+    # `@name` on erasure would have made an *empty* name ambiguous between
+    # "never had one" and "erased". `Game::State` keeps this `Picture` object
+    # in `@pictures` after an erase (see `#erase_picture`) specifically so
+    # `#to_lsd` can still read these fields back out.
+    # Whether a picture still mid-move at the moment of Erase Picture freezes
+    # at its live interpolated position (as here, forcing frames to 0) or
+    # keeps gliding toward its old target was not tested this cycle -- this
+    # is the conservative reading (RPG_RT's own event thread is
+    # single-stepped, so nothing else could still be advancing the move
+    # in the same instant Erase Picture runs) and errs toward *not*
+    # inventing unverified motion, not toward matching a real capture.
+    def erase!
+      @shown = false
+      @frames = 0
+    end
 
     # Advance one frame of the in-flight move (a no-op when at rest). Every
     # parameter eases a `1/remaining` fraction toward its target, in float
@@ -14452,12 +14497,25 @@ module Game
 
     # Start a move on picture `id` (a no-op if it is not shown). `args` are the
     # Picture#move_to arguments (x, y, zoom, opacity, r, g, b, s, frames).
+    # Gated on `#shown?`, not mere hash presence: since cycle #159, an erased
+    # id's `Picture` object lingers in `@pictures` (see `#erase_picture`'s own
+    # comment), and this must stay a no-op for that id exactly as it already
+    # was for a never-shown one.
     def move_picture(id, *args)
       pic = @pictures[id]
-      pic.move_to(*args) if pic
+      pic.move_to(*args) if pic&.shown?
     end
 
-    def erase_picture(id); @pictures.delete(id); end
+    # Erase Picture (11130): the `Picture` object itself is kept, not deleted
+    # -- see `Picture#erase!`'s own comment for the genuine-RPG_RT.exe
+    # evidence (cycle #159) that its position/zoom/tone fields must still
+    # round-trip through `#to_lsd` after an erase, distinct from an id that
+    # was never shown at all (which has no entry here to begin with, and
+    # `#to_lsd` still writes as a fully field-less placeholder).
+    def erase_picture(id)
+      pic = @pictures[id]
+      pic&.erase!
+    end
 
     # Drop every shown picture. RPG2000 does this on every map change, so a
     # cutscene's pictures never survive into the map it teleports to.
@@ -14941,7 +14999,16 @@ module Game
         p = @pictures[id]
         e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
         if p
-          e[1] = p.name
+          # Field 1 (name) is present only while the picture is actually
+          # shown (`#shown?`, not mere name-emptiness -- see Picture#erase!'s
+          # own comment for why) -- this table's own SAVE_PICTURE schema
+          # comment carries cycle #159's genuine-RPG_RT evidence: an id that
+          # was shown and then Erase Picture'd keeps every position/zoom/tone
+          # field at its last value but drops the name outright, distinct
+          # from an id that was never shown at all (which this loop leaves
+          # as a fully field-less placeholder, `p` nil, matching cycle #154's
+          # own finding unchanged).
+          e[1] = p.name if p.shown?
           e[2] = p.show_x
           e[3] = p.show_y
           e[4] = p.x

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -9604,7 +9604,16 @@ class RPG2k
         @pictures_sig = sig
         @picture_bmp.clear
         return if pics.empty?
-        pics.keys.sort.each { |id| draw_picture pics[id], cam_x, cam_y }
+        # An erased id's own `Game::Picture` object lingers in `@state.
+        # pictures` (cycle #159, so `#to_lsd` can still read its stale
+        # fields back out onto a save -- see `Picture#erase!`'s own
+        # comment) but must never draw again; `#shown?` is the explicit
+        # signal for that, not `Picture#name` (deliberately left untouched
+        # by an erase, so relying on emptiness here would be wrong too).
+        pics.keys.sort.each do |id|
+          p = pics[id]
+          draw_picture p, cam_x, cam_y if p.shown?
+        end
       end
 
       # One array describing the whole picture layer's drawn output: the shown

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9691,7 +9691,9 @@ check 'Move Picture with an instant (zero-duration) move still waits one frame' 
   eq true, st.switches[1], 'resumed the very next frame, since nothing is left moving'
 end
 
-check 'Erase Picture removes the picture' do
+check 'Erase Picture stops showing the picture, but its Game::Picture object ' \
+      'lingers (#shown? flips false, nothing else is deleted or cleared) so ' \
+      '#to_lsd can still read its stale fields back out' do
   st = new_state
   # Show alone first, to confirm it is present before erasing.
   its = Game::Interpreter.new(st)
@@ -9700,11 +9702,73 @@ check 'Erase Picture removes the picture' do
                          string: 'p')])
   its.update
   ok st.pictures[5], 'shown'
+  ok st.pictures[5].shown?, 'shown? true while displayed'
   # Then Erase (both commands are non-blocking, so they run in one update).
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::ERASE_PICTURE, [5])])
   it.update
-  ok st.pictures[5].nil?, 'erased'
+  # Cycle #159 confirmed against genuine RPG_RT.exe under wine (autostart:
+  # Show Picture id 5, Wait, Erase Picture 5, Open Save Menu) that an erased
+  # id's genuine `.lsd` chunk 103 entry keeps every position/zoom/tone field
+  # at its pre-erase value with only field 1 (name) absent -- decisively
+  # distinct from an id never shown at all, which writes as a fully
+  # field-less placeholder (cycle #154). `Game::State#erase_picture` must
+  # therefore keep the `Picture` object (not delete it outright, the prior
+  # behavior this check used to assert) so `#to_lsd` has those fields to
+  # read; `#shown?` (a dedicated flag, not name-emptiness -- several
+  # pre-existing scene-check fixtures build a nameless `Picture.new` directly
+  # and must still read as shown) governs whether anything draws, can be
+  # moved, or is written to field 1.
+  ok !st.pictures[5].nil?, 'the Picture object itself is NOT deleted'
+  ok !st.pictures[5].shown?, 'shown? false once erased'
+  eq 'p', st.pictures[5].name, 'the name itself is left untouched, only #shown? flips'
+  eq 0, st.pictures[5].x, 'position is unaffected by erasure (still 0,0 here)'
+  # Move Picture on an erased id must stay the same no-op it already was for
+  # an id that had never been shown at all -- gated on #shown?, not mere
+  # `@pictures[id]` presence, now that presence alone no longer implies shown.
+  mv = Game::Interpreter.new(st)
+  mv.start([FakeCmd.new(IC::MOVE_PICTURE,
+                        [5, 0, 30, 30, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0, 10, 0])])
+  mv.update
+  ok !st.pictures[5].moving?, 'Move Picture on an erased id is still a no-op'
+end
+
+check 'to_lsd writes an erased-but-previously-shown picture with its stale ' \
+      'position/zoom/tone fields present and field 1 (name) absent, matching ' \
+      'genuine RPG_RT.exe (cycle #159) -- distinct from an id never shown at ' \
+      'all, which stays a fully field-less placeholder' do
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.show_picture(5, name: 'black', x: 111, y: 77, zoom: 133,
+                  opacity: Game.trans_to_opacity(25),
+                  red: 140, green: 60, blue: 180, saturation: 50)
+  st.erase_picture(5)
+
+  save = st.to_lsd
+  pics = save[103]
+  erased = pics[5]
+  ok !erased.key?(1), 'field 1 (name) is absent once erased'
+  %i[show_x show_y current_x current_y current_zoom current_transparency
+     current_tone_red current_tone_green current_tone_blue
+     current_tone_saturation finish_x finish_y zoom transparency
+     tone_red tone_green tone_blue tone_saturation].each do |name|
+    id = LCF::Schema::SAVE_PICTURE.find { |_, spec| spec[:name] == name }.first
+    ok erased.key?(id), "field #{id} (#{name}) is still present after erase"
+  end
+  eq 111, erased.show_x
+  eq 77, erased.show_y
+  eq 133, erased.zoom
+  # 26, not 25: the same pre-existing opacity<->transparency round-trip
+  # precision gap the "to_lsd writes chunk 103..." check above already
+  # documents (out of scope for this fix; unrelated to erasure).
+  eq 26, erased.transparency
+  eq 140, erased.tone_red
+
+  # Control: an id that was never shown at all is still a fully field-less
+  # placeholder (cycle #154, unchanged by this fix).
+  never_touched = pics[6]
+  eq [], (1..51).select { |id| LCF::Schema::SAVE_PICTURE[id] && never_touched.key?(id) },
+     'a never-touched id carries no fields at all, not even absent-name'
 end
 
 check 'Show Picture on an id past the 50-slot range is a no-op' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3765,11 +3765,16 @@ check 'Show/Move/Erase Picture from an independently-running parallel process ar
   scene3.send(:open_message, ['hi'], false)
 
   10.times { scene3.update }
-  ok st3.pictures.key?(1), 'Erase Picture from the parallel process must not apply while the window is open'
+  ok st3.pictures.key?(1) && st3.pictures[1].shown?,
+     'Erase Picture from the parallel process must not apply while the window is open'
 
   scene3.send(:close_message)
   5.times { scene3.update }
-  ok !st3.pictures.key?(1), 'Erase Picture applies once the window closes'
+  # Cycle #159: an erased id's own `Game::Picture` now lingers in `@pictures`
+  # (so `#to_lsd` can still read its stale fields, see `Picture#erase!`'s own
+  # comment) rather than being deleted outright, so `#shown?`, not hash
+  # presence, is what this must have flipped once the window closes.
+  ok st3.pictures.key?(1) && !st3.pictures[1].shown?, 'Erase Picture applies once the window closes'
 end
 
 check 'a blocked Show Picture resumes the command right after it the same ' \


### PR DESCRIPTION
## Summary
- An Erase Picture'd id previously had its `Game::Picture` object deleted outright, so `#to_lsd` wrote a fully field-less placeholder — identical to an id that had never been shown at all.
- Confirmed against genuine RPG_RT.exe under wine: a Show Picture immediately followed by Erase Picture, then Open Save Menu, produced a genuine `.lsd` chunk 103 entry with field 1 (name) absent but every position/zoom/tone field (2/3/4/5/7/8/11-14/31/32/33/34/41-44) still present, carrying the exact pre-erase values — decisively distinct from a never-shown id.
- `Game::Picture` gains a dedicated `#shown?` flag (not name-emptiness, since several pre-existing test fixtures build a nameless `Picture` directly) that `#erase!` flips false while leaving every other field untouched; `#erase_picture` keeps the `Picture` object instead of deleting it; `#to_lsd` gates field 1 on `#shown?`; `#move_picture` and `Scene::Map#draw_pictures` gate on `#shown?` instead of hash presence.
- Also documented (`schema.rb`) that `SAVE_PICTURE` field 9 (`visible`) remains unconfirmed after five distinct genuine capture shapes across three cycles have never once observed it present.
- This cycle also confirmed cycle #158's newly-reported "Open Save Menu crashes genuine RPG_RT.exe" finding did not reproduce (5/5 clean runs against the identical fixture) — likely a session-local artifact in that cycle's own run, not a genuine RPG_RT behavior; this unblocked reaching save-menu state again for this fix.

## Verification
- New/updated regression checks confirmed to fail against pre-fix code (`git stash` of `game.rb`+`scene/map.rb`) across both `rpg2k_logic_check.rb` (2 checks: `NoMethodError: undefined method 'shown?'`, `RuntimeError: field 2 (show_x) is still present after erase`) and `rpg2k_scene_check.rb` (1 check), then pass after restoring — independently re-verified by me as well.
- All check suites pass: `rpg2k_scene_check.rb` 929/929, `rpg2k_render_check.rb` 41/41, `rpg2k_logic_check.rb` 1141/1141 (up from 1140), `rpg2k3_battle_row_check.rb` 19/19, `rpg2k3_battle_gauge_check.rb` 15/15.
- No EasyRPG Player source was consulted for this fix.
- Note: `scripts/rpg2k_save_load_check.rb` (a separate suite from an unrelated workstream, not part of this project's own established four/five check list) has 3 pre-existing failures (BGM `balance`, show_x/y presence) — confirmed unaffected by this PR (identical failures before and after via `git stash`), out of scope for this fix.

## Test plan
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929/929
- [x] `ruby scripts/rpg2k_render_check.rb` — 41/41
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1141/1141
- [x] `ruby scripts/rpg2k3_battle_row_check.rb` — 19/19
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb` — 15/15
- [x] Pre-fix regression proof via `git stash` (independently reproduced)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_