### PR TITLE
Cycle #172/#173: Parallax.anchored_offset investigation notes + gen-rpg2k-save.rb --facing fix

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4804,6 +4804,89 @@ The work below is roughly ordered by the critical path to a walkable game
   confirmed by `md5sum` on every `.lmu`/`.lmt` touched during the wine
   probes, and all wine/Xvfb/matchbox processes were confirmed terminated
   before finishing.
+  ✅ **Follow-up (cycle #173, 2026-08-26): attempted to verify the `Game::
+  Shop#sellable_items` citation (`mruby-rpg2k/mrblib/game.rb`, "a price-0
+  item a player holds still shows up in the Sell list") via a genuine
+  RPG_RT.exe wine probe (Nepheshel's own item-shop NPC, `Map0016.lmu` event
+  4, the same reachable-with-zero-synthetic-editing recipe cycles #144/#145
+  used) but did not reach a conclusion -- instead found and fixed a real
+  bug in `scripts/gen-rpg2k-save.rb`'s own `--facing` option that actively
+  produced a wrong test setup, and hit a second, unexplained wine input
+  freeze this cycle could not root-cause in the time remaining.** The
+  `--facing` bug: `gen-rpg2k-save.rb` wrote its numpad-convention direction
+  value (`DIRECTIONS`, e.g. 8 for 'up') straight into the save's chunk 104
+  field 22 -- but `LCF::Schema::SAVE_MOVABLE`'s own pre-existing doc comment
+  for that exact field says it holds liblcf's *own* 0=up/1=right/2=down/
+  3=left enum instead, with `Game::CharSet::DIR_ROW` (`mruby-rpg2k/mrblib/
+  game.rb`) named as the numpad -> liblcf-index conversion table -- and the
+  script was never applying it. Confirmed the mismatch is real and
+  consequential, not just cosmetic, two ways: (1) every direction but
+  'down' writes a value this codebase's own decoder (`EventGraphic.
+  numpad_direction`'s `LCF_DIR_TO_NUMPAD[lcf_dir] || 2` fallback) cannot
+  recognise at all (out of its 0..3 domain), silently falling back to
+  facing down regardless of the option requested -- 'down' alone survives
+  by coincidence, since its numpad value (2) already equals its own liblcf
+  index; (2) a `--facing up` save resumed under genuine RPG_RT.exe under
+  wine this cycle also visibly drew the leader facing down, not up,
+  consistent with that same fallback -- though this single observation is
+  *not* claimed as this cycle's own confirmed behavioral finding on its
+  own, since an unrelated freeze (below) hit the same probe run and was
+  never cleanly isolated from it; the schema's own pre-existing
+  documentation is this fix's real, independent basis. **Fixed**: added a
+  correct `LCF_DIRECTION` (up/right/down/left -> 0/1/2/3) table and pointed
+  the hero-direction write at it instead of the numpad-convention
+  `DIRECTIONS` (kept, unchanged, for the CLI's own `--facing` option-name
+  list); extended the script's own existing post-write read-back
+  verification to also assert the written direction round-trips as the
+  correct liblcf value, so a future regression fails loudly instead of
+  silently mis-positioning a probe. **Verification**: reverting only the
+  write line (keeping the new check) reproduces a clean `FAILED: wrote
+  facing=up (liblcf 0) but read back 8 ...` and a non-zero exit; all four
+  directions round-trip to their correct liblcf indices (0/1/2/3) with the
+  fix in place; `ruby -c` and a dry run against Nepheshel's own `Save01.lsd`
+  both pass. Since this change touches only a standalone CRuby dev script,
+  not any shipped `mrblib` code, the shipped-engine check suites were run
+  purely as a sanity confirmation rather than because they could exercise
+  this diff: `scripts/rpg2k_scene_check.rb` (929), `scripts/
+  rpg2k_logic_check.rb` (1147), `scripts/rpg2k_render_check.rb` (41),
+  `scripts/rpg2k3_battle_row_check.rb` (19), `scripts/
+  rpg2k3_battle_gauge_check.rb` (15) and `ctest -R mruby_test` all
+  unchanged and green; `scripts/rpg2k_save_load_check.rb` reconfirmed at
+  exactly its 3 known pre-existing, unrelated failures. No changelog
+  fragment applies (a dev-tooling fix, not a shipped behavior change).
+  **The second, unexplained problem, left open:** after correcting the
+  save's own direction field (via a raw one-off edit, not yet through the
+  fixed script) and reloading, genuine RPG_RT.exe stopped responding to
+  *any* key at all (movement included, not just the shop NPC's own action-
+  key interaction) for the remainder of that run, surviving a full process
+  kill-and-relaunch of RPG_RT.exe itself (a fresh interpreter reading the
+  same save from disk) -- `WINEDEBUG=+key` traced the keys still reaching
+  the game's own hwnd correctly throughout, so this is not a repeat of
+  cycle #145's own "wrong key bound" finding. Low confidence this is a
+  genuine RPG_RT quirk rather than an artifact of this cycle's own several
+  earlier exploratory `z` presses (sent before the direction bug was
+  understood, potentially already having triggered event 4's own 48-command
+  script, which was never confirmed to have exited cleanly) -- not chased
+  further given the time-box. **Left open for a future cycle:** retry the
+  `sellable_items` verification from a completely fresh save (no
+  exploratory keypresses beforehand) using the now-fixed
+  `gen-rpg2k-save.rb`, standing the party at Map0016 (14,11) `--facing up`
+  with item 17 (天使の翼, price 0, confirmed via a fresh `RPG_RT.ldb` item-
+  table dump this cycle) added alongside the save's existing item 1 (薬草)
+  in chunk 109, then driving `z` once cleanly into the shopkeeper's own
+  Show Choices -> Sell list and screenshotting it; if the same total-input-
+  freeze recurs on a clean save with correct facing, that itself becomes
+  the more interesting, reproducible finding to chase next. Also
+  unchanged: everything else already listed as open in cycle #172's own
+  note above, and every other EasyRPG-style citation this file's own past
+  cycles have not yet swept (a large remainder spanning both `mrblib`
+  files -- see cycle #154's own list plus the many more recent instances a
+  fresh repo-wide grep this cycle ran still turns up, none yet individually
+  triaged). `data/` was left byte-identical to this cycle's own starting
+  point (`md5sum`-confirmed on `Save01.lsd`/`Map0012.lmu`/`Map0016.lmu`/
+  `RPG_RT.ldb`/`RPG_RT.lmt`), `git status` on it came back clean, and every
+  wine/Xvfb/matchbox process this cycle started was confirmed terminated
+  before finishing.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4750,6 +4750,60 @@ The work below is roughly ordered by the critical path to a walkable game
   #154's own repo-wide grep turned up that no cycle has yet touched (a large
   remainder -- this cycle deliberately fixed only the two duplicates of the
   one citation named as this cycle's primary target, not the wider sweep).
+  🚧 **Follow-up (cycle #172, 2026-08-26): attempted to verify
+  `Game::Parallax.anchored_offset`'s clamp formula (`mruby-rpg2k/mrblib/
+  game.rb`) -- the one EasyRPG-style citation in this area explicitly
+  flagged by its own module doc as "mirrors EasyRPG's formulae but has not
+  been visually diffed against RPG_RT under wine" -- but hit an unexplained
+  wine reproduction blocker and made no code change.** Plan: inject a
+  synthetic autostart Teleport + Change Parallax Background (11720) pair
+  into a scratch copy of Nepheshel (never the checked-in `data/`) so a
+  fresh New Game lands the hero at a chosen map's far scroll edge with a
+  custom two-colour (red/blue halves) panorama image, letting a screenshot
+  distinguish the clamped-span formula (`[cam_max, img_px-screen_px].min`)
+  from the naive always-full-excess one by whether both colours are visible
+  or only one. The injector itself (a small script using this codebase's
+  own `LCF::MapUnit`/`Array1D`/`Array2D` under CRuby, mirroring `scripts/
+  lcf_testbed_check.rb`'s load pattern) works correctly and was validated
+  three independent ways: (1) editing an existing, real Teleport command's
+  target map/x/y in place (leaving everything else byte-identical) and
+  landing cleanly on Map0372 with no error, confirmed twice with different
+  target coordinates; (2) a full round-trip re-read of every edited `.lmu`
+  parsing back exactly as authored; (3) map dimensions unchanged after
+  editing. **The blocker:** the identical teleport-editing technique, when
+  retargeted to two other, unrelated maps (Map0008 "スタッフルーム", chipset
+  2; Map0057, a dungeon room, chipset 4) -- chosen only for their width
+  (cam_max 128px / 160px, comfortably under the test image's 320px excess,
+  so the clamp is actually exercised) -- makes genuine RPG_RT.exe pop a
+  small native-looking dialog window (~241x108px, cyan titlebar reading
+  "Nepheshel Ver2.04b", an X close button, no OK/Cancel) with a completely
+  blank body immediately after the teleport, before any parallax command
+  even runs (reproduced with the Change Parallax Background command
+  removed entirely, isolating it to the Teleport alone). Both suspect
+  maps' own chipset graphic files were confirmed present on disk
+  (`町１.png`, `wall_01.png`), ruling out the obvious missing-asset
+  explanation; a CJK font-substitution registry pass (mirroring
+  `scripts/run-rpg2k-rpgrt-wine.bash`'s own trick) did not make the dialog
+  body's text render, so its content is still unread. Whether this is a
+  real, reproducible RPG_RT behavior (e.g. some validation on the
+  destination map/chipset pairing) or an artifact of forcing a teleport
+  before the game's own normal state machine would ever reach that map
+  this early is undetermined. **Left open for a future cycle:** read the
+  dialog's actual text (a debugger breakpoint on the relevant Win32 call,
+  or testing against a game with ASCII map/chipset names to rule out a
+  CJK-rendering-specific dialog, would both help); once understood, retry
+  the parallax-clamp screenshot test on a map confirmed teleport-safe
+  (Map0372 chipset 1 is proven safe but is exactly at the clamp boundary,
+  `cam_max == img excess`, so not discriminating -- a *different*,
+  genuinely narrow map is still needed, ideally reached by walking there
+  through ordinary early-game progression rather than a forced teleport,
+  which would sidestep this whole blocker); everything else already listed
+  as open in cycle #171's own note above, unchanged. No source or `data/`
+  files were modified this cycle -- `git status` on both came back clean
+  (the pre-existing, unrelated `3rd/mruby` submodule-pointer drift aside),
+  confirmed by `md5sum` on every `.lmu`/`.lmt` touched during the wine
+  probes, and all wine/Xvfb/matchbox processes were confirmed terminated
+  before finishing.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/scripts/gen-rpg2k-save.rb
+++ b/scripts/gen-rpg2k-save.rb
@@ -146,6 +146,32 @@ end
 
 DIRECTIONS = { 'up' => 8, 'right' => 6, 'left' => 4, 'down' => 2 }.freeze
 
+# LCF::Schema::SAVE_MOVABLE's own field 22 (which HERO_DIRECTION above points
+# at) is documented there as liblcf's own facing enum -- 0=up, 1=right,
+# 2=down, 3=left, matching `Game_Character::Direction`'s enum order -- NOT
+# this runtime's numpad convention (2/4/6/8) DIRECTIONS holds. Game::CharSet
+# ::DIR_ROW (mruby-rpg2k/mrblib/game.rb) is that exact numpad -> liblcf-index
+# table, so it doubles as the encoder here (this script cannot load the mruby
+# gem, so the table is inlined rather than shared).
+#
+# Found by hand this cycle: this script used to write DIRECTIONS.fetch(...)
+# (the numpad value, e.g. 8 for 'up') straight into field 22 instead of
+# converting it first, putting an out-of-range value into a field this
+# codebase's own decoder (`EventGraphic.numpad_direction`'s own
+# `LCF_DIR_TO_NUMPAD[lcf_dir] || 2` fallback) reads back as facing *down*
+# for anything it does not recognise -- silently wrong for every direction
+# but 'down' (whose numpad value, 2, happens to equal its own liblcf index,
+# masking the bug for that one case). A `--facing up` save resumed under
+# genuine RPG_RT.exe under wine this cycle also drew the leader facing down
+# rather than up, consistent with the same fallback, though that single
+# observation was not isolated cleanly enough (an unrelated input freeze hit
+# the same probe) to stand as this cycle's own confirmed behavioral finding
+# on its own -- the schema's own pre-existing documentation above is this
+# fix's real basis, independent of that wine capture. A future probe relying
+# on `--facing up/right/left` should confirm the resulting facing with a
+# screenshot rather than assume this bug is the only thing that can go wrong.
+LCF_DIRECTION = { 'up' => 0, 'right' => 1, 'down' => 2, 'left' => 3 }.freeze
+
 options = { slot: 1 }
 parser = OptionParser.new do |o|
   o.banner = 'Usage: ruby scripts/gen-rpg2k-save.rb [GAME_DIR] [options]'
@@ -201,7 +227,7 @@ end
 hero[HERO_MAP] = map_id
 hero[HERO_X] = x
 hero[HERO_Y] = y
-hero[HERO_DIRECTION] = DIRECTIONS.fetch(options[:facing]) if options[:facing]
+hero[HERO_DIRECTION] = LCF_DIRECTION.fetch(options[:facing]) if options[:facing]
 
 # Reading a chunk decodes a detached copy, so the edited chunk has to go back in
 # before serialising (same as scripts/lcf_save_roundtrip.rb).
@@ -245,6 +271,17 @@ unless got == [map_id, x, y]
   warn "FAILED: wrote map=#{map_id} (#{x},#{y}) but read back " \
        "map=#{got[0]} (#{got[1]},#{got[2]})"
   exit 1
+end
+if options[:facing]
+  want_dir = LCF_DIRECTION.fetch(options[:facing])
+  got_dir = back[104][HERO_DIRECTION]
+  unless got_dir == want_dir
+    warn "FAILED: wrote facing=#{options[:facing]} (liblcf #{want_dir}) but " \
+         "read back #{got_dir} -- this would resume facing the wrong way " \
+         '(or the schema default fallback, "down") in any runtime that reads ' \
+         'this field, not just the writer bug this check exists to catch'
+    exit 1
+  end
 end
 if options[:clear_scene] && (back.key?(FOREGROUND_EVENT) || back.key?(PICTURES))
   warn 'FAILED: --clear-scene left chunk 113/103 in the written save'


### PR DESCRIPTION
## Summary

Two unrelated changes landed on the same session branch while this PR was open (cycle #173 pushed before #172 merged); documenting both here rather than bundling their narratives.

### Cycle #172 (docs-only, no code change)

- Attempted to verify `Game::Parallax.anchored_offset`'s clamp formula (the one EasyRPG-style citation in this area explicitly flagged by its own module doc as never visually diffed against RPG_RT under wine) using a synthetic teleport + Change Parallax Background probe with a two-colour test image designed to discriminate the clamped-span formula from a naive always-full-excess one.
- The injection technique itself was validated three independent ways against genuine RPG_RT.exe (editing a real Teleport command in place, a full round-trip re-read, unchanged map dimensions).
- Retargeting it to either of two candidate maps narrow enough to actually exercise the clamp made genuine RPG_RT.exe pop an unexplained native dialog with a blank, unreadable body immediately after the teleport — reproduced with the parallax command removed entirely, isolating it to the teleport/destination alone. Ruled out the obvious missing-chipset-asset explanation.
- Left open for a future cycle rather than shipping a weak or unverified conclusion.

### Cycle #173: fix `scripts/gen-rpg2k-save.rb`'s `--facing` option

While attempting to verify `Game::Shop#sellable_items`'s citation (price-0 items still appearing in a shop's Sell list), found and fixed a real bug in this dev tool that nearly every prior wine-probe cycle relies on to reposition a save's party.

`--facing` wrote the runtime's numpad direction convention (`up`→8, `right`→6, `left`→4, `down`→2) directly into the save's chunk 104 field 22 — but `LCF::Schema::SAVE_MOVABLE`'s own pre-existing doc comment says that field holds liblcf's *own* enum instead (0=up, 1=right, 2=down, 3=left), with `Game::CharSet::DIR_ROW` named as the exact conversion table to use. The script never applied it, so this codebase's own decoder (`EventGraphic.numpad_direction`'s `LCF_DIR_TO_NUMPAD[lcf_dir] || 2` fallback) silently read any out-of-range value as facing *down* — every direction but `'down'` was silently wrong (masked only because down's numpad value, 2, happens to equal its own liblcf index).

Added a correct `LCF_DIRECTION` table (`up/right/down/left → 0/1/2/3`) and pointed the hero-direction write at it; extended the script's own existing post-write read-back check to also assert the direction round-trips correctly, so a future regression fails loudly instead of silently mis-positioning a probe.

Also flagged in `docs/TODO.md`, left open: a second unexplained wine input-freeze hit during this cycle's probe, not cleanly isolated from an unrelated earlier issue; and the original `sellable_items` question itself remains unverified.

## Verification

- Personally reproduced the regression: reverting only the write line (keeping the new check) gives a clean `FAILED: wrote facing=up (liblcf 0) but read back 8 ...` and a non-zero exit.
- Personally confirmed all four directions (`up`/`right`/`down`/`left`) now round-trip to the correct liblcf indices (0/1/2/3) against a real save (`Nepheshel206beta`).
- Cross-checked the fix against `mruby-lcf/mrblib/schema.rb`'s own SAVE_MOVABLE field-22 doc comment and `mruby-rpg2k/mrblib/game.rb`'s `EventGraphic::LCF_DIR_TO_NUMPAD`/`CharSet::DIR_ROW` — the new table matches both exactly.
- `ruby -c scripts/gen-rpg2k-save.rb` passes.
- Full check suites and `ctest -R mruby_test` unchanged and green: `rpg2k_scene_check.rb` (929), `rpg2k_logic_check.rb` (1147), `rpg2k_render_check.rb` (41), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15), `ctest -R mruby_test`.
- No `data`/source files changed beyond `scripts/gen-rpg2k-save.rb` and `docs/TODO.md`; the pre-existing `3rd/mruby` submodule marker is the only other `git status` entry, as usual.

## Changelog

None — cycle #172 produced no fix, and cycle #173's fix is to a standalone CRuby dev script, not shipped `mrblib` behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_