### PR TITLE
Fix kk1.12 download extracting Shift_JIS filenames as mojibake

### DIFF
--- a/changelog.d/killer-knights-cp932-filenames.fixed.md
+++ b/changelog.d/killer-knights-cp932-filenames.fixed.md
@@ -1,0 +1,10 @@
+- `scripts/download-killer-knights.bash` now extracts kk1.12.zip with
+  `unar -e cp932`, matching `rtp_install.bash`'s own RTP unpack. The archive's
+  internal file names are Shift_JIS (`Picture/キラーナイツ隊旗.png`,
+  `Picture/地名：レスト城.png`, ...); `unar`'s default guess mangled every
+  one into mojibake that the LCF/`RPG_RT.ldb`-only checks never notice (none
+  of them read a filename a game database points at) but that broke the
+  genuine RPG_RT.EXE outright — confirmed by actually running it live under
+  wine: it reached the title screen and the opening story scenes fine on a
+  plain `unar -q` extraction, then failed to open a Picture file by its exact
+  name the moment a map event tried to show one.

--- a/scripts/download-killer-knights.bash
+++ b/scripts/download-killer-knights.bash
@@ -31,5 +31,14 @@ if [ ! -f kk1.12.zip ] ; then
 fi
 
 if [ ! -d kk1.12 ] ; then
-    unar -q kk1.12.zip
+    # -e cp932: the archive's internal file names are Shift_JIS (e.g.
+    # Picture/キラーナイツ隊旗.png, Picture/地名：レスト城.png) -- unar's
+    # default guess mangles every one of them into mojibake that the LCF/
+    # RPG_RT.ldb-only checks never notice (they read no filenames a game
+    # database points at) but that breaks the genuine RPG_RT.EXE outright:
+    # running it live under wine, it opened cleanly up to the title screen
+    # on a plain `unar -q` extraction, then failed to open a Picture file by
+    # name the moment a map event actually showed one. rtp_install.bash's
+    # own RTP unpack already carries this same flag for the same reason.
+    unar -q -e cp932 kk1.12.zip
 fi


### PR DESCRIPTION
## Summary

- `scripts/download-killer-knights.bash` now extracts `kk1.12.zip` with `unar -e cp932`, matching `rtp_install.bash`'s own RTP unpack.

## Details

The archive's internal file names are Shift_JIS (e.g. `Picture/キラーナイツ隊旗.png`, `Picture/地名：レスト城.png`). `unar`'s default guess mangled every one of them into mojibake that the LCF/`RPG_RT.ldb`-only checks (`lcf_testbed_check.rb`, `rpg2k_testbed_logic_check.rb`, `rpg2k_command_soak.rb`) never notice — none of them read a filename a game database points at — but that breaks the genuine `RPG_RT.EXE` outright.

Confirmed by actually running the game's own `RPG_RT.EXE` live under wine (32-bit, `ja_JP.UTF-8` locale, both the 2000 and 2003 RTPs installed, a virtual desktop to work around wine's DirectDraw-over-GL path under Xvfb): it boots, plays through the opening story scenes, and the party's actor stats (HP/MP/EXP/ATK/DEF/INT/AGI, all matching this engine's own computed values exactly) resolve correctly — but a later map event failed to open a Picture file by name, tracing back to `unar`'s default extraction mangling the archive's Shift_JIS filenames.

This is a follow-up to #1387 (already merged), which added the `kk1.12` test bed itself.

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_