### PR TITLE
Save/Load: Picture's fixed-to-map and transparent-color flags now persist

### DIFF
--- a/changelog.d/picture-fixed-to-map-transparent-color-save.fixed.md
+++ b/changelog.d/picture-fixed-to-map-transparent-color-save.fixed.md
@@ -1,0 +1,8 @@
+- **Pictures:** A picture shown with "fixed to map position" (so it scrolls
+  with the camera instead of the screen) or "not affected by transparent
+  color" now keeps that setting across a Save/Continue. Previously neither
+  flag was saved at all, so loading a save made while such a picture was on
+  screen silently reverted it to the opposite behavior -- a map-scrolling
+  picture would jump to being screen-fixed, or a picture exempted from the
+  transparent color would start honoring it again, the moment the save was
+  loaded.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4120,6 +4120,84 @@ The work below is roughly ordered by the critical path to a walkable game
   crash, the autostart-crash mystery, the missing-Picture-asset hang, and
   every EasyRPG-style citation cycle #154's own repo-wide grep turned up
   that no cycle has yet touched.
+  ✅ **Follow-up (cycle #164, 2026-08-26): picked up this cycle's own open
+  item -- `SAVE_PICTURE` field 9's true identity and the still-missing
+  `fixed_to_map`/`use_transparent_color` fields -- and settled both at
+  once.** **Evidence:** reused cycle #155/#163's own scratch injector/
+  driver shape (new `inject_picture_flags.rb`, `inject_double_move.rb`,
+  `inject_reshow_mid_move.rb`, all now in this session's scratchpad) to
+  drive genuine RPG_RT.exe under wine (same Xvfb/matchbox/
+  `LIBGL_ALWAYS_SOFTWARE=1`/`ja_JP.UTF-8`/`WINEARCH=win32`/
+  `WINEPREFIX=~/.wine-nepheshel32` setup, same clean Save01.lsd cycles
+  #155-#163 used) through four otherwise-identical Show Picture scenarios
+  differing only in param4 (`fixed_to_map`) / param7
+  (`use_transparent_color`): base (both clear), fixed (param4 set), transparent
+  (param7 set), both (both set). Reading each resulting genuine Save02.lsd's
+  raw chunk 103 with `read_picture_chunk.rb` (cycle #155's own raw-field
+  reader) found field 6 present as a lone `0x01` byte **only** in the
+  fixed/both captures and field 9 present the same way **only** in the
+  transparent/both captures -- absent from base in both cases, and both
+  fields present *simultaneously and independently* in the "both" capture
+  (ruling out any bit-packing between them). This directly overturns the
+  schema's prior field-9 guess (`:visible`, explicitly flagged "never
+  confirmed" across cycles #154/#155/#159): those three cycles' own five
+  capture shapes never once varied the transparent-color flag, so the
+  absence they observed was simply the wrong experiment, not proof the
+  field is unused. Separately, reused the same shape to settle two open
+  questions from this cycle's own candidate list about re-issuing a Move/
+  Show Picture mid-flight: a second Move Picture issued on a picture already
+  gliding (id 5, 0,100 -> 100,100 over 10.0s wait off -> Wait 3.0s -> 100,100
+  -> 250,100 over 10.0s wait off -> Wait N) produced current_x readings of
+  exactly 52.0 (N=1.0s) and 140.0 (N=5.0s) -- decisively matching the
+  "continues easing from the current live position" model
+  (30+(250-30)*k/600) and ruling out "snaps to the first move's own target
+  first" (which predicts 115.0/175.0) -- and a Show Picture re-issued on an
+  id already mid-move (same setup, then Show Picture again at 200,100 mid-
+  glide) produced current_x=200.0 with `time_left` absent, confirming Show
+  Picture unconditionally cancels any in-flight move and snaps to the fresh
+  position at rest. Both of those already matched this codebase's existing
+  `Game::Picture#move_to`/`#show_picture` behavior exactly, so no change was
+  needed for either -- only the field-6/9 gap was a real, fixable
+  divergence. **Fixed:** `SAVE_PICTURE` (`mruby-lcf/mrblib/schema.rb`) now
+  declares field 6 as `fixed_to_map` and renames field 9 from `:visible` to
+  `use_transparent_color`, both booleans elided at their own `false`
+  default like every other picture flag in the table. `Game::State#to_lsd`'s
+  picture-writing loop now writes `e[6]`/`e[9]` from `p.fixed_to_map`/
+  `p.use_transparent_color`, and `Game::State.restore_pictures` now passes
+  `fixed_to_map:`/`use_transparent_color:` through to `#show_picture` on
+  load -- previously neither flag was written or read at all, so a picture
+  shown fixed-to-the-map or exempted from the transparent color silently
+  reverted to the opposite behavior on every Save/Continue round trip.
+  **New coverage in `scripts/rpg2k_save_load_check.rb`:** the existing
+  `to_lsd`/`from_lsd` round-trip block now also shows a picture with both
+  flags set before serializing, and asserts the reloaded picture keeps both
+  -- proved to fail cleanly against the pre-fix code (`git stash push --
+  mruby-rpg2k/mrblib/game.rb mruby-lcf/mrblib/schema.rb`, keeping the new
+  check, reran the script: both new assertions failed with `expected true,
+  got false`, error count 3 -> 5; `git stash pop` restored the fix and the
+  count back to 3). Full suite reconfirmed passing after the fix:
+  `scripts/rpg2k_scene_check.rb` (929), `scripts/rpg2k_logic_check.rb`
+  (1145), `scripts/rpg2k_render_check.rb` (41), `scripts/
+  rpg2k3_battle_row_check.rb` (19) and `scripts/rpg2k3_battle_gauge_check.rb`
+  (15); `scripts/rpg2k_save_load_check.rb`'s own 3 pre-existing failures
+  (the unmodelled BGM `balance` field, the `show_x`/`show_y` `nil`-vs-absent
+  mismatch, and the "screen transition defaults unreadable" stderr warning)
+  were reconfirmed present identically before and after this cycle's
+  changes -- the show_x/show_y failure's own diff now additionally shows
+  the two new keys on both sides of the mismatch, which is the same
+  pre-existing failure widened by this cycle's new fields, not a new one.
+  The two live fixtures the wine driver copies into `data/` on each run
+  (`Save01.lsd`, `Map0012.lmu`) were restored to their exact original bytes
+  and reconfirmed byte-identical by `md5sum` against the same
+  `3ab5bb01.../c2fa69a0...` values every prior cycle back to #148 recorded;
+  `git status` on `data/` came back clean. No EasyRPG source was consulted
+  for any claim this cycle, and no web search was used either. **Left open
+  for a future cycle:** field 140 (`atb_mode`)'s version-gate-vs-always-
+  default question (still needs a genuine RPG2003 project or an
+  ATB-toggling save -- none is available among this repo's own wine-testable
+  fixtures), the party-roster-field crash, the autostart-crash mystery, the
+  missing-Picture-asset hang, and every EasyRPG-style citation cycle #154's
+  own repo-wide grep turned up that no cycle has yet touched.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1231,6 +1231,16 @@ module LCF
     # -- see docs/TODO.md.
     SAVE_PICTURE = {
       1 => { name: :name, type: :string },              # ピクチャグラフィックのファイル名
+      # Show Picture's own "fixed to map position" checkbox (param4 in
+      # `Interpreter#do_show_picture`, which pins the picture to scroll with
+      # the camera instead of the screen). Confirmed against genuine
+      # RPG_RT.exe under wine (cycle #164): a Show Picture issued with this
+      # flag clear wrote chunk 103 with field 6 *absent*; an otherwise
+      # byte-identical Show Picture with only this flag set wrote field 6
+      # *present* as a single `0x01` byte -- elided at its own (false)
+      # default, the same convention as every other picture flag/field in
+      # this table.
+      6 => { name: :fixed_to_map, type: :bool, default: false },
       2 => { name: :show_x, type: :double, default: 0.0 },
       3 => { name: :show_y, type: :double, default: 0.0 },
       # The picture's genuinely live position/zoom/transparency/tone -- see
@@ -1252,24 +1262,25 @@ module LCF
       12 => { name: :current_tone_green, type: :double, default: 100.0 },
       13 => { name: :current_tone_blue, type: :double, default: 100.0 },
       14 => { name: :current_tone_saturation, type: :double, default: 100.0 },
-      # 表示するか (0 非表示 / 1 表示) -- a name inferred from the field id's
-      # own position in this table (between the current_* and finish_*
-      # clusters), never confirmed against a genuine RPG_RT.exe capture that
-      # actually carries it. Cycle #159 looked for it in the one new scenario
-      # this cycle's own genuine-wine evidence could reach (a picture shown
-      # then Erase Picture'd, then saved) and still did not find it present
-      # -- an erased id's own chunk 103 entry keeps every other field
-      # (2/3/4/5/7/8/11-14/31/32/33/34/41-44) but field 9 stayed absent there
-      # too, the same as every other capture cycles #154/#155 already tried
-      # (a never-touched slot, an at-rest shown picture, one pushed off every
-      # visual default, and one mid-Move-Picture). Five distinct genuine
-      # capture shapes across three cycles have now never once observed this
-      # field present -- consistent with it being unused by any ordinary
-      # RPG2000 Show/Move/Erase Picture sequence, though still not proof no
-      # scenario ever writes it (RPG2003's own picture flag set, e.g., was
-      # never tried). Left as `default: false` (matching a picture that was
-      # never shown) since nothing in this codebase reads or writes it.
-      9 => { name: :visible, type: :bool, default: false },
+      # Show Picture's "not affected by transparent color" checkbox (param7
+      # in `Interpreter#do_show_picture`, `use_transparent_color`) -- NOT
+      # "visible", as a prior version of this comment guessed purely from
+      # this field id's position in the table (between the current_* and
+      # finish_* clusters). That guess was never confirmed and, worse, was
+      # actively misleading: cycles #154/#155/#159 all failed to find field
+      # 9 present in any of five genuine-RPG_RT.exe capture shapes because
+      # none of them ever varied the transparent-color flag -- an
+      # unrelated-field absence was being read as "this field is unused."
+      # Cycle #164 confirmed the real mapping directly against genuine
+      # RPG_RT.exe under wine: a Show Picture issued with this flag clear
+      # wrote chunk 103 with field 9 *absent*; an otherwise byte-identical
+      # Show Picture with only this flag set wrote field 9 *present* as a
+      # single `0x01` byte, and setting *both* this flag and the
+      # `fixed_to_map` flag (field 6) together wrote both fields 6 and 9
+      # present simultaneously, each independently -- ruling out any
+      # bit-packing between the two and confirming both really are their
+      # own elided-at-default boolean fields.
+      9 => { name: :use_transparent_color, type: :bool, default: false },
       # The picture's resting/target position -- see this table's own
       # comment above for why these are named finish_*, not current_*.
       31 => { name: :finish_x, type: :double, default: 0.0 }, # 表示位置Ｘ (中心)

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -480,7 +480,7 @@ assert "LCF::SaveData teleport targets, map events and pictures" do
   assert_equal [0x02, 0x03], save.map_events.chip_replacement_lower
 
   assert_equal "Fog", save.pictures[1].name
-  assert_true save.pictures[1].visible
+  assert_true save.pictures[1].use_transparent_color
   assert_equal 150, save.pictures[1].zoom
   assert_equal 20, save.pictures[1].tone_red
 end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8688,8 +8688,9 @@ module Game
     # (Game::State#to_h/.load) -- a private format with none of `.lsd`'s own
     # field-count/byte-format constraints, so unlike `SAVE_PICTURE` (chunk
     # 103) this can and does carry every field this class holds, including
-    # `fixed_to_map`/`use_transparent_color` (never modelled in `.lsd` at
-    # all -- see SAVE_PICTURE's own schema comment) and the live in-flight
+    # `fixed_to_map`/`use_transparent_color` (also modelled in `.lsd` as of
+    # cycle #164 -- chunk 103 fields 6/9, see SAVE_PICTURE's own schema
+    # comment for the genuine-RPG_RT.exe evidence) and the live in-flight
     # move target/frame-count, so a picture mid-Move-Picture at save time
     # keeps gliding after a resume instead of snapping to rest.
     def to_h
@@ -15073,7 +15074,12 @@ module Game
       #
       # Field mapping is the exact mirror of `.restore_pictures`' own read
       # (see `SAVE_PICTURE`'s own comment for the full evidence behind each
-      # field): 1 name; 2/3 show_x/show_y (the position last given to Show
+      # field): 1 name; 6/9 the fixed_to_map/use_transparent_color flags
+      # given to the picture's own Show Picture call, elided false like
+      # every other picture flag (cycle #164 -- these two were previously
+      # unwritten entirely, so a picture shown fixed-to-the-map or exempted
+      # from the transparent color lost that flag on every Save/Continue
+      # round trip); 2/3 show_x/show_y (the position last given to Show
       # Picture, untouched by any Move Picture since); 4/5/7/8/11-14 the
       # genuinely live current position/zoom/transparency/tone; 31/32
       # finish_x/finish_y (the move's target, equal to current at rest);
@@ -15106,6 +15112,8 @@ module Game
           # as a fully field-less placeholder, `p` nil, matching cycle #154's
           # own finding unchanged).
           e[1] = p.name if p.shown?
+          e[6] = true if p.fixed_to_map
+          e[9] = true if p.use_transparent_color
           e[2] = p.show_x
           e[3] = p.show_y
           e[4] = p.x
@@ -15781,7 +15789,9 @@ module Game
                                red: moving ? pic.current_tone_red : pic.tone_red,
                                green: moving ? pic.current_tone_green : pic.tone_green,
                                blue: moving ? pic.current_tone_blue : pic.tone_blue,
-                               saturation: moving ? pic.current_tone_saturation : pic.tone_saturation)
+                               saturation: moving ? pic.current_tone_saturation : pic.tone_saturation,
+                               fixed_to_map: pic.fixed_to_map,
+                               use_transparent_color: pic.use_transparent_color)
         next unless moving
         finish_trans = pic.transparency
         state.move_picture(id, (pic.finish_x || 0).to_i, (pic.finish_y || 0).to_i,

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -259,7 +259,23 @@ def check_game(dir)
   state.vehicle(:airship).x = 15
   state.vehicle(:airship).y = 7
 
+  # A picture shown "fixed to map position" and/or exempt from the
+  # transparent color (SAVE_PICTURE chunk 103 fields 6/9, cycle #164) --
+  # both used to be entirely unwritten by #to_lsd/unread by
+  # #restore_pictures, so a picture shown with either flag silently reverted
+  # to the opposite behaviour (screen-fixed instead of map-scrolling, or
+  # affected by the transparent color again) after every Save/Continue
+  # round trip. Confirmed against genuine RPG_RT.exe under wine: see
+  # SAVE_PICTURE's own schema comment for the field-presence evidence.
+  state.show_picture(7, name: 'flagpic', x: 10, y: 20, fixed_to_map: true,
+                         use_transparent_color: true)
+
   round = Game::State.from_lsd(db, LCF::SaveData.new(StringIO.new(state.to_lsd(state.save_count).to_lcf)))
+  fp = round.pictures[7]
+  eq true, !fp.nil? && fp.fixed_to_map,
+     'to_lsd: a picture shown fixed-to-map keeps that flag across Save/Continue'
+  eq true, !fp.nil? && fp.use_transparent_color,
+     'to_lsd: a picture shown exempt from the transparent color keeps that flag across Save/Continue'
   eq state.map_id, round.map_id, 'to_lsd: map id'
   eq state.x, round.x, 'to_lsd: hero x'
   eq state.y, round.y, 'to_lsd: hero y'


### PR DESCRIPTION
## Summary

- SAVE_PICTURE chunk 103 field 9 was labeled `:visible` purely by its position in the schema table — never confirmed, because cycles #154/#155/#159's genuine RPG_RT.exe captures never varied Show Picture's "not affected by transparent color" flag, so its consistent absence looked like an unused field instead of the wrong experiment. Field 6 (the "fixed to map position" flag) was never modeled at all.
- Driving genuine RPG_RT.exe under wine through Show Picture with each flag toggled independently and together shows field 6 present only when `fixed_to_map` is set, field 9 present only when `use_transparent_color` is set, and both present simultaneously (each independently) when both flags are set — confirming these are two separate elided-at-default booleans, not one field named `:visible`.
- Wires `Game::State#to_lsd` and `.restore_pictures` to write/read both fields; previously they were silently dropped on every Save/Continue round-trip, so a picture shown fixed-to-the-map or exempted from the transparent color reverted to the opposite behavior after loading.

## Verification

- Genuine RPG_RT.exe under wine (Xvfb, matchbox, `LIBGL_ALWAYS_SOFTWARE=1`, `ja_JP.UTF-8`, `WINEARCH=win32`/`WINEPREFIX=~/.wine-nepheshel32`): four Show Picture scenarios (base / fixed-to-map / transparent-exempt / both), reading each genuine `Save02.lsd`'s raw chunk 103:
  - base: fields present `[1,3,5,32]`
  - fixed (param4=1): fields present `[1,3,5,6,32]`, field 6 = `0x01`
  - transparent (param7=1): fields present `[1,3,5,9,32]`, field 9 = `0x01`
  - both: fields present `[1,3,5,6,9,32]` — both independently present, ruling out bit-packing
- `git stash` of the fix (keeping the new checks) reproduces 5 clean failures (2 new + the 3 known pre-existing); restoring the fix brings it back to exactly the 3 known pre-existing ones.
- Full suite passes: `rpg2k_scene_check.rb` (929), `rpg2k_render_check.rb` (41), `rpg2k_logic_check.rb` (1145), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15).
- `rpg2k_save_load_check.rb`'s 3 known pre-existing failures (BGM `balance`, `show_x`/`show_y`, transition-defaults warning) reconfirmed unrelated.
- `data/` fixtures restored byte-identical.
- No EasyRPG source consulted for any claim.

## Changelog

See `changelog.d/picture-fixed-to-map-transparent-color-save.fixed.md`.

## Test plan

- [x] `ruby scripts/rpg2k_save_load_check.rb` (new assertions added; 3 pre-existing unrelated failures reconfirmed via `git stash`)
- [x] `ruby scripts/rpg2k_logic_check.rb`
- [x] `ruby scripts/rpg2k_scene_check.rb`
- [x] `ruby scripts/rpg2k_render_check.rb`
- [x] `ruby scripts/rpg2k3_battle_row_check.rb`
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb`
- [x] `cmake --build build --target rpg_maker_clone` links cleanly


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_