### PR TITLE
Mirror chunk 104 field 21 (sprite direction) off field 22; document remaining hero-record gaps

### DIFF
--- a/changelog.d/hero-sprite-direction-mirror.fixed.md
+++ b/changelog.d/hero-sprite-direction-mirror.fixed.md
@@ -1,0 +1,15 @@
+- `Game::State#to_lsd` now writes chunk 104 (hero) field 21 (liblcf's own
+  `direction`, "sprite direction") as a mirror of field 22 (`facing`).
+  Confirmed against a genuine kk1.12 save under wine: field 21 was present,
+  holding the exact same raw value as field 22 in that capture — `#to_lsd`
+  previously left it entirely absent. This codebase has no separate
+  "mid-turn sprite direction vs logical facing" concept to source an
+  independent value from, so the two are always written identically, the
+  same write-only-mirror shape already established for chunk 104's own
+  73/74 (`charset_name`/`charset_index`).
+- Documented (schema.rb, no behavior change) the substantial rest of
+  liblcf's `SaveMapEventBase` struct that a genuine save's hero record
+  (chunk 104) carries and this codebase still doesn't model at all: `layer`,
+  an in-progress custom `move_route`, `through`, several movement/animation
+  frame timers, in-flight jump coordinates, and a live Flash Sprite's
+  color/duration state. Left as a known gap for a future cycle.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1167,6 +1167,19 @@ module LCF
       # field's meaning being wrong. Left open: repeat this probe against a
       # save whose leader is an ordinary, non-placeholder actor.
       22 => { name: :direction, type: :int },
+      # liblcf's own generator/csv/fields.csv names field 0x15/21 `direction`
+      # ("Sprite direction") and field 0x16/22 (just above) `facing` -- the
+      # reverse of the names already established here, kept as-is rather
+      # than risk an invasive rename of the widely-referenced field 22.
+      # Confirmed present on a genuine kk1.12 save under wine, holding the
+      # exact same raw value as field 22 in that capture (both "\x02",
+      # facing down) -- consistent with 21 simply mirroring 22 whenever the
+      # hero is not itself mid-turn-animation (the one case liblcf's own
+      # naming implies the two could differ), which this codebase has no
+      # separate concept of. Not otherwise investigated -- left as a
+      # write-only mirror, the same shape as chunk 104's own 73/74
+      # (`charset_name`/`charset_index`) sprite mirror.
+      21 => { name: :sprite_direction, type: :int },
       # liblcf's `SaveMapEventBase.transparency` (generator/csv/fields.csv,
       # 0x18 == 24): "0 or 3 - Transparency level of the current event page".
       # On the *hero's* own record (chunk 104) this is Set Transparent Flag's
@@ -1217,6 +1230,25 @@ module LCF
       74 => { name: :charset_index, type: :int },
     }
 
+    # A genuine kk1.12 save's own chunk 104 (the hero's SAVE_MOVABLE record)
+    # carries a lot more of liblcf's full `SaveMapEventBase` struct
+    # (generator/csv/fields.csv) than this table models: `layer` (0x21/33),
+    # a full in-progress `move_route` (`MoveRoute` chunk, 0x29/41 -- the
+    # hero had a live custom route recorded in that capture), `through`
+    # (0x33/51), `stop_count`/`anim_count`/`max_stop_count` (0x34-36/52-54,
+    # movement/animation frame timers), `begin_jump_x`/`_y` (0x3E-3F/62-63),
+    # `processed` (0x4B/75, already noted above), and
+    # `flash_red`/`_green`/`_blue`/`_current_level`/`_time_left`
+    # (0x51-55/81-85, a live Flash Sprite in progress). None of these are
+    # modelled here: several need genuine new state this codebase's own
+    # `Game::State`/`Game::Character` don't track for the hero at all
+    # (an in-flight custom move route or Flash Sprite survives a save only
+    # by chance today, via whatever the interpreter re-derives), and the
+    # movement/animation timers are pure per-frame scheduling this engine
+    # already recomputes fresh rather than resuming byte-for-byte. Left as a
+    # known, larger gap for a future cycle -- see this table's own field 43
+    # comment for the one piece (`move_route_index`) already covered.
+    #
     # https://w.atwiki.jp/rpg2kpsp/pages/21.html
     #
     # Runtime state of a "show picture" command (chunk 103 of the save file),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15040,6 +15040,11 @@ module Game
       # CharSet row, which is numerically identical to liblcf's own facing
       # enum (both walk up/right/down/left in that order).
       hero[22] = CharSet::DIR_ROW[@direction] || 2
+      # Field 21 (liblcf's own `direction`/"sprite direction", distinct from
+      # field 22's `facing`) mirrors field 22 -- see SAVE_MOVABLE's own
+      # schema.rb comment for the genuine-save evidence and why this
+      # codebase has no separate value to give it.
+      hero[21] = hero[22]
       # Set Transparent Flag's own override (Player Visibility, 11310) --
       # liblcf's own "0 or 3" convention for this field (see schema.rb's
       # SAVE_MOVABLE comment on why it lives here, on the hero's own movable

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4360,6 +4360,22 @@ check 'to_lsd writes the leader/vehicle sprite index at the correct liblcf ' \
   eq 2, boat_chunk[74]
 end
 
+check 'to_lsd mirrors chunk 104 field 21 (liblcf\'s own "direction") off ' \
+      'field 22 ("facing")' do
+  # Confirmed against a genuine kk1.12 save under wine: field 21 was present
+  # holding the exact same raw value as field 22 in that capture -- see
+  # SAVE_MOVABLE's own schema.rb comment. #to_lsd used to leave field 21
+  # entirely absent.
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.direction = 4 # numpad left
+  hero = st.to_lsd[104]
+  ok hero.key?(21), 'field 21 is present'
+  eq hero[22], hero[21], 'field 21 mirrors field 22 exactly'
+end
+
 check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrides' do
   # do_change_system_bgm/_sfx (interpreter.rb) stash overrides in
   # @state.system_bgm/@state.system_sfx, keyed by slot -- the same slots


### PR DESCRIPTION
## Summary

Continuing the autonomous diff-hunt against a genuine `RPG_RT.exe` (kk1.12, RPG2003, under wine): chunk 104 (the hero's own SAVE_MOVABLE record) turned out to use liblcf's full `SaveMapEventBase` struct, not the small subset this schema currently models.

- **Field 21** (liblcf's own `direction`, "sprite direction" — distinct from field 22's `facing`) was present in the real save holding the exact same raw value as field 22 in that capture. `#to_lsd` never wrote it at all. Now mirrored, the same write-only-mirror shape chunk 104's own 73/74 (`charset_name`/`charset_index`) already use.
- The rest of what that save's chunk 104 carries beyond this schema's own fields — `layer`, an in-progress custom move route, several movement/animation frame timers, in-flight jump coordinates, and a live Flash Sprite's color/duration state — is documented (schema.rb comment, no behavior change) as a known, larger gap for a future cycle. Several of these need genuine new state this codebase's `Game::State`/`Game::Character` don't track for the hero at all, so implementing them properly is a bigger undertaking than a quick field fix.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1154 checks pass (1 new)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks pass
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parses cleanly
- [x] Verified against a genuine `RPG_RT.exe` save (kk1.12) under wine: field 21 now matches


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_