### PR TITLE
Pictures: Erase Picture no longer freezes an in-flight Move Picture

### DIFF
--- a/changelog.d/erase-picture-mid-move.fixed.md
+++ b/changelog.d/erase-picture-mid-move.fixed.md
@@ -1,0 +1,8 @@
+- **Pictures:** Calling Erase Picture on a picture that is still animating
+  toward a target from a Move Picture command no longer freezes it in place.
+  It now keeps gliding invisibly toward its old destination and only settles
+  once the move's own duration elapses, matching RPG_RT. This is only
+  observable through a saved game made while the picture is still gliding
+  (its saved position/countdown keep advancing instead of being stuck), so a
+  save made shortly after such an Erase Picture will now restore a picture
+  further along its old path than before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4039,6 +4039,87 @@ The work below is roughly ordered by the critical path to a walkable game
   missing-Picture-asset hang; and every EasyRPG-style citation cycle #154's
   own repo-wide grep turned up that no cycle has yet touched (see cycle
   #154's own list, unchanged).
+  ✅ **Follow-up (cycle #163, 2026-08-26): picked up cycle #159's own open
+  item, still unresolved through cycle #162 -- whether a picture still
+  mid-Move-Picture at the instant of Erase Picture freezes at its live
+  interpolated position or keeps gliding invisibly toward its old target --
+  and settled it with a genuine RPG_RT.exe capture pair, landing a real
+  fix.** **Evidence:** reused cycle #155/#159's own scratch injector/driver
+  shape (`inject_picture_probe.rb`, `drive_picture_probe.bash`, both still
+  present in this session's scratchpad, untouched) to build a new injector
+  (`inject_erase_mid_move.rb`) with two scenarios sharing one Show Picture
+  (id 5, x=50,y=50) -> Move Picture (to x=250,y=250 over 10.0s, wait flag
+  OFF so the event continues immediately while the picture keeps gliding)
+  -> Erase Picture 5 (the very next command, no wait in between) -> Wait N
+  -> Open Save Menu sequence, differing only in N (`erase_early` = 1.0s,
+  `erase_late` = 5.0s). Drove genuine RPG_RT.exe under wine (Xvfb
+  640x480x16, matchbox, `LIBGL_ALWAYS_SOFTWARE=1`, `ja_JP.UTF-8`,
+  `WINEARCH=win32`/`WINEPREFIX=~/.wine-nepheshel32`, continuing from the
+  same clean Save01.lsd cycles #155-#162 used, `BOOT_WAIT=35`) through both
+  scenarios, saving into empty slot 2 each time, then read each resulting
+  genuine Save02.lsd's raw chunk 103 with `read_picture_chunk.rb` (cycle
+  #155's own raw-field reader): `erase_early` came back with field 4/5
+  (current_x/current_y) at **70.0** and field 51 (time_left) at **540**;
+  `erase_late` came back with field 4/5 at **150.0** and field 51 at
+  **300**. Both current_x/y values sit strictly between the 50/250
+  endpoints and *increase* with elapsed time since the erase -- the
+  opposite of what freezing predicts (which would read identically in both
+  captures, pinned at whatever position the picture held the instant Erase
+  Picture ran) -- and the time_left drop (540 to 300, a 240-frame gap
+  across 4.0s of extra wait) is internally consistent with a 60fps engine
+  and the move's own 600-frame/10.0s total (540 + 1.0s*60fps = 600):
+  decisive proof the move keeps running to completion in the background,
+  invisibly, exactly as if Erase Picture had never been issued except for
+  the drawn sprite itself. **Fixed:** `Game::Picture#erase!` no longer
+  forces `@frames = 0` -- it already happens for free once that line is
+  gone, since `Game::State#update_pictures` (`@pictures.each_value(&:
+  update)`) already iterates every id in `@pictures` regardless of
+  `#shown?`. Also corrected a stale comment above `Game::State#to_lsd`'s
+  own picture-writing loop left over from before cycle #159's fix, which
+  still claimed "`#erase_picture` deletes the entry outright" -- directly
+  contradicted by the actual code (and by `#erase_picture`'s own correct
+  neighbouring comment) ever since cycle #159 changed it to keep the
+  `Picture` object around instead. **New coverage in
+  `scripts/rpg2k_logic_check.rb`:** added "Erase Picture mid-Move-Picture
+  does NOT freeze the move" replaying the same Show -> Move (wait off) ->
+  Erase shape at the interpreter level, then advancing frames and asserting
+  the picture is still invisible *and* still interpolating (`x` strictly
+  past its erase-instant value), and finally that running out the rest of
+  the move's own duration lands it exactly on the target and stops --
+  matching a shown picture's own completion behaviour. **Proved the fix and
+  the new check actually catch the regression:** `git stash push --
+  mruby-rpg2k/mrblib/game.rb` (keeping the new check in
+  `scripts/rpg2k_logic_check.rb`) reverted to the pre-fix code and rerunning
+  `rpg2k_logic_check.rb` failed immediately with `RuntimeError: but the
+  move itself is still in flight right after erase` before `git stash pop`
+  restored the fix and all checks passed again. Full suite reconfirmed
+  passing after the fix: `scripts/rpg2k_scene_check.rb` (929),
+  `scripts/rpg2k_render_check.rb` (41), `scripts/rpg2k_logic_check.rb`
+  (1145, up from 1144 -- one new check added), `scripts/
+  rpg2k3_battle_row_check.rb` (19) and `scripts/rpg2k3_battle_gauge_check.rb`
+  (15); `scripts/rpg2k_save_load_check.rb`'s own 3 pre-existing failures
+  (the unmodelled BGM `balance` field, the `show_x`/`show_y` `nil`-vs-absent
+  mismatch, and the "screen transition defaults unreadable" stderr warning)
+  were reconfirmed present identically before and after this cycle's
+  changes. This cycle also built the mruby engine binary from source
+  (`cmake --build build --target rpg_maker_clone`, using the two
+  hash-pinned Unicode tables already fetched to `/tmp/tables` by an earlier
+  cycle) and confirmed it links cleanly. Every scratch map/save this cycle's
+  probes produced lived entirely under this session's own scratch dir; the
+  two live fixtures the wine driver copies into `data/` on each run
+  (`Save01.lsd`, `Map0012.lmu`) were restored to their exact original bytes
+  and reconfirmed byte-identical by `md5sum` against the same
+  `c2fa69a0.../3ab5bb01...` values every prior cycle back to #148 recorded;
+  `git status` on `data/` came back clean. No EasyRPG source was consulted
+  for any claim this cycle, and no web search was used either. **Left open
+  for a future cycle:** everything cycle #162's own "left open" list still
+  names, now minus the Erase-Picture-mid-move item this cycle closed --
+  field 140 (`atb_mode`)'s version-gate-vs-always-default question,
+  `SAVE_PICTURE` field 9, `SAVE_PICTURE`'s own still-missing
+  `fixed_to_map`/`use_transparent_color` fields, the party-roster-field
+  crash, the autostart-crash mystery, the missing-Picture-asset hang, and
+  every EasyRPG-style citation cycle #154's own repo-wide grep turned up
+  that no cycle has yet touched.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8562,7 +8562,9 @@ module Game
     # #erase! turns this false. An id that has never been shown at all has no
     # `Picture` object in `Game::State#pictures` to begin with (see
     # `#erase_picture`'s own comment), so this predicate only ever needs to
-    # distinguish "currently shown" from "was shown, now erased".
+    # distinguish "currently shown" from "was shown, now erased". Deliberately
+    # independent of #moving? -- see #erase!'s own comment: an erased picture
+    # can still be moving (invisibly) for a while after this goes false.
     def shown?; @shown; end
 
     def initialize(id, opts = {})
@@ -8604,35 +8606,54 @@ module Game
 
     # Erase Picture (11130): turns #shown? false (so nothing draws --
     # `Scene::Map#draw_pictures` gates on it explicitly, since the name
-    # itself is deliberately left alone here, see below) and halts any
-    # in-flight move, but otherwise leaves name/position/zoom/tone exactly as
-    # they stood at the moment of erasure -- confirmed against genuine
-    # RPG_RT.exe under wine (cycle #159): a Show Picture immediately followed
-    # by Erase Picture, then an Open Save Menu, produced a genuine `.lsd`
-    # chunk 103 entry with field 1 (name) *absent* but fields
-    # 2/3/4/5/7/8/11-14/31/32/33/34/41-44 all still *present*, carrying the
-    # exact values the picture held before erasure -- decisively distinct
-    # from an id that was never shown at all, which cycle #154 already
-    # established writes as a fully field-less placeholder (every one of
-    # those fields absent, not merely zero). `#to_lsd` reads `#shown?`, not
-    # `#name`, to decide whether to write field 1 -- `@name` itself is left
-    # untouched here (rather than cleared) because several pre-existing
+    # itself is deliberately left alone here, see below) but otherwise leaves
+    # name/position/zoom/tone exactly as they stood at the moment of erasure,
+    # and -- confirmed by cycle #163, see below -- does NOT halt an in-flight
+    # move: a picture erased mid-Move-Picture keeps gliding invisibly toward
+    # its old target and only stops when the move's own duration elapses.
+    # Confirmed against genuine RPG_RT.exe under wine (cycle #159): a Show
+    # Picture immediately followed by Erase Picture, then an Open Save Menu,
+    # produced a genuine `.lsd` chunk 103 entry with field 1 (name) *absent*
+    # but fields 2/3/4/5/7/8/11-14/31/32/33/34/41-44 all still *present*,
+    # carrying the exact values the picture held before erasure -- decisively
+    # distinct from an id that was never shown at all, which cycle #154
+    # already established writes as a fully field-less placeholder (every one
+    # of those fields absent, not merely zero). `#to_lsd` reads `#shown?`,
+    # not `#name`, to decide whether to write field 1 -- `@name` itself is
+    # left untouched here (rather than cleared) because several pre-existing
     # scene-check fixtures build a `Picture.new` directly with no `:name` at
     # all, purely to seed a position, and must still read as shown; clearing
     # `@name` on erasure would have made an *empty* name ambiguous between
     # "never had one" and "erased". `Game::State` keeps this `Picture` object
     # in `@pictures` after an erase (see `#erase_picture`) specifically so
     # `#to_lsd` can still read these fields back out.
+    #
     # Whether a picture still mid-move at the moment of Erase Picture freezes
-    # at its live interpolated position (as here, forcing frames to 0) or
-    # keeps gliding toward its old target was not tested this cycle -- this
-    # is the conservative reading (RPG_RT's own event thread is
-    # single-stepped, so nothing else could still be advancing the move
-    # in the same instant Erase Picture runs) and errs toward *not*
-    # inventing unverified motion, not toward matching a real capture.
+    # at its live interpolated position or keeps gliding toward its old
+    # target (left open by cycle #159, still open through cycle #162) is now
+    # settled: cycle #163 drove genuine RPG_RT.exe under wine through two
+    # scenarios sharing one Show Picture (x=50,y=50) -> Move Picture (to
+    # x=250,y=250 over 10.0s, wait flag off) -> Erase Picture -> Wait N ->
+    # Open Save Menu sequence, differing only in N (1.0s vs 5.0s), and read
+    # each resulting genuine Save0N.lsd's raw chunk 103 with
+    # `LCF::SaveData` + the raw-field reader: field 4/5 (current_x/y) came
+    # back **70.0** after the 1.0s wait and **150.0** after the 5.0s wait --
+    # both strictly between the 50/250 endpoints and increasing with elapsed
+    # time since the erase, not frozen at a single value -- while field 51
+    # (time_left) came back 540 and 300 respectively, a 240-frame drop across
+    # 4.0s of extra elapsed time (60fps, matching the 600-frame/10.0s move
+    # total implied by 540 + 1.0s*60fps). A frozen picture would have shown
+    # identical current_x/y and time_left in both captures regardless of N;
+    # instead both tracked continued, undisturbed progress toward the
+    # original target exactly as if Erase Picture had never been issued,
+    # except for the drawn sprite itself. This is simply what already
+    # happens for free once `#erase!` stops forcing `@frames` to 0: `Game::
+    # State#update_pictures` (`@pictures.each_value(&:update)`) already
+    # iterates every id in `@pictures` regardless of `#shown?`, so an erased-
+    # but-still-moving `Picture` keeps ticking down and interpolating exactly
+    # like a shown one, invisibly, until its own move naturally completes.
     def erase!
       @shown = false
-      @frames = 0
     end
 
     # Advance one frame of the in-flight move (a no-op when at rest). Every
@@ -15044,10 +15065,11 @@ module Game
       # array entirely unless a picture has ever been shown there" shape
       # (which also, as a side effect, only ever emitted however many ids
       # had been *touched*, never the full 50-wide range genuine RPG_RT.exe
-      # always carries). `@pictures` only ever holds currently-shown pictures
-      # (#erase_picture deletes the entry outright), so an ordinary shown
-      # picture is a slot with an entry here and an untouched slot is
-      # nil/absent from `@pictures`, both handled below.
+      # always carries). `@pictures` holds every id ever shown, including an
+      # erased one (see `#erase_picture`'s own comment -- the entry lingers
+      # so its fields keep round-tripping through here), so a shown-or-
+      # erased id is a slot with an entry here and only a genuinely
+      # untouched id is nil/absent from `@pictures`, both handled below.
       #
       # Field mapping is the exact mirror of `.restore_pictures`' own read
       # (see `SAVE_PICTURE`'s own comment for the full evidence behind each

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9955,6 +9955,63 @@ check 'to_lsd writes an erased-but-previously-shown picture with its stale ' \
      'a never-touched id carries no fields at all, not even absent-name'
 end
 
+check 'Erase Picture mid-Move-Picture does NOT freeze the move: the picture ' \
+      'keeps gliding invisibly toward its old target, matching genuine ' \
+      'RPG_RT.exe (cycle #163)' do
+  # Cycle #163 drove genuine RPG_RT.exe under wine through two scenarios
+  # sharing one Show Picture (id 5, x=50,y=50) -> Move Picture (to
+  # x=250,y=250 over 10.0s, wait flag off, so the event continues
+  # immediately while the picture is still gliding) -> Erase Picture 5 ->
+  # Wait N -> Open Save Menu sequence, differing only in N (1.0s vs 5.0s),
+  # and read each resulting genuine Save0N.lsd's raw chunk 103: field 4/5
+  # (current_x/current_y) came back 70.0 after the 1.0s wait and 150.0
+  # after the 5.0s wait -- strictly between the 50/250 endpoints and
+  # increasing with elapsed time since the erase, not frozen at a single
+  # value -- while field 51 (time_left) came back 540 then 300, a
+  # 240-frame drop across 4.0s of extra elapsed time (60fps, matching the
+  # 600-frame/10.0s move total implied by 540 + 1.0s*60fps). A frozen
+  # picture would have shown identical current_x/y and time_left in both
+  # captures regardless of N. This replays that same shape at the
+  # interpreter level: Show -> Move (wait off) -> Erase, immediately
+  # followed, then advances a handful of frames and checks the picture is
+  # still interpolating rather than stuck at its erase-instant position.
+  st = new_state
+  show = Game::Interpreter.new(st)
+  show.start([FakeCmd.new(IC::SHOW_PICTURE,
+                          [5, 0, 50, 50, 0, 100, 0, 0, 100, 100, 100, 100],
+                          string: 'p')])
+  show.update
+
+  mv = Game::Interpreter.new(st)
+  mv.start([FakeCmd.new(IC::MOVE_PICTURE,
+                        [5, 0, 250, 250, 0, 100, 0, 0, 100, 100, 100, 100,
+                         0, 0, 100, 0])]) # 100 tenths = 10.0s, wait flag off
+  mv.update
+
+  er = Game::Interpreter.new(st)
+  er.start([FakeCmd.new(IC::ERASE_PICTURE, [5])])
+  er.update
+
+  p = st.pictures[5]
+  ok !p.shown?, 'erased: nothing draws'
+  ok p.moving?, 'but the move itself is still in flight right after erase'
+  x_at_erase = p.x
+
+  30.times { st.update_pictures }
+  ok !p.shown?, 'still invisible 30 frames later'
+  ok p.moving?, 'still gliding 30 frames later -- erase did not freeze it'
+  ok p.x > x_at_erase, "current x kept advancing toward the target " \
+                        "(#{x_at_erase} -> #{p.x}), matching the genuine " \
+                        "70.0/150.0 divergence cycle #163 captured"
+
+  # Run out the rest of the move's own duration: it must land exactly on
+  # the target and then stop, the same as a shown picture would.
+  600.times { st.update_pictures }
+  ok !p.moving?, 'the move completes on its own once the duration elapses'
+  eq 250, p.x
+  eq 250, p.y
+end
+
 check 'Show Picture on an id past the 50-slot range is a no-op' do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

- Cycle #159 left this as an explicitly unverified assumption: Erase Picture forced a moving picture's remaining frames to 0, reasoning conservatively (never tested) that RPG_RT's single-stepped event thread couldn't still be advancing the move after erasure.
- Driving genuine RPG_RT.exe under wine through a Show Picture → Move Picture (10s, wait flag off) → Erase Picture → Wait N → Open Save Menu sequence at two different N values (1.0s and 5.0s) shows the saved picture's position and move countdown both keep advancing between captures, strictly between the move's endpoints and tracking elapsed time at 60fps — the opposite of frozen.
- Erase Picture only hides the sprite; the move keeps running to completion in the background exactly as if it had never been erased.

## Fix

`Game::Picture#erase!` no longer clears `@frames`. Nothing else needed — `Game::State#update_pictures` already updates every picture regardless of `#shown?`, so an erased-but-still-moving picture keeps interpolating and counting down invisibly until its own duration elapses.

## Verification

- Genuine RPG_RT.exe under wine (Xvfb, matchbox, `LIBGL_ALWAYS_SOFTWARE=1`, `ja_JP.UTF-8`, `WINEARCH=win32`/`WINEPREFIX=~/.wine-nepheshel32`): two scenarios sharing one Show→Move→Erase sequence, differing only in the wait before Open Save Menu (1.0s vs 5.0s). Reading raw chunk 103 fields 4/5 (current_x/y) and 51 (time_left) from each genuine `Save0N.lsd`:
  - 1.0s wait: current_x/y = 70.0, time_left = 540
  - 5.0s wait: current_x/y = 150.0, time_left = 300
  - Both strictly between the 50/250 move endpoints, tracking a consistent 60fps countdown — decisive against "frozen".
- `git stash` of just the `game.rb` fix (keeping the new check) reproduces a clean failure against the pre-fix code; restoring the fix passes again.
- Full suite passes: `rpg2k_scene_check.rb` (929), `rpg2k_render_check.rb` (41), `rpg2k_logic_check.rb` (1145, one new check added), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15).
- `rpg2k_save_load_check.rb`'s 3 known pre-existing failures (BGM `balance`, `show_x`/`show_y`, transition-defaults warning) reconfirmed identical before/after, unrelated to this change.
- `data/` fixtures restored byte-identical.
- No EasyRPG source consulted for any claim.

## Changelog

See `changelog.d/erase-picture-mid-move.fixed.md`.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb`
- [x] `ruby scripts/rpg2k_scene_check.rb`
- [x] `ruby scripts/rpg2k_render_check.rb`
- [x] `ruby scripts/rpg2k3_battle_row_check.rb`
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb`
- [x] `ruby scripts/rpg2k_save_load_check.rb` (3 pre-existing unrelated failures reconfirmed via `git stash`)
- [x] `cmake --build build --target rpg_maker_clone` links cleanly


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_