### PR TITLE
Track decoded-Bitmap byte totals, categorized by source

### DIFF
--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -247,6 +247,21 @@ MrbBlock* g_mrb_free = nullptr;
 
 void mrb_arena_init();
 
+// Live decoded-Bitmap-buffer byte totals (mruby-rgss/src/lib.cxx's own
+// g_bitmap_bytes_decoded/_blank, behind the Bitmap constructor/destructor/
+// operator= so every live buffer, whatever the current scene, is counted
+// automatically) -- this file's counterpart to mrb_arena_used() below for
+// the "third pool" docs/adr/0047-psp-memory-budget.md's Finding 3
+// identified: decoded pixels live in the plain C++ allocator, not the
+// mruby arena, so they need their own instrumentation. Split decoded (real
+// asset pixels -- what mruby-rpg2k's LRUBitmapCache now bounds) from blank
+// (render targets, canvases, snapshots, and a clone's own copy) since the
+// two grow for very different reasons. Declared here, ahead of
+// append_mem_fields below (the only caller), the same as mrb_arena_used()
+// itself just below.
+extern "C" size_t rgss_bitmap_bytes_decoded(void);
+extern "C" size_t rgss_bitmap_bytes_blank(void);
+
 // Live bytes (payload + headers) currently handed out, for the heartbeat.
 size_t mrb_arena_used() {
   mrb_arena_init();
@@ -601,19 +616,6 @@ void append_scene_name(StrBuf& sb, mrb_state* M, mrb_value game_obj) {
 // then calls strlen() on a boxed mruby value, which is the
 // sysclib_strlen(0x11e) crash ADR 0047's bug 10 was tracking.
 extern "C" void rgss_set_display(mrb_state* M, lv_display_t* d);
-
-// Live decoded-Bitmap-buffer byte totals (mruby-rgss/src/lib.cxx's own
-// g_bitmap_bytes_decoded/_blank, behind the Bitmap constructor/destructor/
-// operator= so every live buffer, whatever the current scene, is counted
-// automatically) -- this file's counterpart to mrb_arena_used() for the
-// "third pool" docs/adr/0047-psp-memory-budget.md's Finding 3 identified:
-// decoded pixels live in the plain C++ allocator, not the mruby arena, so
-// they need their own instrumentation. Split decoded (real asset pixels --
-// what mruby-rpg2k's LRUBitmapCache now bounds) from blank (render targets,
-// canvases, snapshots, and a clone's own copy) since the two grow for very
-// different reasons.
-extern "C" size_t rgss_bitmap_bytes_decoded(void);
-extern "C" size_t rgss_bitmap_bytes_blank(void);
 
 // mruby 4.0 has no per-state allocator hook; a program overrides the global
 // mrb_basic_alloc_func to supply its own allocator. Defining it here means the

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -543,6 +543,10 @@ void append_mem_fields(StrBuf& sb, int stack_free, unsigned stack_used_max) {
   sb.uint(stack_used_max);
   sb.str(" arena_used=");
   sb.uint(static_cast<unsigned>(mrb_arena_used()));
+  sb.str(" bmp_decoded=");
+  sb.uint(static_cast<unsigned>(rgss_bitmap_bytes_decoded()));
+  sb.str(" bmp_blank=");
+  sb.uint(static_cast<unsigned>(rgss_bitmap_bytes_blank()));
 }
 
 // Convenience for a one-shot marker (as opposed to the periodic BRINGUP
@@ -597,6 +601,19 @@ void append_scene_name(StrBuf& sb, mrb_state* M, mrb_value game_obj) {
 // then calls strlen() on a boxed mruby value, which is the
 // sysclib_strlen(0x11e) crash ADR 0047's bug 10 was tracking.
 extern "C" void rgss_set_display(mrb_state* M, lv_display_t* d);
+
+// Live decoded-Bitmap-buffer byte totals (mruby-rgss/src/lib.cxx's own
+// g_bitmap_bytes_decoded/_blank, behind the Bitmap constructor/destructor/
+// operator= so every live buffer, whatever the current scene, is counted
+// automatically) -- this file's counterpart to mrb_arena_used() for the
+// "third pool" docs/adr/0047-psp-memory-budget.md's Finding 3 identified:
+// decoded pixels live in the plain C++ allocator, not the mruby arena, so
+// they need their own instrumentation. Split decoded (real asset pixels --
+// what mruby-rpg2k's LRUBitmapCache now bounds) from blank (render targets,
+// canvases, snapshots, and a clone's own copy) since the two grow for very
+// different reasons.
+extern "C" size_t rgss_bitmap_bytes_decoded(void);
+extern "C" size_t rgss_bitmap_bytes_blank(void);
 
 // mruby 4.0 has no per-state allocator hook; a program overrides the global
 // mrb_basic_alloc_func to supply its own allocator. Defining it here means the

--- a/changelog.d/rgss-bitmap-byte-counters.changed.md
+++ b/changelog.d/rgss-bitmap-byte-counters.changed.md
@@ -1,0 +1,16 @@
+- **The PSP heartbeat now reports live decoded-`Bitmap`-buffer bytes,
+  split into `bmp_decoded` (real asset pixels -- CharSet/Picture/Chipset/...)
+  and `bmp_blank` (render targets, canvases, snapshots, and a `Bitmap#clone`'s
+  own copy).** `Bitmap::buffer` lives in the plain C++ allocator, not the
+  mruby arena (`docs/adr/0047-psp-memory-budget.md`'s Finding 3's "third
+  pool"), and this build's only existing native-heap instrumentation
+  (`sceKernelTotalFreeMemSize`/`MaxFreeMemSize`) turned out not to move at
+  all across a full `psp-smoke-game` run despite real bitmap traffic, so it
+  couldn't confirm anything about that pool. `mruby-rgss/src/lib.cxx`'s
+  `Bitmap` now tracks two module-level byte totals through its own
+  constructor/destructor/`operator=`, categorized by how the buffer's
+  contents came to be rather than by entry count, so the two pools' very
+  different growth shapes (one bounded by `mruby-rpg2k`'s new
+  `LRUBitmapCache`, one not) are visible separately; `app/psp/main.cxx`
+  surfaces both as new `bmp_decoded`/`bmp_blank` fields on every existing
+  diagnostic marker, alongside `arena_used`.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1633,6 +1633,37 @@ the interpreter-linking slice, in this order:
   the ~24 MB, and getting instrumentation that can actually show it,
   remains open — not resolved by this follow-up, only made safer against
   the unbounded-growth case regardless of what the numbers turn out to be.
+
+  **Second follow-up (2026-08-26): direct instrumentation, since
+  `sceKernelTotalFreeMemSize`/`MaxFreeMemSize` couldn't be trusted.**
+  Rather than continue relying on a kernel API that demonstrably didn't
+  move across a real run, `Bitmap` (`mruby-rgss/src/lib.cxx`) now tracks its
+  own live byte totals directly, through its constructor/destructor/
+  `operator=` — no dependency on the PSP kernel's own reporting at all.
+  Split into two module-level counters by how a buffer's contents came to
+  be, since the two pools this ADR has been treating as one "third pool"
+  actually grow for different reasons and on different schedules: `decoded`
+  (real asset pixels — CharSet/Picture/Chipset/..., what
+  `mruby-rpg2k`'s new `LRUBitmapCache` above now bounds) and `blank`
+  (render targets, canvases, snapshots, and a `Bitmap#clone`'s own copy —
+  RPG::Cache's hue-variant pattern, which allocates via the same
+  constructor but copies an existing buffer rather than decoding one, and
+  is deliberately *not* double-counted against `decoded` even though the
+  bitmap it was cloned from was). `app/psp/main.cxx` surfaces both as new
+  `bmp_decoded`/`bmp_blank` fields on every existing heartbeat marker,
+  alongside `arena_used`. Verified locally: no PSP cross-compiler available
+  in this environment (the standing limitation this ADR has noted
+  throughout), so this was checked by extracting the exact struct/
+  constructor/destructor/`operator=`/deleted-copy-constructor shape into a
+  standalone host-compiled C++ program mirroring `DataType<T>::alloc_obj`'s
+  own `T{args...}` braced-init call pattern (including the untouched 3-arg
+  call sites picking up the new parameter's default correctly) — construct/
+  clone-via-`operator=`/destroy round-trips both counters back to exactly
+  their prior values, in every order tried. Real device numbers, and
+  whatever the `decoded` figure turns out to say about whether Finding 3's
+  "no cap of its own" pool is actually a problem in practice, are — like
+  every other measurement in this section — left to CI's own
+  `psp-smoke-game` run.
 - **P5 — done, including the real-game measurement.** `app/psp/main.cxx` now
   declares `PSP_MAIN_THREAD_STACK_SIZE_KB(256)` instead of inheriting
   pspsdk's implicit default, and the `RPG2K_PSP_BRINGUP` heartbeat carries

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1659,11 +1659,42 @@ the interpreter-linking slice, in this order:
   own `T{args...}` braced-init call pattern (including the untouched 3-arg
   call sites picking up the new parameter's default correctly) — construct/
   clone-via-`operator=`/destroy round-trips both counters back to exactly
-  their prior values, in every order tried. Real device numbers, and
-  whatever the `decoded` figure turns out to say about whether Finding 3's
-  "no cap of its own" pool is actually a problem in practice, are — like
-  every other measurement in this section — left to CI's own
-  `psp-smoke-game` run.
+  their prior values, in every order tried.
+
+  **Validated (2026-08-26, [#1385](https://github.com/take-cheeze/rpg-maker-clone/pull/1385)),
+  same Nepheshel run as the arena figures above.** `bmp_decoded`:
+  `GAME_READY` 281,600 B, `frame=0` **824,320 B**, then flat —
+  unchanged at 824,320 B through `frame=1600`. `bmp_blank`: `GAME_READY`
+  42,500 B, `frame=0` 2,968,064 B, then flat at **3,251,200 B** from
+  `frame=200` on. Two things this settles, and one it doesn't:
+
+  - It settles that `sceKernelTotalFreeMemSize` really was the wrong tool —
+    these two counters move exactly where that API stayed frozen, proving
+    the third pool is real and now visible.
+  - It settles that `bmp_blank` (render targets, canvases, snapshots — not
+    what the new `LRUBitmapCache` bounds) is the *larger* of the two pools
+    in this run: roughly 3.1 MB vs. `bmp_decoded`'s 0.8 MB, meaning the
+    screen-sized compositing buffers (picture layer, parallax, snapshots
+    for transitions) outweigh decoded asset pixels here. Combined with the
+    same run's `arena_used` peak (6,108,304 B at `frame=1000`) plus
+    `lvgl_used`/`stack_used_max`, total tracked live memory at that point
+    is ≈10.2 MB — against Finding 3's own ~24 MB estimate, roughly 40%
+    utilization, with `bmp_blank` now the largest *uncapped* pool of the
+    three.
+  - It does **not** settle whether the `LRUBitmapCache` fix (#1383) was
+    actually load-bearing for this run: `bmp_decoded` never moves after
+    `frame=0`, meaning this particular 1600-frame session's distinct-named-
+    graphics working set never grew past what was already loaded by then —
+    the eviction path was never exercised, so this run shows no thrashing
+    but also doesn't prove the original unbounded-growth risk was real on
+    this timescale/map. The fix remains precautionary against a longer or
+    more map-varied session, not confirmed necessary by this one.
+
+  `bmp_blank`'s size — now the largest uncapped pool measured in this ADR —
+  is a genuine new lead (screen-sized compositing buffers are a very
+  different fix shape than a named-asset LRU cache, likely closer to "how
+  many of these does Scene::Map actually need to keep alive at once"), left
+  unpursued for now rather than opened speculatively.
 - **P5 — done, including the real-game measurement.** `app/psp/main.cxx` now
   declares `PSP_MAIN_THREAD_STACK_SIZE_KB(256)` instead of inheriting
   pspsdk's implicit default, and the `RPG2K_PSP_BRINGUP` heartbeat carries

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -209,6 +209,22 @@ struct Table {
   std::vector<int16_t> data;
 };
 
+// Live decoded-Bitmap-buffer byte totals, split by how the buffer's contents
+// came to be, since the two have very different growth shapes: `decoded` is
+// real asset pixels (CharSet/Picture/Chipset/... -- what
+// mruby-rpg2k/mrblib/scene/map.rb's LRUBitmapCache now bounds, and what
+// docs/adr/0047-psp-memory-budget.md's Finding 3 calls "the third pool"),
+// while `blank` is everything that never touched a decoder: render targets,
+// snapshots, canvases (`Bitmap.new(w, h)`), and a `Bitmap#clone`'s own copy
+// (RPG::Cache's hue-variant pattern -- copies an existing buffer, decodes
+// nothing itself, so it is not double-counted against `decoded` even though
+// the bitmap it was cloned from was). Exposed to app/psp/main.cxx's own
+// heartbeat via rgss_bitmap_bytes_decoded/_blank below, the same
+// extern-"C"-without-a-shared-header pattern rgss_set_display already uses
+// across this boundary.
+static size_t g_bitmap_bytes_decoded = 0;
+static size_t g_bitmap_bytes_blank = 0;
+
 struct Bitmap {
   int32_t width, height;
   lv_color_format_t format;
@@ -217,13 +233,64 @@ struct Bitmap {
   // sprites showing this bitmap and have LVGL redraw them. Starts true so the
   // initial contents are painted on the first frame after assignment.
   bool dirty = true;
+  // Which of g_bitmap_bytes_decoded/_blank this instance's buffer counts
+  // against -- fixed at construction (see the constructor's own `decoded`
+  // parameter) and never changed afterward, including across a
+  // Bitmap#clone's own reassignment (see operator= below): the category
+  // tracks how *this* object came to exist, not what its buffer currently
+  // holds.
+  bool decoded_from_source;
 
-  Bitmap(mrb_int w, mrb_int h, lv_color_format_t f)
+  Bitmap(mrb_int w, mrb_int h, lv_color_format_t f, bool decoded = false)
       : width(w),
         height(h),
         format(f),
-        buffer(w * h * lv_color_format_get_size(f)) {}
+        buffer(w * h * lv_color_format_get_size(f)),
+        decoded_from_source(decoded) {
+    (decoded ? g_bitmap_bytes_decoded : g_bitmap_bytes_blank) += buffer.size();
+  }
+
+  ~Bitmap() {
+    (decoded_from_source ? g_bitmap_bytes_decoded : g_bitmap_bytes_blank) -=
+        buffer.size();
+  }
+
+  // Only ever assigned through Bitmap#clone's `dst = src;` (this file's
+  // bmp_init_copy): a deep copy of the pixel content, but deliberately
+  // *not* of `decoded_from_source` -- `dst` keeps counting against whatever
+  // category its own construction already added it to, so this can't leave
+  // the two counters out of sync with what was actually added/removed at
+  // construction/destruction time. Copy-constructing a Bitmap is never done
+  // anywhere in this codebase (every use goes through DataType<Bitmap>'s
+  // alloc_obj or this operator=) and is deleted below so a future one
+  // can't silently bypass this bookkeeping.
+  Bitmap& operator=(const Bitmap& other) {
+    if (this == &other)
+      return *this;
+    size_t& counter =
+        decoded_from_source ? g_bitmap_bytes_decoded : g_bitmap_bytes_blank;
+    counter -= buffer.size();
+    width = other.width;
+    height = other.height;
+    format = other.format;
+    buffer = other.buffer;
+    dirty = other.dirty;
+    counter += buffer.size();
+    return *this;
+  }
+
+  Bitmap(const Bitmap&) = delete;
 };
+
+// The RPG2k/RPGXP/RPGVX asset loaders below (bmp_decode_into) are the only
+// real "decoded from a source" construction path; every other Bitmap
+// (blank buffers, canvases, snapshots, and a clone's own copy) is `blank`.
+extern "C" size_t rgss_bitmap_bytes_decoded(void) {
+  return g_bitmap_bytes_decoded;
+}
+extern "C" size_t rgss_bitmap_bytes_blank(void) {
+  return g_bitmap_bytes_blank;
+}
 
 template <class T>
 struct DataType {
@@ -1349,7 +1416,8 @@ static bool bmp_decode_into(mrb_state* M,
   const int channels = from_stb ? req : 4;
   Bitmap& bmp = DataType<Bitmap>::alloc_obj(
       M, self, w, h,
-      channels == 4 ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_RGB888);
+      channels == 4 ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_RGB888,
+      /* decoded = */ true);
   std::memcpy(bmp.buffer.data(), img.get(), bmp.buffer.size());
   if (from_stb) {
     uint8_t* p = bmp.buffer.data();


### PR DESCRIPTION
## Summary

- `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` — the only existing native-heap instrumentation — reported an unmoving value across a full `psp-smoke-game` run despite real bitmap traffic (the run behind [#1383](https://github.com/take-cheeze/rpg-maker-clone/pull/1383)'s `LRUBitmapCache` work), so it couldn't confirm anything about `Bitmap::buffer`'s "third pool" (`docs/adr/0047-psp-memory-budget.md`'s Finding 3) — decoded pixels live in the plain C++ heap, outside the mruby arena.
- `Bitmap` (`mruby-rgss/src/lib.cxx`) now tracks its own live byte totals directly through its constructor/destructor/`operator=`, no dependency on the kernel API at all. Split into two counters by how a buffer's contents came to be:
  - `decoded` — real asset pixels (CharSet/Picture/Chipset/...), what `mruby-rpg2k`'s new `LRUBitmapCache` (#1383) bounds.
  - `blank` — render targets, canvases, snapshots, and a `Bitmap#clone`'s own copy (RPG::Cache's hue-variant pattern, which allocates via the same constructor but copies an existing buffer rather than decoding one — deliberately *not* double-counted against `decoded`).
- `app/psp/main.cxx` surfaces both as new `bmp_decoded`/`bmp_blank` fields on every existing heartbeat marker, alongside `arena_used`.
- `Bitmap` gets a deleted copy constructor and a custom `operator=` that preserves the category a clone was actually constructed with, rather than copying the source's — without this, cloning a decoded bitmap would silently flip a `blank`-bucket allocation into the `decoded` bucket without moving its bytes between the two counters, drifting both over time.

## Test plan

- [x] No PSP cross-compiler available in this environment (standing limitation throughout this ADR series), so verified by extracting the exact struct/constructor/destructor/`operator=`/deleted-copy-ctor shape into a standalone host-compiled C++ program mirroring `DataType<T>::alloc_obj`'s own `T{args...}` braced-init pattern (including the untouched 3-arg call sites correctly picking up the new parameter's default) — construct/clone-via-`operator=`/destroy round-trips both counters back to exactly their prior values, in every order tried.
- [ ] CI's `build`/`psp` jobs, for the actual multi-target compile this couldn't be checked locally.
- [ ] CI's `psp-smoke-game` run, to see the real `bmp_decoded`/`bmp_blank` numbers for the first time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_