### PR TITLE
Save/Continue: sprite override lives on chunk 108, not chunk 104

### DIFF
--- a/changelog.d/save-actor-sprite-override-chunk108.fixed.md
+++ b/changelog.d/save-actor-sprite-override-chunk108.fixed.md
@@ -1,0 +1,13 @@
+- **Save/Continue:** A live Change Sprite Association (10630) graphic
+  override now survives Save/Continue the way genuine RPG_RT.exe itself
+  persists it -- as fields on the changed actor's own roster entry (chunk
+  108, `SAVE_PARTY_ACTOR`), not on the hero's own map-position record (chunk
+  104). Previously `Game::State#to_lsd`/`.from_lsd` wrote/read the override
+  only on chunk 104, which a genuine RPG_RT.exe save never reads back for
+  this at all (confirmed under wine): a save produced by this codebase with
+  an active sprite override would show the actor's plain database graphic
+  again after a Continue in genuine RPG_RT.exe, and a genuine RPG_RT.exe save
+  carrying a live override would silently lose it on Continue here. Also
+  fixes the *un*-overridden case: an actor whose database row simply has a
+  non-blank default graphic no longer round-trips as though a live override
+  had been applied to it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4626,6 +4626,72 @@ The work below is roughly ordered by the critical path to a walkable game
   claim noticed but out of scope this cycle); and every other EasyRPG-style
   citation cycle #154's own repo-wide grep turned up that no cycle has yet
   touched.
+  ✅ **Follow-up (cycle #170, 2026-08-26): resolved cycle #169's own left-open
+  question -- genuine RPG_RT.exe does NOT read a save's chunk 104 hero
+  `charset_name`/`charset_index` as a live sprite override, but it DOES
+  persist and restore a live Change Sprite Association (10630) override, just
+  from a different chunk than this codebase assumed.** Verified under wine
+  with a from-scratch experiment sidestepping cycle #169's own uncertainties
+  entirely (no patched save, no pre-existing fixture): a fresh New Game
+  autostart on Map0371 (the genuine start map, per `RPG_RT.lmt`'s own
+  `initial_map_id`) ran a real Change Sprite Association on the default
+  leader (actor 15, blank database charset) to `"mainchr"`/4, then opened the
+  Save menu and saved to file 1. Diffing that save against two controls (no
+  command at all; the same non-blank graphic baked into actor 15's own
+  *database* row instead, with no event command run) isolated the effect
+  precisely: all three saves wrote chunk 104's hero fields 73/74 whenever the
+  leader's *currently drawn* sprite was non-blank, override or plain
+  database default alike (elided only when blank) -- but only the genuine
+  live-override save wrote three previously-undeclared fields on the
+  *actor's own* chunk 108 (`SAVE_PARTY_ACTOR`) entry: 11 (`sprite_name`,
+  `"mainchr"`), 12 (`sprite_id`, 4), and, only when the command's own
+  transparency param was also set in a third variant, 13
+  (`sprite_transparent`, `\x03`, liblcf's familiar "0 or 3" convention).
+  Continuing the live-override save under genuine RPG_RT.exe (with the
+  injected autostart page removed, so nothing could re-trigger the change)
+  rendered the leader with the saved-off `"mainchr"` graphic; continuing the
+  no-override control left the leader invisible (blank database charset) --
+  directly confirming chunk 108's fields, not chunk 104's, are what a genuine
+  Continue actually restores the sprite from, and fully explaining cycle
+  #169's own negative result (it only ever patched chunk 104). **Fixed**:
+  `SAVE_PARTY_ACTOR` (`mruby-lcf/mrblib/schema.rb`) gained fields 11/12/13;
+  `Game::Actor` (`mruby-rpg2k/mrblib/game.rb`) gained a `@sprite_changed`
+  flag (set by `#set_charset`, mirroring `@class_changed`'s own convention)
+  so a plain database-default graphic is never mistaken for a live override;
+  `Game::State#to_lsd` now writes chunk 108's fields 11-13 per roster actor
+  gated on `#sprite_changed?` (not just the leader -- Change Sprite
+  Association can target any actor id) and elides chunk 104's own 73/74 only
+  when the leader's current sprite is genuinely blank (previously written
+  unconditionally as `''`, unlike genuine RPG_RT); `Game::State.from_lsd` now
+  restores the override from chunk 108 per actor instead of chunk 104's hero
+  record. `Party#to_h`/`#apply_actor_meta` (the engine's own separate,
+  non-`.lsd` quicksave format) also carry the new flag, so an actor's plain
+  database default no longer round-trips there as a spurious live override
+  either, with an explicit `nil`-vs-`false` fallback keeping an
+  already-in-flight quicksave from before this fix working unchanged.
+  **Verification:** `scripts/rpg2k_save_load_check.rb` gained two new
+  round-trip assertions (a live override lands on chunk 108 and
+  `#sprite_changed?` survives it; an untouched actor's chunk 108 sprite
+  fields and `#sprite_changed?` both stay absent/false) -- both pass on the
+  fixed code and, via `git stash` of just the two `mrblib` files (keeping the
+  check-script change), the untouched-actor code path in the pre-fix
+  `Game::Actor` errors outright (`sprite_changed?` did not exist), confirming
+  the check exercises the fix. All of `scripts/rpg2k_scene_check.rb` (929),
+  `scripts/rpg2k_logic_check.rb` (1146), `scripts/rpg2k_render_check.rb`
+  (41), `scripts/rpg2k3_battle_row_check.rb` (19), `scripts/
+  rpg2k3_battle_gauge_check.rb` (15) and `ctest -R mruby_test` all passed;
+  `scripts/rpg2k_save_load_check.rb`'s own 3 pre-existing failures (BGM
+  `balance`, `show_x`/`show_y`, the transition-defaults warning) were
+  reconfirmed present identically, unchanged by this fix. All wine work ran
+  against an isolated scratch copy of Nepheshel's game directory, never the
+  checked-in one -- `RPG_RT.ldb`/`Map0012.lmu`/`Save01.lsd`/`Map0371.lmu`/
+  `RPG_RT.lmt` are reconfirmed byte-identical by `md5sum` to their
+  previously-recorded values, `git status` on `data/` (gitignored) came back
+  clean, and no stray Xvfb/wine/engine processes were left running. No
+  EasyRPG source and no `generator/csv/fields.csv` were consulted for any
+  part of this cycle's fields 11/12/13 -- purely wine experiment, unlike
+  fields 1/2/31/32/etc.'s own liblcf-confirmed provenance already documented
+  in `SAVE_PARTY_ACTOR`'s own comment.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1345,6 +1345,34 @@ module LCF
     SAVE_PARTY_ACTOR = {
       1 => { name: :actor_name, type: :string },            # 名前
       2 => { name: :title, type: :string },                 # 二つ名 (Change Actor Title)
+      # A live Change Sprite Association (10630) override, confirmed against
+      # genuine RPG_RT.exe under wine (cycle #170) -- NOT liblcf's own field
+      # table (no network access to `generator/csv/fields.csv` this cycle),
+      # purely by experiment: a fresh New Game autostart running Change
+      # Sprite Association on the default party leader (actor 15, a blank-
+      # charset database row) then immediately opening the Save menu wrote
+      # these three fields onto that actor's own chunk-108 entry -- 11
+      # ("mainchr"), 12 (4), and, only when the command's own transparency
+      # param was also set, 13 (`\x03`, the same liblcf "0 or 3" convention
+      # SAVE_MOVABLE field 24 uses). A second control save from the same
+      # autostart page with the Change Sprite Association command removed
+      # left all three fields absent. A third save, from an actor whose
+      # *database* row was patched to that same non-blank graphic with no
+      # Change Sprite Association command ever run, also left 11-13 entirely
+      # absent -- proving these are gated on a live "the command actually
+      # ran" flag (Game::Actor#sprite_changed?), not merely "the current
+      # sprite happens to be non-blank" (that weaker, blank-elided condition
+      # is what chunk 104's own hero-record mirror, fields 73/74, actually
+      # uses instead -- see #to_lsd's own citation). Continuing the
+      # Change-Sprite-Association save under genuine RPG_RT.exe rendered the
+      # leader with the saved-off "mainchr" graphic, confirming these fields
+      # -- not chunk 104's -- are what a genuine Continue actually restores
+      # from; this directly explains cycle #169's own negative finding that
+      # patching only chunk 104's fields 73/74 in a real save never changed
+      # what Continue drew.
+      11 => { name: :sprite_name, type: :string },
+      12 => { name: :sprite_id, type: :int },
+      13 => { name: :sprite_transparent, type: :int, default: 0 },
       31 => { name: :level, type: :int, default: 1 },      # レベル
       32 => { name: :exp, type: :int, default: 0 },        # 経験値
       51 => { name: :skill_size, type: :int, default: 0 }, # 『特技』情報のデータ数

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1578,6 +1578,20 @@ module Game
       # mirrors it by keying on this flag rather than on `@class_id > 0` alone.
       @battler_animation_override = 0
       @class_changed = false
+      # Whether a Change Sprite Association (10630) has actually run for this
+      # actor, as opposed to @charset_name/@charset_index still being the
+      # actor's own untouched database default set two lines up -- confirmed
+      # against genuine RPG_RT.exe under wine (cycle #170): a save taken right
+      # after Change Sprite Association wrote new fields 11 (sprite_name) / 12
+      # (sprite_id) / 13 (sprite_transparent, absent unless the transparency
+      # flag was set) onto that actor's own SAVE_PARTY_ACTOR entry (chunk
+      # 108), while an otherwise identical actor whose *database* row already
+      # carried that same non-blank graphic -- no Change Sprite Association
+      # ever run -- left chunk 108 entirely without fields 11-13 (only the
+      # hero's own live-sprite mirror on chunk 104, fields 73/74, reflected
+      # it, elided only when blank). See SAVE_PARTY_ACTOR's own schema.rb
+      # comment and #to_lsd/.from_lsd's own citations for the full writeup.
+      @sprite_changed = false
       @battle_commands = nil # lazily taken from the database on the first change
       # RPG2003 battle front/back row (ADR 0053): purely runtime/save state,
       # never derived from the database's own `battle_x`/`battle_y` manual
@@ -1670,11 +1684,20 @@ module Game
     end
 
     # Replace the actor's CharSet graphic (the Change Sprite Association event
-    # command): `name` is the file and `index` the cell within it.
+    # command): `name` is the file and `index` the cell within it. Also called
+    # while restoring a saved override (Game::State.from_lsd) -- both are a
+    # real, persisted "changed" event, not the actor's own untouched database
+    # default set at #initialize -- see @sprite_changed's own comment there.
     def set_charset(name, index)
       @charset_name = name
       @charset_index = index
+      @sprite_changed = true
     end
+
+    # Whether #set_charset has actually run for this actor (a live Change
+    # Sprite Association, or one restored from a save) -- see @sprite_changed's
+    # own comment at #initialize.
+    def sprite_changed?; @sprite_changed; end
 
     # The actor's FaceSet graphic (顔グラフィック), shown on the save-select
     # screen (the SAVE_TITLE face slots) -- distinct from the message face
@@ -3613,6 +3636,17 @@ module Game
         meta[a.id] = { name: a.name, title: a.title,
                        charset_name: a.charset_name,
                        charset_index: a.charset_index,
+                       # Gates whether a restore actually calls #set_charset
+                       # (see #apply_actor_meta below) -- without it, an actor
+                       # whose charset_name is merely their own non-blank
+                       # database default (never a real Change Sprite
+                       # Association) would spuriously come back marked
+                       # #sprite_changed?, the same "changed at all" flag
+                       # Game::State#to_lsd now gates chunk 108's own
+                       # sprite_name/sprite_id/sprite_transparent fields on
+                       # (see that method's own citation) -- mirrors
+                       # class_changed just below.
+                       sprite_changed: a.sprite_changed?,
                        transparent: a.transparent, states: a.states.dup,
                        # A Change Parameters command's unclamped shadow total
                        # (see Actor#change_param / #restore_base) -- without
@@ -3700,7 +3734,12 @@ module Game
       return unless m
       actor.name = m[:name] if m[:name]
       actor.title = m[:title] unless m[:title].nil?
-      if m[:charset_name]
+      # `sprite_changed` false means the database default was never actually
+      # overridden -- skip #set_charset so the actor's own #sprite_changed?
+      # stays false too (see #to_h's own citation). A save written before
+      # `sprite_changed` existed carries no such key (nil, not false), read
+      # as "assume changed" -- the old behavior, gated on charset_name alone.
+      if m[:charset_name] && m[:sprite_changed] != false
         actor.set_charset(m[:charset_name], m[:charset_index] || actor.charset_index)
       end
       actor.transparent = m[:transparent] unless m[:transparent].nil?
@@ -14799,8 +14838,22 @@ module Game
       # SAVE_MOVABLE comment on why it lives here, on the hero's own movable
       # record, not the system chunk).
       hero[24] = @player_transparent ? 3 : 0
-      if leader
-        hero[73] = leader.charset_name || ''
+      # A live mirror of the leader's *currently drawn* CharSet graphic --
+      # elided when blank, confirmed against genuine RPG_RT.exe under wine
+      # (cycle #170): a leader whose graphic was blank (no override, blank
+      # database default) left these fields absent, one whose *database* row
+      # already carried a non-blank graphic (still no override) wrote them
+      # present anyway, and one with a live Change Sprite Association
+      # override also wrote them present with the overridden value -- so
+      # this pair tracks "what the hero currently looks like", not "was
+      # there a live override" (that is chunk 108's own sprite_name/
+      # sprite_id/sprite_transparent job instead, on the *actor's* own
+      # SAVE_PARTY_ACTOR entry -- see #to_lsd's own citation just below and
+      # SAVE_PARTY_ACTOR's schema.rb comment). Continuing a save never reads
+      # this pair back (see .from_lsd's own citation) -- it is write-only
+      # parity with what genuine RPG_RT itself puts here, not a restore path.
+      if leader && leader.charset_name && !leader.charset_name.empty?
+        hero[73] = leader.charset_name
         hero[74] = leader.charset_index || 0
       end
       save[104] = hero
@@ -14973,6 +15026,19 @@ module Game
         # Actor Title), confirmed against liblcf's SaveActor field table --
         # see SAVE_PARTY_ACTOR's comment in schema.rb.
         e[2] = a.title
+        # A live Change Sprite Association (10630) override -- fields 11
+        # (sprite_name) / 12 (sprite_id) / 13 (sprite_transparent), gated on
+        # #sprite_changed? (the command actually having run), not merely a
+        # non-blank current graphic -- see SAVE_PARTY_ACTOR's own schema.rb
+        # comment for the genuine-RPG_RT wine verification this cycle (#170)
+        # that pinned these fields down, and for why chunk 104's own hero-
+        # record mirror (fields 73/74) is *not* what a genuine Continue
+        # restores the sprite from.
+        if a.sprite_changed?
+          e[11] = a.charset_name || ''
+          e[12] = a.charset_index || 0
+          e[13] = 3 if a.transparent
+        end
         e[31] = a.level
         e[32] = a.exp
         e[51] = a.skills.size
@@ -15477,6 +15543,18 @@ module Game
           # only the reserve-actor placeholder byte is skipped.
           tt = sa.title
           actor.title = tt if tt && tt != "\x01"
+          # A live Change Sprite Association override (chunk 108 fields
+          # 11/12/13) -- what genuine RPG_RT.exe itself restores the on-map
+          # sprite from, not chunk 104's hero-record mirror (fields 73/74,
+          # never read back -- see #to_lsd's own citation and
+          # SAVE_PARTY_ACTOR's schema.rb comment for cycle #170's wine
+          # verification of both halves of this). Gated on sprite_name's own
+          # presence, the same "the command actually ran" signal #to_lsd
+          # writes it under; an absent field leaves the actor's own database
+          # default charset (#initialize) untouched.
+          sn = sa.sprite_name
+          actor.set_charset(sn, sa.sprite_id || 0) if sn
+          actor.transparent = (sa.sprite_transparent || 0) != 0 if sn
         end
         hp[aid] = sa.hp if sa.hp
         mp[aid] = sa.mp if sa.mp
@@ -15519,11 +15597,10 @@ module Game
             { x: t.x || 0, y: t.y || 0, switch_id: t.switch_on ? t.switch_id : nil }
         end
       end
-      # The leader's on-map sprite override (a Change Sprite Association), stored
-      # in the hero chunk's CharSet fields.
-      if party.leader && hero.charset_name && !hero.charset_name.empty?
-        party.leader.set_charset(hero.charset_name, hero.charset_index || 0)
-      end
+      # A live Change Sprite Association override is restored per-actor above,
+      # from chunk 108's own sprite_name/sprite_id/sprite_transparent fields
+      # (not chunk 104's hero-record mirror, fields 73/74 -- see #to_lsd's own
+      # citation and SAVE_PARTY_ACTOR's schema.rb comment for why).
       sys = save[101]
       switches = {}
       (sys.switches || []).each_with_index { |v, i| switches[i + 1] = v if v }

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -270,7 +270,8 @@ def check_game(dir)
   state.show_picture(7, name: 'flagpic', x: 10, y: 20, fixed_to_map: true,
                          use_transparent_color: true)
 
-  round = Game::State.from_lsd(db, LCF::SaveData.new(StringIO.new(state.to_lsd(state.save_count).to_lcf)))
+  round_lsd = LCF::SaveData.new(StringIO.new(state.to_lsd(state.save_count).to_lcf))
+  round = Game::State.from_lsd(db, round_lsd)
   fp = round.pictures[7]
   eq true, !fp.nil? && fp.fixed_to_map,
      'to_lsd: a picture shown fixed-to-map keeps that flag across Save/Continue'
@@ -340,6 +341,26 @@ def check_game(dir)
     eq 'HeroAlt', round.party.leader.charset_name, 'to_lsd: leader sprite override'
     eq 5, round.party.leader.charset_index, 'to_lsd: leader sprite index'
     eq 'Renamed', round.party.leader.name, 'to_lsd: leader name override'
+    lentry = round_lsd[108][round.party.leader.id]
+    eq 'HeroAlt', lentry && lentry.sprite_name,
+       'to_lsd: chunk 108 carries the live sprite override (not chunk 104)'
+    eq true, round.party.leader.sprite_changed?,
+       'to_lsd: leader sprite_changed? survives the round trip'
+  end
+  # An actor whose charset was never touched by a live Change Sprite
+  # Association must keep chunk 108's own sprite fields (11/12/13) elided --
+  # confirmed against genuine RPG_RT.exe under wine (cycle #170): a plain
+  # database-default graphic must not round-trip as though it were a live
+  # override. See Game::Actor#sprite_changed?'s own citation and
+  # SAVE_PARTY_ACTOR's schema.rb comment for the full writeup.
+  untouched = state.party.actors.find { |a| state.party.leader.nil? || a.id != state.party.leader.id }
+  if untouched
+    uentry = round_lsd[108][untouched.id]
+    eq nil, uentry && uentry.sprite_name,
+       "to_lsd: actor #{untouched.id}'s untouched sprite stays elided from chunk 108"
+    ub = round.party.actor_by_id(untouched.id)
+    eq false, ub && ub.sprite_changed?,
+       "to_lsd: actor #{untouched.id}'s sprite_changed? stays false untouched"
   end
 
   puts "  leader=#{state.party.leader.name.inspect} hp=#{state.party.leader.hp} " \


### PR DESCRIPTION
## Summary

- Cycle #169 found that patching a save's chunk 104 hero-record CharSet fields never changed what genuine RPG_RT.exe drew on Continue, leaving the actual mechanism unresolved.
- Driving genuine RPG_RT.exe under wine: a live Change Sprite Association (10630) writes new fields (`sprite_name`/`sprite_id`/`sprite_transparent`) onto the *changed actor's own* `SAVE_PARTY_ACTOR` entry (chunk 108), gated on the command actually having run — an actor whose database row already has that same non-blank graphic, with no live override, leaves chunk 108 untouched.
- Continuing a save with the live override restores the overridden graphic; chunk 104's own hero-record fields 73/74 turned out to be a write-only mirror of whatever the hero currently looks like (elided only when blank), never read back on Continue at all — directly explaining cycle #169's negative result.
- `Game::Actor` gains `#sprite_changed?`, set by `#set_charset` and mirroring the existing `@class_changed` convention, so a plain database-default graphic is never mistaken for a live override. `to_lsd`/`from_lsd` now read/write the override on chunk 108 per actor instead of the ineffective chunk-104 path, and elide chunk 104's fields when the leader's sprite is blank (previously written unconditionally as `''`).
- The engine's own internal quicksave format (`Party#to_h`/`#apply_actor_meta`) carries the same flag, with a `nil`-vs-`false` fallback so an in-flight quicksave from before this fix keeps working.

## Verification

- Genuine RPG_RT.exe under wine (isolated scratch copy of Nepheshel's game dir, never the checked-in fixtures): a fresh New Game autostart ran Change Sprite Association on the default leader (blank-charset actor), then opened the Save menu. Diffed against two controls (no command run; a non-blank *database* default with no command run). Chunk 104 fields 73/74 appeared whenever the current sprite was non-blank (override or plain default alike); chunk 108 fields 11/12/13 appeared **only** in the true live-override case. Continuing the live-override save rendered the overridden graphic; continuing the no-override control left the leader invisible — proving chunk 108, not 104, is what Continue restores from.
- `git stash` of just the two `mrblib` files (keeping the extended check) makes the new check crash outright (`sprite_changed?` undefined), confirming the check exercises the fix; restoring the fix brings the suite back to exactly the 3 known pre-existing `rpg2k_save_load_check.rb` failures (BGM `balance`, `show_x`/`show_y`, transition-defaults warning).
- Full suite passes: `rpg2k_scene_check.rb` (929), `rpg2k_logic_check.rb` (1146), `rpg2k_render_check.rb` (41), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15), `ctest -R mruby_test`.
- `data/` fixtures (`RPG_RT.ldb`/`Map0012.lmu`/`Save01.lsd`/`Map0371.lmu`/`RPG_RT.lmt`) restored byte-identical.
- No EasyRPG source or `generator/csv/fields.csv` consulted for any claim.

## Changelog

See `changelog.d/save-actor-sprite-override-chunk108.fixed.md`.

## Test plan

- [x] `ruby scripts/rpg2k_save_load_check.rb` (new assertions added; 3 pre-existing unrelated failures reconfirmed via `git stash`)
- [x] `ruby scripts/rpg2k_logic_check.rb`
- [x] `ruby scripts/rpg2k_scene_check.rb`
- [x] `ruby scripts/rpg2k_render_check.rb`
- [x] `ruby scripts/rpg2k3_battle_row_check.rb`
- [x] `ruby scripts/rpg2k3_battle_gauge_check.rb`
- [x] `cd build && ctest -R mruby_test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_