### PR TITLE
Fix blt row-copy fast path alpha check for mixed-opacity rows

### DIFF
--- a/changelog.d/blt-opaque-row-alpha-check.fixed.md
+++ b/changelog.d/blt-opaque-row-alpha-check.fixed.md
@@ -1,0 +1,11 @@
+- **`Bitmap#blt`/`#blt_quads`'s row-copy fast path no longer mistakes a
+  partially-transparent row for a fully opaque one.** The scan that decides
+  whether a source row can be `memcpy`'d straight across stopped as soon as it
+  found *one* pixel with alpha 255, instead of confirming every pixel in the
+  row was opaque, so a row with both opaque and transparent pixels (exactly
+  what an autotile quarter-tile's diagonal corner mask looks like) got copied
+  verbatim — pasting the transparent pixel's raw, typically black, source
+  bytes over the destination instead of leaving it alone. This is what made
+  chipset autotile corners render as black instead of blending. Covered by a
+  new `mruby-rgss/test/test.rb` case that blits a mixed-alpha row and asserts
+  the transparent pixel leaves the destination untouched.

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1929,8 +1929,11 @@ static void blt_pixels(Bitmap& dst,
       uint8_t* d =
           dst.buffer.data() + ((size_t)(y + row) * dst.width + x) * bpp;
       bool opaque = bpp < 4;
-      for (mrb_int col = 0; !opaque && col < w; ++col)
-        opaque = s[(size_t)col * bpp + 3] == 255;
+      if (!opaque) {
+        opaque = true;
+        for (mrb_int col = 0; opaque && col < w; ++col)
+          opaque = s[(size_t)col * bpp + 3] == 255;
+      }
       if (opaque)
         std::memcpy(d, s, (size_t)w * bpp);
       else

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -669,6 +669,39 @@ assert "RGSS::Bitmap blt_quads matches per-quad blt" do
   end
 end
 
+assert "RGSS::Bitmap blt_quads blends a row with only some opaque pixels" do
+  # The batch's row-copy fast path only memcpy's a source row when *every*
+  # pixel in it is fully opaque (alpha 255) -- a row with a mix of opaque and
+  # non-opaque pixels must still blend pixel by pixel. This is exactly the
+  # shape of an autotile quarter-tile: a solid chip next to a transparent
+  # corner mask in the same row. Misclassifying such a row as opaque memcpy's
+  # the transparent pixel's raw (typically black) source bytes straight over
+  # the destination instead of leaving it alone, blacking out the corner.
+  src = RGSS::Bitmap.new(2, 1)
+  src.set_pixel(0, 0, RGSS::Color.new(10, 200, 30, 255))  # opaque
+  src.set_pixel(1, 0, RGSS::Color.new(0, 0, 0, 0))        # fully transparent
+
+  under = RGSS::Color.new(50, 60, 200, 255)
+  want = RGSS::Bitmap.new(2, 1)
+  want.fill_rect(0, 0, 2, 1, under)
+  want.blt(0, 0, src, RGSS::Rect.new(0, 0, 2, 1))
+
+  got = RGSS::Bitmap.new(2, 1)
+  got.fill_rect(0, 0, 2, 1, under)
+  got.blt_quads(0, 0, src, [[0, 0, 0, 0, 2, 1]])
+
+  2.times do |x|
+    w, g = want.get_pixel(x, 0), got.get_pixel(x, 0)
+    assert_equal w.red, g.red, "red at #{x}"
+    assert_equal w.green, g.green, "green at #{x}"
+    assert_equal w.blue, g.blue, "blue at #{x}"
+    assert_equal w.alpha, g.alpha, "alpha at #{x}"
+  end
+  # The transparent pixel must leave the destination untouched, not paint it
+  # black -- the failure mode the row-copy fast path's bug produced.
+  assert_equal 200.0, got.get_pixel(1, 0).blue
+end
+
 assert "RGSS::Bitmap copy_blt matches blt onto a cleared destination" do
   # The justification for #copy_blt is that onto a *cleared* destination it
   # shows the same picture as #blt -- that is what lets the map renderer swap


### PR DESCRIPTION
## Summary
Fixed a bug in `Bitmap#blt` and `#blt_quads` where the row-copy optimization incorrectly classified rows with mixed opaque and transparent pixels as fully opaque, causing transparent pixels to be copied verbatim instead of blended. This manifested as black corners on autotile chipsets.

## Changes
- **Fixed alpha opacity scan logic** in `mruby-rgss/src/lib.cxx`: Changed the loop condition from stopping at the first opaque pixel (`!opaque && col < w`) to continuing until a non-opaque pixel is found (`opaque && col < w`). The original logic would exit early when finding alpha=255, incorrectly marking the row as opaque without checking remaining pixels.
- **Added comprehensive test case** in `mruby-rgss/test/test.rb`: New assertion that verifies `blt_quads` correctly blends a row containing both opaque and fully transparent pixels, ensuring the transparent pixel leaves the destination untouched rather than painting it black.
- **Added changelog entry** documenting the fix and its impact on autotile rendering.

## Implementation Details
The bug was in the row-copy fast path optimization that uses `memcpy` when all pixels in a source row are fully opaque (alpha=255). The scan loop had inverted logic: it would set `opaque = true` and exit as soon as it found a single pixel with alpha=255, rather than verifying that *all* pixels were opaque. This caused rows with mixed opacity (like autotile corner masks with a solid chip and transparent corner) to be incorrectly fast-pathed, copying raw source bytes including the transparent pixel's typically-black color values directly over the destination.

https://claude.ai/code/session_0156CEVTuSK4VWytP8W4yBqc