### PR TITLE
Mirror chunk 108 combat-toggle fields 92-95 off the actor's own class/database traits

### DIFF
--- a/changelog.d/actor-combat-toggle-mirror-fields.fixed.md
+++ b/changelog.d/actor-combat-toggle-mirror-fields.fixed.md
@@ -1,0 +1,10 @@
+- `Game::State#to_lsd` now writes chunk 108 (SAVE_PARTY_ACTOR) fields 92-95
+  (`two_weapon`/`lock_equipment`/`auto_battle`/`super_guard`, liblcf's own
+  generator/csv/fields.csv names, right after field 91's own row) as a live
+  mirror of `Game::Actor#double_hand?`/`#equipment_fixed?`/`#force_ai?`/
+  `#strong_defence?`. Confirmed against a genuine kk1.12 save under wine:
+  several roster slots carried one or more of these fields, each present
+  only when the underlying actor/class trait was actually on — `#to_lsd`
+  never wrote any of the four before. `.from_lsd` has nothing new to
+  restore: this engine already derives all four live from the actor's own
+  class/database row, so they're written for byte parity only.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1498,10 +1498,23 @@ module LCF
       # in-battle Row command (ADR 0053's row mechanic). liblcf's own
       # `ChunkSaveActor` enum (lsd/chunks.h) numbers this field 0x5B, right
       # after class_id (0x5A) and before the two_weapon/lock_equipment/
-      # auto_battle/super_guard/battler_animation fields this schema does not
-      # declare yet -- 0 (RowType_front) is both liblcf's own default and the
-      # only row RPG2000 ever writes.
+      # auto_battle/super_guard/battler_animation fields below -- 0
+      # (RowType_front) is both liblcf's own default and the only row
+      # RPG2000 ever writes.
       91 => { name: :row, type: :int, default: 0 }, # 隊列 (2003)
+      # liblcf's own generator/csv/fields.csv (0x5C-0x5F): a live mirror of
+      # the actor's own current class/database-derived combat toggles
+      # (Game::Actor#double_hand?/#equipment_fixed?/#force_ai?/
+      # #strong_defence?), confirmed present (each only when true) on a
+      # genuine kk1.12 save under wine. Purely a snapshot of state this
+      # codebase already derives live from the actor's own class/database
+      # row -- #to_lsd writes it for byte parity, but `.from_lsd` has
+      # nothing to restore *to* (there is no separate "was this overridden"
+      # concept for these four, unlike class_id/battle_commands above).
+      92 => { name: :two_weapon, type: :bool, default: false },
+      93 => { name: :lock_equipment, type: :bool, default: false },
+      94 => { name: :auto_battle, type: :bool, default: false },
+      95 => { name: :super_guard, type: :bool, default: false },
 
       # The live Change Parameters shadow (Game::Actor#change_param's
       # @base_raw, isolated from the level curve) -- confirmed against a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15334,6 +15334,12 @@ module Game
         # RPG2000 save (or a 2003 save whose party never touched Row) never
         # gains the field.
         e[91] = a.battle_row if a.battle_row != Battle::ROW_FRONT
+        # A live mirror of the actor's own current class/database-derived
+        # combat toggles -- see SAVE_PARTY_ACTOR's own schema.rb comment.
+        e[92] = true if a.double_hand?
+        e[93] = true if a.equipment_fixed?
+        e[94] = true if a.force_ai?
+        e[95] = true if a.strong_defence?
         # A live Change Parameters edit (#change_param) survives Save/
         # Continue too -- see SAVE_PARTY_ACTOR's own comment for the
         # genuine-RPG_RT verification. `@base_raw` is the curve plus this

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4171,6 +4171,51 @@ check 'to_lsd/from_lsd round-trips a live Change Parameters edit on every ' \
       untouched_round.party.leader.int, untouched_round.party.leader.agi]
 end
 
+check 'to_lsd mirrors chunk 108\'s own class/database-derived combat ' \
+      'toggles (fields 92-95), confirmed present only when true on a ' \
+      'genuine kk1.12 save' do
+  # liblcf's own generator/csv/fields.csv names these 0x5C-0x5F
+  # two_weapon/lock_equipment/auto_battle/super_guard, right after row
+  # (0x5B, field 91). #to_lsd never wrote any of the four before -- a
+  # genuine kk1.12 save under wine had them present (each only when the
+  # underlying actor/class trait was actually on) on several roster slots.
+  # There is nothing for .from_lsd to restore *to*: unlike class_id or
+  # battle_commands, these four are a pure live snapshot of a value this
+  # engine already derives from the actor's own class/database row, so a
+  # fresh load simply re-derives the same true/false rather than reading
+  # the field back.
+  row = FakePlayerRow.new('Hero', '', 0, 5, { max_hp: 100, max_mp: 30, atk: 10, def: 8 })
+  row.double_hand = true
+  row.equipment_fixed = true
+  row.force_ai = true
+  row.strong_defence = true
+  db = FakeActorDB.new({ 1 => row }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+  ok hero.double_hand?
+  ok hero.equipment_fixed?
+  ok hero.force_ai?
+  ok hero.strong_defence?
+
+  saved = st.to_lsd[108][1]
+  eq true, saved.two_weapon
+  eq true, saved.lock_equipment
+  eq true, saved.auto_battle
+  eq true, saved.super_guard
+
+  # None of the four ever set: a genuine save leaves the field absent
+  # rather than writing an explicit false -- same "omit at default"
+  # convention as field 91 (row) right above them.
+  plain_row = FakePlayerRow.new('Hero', '', 0, 5, { max_hp: 100, max_mp: 30, atk: 10, def: 8 })
+  plain_db = FakeActorDB.new({ 1 => plain_row }, [1])
+  plain_st = Game::State.new(Game::Party.new(plain_db), 1, 0, 0)
+  plain_saved = plain_st.to_lsd[108][1]
+  eq false, plain_saved.two_weapon
+  eq false, plain_saved.lock_equipment
+  eq false, plain_saved.auto_battle
+  eq false, plain_saved.super_guard
+end
+
 check 'to_lsd/from_lsd leaves an actor untouched by either command exactly ' \
       'as it was' do
   players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,


### PR DESCRIPTION
## Summary
- `Game::State#to_lsd` now writes chunk 108 (SAVE_PARTY_ACTOR) fields 92-95 (`two_weapon`/`lock_equipment`/`auto_battle`/`super_guard`, liblcf's own `generator/csv/fields.csv` names, right after field 91's own row) as a live mirror of `Game::Actor#double_hand?`/`#equipment_fixed?`/`#force_ai?`/`#strong_defence?`.
- Confirmed against a genuine kk1.12 save under wine: several roster slots carried one or more of these fields, each present only when the underlying trait was actually on — `#to_lsd` never wrote any of the four before.
- `.from_lsd` has nothing new to restore: this engine already derives all four live from the actor's own class/database row, so they're written for byte parity only.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1156 checks passed (new check added for fields 92-95)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks passed
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parsed cleanly
- [x] Manually diffed chunk 108 against a genuine kk1.12 `.lsd` save written by RPG_RT.exe under wine

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_