### PR TITLE
Elide chunk 109 (SAVE_INVENTORY) timer/tally fields at their own default

### DIFF
--- a/changelog.d/inventory-timers-tallies-elision.fixed.md
+++ b/changelog.d/inventory-timers-tallies-elision.fixed.md
@@ -1,0 +1,7 @@
+- `Game::State#to_lsd` now elides chunk 109 (SAVE_INVENTORY)'s timer fields
+  (23-30) and battle tallies/step counter (32-35, 42) at their own
+  never-touched default (0/false) instead of always writing them. Confirmed
+  against a genuine kk1.12 save under wine, taken well into a real
+  playthrough: every one of these fields was still absent, matching
+  liblcf's own `generator/csv/fields.csv` declared defaults — `#to_lsd`
+  previously wrote all of them unconditionally.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15519,20 +15519,26 @@ module Game
       # save keeps them -- .from_lsd and RPG_RT alike read them by index.
       inv[14] = item_ids.map { |i| @party.item_usage[i] || 0 }
       inv[21] = @party.gold
+      # liblcf's own generator/csv/fields.csv declares every one of these
+      # fields (timers, battle tallies, steps) at default 0/false, and a
+      # genuine kk1.12 save under wine omits all of them -- confirmed even
+      # for a save taken well into a real playthrough, so #to_lsd eliding
+      # only at the literal never-touched value (not "close enough to
+      # start") matches. #to_lsd previously wrote every one unconditionally.
       t1, t2 = @timers[0], @timers[1]
-      inv[23] = t1.frames
-      inv[24] = t1.running
-      inv[25] = t1.visible
-      inv[26] = t1.in_battle
-      inv[27] = t2.frames
-      inv[28] = t2.running
-      inv[29] = t2.visible
-      inv[30] = t2.in_battle
-      inv[32] = @battle_count
-      inv[33] = @defeat_count
-      inv[34] = @escape_count
-      inv[35] = @win_count
-      inv[42] = @steps
+      inv[23] = t1.frames if t1.frames != 0
+      inv[24] = true if t1.running
+      inv[25] = true if t1.visible
+      inv[26] = true if t1.in_battle
+      inv[27] = t2.frames if t2.frames != 0
+      inv[28] = true if t2.running
+      inv[29] = true if t2.visible
+      inv[30] = true if t2.in_battle
+      inv[32] = @battle_count if @battle_count != 0
+      inv[33] = @defeat_count if @defeat_count != 0
+      inv[34] = @escape_count if @escape_count != 0
+      inv[35] = @win_count if @win_count != 0
+      inv[42] = @steps if @steps != 0
       # Undefaulted, like the other counters -- absent until a battle has ever
       # finished (see #last_battle_turns).
       inv[41] = @last_battle_turns if @last_battle_turns

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4866,6 +4866,26 @@ check 'to_lsd/from_lsd round-trips the step counter and battle tallies' do
   eq 0, old.win_count
   eq 0, old.defeat_count
   eq 0, old.escape_count
+
+  # #to_lsd itself must also elide these (and the two timers' own fields)
+  # at their own neutral/never-touched value, the same "old save" shape
+  # above -- confirmed against a genuine kk1.12 save under wine: a save
+  # taken well into a real playthrough still omitted every one of fields
+  # 23-30/32-35/42 entirely, matching liblcf's own generator/csv/fields.csv
+  # declared defaults (0/false) for all of them. #to_lsd used to write
+  # every one unconditionally.
+  fresh = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  untouched = fresh.to_lsd[109].instance_variable_get(:@data)
+  [23, 24, 25, 26, 27, 28, 29, 30, 32, 33, 34, 35, 42].each do |field|
+    ok untouched[field].nil?, "field #{field} is absent when never touched"
+  end
+
+  fresh.timer(0).frames = 100
+  fresh.timer(0).running = true
+  touched = fresh.to_lsd[109]
+  eq 100, touched.timer1_frames, 'a touched timer is still written'
+  ok touched.timer1_active
+  ok !touched.instance_variable_get(:@data)[25], 'the untouched sibling field (visible) stays absent'
 end
 
 check 'restore_pictures restores zoom, opacity and tone, not just name/position' do


### PR DESCRIPTION
## Summary

Continuing the autonomous diff-hunt against a genuine `RPG_RT.exe` (kk1.12, RPG2003, under wine): chunk 109 (SAVE_INVENTORY) fields 23-30 (both Timer Operation timers' frames/active/visible/battle flags) and 32-35/42 (battle tallies, step counter) were written unconditionally by `#to_lsd`, but liblcf's own `generator/csv/fields.csv` declares 0/false as every one of their defaults, and a genuine save taken well into a real playthrough still omitted all of them entirely. Now elided the same way field 41 (`last_battle_turns`) already was.

Chunk 109 is now byte-for-byte identical to the real save's own chunk after a `from_lsd`/`to_lsd` round trip.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1154 checks pass (existing coverage extended)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks pass
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parses cleanly
- [x] Verified against a genuine `RPG_RT.exe` save (kk1.12) under wine: chunk 109 now matches byte-for-byte


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_