### PR TITLE
Confirm Set Transparent Flag polarity against genuine RPG_RT.exe

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4554,6 +4554,78 @@ The work below is roughly ordered by the critical path to a walkable game
   party-roster-field crash; the autostart-crash mystery (cycles #137-139);
   the missing-Picture-asset hang; and every EasyRPG-style citation cycle
   #154's own repo-wide grep turned up that no cycle has yet touched.
+  ✅ **Follow-up (cycle #169, 2026-08-26): finished cycle #168's own Set
+  Transparent Flag polarity investigation against genuine RPG_RT.exe --
+  **the existing polarity was already correct; only its citation was not.**
+  Two attempts at swapping in a leader with a real charset without touching
+  the checked-in fixture both left the hero invisible under genuine
+  RPG_RT.exe despite this engine's own renderer showing one clearly at the
+  identical position: (1) a from-scratch `Game::State#to_lsd` save (leader
+  rebuilt as actor 1, `Struct.new(:width,:height)` stood in for `self.map` so
+  the hero-centred camera scroll -- chunk 111 -- still got written without a
+  per-event position table) loaded fine (the file-select screen correctly
+  showed "リト" LV1 HP50) but drew no hero on the map; (2) a minimal,
+  surgical patch of the real save's own chunk 104 fields 73/74 (`charset_
+  name`/`charset_index`, schema.rb's own "sprite override" fields) -- every
+  other byte, including who the leader *is*, left untouched -- did nothing
+  either. Both are recorded here as a real, if incidental, finding: genuine
+  RPG_RT.exe does not appear to read chunk 104's hero-record charset fields
+  as a live per-save sprite override the way `Game::State#to_lsd`'s own
+  comment assumed (never chased further -- out of scope for this cycle,
+  flagged below for whoever wants it). **What worked:** left the checked-in
+  `Save01.lsd` and its resolved leader (database actor 15, "デモ用")
+  completely alone and instead patched a *scratch copy* of `RPG_RT.ldb`
+  (chunk 11, actor 15's own `charset_name`/`charset_index`, fields 3/4) to
+  `"mainchr"`/4 -- actor 1's own real graphic -- then repositioned the
+  untouched save with `scripts/gen-rpg2k-save.rb --map 12 --at 9,7
+  --clear-scene` onto a Map0012 tile confirmed via this engine's own
+  `Game::ChipSet#elevated?` to have no upper-layer tile drawing in front of
+  characters (the original saved position, (40,15), does have one -- an
+  unrelated, genuine reason that exact spot never shows a sprite regardless
+  of charset or the transparent flag, also newly root-caused this cycle).
+  That combination showed the hero cleanly under genuine RPG_RT.exe. Using
+  cycle #168's own proven single-page-plus-terminator injector
+  (`inject_transparency_probe2.rb`) to splice a lone Set Transparent Flag
+  (11310) autostart command onto the map's own event 1: **param0=0 left the
+  hero invisible for the rest of the run; param0=1 showed it normally,
+  identical to the untouched-flag baseline** -- reproduced twice for
+  param0=0. This matches `do_player_visibility`'s existing polarity
+  (`@state.player_transparent = cmd.param(0) == 0`) exactly. **Fixed** only
+  the citation, in the four places it was duplicated verbatim
+  (`Interpreter#do_player_visibility` and `Scene::Map#player_hidden?` in
+  `mruby-rpg2k/mrblib/{interpreter.rb,scene/map.rb}`, and the matching check
+  comments in `scripts/{rpg2k_logic_check.rb,rpg2k_scene_check.rb}`), which
+  all cited EasyRPG Player's own `Game_Interpreter::CommandPlayerVisibility`
+  (`src/game_interpreter.cpp`) as if it were "RPG_RT's own live source" --
+  replaced with this cycle's genuine wine evidence above. No behavioral code
+  changed (`cmd.param(0) == 0` stands), so no regression check applies.
+  **Verification:** all of `scripts/rpg2k_scene_check.rb` (929), `scripts/
+  rpg2k_logic_check.rb` (1146), `scripts/rpg2k_render_check.rb` (41),
+  `scripts/rpg2k3_battle_row_check.rb` (19), `scripts/
+  rpg2k3_battle_gauge_check.rb` (15) and `ctest -R mruby_test` all passed;
+  `scripts/rpg2k_save_load_check.rb`'s own 3 pre-existing failures (BGM
+  `balance`, `show_x`/`show_y`, the transition-defaults warning) were
+  reconfirmed present identically. The checked-in `RPG_RT.ldb`/`Map0012.lmu`/
+  `Save01.lsd` were never opened for writing (only read, to build scratch
+  copies elsewhere) and are reconfirmed byte-identical by `md5sum` to the
+  values recorded since cycle #148 (`a738d3b9.../c2fa69a0.../3ab5bb01...`);
+  `git status` on `data/` (gitignored) came back clean, and no stray
+  Xvfb/wine/engine processes were left running. No EasyRPG source was
+  consulted for any behavioral claim this cycle (the citations under review
+  were read only to identify and replace them), and no web search was used.
+  **Left open for a future cycle:** whether genuine RPG_RT.exe actually reads
+  a save's own chunk 104 hero `charset_name`/`charset_index` fields at all
+  (this cycle's own incidental finding above suggests maybe not, but it was
+  never chased to a real root cause, and `Game::State#to_lsd`'s own comment
+  claiming they round-trip a "live graphic override" is itself now suspect
+  and unverified against genuine RPG_RT.exe); field 125's own remaining
+  "what is it" question; the party-roster-field crash; the autostart-crash
+  mystery (cycles #137-139); the missing-Picture-asset hang; the leader's
+  own actor-graphic "Transparent" ghost-opacity mechanism (`Scene::Map
+  #player_translucent?`, a still-EasyRPG-cited, still-unverified *separate*
+  claim noticed but out of scope this cycle); and every other EasyRPG-style
+  citation cycle #154's own repo-wide grep turned up that no cycle has yet
+  touched.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3345,11 +3345,25 @@ module Game
     # Set Transparent Flag (Change Player Visibility): toggle whether the party
     # leader's map sprite is hidden. Non-blocking — it only records the flag on
     # the shared game state; the owning scene reads it each frame. The polarity
-    # (param0 zero = hidden) follows RPG_RT's own live source: `Game_Interpreter
-    # ::CommandPlayerVisibility` (`src/game_interpreter.cpp`, code 11310) is
-    # `bool hidden = (com.parameters[0] == 0); player->SetSpriteHidden(hidden);`
-    # -- the reverse of an earlier, uncited pass here that had param0 non-zero
-    # meaning hidden instead. The flag persists through Save / Continue.
+    # (param0 zero = hidden) used to be cited to EasyRPG Player's own
+    # `Game_Interpreter::CommandPlayerVisibility` (`src/game_interpreter.cpp`)
+    # as if that were RPG_RT's own source -- it is not, and that citation was
+    # never checked against the genuine executable (see docs/TODO.md's cycle
+    # #168/#169 entries). Confirmed against genuine RPG_RT.exe under wine this
+    # cycle instead: this exact Nepheshel `Save01.lsd`'s own resolved party
+    # leader (database actor 15, see `Game::State.from_lsd`'s title-chunk
+    # leader fixup) has a blank `charset_name`, so a blank-sprite save can
+    # never show a visibility difference on its own -- worked around by
+    # patching a *scratch copy* of `RPG_RT.ldb` to give that same actor 15 a
+    # real charset (`"mainchr"`/4, actor 1's own graphic; the checked-in
+    # fixture itself was never touched), then splicing a single-command
+    # autostart page (`Set Transparent Flag` + the required `code=0`
+    # terminator -- an event command list with no terminator hangs genuine
+    # RPG_RT.exe, cycle #168's own finding) onto an existing Map0012 event.
+    # param0=0 left the hero invisible for the rest of the run and param0=1
+    # showed it normally (matching the untouched-flag baseline) -- i.e. param0
+    # zero really is hidden, confirming this polarity was already correct,
+    # only its citation was not. The flag persists through Save / Continue.
     def do_player_visibility(cmd)
       @state.player_transparent = cmd.param(0) == 0
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3641,13 +3641,15 @@ class RPG2k
 
       # Whether the party leader's map sprite is genuinely hidden this frame --
       # the Set Transparent Flag command (11310), which RPG_RT itself calls
-      # "Change Player Visibility" and implements as a real hide. Confirmed
-      # against RPG_RT's own live source: `Game_Interpreter::
-      # CommandPlayerVisibility` (`src/game_interpreter.cpp`) is `bool hidden =
-      # (com.parameters[0] == 0); player->SetSpriteHidden(hidden);` -- a wholly
-      # separate mechanism from #player_translucent? below (`IsSpriteHidden()`
-      # vs `GetOpacity()`, both independently gating `Game_Character::
-      # IsVisible()`).
+      # "Change Player Visibility" and implements as a real hide (param0 zero
+      # hides, non-zero shows -- confirmed against genuine RPG_RT.exe under
+      # wine, cycle #169; not EasyRPG source, correcting a prior comment here
+      # that mislabelled EasyRPG Player's own `src/game_interpreter.cpp` as
+      # "RPG_RT's own live source" -- see `Interpreter#do_player_visibility`'s
+      # own comment in interpreter.rb for the full evidence). A wholly
+      # separate mechanism from #player_translucent? below (a real hide vs. a
+      # translucency tint, independently gating whether the sprite draws at
+      # all).
       def player_hidden?
         @state.player_transparent ? true : false
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10070,11 +10070,12 @@ end
 
 # -- Player Visibility / Return to Title --------------------------------------
 
-# Confirmed against RPG_RT's own live source: `Game_Interpreter::
-# CommandPlayerVisibility` (`src/game_interpreter.cpp`, code 11310) is
-# `bool hidden = (com.parameters[0] == 0); player->SetSpriteHidden(hidden);`
-# -- param0 *zero* hides the player, non-zero shows it, the reverse of an
-# earlier, uncited pass here that had the polarity backwards.
+# param0 *zero* hides the player, non-zero shows it again -- confirmed
+# against genuine RPG_RT.exe under wine (cycle #169; not EasyRPG source,
+# correcting a prior comment here that mislabelled EasyRPG Player's own
+# `src/game_interpreter.cpp` as "RPG_RT's own live source"): see
+# `Interpreter#do_player_visibility`'s own comment in interpreter.rb for the
+# full wine-verification evidence.
 check 'Set Transparent Flag toggles the player-transparent state, non-blocking' do
   st = party_state
   it = Game::Interpreter.new(st)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4047,9 +4047,11 @@ check "Halt All Movement lands an in-progress jump but drops the route's trailin
   ok scene.instance_variable_get(:@player_route).nil?, 'the route itself is cancelled'
 end
 
-# Confirmed against RPG_RT's own live source: `Game_Interpreter::
-# CommandPlayerVisibility` (`src/game_interpreter.cpp`) is `bool hidden =
-# (com.parameters[0] == 0)` -- param0 zero hides.
+# param0 zero hides -- confirmed against genuine RPG_RT.exe under wine
+# (cycle #169; not EasyRPG source, correcting a prior comment here that
+# mislabelled EasyRPG Player's own `src/game_interpreter.cpp` as "RPG_RT's
+# own live source"): see `Interpreter#do_player_visibility`'s own comment in
+# mruby-rpg2k/mrblib/interpreter.rb for the full wine-verification evidence.
 check 'Set Transparent Flag hides and shows the player sprite' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Interpreter#do_player_visibility`'s polarity (param0 zero = hidden) was cited to EasyRPG Player's own `Game_Interpreter::CommandPlayerVisibility` as if that were RPG_RT's own source — never actually checked against the genuine executable.
- Continuing cycle #168's investigation: cycle #168 found the reused demo save's resolved party leader (database actor 15) has a blank charset, so no toggle could ever produce a visible difference there.
- This cycle worked around it by patching a **scratch copy** of `RPG_RT.ldb` (never the checked-in fixture) to give that same actor a real graphic, and repositioning the untouched save onto a tile confirmed to have no upper-layer occlusion. Splicing a single Set Transparent Flag command onto a map event using cycle #168's proven injector: **param0=0 hid the hero for the rest of the run; param0=1 showed it normally**, matching the existing code exactly.
- **No behavior changed** — only the citation, duplicated in four places (`interpreter.rb`, `scene/map.rb`, and the matching check comments in `rpg2k_logic_check.rb`/`rpg2k_scene_check.rb`), is corrected to cite this cycle's genuine wine evidence instead of EasyRPG source.
- Along the way, found an incidental new lead: two separate attempts to give the party leader a real charset via the save's own chunk 104 fields (rather than the database) drew nothing under genuine RPG_RT.exe despite this engine's own renderer showing a sprite there — suggesting `Game::State#to_lsd`'s existing comment about those fields being a "live sprite override" may itself be wrong. Left open in `docs/TODO.md` for a future cycle, not chased further here.

## Verification

- `scripts/rpg2k_scene_check.rb` (929), `rpg2k_logic_check.rb` (1146), `rpg2k_render_check.rb` (41), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15), and `ctest -R mruby_test` all pass — comment-only change, no regression check needed.
- `rpg2k_save_load_check.rb`'s 3 known pre-existing failures reconfirmed unrelated.
- The checked-in `RPG_RT.ldb`/`Map0012.lmu`/`Save01.lsd` were only ever read (scratch copies used for the actual probes); reconfirmed byte-identical via `md5sum`.

## Changelog

None — comment/citation-only fix, no user-facing behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_