### PR TITLE
Fix gen-rpg2k-save.rb's stale comment on the missing hero sprite

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4484,6 +4484,76 @@ The work below is roughly ordered by the critical path to a walkable game
   Menu after a genuine battle script's own tail" idiom this cycle proved
   safe are both reusable building blocks for any future cycle needing a
   clean post-battle save capture from this specific encounter.
+  ✅ **Follow-up (cycle #168, 2026-08-26): investigated the never-wine-
+  verified "Set Transparent Flag polarity" EasyRPG citation (`do_player_
+  visibility`, fixed 2026-08-20 purely from reading EasyRPG's
+  `Game_Interpreter::CommandPlayerVisibility` source, never against genuine
+  RPG_RT.exe) using the reused Nepheshel `Save01.lsd`/`Map0012.lmu` autostart
+  harness -- inconclusive on the polarity question itself, but landed one
+  real fix along the way and fully root-caused a long-standing loose end in
+  `scripts/gen-rpg2k-save.rb`'s own comment. No production `mrblib` code was
+  changed; the existing polarity code is neither confirmed nor disproven.**
+  Built a fresh single-command autostart-page injector (`LCF::MapUnit`-based,
+  this session's own scratchpad) to splice a lone Set Transparent Flag
+  (11310) command onto an existing Map0012 event as a new page (not a new
+  event id, to keep the save's own 21-entry per-event position array the
+  same shape) and toggle param0 while resuming the shared demo save under
+  wine. First attempt hung/black-screened genuine RPG_RT.exe regardless of
+  param0 -- traced to this cycle's own harness bug, not an engine finding:
+  every genuine RPG2000 event-command list ends with an explicit `code=0`
+  terminator command (confirmed by decoding the map's own existing pages --
+  an empty page is exactly one `code=0` entry, `event_command_size` 4 bytes,
+  matching cycles #137-150's own "1 bare BlankLine" description of this
+  identical shape), and the injector's list lacked one; adding it (two
+  commands total: the real one + the terminator, computing field 51 as the
+  encoded blob's actual byte length rather than a command count, also
+  wrong in the first draft) fixed the hang. With that fixed, **both param0=0
+  and param0=1 produced an identical result (no hero sprite either way)**,
+  making the probe unable to answer the polarity question on this fixture --
+  chased down why: this exact `Save01.lsd`'s real party leader (per
+  `scripts/rpg2k_save_load_check.rb`'s own already-established "leader is
+  not chunk 109's first roster entry" finding, re-confirmed by directly
+  reading `RPG_RT.ldb` this cycle) is database actor 15 ("デモ用"), whose own
+  `charset_name` is a blank string -- a blank charset draws nothing in
+  genuine RPG_RT regardless of the transparent flag, so no toggle of that
+  flag can ever produce a visible difference from this save/position. Also
+  confirmed `Game::State.from_lsd` already promotes the correct leader (15)
+  via its own title-chunk fixup, and that this engine's own `--test_play`-
+  only debug marker (`Scene::Map`, `mruby-rpg2k/mrblib/scene/map.rb`,
+  explicitly alpha-0/invisible outside test play) was the only reason our
+  own renderer ever showed anything different there -- not a real rendering
+  gap. **Fixed:** `scripts/gen-rpg2k-save.rb`'s own stale comment, which
+  blamed the missing hero sprite on "Set Transparent Flag is on (chunk 101
+  field 55)" -- wrong twice over (field 55 is liblcf's unrelated
+  `event_message_active`, and the live fixture's actual transparency field,
+  chunk 104 field 24, already reads 0/not-transparent) -- rewritten with the
+  real, now fully root-caused mechanism above. **Verification:** all of
+  `scripts/rpg2k_scene_check.rb` (929), `scripts/rpg2k_logic_check.rb`
+  (1146), `scripts/rpg2k_render_check.rb` (41), `scripts/
+  rpg2k3_battle_row_check.rb` (19), `scripts/rpg2k3_battle_gauge_check.rb`
+  (15) and `ctest -R mruby_test` reconfirmed passing (comment-only change,
+  no script logic touched); `scripts/rpg2k_save_load_check.rb`'s own 3
+  pre-existing failures (BGM `balance`, `show_x`/`show_y`, the transition-
+  defaults warning) were reconfirmed present identically. All three touched
+  fixtures (`RPG_RT.ldb`, `Map0012.lmu`, `Save01.lsd`) were restored and
+  reconfirmed byte-identical by `md5sum` to the values recorded since cycle
+  #148 (`a738d3b9.../c2fa69a0.../3ab5bb01...`); `git status` on `data/`
+  (gitignored) came back clean, and no stray Xvfb/wine/engine processes were
+  left running. No EasyRPG source was consulted for any claim this cycle
+  (the citation under review was read only to identify it as unverified, not
+  relied on), and no web search was used. **Left open for a future cycle:**
+  the Set Transparent Flag polarity question itself is still genuinely
+  unverified against real RPG_RT.exe -- answering it needs a hero position
+  where the leader actually has a real charset (e.g. reposition this same
+  save with `scripts/gen-rpg2k-save.rb --map --at` onto a tile where actor 1,
+  not actor 15, is confirmed to render, or patch the save's own party roster
+  to a leader with a non-blank `charset_name` before probing); the now-fixed
+  single-command-plus-terminator autostart-page-injection technique above is
+  a reusable, wine-proven building block for that follow-up. Also still
+  open, unchanged: field 125's own remaining "what is it" question; the
+  party-roster-field crash; the autostart-crash mystery (cycles #137-139);
+  the missing-Picture-asset hang; and every EasyRPG-style citation cycle
+  #154's own repo-wide grep turned up that no cycle has yet touched.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/scripts/gen-rpg2k-save.rb
+++ b/scripts/gen-rpg2k-save.rb
@@ -57,13 +57,38 @@
 # lock-step. Everything else in the save (map event positions, the party,
 # switches and variables) is preserved byte-for-byte.
 #
-# One thing --clear-scene cannot restore is the hero *sprite*: the debug save is
-# taken in Nepheshel's demo mode, where Set Transparent Flag is on (chunk 101
-# field 55). Clearing that flag and giving the hero the party leader's CharSet
-# makes our engine draw him, but the genuine RPG_RT resumed from the same file
-# still does not, so it only manufactures a difference. Character-sprite
-# rendering is therefore compared through the map's *events*, which both
-# runtimes do draw -- and that is what caught the CharSet colour-key bug.
+# One thing --clear-scene cannot restore is the hero *sprite*: this comment
+# used to blame that on Set Transparent Flag being on via "chunk 101 field
+# 55" -- wrong on two counts, corrected here rather than left to mislead the
+# next reader. Field 55 of the *system* chunk (101) is liblcf's own
+# `event_message_active` (ShowMessage/ShowChoices/NumberInput bookkeeping),
+# not a visibility flag at all, and Set Transparent Flag's own runtime state
+# actually lives on the hero's movable record instead (chunk 104, field 24 of
+# `LCF::Schema::SAVE_MOVABLE`) -- but checking that field against the
+# checked-in `data/Nepheshel206beta` fixture's own `Save01.lsd` (gitignored,
+# reused by many prior cycles' own wine probes) shows it already reads 0 (not
+# transparent), so transparency was never the actual mechanism either. The
+# real cause, per `scripts/rpg2k_save_load_check.rb`'s own established
+# finding (see its "leader is not simply chunk 109's party list's first
+# entry" comment): this exact save's *actual* party leader, the one genuine
+# RPG_RT.exe resolves and shows throughout its own menus, is database actor
+# 15 ("デモ用", matching the title chunk's hero_name/level/hp) -- a demo/
+# placeholder actor whose own `charset_name` (RPG_RT.ldb chunk 11 field 3) is
+# a blank string, not chunk 109's nominal first roster entry (actor 1,
+# "リト", which does carry a real "mainchr" charset). `Game::State.from_lsd`
+# already promotes the correct leader (actor 15) via that same title-chunk
+# fixup, so our own engine resolves the identical blank charset here too --
+# a blank charset draws nothing in production in both runtimes alike, not a
+# bug, just this particular save's own leader having no assigned graphic at
+# capture time. The only reason our own renderer ever shows *anything* at
+# this hero position is `Scene::Map`'s own `--test_play`-only debug marker
+# for an unavailable CharSet graphic (`mruby-rpg2k/mrblib/scene/map.rb`,
+# gated on `parent.test_play`, alpha 0 -- i.e. invisible -- otherwise); that
+# marker is exactly what a naive screenshot diff of this save would
+# manufacture as a difference, not a genuine rendering gap. Character-sprite rendering
+# is therefore compared through the map's *events*, which both runtimes do
+# draw regardless of which actor the party leader resolves to -- and that is
+# what caught the CharSet colour-key bug.
 
 require 'stringio'
 require 'optparse'


### PR DESCRIPTION
## Summary

Docs-only cycle (#168) — no production `mrblib` code changed.

- The comment in `scripts/gen-rpg2k-save.rb` blamed the demo save's missing hero sprite on "Set Transparent Flag is on (chunk 101 field 55)" — wrong twice over: field 55 of the system chunk is liblcf's own `event_message_active` bookkeeping, not a visibility flag, and the live fixture's actual transparency field (chunk 104 field 24) already reads not-transparent.
- Root-caused while trying to verify a never-wine-checked EasyRPG citation (`do_player_visibility`'s polarity, fixed 2026-08-20 purely from reading EasyRPG source): this save's real party leader is database actor 15, a demo/placeholder actor with a blank `charset_name` — a blank charset draws nothing in genuine RPG_RT regardless of any transparency flag, so no toggle of that flag could ever have produced a visible difference from this save/position. `Game::State.from_lsd` already resolves the same leader via its own title-chunk fixup, so this engine's rendering matches; the only reason this engine's own screenshot ever looked different is a `--test_play`-only debug marker unrelated to transparency.
- The Set Transparent Flag polarity question itself remains unverified and is left open in `docs/TODO.md`, along with a now-fixed reusable single-command-plus-terminator autostart-page-injection technique (a prior harness bug — a missing `code=0` terminator command — caused an unrelated hang, separately fixed and documented for future cycles).

## Verification

- `scripts/rpg2k_scene_check.rb` (929), `rpg2k_logic_check.rb` (1146), `rpg2k_render_check.rb` (41), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15), and `ctest -R mruby_test` all pass, unaffected by this comment-only change.
- `rpg2k_save_load_check.rb`'s 3 known pre-existing failures reconfirmed unrelated.
- All touched fixtures restored byte-identical; `git status` on `data/` clean.

## Changelog

None — no user-facing behavior change (comment-only fix in a dev/probe script).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_