### PR TITLE
Confirm player_translucent? against genuine RPG_RT.exe

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4692,6 +4692,64 @@ The work below is roughly ordered by the critical path to a walkable game
   part of this cycle's fields 11/12/13 -- purely wine experiment, unlike
   fields 1/2/31/32/etc.'s own liblcf-confirmed provenance already documented
   in `SAVE_PARTY_ACTOR`'s own comment.
+  ✅ **Follow-up (cycle #171, 2026-08-26): resolved cycle #169's own left-open
+  question about `Scene::Map#player_translucent?` (the leader actor
+  graphic's "Transparent" ghost-opacity flag) -- the behavior was already
+  correct, only its citation, duplicated in two places, was not.** Verified
+  under wine with a from-scratch experiment: a fresh autostart page on
+  Map0371 (the genuine New Game start map)'s own event 1 ran a real Change
+  Sprite Association (10630) on the default leader (actor 15) to a known
+  graphic (`"mainchr"`/4), with the command's own "Transparent" param0 either
+  0 (control) or 1 (trans), then went idle with no further command so the
+  hero stood still on the map for a clean screenshot -- no Save menu, no
+  animation-frame drift between the two runs. Sampling every high-signal
+  colour channel across the whole sprite (1298 samples) showed the "trans"
+  run's pixels consistently at 0.616 mean ratio (min 0.48, max 0.65) of the
+  "control" run's own values against the map's black background -- a real
+  alpha blend, not a hide (0%) and not unaffected (100%), closely matching
+  this codebase's own already-implemented `TRANSLUCENT_OPACITY = 159`
+  (159/255 = 0.6235; wine screenshots came through a 16bpp X11 framebuffer,
+  which explains the spread but not the central tendency). **Fixed**: only
+  the citation, in the two places it was duplicated verbatim
+  (`Scene::Map#player_translucent?` in `mruby-rpg2k/mrblib/scene/map.rb` and
+  the matching check comment in `scripts/rpg2k_scene_check.rb`), which both
+  cited EasyRPG Player's own `Game_Actor::SetSprite`/`Game_Character::
+  GetOpacity` (`src/game_actor.cpp`/`src/game_character.cpp`) as if it were
+  "RPG_RT's own live source" -- replaced with this cycle's genuine wine
+  evidence above; the exact 159 vs 160 distinction is left as EasyRPG's own
+  derivation since wine's own 16bpp screenshots can't resolve it. Also fixed
+  a second, independent bug found in passing: `Interpreter#do_change_actor_
+  sprite`'s own comment in `mruby-rpg2k/mrblib/interpreter.rb` flatly said
+  the Change Sprite Association command's transparent param "hides the
+  sprite" -- factually wrong, and contradicted this codebase's own already-
+  correct `player_translucent?` (which the same line of code, `actor.
+  transparent = cmd.param(2) != 0`, feeds); corrected to describe the real
+  translucent-ghost effect. No behavioral code changed anywhere (`git diff`
+  on both `mrblib` files touched only `#` comment lines), so no regression
+  check applies, matching cycle #169's own precedent for citation-only
+  fixes. **Verification:** all of `scripts/rpg2k_scene_check.rb` (929, incl.
+  the pre-existing "Transparent flag makes the player sprite translucent"
+  check, whose own `eq 159, spr.opacity` assertion is unchanged and still
+  passes), `scripts/rpg2k_logic_check.rb` (1146), `scripts/
+  rpg2k_render_check.rb` (41), `scripts/rpg2k3_battle_row_check.rb` (19),
+  `scripts/rpg2k3_battle_gauge_check.rb` (15) and `ctest -R mruby_test` all
+  passed; `scripts/rpg2k_save_load_check.rb`'s own 3 pre-existing failures
+  (BGM `balance`, `show_x`/`show_y`, the transition-defaults warning) were
+  reconfirmed present identically. All wine work ran against scratch copies
+  of Nepheshel's game directory (a fresh copy of cycle #170's own
+  `game/`, never the checked-in one) -- `RPG_RT.ldb`/`Map0012.lmu`/
+  `Save01.lsd`/`Map0371.lmu`/`RPG_RT.lmt` are reconfirmed byte-identical by
+  `md5sum` to their previously-recorded values, `git status` on `data/`
+  (gitignored) came back clean, and no stray Xvfb/wine/engine processes were
+  left running. No EasyRPG source was consulted for any behavioral claim
+  this cycle (the citations under review were read only to identify and
+  replace them), and no web search was used. **Left open for a future
+  cycle:** field 125's own remaining "what is it" question; the party-
+  roster-field crash; the autostart-crash mystery (cycles #137-139); the
+  missing-Picture-asset hang; and every other EasyRPG-style citation cycle
+  #154's own repo-wide grep turned up that no cycle has yet touched (a large
+  remainder -- this cycle deliberately fixed only the two duplicates of the
+  one citation named as this cycle's primary target, not the wider sweep).
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2483,9 +2483,12 @@ module Game
 
     # Change Sprite Association (Change Actor Graphic): give the actor whose id is
     # param0 a new CharSet graphic — the command string names the file, param1 is
-    # the cell index and param2 the transparency flag (non-zero hides the sprite).
-    # Records a one-shot request so the owning scene can reload the party leader's
-    # on-screen sprite.
+    # the cell index and param2 the dialog's own "Transparent" checkbox (non-zero
+    # renders the sprite as a translucent ghost, ~62% opacity, via
+    # `Scene::Map#player_translucent?` -- it does NOT hide the sprite; confirmed
+    # against genuine RPG_RT.exe under wine, cycle #171, see that method's own
+    # citation). Records a one-shot request so the owning scene can reload the
+    # party leader's on-screen sprite.
     def do_change_actor_sprite(cmd)
       actor = identity_target(cmd)
       return unless actor

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3655,21 +3655,38 @@ class RPG2k
       end
 
       # Whether the leader's *actor graphic* carries RPG2000's "Transparent"
-      # ghost flag (the ChangeActorGraphic/database Actor checkbox) -- this
-      # does not hide the sprite, it makes it translucent. Confirmed against
-      # RPG_RT's own live source: `Game_Actor::SetSprite` stores `data.
-      # transparency = transparent ? 3 : 0` (`src/game_actor.cpp`), and
-      # `Game_Character::GetOpacity` (`src/game_character.cpp`) is `Clamp((8 -
-      # GetTransparency()) * 32 - 1, 0, 255)` -- level 3 yields opacity
-      # 159/255 (~62%), not 0. This codebase used to fold this flag into
-      # #player_hidden? and hide the sprite outright instead.
+      # ghost flag (the Change Actor Graphic (10630) dialog's own checkbox,
+      # param2, or the database Actor's "Transparent" checkbox, field 5
+      # `semi_transparent`) -- this does not hide the sprite, it makes it
+      # translucent. Confirmed against genuine RPG_RT.exe under wine, cycle
+      # #171: a from-scratch autostart page ran a real Change Sprite
+      # Association on actor 15 to a real graphic ("mainchr"/4) on Map0371
+      # (the genuine New Game start map), once with the command's own
+      # transparent param 0 (control) and once with it 1, and the two runs
+      # were screenshotted at the identical frame with no further commands
+      # run. The "transparent" run's sprite pixels were consistently ~61-63%
+      # of the control run's own values (1298 sampled colour channels across
+      # the whole sprite, mean ratio 0.616, matching this codebase's own
+      # already-implemented TRANSLUCENT_OPACITY below almost exactly) --
+      # genuinely alpha-blended with the background, not hidden (0%) and not
+      # left unaffected (100%). This corrects a prior version of this comment
+      # that mislabelled EasyRPG Player's own `src/game_actor.cpp` and
+      # `src/game_character.cpp` as "RPG_RT's own live source" -- the 159/255
+      # constant below happens to already match genuine RPG_RT.exe, but that
+      # was never actually confirmed against real RPG_RT.exe until this
+      # cycle. This codebase used to fold this flag into #player_hidden? and
+      # hide the sprite outright instead.
       def player_translucent?
         leader = @state.party.leader
         leader && leader.transparent ? true : false
       end
 
-      # RPG_RT's own opacity for the "Transparent" ghost flag (see
-      # #player_translucent?'s citation) -- `(8 - 3) * 32 - 1 == 159`.
+      # The "Transparent" ghost flag's own opacity -- confirmed against
+      # genuine RPG_RT.exe (see #player_translucent?'s own citation above) to
+      # land around 159-160/255 (~62%); kept at 159, the exact value EasyRPG
+      # Player's own source independently derives via `(8 - 3) * 32 - 1`, since
+      # wine's own screenshot pixels (taken through a 16bpp X11 framebuffer)
+      # can't distinguish 159 from 160 to the last unit.
       TRANSLUCENT_OPACITY = 159
 
       # Apply both independent visibility signals to the player sprite: a

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4070,12 +4070,17 @@ end
 
 # The leader's own actor graphic "Transparent" flag (Change Actor Graphic /
 # the database Actor checkbox) is a wholly separate, ghost-opacity mechanism
-# from Set Transparent Flag's real hide -- confirmed against RPG_RT's own
-# live source: `Game_Actor::SetSprite` stores `data.transparency = 3`
-# (`src/game_actor.cpp`), and `Game_Character::GetOpacity` (`src/
-# game_character.cpp`) is `Clamp((8 - GetTransparency()) * 32 - 1, 0, 255)`
-# -- level 3 yields 159/255, not a hide. This codebase used to fold the two
-# into one hide-only flag.
+# from Set Transparent Flag's real hide -- confirmed against genuine
+# RPG_RT.exe under wine, cycle #171 (see `Scene::Map#player_translucent?`'s
+# own comment in `mruby-rpg2k/mrblib/scene/map.rb` for the full write-up): a
+# from-scratch Change Sprite Association autostart probe on the genuine New
+# Game start map, screenshotted at an identical frame with the command's own
+# transparent param 0 vs 1, showed the "on" sprite's pixels consistently at
+# ~61-63% of the "off" run's own values -- alpha-blended with the
+# background, never a hide. This corrects a prior version of this comment
+# that mislabelled EasyRPG Player's own `src/game_actor.cpp`/
+# `src/game_character.cpp` as "RPG_RT's own live source". This codebase used
+# to fold the two into one hide-only flag.
 check 'the leader actor graphic\'s Transparent flag makes the player sprite ' \
       'translucent, not hidden' do
   scene = new_scene({}, player: [5, 5], members: [SlipActor.new])
@@ -4087,7 +4092,7 @@ check 'the leader actor graphic\'s Transparent flag makes the player sprite ' \
   st.party.leader.transparent = true
   scene.update
   eq true, spr.visible, 'the ghost flag never hides the sprite outright'
-  eq 159, spr.opacity, 'ghost-translucent, RPG_RT\'s own (8 - 3) * 32 - 1'
+  eq 159, spr.opacity, 'ghost-translucent, ~62% opacity confirmed under wine'
   st.party.leader.transparent = false
   scene.update
   eq 255, spr.opacity, 'and clears back to fully opaque'


### PR DESCRIPTION
## Summary

Docs-only cycle (#171) — no behavioral code changed.

- Cycle #169 flagged `Scene::Map#player_translucent?` (the leader actor graphic's "Transparent" ghost-opacity flag) as still cited to EasyRPG Player's own source as if that were RPG_RT's, never actually checked against the genuine executable.
- Ran a real Change Sprite Association on the New Game start map's default leader with the command's own transparent param toggled, screenshotting an identical idle frame under wine for each. The "transparent" run's sprite pixels landed at a consistent ~62% of the control run's values against the map background — a genuine alpha blend, matching this codebase's own existing `TRANSLUCENT_OPACITY = 159` almost exactly.
- No behavior changed; only the citation, duplicated in two places (`scene/map.rb` and `scripts/rpg2k_scene_check.rb`), is corrected to cite this cycle's evidence instead of EasyRPG source.
- Also fixed a second, unrelated stale comment found in passing: `do_change_actor_sprite`'s own doc said the transparent param "hides the sprite" — wrong, and contradicted this codebase's own already-correct translucent-ghost implementation fed by that same line.

## Verification

- `scripts/rpg2k_scene_check.rb` (929, including the pre-existing check whose `eq 159, spr.opacity` assertion is unchanged and still passes), `rpg2k_logic_check.rb` (1146), `rpg2k_render_check.rb` (41), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15), and `ctest -R mruby_test` all pass — comment-only change, no regression check needed.
- `rpg2k_save_load_check.rb`'s 3 known pre-existing failures reconfirmed unrelated.
- All wine work ran against scratch copies; the checked-in fixtures reconfirmed byte-identical.

## Changelog

None — comment/citation-only fix, no user-facing behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_