### PR TITLE
Fix chunk 108 (actor) save round-trip vs genuine RPG_RT.exe (name/title placeholder, dense states array, unconditional fields)

### DIFF
--- a/changelog.d/actor-mods-battle-commands-unconditional.fixed.md
+++ b/changelog.d/actor-mods-battle-commands-unconditional.fixed.md
@@ -1,0 +1,10 @@
+- `Game::State#to_lsd` now writes chunk 108 fields 33/34 (hp_mod/sp_mod) and
+  80 (battle_commands) unconditionally, matching a genuine kk1.12 save under
+  wine: every actor's own untouched hp_mod/sp_mod is present as an explicit
+  `0` (distinct from liblcf's declared `-1` "never touched" default), and
+  field 80 is present with liblcf's own literal `[-1]*7` sentinel default
+  even when no Change Battle Commands ever ran (field 83,
+  `changed_battle_commands`, stays absent alongside it, gated on
+  `Actor#battle_commands_changed?` as before). Fields 41-44
+  (attack/defense/spirit/agility mod) keep the opposite "omit at zero"
+  convention the same save confirms, unchanged.

--- a/changelog.d/actor-name-title-placeholder-sentinel.fixed.md
+++ b/changelog.d/actor-name-title-placeholder-sentinel.fixed.md
@@ -1,0 +1,10 @@
+- `Game::State#to_lsd` now writes chunk 108 (SAVE_PARTY_ACTOR) fields 1
+  (name) and 2 (title) as the ADR 0014 `"\x01"` placeholder byte unless the
+  actor's name/title actually differs from its own database row
+  (`Actor#name_changed?`/`#title_changed?`). A genuine kk1.12 save under
+  wine carries that placeholder for every roster actor never touched by
+  Change Actor Name/Title — this codebase's own writer previously wrote the
+  actor's current (here, unchanged-from-default) name/title unconditionally
+  instead, which happened to look correct against a save whose party
+  actually had been renamed but silently diverged from genuine RPG_RT for
+  any untouched actor.

--- a/changelog.d/actor-states-dense-array.fixed.md
+++ b/changelog.d/actor-states-dense-array.fixed.md
@@ -1,0 +1,14 @@
+- `Game::State#to_lsd`/`.from_lsd` now encode chunk 108's states field (81
+  count / 82 data) as a dense array, one slot per database state id, instead
+  of a sparse list of only the currently-afflicted ids. A genuine kk1.12
+  (RPG2003) save under wine carries field 81 as the game's own total state
+  count (30) on every actor, none of them afflicted with anything — matching
+  EasyRPG Player's own live source (`Game_Battler::GetInflictedStates`,
+  `src/game_battler.cpp`), which walks this same dense, per-state-id vector.
+  This codebase's own writer previously wrote nothing at all for an
+  unafflicted actor (an empty sparse list) and, for an afflicted one, a
+  short array of literal state ids at the wrong field length entirely — a
+  save written by this engine's own Save/Continue would have desynced state
+  data from any tool (including a genuine RPG_RT.exe) expecting the real
+  per-state-id layout. `Actor#total_state_count` is new, reading the
+  database's own state table size.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1404,6 +1404,18 @@ module LCF
       61 => { name: :equipment, type: :int16_array },      # 装備 [武器,盾,鎧,兜,装飾]
       71 => { name: :hp, type: :int },                     # 現在ＨＰ
       72 => { name: :mp, type: :int },                     # 現在ＭＰ
+      # A dense array, one slot per database state id (index `state_id - 1`,
+      # length `state_size`), NOT a sparse list of only the afflicted ones --
+      # confirmed against a genuine kk1.12 (RPG2003) save under wine: field
+      # 81 read exactly 30, that game's own total state count, on every
+      # actor, none of them afflicted with anything, and against EasyRPG
+      # Player's own live source (`Game_Battler::GetInflictedStates`,
+      # `src/game_battler.cpp`), which walks this exact shape of vector and
+      # collects `i + 1` wherever the slot is nonzero. Each slot is a
+      # per-state turn counter in genuine RPG_RT (`> 0` means afflicted),
+      # not a plain boolean -- see `Game::Actor#total_state_count`'s own
+      # comment for why this codebase's own writer only ever puts a plain
+      # `1` there.
       81 => { name: :state_size, type: :int, default: 0 }, # 『状態』情報のデータ数
       82 => { name: :states, type: :int16_array },         # 『状態』情報 (uint16[])
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1699,6 +1699,49 @@ module Game
     # own comment at #initialize.
     def sprite_changed?; @sprite_changed; end
 
+    # Whether #name/#title currently differ from this actor's own database
+    # row -- the gate #to_lsd uses for chunk 108 fields 1/2, confirmed
+    # against a genuine kk1.12 (RPG2003) save under wine: every actor in
+    # that save's roster (no Change Actor Name/Title ever run against any of
+    # them) carried the "\x01" placeholder byte ADR 0014 already documents,
+    # not its own database name/title -- a value this codebase's own writer
+    # used to ignore, unconditionally writing the actor's current (here,
+    # untouched-from-default) name/title instead. This is a plain value
+    # comparison, not a "did the command ever run" flag like
+    # #sprite_changed?/#class_changed?: `Game_Actor::SetName`'s own real
+    # RPG_RT source (see #do_change_actor_name's own citation) collapses
+    # "set back to exactly the database name" into the identical
+    # no-override state as never having touched it at all, so comparing
+    # against the database row's own value reproduces that same collapse
+    # for free, with no separate "ever changed" bookkeeping to keep in sync.
+    def name_changed?; @name != (@db_row.name || ''); end
+    def title_changed?
+      default = @db_row.respond_to?(:title) ? (@db_row.title || '') : ''
+      @title != default
+    end
+
+    # Total number of states (状態) this game's database defines -- the fixed
+    # length genuine RPG_RT.exe's own chunk 108 field 82 always uses, index
+    # `state_id - 1`, one slot per database state id, confirmed against a
+    # genuine kk1.12 save under wine: field 81 (its paired count) read
+    # exactly 30, this test bed's own total state count, for every actor,
+    # none of them afflicted with anything -- not "how many states are
+    # currently active" as `#to_lsd` used to assume when it treated this
+    # pair as a sparse list of only the afflicted ids (the same
+    # count-then-data shape, but the wrong cardinality). EasyRPG Player's own
+    # `Game_Battler::GetInflictedStates` (`src/game_battler.cpp`) confirms
+    # the wire semantics too: it walks its own dense, database-sized status
+    # vector and collects `i + 1` wherever `states[i] > 0` -- a per-state
+    # turn counter, not a boolean -- so a slot's value is genuinely `0` for
+    # "not afflicted" and *some* positive count for "afflicted", though this
+    # codebase has no turn-counter of its own to round-trip once a state
+    # survives past the battle that inflicted it, so `#to_lsd` below writes
+    # a plain `1` for "afflicted" rather than a real duration.
+    def total_state_count
+      table = @db.respond_to?(:situation) ? @db.situation : nil
+      table ? table.to_a.size : 0
+    end
+
     # The actor's FaceSet graphic (顔グラフィック), shown on the save-select
     # screen (the SAVE_TITLE face slots) -- distinct from the message face
     # configured per Show Message. Comes from the database row until a Change
@@ -14219,6 +14262,12 @@ module Game
     # picture and Show Picture on one is a no-op (yado.tk).
     MAX_PICTURE_ID = 50
 
+    # liblcf's own declared default for chunk 108 field 80 (battle_commands):
+    # seven "defer to class/database" slots -- see #to_lsd's own citation for
+    # why this is written unconditionally (not merely when
+    # Actor#battle_commands_changed?).
+    BATTLE_COMMANDS_DEFAULT = [-1, -1, -1, -1, -1, -1, -1].freeze
+
     attr_reader :party, :switches, :variables, :message_config, :screen, :weather
     attr_accessor :map, :map_id, :x, :y, :direction
     # Whether the player may open the main menu / save, toggled by the Change
@@ -15025,15 +15074,22 @@ module Game
       actors = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
       @party.roster.each do |a|
         e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
-        # Field 1 carries the actor's *current* name (renamed or not, matching
-        # a genuine save), so a Change Actor Name override on any roster
-        # member -- not just the leader, who also gets it via chunk 100's
-        # title -- survives Save/Continue.
-        e[1] = a.name
-        # Field 2 is the actor's current title (renamed or not by Change
-        # Actor Title), confirmed against liblcf's SaveActor field table --
-        # see SAVE_PARTY_ACTOR's comment in schema.rb.
-        e[2] = a.title
+        # Field 1 is the actor's current name, but ONLY while it actually
+        # differs from the database row (#name_changed?) -- an untouched
+        # actor writes the ADR 0014 "\x01" placeholder instead, confirmed
+        # against a genuine kk1.12 save under wine (see #name_changed?'s own
+        # citation); a prior version of this line wrote the current name
+        # unconditionally, which happens to equal the database default for
+        # any actor never hit by Change Actor Name, so it looked correct
+        # against a save whose leader/party actually had been renamed
+        # (Nepheshel Save01) while silently diverging from genuine RPG_RT
+        # for every other, untouched roster entry.
+        e[1] = a.name_changed? ? a.name : "\x01"
+        # Field 2 is the actor's current title, gated on #title_changed? the
+        # same way -- confirmed against liblcf's SaveActor field table (see
+        # SAVE_PARTY_ACTOR's comment in schema.rb) for the field id, and
+        # against the same genuine kk1.12 save for the placeholder gating.
+        e[2] = a.title_changed? ? a.title : "\x01"
         # A live Change Sprite Association (10630) override -- fields 11
         # (sprite_name) / 12 (sprite_id) / 13 (sprite_transparent), gated on
         # #sprite_changed? (the command actually having run), not merely a
@@ -15054,10 +15110,18 @@ module Game
         e[61] = a.equipment
         e[71] = a.hp
         e[72] = a.mp
-        unless a.states.empty?
-          e[81] = a.states.size
-          e[82] = a.states
-        end
+        # Field 82 is a dense array, one slot per database state id
+        # (`total_state_count` long), not a sparse list of only the
+        # currently-afflicted ids -- see Actor#total_state_count's own
+        # citation. Written unconditionally (even all-zero) to match a
+        # genuine save, the same "container present, contents sparse"
+        # convention chunk 103's own 50-slot picture range already
+        # established.
+        n = a.total_state_count
+        dense = Array.new(n, 0)
+        a.states.each { |sid| dense[sid - 1] = 1 if sid >= 1 && sid <= n }
+        e[81] = n
+        e[82] = dense
         # A live Change Class survives Save/Continue too, not just the name/
         # title/sprite overrides above -- only once #change_class (or a
         # restored one) has actually run, matching EasyRPG's own
@@ -15065,13 +15129,18 @@ module Game
         # default), not merely "class_id > 0" -- Change Class to "no class"
         # (id 0) is itself a real, persisted change.
         e[90] = a.class_id if a.class_changed?
-        # Same for a live Change Battle Commands (or a Change Class, which
-        # also materializes the list): EasyRPG's `changed_battle_commands`
-        # flag, mirrored by #battle_commands_changed?'s own raw-ivar check.
-        if a.battle_commands_changed?
-          e[80] = a.battle_commands
-          e[83] = true
-        end
+        # Field 80 (battle_commands) is written unconditionally -- liblcf's
+        # own generator/csv/fields.csv declares its default as the literal
+        # sentinel array `[-1]*7` (seven "defer to class/database" slots),
+        # and a genuine kk1.12 save under wine carries field 80 present with
+        # exactly that default on every actor whose commands were never
+        # touched (field 83, `changed_battle_commands`, absent alongside
+        # it) -- not omitted the way this codebase's own writer used to
+        # treat "untouched" fields. Field 83 stays gated on
+        # #battle_commands_changed? (EasyRPG's own flag of the same name),
+        # the actual "was this ever overridden" signal `.from_lsd` reads.
+        e[80] = a.battle_commands_changed? ? a.battle_commands : BATTLE_COMMANDS_DEFAULT
+        e[83] = true if a.battle_commands_changed?
         # RPG2003 battle row (0x5B/91, liblcf's `ChunkSaveActor::row`) --
         # only written off the front-row default, the same eliding-writer
         # convention `class_id`/`battle_commands` follow above, so an
@@ -15082,14 +15151,20 @@ module Game
         # Continue too -- see SAVE_PARTY_ACTOR's own comment for the
         # genuine-RPG_RT verification. `@base_raw` is the curve plus this
         # modifier with no equipment folded in, so subtracting the curve
-        # back out isolates the same delta #change_param itself computes;
-        # only written per-stat when actually nonzero, the same
-        # eliding-writer convention every field above follows.
+        # back out isolates the same delta #change_param itself computes.
         raw = a.base_raw
         curve = a.base_stats(a.level)
-        # Field ids in STAT_NAMES order (max_hp, max_mp, atk, def, int, agi).
-        [33, 34, 41, 42, 43, 44].each_with_index do |field, i|
-          delta = raw[i] - curve[i]
+        # hp_mod/sp_mod (33/34) are written unconditionally, delta 0
+        # included -- confirmed against a genuine kk1.12 save under wine,
+        # every actor's own untouched hp_mod/sp_mod present as an explicit
+        # 0, distinct from liblcf's own declared -1 ("never touched")
+        # default (see schema.rb's own comment on these two fields).
+        # attack_mod/defense_mod/spirit_mod/agility_mod (41-44) keep the
+        # opposite, "omit at zero" convention the same save confirms.
+        e[33] = raw[0] - curve[0]
+        e[34] = raw[1] - curve[1]
+        [41, 42, 43, 44].each_with_index do |field, i|
+          delta = raw[i + 2] - curve[i + 2]
           e[field] = delta if delta != 0
         end
         actors[a.id] = e
@@ -15535,7 +15610,16 @@ module Game
           end
           actor.equip(sa.equipment) if sa.equipment
           actor.skills = sa.skills if sa.skills
-          actor.states = sa.states if sa.states
+          # sa.states is the same dense, database-sized array #to_lsd now
+          # writes (see Actor#total_state_count's own citation) -- a
+          # nonzero slot means "afflicted", regardless of its actual
+          # turn-counter value, which this codebase does not otherwise
+          # track once a state survives past the battle that inflicted it.
+          if sa.states
+            ids = []
+            sa.states.each_index { |i| ids << (i + 1) if sa.states[i] && sa.states[i] != 0 }
+            actor.states = ids
+          end
           # A live Change Battle Commands (or a Change Class, which also
           # materializes the list) -- gated on `changed_battle_commands` the
           # same way EasyRPG's own read does, not merely "the field is

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4186,6 +4186,51 @@ check 'to_lsd/from_lsd leaves an actor untouched by either command exactly ' \
   eq false, restored.battle_commands_changed?
 end
 
+check 'to_lsd/from_lsd writes chunk 108\'s states (81/82) as a dense, ' \
+      'database-sized array, not a sparse list of only the afflicted ids' do
+  # Confirmed against a genuine kk1.12 (RPG2003) save under wine: field 81
+  # (the paired count) read exactly 30, that game's own total state count,
+  # on every actor in the roster, none of them afflicted with anything --
+  # not "how many states are currently active", which #to_lsd used to write
+  # there (0 for an unafflicted actor, so the chunk carried no 81/82 at all,
+  # rather than the fixed-length all-zero array a genuine save always has).
+  # See Actor#total_state_count's own citation for the EasyRPG source
+  # confirming the dense, per-state-id shape.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) }, [1],
+                       {}, {}, {}, { 1 => FakeStateDef.new(0), 2 => FakeStateDef.new(0),
+                                     3 => FakeStateDef.new(0) })
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+  eq 3, hero.total_state_count
+
+  # Unafflicted: the chunk is still present, all-zero, sized to the
+  # database's own state count -- not omitted (this codebase's own prior
+  # "unless a.states.empty?" guard).
+  untouched = st.to_lsd[108][1]
+  eq 3, untouched.state_size
+  eq [0, 0, 0], untouched.states
+
+  # Afflicted with state 2 (index 1): only that slot goes nonzero.
+  hero.states = [2]
+  saved = st.to_lsd[108][1]
+  eq 3, saved.state_size
+  eq [0, 1, 0], saved.states, 'state id 2 sets slot index 1 (state_id - 1), the rest stay 0'
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq [2], round.party.leader.states,
+     'a nonzero slot reads back as "afflicted", regardless of its own turn-counter value'
+
+  # A dangling save with no situation table at all (an old fixture, or a
+  # database edition with zero defined states) must not blow up: an empty
+  # dense array round-trips to no active states, the same as before.
+  bare_db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) }, [1])
+  bare_st = Game::State.new(Game::Party.new(bare_db), 1, 0, 0)
+  eq 0, bare_st.party.leader.total_state_count
+  bare_saved = bare_st.to_lsd[108][1]
+  eq 0, bare_saved.state_size
+  eq [], bare_saved.states || []
+end
+
 check 'to_lsd/from_lsd round-trips the file-select screen\'s face-thumbnail ' \
       'snapshot (State#preview_faces), independent of the loaded actors\' own data' do
   # Confirmed against a genuine RPG_RT.exe under wine: the save/load


### PR DESCRIPTION
## Summary

Continuing the autonomous diff-hunt against a genuine `RPG_RT.exe` (kk1.12, RPG2003, under wine): comparing chunk 108 (SAVE_PARTY_ACTOR) between a real save and this engine's own `from_lsd`/`to_lsd` round-trip of it turned up three real gaps:

- **Fields 1/2 (name/title)**: `#to_lsd` wrote the actor's current value unconditionally. Genuine RPG_RT writes the ADR 0014 `"\x01"` placeholder byte unless the value actually differs from the actor's own database row (`Actor#name_changed?`/`#title_changed?`, new). This happened to look correct against a save whose party had genuinely been renamed, but silently diverged for every untouched actor.
- **Fields 81/82 (states)**: modelled as a sparse "count + list of active state ids" pair (the same shape as skills/item ids). Both liblcf's own `generator/csv/fields.csv` and EasyRPG Player's live source (`Game_Battler::GetInflictedStates`, `src/game_battler.cpp`) confirm this is actually a **dense** array, one slot per database state id — a genuine save's field 81 read the game's own total state count (30), not the afflicted count (0). `Actor#total_state_count` is new.
- **Fields 33/34 (hp_mod/sp_mod) and 80 (battle_commands)**: elided whenever untouched, but a genuine save writes them unconditionally (hp_mod/sp_mod present at an explicit `0`, battle_commands present at liblcf's own `[-1]*7` default) — unlike fields 41-44, which really are elided at zero.

After all three fixes, several actors' full chunk 108 entries are now byte-for-byte identical to the real save.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1150 checks pass (1 new, covering the states dense-array round trip)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks pass
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parses cleanly
- [x] Verified against a genuine `RPG_RT.exe` save (kk1.12) under wine: several actors' chunk 108 entries are byte-for-byte identical after a `from_lsd`/`to_lsd` round trip (previously differed in name/title, states array shape, and several unconditional fields)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_