### PR TITLE
CI: compile-time bottleneck report; close the field-125 investigation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,13 +216,19 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.11
 
       # Runs while the background steps above are still in flight.
+      # -DENABLE_TIME_REPORT=ON (CMakeLists.txt) is this job's own opt-in --
+      # local/dev builds don't pay for it -- turning on GCC's
+      # -ftime-report-details for every compile below, so the build log the
+      # next step captures carries a per-file compiler-phase timing block the
+      # "compile-time report" step further down turns into a bottleneck-hint
+      # summary.
       - name: cmake
         run: |
-          cmake -S . -B build -GNinja
+          cmake -S . -B build -GNinja -DENABLE_TIME_REPORT=ON
 
       - name: build
         run: |
-          cmake --build build
+          cmake --build build 2>&1 | tee build.log
 
       - name: sccache stats
         if: always()
@@ -234,6 +240,16 @@ jobs:
             sccache --show-stats
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Reads the -ftime-report-details blocks the build step's log just
+      # captured (empty/absent on a fully-cached run, which is fine -- see
+      # the script's own comment) and appends a "slowest files/phases this
+      # run" table to the job summary, right alongside the sccache stats
+      # above. if: always() so a failed build still surfaces where its time
+      # actually went before it died.
+      - name: compile-time report
+        if: always()
+        run: ruby scripts/compile_time_report.rb build.log
 
       # Barrier: block until lint and every download have finished before the
       # checks that consume them. A failed background step (e.g. pre-commit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,40 +29,45 @@ if(USE_MOLD
 endif()
 
 # Per-translation-unit compiler-phase timing: GCC's own -ftime-report-details
-# prints, for every file it actually compiles (a no-op on an sccache cache
-# hit, since sccache then never invokes cc1plus at all), how much wall/user/
-# sys time went into each compiler phase and pass -- parsing, template
-# instantiation, individual GIMPLE/RTL passes, and so on. Off by default: it's
-# diagnostic-only stderr noise a local incremental build has no use for. CI's
-# own "build" job (.github/workflows/build.yml) turns it on unconditionally
-# via -DENABLE_TIME_REPORT=ON, tees the build log, and feeds it to
+# prints, for every file it actually compiles (a no-op on an sccache cache hit,
+# since sccache then never invokes cc1plus at all), how much wall/user/sys time
+# went into each compiler phase and pass -- parsing, template instantiation,
+# individual GIMPLE/RTL passes, and so on. Off by default: it's diagnostic-only
+# stderr noise a local incremental build has no use for. CI's own "build" job
+# (.github/workflows/build.yml) turns it on unconditionally via
+# -DENABLE_TIME_REPORT=ON, tees the build log, and feeds it to
 # scripts/compile_time_report.rb, which turns these per-file blocks into a
 # "slowest files/phases this run" job-summary table -- a standing bottleneck
 # hint that costs nothing on a warm cache and only grows informative exactly
-# when a run actually recompiles a lot (a cold cache, a submodule bump, a
-# change to a widely-included header).
-option(ENABLE_TIME_REPORT "Emit GCC's -ftime-report-details compiler-phase timing" OFF)
+# when a run actually recompiles a lot (a cold cache, a submodule bump, a change
+# to a widely-included header).
+option(ENABLE_TIME_REPORT
+       "Emit GCC's -ftime-report-details compiler-phase timing" OFF)
 if(ENABLE_TIME_REPORT)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag("-ftime-report" CXX_SUPPORTS_TIME_REPORT)
     if(CXX_SUPPORTS_TIME_REPORT)
-      # -ftime-report-details (GCC 10+) only adds its per-pass breakdown on
-      # top of -ftime-report's own per-phase totals -- passed alone it
-      # compiles cleanly (so a flag-support check alone can't tell them
-      # apart) but emits nothing at all, so -ftime-report itself always goes
-      # first and -ftime-report-details is an addition, never a substitute.
+      # -ftime-report-details (GCC 10+) only adds its per-pass breakdown on top
+      # of -ftime-report's own per-phase totals -- passed alone it compiles
+      # cleanly (so a flag-support check alone can't tell them apart) but emits
+      # nothing at all, so -ftime-report itself always goes first and
+      # -ftime-report-details is an addition, never a substitute.
       add_compile_options("-ftime-report")
-      check_cxx_compiler_flag("-ftime-report-details" CXX_SUPPORTS_TIME_REPORT_DETAILS)
+      check_cxx_compiler_flag("-ftime-report-details"
+                              CXX_SUPPORTS_TIME_REPORT_DETAILS)
       if(CXX_SUPPORTS_TIME_REPORT_DETAILS)
         add_compile_options("-ftime-report-details")
       endif()
     else()
-      message(WARNING "ENABLE_TIME_REPORT requested but this GCC does not support -ftime-report -- no-op")
+      message(
+        WARNING
+          "ENABLE_TIME_REPORT requested but this GCC does not support -ftime-report -- no-op"
+      )
     endif()
   else()
     message(STATUS "ENABLE_TIME_REPORT requested but the compiler is "
-                    "${CMAKE_CXX_COMPILER_ID}, not GCC -- no-op (GCC-only flag)")
+                   "${CMAKE_CXX_COMPILER_ID}, not GCC -- no-op (GCC-only flag)")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,44 @@ if(USE_MOLD
   endif()
 endif()
 
+# Per-translation-unit compiler-phase timing: GCC's own -ftime-report-details
+# prints, for every file it actually compiles (a no-op on an sccache cache
+# hit, since sccache then never invokes cc1plus at all), how much wall/user/
+# sys time went into each compiler phase and pass -- parsing, template
+# instantiation, individual GIMPLE/RTL passes, and so on. Off by default: it's
+# diagnostic-only stderr noise a local incremental build has no use for. CI's
+# own "build" job (.github/workflows/build.yml) turns it on unconditionally
+# via -DENABLE_TIME_REPORT=ON, tees the build log, and feeds it to
+# scripts/compile_time_report.rb, which turns these per-file blocks into a
+# "slowest files/phases this run" job-summary table -- a standing bottleneck
+# hint that costs nothing on a warm cache and only grows informative exactly
+# when a run actually recompiles a lot (a cold cache, a submodule bump, a
+# change to a widely-included header).
+option(ENABLE_TIME_REPORT "Emit GCC's -ftime-report-details compiler-phase timing" OFF)
+if(ENABLE_TIME_REPORT)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-ftime-report" CXX_SUPPORTS_TIME_REPORT)
+    if(CXX_SUPPORTS_TIME_REPORT)
+      # -ftime-report-details (GCC 10+) only adds its per-pass breakdown on
+      # top of -ftime-report's own per-phase totals -- passed alone it
+      # compiles cleanly (so a flag-support check alone can't tell them
+      # apart) but emits nothing at all, so -ftime-report itself always goes
+      # first and -ftime-report-details is an addition, never a substitute.
+      add_compile_options("-ftime-report")
+      check_cxx_compiler_flag("-ftime-report-details" CXX_SUPPORTS_TIME_REPORT_DETAILS)
+      if(CXX_SUPPORTS_TIME_REPORT_DETAILS)
+        add_compile_options("-ftime-report-details")
+      endif()
+    else()
+      message(WARNING "ENABLE_TIME_REPORT requested but this GCC does not support -ftime-report -- no-op")
+    endif()
+  else()
+    message(STATUS "ENABLE_TIME_REPORT requested but the compiler is "
+                    "${CMAKE_CXX_COMPILER_ID}, not GCC -- no-op (GCC-only flag)")
+  endif()
+endif()
+
 if(EMSCRIPTEN)
   # Emscripten ships SDL2 and SDL2_mixer as "ports": -sUSE_SDL=2 /
   # -sUSE_SDL_MIXER=2 provide both the headers (needed while compiling lvgl's

--- a/changelog.d/ci-compile-time-report.added.md
+++ b/changelog.d/ci-compile-time-report.added.md
@@ -1,0 +1,7 @@
+- **CI:** the native build job now enables GCC's `-ftime-report-details`
+  compiler-phase timing by default and posts a "slowest files/phases this
+  run" bottleneck-hint table to the job summary, next to the existing sccache
+  stats. Reports nothing on a fully cache-hit run, since sccache then never
+  invokes the compiler at all -- it only grows informative exactly when a run
+  actually recompiles a lot (a cold cache, a submodule bump, a widely-included
+  header change).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4412,6 +4412,78 @@ The work below is roughly ordered by the critical path to a walkable game
   field crash; the autostart-crash mystery (cycles #137-139); the missing-
   Picture-asset hang; and every EasyRPG-style citation cycle #154's own
   repo-wide grep turned up that no cycle has yet touched.
+  ✅ **Follow-up (cycle #167, 2026-08-26): completed cycle #165/#166's own
+  `SAVE_SYSTEM` field 125 (`battle_background`) investigation and closed it
+  with a definitive negative result -- genuine RPG_RT.exe does NOT persist
+  a Change Battle Background override past the battle it was issued in, so
+  this codebase's existing (unwired) behavior was already correct. No
+  production code changed; only `mruby-lcf/mrblib/schema.rb`'s own comment
+  on field 125 was extended to record the finding.** **Evidence:** picked
+  up cycle #166's own option (a) -- rather than hand-authoring a different
+  Enemy Encounter map event (option (b), which would have repeated cycles
+  #137-139's own demonstrated "hand-built battle-event map commands crash
+  genuine RPG_RT.exe" risk with unverified content), extended cycle
+  #130-165's proven-safe Map0478-event-2 splice to copy **all three** of
+  that event's genuine pages (not just page 2), preserving their own real
+  conditions/triggers (`build_battle_probe3.rb`, this session's scratchpad):
+  page 1 (flags=0, always active, trigger forced to autostart(3) since its
+  genuine trigger is touch-by-player) sets switch 911 at its own end: page 2
+  (genuinely autostart already, condition switch 911) is the real 89-command
+  Victory/Escape/Defeat script, and sets switch 913 on Victory; page 3
+  (genuinely trigger=action-key i.e. inert once selected, condition switch
+  913) is what stops the event from re-autostarting -- this is the exact
+  genuine mechanism cycle #166 was missing when its page-2-only splice
+  looped forever on Victory. Confirmed under wine: boots, Continues, the
+  full genuine dialogue plays, the fight is winnable, and afterward the
+  party returns to an ordinary map with no loop and no reduced menu from
+  the splice itself. Separately discovered the actual remaining blocker
+  wasn't the loop at all: `Save01_clean.lsd` (the demo save cycles #130-165
+  have reused since #148) itself carries `save_allowed: false` (field 123),
+  so the ordinary in-game System menu never offers Save regardless of
+  Victory/Escape -- this is a property of the fixture, not of the battle
+  script, and would have blocked cycle #166's option (a) too. Worked around
+  it the same way cycle #155's own picture probes already do: appended a
+  trailing Open Save Menu (11910) command, no Wait, right after page 2's
+  own genuine tail (`APPEND_SAVE_MENU=1` in `build_battle_probe3.rb`) --
+  Open Save Menu forces the save screen open regardless of `save_allowed`,
+  same as it did for cycles #160/#161's own field-123/124 probes. Ran the
+  full battle -> Victory -> auto-opened Save Menu -> save sequence twice
+  under wine: (1) troop 103 completely unmodified (baseline) and (2) with
+  cycle #166's own proven-safe troop-page-injection technique reapplied
+  (one new page on troop 103's own `RPG_RT.ldb` entry, condition copied
+  from the troop's own page 2 shape `flags=8/turn_a=1/turn_b=0`, running
+  Change Battle Background("light")) -- confirmed the backdrop visibly
+  changed to the real pink/white `Backdrop/light.png` gradient mid-fight in
+  run (2) (screenshot evidence in this session's scratchpad), the same
+  visible effect cycle #166 already established. Reading each resulting
+  genuine `Save01.lsd`'s chunk 101 with `LCF::SaveData`/`Array1D#key?(125)`
+  came back **absent in both runs** -- a real A/B result (only the Change
+  Battle Background firing differed between the two runs) rather than an
+  inconclusive one, settling the open question: this override is
+  battle-scoped only, exactly matching this codebase's own pre-existing
+  `@battle_background`-on-`Scene::Battle` behavior. **Verification:** all of
+  `scripts/rpg2k_scene_check.rb` (929), `scripts/rpg2k_logic_check.rb`
+  (1145), `scripts/rpg2k_render_check.rb` (41), `scripts/
+  rpg2k3_battle_row_check.rb` (19), `scripts/rpg2k3_battle_gauge_check.rb`
+  (15) and `ctest -R mruby_test` reconfirmed passing after the comment-only
+  change (identical counts to before); `scripts/rpg2k_save_load_check.rb`'s
+  own 3 pre-existing failures (BGM `balance`, `show_x`/`show_y`, the
+  transition-defaults warning) were reconfirmed present identically. All
+  three touched fixtures (`RPG_RT.ldb`, `Map0012.lmu`, `Save01.lsd`) were
+  restored and reconfirmed byte-identical by `md5sum` to the values
+  recorded since cycle #148 (`a738d3b9.../c2fa69a0.../3ab5bb01...`); `git
+  status` on `data/` (gitignored) came back clean. No EasyRPG source was
+  consulted for any claim, and no web search was used. **Left open for a
+  future cycle:** what field 125 actually represents, if anything (this
+  schema's own `:battle_background` name was always a positional guess, now
+  disproven for this specific command -- no alternative candidate
+  identified); the party-roster-field crash; the autostart-crash mystery
+  (cycles #137-139); the missing-Picture-asset hang; and every EasyRPG-style
+  citation cycle #154's own repo-wide grep turned up that no cycle has yet
+  touched. The 3-genuine-page splice technique and the "append Open Save
+  Menu after a genuine battle script's own tail" idiom this cycle proved
+  safe are both reusable building blocks for any future cycle needing a
+  clean post-battle save capture from this specific encounter.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1678,6 +1678,47 @@ module LCF
       122 => { name: :escape_allowed, type: :bool },
       123 => { name: :save_allowed, type: :bool },
       124 => { name: :menu_allowed, type: :bool },
+      # Cycle #165 surfaced this field as declared but completely unplumbed
+      # (`Game::State#to_lsd`/`.from_lsd` never read or wrote it) and cycle
+      # #166 confirmed the underlying command it names -- Change Battle
+      # Background (13210), decoded correctly by `Interpreter#
+      # do_change_battle_bg` -- genuinely fires and visibly changes the live
+      # battle backdrop when issued from a troop's own battle-event page
+      # (verified against genuine RPG_RT.exe: troop 103's real "light"
+      # backdrop swap). **Cycle #167 completed the open question and closed
+      # it: this override does NOT survive past the battle it was issued in.**
+      # Evidence: reused cycles #130-165's own proven-safe splice technique
+      # (Map0478 event 2's genuine autostart script, spliced onto a scratch
+      # Map0012.lmu copy) extended to all three of that event's real pages
+      # (not just page 2 in isolation, which cycle #166 found loops forever
+      # on Victory) so the fight could be won cleanly and reach an ordinary
+      # save-capable map state, then appended a trailing Open Save Menu
+      # (11910) command (same "genuine content + appended Open Save Menu, no
+      # Wait" idiom cycle #155's picture probes already used safely) to save
+      # immediately after Victory -- sidestepping the demo save's own
+      # `save_allowed: false` baked into `Save01_clean.lsd`, which blocks the
+      # ordinary in-game System menu's own Save entry regardless of anything
+      # the battle does. Ran this twice under wine: once against troop 103
+      # unmodified (baseline) and once with cycle #166's own proven-safe
+      # troop-page-injection technique added to troop 103's own `RPG_RT.ldb`
+      # entry (a new page, condition copied from the troop's own page 2
+      # shape, running Change Battle Background("light")) -- the backdrop
+      # visibly changed to the pink/white `Backdrop/light.png` gradient mid-
+      # fight in the second run (screenshot evidence), confirming the change
+      # genuinely fired, yet the resulting genuine `Save01.lsd`'s chunk 101
+      # came back with field 125 **absent in both captures** (`LCF::
+      # SaveData#key?(125)` false either way). This is a real, symmetric A/B
+      # result, not an inconclusive one: the only variable between the two
+      # runs was whether Change Battle Background fired, and the save
+      # chunk's own shape did not differ on that field. This codebase's own
+      # existing behavior -- `@battle_background` scoped entirely to the
+      # live `Scene::Battle` instance, discarded when the fight ends, never
+      # touching `Game::State` -- therefore already matches genuine RPG_RT.exe
+      # and needs no change. Left genuinely open (not this field's own
+      # concern): what field 125 actually is, if anything -- this schema's
+      # `:battle_background` name was always a guess from the field's
+      # position in the table, now disproven as this specific command's
+      # persistence slot; no alternative candidate has been identified.
       125 => { name: :battle_background, type: :string },
        131 => { name: :save_count, type: :int },
       # The file slot this save was written to. Confirmed against genuine

--- a/scripts/compile_time_report.rb
+++ b/scripts/compile_time_report.rb
@@ -1,0 +1,203 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Turns a CI build log captured with -DENABLE_TIME_REPORT=ON (CMakeLists.txt)
+# into a "slowest files / slowest compiler phases this run" job-summary
+# report.
+#
+# GCC's own -ftime-report(-details) prints, right after every file it
+# actually compiles, a per-phase/per-pass wall-clock breakdown ending in a
+# TOTAL line -- a no-op on an sccache cache hit, since sccache then never
+# invokes cc1plus at all (see CMakeLists.txt's own comment on
+# ENABLE_TIME_REPORT). This scans Ninja's build log for those blocks,
+# attributes each one to the "Building CXX/C object ..." status line
+# immediately above it, and aggregates:
+#
+#   - the slowest individual files this run,
+#   - time summed by GCC's own top-level "phase" buckets (these are
+#     mutually exclusive and sum to the per-file TOTAL, so this splits
+#     compile time into e.g. parsing vs. optimization/codegen),
+#   - the biggest named passes (these overlap each other and the phases
+#     above -- GCC's own accounting nests and cross-cuts them -- so this
+#     list is a set of individually-true "this pass cost this much"
+#     hints, not a second partition of the same total).
+#
+# Usage: ruby scripts/compile_time_report.rb <build.log> [--top N]
+#
+#   --top N   how many slowest files / passes to list (default 20)
+#   --help
+#
+# Writes a Markdown report to $GITHUB_STEP_SUMMARY when set (appended, like
+# every other *_report.rb in this directory), and a plain-text summary to
+# stdout either way.
+
+top_n = 20
+path = nil
+args = ARGV.dup
+until args.empty?
+  arg = args.shift
+  case arg
+  when '--top' then top_n = Integer(args.shift)
+  when /\A--top=(.+)\z/ then top_n = Integer(Regexp.last_match(1))
+  when '-h', '--help'
+    puts File.read(__FILE__)[/^# Usage:.*?(?=\n[^#])/m].gsub(/^# ?/, '')
+    exit 0
+  else
+    if path
+      warn "compile_time_report: unexpected argument #{arg.inspect} (try --help)"
+      exit 2
+    end
+    path = arg
+  end
+end
+
+if path.nil?
+  warn 'compile_time_report: missing <build.log> argument (try --help)'
+  exit 2
+end
+
+def write_no_data_summary(reason)
+  return unless (summary_path = ENV['GITHUB_STEP_SUMMARY']) && !summary_path.empty?
+
+  File.open(summary_path, 'a') do |io|
+    io.puts '## Compile-time bottleneck hints'
+    io.puts
+    io.puts reason
+  end
+end
+
+unless File.exist?(path)
+  puts "compile_time_report: #{path} not found -- nothing to report"
+  write_no_data_summary("Build log `#{path}` not found -- nothing to report.")
+  exit 0
+end
+
+# Ninja's default status line, e.g. "[123/456] Building CXX object foo.cxx.o".
+STATUS_LINE = /\A\[\d+\/\d+\]\s+(.+?)\s*\z/
+# A phase/pass row, e.g.
+#   " phase parsing            :   0.24 ( 96%)   0.11 ( 92%)   0.34 ( 87%)  19M ( 88%)"
+#   " `- template instantiation:   0.00 (  0%)   0.00 (  0%)   0.01 (  3%)  452k (  2%)"
+# The optional leading "`- " or "|" marks a nested drill-down of an already-
+# counted parent row -- excluded from the sums below to avoid double-counting.
+MEASURED_ROW =
+  /\A\s*(`- |\|)?(.+?)\s*:\s*[\d.]+\s*\(\s*\d+%\)\s+[\d.]+\s*\(\s*\d+%\)\s+([\d.]+)\s*\(\s*\d+%\)\s+\S+\s*\(\s*\d+%\)\s*\z/
+# The block-ending totals row, e.g. " TOTAL  :   0.25   0.12   0.39   21M" --
+# same 4 columns as above but with no percentages.
+TOTAL_ROW = /\A\s*TOTAL\s*:\s*[\d.]+\s+[\d.]+\s+([\d.]+)\s+\S+\s*\z/
+
+FileReport = Struct.new(:label, :wall, :phases, :passes)
+
+reports = []
+current_label = nil
+in_block = false
+phases = nil
+passes = nil
+
+File.foreach(path, encoding: 'UTF-8', invalid: :replace, undef: :replace) do |line|
+  if (m = STATUS_LINE.match(line))
+    # Strip Ninja's own "Building CXX/C/ASM object " prefix -- it's identical
+    # on every row, so the object path alone reads better in a ranked list.
+    current_label = m[1].sub(/\ABuilding \S+ object /, '')
+    next
+  end
+
+  if line.start_with?('Time variable')
+    in_block = true
+    phases = Hash.new(0.0)
+    passes = Hash.new(0.0)
+    next
+  end
+
+  next unless in_block
+
+  if (m = TOTAL_ROW.match(line))
+    reports << FileReport.new(current_label || '(unknown file)', m[1].to_f, phases, passes)
+    in_block = false
+    next
+  end
+
+  next unless (m = MEASURED_ROW.match(line))
+
+  next if m[1] # nested drill-down row, already counted in its parent
+
+  name = m[2]
+  wall = m[3].to_f
+  if name.start_with?('phase ')
+    phases[name] += wall
+  else
+    passes[name] += wall
+  end
+end
+
+if reports.empty?
+  puts 'compile_time_report: no -ftime-report block found in the log ' \
+       '(a fully cache-hit run recompiles nothing) -- nothing to report'
+  write_no_data_summary('No file was actually recompiled this run (full sccache cache hit) -- ' \
+                        'nothing to report.')
+  exit 0
+end
+
+total_wall = reports.sum(&:wall)
+slowest = reports.sort_by { |r| -r.wall }.first(top_n)
+
+phase_totals = Hash.new(0.0)
+pass_totals = Hash.new(0.0)
+reports.each do |r|
+  r.phases.each { |k, v| phase_totals[k] += v }
+  r.passes.each { |k, v| pass_totals[k] += v }
+end
+top_phases = phase_totals.sort_by { |_, v| -v }.first(10)
+top_passes = pass_totals.sort_by { |_, v| -v }.first(top_n)
+
+pct = ->(wall) { total_wall.zero? ? 0.0 : (wall * 100.0 / total_wall) }
+
+puts
+puts 'Compile-time bottleneck hints (-ftime-report)'
+puts
+puts format('  %d file(s) recompiled this run, %.1fs of measured compiler wall time total',
+            reports.size, total_wall)
+puts
+puts '  Slowest files:'
+slowest.each { |r| puts format('    %7.2fs  %s', r.wall, r.label) }
+puts
+puts '  Time by phase (mutually exclusive, sums to the total above):'
+top_phases.each { |name, wall| puts format('    %7.2fs (%5.1f%%)  %s', wall, pct.call(wall), name) }
+puts
+puts '  Notable passes (informational -- overlap each other and the phases above):'
+top_passes.each { |name, wall| puts format('    %7.2fs  %s', wall, name) }
+
+if (summary_path = ENV['GITHUB_STEP_SUMMARY']) && !summary_path.empty?
+  File.open(summary_path, 'a') do |io|
+    io.puts '## Compile-time bottleneck hints'
+    io.puts
+    io.puts format('**%d** file(s) recompiled this run (sccache cache misses only), ' \
+                   '**%.1fs** of measured compiler wall time total (`-ftime-report`). ' \
+                   'A fully warm cache reports nothing here -- this only grows informative ' \
+                   'exactly when a run recompiles a lot.',
+                   reports.size, total_wall)
+    io.puts
+    io.puts '<details><summary>Slowest files this run</summary>'
+    io.puts
+    io.puts '| File | Wall (s) |'
+    io.puts '| --- | ---: |'
+    slowest.each { |r| io.puts format('| `%s` | %.2f |', r.label, r.wall) }
+    io.puts
+    io.puts '</details>'
+    io.puts
+    io.puts '<details><summary>Time by phase (mutually exclusive, sums to the total above)</summary>'
+    io.puts
+    io.puts '| Phase | Wall (s) | % of total |'
+    io.puts '| --- | ---: | ---: |'
+    top_phases.each { |name, wall| io.puts format('| %s | %.2f | %.1f%% |', name, wall, pct.call(wall)) }
+    io.puts
+    io.puts '</details>'
+    io.puts
+    io.puts '<details><summary>Notable passes (overlap each other and the phases above)</summary>'
+    io.puts
+    io.puts '| Pass | Wall (s) |'
+    io.puts '| --- | ---: |'
+    top_passes.each { |name, wall| io.puts format('| %s | %.2f |', name, wall) }
+    io.puts
+    io.puts '</details>'
+  end
+end


### PR DESCRIPTION
Two unrelated changes ended up sharing this PR because both landed on this session's single designated branch back-to-back while the first was still open — noted here for reviewer clarity rather than split across two PRs.

## 1. CI: enable GCC -ftime-report-details by default, summarize bottlenecks

- The native `build` job had no visibility into where its own compile time goes beyond the aggregate sccache hit rate.
- `CMakeLists.txt` gains `ENABLE_TIME_REPORT` (off by default, so local incremental builds don't pay for it). When on, GCC prints a per-phase/per-pass wall-clock breakdown after every file it actually compiles — a no-op on an sccache cache hit, since sccache then never invokes the real compiler at all.
- `.github/workflows/build.yml`'s `cmake` step now passes `-DENABLE_TIME_REPORT=ON` unconditionally, and the `build` step tees its log.
- `scripts/compile_time_report.rb` scans that log for Ninja's `Building CXX/C object ...` status lines and the `-ftime-report` blocks that follow them, attributes each block to its file, and appends a "slowest files this run / time by phase / notable passes" table to the job summary, right alongside the existing sccache stats.

The report costs nothing on a warm cache (nothing to parse, nothing recompiled) and only grows informative exactly when a run actually recompiles a lot — a cold cache, a submodule bump, a change to a widely-included header.

**Verification:**
- `check_cxx_compiler_flag` gates both flags so this is a no-op (with a `message(STATUS ...)`) on any non-GCC compiler or an old-enough GCC — the other build jobs (wasm/emscripten, Android, PSP) are untouched since only the native job's own cmake invocation passes `-DENABLE_TIME_REPORT=ON`.
- Confirmed `-ftime-report-details` alone (without `-ftime-report`) compiles cleanly but emits nothing — a `check_cxx_compiler_flag`-only implementation would silently produce no report. Fixed by always adding `-ftime-report` first and `-ftime-report-details` as an addition on top.
- Ran a real, full from-scratch build of `rpg_maker_clone` with both flags: it completes and links cleanly (600+ translation units, including every vendored `3rd/*` dependency), and `ctest` (all 8 tests) still passes.
- Ran `scripts/compile_time_report.rb` against that real build's captured log: correctly attributes and ranks the slowest files (e.g. `ng-log`'s `logging.cc.o`, several Effekseer files), aggregates the mutually-exclusive "phase" totals (which sum to each file's own TOTAL), and lists the biggest individually-named passes.
- Verified the empty-log and missing-log-file paths degrade gracefully (print/append "nothing to report", exit 0) rather than erroring — the expected case on a fully cache-hit run.

Changelog: `changelog.d/ci-compile-time-report.added.md`.

## 2. Close the field-125 (battle_background) persistence question: no fix needed

Part of this repo's ongoing RPG_RT-fidelity investigation loop (cycles #165/#166 left open whether a Change Battle Background override persists past the battle it was issued in via `SAVE_SYSTEM` field 125).

Extended the proven-safe Map478-event-2 splice to all three of that event's genuine pages instead of just page 2, preserving the real switch-gated page-priority relationship that lets the fight resolve cleanly. Appended a trailing Open Save Menu command after the genuine script's own tail to force a save despite the demo fixture's own `save_allowed:false`. Ran the full battle → Victory → save sequence twice under wine, with and without a Change Battle Background firing mid-fight (confirmed visibly via screenshot in both cases) — field 125 came back absent in both captures, a real A/B result settling the question: this override is battle-scoped only, matching this codebase's own pre-existing behavior.

No production code changed; the comment on field 125 (`mruby-lcf/mrblib/schema.rb`) records the finding, and `docs/TODO.md` gets the cycle #167 follow-up entry. No changelog fragment — documentation/investigation closure only, not a user-facing behavior change.

**Verification:** `scripts/rpg2k_scene_check.rb` (929), `rpg2k_logic_check.rb` (1145), `rpg2k_render_check.rb` (41), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15) and `ctest -R mruby_test` all pass, identical counts to before (comment-only change). `rpg2k_save_load_check.rb`'s 3 known pre-existing failures reconfirmed unrelated. All touched fixtures restored byte-identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_