### PR TITLE
Save/Load: Teleport and Escape access default to allowed, matching RPG_RT

### DIFF
--- a/changelog.d/teleport-escape-access-default.fixed.md
+++ b/changelog.d/teleport-escape-access-default.fixed.md
@@ -1,0 +1,8 @@
+- **Save data:** Teleport and Escape access (the flags the "Enable/Disable
+  Teleport" and "Enable/Disable Escape" event commands toggle) now default to
+  **allowed**, matching genuine RPG_RT.exe. Previously a new game started
+  with both forbidden until an event explicitly enabled them, and a saved
+  game where they had simply never been touched could load back with them
+  wrongly forbidden instead of allowed. Save files also now only record
+  these two flags when they differ from that allowed default, the same way
+  Save/Menu access already did, instead of always writing a value.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3919,6 +3919,126 @@ The work below is roughly ordered by the critical path to a walkable game
   missing-Picture-asset hang; and every EasyRPG-style citation cycle #154's
   own repo-wide grep turned up that no cycle has yet touched (see cycle
   #154's own list, unchanged).
+  ✅ **Follow-up (cycle #162, 2026-08-26): picked up the explicitly-flagged
+  gap left by cycle #161 -- field 122 (`escape_allowed`) was never
+  independently probed and was only assumed to share field 121's
+  "unconditional write" convention "by analogy" -- and found that
+  assumption was itself built on an incomplete test, landing a real fix
+  that corrects both fields 121 and 122 at once, plus each one's own
+  constructor default.** **Evidence:** reused cycle #161's own scratch
+  injector/driver shape (`inject_access_probe.rb`, `drive_slot_probe.bash`,
+  both still present in this session's scratchpad from that cycle,
+  untouched) to add two new scenarios -- `escape_reset` (Control Escape
+  Access ENABLE(1) then DISABLE(0), ending at false, mirroring cycle #161's
+  own `teleport_reset`) and, critically, `escape_on`/`teleport_on` (ENABLE
+  only, leaving the flag at **true** -- the one end of the value range
+  neither cycle #160 nor #161 had ever tested for this cluster). Drove
+  genuine RPG_RT.exe under wine (Xvfb 640x480x16, matchbox,
+  `LIBGL_ALWAYS_SOFTWARE=1`, `ja_JP.UTF-8`, continuing from the same clean
+  Save01.lsd cycle #160/#161 used, `BOOT_WAIT=35` -- the previously-recorded
+  25s was occasionally too short for this session's boot and produced a
+  blank splash-screen capture, caught by inspecting the boot screenshot
+  before trusting a run) through four scenarios, reading each resulting
+  genuine Save0N.lsd's raw chunk 101 with `LCF::SaveData` + `Array1D#key?`:
+  `escape_reset` came back **present** with value **false** (matching
+  `teleport_reset`'s own already-recorded result exactly); `escape_on` and
+  `teleport_on` each came back **fully absent** -- the opposite of what an
+  "unconditional write" convention predicts (which would stay present
+  regardless of value) and exactly what "omit at true default" predicts,
+  *provided the true default is actually allowed, not forbidden*. Cross-
+  checked against the project's own untouched continued-game baseline
+  (`notouch2`, produced by cycle #161 and still on disk in this session's
+  scratchpad): both 121 and 122 were present with value false there too,
+  consistent with this checkpoint's own story having explicitly forbidden
+  both earlier, not with either field being freshly at some engine default.
+  **The gap:** cycle #161's own probe for field 121 only ever tested an
+  ENABLE-then-DISABLE round trip that ends at the codebase's *assumed* false
+  default -- present in that shape either way, so it could never distinguish
+  "written unconditionally" from "written because false is the actual
+  non-default value" -- and it treated field 122 as sharing 121's conclusion
+  "by analogy" without any probe of its own. This cycle's `_on` scenarios
+  close exactly that gap and show both fields are gated by value, at a true
+  default -- meaning `Game::State#initialize`'s own `@teleport_access =
+  false` / `@escape_access = false` (present since long before this cycle,
+  and contradicted by that very method's own neighbouring comment claiming
+  parity with `#save_access`) had the *default itself* backwards: genuine
+  RPG_RT.exe allows Teleport and Escape until an event forbids them, the
+  same on-by-default posture Save/Menu access already had. **Fixed:**
+  `Game::State#initialize` now sets `@teleport_access = true` /
+  `@escape_access = true`; `#to_lsd` now writes `sys[121] = false unless
+  @teleport_access` / `sys[122] = false unless @escape_access` (previously
+  unconditional `@teleport_access ? true : false` etc.); and `.from_h` (the
+  internal mruby quicksave format) had a latent second bug in the same
+  neighbourhood -- it coerced a missing key straight to `false`
+  (`h[:teleport_access] ? true : false`) instead of falling back to the
+  constructor default the way `#menu_access`/`#save_access` already do,
+  harmless while the constructor default was itself false but silently
+  defeating the new true default for any legacy quicksave missing the key --
+  fixed to the same `unless h[:key].nil?` pattern. `.from_lsd` needed no
+  change: its own `unless sys.xxx_allowed.nil?` guard already deferred to
+  whatever the constructor default was. Updated `SAVE_SYSTEM`'s own schema
+  comments (`mruby-lcf/mrblib/schema.rb`) and `Game::State`'s own comments
+  (`mruby-rpg2k/mrblib/game.rb`, both the `attr_accessor` doc and `#to_lsd`'s
+  own inline comment) to document the corrected, now-uniform convention
+  covering all of fields 121-124 alike. **New/extended coverage in
+  `scripts/rpg2k_logic_check.rb`:** rewrote the fields-121-124 check to
+  assert all four are absent at a fresh state's own true default and present
+  holding false once flipped, replacing the old assertion that 121/122 stay
+  present at their (then-false) default; added an explicit-false reset
+  branch to the same check proving a fresh-state `false` value still writes
+  and round-trips correctly rather than being swallowed by the new default;
+  updated the "Change Teleport / Escape Access" interpreter check's own
+  opening assertion from "defaults off" to "defaults on"; and extended the
+  quicksave round-trip check with a legacy-missing-key case now expecting
+  `true` (previously `false`) plus a new explicit-`false` case proving that
+  value still survives `.from_h`'s corrected fallback. **Proved the fix and
+  the updated checks actually catch the regression:** `git stash` of just
+  `mruby-rpg2k/mrblib/game.rb` and `mruby-lcf/mrblib/schema.rb` (keeping the
+  updated check file) reverted to the pre-fix code and rerunning
+  `rpg2k_logic_check.rb` failed three checks immediately with precise,
+  specific errors (`RuntimeError: expected false, got true (field 121 absent
+  at its own true default (omit-at-default))`, `expected true, got false
+  (teleport access defaults on)`, and a plain `expected true, got false` from
+  the round-trip check) before `git stash pop` restored the fix and all
+  checks passed again. Full suite reconfirmed passing, `scripts/
+  rpg2k_logic_check.rb` unchanged in count at 1144 (existing checks extended
+  in place rather than new ones added): `scripts/rpg2k_scene_check.rb`
+  (929), `scripts/rpg2k_render_check.rb` (41), `scripts/rpg2k_logic_check.rb`
+  (1144), `scripts/rpg2k3_battle_row_check.rb` (19) and `scripts/
+  rpg2k3_battle_gauge_check.rb` (15); `scripts/rpg2k_save_load_check.rb`'s
+  own 3 pre-existing failures (the unmodelled BGM `balance` field, the
+  `show_x`/`show_y` `nil`-vs-absent mismatch, and the "screen transition
+  defaults unreadable" stderr warning) were reconfirmed present identically
+  before and after this cycle's changes, ruling this cycle out as their
+  cause. This cycle also built the mruby engine binary from source
+  (`cmake --build build --target rpg_maker_clone`, using the two
+  hash-pinned Unicode tables already fetched to `/tmp/tables` by an earlier
+  cycle) and confirmed it links cleanly. Every scratch map/save this cycle's
+  probes produced lived entirely under this session's own scratch dir; the
+  two live fixtures the wine driver copies into `data/` on each run
+  (`Save01.lsd`, `Map0012.lmu`) were restored to their exact original bytes
+  and reconfirmed byte-identical by `md5sum` against the same
+  `c2fa69a0.../3ab5bb01...` values every prior cycle back to #148 recorded;
+  `git status` on `data/` came back clean. No EasyRPG source was consulted
+  for any claim this cycle, and no web search was used either. **Left open
+  for a future cycle:** field 140 (`atb_mode`) was still not re-probed this
+  cycle -- its "2003-only, default-gated" status rests on the same
+  repeated-absence observation (every capture across cycles #159-#162 alike)
+  already recorded rather than a dedicated fresh test, and *why* it is
+  always absent from this RPG2000 project's own saves (a version-gated
+  chunk vs. simply always being at its default 0) still was never
+  disambiguated the way this cycle disambiguated 121/122's identical
+  question -- a future cycle with access to a genuine RPG2003 project could
+  settle both by the same explicit-DISABLE/ENABLE-then-reset technique used
+  here; whether RPG2003's own picture-flag commands would ever surface
+  `SAVE_PICTURE` field 9 (cycle #159's own open item); whether a picture
+  mid-Move-Picture at the instant of Erase Picture freezes or keeps gliding
+  (cycle #159's own open item); `SAVE_PICTURE`'s own still-missing
+  `fixed_to_map`/`use_transparent_color` fields (cycle #155/#158); the
+  party-roster-field crash; the autostart-crash mystery; the
+  missing-Picture-asset hang; and every EasyRPG-style citation cycle #154's
+  own repo-wide grep turned up that no cycle has yet touched (see cycle
+  #154's own list, unchanged).
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1570,10 +1570,11 @@ module LCF
       # RPG_RT.exe save under wine (cycle #160): each field is written only
       # when it differs from its own declared default here, independently of
       # the other three -- the same per-field "omit at default" convention
-      # already confirmed for the message-config cluster just above (41-44)
-      # and for field 61 (`bgm_stopping`) -- not the unconditional-write
-      # convention fields 121-124 use. See `Game::State#to_lsd`'s own comment
-      # in game.rb for the exact capture shapes tried.
+      # already confirmed for the message-config cluster just above (41-44),
+      # for field 61 (`bgm_stopping`), and for the 121-124 access cluster
+      # further down (see that cluster's own comment for cycle #161/#162's
+      # correction there). See `Game::State#to_lsd`'s own comment in game.rb
+      # for the exact capture shapes tried.
       51 => { name: :face_name, type: :string, default: '' },
       52 => { name: :face_index, type: :int, default: 0 },
       53 => { name: :face_right_position, type: :int, default: 0 },
@@ -1596,7 +1597,8 @@ module LCF
       # restart or not), both omitted field 61 entirely -- so real RPG_RT
       # writes this field only when true, the same "false is simply absent"
       # convention field 41 (`message_transparent`) already follows here,
-      # not the unconditional-write convention fields 121-124 use.
+      # and the 121-124 access cluster further down uses too (with true, not
+      # false, as its own "absent" default).
       61 => { name: :bgm_stopping, type: :bool, default: false },
       # Overridden BGM/SE playback state. An empty file name means "use the
       # database value".
@@ -1632,31 +1634,35 @@ module LCF
       115 => { name: :battle_end_erase_transition, type: :uint8 },
       116 => { name: :battle_end_show_transition, type: :uint8 },
       # Control Teleport/Escape/Save/Menu Access (11820/11840/11930/11960).
-      # These four are NOT one uniform cluster despite looking identical --
-      # confirmed against genuine RPG_RT.exe under wine (cycle #161), probing
-      # each with a synthetic autostart event issuing the matching Control
-      # command then Open Save Menu with no Wait in between (the same shape
-      # cycle #160 used for fields 51-54): 121/122 stayed **present** (with
-      # their own false constructor default) even right after an explicit
-      # ENABLE-then-DISABLE resetting them back to that exact default,
-      # mid-event -- an unconditional write -- while 123/124 went from
-      # **present** (false) right after an explicit DISABLE to **absent**
-      # once a further ENABLE put them back to their own true default, still
-      # mid-event -- the same per-value "omit at default" convention already
-      # confirmed for fields 41-44/51-54/61. No `default:` is given here for
-      # any of the four, deliberately: `Game::State.from_lsd` (game.rb) tells
-      # "not in this save" (nil) from "explicitly false" for all four the
-      # same way (`unless sys.xxx_allowed.nil?`), so 123/124's own
-      # constructor-side true default lives in `Game::State#initialize`, not
-      # here -- adding `default: true` here would make an absent field decode
-      # as the concrete value `true` instead of `nil`, collapsing that
-      # distinction (see SAVE_INVENTORY's own near-identical comment on its
-      # eight undefaulted timer/tally fields, which already cites this exact
-      # field as its template). #to_lsd's own comment in game.rb records the
-      # write-side "omit at true" gating for 123/124 that this cycle added.
-      # (122 was not independently probed this cycle -- it shares 121's exact
-      # code shape and command family, so is treated as the same convention
-      # by analogy pending its own direct check.)
+      # All four turn out to be ONE uniform "omit at true default" cluster --
+      # confirmed against genuine RPG_RT.exe under wine, probing each with a
+      # synthetic autostart event issuing the matching Control command then
+      # Open Save Menu with no Wait in between (the same shape cycle #160
+      # used for fields 51-54). Cycle #161 tested 123/124 fully (present at
+      # false right after an explicit DISABLE, absent again once a further
+      # ENABLE put them back to their own true default) but only ever tested
+      # 121 with an ENABLE-then-DISABLE round trip that ends at false -- a
+      # test that cannot tell "written unconditionally" apart from "written
+      # because false is the non-default value" -- and never independently
+      # probed 122 at all, so it wrongly concluded 121/122 were an
+      # "unconditional write" pair, sharing 122's convention with 121 only
+      # "by analogy". Cycle #162 ran the missing test for both: an ENABLE-only
+      # probe leaving each flag at **true** came back with the field
+      # **absent**, matching 123/124's own pattern exactly and revealing that
+      # genuine RPG_RT.exe's actual default for Teleport/Escape access is
+      # **allowed**, not forbidden -- the codebase's own prior assumption
+      # (`Game::State#initialize` used to set both false) was backwards. No
+      # `default:` is given here for any of the four, deliberately:
+      # `Game::State.from_lsd` (game.rb) tells "not in this save" (nil) from
+      # "explicitly false" for all four the same way (`unless
+      # sys.xxx_allowed.nil?`), so each field's own true-default constructor
+      # value lives in `Game::State#initialize`, not here -- adding `default:
+      # true` here would make an absent field decode as the concrete value
+      # `true` instead of `nil`, collapsing that distinction (see
+      # SAVE_INVENTORY's own near-identical comment on its eight undefaulted
+      # timer/tally fields, which already cites this exact field as its
+      # template). #to_lsd's own comment in game.rb records the write-side
+      # "omit at true" gating this cluster uses.
       121 => { name: :teleport_allowed, type: :bool },
       122 => { name: :escape_allowed, type: :bool },
       123 => { name: :save_allowed, type: :bool },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14149,7 +14149,9 @@ module Game
     # setting on every map load and Teleport (`Scene::Map#apply_map_access`,
     # `Game::MapAccess.teleport_allowed?` / `#escape_allowed?`) -- so a value
     # set here is only the *initial* one (before any map has loaded), matching
-    # `#save_access`. Persisted in the save. Read by
+    # `#save_access`. Both default **on** (cycle #162, confirmed against
+    # genuine RPG_RT.exe -- see `#to_lsd`'s own comment below), the same as
+    # `#save_access`/`#menu_access`. Persisted in the save. Read by
     # Game::Party#escape_skill_available? / #teleport_skill_available? to gate
     # the field skill menu.
     attr_accessor :teleport_access, :escape_access
@@ -14375,8 +14377,11 @@ module Game
       @message_config = MessageConfig.new
       @menu_access = true
       @save_access = true
-      @teleport_access = false
-      @escape_access = false
+      # Cycle #162: confirmed **on** by default against genuine RPG_RT.exe
+      # (previously false here, the reverse of the confirmed default -- see
+      # `#to_lsd`'s own comment for the capture evidence).
+      @teleport_access = true
+      @escape_access = true
       @current_bgm = nil
       @memorized_bgm = nil
       @bgm_looped = false
@@ -14859,35 +14864,40 @@ module Game
         sys[field] = se_chunk(se) if se
       end
       # SAVE_SYSTEM fields 121-124 (Control Teleport/Escape/Save/Menu Access)
-      # are NOT one uniform "unconditional write" cluster the way an earlier
-      # cycle's own schema comment claimed -- confirmed against genuine
-      # RPG_RT.exe under wine (cycle #161), each field probed independently
-      # via a synthetic autostart event issuing the matching Control command
-      # then Open Save Menu with no Wait in between (same shape cycle #160
-      # used for fields 51-54): 121 (`teleport_access`, constructor default
-      # false) stayed **present** with value false even after an explicit
-      # ENABLE followed immediately by a DISABLE resetting it back to that
-      # same default, mid-event -- ruling out "omit at default" for this
-      # field and confirming the unconditional-write claim only for it (122
-      # was not independently probed this cycle but shares 121's exact code
-      # shape and command family, so is treated as the same convention by
-      # analogy pending its own direct check); by contrast 123
-      # (`save_access`, constructor default true) and 124 (`menu_access`,
-      # constructor default true) both went from **present** (value false)
-      # right after an explicit DISABLE to **absent** once a further ENABLE
-      # put them back to their own true default, still mid-event -- the same
-      # per-value "omit at default" convention already confirmed for fields
-      # 41-44/51-54/61/132, not the unconditional-write convention 121/122
-      # actually use. This codebase's own #to_lsd used to write all four
-      # fields unconditionally (`@save_access ? true : false` etc.,
-      # inherited from whichever earlier cycle wrote the doc comment this
-      # cycle corrected), so a save taken with save/menu access still at
-      # their own true default carried explicit `true`-valued bytes for
-      # fields 123/124 that a genuine RPG_RT.exe save never does -- the same
-      # species of over-writing bug cycles #152/#153/#160 already fixed for
-      # other fields in this schema.
-      sys[121] = @teleport_access ? true : false
-      sys[122] = @escape_access ? true : false
+      # are all ONE uniform "omit at true default" cluster after all --
+      # cycle #161 mistakenly split them into an "unconditional" pair
+      # (121/122) and an "omit at true default" pair (123/124), because its
+      # own probe for 121 only ever tested an ENABLE-then-DISABLE round trip
+      # that ends at the codebase's *assumed* false default -- a test that
+      # cannot distinguish "written unconditionally" from "written because
+      # false is actually the non-default value", and it never independently
+      # probed 122 at all (treated as sharing 121's convention "by analogy").
+      # Cycle #162 closed both gaps against genuine RPG_RT.exe under wine
+      # (same synthetic-autostart-event + Open-Save-Menu-with-no-Wait shape
+      # cycles #160/#161 used): an ENABLE-only probe for each of 121
+      # (`teleport_access`) and 122 (`escape_access`) -- leaving the flag at
+      # **true**, the opposite end from every previous probe -- came back
+      # with the field **absent**, while the project's own untouched
+      # continued-game baseline (where prior story events had already left
+      # both flags at false) and an ENABLE-then-DISABLE round trip (also
+      # ending at false) both came back **present** with value false. That
+      # present-at-false/absent-at-true split is exactly the per-value "omit
+      # at true default" convention already confirmed for 123/124 (and for
+      # fields 41-44/51-54/61/132 elsewhere in this schema) -- not a written-
+      # regardless-of-value convention -- which also means this codebase's
+      # own claimed *default* for 121/122 was backwards: genuine RPG_RT.exe
+      # treats Teleport and Escape as **allowed** until an event forbids
+      # them, the same on-by-default posture Save and Menu access already
+      # had, not forbidden-by-default as `Game::State#initialize` used to set
+      # (see its own updated comment above). This codebase's own #to_lsd used
+      # to write 121/122 unconditionally (`@teleport_access ? true : false`
+      # etc.), so a save taken with teleport/escape access still at their
+      # true default carried explicit `true`-valued bytes a genuine
+      # RPG_RT.exe save never does, the same species of over-writing bug
+      # cycles #152/#153/#160 already fixed elsewhere in this schema, now
+      # shown to cover this whole cluster.
+      sys[121] = false unless @teleport_access
+      sys[122] = false unless @escape_access
       sys[123] = false unless @save_access
       sys[124] = false unless @menu_access
       # Screen-transition slots 0..5 map to chunks 111..116 in order.
@@ -15838,8 +15848,16 @@ module Game
         pic = Picture.from_h(id, ph)
         state.pictures[id] = pic if pic
       end
-      state.teleport_access = h[:teleport_access] ? true : false
-      state.escape_access = h[:escape_access] ? true : false
+      # Cycle #162: these two used to coerce a missing key straight to false
+      # (`h[:teleport_access] ? true : false`) instead of falling back to the
+      # constructor default the way `#menu_access`/`#save_access` just above
+      # do -- harmless while the constructor default was itself false, but
+      # wrong now that it is true (see `Game::State#initialize`'s own
+      # comment): a quicksave written before these two keys existed should
+      # resume with Teleport/Escape allowed, the same "defaults on" fallback
+      # `#menu_access`/`#save_access` already give an older save.
+      state.teleport_access = h[:teleport_access] unless h[:teleport_access].nil?
+      state.escape_access = h[:escape_access] unless h[:escape_access].nil?
       # Registries default empty / unset; a save written before these existed
       # simply restores nothing.
       state.encounter_rate = h[:encounter_rate]

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4537,79 +4537,77 @@ check 'to_lsd omits SAVE_SYSTEM fields 51-54 (Change Face Graphic state) when ' 
   eq false, saved4.key?(54), 'field 54 absent (face_flipped still at its default, false)'
 end
 
-check 'to_lsd writes SAVE_SYSTEM fields 121/122 (teleport/escape access) ' \
-      'unconditionally but omits 123/124 (save/menu access) at their own ' \
-      'true default, matching genuine RPG_RT.exe' do
-  # Cycle #161: probed each of the four Control Teleport/Escape/Save/Menu
-  # Access fields independently against a genuine RPG_RT.exe save under wine
-  # (a synthetic autostart event issuing the matching Control command --
+check 'to_lsd omits SAVE_SYSTEM fields 121/122/123/124 (teleport/escape/' \
+      'save/menu access) alike at their own true default, matching genuine ' \
+      'RPG_RT.exe' do
+  # Cycle #161 probed all four Control Teleport/Escape/Save/Menu Access
+  # fields against a genuine RPG_RT.exe save under wine (a synthetic
+  # autostart event issuing the matching Control command --
   # 11820/11840/11930/11960 -- then Open Save Menu with no Wait in between,
-  # the same shape cycle #160 used for fields 51-54, continuing from the
-  # project's own baseline save whose inherited state already has
-  # teleport_access/escape_access/save_access all false and menu_access at
-  # its true default): 121 (teleport_allowed) stayed present with value
-  # false even right after an explicit ENABLE-then-DISABLE putting it back
-  # to that exact false default, mid-event -- an unconditional write. 123
-  # (save_allowed) went from present (false) right after an explicit DISABLE
-  # to fully absent once a further ENABLE put it back to its own true
-  # default, still mid-event; 124 (menu_allowed), never touched at all
-  # (still at its own true default), was absent from every capture, and an
-  # explicit DISABLE-then-ENABLE round trip (matching the "notouch" and
-  # "reset" pair already used for fields 51-54/132) showed the identical
-  # present-then-absent-again pattern -- the same per-value "omit at
-  # default" convention already confirmed for 41-44/51-54/61/132, not the
-  # unconditional-write convention 121/122 actually use and this codebase's
-  # own #to_lsd previously applied to all four alike (`@save_access ? true :
-  # false`, `@menu_access ? true : false`).
+  # the same shape cycle #160 used for fields 51-54) but only ever tested
+  # 121 with an ENABLE-then-DISABLE round trip that ends at the codebase's
+  # then-assumed false default -- a test that cannot tell "written
+  # unconditionally" apart from "written because false is the non-default
+  # value" -- and never independently probed 122 at all, concluding (wrongly)
+  # that 121/122 were an unconditional-write pair unlike 123/124's confirmed
+  # "omit at true default". Cycle #162 ran the missing ENABLE-only probe
+  # (leaving the flag at **true**, the untested end) for both 121 and 122
+  # against a genuine RPG_RT.exe save: both came back **absent**, exactly
+  # matching 123/124's own pattern and revealing that real RPG_RT.exe's
+  # actual default for Teleport/Escape access is **allowed** (true), not
+  # forbidden -- so all four fields share one "omit at true default"
+  # convention, and `Game::State#initialize`'s prior `false` default for
+  # teleport_access/escape_access was itself backwards.
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
 
   # A freshly-constructed state already sits at every one of these fields'
-  # own constructor default (teleport/escape_access false, save/menu_access
-  # true) -- exactly the "notouch" genuine capture shape.
+  # own constructor default (all four true) -- exactly the "notouch" genuine
+  # capture shape, and all four should be absent.
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   saved = st.to_lsd[101]
-  eq true, saved.key?(121), 'field 121 present even at its own false default (unconditional)'
-  eq false, saved[121], 'field 121 holds false'
-  eq true, saved.key?(122), 'field 122 present even at its own false default (unconditional)'
-  eq false, saved[122], 'field 122 holds false'
+  eq false, saved.key?(121), 'field 121 absent at its own true default (omit-at-default)'
+  eq false, saved.key?(122), 'field 122 absent at its own true default (omit-at-default)'
   eq false, saved.key?(123), 'field 123 absent at its own true default (omit-at-default)'
   eq false, saved.key?(124), 'field 124 absent at its own true default (omit-at-default)'
 
-  # Flip all four away from their defaults (Control Teleport/Escape/Save/Menu
-  # Access DISABLE/DISABLE/DISABLE/DISABLE) -- every field should now be
-  # present holding its changed (non-default) value.
+  # Flip all four away from their true defaults (Control Teleport/Escape/
+  # Save/Menu Access DISABLE/DISABLE/DISABLE/DISABLE) -- every field should
+  # now be present holding false.
   st2 = Game::State.new(Game::Party.new(db), 1, 0, 0)
-  st2.teleport_access = true   # away from its own false default
-  st2.escape_access = true     # away from its own false default
+  st2.teleport_access = false  # away from its own true default
+  st2.escape_access = false    # away from its own true default
   st2.save_access = false      # away from its own true default
   st2.menu_access = false      # away from its own true default
   saved2 = st2.to_lsd[101]
-  eq true, saved2.key?(121), 'field 121 present once teleport_access differs from its default'
-  eq true, saved2[121]
-  eq true, saved2.key?(122), 'field 122 present once escape_access differs from its default'
-  eq true, saved2[122]
-  eq true, saved2.key?(123), 'field 123 present once save_access differs from its default (true)'
+  eq true, saved2.key?(121), 'field 121 present once teleport_access differs from its true default'
+  eq false, saved2[121]
+  eq true, saved2.key?(122), 'field 122 present once escape_access differs from its true default'
+  eq false, saved2[122]
+  eq true, saved2.key?(123), 'field 123 present once save_access differs from its true default'
   eq false, saved2[123]
-  eq true, saved2.key?(124), 'field 124 present once menu_access differs from its default (true)'
+  eq true, saved2.key?(124), 'field 124 present once menu_access differs from its true default'
   eq false, saved2[124]
   round2 = Game::State.from_lsd(db, st2.to_lsd)
-  eq true, round2.teleport_access, 'teleport_access round-trips true'
-  eq true, round2.escape_access, 'escape_access round-trips true'
+  eq false, round2.teleport_access, 'teleport_access round-trips false'
+  eq false, round2.escape_access, 'escape_access round-trips false'
   eq false, round2.save_access, 'save_access round-trips false'
   eq false, round2.menu_access, 'menu_access round-trips false'
 
-  # Put 123/124 back to their own true default, still mid-scenario (no
+  # Put all four back to their own true default, still mid-scenario (no
   # save/load boundary crossed) -- mirrors the "reset" genuine-RPG_RT probe:
-  # the fields go absent again, not "present, but re-holding the default
-  # value". 121/122 stay present even back at their own false default,
-  # since they are unconditional.
-  st2.teleport_access = false
-  st2.escape_access = false
+  # every field goes absent again, not "present, but re-holding the default
+  # value".
+  st2.teleport_access = true
+  st2.escape_access = true
   st2.save_access = true
   st2.menu_access = true
   saved3 = st2.to_lsd[101]
-  eq true, saved3.key?(121), 'field 121 still present back at its own false default (unconditional)'
-  eq true, saved3.key?(122), 'field 122 still present back at its own false default (unconditional)'
+  eq false, saved3.key?(121),
+     'field 121 is absent again once teleport_access is put back to its true default, ' \
+     'not left present holding the default value'
+  eq false, saved3.key?(122),
+     'field 122 is absent again once escape_access is put back to its true default, ' \
+     'not left present holding the default value'
   eq false, saved3.key?(123),
      'field 123 is absent again once save_access is put back to its true default, ' \
      'not left present holding the default value'
@@ -10767,8 +10765,12 @@ end
 
 check 'Change Teleport / Escape Access toggle their flags, non-blocking' do
   st = party_state
-  eq false, st.teleport_access, 'teleport access defaults off'
-  eq false, st.escape_access, 'escape access defaults off'
+  # Cycle #162: confirmed against genuine RPG_RT.exe that these default
+  # **on** (allowed), not off -- see Game::State#initialize's own comment.
+  eq true, st.teleport_access, 'teleport access defaults on'
+  eq true, st.escape_access, 'escape access defaults on'
+  st.teleport_access = false
+  st.escape_access = false
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::CHANGE_TELEPORT_ACCESS, [1]),
             FakeCmd.new(IC::CHANGE_ESCAPE_ACCESS, [1]),
@@ -10797,13 +10799,28 @@ check 'Teleport / Escape access round-trip through the save' do
   loaded = Game::State.load(db, st.to_h)
   eq true, loaded.teleport_access
   eq true, loaded.escape_access
-  # A save written before these existed defaults them off.
+
+  # A save written before these existed defaults them **on** -- cycle #162:
+  # `.from_h` used to coerce a missing key straight to false
+  # (`h[:teleport_access] ? true : false`) instead of falling back to the
+  # constructor default the way `#menu_access`/`#save_access` do; fixed to
+  # match, and the constructor default itself is now true (confirmed against
+  # genuine RPG_RT.exe), so a legacy save missing the key resumes allowed.
   legacy = st.to_h
   legacy.delete(:teleport_access)
   legacy.delete(:escape_access)
   legacy_loaded = Game::State.load(db, legacy)
-  eq false, legacy_loaded.teleport_access
-  eq false, legacy_loaded.escape_access
+  eq true, legacy_loaded.teleport_access
+  eq true, legacy_loaded.escape_access
+
+  # An explicit false still round-trips as false, not swallowed by the new
+  # constructor-default fallback.
+  st2 = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st2.teleport_access = false
+  st2.escape_access = false
+  loaded2 = Game::State.load(db, st2.to_h)
+  eq false, loaded2.teleport_access, 'an explicit false still loads as false'
+  eq false, loaded2.escape_access, 'an explicit false still loads as false'
 end
 
 # -- EXP / level (Change EXP / Change Level) ---------------------------------


### PR DESCRIPTION
## Summary

- Cycle #161 left an explicit open item: SAVE_SYSTEM field 122 (`escape_allowed`) was never independently probed against genuine RPG_RT.exe, and was assumed by analogy to share field 121's "unconditional write" convention. That analogy — and cycle #161's own conclusion about field 121 — were both wrong.
- The gap in cycle #161's own probe: it only ever tested an ENABLE-then-DISABLE round trip ending at the codebase's *assumed* false default, which can't distinguish "written unconditionally" from "written because false is the non-default value". This cycle ran the missing ENABLE-only probe (ending at **true**) against genuine RPG_RT.exe: both fields 121 and 122 came back **absent**, matching the "omit at true default" convention already confirmed for fields 123/124 — meaning real RPG_RT.exe's own default for Teleport/Escape access is **allowed**, not forbidden.
- Fixed `Game::State#initialize`'s `teleport_access`/`escape_access` defaults to `true` (were `false`), made `#to_lsd` omit fields 121/122 unless explicitly disabled (were unconditional writes), and fixed a latent `.from_h` bug where a missing legacy quicksave key coerced straight to `false` instead of falling back to the constructor default like `#menu_access`/`#save_access` already do.

## Verification

- Reused cycle #161's own scratch injector/driver, adding the untested ENABLE-only scenario shape, and drove genuine RPG_RT.exe under wine (Xvfb, matchbox, `LIBGL_ALWAYS_SOFTWARE=1`, `ja_JP.UTF-8`) through `escape_reset`/`escape_on`/`teleport_on` scenarios, reading each real `Save0N.lsd`'s chunk 101 with `LCF::SaveData`/`Array1D#key?`.
- `git stash` of just `game.rb`/`schema.rb` (keeping the extended check file) reproduces 3 clean check failures against the pre-fix code; restoring the fix makes them pass again.
- Full suite passes: `rpg2k_scene_check.rb` (929), `rpg2k_render_check.rb` (41), `rpg2k_logic_check.rb` (1144, extended in place), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15).
- `rpg2k_save_load_check.rb`'s 3 known pre-existing failures (BGM `balance`, `show_x`/`show_y`, transition-defaults warning) reconfirmed unrelated via `git stash`.
- `data/` fixtures restored byte-identical (same md5s recorded since cycle #148).
- No EasyRPG source consulted for any claim.

## Changelog

See `changelog.d/teleport-escape-access-default.fixed.md`.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb`
- [x] `ruby scripts/rpg2k_scene_check.rb`
- [x] `ruby scripts/rpg2k_render_check.rb`
- [x] `ruby scripts/rpg2k3_battle_row_check.rb`
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb`
- [x] `ruby scripts/rpg2k_save_load_check.rb` (3 pre-existing unrelated failures reconfirmed via `git stash`)
- [x] `cmake --build build --target rpg_maker_clone` links cleanly


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_