### PR TITLE
RPG2k: lazily build weather/flash/picture overlay buffers

### DIFF
--- a/changelog.d/rpg2k-lazy-blank-overlays.changed.md
+++ b/changelog.d/rpg2k-lazy-blank-overlays.changed.md
@@ -1,0 +1,20 @@
+- **RPG2k's weather, screen-flash, and picture compositing overlays now
+  build their screen-sized buffer lazily on first actual use, instead of
+  every map visit paying for all three whether or not they're ever
+  needed.** `Scene::Map#setup_screen_overlay`/`#setup_pictures` used to
+  allocate `@weather_bmp`/`@flash_bmp`/`@picture_bmp` (307,200 B decoded
+  each, ARGB8888) unconditionally at scene setup; most maps never turn on
+  weather, many never trigger a Screen Flash, and a fair number never run
+  Show Picture at all. Each buffer (and the sprite it feeds) is now created
+  the first time `#draw_weather`/the flash branch of
+  `#update_screen_overlay`/`#draw_pictures` actually needs to paint into
+  it -- an untouched map now skips up to ~900 KB of what
+  `docs/adr/0047-psp-memory-budget.md`'s Finding 3 calls the "third pool"
+  (native-heap `Bitmap` buffers, not the mruby arena; see also #1385's new
+  `bmp_blank` heartbeat field, which measured this exact pool as the
+  largest uncapped one found so far). `@fade_bmp` stays eager -- a map
+  transition arrives via a fade far too often for laziness to pay off
+  there. Verified locally: `scripts/rpg2k_scene_check.rb` (929 checks) and
+  `scripts/rpg2k_logic_check.rb` (1145 checks) both pass unchanged, after
+  updating four scene-check tests that grabbed `@picture_bmp`/`@weather_bmp`
+  before the first draw that would now create them.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -1695,6 +1695,30 @@ the interpreter-linking slice, in this order:
   different fix shape than a named-asset LRU cache, likely closer to "how
   many of these does Scene::Map actually need to keep alive at once"), left
   unpursued for now rather than opened speculatively.
+
+  **Third follow-up (2026-08-26): three of the buffers behind `bmp_blank`
+  turned out to be exactly that shape.** `Scene::Map#setup_screen_overlay`/
+  `#setup_pictures` built `@weather_bmp`/`@flash_bmp`/`@picture_bmp`
+  (307,200 B decoded each) unconditionally at scene setup, whether or not
+  that map ever turns on weather, triggers a Screen Flash, or runs Show
+  Picture -- up to ~900 KB of the run above's own `bmp_blank` figure, paid
+  by every map visit regardless. Each is now built lazily, the first time
+  `#draw_weather`/the flash branch of `#update_screen_overlay`/
+  `#draw_pictures` actually needs to paint into it -- the same "materialize
+  N objects when a fraction are ever used" shape as the RPG2k/Array1D/Array2D
+  fixes earlier in this ADR, just one layer up (a compositing buffer, not a
+  decoded chunk). `@fade_bmp` -- the fourth screen-sized overlay, right next
+  to `@flash_bmp`/`@weather_bmp` in the same method -- stays eager: a map
+  transition arrives via a fade far too often (it's how most Transfer
+  Player/Teleport commands read as a scene change at all) for laziness to
+  plausibly pay off there, unlike the other three's genuinely occasional
+  use. Verified locally: `scripts/rpg2k_scene_check.rb` (929 checks,
+  including four tests updated to grab `@picture_bmp`/`@weather_bmp` after
+  the first draw that now creates them rather than before) and
+  `scripts/rpg2k_logic_check.rb` (1145 checks) both pass. Real impact on
+  `bmp_blank` -- and how much of it survives once a real playthrough
+  actually uses pictures/flash/weather somewhere -- left to CI's own
+  `psp-smoke-game` run, as always in this section.
 - **P5 — done, including the real-game measurement.** `app/psp/main.cxx` now
   declares `PSP_MAIN_THREAD_STACK_SIZE_KB(256)` instead of inheriting
   pspsdk's implicit default, and the `RPG2K_PSP_BRINGUP` heartbeat carries

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -813,18 +813,24 @@ class RPG2k
 
         @flash_sprite = Sprite.new
         @flash_sprite.z = 450
-        @flash_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
-        @flash_sprite.bitmap = @flash_bmp
         @flash_sprite.opacity = 0
+        # Built lazily by #update_screen_overlay on the first real Flash
+        # Screen -- most maps never trigger one, so this screen-sized
+        # (307,200 B decoded) buffer shouldn't be every map visit's cost.
+        # @flash_rgb stays nil until then, which is also what forces that
+        # first real flash to allocate it (see the fill_rect branch below).
         @flash_rgb = nil
 
 
         # Weather Effects: rain / snow particles drawn on a screen-sized layer
-        # (under the flash / fade overlays), animated by @anim_frame.
+        # (under the flash / fade overlays), animated by @anim_frame. Most
+        # maps never turn weather on at all, so its screen-sized (307,200 B
+        # decoded) buffer is built lazily by #draw_weather on first actual
+        # use rather than paid by every map visit -- unlike @fade_bmp/
+        # @flash_bmp just above, whose bitmaps #draw_weather's own siblings
+        # need from frame one (a fade is how most map transitions arrive).
         @weather_sprite = Sprite.new
         @weather_sprite.z = 430
-        @weather_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
-        @weather_sprite.bitmap = @weather_bmp
         @weather_sprite.visible = false
       end
 
@@ -843,6 +849,10 @@ class RPG2k
         else
           rgb = [r, g, b]
           if @flash_rgb != rgb
+            unless @flash_bmp
+              @flash_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+              @flash_sprite.bitmap = @flash_bmp
+            end
             @flash_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(r, g, b, 255)
             @flash_rgb = rgb
           end
@@ -1020,6 +1030,10 @@ class RPG2k
           @weather_sprite.visible = false
           return
         end
+        unless @weather_bmp
+          @weather_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+          @weather_sprite.bitmap = @weather_bmp
+        end
         @weather_sprite.visible = true
         @weather_bmp.clear
         n = weather_particle_count(w)
@@ -1134,8 +1148,10 @@ class RPG2k
       def setup_pictures
         @picture_sprite = Sprite.new
         @picture_sprite.z = 250
-        @picture_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
-        @picture_sprite.bitmap = @picture_bmp
+        # Built lazily by #draw_pictures on the first frame that actually
+        # shows one -- a map that never runs Show Picture (or a Parallel
+        # Process that only ever shows one on some maps, not this one)
+        # shouldn't pay for this screen-sized (307,200 B decoded) buffer.
         # Toned copies of picture sources, keyed by image + tone (see
         # #toned_picture_src). Picture sources themselves are cached in
         # @picture_cache (see #picture_src).
@@ -9702,6 +9718,11 @@ class RPG2k
         sig = pictures_signature pics, cam_x, cam_y
         return if sig == @pictures_sig
         @pictures_sig = sig
+        return if pics.empty? && @picture_bmp.nil?
+        unless @picture_bmp
+          @picture_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+          @picture_sprite.bitmap = @picture_bmp
+        end
         @picture_bmp.clear
         return if pics.empty?
         # An erased id's own `Game::Picture` object lingers in `@state.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6492,9 +6492,12 @@ check 'pictures composite in ascending id order, independent of show order' do
   st = scene.instance_variable_get(:@state)
   st.show_picture(2, name: 'picB', x: 160, y: 120, zoom: 100, opacity: 255)
   st.show_picture(1, name: 'picA', x: 160, y: 120, zoom: 100, opacity: 255)
-  bmp = scene.instance_variable_get(:@picture_bmp)
-  bmp.clear_stretch_calls
+  # @picture_bmp is built lazily by #draw_pictures on the first frame that
+  # actually shows one, so it doesn't exist until this first #update -- no
+  # #clear_stretch_calls needed beforehand, the freshly-built stub starts
+  # with none recorded.
   scene.update
+  bmp = scene.instance_variable_get(:@picture_bmp)
   srcs = bmp.stretch_calls.map { |c| c[1] } # stretch_blt(dest, src, src_rect, opacity)
   eq 2, srcs.size, 'both pictures drew'
   # Picture 1 (id 1) composites first, so picture 2 (higher id) ends up on top.
@@ -6518,10 +6521,10 @@ check 'a picture not fixed to the map still shakes with Shake Screen (RPG_RT)' d
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)
   st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
-  bmp = scene.instance_variable_get(:@picture_bmp)
-
-  bmp.clear_stretch_calls
+  # @picture_bmp is built lazily by #draw_pictures on the first frame that
+  # actually shows one, so it doesn't exist until this first #update.
   scene.update
+  bmp = scene.instance_variable_get(:@picture_bmp)
   baseline_x = bmp.stretch_calls.first[0].x
 
   st.screen.shake(6, 5, 30) # power 6, speed 5, 30 frames
@@ -11193,9 +11196,14 @@ check 'Weather rain falls and drifts at RPG_RT\'s own per-frame rate, and ' \
   # every frame it's alive (`p.y += 4; p.x -= 1`), snow drifts leftward
   # only, never rightward (`p.x -= Rand::GetRandomNumber(0, 1)`).
   scene = new_scene({})
-  bmp = scene.instance_variable_get(:@weather_bmp)
+  # @weather_bmp is built lazily by #draw_weather on the first frame weather
+  # is actually active (most maps never turn it on) -- this check calls
+  # #draw_weather_particle directly, bypassing that, so it needs the buffer
+  # in place itself.
   h = RPG2k::Scene::Map::SCREEN_H
   w = RPG2k::Scene::Map::SCREEN_W
+  bmp = RGSS::Bitmap.new(w, h)
+  scene.instance_variable_set(:@weather_bmp, bmp)
 
   scene.instance_variable_set(:@anim_frame, 5)
   scene.send(:draw_weather_particle, RPG2k::Scene::Map::WEATHER_RAIN, 0)
@@ -15095,7 +15103,6 @@ check 'pictures are hidden while the battle screen is up (yado.tk: none show on 
   st = scene.instance_variable_get(:@state)
   st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
   sprite = scene.instance_variable_get(:@picture_sprite)
-  bmp = scene.instance_variable_get(:@picture_bmp)
 
   10.times do
     scene.update
@@ -15104,6 +15111,10 @@ check 'pictures are hidden while the battle screen is up (yado.tk: none show on 
   end
   ok battle_ui(scene), 'the battle opened'
   ok !sprite.visible, 'the picture layer is hidden the instant the battle screen is up'
+  # @picture_bmp is built lazily by #draw_pictures, but the loop above
+  # already ran it at least once before the battle opened (the picture was
+  # shown first), so it exists by now.
+  bmp = scene.instance_variable_get(:@picture_bmp)
   bmp.clear_stretch_calls
   scene.update
   eq 0, bmp.stretch_calls.size, 'and stops compositing pictures entirely while the fight runs'


### PR DESCRIPTION
## Summary

- `Scene::Map#setup_screen_overlay`/`#setup_pictures` built `@weather_bmp`/`@flash_bmp`/`@picture_bmp` (307,200 B decoded each, ARGB8888) unconditionally at scene setup, whether or not that map ever turns on weather, triggers a Screen Flash, or runs Show Picture — up to ~900KB of [#1385](https://github.com/take-cheeze/rpg-maker-clone/pull/1385)'s own `bmp_blank` figure, paid by every map visit regardless of use.
- Each is now built lazily, the first time `#draw_weather`/the flash branch of `#update_screen_overlay`/`#draw_pictures` actually needs to paint into it. Same "materialize N objects when a fraction are ever used" shape as the earlier `Array1D`/`Array2D`/common-event fixes in this series ([#1367](https://github.com/take-cheeze/rpg-maker-clone/pull/1367), [#1374](https://github.com/take-cheeze/rpg-maker-clone/pull/1374)), one layer up: a compositing buffer instead of a decoded chunk.
- `@fade_bmp`, the fourth screen-sized overlay right next to `@flash_bmp`/`@weather_bmp` in the same method, stays eager: a map transition arrives via a fade far too often (most Transfer Player/Teleport commands read as a scene change through it) for laziness to plausibly pay off there.
- Docs: `docs/adr/0047-psp-memory-budget.md`'s P4 section gets a third follow-up recording this.

## Test plan

- [x] `scripts/rpg2k_scene_check.rb` — 929 checks passed. Four tests updated to grab `@picture_bmp`/`@weather_bmp` after the first draw that now creates them, rather than before (a legitimate consequence of the laziness, not a bug — one test calls `#draw_weather_particle` directly and now sets up its own stub bitmap since it bypasses `#draw_weather`'s creation path entirely).
- [x] `scripts/rpg2k_logic_check.rb` — 1145 checks passed, unchanged.
- [ ] CI's `psp-smoke-game` run — to measure the real impact on `bmp_blank`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MikxyS2EAyyfwCi9gmxqMt)_