### PR TITLE
Decode LCF::Array2D rows lazily instead of all up front

### DIFF
--- a/changelog.d/lcf-array2d-lazy-rows.changed.md
+++ b/changelog.d/lcf-array2d-lazy-rows.changed.md
@@ -1,0 +1,19 @@
+- **`LCF::Array2D` decodes rows lazily instead of building one `Array1D`
+  object per row the instant a table opens.** Every `.lmt` map-properties
+  table (one row per map in the project) and every `.ldb` database table
+  (items/actors/skills/enemies/troops/animations/common_events/...) used to
+  pay for a full row of decoded objects up front, even though a session only
+  ever touches the current map's tree-ancestry and a fraction of database
+  rows. Table-open now only scans each row's chunk stream to capture its raw
+  byte span (seeking over payloads instead of reading them); `#[]`/`#each`
+  decode a row into an `Array1D` on first actual access and cache it in
+  place, the same trick `Array1D#[]` already uses for its own nested chunks.
+  `#[]=`/`#to_lcf` needed no changes -- they already handled a mixed
+  String/`Array1D` entry, so an untouched row now round-trips as a direct
+  byte passthrough rather than a decode-then-reencode. Verified locally for
+  round-trip fidelity (passthrough, decode-and-cache identity, sparse-table
+  holes, an empty writable-from-scratch table, editing one row without
+  disturbing siblings, and a nested `Array2D`-inside-`Array1D` field); the
+  existing synthetic RPG2000 logic and scene checks (2000+ combined
+  assertions, exercising `LCF::Database`/`LCF::MapTree`/`LCF::MapUnit`
+  through real Scene::Map/battle/event-command paths) pass unchanged.

--- a/changelog.d/lcf-array2d-lazy-rows.changed.md
+++ b/changelog.d/lcf-array2d-lazy-rows.changed.md
@@ -5,7 +5,7 @@
   pay for a full row of decoded objects up front, even though a session only
   ever touches the current map's tree-ancestry and a fraction of database
   rows. Table-open now only scans each row's chunk stream to capture its raw
-  byte span (seeking over payloads instead of reading them); `#[]`/`#each`
+  byte span (reading forward past payloads without decoding them); `#[]`/`#each`
   decode a row into an `Array1D` on first actual access and cache it in
   place, the same trick `Array1D#[]` already uses for its own nested chunks.
   `#[]=`/`#to_lcf` needed no changes -- they already handled a mixed

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1307,25 +1307,44 @@ the interpreter-linking slice, in this order:
   directly) is now lazy too, via a `#summary` that reports a not-yet-loaded
   table's on-disk byte size instead of forcing a decode just to count it.**
 
-  **Open follow-up, deliberately not yet implemented: `LCF::Array2D` still
-  eagerly builds one `Array1D` object per row for an entire table the
-  instant it's decoded** (`mruby-lcf/mrblib/lcf.rb`'s `Array2D#initialize`)
-  -- applies to `.lmt`'s `map_properties` (one row per map in the project)
-  and every `Array2D` table in `.ldb` (items/actors/skills/enemies/troops/
-  animations/common_events/...), even though a session only ever touches
-  the current map's tree-ancestry and a fraction of database rows. This is
-  the same shape as the fixes above (materializing N objects when a
-  fraction are ever read), but riskier to land blind: unlike caching a
-  decode result, this means Array2D would need to store each row's raw
-  byte span instead of a materialized `Array1D`, decoding lazily on first
-  `#[]`/`#each` access -- new binary-format boundary-scanning logic, not
-  just deferred work, in a class whose byte-exact `#to_lcf` round-trip
-  real save/database files depend on. Not implemented without a way to
-  measure its actual payoff first (a real game's map-tree/database row
-  counts) and confirm no round-trip regression on real data -- both blocked
-  in the environment that did this investigation (no network path to the
-  test fixtures beyond what CI already fetches). Left as a scoped,
-  concrete option for whoever picks this up next, not a vague TODO.
+  **Further fixes (2026-08-26,
+  [#1372](https://github.com/take-cheeze/rpg-maker-clone/pull/1372)):
+  `LCF::Array2D` no longer builds one `Array1D` object per row for an
+  entire table the instant it's decoded** (`mruby-lcf/mrblib/lcf.rb`'s
+  `Array2D#initialize`) -- this applied to `.lmt`'s `map_properties` (one
+  row per map in the project) and every `Array2D` table in `.ldb`
+  (items/actors/skills/enemies/troops/animations/common_events/...), even
+  though a session only ever touches the current map's tree-ancestry and a
+  fraction of database rows. This was left as a deliberately-scoped open
+  follow-up above because, unlike caching a decode result, it meant
+  `Array2D` storing each row's raw byte span instead of a materialized
+  `Array1D` and decoding lazily on first `#[]`/`#each` access -- new
+  binary-format boundary-scanning logic in a class whose byte-exact
+  `#to_lcf` round-trip real save/database files depend on, not just
+  deferred work. Implemented by scanning (not decoding) each row's chunk
+  stream at table-open time -- walking the same id/len structure
+  `Array1D#initialize` already does, but seeking over each chunk's payload
+  (`StringIO#seek`/`IO::SEEK_CUR`, confirmed present in this mruby build)
+  instead of reading it -- and capturing the exact consumed byte span (id
+  through the id-0 terminator, inclusive) as a raw String. `#[]`/`#each`
+  decode a row's span into an `Array1D` on first access and replace it in
+  place, the same in-place-cache trick `Array1D#[]` already uses for its
+  own nested chunks; `#[]=`/`#to_lcf` needed no changes at all, since they
+  already handled a mixed String/`Array1D` entry polymorphically -- an
+  untouched row now round-trips as a direct byte passthrough instead of a
+  decode-then-reencode, which is faster as well as smaller. Verified
+  locally for round-trip fidelity (the real risk here, not the impact
+  magnitude): a standalone script exercising untouched-row passthrough,
+  touched-row decode-and-cache identity, sparse-table holes through
+  `#each`, an empty writable-from-scratch table, editing one row without
+  disturbing siblings, and a nested `Array2D`-inside-`Array1D` field (the
+  actor parameter-table shape) all round-trip byte-exact; `scripts/
+  rpg2k_logic_check.rb` (1140 checks) and `scripts/rpg2k_scene_check.rb`
+  (929 checks) -- both of which exercise `LCF::Database`/`LCF::MapTree`/
+  `LCF::MapUnit` through real Scene::Map/battle/event-command paths against
+  synthetic RPG2000 fixtures -- still pass unchanged. Real map-tree/database
+  row counts and arena-usage impact on Nepheshel are, as with every prior
+  round in this section, left to CI's own `psp-smoke-game` run to measure.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1308,7 +1308,7 @@ the interpreter-linking slice, in this order:
   table's on-disk byte size instead of forcing a decode just to count it.**
 
   **Further fixes (2026-08-26,
-  [#1372](https://github.com/take-cheeze/rpg-maker-clone/pull/1372)):
+  [#1374](https://github.com/take-cheeze/rpg-maker-clone/pull/1374)):
   `LCF::Array2D` no longer builds one `Array1D` object per row for an
   entire table the instant it's decoded** (`mruby-lcf/mrblib/lcf.rb`'s
   `Array2D#initialize`) -- this applied to `.lmt`'s `map_properties` (one

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1323,28 +1323,48 @@ the interpreter-linking slice, in this order:
   `#to_lcf` round-trip real save/database files depend on, not just
   deferred work. Implemented by scanning (not decoding) each row's chunk
   stream at table-open time -- walking the same id/len structure
-  `Array1D#initialize` already does, but seeking over each chunk's payload
-  (`StringIO#seek`/`IO::SEEK_CUR`, confirmed present in this mruby build)
-  instead of reading it -- and capturing the exact consumed byte span (id
+  `Array1D#initialize` already does -- and capturing the byte span (id
   through the id-0 terminator, inclusive) as a raw String. `#[]`/`#each`
   decode a row's span into an `Array1D` on first access and replace it in
   place, the same in-place-cache trick `Array1D#[]` already uses for its
   own nested chunks; `#[]=`/`#to_lcf` needed no changes at all, since they
   already handled a mixed String/`Array1D` entry polymorphically -- an
   untouched row now round-trips as a direct byte passthrough instead of a
-  decode-then-reencode, which is faster as well as smaller. Verified
-  locally for round-trip fidelity (the real risk here, not the impact
-  magnitude): a standalone script exercising untouched-row passthrough,
+  decode-then-reencode, which is faster as well as smaller.
+
+  **A first version used `StringIO#seek`/`IO::SEEK_CUR` to skip over each
+  chunk's payload instead of reading it, confirmed present in this mruby
+  build via the C source -- and passed every local check (StringIO-backed,
+  CRuby). CI's `build` job caught what the local check couldn't: booting
+  Nepheshel and a second real project both failed immediately with
+  `RuntimeError: truncated BER integer`, corrupting the stream from the
+  second row on whenever the table was opened from a real `File`, not a
+  `StringIO`.** mruby-io's `IO#seek` issues a raw `lseek` on the file
+  descriptor without correcting for bytes already pulled into its internal
+  read-ahead buffer but not yet consumed by the small buffered reads
+  `read_ber`'s `#getbyte` makes -- interleaving the two desyncs the logical
+  read position from the real one. `StringIO` has no such buffer, so a
+  StringIO-backed local check could not have caught this; it takes a
+  `File`-backed stream, which only CI's own fetched game fixtures provided.
+  Fixed by dropping `#seek` entirely: the scan now reads forward only,
+  re-emitting each id/len via `write_ber` as it goes (exactly what
+  `Array1D#to_lcf` already does for every chunk, so this changes nothing
+  about what "byte-exact" means for a real file, whose ids/lengths already
+  round-trip through `write_ber` unchanged -- see `write_ber`'s own
+  comment) instead of skip-and-rewind. Re-verified locally, including a new
+  `File`-backed (not just `StringIO`-backed) case exercising the same
+  forward-only path CI's failure was in: untouched-row passthrough,
   touched-row decode-and-cache identity, sparse-table holes through
   `#each`, an empty writable-from-scratch table, editing one row without
-  disturbing siblings, and a nested `Array2D`-inside-`Array1D` field (the
-  actor parameter-table shape) all round-trip byte-exact; `scripts/
-  rpg2k_logic_check.rb` (1140 checks) and `scripts/rpg2k_scene_check.rb`
-  (929 checks) -- both of which exercise `LCF::Database`/`LCF::MapTree`/
-  `LCF::MapUnit` through real Scene::Map/battle/event-command paths against
-  synthetic RPG2000 fixtures -- still pass unchanged. Real map-tree/database
-  row counts and arena-usage impact on Nepheshel are, as with every prior
-  round in this section, left to CI's own `psp-smoke-game` run to measure.
+  disturbing siblings, a nested `Array2D`-inside-`Array1D` field (the actor
+  parameter-table shape), and a real-`File` multi-row round-trip all pass;
+  `scripts/rpg2k_logic_check.rb` (1140 checks) and
+  `scripts/rpg2k_scene_check.rb` (929 checks) -- both of which exercise
+  `LCF::Database`/`LCF::MapTree`/`LCF::MapUnit` through real
+  Scene::Map/battle/event-command paths against synthetic RPG2000 fixtures
+  -- still pass unchanged. Real map-tree/database row counts and
+  arena-usage impact on Nepheshel are, as with every prior round in this
+  section, left to CI's own `psp-smoke-game` run to measure.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -694,26 +694,36 @@ module LCF
 
     private
 
-    # Scan (without decoding) one row's chunk stream and return its exact raw
-    # bytes, from the first chunk id through the id-0 terminator inclusive --
+    # Scan (without decoding) one row's chunk stream and return its raw bytes,
+    # from the first chunk id through the id-0 terminator inclusive --
     # precisely the span Array1D#to_lcf(true) would itself produce, so handing
-    # it back out unread through #to_lcf is a byte-for-byte passthrough. Walks
-    # the same id/len chunk structure Array1D#initialize does, but seeks over
-    # each chunk's payload instead of reading it, then rewinds and takes the
-    # whole span in one read -- cheaper than decoding, and it never touches
-    # cp932 conversion or nested Array1D/Array2D construction at all.
+    # it back out unread through #to_lcf is a byte-for-byte passthrough for a
+    # real file (write_ber always re-emits the same shortest encoding RPG_RT
+    # itself writes -- see write_ber's own comment). Walks the same id/len
+    # chunk structure Array1D#initialize does, forward-only: each id/len is
+    # read then re-emitted via write_ber (exactly what Array1D#to_lcf already
+    # does for every chunk, touched or not, so this changes nothing about
+    # what "byte-exact" means here) and each payload is read and appended
+    # rather than decoded, so this never touches cp932 conversion or nested
+    # Array1D/Array2D construction. Deliberately forward-only, no #seek: a
+    # `#seek(len, IO::SEEK_CUR)` skip here -- tried first -- desyncs mruby-io's
+    # read-ahead buffer against the real fd position when interleaved with
+    # read_ber's own small buffered reads (`#seek` issues a raw `lseek` on the
+    # fd without correcting for bytes already buffered-but-unconsumed), which
+    # silently corrupted every row after the first on a real `File`-backed
+    # stream (StringIO has no such buffer, so a local, String-only check
+    # missed it entirely -- confirmed by CI's real-game boot check).
     def read_row_bytes s
-      start_pos = s.pos
+      out = String.new
       loop do
         break if s.eof?
         idx = LCF.read_ber s
+        out = out + LCF.write_ber(idx)
         break if idx == 0
         len = LCF.read_ber s
-        s.seek(len, IO::SEEK_CUR)
+        out = out + LCF.write_ber(len) + s.read(len)
       end
-      end_pos = s.pos
-      s.seek(start_pos, IO::SEEK_SET)
-      s.read(end_pos - start_pos)
+      out
     end
   end
 end

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -628,18 +628,33 @@ module LCF
       s = StringIO.new s if s.is_a? String
 
       @data = []
-      @scheme = schema
+      @schema = schema
 
       # An empty string builds an empty, writable table from scratch (populate
       # via #[]= then #to_lcf); a real chunk starts with a BER entry count.
       return if s.eof?
 
+      # Each row used to be decoded into an Array1D right here, so opening a
+      # table meant building N objects up front (one per project map, or per
+      # item/actor/skill/... row in the database) even though a session only
+      # ever touches a fraction of them -- the tree-ancestry maps, or whatever
+      # database rows the current scene reads. Only the row's raw byte span is
+      # captured now; #[] and #each decode it into an Array1D lazily, on first
+      # actual access, and keep the result (the same in-place-replace trick
+      # Array1D#[] uses for its own nested chunks).
       (0...LCF.read_ber(s)).each do
-        @data[LCF.read_ber s] = Array1D.new(s, schema)
+        idx = LCF.read_ber s
+        @data[idx] = read_row_bytes(s)
       end
     end
 
-    def [] idx ; @data[idx] end
+    # Decode (and cache) row +idx+ on first access; a row never read stays a
+    # raw byte span forever. nil for an id the table never had.
+    def [] idx
+      entry = @data[idx]
+      return entry unless entry.is_a? String
+      @data[idx] = Array1D.new(entry, @schema)
+    end
 
     # Store an entry (an Array1D, or its already-serialised bytes) at id +idx+,
     # so an authored table can be assembled and written back out via #to_lcf.
@@ -649,9 +664,13 @@ module LCF
     end
 
     # Iterate over defined (id, Array1D) entries; useful for walking event or
-    # actor tables that are sparsely populated.
+    # actor tables that are sparsely populated. Decodes each row it yields,
+    # same as #[] -- a full-table scan (e.g. searching common events by name)
+    # still pays for every row it actually visits, just no longer for the
+    # ones it doesn't.
     def each
-      @data.each_with_index do |v, i|
+      @data.size.times do |i|
+        v = self[i]
         yield i, v unless v.nil?
       end
     end
@@ -671,6 +690,30 @@ module LCF
         out = out + LCF.write_ber(i) + bytes
       end
       out
+    end
+
+    private
+
+    # Scan (without decoding) one row's chunk stream and return its exact raw
+    # bytes, from the first chunk id through the id-0 terminator inclusive --
+    # precisely the span Array1D#to_lcf(true) would itself produce, so handing
+    # it back out unread through #to_lcf is a byte-for-byte passthrough. Walks
+    # the same id/len chunk structure Array1D#initialize does, but seeks over
+    # each chunk's payload instead of reading it, then rewinds and takes the
+    # whole span in one read -- cheaper than decoding, and it never touches
+    # cp932 conversion or nested Array1D/Array2D construction at all.
+    def read_row_bytes s
+      start_pos = s.pos
+      loop do
+        break if s.eof?
+        idx = LCF.read_ber s
+        break if idx == 0
+        len = LCF.read_ber s
+        s.seek(len, IO::SEEK_CUR)
+      end
+      end_pos = s.pos
+      s.seek(start_pos, IO::SEEK_SET)
+      s.read(end_pos - start_pos)
     end
   end
 end


### PR DESCRIPTION
## Summary

- `LCF::Array2D#initialize` used to build one `Array1D` object per row for an entire table the instant it was decoded -- every map in a project's `.lmt` map-properties table, and every row of every `.ldb` database table (items/actors/skills/enemies/troops/animations/common_events/...), even though a session only ever touches the current map's tree-ancestry and a fraction of database rows. This was documented as a deliberately-scoped open follow-up in `docs/adr/0047-psp-memory-budget.md`'s P1c section (left unimplemented in [#1369](https://github.com/take-cheeze/rpg-maker-clone/pull/1369) pending a safe way to validate correctness).
- Table-open now only scans each row's chunk stream to capture its raw byte span (seeking over chunk payloads via `StringIO#seek`/`IO::SEEK_CUR` instead of reading them); `#[]`/`#each` decode a row into an `Array1D` on first actual access and cache it in place, the same in-place-cache trick `Array1D#[]` already uses for its own nested chunks.
- `#[]=`/`#to_lcf` needed **no changes** -- they already handled a mixed String/`Array1D` entry polymorphically, so an untouched row now round-trips as a direct byte passthrough instead of a decode-then-reencode (faster as well as smaller).
- ADR updated with the implementation details; real map-tree/database row counts and arena-usage impact are, as with every prior round in this series (#1360, #1367, #1368), left to CI's `psp-smoke-game` run to measure and will be recorded once that lands.

## Test plan

- [x] Standalone local script (no mruby cross-compiler available in this sandbox) covering: untouched-row byte-exact passthrough, touched-row decode-and-cache identity, sparse-table holes through `#each`, an empty writable-from-scratch table, editing one row without disturbing sibling bytes, and a nested `Array2D`-inside-`Array1D` field (the actor parameter-table shape) -- all pass.
- [x] `scripts/rpg2k_logic_check.rb` -- 1140 checks passed, unchanged.
- [x] `scripts/rpg2k_scene_check.rb` -- 929 checks passed, unchanged (exercises `LCF::Database`/`LCF::MapTree`/`LCF::MapUnit` through real Scene::Map/battle/event-command paths).
- [x] `scripts/rpgxp_testbed_check.rb data/OpenGame.exe/Testbed/XP` -- passed (unrelated to this change, run as a general regression check).
- [ ] CI's `mruby_test` job (real mruby build, not CRuby) -- this touches `lcf.rb`'s binary parsing directly, watching for it.
- [ ] CI's `psp-smoke-game` run -- to measure real arena-usage impact on Nepheshel.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_