### PR TITLE
Fix chunk 101 (SAVE_SYSTEM) save round-trip vs genuine RPG_RT.exe (unconditional BGM/SFX slots, scene/font/switch elision)

### DIFF
--- a/changelog.d/save-system-bgm-sfx-unconditional.fixed.md
+++ b/changelog.d/save-system-bgm-sfx-unconditional.fixed.md
@@ -1,0 +1,18 @@
+- `Game::State#to_lsd` now writes chunk 101 (SAVE_SYSTEM)'s BGM/SE override
+  slots unconditionally, matching a genuine kk1.12 save under wine: every
+  one of `title_music`(71)/`battle_music`(72)/`battle_end_music`(73)/
+  `inn_music`(74)/`boat_music`(79)/`ship_music`(80)/`airship_music`(81)/
+  `gameover_music`(82) and `cursor_se`(91)..`item_se`(102) is present,
+  blank-named, even on a save that never touched Change System BGM/SFX at
+  all — `#to_lsd` previously omitted every one of these fields entirely in
+  that case. `#bgm_chunk`/`#se_chunk` also now elide their own
+  volume/pitch/balance fields at each one's schema default (100/100/50)
+  instead of always writing them, matching the same genuine save's own
+  blank BGM/SE records exactly.
+- Field 1 (`scene`) is now written as the constant `5`, matching a legacy
+  field genuine RPG_RT always sets this way for any save file (EasyRPG
+  Player itself never reads it back). Field 23 (`font_id`, née `font`) is
+  now elided at its own default (0) instead of always written. Field 31
+  (switch count) is now elided when no switch has ever been touched, while
+  field 32 (the switch data array) is still written even then — an
+  asymmetric elision confirmed against the same genuine save.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1635,6 +1635,33 @@ module LCF
     # common-event id -- 505 entries in a real Nepheshel save. Each entry's
     # field 1 is that event's interpreter execution state, kept as an opaque blob
     # (like SAVE_MAP_EVENT's tile replacements) until its grammar is documented.
+    #
+    # liblcf's own generator/csv/fields.csv (not yet decoded field-by-field
+    # here) names field 1 (0x01) `parallel_event_execstate`, a
+    # `SaveEventExecState` struct -- NOT a simple resume index like this
+    # codebase's own `Game::State#common_event_progress` (a command-list
+    # cursor per running Common Event). It is a genuine interpreter call-
+    # stack snapshot: `stack` (0x01, `Array<SaveEventExecFrame>`), each frame
+    # carrying its OWN full `commands` list (0x02, `Vector<EventCommand>`,
+    # i.e. the exact command page being executed, not just an id — a Call
+    # Event pushes a frame whose commands come from the called event, so
+    # nested calls round-trip correctly), `current_command` (0x0B, the
+    # index into that frame's own commands), `event_id` (0x0C, 0 for a
+    # common event or one belonging to another map), a
+    # `triggered_by_decision_key` flag (0x0D), and `subcommand_path` (0x15
+    # count / 0x16 data) -- one byte per nesting level, the chosen Show
+    # Choice branch id at that level (255 once taken, per liblcf's own
+    # comment on the field). `SaveEventExecState` itself also carries
+    # `show_message` (0x04), `abort_on_escape` (0x0B), `wait_movement`
+    # (0x0D), a `wait_time` countdown (0x1F), and a whole keyinput_* cluster
+    # (0x15-0x2A) for a live Wait For Key Input / mouse-input pause.
+    # `SaveMapEvent`'s own 0x6C field and `SaveCommonEvent`'s 0x01 both point
+    # at this same struct. Implementing this for real means snapshotting
+    # `Game::Interpreter`'s actual call stack (command list + cursor per
+    # frame, not just the coarser resume-index this codebase tracks today)
+    # -- a genuine feature addition, not a small field fix, so it stays
+    # undecoded here; `Game::State#common_event_progress`'s own comment
+    # tracks this as a standing gap.
     SAVE_COMMON_EVENT = {
       1 => { name: :execution_state, type: :int8_array },
     }
@@ -1643,6 +1670,11 @@ module LCF
     # that was mid-execution when the game was saved. A save taken from an
     # on-screen choice keeps that choice's option strings inside this blob, which
     # is how the section was identified; its inner grammar is left opaque for now.
+    #
+    # Same `SaveEventExecState` struct as SAVE_COMMON_EVENT's own field 1 --
+    # see that table's own comment for liblcf's full field breakdown
+    # (`generator/csv/fields.csv`'s `Save.foreground_event_execstate` field,
+    # 0x71 at the top-level Save struct).
     SAVE_FOREGROUND_EVENT = {
       1 => { name: :execution_state, type: :int8_array },
     }

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15082,11 +15082,22 @@ module Game
       end
 
       sys = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SYSTEM })
+      # liblcf's own `scene` field (0x01/1): a legacy field RPG_RT itself
+      # always writes as 5 (its own "file menu" scene id) for any save file
+      # and EasyRPG Player never reads back -- confirmed present with
+      # exactly this value on a genuine kk1.12 save under wine.
+      sys[1] = 5
       sw = @switches.to_h
       sw_max = sw.empty? ? 0 : sw.keys.max
       switches = Array.new(sw_max, false)
       sw.each { |id, v| switches[id - 1] = v ? true : false }
-      sys[31] = sw_max
+      # Field 31 (the count) is elided when no switch has ever been touched
+      # (sw_max 0), but field 32 (the data array, empty in that case) is
+      # still written -- confirmed against a genuine kk1.12 save under
+      # wine: an early save whose party had never touched a switch omitted
+      # field 31 entirely (rather than an explicit count of 0) while still
+      # carrying field 32 present as a zero-length array.
+      sys[31] = sw_max if sw_max > 0
       sys[32] = switches
       vr = @variables.to_h
       vr_max = vr.empty? ? 0 : vr.keys.max
@@ -15145,18 +15156,30 @@ module Game
       # both a save taken with no fade ever issued and one taken after a
       # later Play BGM cleared the flag back to false both omit it entirely.
       sys[61] = true if @bgm_stopping
+      # Field 71 (title_bgm) has no live tracking of its own in this
+      # codebase -- RPG_RT never lets Change System BGM touch it (see
+      # SYSTEM_BGM_SAVE_FIELD's own comment) -- but a genuine save still
+      # carries it present, always at its own blank-name default, alongside
+      # 72-82. Written unconditionally to match.
+      sys[71] = bgm_chunk({})
       sys[75] = bgm_chunk(@current_bgm) if @current_bgm
       sys[78] = bgm_chunk(@memorized_bgm) if @memorized_bgm
-      # Change System BGM (10660) / Change System SFX (10670) overrides, one
-      # save field per populated slot (see SYSTEM_BGM_SAVE_FIELD /
-      # SYSTEM_SFX_SAVE_FIELD above).
+      # Change System BGM (10660) overrides (SYSTEM_BGM_SAVE_FIELD above) --
+      # like field 71 and the SFX slots below, all seven are written
+      # unconditionally (blank when unset), confirmed against the same
+      # genuine kk1.12 save under wine: every one of battle_music(72)..
+      # gameover_music(82) was present, blank-named, even though that
+      # save's party never ran Change System BGM at all.
       SYSTEM_BGM_SAVE_FIELD.each do |slot, field|
-        bgm = @system_bgm[slot]
-        sys[field] = bgm_chunk(bgm) if bgm
+        sys[field] = bgm_chunk(@system_bgm[slot] || {})
       end
+      # Change System SFX (10670) overrides (SYSTEM_SFX_SAVE_FIELD above) --
+      # unlike the BGM slots, all 12 are written unconditionally (blank when
+      # unset), confirmed against a genuine kk1.12 save under wine: every
+      # one of cursor_se(91)..item_se(102) was present, blank-named, even
+      # though that save's party never ran Change System SFX at all.
       SYSTEM_SFX_SAVE_FIELD.each do |slot, field|
-        se = @system_sfx[slot]
-        sys[field] = se_chunk(se) if se
+        sys[field] = se_chunk(@system_sfx[slot] || {})
       end
       # SAVE_SYSTEM fields 121-124 (Control Teleport/Escape/Save/Menu Access)
       # are all ONE uniform "omit at true default" cluster after all --
@@ -15197,9 +15220,13 @@ module Game
       sys[124] = false unless @menu_access
       # Screen-transition slots 0..5 map to chunks 111..116 in order.
       @screen_transitions.each_with_index { |style, i| sys[111 + i] = style || 0 }
-      # System windowskin / font override (Change System Graphics).
+      # System windowskin / font override (Change System Graphics). Font id
+      # is elided at its own declared default (0) -- confirmed against a
+      # genuine kk1.12 save under wine, whose party never touched Change
+      # System Graphics' font option, omitting field 23 entirely rather than
+      # writing an explicit 0 the way this codebase's own writer always did.
       sys[21] = @system_graphic if @system_graphic
-      sys[23] = @font_id
+      sys[23] = @font_id if @font_id != 0
       # RPG2003's wait/active toggle (chunk 140). Written only when it leaves
       # the default 0 (wait) -- the chunk is 2003-only, so an RPG2000 save
       # must not gain a stray 0 here.
@@ -15644,9 +15671,17 @@ module Game
     def bgm_chunk(bgm)
       b = LCF::Array1D.new('', { elements: LCF::Schema::BGM })
       b[1] = bgm[:name] || ''
-      b[3] = bgm[:volume] || 100
-      b[4] = bgm[:tempo] || 100
-      b[5] = bgm[:balance] || 50
+      # Elided at their own schema default (100/100/50) -- confirmed against
+      # a genuine kk1.12 save under wine: an untouched BGM record's raw
+      # bytes carried field 1 (name) alone, with fields 3-5 entirely absent,
+      # not present holding the default values this codebase's own writer
+      # used to always emit.
+      vol = bgm[:volume] || 100
+      tempo = bgm[:tempo] || 100
+      bal = bgm[:balance] || 50
+      b[3] = vol if vol != 100
+      b[4] = tempo if tempo != 100
+      b[5] = bal if bal != 50
       b
     end
 
@@ -15661,9 +15696,14 @@ module Game
     def se_chunk(se)
       s = LCF::Array1D.new('', { elements: LCF::Schema::SE })
       s[1] = se[:name] || ''
-      s[3] = se[:volume] || 100
-      s[4] = se[:tempo] || 100
-      s[5] = se[:balance] || 50
+      # Elided at default, the same as #bgm_chunk's own fields 3-5 -- see
+      # that method's own citation.
+      vol = se[:volume] || 100
+      tempo = se[:tempo] || 100
+      bal = se[:balance] || 50
+      s[3] = vol if vol != 100
+      s[4] = tempo if tempo != 100
+      s[5] = bal if bal != 50
       s
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4393,6 +4393,63 @@ check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrid
   eq nil, round.system_sfx[1], 'an untouched SFX slot round-trips as absent, not an empty override'
 end
 
+check 'to_lsd writes SAVE_SYSTEM fields 71-82/91-102 (title/battle/etc. ' \
+      'BGM and every system SE slot) unconditionally, blank when untouched' do
+  # Confirmed against a genuine kk1.12 save under wine: every one of
+  # title_music(71)/battle_music(72)/battle_end_music(73)/inn_music(74)/
+  # boat_music(79)/ship_music(80)/airship_music(81)/gameover_music(82) and
+  # cursor_se(91)..item_se(102) was present, blank-named, on a save whose
+  # party never touched Change System BGM/SFX at all -- #to_lsd used to
+  # omit every one of these fields entirely in that case (the same species
+  # of bug as chunk 103's own picture-slot range, cycle #154).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  sys = st.to_lsd[101]
+  [71, 72, 73, 74, 79, 80, 81, 82].each do |field|
+    ok sys.key?(field), "BGM field #{field} is present even when never touched"
+    eq '', sys[field].file, "BGM field #{field} is blank-named"
+  end
+  (91..102).each do |field|
+    ok sys.key?(field), "SE field #{field} is present even when never touched"
+    eq '', sys[field].file, "SE field #{field} is blank-named"
+  end
+end
+
+check 'to_lsd writes SAVE_SYSTEM field 1 (scene) as the constant 5, and ' \
+      'elides field 23 (font_id) at its own default' do
+  # Field 1 (`scene`) is a legacy field RPG_RT itself always writes as 5
+  # (its own "file menu" scene id) for any save file; field 23 (`font_id`)
+  # follows the ordinary "omit at default" convention -- both confirmed
+  # against a genuine kk1.12 save under wine.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  sys = st.to_lsd[101]
+  eq 5, sys.scene
+  ok !sys.key?(23), 'font_id is absent at its own default (0)'
+
+  st.font_id = 2
+  eq 2, st.to_lsd[101].font, 'a changed font_id is still written'
+end
+
+check 'to_lsd elides SAVE_SYSTEM field 31 (switch count) when no switch ' \
+      'has ever been touched, but still writes field 32 (the empty set)' do
+  # Confirmed against a genuine kk1.12 save under wine: an early save whose
+  # party had never touched a switch omitted field 31 entirely (rather than
+  # an explicit count of 0) while still carrying field 32 present as a
+  # zero-length array -- an asymmetric elision this codebase's own writer
+  # did not previously reproduce (it wrote both, or neither).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  sys = st.to_lsd[101]
+  ok !sys.key?(31), 'switch count is absent when no switch was ever touched'
+  eq [], sys.switches, 'the switch data array is still present, just empty'
+
+  st.switches[3] = true
+  touched = st.to_lsd[101]
+  eq 3, touched.switch_size
+  eq [false, false, true], touched.switches
+end
+
 check 'to_lsd/from_lsd round-trips the current and memorized BGM\'s balance, ' \
       'not just name/volume/tempo' do
   # #bgm_chunk/.bgm_from_chunk (the current-BGM/stored-BGM chunk 75/78


### PR DESCRIPTION
## Summary

Continuing the autonomous diff-hunt against a genuine `RPG_RT.exe` (kk1.12, RPG2003, under wine): comparing chunk 101 (SAVE_SYSTEM) between a real save and this engine's own `from_lsd`/`to_lsd` round-trip of it turned up several more gaps:

- **BGM slots 71-82** (title/battle/battle-end/inn/boat/ship/airship/gameover music) and **SE slots 91-102** (cursor..item sound effects) are all written unconditionally by genuine RPG_RT, blank when untouched — `#to_lsd` previously omitted every one of them entirely unless a live Change System BGM/SFX override existed for that specific slot.
- `#bgm_chunk`/`#se_chunk` always wrote volume/pitch/balance even when they equalled the schema's own declared defaults (100/100/50); a genuine save elides each independently, the same convention already established elsewhere in this schema.
- **Field 1 (scene)** is a legacy constant (always `5`) genuine RPG_RT writes on every save; this codebase never wrote it. **Field 23 (font_id)** was written unconditionally instead of elided at its own default. **Field 31 (switch count)** is elided when no switch has ever been touched, while **field 32** (the switch data array) is still written even then — an asymmetric elision this codebase's writer did not previously reproduce.

After these fixes, every common field between the real save's chunk 101 and this engine's own round trip of it is byte-for-byte identical. The remaining differences are documented, deliberately out-of-scope gaps (`frame_count`, the live "message box open" flag, the before-vehicle/battle music memory, and an unidentified `background` field) that would need scene-level state this codebase's save layer doesn't track yet.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1153 checks pass (3 new)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks pass
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parses cleanly
- [x] Verified against a genuine `RPG_RT.exe` save (kk1.12) under wine: every common chunk-101 field is byte-for-byte identical after a `from_lsd`/`to_lsd` round trip


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_