### PR TITLE
Fix Game::State#to_lsd writing a save that crashes genuine RPG_RT.exe

### DIFF
--- a/changelog.d/save-inventory-party-roster-crash.fixed.md
+++ b/changelog.d/save-inventory-party-roster-crash.fixed.md
@@ -1,0 +1,19 @@
+- `Game::State#to_lsd` no longer writes a save file that crashes a genuine
+  `RPG_RT.exe` on load. `SAVE_INVENTORY` (chunk 109) field 1 was modelled as a
+  self-contained `int8_array` holding the party roster directly, and `#to_lsd`
+  wrote the roster there and nothing else — but liblcf's own
+  `generator/csv/fields.csv` documents field 1 as the roster
+  `Vector<Int16>`'s *count* and field 2 as its *data*, the identical
+  count-then-data split `item_count`/`item_ids` (fields 11/12) already use.
+  A save missing field 2 that a genuine RPG_RT.exe itself always writes
+  crashes the real engine outright on load with a null-pointer read
+  (confirmed live under wine), regardless of what field 1's count says. A
+  solo party's field 1 byte happens to read identically under either
+  schema (count 1 and "array `[1]`" are the same one byte), which is
+  exactly why every prior real-game save this engine has loaded never
+  exposed it; a multi-actor party (kk1.12, a real RPG2003 game) does not
+  share that coincidence. This also resolves a crash a prior session's own
+  investigation had already run into and worked around without diagnosing
+  (see the "Methodology note" in `Actor#use_skill_book`'s comment,
+  `mruby-rpg2k/mrblib/game.rb`). Covered by a new fixture check in
+  `rpg2k_logic_check.rb`.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1479,16 +1479,32 @@ module LCF
     # save: gold (21) matched the on-screen 100G, and the parallel item id/count
     # arrays matched the held items looked up in the database -- 薬草 (item 1) ×3
     # and 導きの書 (item 451) ×1, after the gate crystal had been spent. Item ids
-    # are int16; counts and per-item use-counts are one byte each. Field 1 is the
-    # party roster (actor ids); the sole entry `[1]` is actor 1, whose database
-    # charset matches the saved hero. The turn/step counters (fields 0x29/0x2A)
-    # are now decoded too, below. Fields 23-30 (0x17-0x1E) are the two Timer
-    # Operation countdowns -- ids and "value is seconds*60+59" both confirmed
-    # against liblcf's own `ChunkSaveInventory` enum, which documents them
-    # under this chunk rather than the system chunk (101) `docs/TODO.md` used
-    # to guess they would need a new id in.
+    # are int16; counts and per-item use-counts are one byte each. The turn/step
+    # counters (fields 0x29/0x2A) are now decoded too, below. Fields 23-30
+    # (0x17-0x1E) are the two Timer Operation countdowns -- ids and "value is
+    # seconds*60+59" both confirmed against liblcf's own `ChunkSaveInventory`
+    # enum, which documents them under this chunk rather than the system chunk
+    # (101) `docs/TODO.md` used to guess they would need a new id in.
+    #
+    # party_count (1) / party (2): the actor-id roster, split the same
+    # count-then-data way as item_count/item_ids (11/12) just below --
+    # confirmed against liblcf's own generator/csv/fields.csv, which
+    # documents field 1 as the `Vector<Int16>` *count* and field 2 as its
+    # *data*, not (as this schema had it, and #to_lsd wrote to match) a
+    # single self-contained int8_array crammed into field 1 alone with field
+    # 2 never written at all. A single-actor party's field 1 byte happens to
+    # read identically under either schema (count 1 and "array `[1]`" are the
+    # same one byte), which is exactly why this went unnoticed: kk1.12's
+    # three-actor roster (`party_count` 3, `party` data `[1, 2, 3]`) does not
+    # share that coincidence, and a save missing field 2 that a genuine
+    # RPG_RT.exe writes crashes the real engine outright on load (confirmed
+    # live under wine: the same crash a prior session's own methodology note
+    # a few hundred lines down in game.rb already flagged and worked around
+    # without diagnosing). `#to_lsd`/`#from_lsd` (mruby-rpg2k/mrblib/game.rb)
+    # updated to match.
     SAVE_INVENTORY = {
-      1 => { name: :party, type: :int8_array },
+      1 => { name: :party_count, type: :int, default: 0 },
+      2 => { name: :party, type: :int16_array },
       11 => { name: :item_count, type: :int, default: 0 },
       12 => { name: :item_ids, type: :int16_array },
       13 => { name: :item_counts, type: :int8_array },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4769,7 +4769,15 @@ module Game
     # genuine RPG_RT.exe under wine on this exact save/map the instant the
     # field menu was opened -- so this test left it untouched and used
     # whichever actor the save already, genuinely led with instead of adding
-    # a second party member. Separately, and unrelated to this claim: a
+    # a second party member. Root cause since found (kk1.12, a later
+    # session): `#to_lsd` wrote the roster into field 1 alone as a raw
+    # int8_array and never wrote field 2 at all, but liblcf's own
+    # generator/csv/fields.csv documents field 1 as the roster vector's
+    # *count* and field 2 as its *data* -- the same count-then-data split
+    # item_count/item_ids (11/12) already use. A save missing the data field
+    # that a genuine RPG_RT.exe itself always writes crashes it on load
+    # regardless of what the count says, roster edited or not; see
+    # SAVE_INVENTORY's own comment. Separately, and unrelated to this claim: a
     # synthetic autostart map event of 2+ commands reliably wedges or crashes
     # genuine RPG_RT.exe on the very next Cancel/menu-open press on this same
     # save/map, reproducing cycles #137-151's own open "autostart-crash
@@ -15163,7 +15171,14 @@ module Game
       save[103] = pics
 
       inv = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_INVENTORY })
-      inv[1] = @party.actors.map { |a| a.id }
+      # party_count (1) / party (2): the same count-then-data split as
+      # item_count/item_ids (11/12) just below -- see SAVE_INVENTORY's own
+      # comment. A genuine RPG_RT.exe requires both fields; writing only the
+      # count (or, as this used to, cramming the roster into field 1 alone
+      # and never writing field 2 at all) crashes it outright on load.
+      party_ids = @party.actors.map { |a| a.id }
+      inv[1] = party_ids.size
+      inv[2] = party_ids
       item_ids = @party.items.keys.sort
       inv[11] = item_ids.size
       inv[12] = item_ids

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7301,6 +7301,36 @@ check 'to_lsd/from_lsd round-trips the 使用回数 tally (chunk 109 field 14)' 
   eq 1, round.party.item_count(4)
 end
 
+check 'to_lsd writes the party roster as a count-then-data pair (chunk 109 ' \
+      'fields 1/2), the same split item_count/item_ids (11/12) already use' do
+  # liblcf's own generator/csv/fields.csv documents SAVE_INVENTORY field 1 as
+  # the roster Vector<Int16>'s *count* and field 2 as its *data* -- #to_lsd
+  # used to write the roster into field 1 alone as a self-contained
+  # int8_array and never write field 2 at all. A solo party's field 1 byte
+  # happens to read identically either way (count 1 and "array [1]" are the
+  # same one byte), which is exactly why this went unnoticed until a
+  # multi-actor party (kk1.12, a real RPG2003 game) exposed it: a save
+  # missing field 2 that a genuine RPG_RT.exe itself always writes crashes
+  # the real engine outright on load, confirmed live under wine.
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
+    2 => FakePlayerRow.new('Ally', '', 0, 3, max_hp: 50, max_mp: 20, atk: 6, def: 5),
+    3 => FakePlayerRow.new('Mage', '', 0, 3, max_hp: 40, max_mp: 40, atk: 4, def: 3),
+  }
+  db = FakeActorDB.new(players, [1])
+  party = Game::Party.new(db)
+  party.add_actor(2)
+  party.add_actor(3)
+  st = Game::State.new(party, 1, 0, 0)
+
+  inv = st.to_lsd[109]
+  eq 3, inv.party_count, 'field 1 is the count, not the roster itself'
+  eq [1, 2, 3], inv.party, 'field 2 is the roster data'
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq [1, 2, 3], round.party.actors.map(&:id)
+end
+
 check 'field_items lists every held item in id order with counts, including ' \
       'an unusable one -- RPG_RT lists it disabled, it does not omit it' do
   items = { 5 => fake_item(type: 6, rhp: 50),   # medicine


### PR DESCRIPTION
## Summary

- `Game::State#to_lsd` no longer writes a save file that crashes a genuine `RPG_RT.exe` on load.

## Details

`SAVE_INVENTORY` (chunk 109) field 1 was modelled as a self-contained `int8_array` holding the party roster directly, and `#to_lsd` wrote the roster there and nothing else. liblcf's own `generator/csv/fields.csv` documents field 1 as the roster `Vector<Int16>`'s *count* and field 2 as its *data* — the same count-then-data split `item_count`/`item_ids` (fields 11/12) already use. A save missing field 2 that a genuine RPG_RT.exe itself always writes crashes the real engine outright on load with a null-pointer read, regardless of what field 1's count says.

A solo party's field 1 byte happens to read identically under either schema (count 1 and "array `[1]`" are the same one byte), which is exactly why every prior real-game save this engine has loaded never exposed it — kk1.12's three-actor roster does not share that coincidence.

### How this was found

Continuing to use kk1.12's real `RPG_RT.EXE` (running under wine) as a ground-truth oracle: after confirming it boots and plays correctly, I took a genuine in-game save, round-tripped it through this engine's own `Game::State.from_lsd`/`#to_lsd` with **no semantic changes at all**, and tried loading that unmodified round-trip back into the real engine. It crashed with a deterministic null-pointer read. Bisecting a real `Save01.lsd` chunk-by-chunk against the genuine engine (swapping this engine's re-exported chunks back to the original save's bytes one at a time) isolated it to `SAVE_INVENTORY`'s field 2 being entirely absent from this engine's output.

This also resolves a crash a prior session's own investigation had already run into and worked around without diagnosing (see the "Methodology note" in `Actor#use_skill_book`'s comment, `mruby-rpg2k/mrblib/game.rb`).

Covered by a new fixture check in `rpg2k_logic_check.rb`; verified the fix by re-generating the same real save through the corrected writer and loading it into the genuine `RPG_RT.exe` again (no crash).

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_