### PR TITLE
Fix picture save round-trip vs genuine RPG_RT.exe (bottom-half transparency + erased-picture reconstruction)

### DIFF
--- a/changelog.d/picture-bottom-half-transparency-mirror.fixed.md
+++ b/changelog.d/picture-bottom-half-transparency-mirror.fixed.md
@@ -1,0 +1,13 @@
+- `Game::State#to_lsd` now writes chunk 103 (Show Picture) fields 18
+  (`current_bot_trans`) and 35 (`finish_bot_trans`) as plain mirrors of fields
+  8 (`current_top_trans`) and 34 (`finish_top_trans`). liblcf's own
+  `generator/csv/fields.csv` documents 18/35 as RPG2003's independent
+  bottom-half transparency for its pre-1.12 top/bottom split effect, and a
+  genuine kk1.12 (RPG2003) save under wine carries both halves present with
+  identical values even though it never exercises a real split — `#to_lsd`
+  previously never wrote 18/35 at all, so a picture round-tripped through
+  this engine's own Save/Continue lost the bytes a genuine RPG_RT.exe always
+  carries alongside the top half. `Game::Picture` has no split of its own to
+  restore from, so this is a write-only byte-parity fix, not new gameplay
+  behavior — confirmed against a real kk1.12 save that chunk 103 is now
+  byte-for-byte identical after a load/re-save round trip.

--- a/changelog.d/restore-already-erased-picture.fixed.md
+++ b/changelog.d/restore-already-erased-picture.fixed.md
@@ -1,0 +1,14 @@
+- `Game::State.from_lsd` (via `#restore_pictures`) now reconstructs a picture
+  that was already Erase Picture'd before the save it is loading from was
+  written, instead of silently dropping it. The stale position/zoom/tone
+  fields a genuine RPG_RT.exe always keeps for an erased-but-previously-shown
+  picture (chunk 103, confirmed by an earlier cycle) were being discarded on
+  load whenever the blank name looked like "never shown at all" — so a
+  Continue from such a save, followed by this engine's *own* next Save, wrote
+  a fully field-less placeholder where genuine RPG_RT would keep rewriting
+  the identical stale bytes forever. `#key?(4)` (`current_x`, written
+  unconditionally for any id ever shown) now tells "erased, remembers state"
+  apart from "never touched" so the reconstructed picture is immediately
+  marked erased via the same `#erase_picture` a live Erase Picture uses,
+  keeping a load/save round trip stable instead of drifting further from
+  genuine RPG_RT with each cycle.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1240,6 +1240,21 @@ module LCF
       # *present* as a single `0x01` byte -- elided at its own (false)
       # default, the same convention as every other picture flag/field in
       # this table.
+      #
+      # liblcf's own generator/csv/fields.csv (`SavePicture`) names field 8
+      # `current_top_trans` and field 0x22/34 `finish_top_trans` -- RPG2003
+      # (below 1.12) can split a picture's transparency into independent top
+      # and bottom halves, with `current_bot_trans` at field 0x12/18 and
+      # `finish_bot_trans` at field 0x23/35 as their own separate fields, both
+      # confirmed present (alongside 8/34, holding the identical value) on a
+      # real kk1.12 (RPG2003) save under wine even though that save never
+      # exercises a genuine top/bottom split. `Game::Picture` here has no
+      # top/bottom split of its own -- only the one `#opacity` this table's
+      # field 8/34 already round-trip -- so `#to_lsd` writes 18/35 as plain
+      # mirrors of 8/34 (top == bottom, matching "never split" byte for byte)
+      # rather than modelling the split feature itself, left as a future
+      # extension the same way `docs/TODO.md` already tracks other unmodelled
+      # save fields.
       6 => { name: :fixed_to_map, type: :bool, default: false },
       2 => { name: :show_x, type: :double, default: 0.0 },
       3 => { name: :show_y, type: :double, default: 0.0 },
@@ -1258,6 +1273,10 @@ module LCF
       5 => { name: :current_y, type: :double, default: 0.0 },
       7 => { name: :current_zoom, type: :double, default: 100.0 },
       8 => { name: :current_transparency, type: :double, default: 0.0 },
+      # RPG2003-only bottom-half transparency (`current_bot_trans`) -- see
+      # field 8's own comment above. Written as a plain mirror of field 8
+      # (top == bottom), never independently.
+      18 => { name: :current_bot_transparency, type: :double, default: 0.0 },
       11 => { name: :current_tone_red, type: :double, default: 100.0 },
       12 => { name: :current_tone_green, type: :double, default: 100.0 },
       13 => { name: :current_tone_blue, type: :double, default: 100.0 },
@@ -1303,6 +1322,11 @@ module LCF
       # cluster (cycle #152/#153).
       33 => { name: :zoom, type: :int, default: 100 },        # 拡大率
       34 => { name: :transparency, type: :int, default: 0 },  # 透明度
+      # RPG2003-only bottom-half finish transparency (`finish_bot_trans`) --
+      # see field 8's own comment above for the top/bottom split this table
+      # doesn't model; written as a plain mirror of field 34, never
+      # independently.
+      35 => { name: :bot_transparency, type: :int, default: 0 },
       41 => { name: :tone_red, type: :int, default: 100 },        # 色調：赤(R)
       42 => { name: :tone_green, type: :int, default: 100 },      # 色調：緑(G)
       43 => { name: :tone_blue, type: :int, default: 100 },       # 色調：青(B)

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15208,6 +15208,10 @@ module Game
           e[7] = p.zoom if p.zoom != 100
           cur_trans = Game.opacity_to_trans(p.opacity)
           e[8] = cur_trans if cur_trans != 0
+          # Field 18 (current_bot_trans, RPG2003-only) has no independent
+          # value of its own here -- see SAVE_PICTURE's own schema.rb comment
+          # -- so it mirrors field 8 (top == bottom).
+          e[18] = cur_trans if cur_trans != 0
           e[11] = p.red if p.red != 100
           e[12] = p.green if p.green != 100
           e[13] = p.blue if p.blue != 100
@@ -15226,6 +15230,9 @@ module Game
           e[33] = fzoom if fzoom != 100
           fin_trans = Game.opacity_to_trans(fopacity)
           e[34] = fin_trans if fin_trans != 0
+          # Field 35 (finish_bot_trans, RPG2003-only) mirrors field 34 for
+          # the same reason field 18 mirrors field 8 above.
+          e[35] = fin_trans if fin_trans != 0
           e[41] = fred if fred != 100
           e[42] = fgreen if fgreen != 100
           e[43] = fblue if fblue != 100
@@ -15880,7 +15887,27 @@ module Game
       pictures.each do |id, pic|
         next unless pic
         name = pic.name
-        next if name.nil? || name.empty?
+        # A blank name means either "never shown" (a fully field-less
+        # placeholder -- see SAVE_PICTURE's own comment) or "shown, then
+        # Erase Picture'd" (every position/zoom/tone field still present,
+        # only the name dropped -- confirmed against genuine RPG_RT.exe,
+        # cycle #159). `#key?(4)` (current_x) tells the two apart: it is
+        # written unconditionally for any id ever shown at all, and only
+        # for one, so its presence is exactly "this id has stale state to
+        # keep" -- a never-touched id is truly empty and must stay skipped.
+        # Reconstructing the erased case (rather than dropping it, this
+        # method's own prior behavior) matters for round-trip stability:
+        # this engine's own live Show Picture -> Erase Picture -> Save
+        # already keeps these fields through `#to_lsd` (see
+        # `Game::State#erase_picture`'s own comment), so a save loaded with
+        # an id already in that state must carry it into *this* Continue's
+        # own eventual next save too, the same way genuine RPG_RT keeps
+        # rewriting the identical stale bytes indefinitely -- not silently
+        # revert to a blank placeholder after a single load/save cycle.
+        if name.nil? || name.empty?
+          next unless pic.key?(4)
+          name = ''
+        end
         time_left = pic.time_left || 0
         moving = time_left > 0
         transparency = moving ? pic.current_transparency : pic.transparency
@@ -15897,6 +15924,7 @@ module Game
                                saturation: moving ? pic.current_tone_saturation : pic.tone_saturation,
                                fixed_to_map: pic.fixed_to_map,
                                use_transparent_color: pic.use_transparent_color)
+        state.erase_picture(id) if pic.name.nil? || pic.name.empty?
         next unless moving
         finish_trans = pic.transparency
         state.move_picture(id, (pic.finish_x || 0).to_i, (pic.finish_y || 0).to_i,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4895,6 +4895,38 @@ check 'to_lsd writes chunk 103 (shown pictures), not just from_lsd reading it' d
      'a slot with no picture of its own stays an empty placeholder alongside the live ones'
 end
 
+check 'to_lsd mirrors the RPG2003-only bottom-half transparency fields ' \
+      '(18/35) off the top-half ones (8/34) this codebase actually models' do
+  # liblcf's own generator/csv/fields.csv (SavePicture) names field 8
+  # current_top_trans and field 34 finish_top_trans, and documents a
+  # completely separate pair -- current_bot_trans (0x12/18) and
+  # finish_bot_trans (0x23/35) -- for RPG2003's pre-1.12 top/bottom split
+  # transparency feature. A real kk1.12 (RPG2003) save under wine carries
+  # both 8/18 and 34/35 present with identical values even though it never
+  # exercises a genuine split. Game::Picture has no top/bottom split of its
+  # own, so #to_lsd writes 18/35 as plain mirrors of 8/34 rather than
+  # dropping them (which used to leave a real RPG_RT.exe-written save's own
+  # split-transparency fields with no equivalent on this engine's own
+  # from-scratch write).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.show_picture(3, name: 'backdrop', x: 200, y: 150,
+                  opacity: Game.trans_to_opacity(25))
+  saved = st.to_lsd[103][3]
+  eq saved.transparency, saved.bot_transparency,
+     'finish_bot_trans (35) mirrors finish_top_trans (34)'
+  eq saved.current_transparency, saved.current_bot_transparency,
+     'current_bot_trans (18) mirrors current_top_trans (8)'
+  ok saved.bot_transparency != 0, 'the mirrored value is not just both sides defaulting to 0'
+
+  # A picture never shown (still at its own default opacity/transparency 0)
+  # must leave both mirrored fields elided too, the same "omit at default"
+  # convention every other picture field here already follows.
+  untouched = st.to_lsd[103][7].instance_variable_get(:@data)
+  ok untouched[18].nil?, 'an untouched slot has no current_bot_trans of its own'
+  ok untouched[35].nil?, 'an untouched slot has no finish_bot_trans of its own'
+end
+
 check 'to_lsd/from_lsd round-trips a picture still mid-Move-Picture, resuming ' \
       'the glide instead of snapping straight to its target' do
   # Confirmed against a genuine RPG_RT.exe, not EasyRPG's source: a save
@@ -4984,9 +5016,10 @@ check 'to_lsd writes chunk 103\'s current_x/y/zoom/etc unconditionally (not ' \
   off_default = st.to_lsd[103][9]
   raw2 = off_default.instance_variable_get(:@data)
   present2 = (0...raw2.size).select { |i| raw2[i] }
-  eq [1, 2, 3, 4, 5, 7, 8, 11, 12, 13, 14, 31, 32, 33, 34, 41, 42, 43, 44], present2,
+  eq [1, 2, 3, 4, 5, 7, 8, 11, 12, 13, 14, 18, 31, 32, 33, 34, 35, 41, 42, 43, 44], present2,
      'zoom/transparency/tone are all present (current and finish alike) once ' \
-     'every one is off its own default, though the picture was never moved'
+     'every one is off its own default, though the picture was never moved -- ' \
+     'including the mirrored bottom-half transparency fields 18/35'
   eq 133.0, off_default.current_zoom
   # 26, not 25: the same pre-existing opacity/transparency round-trip
   # precision gap the "to_lsd writes chunk 103..." check above already notes
@@ -10021,6 +10054,47 @@ check 'to_lsd writes an erased-but-previously-shown picture with its stale ' \
   never_touched = pics[6]
   eq [], (1..51).select { |id| LCF::Schema::SAVE_PICTURE[id] && never_touched.key?(id) },
      'a never-touched id carries no fields at all, not even absent-name'
+end
+
+check 'from_lsd reconstructs an already-erased picture\'s stale fields from a ' \
+      'foreign save, so a second Continue -> Save keeps writing the same ' \
+      'bytes forever, matching genuine RPG_RT, instead of dropping them ' \
+      'after one load/save cycle' do
+  # #restore_pictures used to `next` outright on a blank-name entry, so
+  # loading a genuine RPG_RT.exe save whose picture had already been
+  # Erase Picture'd before that save was written left this engine's own
+  # `Game::State#pictures` with no entry for that id at all -- distinct
+  # from this engine's own live Show Picture -> Erase Picture -> Save,
+  # which the check above already confirms keeps the stale fields. A
+  # second Save/Continue from the *loaded* state then wrote a fully
+  # field-less placeholder instead of the identical stale bytes genuine
+  # RPG_RT itself would keep rewriting -- an asymmetry a real kk1.12 save
+  # exposed (its own already-erased pictures round-tripped through this
+  # engine as if they had never been shown at all).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  origin = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  # opacity 0 (transparency 100) is a fixed point of the opacity<->
+  # transparency conversion (like the 255/0 pair the checks above already
+  # use) -- picked deliberately so this check exercises reconstruction/
+  # erasure symmetry only, not the separate, already-documented rounding
+  # gap a lossier opacity value would also trip over.
+  origin.show_picture(5, name: 'black', x: 111, y: 77, zoom: 133,
+                       opacity: 0,
+                       red: 140, green: 60, blue: 180, saturation: 50)
+  origin.erase_picture(5)
+  foreign_save = origin.to_lsd
+
+  loaded = Game::State.from_lsd(db, foreign_save)
+  pic = loaded.pictures[5]
+  ok !pic.nil?, 'the already-erased picture is reconstructed, not dropped'
+  ok !pic.shown?, 'it comes back marked erased, not visible'
+  eq 111, pic.show_x
+  eq 133, pic.zoom
+
+  resaved = loaded.to_lsd[103][5]
+  eq foreign_save[103][5].instance_variable_get(:@data),
+     resaved.instance_variable_get(:@data),
+     'a second Save/Continue writes the exact same stale bytes as the first'
 end
 
 check 'Erase Picture mid-Move-Picture does NOT freeze the move: the picture ' \


### PR DESCRIPTION
## Summary

Continuing the autonomous diff-hunt against a genuine `RPG_RT.exe` (kk1.12, RPG2003, under wine): loading a real save, immediately re-exporting it with `Game::State#to_lsd`, and diffing the two byte-for-byte turned up two real gaps in chunk 103 (Show Picture):

- `#to_lsd` never wrote fields 18/35 (`current_bot_trans`/`finish_bot_trans`, per liblcf's own `generator/csv/fields.csv`) — RPG2003's independent bottom-half transparency for its pre-1.12 top/bottom split effect. A genuine save carries both halves present with identical values even when a picture never actually uses a split. Now `#to_lsd` mirrors 18/35 off 8/34 (this codebase's `Game::Picture` has no split of its own to model).
- `#restore_pictures` (`Game::State.from_lsd`) dropped a picture that was already Erase Picture'd *before* the loaded save was written, instead of reconstructing its stale position/zoom/tone fields the way this engine's own live Show → Erase → Save already does. That meant a Continue from such a save, followed by this engine's own next Save, wrote a fully field-less placeholder where genuine RPG_RT keeps rewriting the identical stale bytes forever — a load/save round trip that drifts further from genuine RPG_RT with every cycle instead of staying stable.

After both fixes, chunk 103 of the re-exported save is byte-for-byte identical to the original genuine `RPG_RT.exe` save.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1149 checks pass (2 new: bottom-half transparency mirroring, and erased-picture reconstruction/round-trip stability)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks pass
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parses cleanly
- [x] Verified against a genuine `RPG_RT.exe` save (kk1.12) under wine: chunk 103 is byte-for-byte identical after a `from_lsd`/`to_lsd` round trip (previously differed in both length and content)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_