### PR TITLE
RPG2k: bound Scene::Map's named-graphic caches with LRU eviction

### DIFF
--- a/changelog.d/rpg2k-lru-bitmap-caches.changed.md
+++ b/changelog.d/rpg2k-lru-bitmap-caches.changed.md
@@ -1,0 +1,20 @@
+- **RPG2k's Scene::Map named-graphic caches (CharSet/Picture/Backdrop/
+  Monster/Animation/BattleCharSet/System2) now evict least-recently-used
+  entries once over a per-category byte budget, instead of growing
+  forever.** Each of the seven caches used to be a plain Hash that only
+  ever gained entries -- every uniquely-named graphic a session ever
+  showed, across every map and battle for the whole play session, stayed
+  decoded in memory permanently, since `Scene::Map` is a session-long
+  singleton only replaced at New Game/Continue, not on an ordinary map
+  transfer. Each cache is now a small `LRUBitmapCache` bounded by estimated
+  decoded pixel bytes (`width * height * 4`, this build's fixed ARGB8888
+  decode format); an evicted entry is simply reloaded and re-cached the
+  next time its name comes up, exactly as a genuine cache miss already
+  was, so this is a size-bound fix with no behavior change on the fast
+  path. `#cached_bitmap`'s own call sites needed no changes -- the new
+  class implements the same `key?`/`[]`/`[]=` surface a plain Hash did,
+  including direct cache manipulation from existing tests. Note this
+  bounds *native*-heap growth (`Bitmap`'s pixel buffer is a
+  `std::vector<uint8_t>` using the ordinary C++ allocator, not the mruby
+  arena), a different budget than the PSP mruby-arena work elsewhere in
+  this series -- see docs/adr/0047-psp-memory-budget.md.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1585,14 +1585,54 @@ the interpreter-linking slice, in this order:
 - **P4 — corrected; not an LVGL-cache problem.** There is no LVGL image
   cache to bound for RGSS bitmaps (Finding 3) — they live in the plain C
   runtime heap via `Bitmap::buffer`, a third pool `LV_MEM_SIZE` never
-  touches. Nothing to implement here that isn't already covered: once the
-  interpreter is linked and real bitmaps are loaded, P1's heartbeat already
-  surfaces this pool's consumption as the gap between
-  `sceKernelTotalFreeMemSize` and `lv_mem_monitor`'s LVGL-only figures. What
-  remains is confirming decoded-bitmap sizes for the target games'
-  resolutions actually fit in what's left of the ~24 MB after `LV_MEM_SIZE`
-  and the stack/statics — a measurement to take once P1's device numbers
-  exist for a real game, not a code change.
+  touches. Originally concluded "nothing to implement here that isn't
+  already covered" on the assumption that P1's heartbeat (the gap between
+  `sceKernelTotalFreeMemSize` and `lv_mem_monitor`'s LVGL-only figures)
+  would surface this pool's consumption once real bitmaps loaded — see the
+  follow-up below for why that assumption no longer holds unquestioned, and
+  what got implemented regardless.
+
+  **Follow-up (2026-08-26): RPG2k's own uncapped bitmap caches, found while
+  investigating a different hypothesis (whether old `Game::Map` objects
+  survive a map transfer — they don't; `Scene::Map#perform_teleport`
+  already resets every per-visit table it owns, including the ones this
+  ADR's Array2D/common-event work above cares about).** One level up from
+  `Game::Map`, `Scene::Map`'s seven named-graphic caches
+  (`@charset_cache`/`@picture_cache`/`@backdrop_cache`/`@monster_cache`/
+  `@animation_cache`/`@battlecharset_cache`/`@system2_cache`,
+  `mruby-rpg2k/mrblib/scene/map.rb`) were never reset or bounded anywhere,
+  including in that same otherwise-thorough per-visit reset block — every
+  uniquely-named graphic a session ever showed, across every map and battle
+  for the entire play session (`Scene::Map` itself is a session-long
+  singleton, only replaced at New Game/Continue), stayed decoded in
+  `Bitmap::buffer` forever. This is exactly Finding 3's "third pool," with
+  no cap of its own, actually filling up over a long session — not
+  hypothetical. Fixed with a small `LRUBitmapCache` class (same file):
+  bounded by estimated decoded bytes (`width * height * 4`, this build's
+  fixed ARGB8888 decode format) per category, evicting least-recently-used
+  entries once over budget; an evicted entry just reloads (and re-caches)
+  the next time its name comes up, the same as any other cache miss.
+  `#cached_bitmap`'s call sites needed no changes — the new class
+  implements the same `key?`/`[]`/`[]=` surface a plain Hash did. Per-
+  category byte budgets are a conservative first cut, not a measured one
+  (see the constants' own comment in `scene/map.rb`): **the assumption this
+  P4 entry originally rested on — that `sceKernelTotalFreeMemSize` would
+  surface this pool's real consumption — does not hold up against what
+  P1's own heartbeat actually reported.** A full `psp-smoke-game` run
+  against Nepheshel (1600 `Scene::Map` frames, definitely loading and
+  caching charsets/chipsets/etc. along the way) logged the exact same
+  `free=782336 maxfree=524288` on *every single heartbeat*, unmoving, while
+  `arena_used` in the same log moved by megabytes frame to frame. Either
+  `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` report something
+  coarser than live heap consumption on this target (a PPSSPP HLE
+  limitation is plausible — untested against real hardware) or this
+  specific run's bitmap traffic genuinely never moved the needle on
+  whatever partition they measure; either way, this instrumentation cannot
+  currently confirm the third pool's actual size or validate that the new
+  cap helps. Confirming decoded-bitmap sizes really fit in what's left of
+  the ~24 MB, and getting instrumentation that can actually show it,
+  remains open — not resolved by this follow-up, only made safer against
+  the unbounded-growth case regardless of what the numbers turn out to be.
 - **P5 — done, including the real-game measurement.** `app/psp/main.cxx` now
   declares `PSP_MAIN_THREAD_STACK_SIZE_KB(256)` instead of inheriting
   pspsdk's implicit default, and the `RPG2K_PSP_BRINGUP` heartbeat carries

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -176,23 +176,123 @@ class RPG2k
       # other call site *is* a fresh entry (New Game's first map, and every
       # Transfer Player / Teleport via #perform_teleport's own separate call)
       # and keeps re-deriving as before.
+      # A name -> Bitmap cache bounded by estimated decoded pixel bytes rather
+      # than entry count (a CharSet and a System2 gauge sheet differ by an
+      # order of magnitude in size), evicting least-recently-used entries once
+      # over budget. Drop-in for the plain Hash #cached_bitmap used to take:
+      # implements the same #key?/#[]/#[]= surface (including tests that poke
+      # a cache directly, e.g. `@animation_cache['GhostAnim'] = nil` to
+      # simulate a poisoned/missing graphic), so #cached_bitmap itself needed
+      # no changes.
+      class LRUBitmapCache
+        def initialize(capacity_bytes)
+          @capacity_bytes = capacity_bytes
+          @entries = {} # key => value, oldest (least-recently-used) first
+          @bytes = 0
+        end
+
+        def key?(key)
+          @entries.key?(key)
+        end
+
+        # Return a cached value (nil for a poisoned/failed-load entry, same as
+        # a plain Hash) and mark it most-recently-used. Callers check #key?
+        # first, exactly as they did against the plain Hash, so a genuine miss
+        # is never confused with a cached nil here.
+        def [] key
+          return nil unless @entries.key?(key)
+          v = @entries.delete(key)
+          @entries[key] = v
+          v
+        end
+
+        def []= key, value
+          @bytes -= bitmap_bytes(@entries.delete(key)) if @entries.key?(key)
+          @entries[key] = value
+          @bytes += bitmap_bytes(value)
+          evict_lru_until_within_budget
+          value
+        end
+
+        private
+
+        # width * height * 4 -- every Bitmap this build decodes from a file is
+        # ARGB8888 (mruby-rgss/src/lib.cxx's file-loading Bitmap.new overload
+        # always passes LV_COLOR_FORMAT_ARGB8888), so this is the buffer size
+        # the native Bitmap struct actually allocates, not a guess. 0 for a
+        # poisoned (nil) or otherwise non-Bitmap entry -- it costs nothing and
+        # so creates no eviction pressure on its own.
+        def bitmap_bytes(v)
+          return 0 unless v.respond_to?(:width) && v.respond_to?(:height)
+          v.width * v.height * 4
+        end
+
+        # Evict oldest-first until back within budget. Stops at one remaining
+        # entry even if that entry alone exceeds the budget: the entry just
+        # inserted is always the newest (last) one, so this never evicts what
+        # the caller is about to use, and never busy-loops reloading the same
+        # single oversized graphic every time it's requested.
+        def evict_lru_until_within_budget
+          while @bytes > @capacity_bytes && @entries.size > 1
+            oldest_key = nil
+            @entries.each_key { |k| oldest_key = k; break }
+            @bytes -= bitmap_bytes(@entries.delete(oldest_key))
+          end
+        end
+      end
+
+      # Per-category caps for the named-graphic caches below (see #initialize),
+      # in estimated decoded bytes (see LRUBitmapCache#bitmap_bytes) -- a
+      # conservative first cut, not a measured budget: this build's only
+      # native-heap instrumentation (sceKernelTotalFreeMemSize/MaxFreeMemSize,
+      # app/psp/main.cxx's `free`/`maxfree` fields) reported the exact same
+      # value across every heartbeat of a full psp-smoke-game run regardless
+      # of arena_used moving by megabytes, so it cannot currently validate
+      # (or rule out) whatever headroom is actually available. Each constant
+      # is independent and trivially raised later once real measurement
+      # exists; sized for now to comfortably outlast one screen's working set
+      # (e.g. a troop's handful of distinct battler graphics) while still
+      # bounding a long session's worth of distinct maps/battles from
+      # retaining every graphic they ever showed.
+      CHARSET_CACHE_BYTES = 1_000_000
+      PICTURE_CACHE_BYTES = 1_000_000
+      BACKDROP_CACHE_BYTES = 500_000
+      MONSTER_CACHE_BYTES = 1_500_000
+      ANIMATION_CACHE_BYTES = 1_500_000
+      BATTLECHARSET_CACHE_BYTES = 500_000
+      SYSTEM2_CACHE_BYTES = 250_000
+
       def initialize parent, state, apply_access: true
         super parent
         @state = state
         # Named graphics loaded and memoized on demand -- see #cached_bitmap.
-        # One hash per graphic category (rather than a single cache keyed by
+        # One cache per graphic category (rather than a single cache keyed by
         # a [kind, name] tuple) so each material's entries stay a plain
         # name -> Bitmap lookup and one category's keys can never collide
-        # with another's.
-        @charset_cache = {}   # CharSet/<name> -- event graphics and the
+        # with another's. Each is a bounded LRUBitmapCache, not a plain Hash:
+        # a long session that visits many maps/battles referencing many
+        # uniquely-named graphics used to retain every one of them for the
+        # rest of the run (nothing here ever cleared these hashes, including
+        # #perform_teleport's otherwise-thorough per-visit reset just below);
+        # now only the most-recently-used ones survive past each cache's own
+        # byte budget, and anything evicted is simply reloaded (and re-cached)
+        # the next time its name comes up.
+        @charset_cache = LRUBitmapCache.new(CHARSET_CACHE_BYTES)
+                               # CharSet/<name> -- event graphics and the
                                # party leader's own graphic share this, since
                                # both load the same files.
-        @picture_cache = {}   # Picture/<name>, keyed by [name, transparent]
-        @backdrop_cache = {}  # Backdrop/<name> (battle background)
-        @monster_cache = {}   # Monster/<name> (battler graphics)
-        @animation_cache = {} # Battle/<name> (battle animation sheets)
-        @battlecharset_cache = {} # BattleCharSet/<name> (RPG2003 actor battler sprites)
-        @system2_cache = {}   # System2/<name> (RPG2003 gauge card sprite sheet)
+        @picture_cache = LRUBitmapCache.new(PICTURE_CACHE_BYTES)
+                               # Picture/<name>, keyed by [name, transparent]
+        @backdrop_cache = LRUBitmapCache.new(BACKDROP_CACHE_BYTES)
+                               # Backdrop/<name> (battle background)
+        @monster_cache = LRUBitmapCache.new(MONSTER_CACHE_BYTES)
+                               # Monster/<name> (battler graphics)
+        @animation_cache = LRUBitmapCache.new(ANIMATION_CACHE_BYTES)
+                               # Battle/<name> (battle animation sheets)
+        @battlecharset_cache = LRUBitmapCache.new(BATTLECHARSET_CACHE_BYTES)
+                               # BattleCharSet/<name> (RPG2003 actor battler sprites)
+        @system2_cache = LRUBitmapCache.new(SYSTEM2_CACHE_BYTES)
+                               # System2/<name> (RPG2003 gauge card sprite sheet)
         apply_map_access if apply_access
         # Same Continue-only split as #apply_map_access just above: a fresh
         # map entry (New Game, or any Transfer Player/Teleport, which


### PR DESCRIPTION
## Summary

- `Scene::Map`'s seven named-graphic caches (`@charset_cache`/`@picture_cache`/`@backdrop_cache`/`@monster_cache`/`@animation_cache`/`@battlecharset_cache`/`@system2_cache`, `mruby-rpg2k/mrblib/scene/map.rb`) were plain Hashes that only ever gained entries. Since `Scene::Map` is a session-long singleton (only replaced at New Game/Continue, not on an ordinary map transfer), every uniquely-named graphic a session ever showed stayed decoded in `Bitmap::buffer` forever — this is exactly the "third pool with no cap of its own" `docs/adr/0047-psp-memory-budget.md`'s Finding 3 already identified, actually filling up over a long session.
- Found while investigating a different hypothesis (whether old `Game::Map` objects survive a map transfer) — they don't; `perform_teleport` already resets every per-visit table it owns thoroughly. The caches one level up were the real gap.
- Adds `LRUBitmapCache`: bounded by estimated decoded bytes (`width * height * 4`, this build's fixed ARGB8888 decode format) per category, evicting least-recently-used entries once over budget. An evicted entry just reloads next time its name comes up, same as any other cache miss. Implements the same `key?`/`[]`/`[]=` surface a plain Hash did, so `#cached_bitmap`'s call sites (and existing tests that poke a cache directly, e.g. `@animation_cache['GhostAnim'] = nil`) needed no changes.
- **Note on scope:** this bounds *native*-heap growth (`Bitmap`'s pixel buffer is `std::vector<uint8_t>` via the ordinary C++ allocator, not the mruby arena) — a different budget than the PSP mruby-arena series (#1360/#1367/#1368/#1374/#1376). No effect on the P1c crash risk specifically.
- Per-category byte budgets are a conservative first cut, not measured against real device headroom — this build's only native-heap instrumentation (`sceKernelTotalFreeMemSize`/`MaxFreeMemSize`) reported an unmoving value across a full 1600-frame `psp-smoke-game` run despite `arena_used` moving by megabytes in the same log, so it couldn't be used to calibrate them. Documented as an open question in the ADR's P4 follow-up rather than glossed over.

## Test plan

- [x] Standalone unit test for `LRUBitmapCache` (parity with plain-Hash semantics, eviction order/LRU-touch, byte accounting — including an overwrite-double-counting bug caught and fixed before this commit, single-oversized-entry safety) — all pass.
- [x] `scripts/rpg2k_logic_check.rb` — 1145 checks passed, unchanged.
- [x] `scripts/rpg2k_scene_check.rb` — 929 checks passed, unchanged (includes tests that directly poke `@animation_cache`/`@monster_cache` and assert hue-keyed cache-sharing behavior).
- [ ] CI's `mruby_test` job, watching for it since this is still mrblib Ruby.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_