### PR TITLE
Document a new field-125 (battle_background) candidate from a genuine kk1.12 save

### DIFF
--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1861,6 +1861,23 @@ module LCF
       # `:battle_background` name was always a guess from the field's
       # position in the table, now disproven as this specific command's
       # persistence slot; no alternative candidate has been identified.
+      #
+      # A new candidate, from a different save entirely: a genuine kk1.12
+      # (RPG2003) `Save01.lsd` captured during ordinary map exploration --
+      # no battle in progress, no Change Battle Background ever issued that
+      # session -- carries field 125 *present*, decoding (Shift_JIS) as
+      # "草原" ("grassland/plains"), a plausible stock battle-backdrop name.
+      # liblcf's own generator/csv/fields.csv independently names this exact
+      # field (0x7D) `background`, a bare `String`, with no further
+      # description. Together these suggest field 125 is simply the current
+      # map's own resolved encounter background (or another background
+      # concept entirely unrelated to Change Battle Background's own live
+      # override) snapshotted for the save, present whenever *some*
+      # background applies -- not gated on a live override surviving past a
+      # fight the way cycle #167's own probe assumed. Not followed up
+      # further this cycle (no wine session running to test the "is it the
+      # map's own default backdrop" hypothesis directly); left for whoever
+      # picks this back up, alongside cycle #167's own note above.
       125 => { name: :battle_background, type: :string },
        131 => { name: :save_count, type: :int },
       # The file slot this save was written to. Confirmed against genuine


### PR DESCRIPTION
## Summary

While diffing chunk 101 (SAVE_SYSTEM) of a genuine kk1.12 (RPG2003) save against this engine's own round-trip of it, field 125 turned up present with a value decoding (Shift_JIS) as "草原" ("grassland/plains") — a plausible stock battle-backdrop name — even though that save was captured during ordinary map exploration, with no battle in progress and no Change Battle Background ever issued that session.

This directly answers a question this file's own field-125 comment (cycle #167) explicitly left open: it closed whether a *live Change Battle Background override* survives past the battle it was issued in (it doesn't — no code change needed there), but said "no alternative candidate has been identified" for what the field actually is otherwise. This new evidence — corroborated by liblcf's own `generator/csv/fields.csv`, which independently names this exact field (`0x7D`) `background` — suggests it may simply be the current map's own resolved encounter background, snapshotted unconditionally, unrelated to the live-override mechanic cycle #167 tested.

This PR is comment-only documentation of the new lead for whoever picks up the investigation next (no wine session available this cycle to test the "is it the map's own default backdrop" hypothesis directly) — no behavior changed.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1153 checks pass (comment-only change, no new checks needed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_