### PR TITLE
Save/Continue: Pan Screen offset now persists; title FaceSet index elided at default

### DIFF
--- a/changelog.d/screen-pan-title-face-index.fixed.md
+++ b/changelog.d/screen-pan-title-face-index.fixed.md
@@ -1,0 +1,14 @@
+- `Game::State#to_lsd` now writes chunk 102 (SAVE_SCREEN) fields 41/42
+  (`pan_x`/`pan_y`, liblcf's own generator/csv/fields.csv names), restoring
+  a live Pan Screen offset through Save/Continue. Confirmed against a
+  genuine kk1.12 save under wine: field 42 (pan_y) was present and
+  nonzero, field 41 (pan_x) absent at its own default 0 — `#to_lsd` never
+  wrote either field before, even though `Game::Screen` already tracks
+  this offset for the portable Marshal save format. Documented (no
+  behavior change) the larger remaining gap in this same chunk: liblcf's
+  own battle-animation fields (43-47), which `Game::Screen` has no
+  equivalent "last played" state to source from at all.
+- `Game::State#to_lsd` now elides chunk 100 (SAVE_TITLE)'s four FaceSet
+  index fields (22/24/26/28) at their own default (0) instead of always
+  writing them, matching a genuine kk1.12 save under wine whose leader's
+  face index was 0 and left the field absent.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1963,6 +1963,24 @@ module LCF
       13 => { name: :tint_current_blue, type: :double, default: 100.0 },
       14 => { name: :tint_current_sat, type: :double, default: 100.0 },
       15 => { name: :tint_time_left, type: :int, default: 0 },
+      # liblcf's own generator/csv/fields.csv (SaveScreen): the live Pan
+      # Screen offset, confirmed present on a genuine kk1.12 save under
+      # wine (field 42/pan_y nonzero, field 41/pan_x absent -- elided at
+      # its own default 0, a vertical-only pan). `Game::Screen` already
+      # tracks this (`#pan_offset`) for the Marshal save format; only the
+      # `.lsd` write was missing.
+      41 => { name: :pan_x, type: :int, default: 0 },
+      42 => { name: :pan_y, type: :int, default: 0 },
+      # liblcf's own fields 0x2B-0x2F (43-47): the last (or currently
+      # playing) battle animation's id/target/frame/active/global-scope --
+      # confirmed present (id/target/frame, all nonzero) on the same
+      # genuine kk1.12 save even though it was taken on the map, not
+      # mid-battle, meaning genuine RPG_RT leaves these as stale leftover
+      # values rather than resetting them once the animation finishes
+      # (`battleanim_active`, field 46, was itself absent/false in that
+      # capture). `Game::Screen` has no equivalent "last played battle
+      # animation" state to source these from at all, so left undecoded --
+      # a larger gap than the pan fields above, for a future cycle.
     }
 
     # https://w.atwiki.jp/rpg2kpsp/pages/13.html documents the LcfSaveData chunk

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15025,7 +15025,12 @@ module Game
           break if i >= face_fields.size
           nf, xf = face_fields[i]
           title[nf] = members[i].faceset_name
-          title[xf] = members[i].faceset_index
+          # Elided at its own default (0) -- confirmed against a genuine
+          # kk1.12 save under wine, whose leader's own FaceSet index was 0
+          # and left field 22 (this member's own index slot) absent rather
+          # than an explicit 0.
+          idx = members[i].faceset_index
+          title[xf] = idx if idx != 0
         end
         save[100] = title
       end
@@ -15389,6 +15394,9 @@ module Game
       scr[13] = current[2] if current[2] != Screen::NEUTRAL
       scr[14] = current[3] if current[3] != Screen::NEUTRAL
       scr[15] = frames if frames != 0
+      pan_x, pan_y = @screen.pan_offset
+      scr[41] = pan_x if pan_x != 0
+      scr[42] = pan_y if pan_y != 0
       save[102] = scr
 
       # Chunk 103 is every picture slot RPG2000 offers (Show Picture, 11110)
@@ -16039,6 +16047,13 @@ module Game
                                    [scr.tint_current_red, scr.tint_current_green,
                                     scr.tint_current_blue, scr.tint_current_sat],
                                    scr.tint_time_left)
+        # The live Pan Screen offset (fields 41/42) -- a genuine save never
+        # carries a separate in-flight target, so this restores at rest
+        # (current == target), the same idle-sync convention already used
+        # for tint/pictures elsewhere in this method.
+        px = scr.pan_x || 0
+        py = scr.pan_y || 0
+        state.screen.load_h(pan_x: px, pan_y: py, pan_tx: px, pan_ty: py)
       end
       restore_pictures(state, save[103])
       # Both Timer Operation countdowns (inventory chunk 109 fields 23-30); a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4272,6 +4272,18 @@ check 'to_lsd/from_lsd round-trips the file-select screen\'s face-thumbnail ' \
   ok no_face_round.preview_faces.nil?,
      'a party with no FaceSet set writes an all-blank snapshot, read back as nil ' \
      "(got #{no_face_round.preview_faces.inspect})"
+
+  # A FaceSet index of 0 (the schema's own declared default for fields
+  # 22/24/26/28) is elided the same way every other "omit at default"
+  # field in this schema is -- confirmed against a genuine kk1.12 save
+  # under wine, whose leader's own face index was 0 and left field 22
+  # absent, not an explicit 0. #to_lsd previously wrote it unconditionally.
+  zero_index_st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  zero_index_st.party.leader.set_faceset('LeaderFace', 0)
+  title = zero_index_st.to_lsd[100]
+  ok !title.key?(22), 'face index 0 is absent, not an explicit 0'
+  eq [['LeaderFace', 0]], Game::State.from_lsd(db, zero_index_st.to_lsd).preview_faces[0, 1],
+     'and still round-trips back to index 0 on load'
 end
 
 check 'to_lsd/from_lsd round-trips the file-select screen\'s level/HP snapshot ' \
@@ -12590,6 +12602,32 @@ check 'to_lsd/from_lsd round-trips a live screen tint transition (chunk 102)' do
   old = Game::State.from_lsd(db, legacy)
   eq [100, 100, 100, 100], old.screen.tint
   eq false, old.screen.tinting?
+end
+
+check 'to_lsd/from_lsd round-trips a live Pan Screen offset (chunk 102 ' \
+      'fields 41/42)' do
+  # Confirmed against a genuine kk1.12 save under wine: field 42 (pan_y)
+  # was present and nonzero (a vertical-only pan), field 41 (pan_x) absent
+  # at its own default 0 -- #to_lsd previously never wrote either field at
+  # all, so a live Pan Screen offset silently reset to (0,0) on Save/
+  # Continue even though `Game::Screen` already tracks it for the portable
+  # Marshal save format.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.screen.instance_variable_set(:@pan_x, 0)
+  st.screen.instance_variable_set(:@pan_y, 96)
+  scr = st.to_lsd[102]
+  ok !scr.key?(41), 'pan_x is absent at its own default (0)'
+  eq 96, scr.pan_y
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq [0, 96], round.screen.pan_offset, 'the pan offset round-trips, restored at rest'
+
+  # A save written before this landed simply omits both fields; from_lsd
+  # must leave the fresh Screen.new neutral (0, 0) offset alone.
+  legacy = Game::State.new(Game::Party.new(db), 1, 0, 0).to_lsd
+  old = Game::State.from_lsd(db, legacy)
+  eq [0, 0], old.screen.pan_offset
 end
 
 # liblcf's SaveMapEventBase.facing (generator/csv/fields.csv, 0x16 == 22) is


### PR DESCRIPTION
## Summary

Continuing the autonomous diff-hunt against a genuine `RPG_RT.exe` (kk1.12, RPG2003, under wine):

- **Chunk 102 (SAVE_SCREEN) fields 41/42** (`pan_x`/`pan_y`, per liblcf's own `generator/csv/fields.csv`) were never written at all, so a live Pan Screen offset silently reset to (0,0) on Save/Continue even though `Game::Screen` already tracks it for the portable Marshal save format. Now written (elided at 0). The chunk's remaining battle-animation fields (43-47) are documented as a larger, separate gap — `Game::Screen` has no equivalent "last played animation" state to source them from at all.
- **Chunk 100 (SAVE_TITLE)'s four FaceSet index fields** (22/24/26/28) were written unconditionally; a genuine save elides each at its own default (0), the same convention already established throughout this schema.

Chunk 100 is now byte-for-byte identical to the real save (aside from the save timestamp, which necessarily differs between captures); chunk 102 gains its first non-tint field.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 1155 checks pass (1 new, plus extended coverage on two existing checks)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks pass
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parses cleanly
- [x] Verified against a genuine `RPG_RT.exe` save (kk1.12) under wine: chunk 100 matches byte-for-byte (aside from timestamp); chunk 102's new pan_y field matches exactly


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_