### PR TITLE
Resolve vehicle charset from the database; document chunk 101 fields 76/77

### DIFF
--- a/changelog.d/vehicle-charset-database-fallback.fixed.md
+++ b/changelog.d/vehicle-charset-database-fallback.fixed.md
@@ -1,0 +1,10 @@
+- `Game::State#to_lsd` now accepts an optional database handle and, when
+  given one, resolves an uncustomized vehicle's `charset_name`/
+  `charset_index` (chunk 105/106/107 fields 73/74) off the database's own
+  System boat/ship/airship_name/_index — the same fallback `Scene::Map`'s
+  own `#vehicle_charset`/`#vehicle_charset_index` already apply for
+  rendering — instead of leaving those two fields absent. `main.rb`'s own
+  save export now passes its database through. A live Change Vehicle
+  Graphic override (or one restored from a prior `.lsd`) still wins over
+  the fallback, and a caller with no database handle (tests, tools) keeps
+  the prior absent-when-uncustomized behavior.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1814,6 +1814,24 @@ module LCF
       73 => { name: :battle_end_bgm, type: :Array1D, elements: BGM },
       74 => { name: :inn_bgm, type: :Array1D, elements: BGM },
       75 => { name: :current_bgm, type: :Array1D, elements: BGM },
+      # liblcf's own generator/csv/fields.csv: `before_vehicle_music`
+      # (0x4C == 76) and `before_battle_music` (0x4D == 77), the track RPG_RT
+      # restores on disembark/after the fight -- the two gaps in this
+      # otherwise-contiguous 71-82 BGM-slot run. Confirmed present on a
+      # genuine kk1.12 save under wine (taken outside any vehicle/battle):
+      # both decode as a BGM struct whose own `file` (field 1) is the
+      # literal string "(OFF)" -- RPG_RT's own placeholder name for "no
+      # track", rather than either field being absent outright. Not wired
+      # into `Game::State#to_lsd`/`.from_lsd` yet: this codebase's own
+      # counterpart to each restore point (`Scene::Map#restore_pre_vehicle_bgm`
+      # and its battle equivalent) is transient scene-layer state, not
+      # anything `Game::State` itself tracks, so `#to_lsd` has nothing to
+      # source these two from today -- and writing the "(OFF)" placeholder
+      # unconditionally would be actively wrong the instant a real session
+      # boards a vehicle or fights a battle before saving. Left for a future
+      # cycle that promotes that scene-layer state onto `Game::State` first.
+      76 => { name: :before_vehicle_music, type: :Array1D, elements: BGM },
+      77 => { name: :before_battle_music, type: :Array1D, elements: BGM },
       78 => { name: :stored_bgm, type: :Array1D, elements: BGM },
       79 => { name: :boat_bgm, type: :Array1D, elements: BGM },
       80 => { name: :ship_bgm, type: :Array1D, elements: BGM },
@@ -1932,6 +1950,20 @@ module LCF
       # further this cycle (no wine session running to test the "is it the
       # map's own default backdrop" hypothesis directly); left for whoever
       # picks this back up, alongside cycle #167's own note above.
+      #
+      # This codebase already has every *piece* the "map's own resolved
+      # encounter background" hypothesis needs -- `Game::Backdrop.name_for`
+      # (the map-tree backdrop_type walk) and `Scene::Map#terrain_backdrop`
+      # (the tile's own terrain background) together compute exactly this
+      # for `Scene::Battle#encounter_backdrop` -- but both live on
+      # `Scene::Map`/`Scene::Battle`, not `Game::State`: `#terrain_backdrop`
+      # needs `Scene::Map`'s own compiled `@chipset` (tile id -> terrain id)
+      # to resolve the party's current tile, which `Game::State#to_lsd` has
+      # no equivalent of at all. Wiring field 125 up for real needs that
+      # chipset/terrain lookup (or an equivalent) threaded into `#to_lsd`
+      # first, the same kind of database/scene-layer handle `#to_lsd`'s own
+      # vehicle-location comment (mrblib/game.rb) already flags as missing
+      # for a different field.
       125 => { name: :battle_background, type: :string },
        131 => { name: :save_count, type: :int },
       # The file slot this save was written to. Confirmed against genuine
@@ -2009,8 +2041,15 @@ module LCF
     # map. Chunks 109 (inventory) and 114 (common-event state), still marked
     # unanalysed on that wiki, were identified against a real Save01.lsd (see
     # ADR 0011). Chunk 102 (screen effects) is now handled for its tint fields
-    # only (see SAVE_SCREEN above). Chunk 112 (a one-byte flag) and 200 (a
-    # non-standard high-id extension chunk) are still left out until confirmed.
+    # only (see SAVE_SCREEN above). Chunk 112 is liblcf's own `SavePanorama`
+    # (generator/csv/fields.csv, top-level Save field 0x70) -- not "a one-byte
+    # flag" as an earlier guess here had it (that byte is simply an empty
+    # nested struct's own terminator: a genuine kk1.12 save under wine carried
+    # chunk 112 present but empty, `\x00`, no fields of its own set at all).
+    # SavePanorama's own field layout has not been identified, and with no
+    # capture yet showing it populated there is nothing to confirm one
+    # against -- left out along with 200 (a non-standard high-id extension
+    # chunk) until one is.
     SAVE_DATA = {
       name: :Save, type: :Array1D,
       elements: {

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15024,7 +15024,13 @@ module Game
     # LCF::Schema::SAVE_INVENTORY's timer1_*/timer2_*,
     # battles/defeats/escapes/victories/steps/turns fields and
     # SAVE_PARTY_ACTOR's actor_name/title), so this is a near-parity export.
-    def to_lsd(save_count = 1, timestamp = nil, save_slot = 1)
+    # `db`, when given, is only consulted for the same database System
+    # boat/ship/airship_name/_index fallback Scene::Map's own
+    # #vehicle_charset/#vehicle_charset_index (mrblib/scene/map.rb) already
+    # apply for rendering an uncustomized vehicle -- see the vehicle-writing
+    # loop below. Every other caller (tests, tools) omits it and gets the
+    # prior behavior (73/74 simply absent for an uncustomized vehicle).
+    def to_lsd(save_count = 1, timestamp = nil, save_slot = 1, db = nil)
       timestamp = State.ole_now if timestamp.nil?
       save = LCF::SaveData.new
 
@@ -15102,16 +15108,16 @@ module Game
       #
       # The same capture also had charset_name ("乗り物") and charset_index
       # (0/1/3) present on all three even though this engine's own model
-      # never wrote them until customized -- but that capture's own
-      # database happens to configure every vehicle's System boat/ship/
-      # airship_name/_index to resolve to exactly those values, the same
-      # fallback Scene::Map's own #vehicle_charset/#vehicle_charset_index
-      # (mrblib/scene/map.rb) already apply for rendering. #to_lsd has no
-      # database handle to resolve that same fallback with (`Game::State`
-      # carries no `db` reference at all), so an uncustomized vehicle's own
-      # 73/74 stay absent here rather than risk baking in kk1.12's own
-      # database values as if they were a universal RPG_RT default --
-      # left for a future cycle that threads a database reference through.
+      # never wrote them until customized -- that capture's own database
+      # configures every vehicle's System boat/ship/airship_name/_index to
+      # resolve to exactly those values, the same fallback Scene::Map's own
+      # #vehicle_charset/#vehicle_charset_index (mrblib/scene/map.rb) apply
+      # for rendering. Mirrored here off the optional `db` argument: when a
+      # caller has one to give (main.rb's own #export_lsd does), an
+      # uncustomized vehicle's 73/74 resolve the database's own name/index
+      # instead of staying absent, exactly like rendering already does; a
+      # caller with no `db` (tests, tools) keeps the prior absent-when-
+      # uncustomized behavior.
       { 105 => :boat, 106 => :ship, 107 => :airship }.each do |chunk, type|
         v = @vehicles[type]
         mv = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
@@ -15127,6 +15133,15 @@ module Game
           mv[73] = v.charset_name
           idx = v.charset_index || 0
           mv[74] = idx if idx != 0
+        elsif db && db.respond_to?(:system) && db.system
+          name_field = "#{type}_name"
+          index_field = "#{type}_index"
+          name = db.system.respond_to?(name_field) ? db.system.send(name_field) : nil
+          if name && !name.to_s.empty?
+            mv[73] = name.to_s
+            idx = db.system.respond_to?(index_field) ? (db.system.send(index_field) || 0) : 0
+            mv[74] = idx if idx != 0
+          end
         end
         mv[101] = Vehicle::TYPE_ID[type]
         save[chunk] = mv

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -933,7 +933,7 @@ class RPG2k
   # Write a real Save<slot>.lsd next to the Marshal save. Best-effort: any error
   # is logged and swallowed so it cannot break the primary save.
   def export_lsd state, slot = 1
-    state.to_lsd(state.save_count, nil, slot).save_to(lsd_path(slot))
+    state.to_lsd(state.save_count, nil, slot, @db).save_to(lsd_path(slot))
   rescue StandardError => e
     $stderr.puts "[RPG2k] .lsd export failed for slot #{slot}: #{e.message}"
   end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10729,11 +10729,11 @@ check 'to_lsd writes chunks 105-107 (vehicle locations) unconditionally, ' \
   eq 0, boat.y
   eq 1, boat.vehicle, "liblcf's own SaveVehicleLocation.vehicle ordinal (field 101), 1 for the boat"
   eq 4, boat.move_speed
-  # Uncustomized (Vehicle.new's own empty charset_name/0 index sentinel):
-  # 73/74 stay absent, the same sentinel Scene::Map's own
-  # #vehicle_charset/#vehicle_charset_index already test for -- #to_lsd has
+  # Uncustomized (Vehicle.new's own empty charset_name/0 index sentinel)
+  # and no `db` given: 73/74 stay absent, the same sentinel Scene::Map's
+  # own #vehicle_charset/#vehicle_charset_index already test for -- with
   # no database handle to resolve the System boat_name/_index fallback
-  # those use, so it must not fabricate a name/index of its own.
+  # those use, #to_lsd must not fabricate a name/index of its own.
   ok !boat.key?(73), 'no charset override written for an uncustomized vehicle'
   ok !boat.key?(74)
 
@@ -10753,6 +10753,45 @@ check 'to_lsd writes chunks 105-107 (vehicle locations) unconditionally, ' \
   customized = st.to_lsd[105]
   eq 'Vehicle', customized.charset_name
   eq 2, customized.charset_index
+end
+
+FakeVehicleSystem = Struct.new(:boat_name, :boat_index, :ship_name, :ship_index,
+                                :airship_name, :airship_index)
+FakeVehicleDB = Struct.new(:system)
+
+check 'to_lsd resolves an uncustomized vehicle\'s charset_name/_index off ' \
+      'the database System fallback when given one' do
+  # Mirrors Scene::Map's own #vehicle_charset/#vehicle_charset_index
+  # fallback (mrblib/scene/map.rb) for the save writer: a caller that has a
+  # database handle to give (main.rb's own #export_lsd does) gets the same
+  # resolved name/index an uncustomized vehicle actually renders with,
+  # instead of leaving 73/74 absent.
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  fake_system = FakeVehicleSystem.new('乗り物', 0, '乗り物', 1, '乗り物', 3)
+  fake_db = FakeVehicleDB.new(fake_system)
+
+  saved = st.to_lsd(1, nil, 1, fake_db)
+  boat = saved[105]
+  eq '乗り物', boat.charset_name
+  ok !boat.key?(74), 'boat_index 0 elides field 74, same as a live customization would'
+
+  ship = saved[106]
+  eq '乗り物', ship.charset_name
+  eq 1, ship.charset_index
+
+  airship = saved[107]
+  eq '乗り物', airship.charset_name
+  eq 3, airship.charset_index
+
+  # A live Change Vehicle Graphic override still wins over the database
+  # fallback, exactly like Scene::Map's own #vehicle_charset does.
+  st.vehicle(:boat).charset_name = 'Vehicle'
+  st.vehicle(:boat).charset_index = 2
+  overridden = st.to_lsd(1, nil, 1, fake_db)[105]
+  eq 'Vehicle', overridden.charset_name
+  eq 2, overridden.charset_index
 end
 
 check 'to_lsd writes the camera scroll (chunk 111 fields 1/2) from the ' \


### PR DESCRIPTION
## Summary
- **`Game::State#to_lsd` now accepts an optional database handle** and, when given one, resolves an uncustomized vehicle's `charset_name`/`charset_index` (chunk 105-107 fields 73/74) off the database's own System boat/ship/airship_name/_index — the same fallback `Scene::Map`'s own `#vehicle_charset`/`#vehicle_charset_index` already apply for rendering. `main.rb`'s save export now passes `@db` through. This closes the gap the earlier vehicle-location-always-written PR (#1416) left documented: verified directly against the genuine kk1.12 database (`db.system.boat_name`/`_index` → "乗り物"/0, ship → "乗り物"/1, airship → "乗り物"/3) that a brand-new `Game::State` now writes these exact values, matching the genuine save byte-for-byte. A live Change Vehicle Graphic override still wins over the fallback; a caller with no database handle keeps the prior absent-when-uncustomized behavior.
- Documents chunk 101 (SAVE_SYSTEM) fields 76/77 (`before_vehicle_music`/`before_battle_music`, liblcf's own names) — the two gaps in an otherwise-contiguous 71-82 BGM-slot run. Confirmed present on a genuine kk1.12 save under wine, decoding as a BGM struct whose `file` is the literal `"(OFF)"` placeholder. Not wired into `#to_lsd`/`.from_lsd`: this codebase's own restore-point equivalents (`Scene::Map#restore_pre_vehicle_bgm` and its battle counterpart) are transient scene-layer state, not tracked on `Game::State`, so hardcoding `"(OFF)"` unconditionally would be actively wrong once a real session boards a vehicle or fights a battle before saving.
- Corrects chunk 112's own top-level comment: it's liblcf's `SavePanorama` (field 0x70), not "a one-byte flag" — that byte is an empty nested struct's own terminator (confirmed present-but-empty on the same capture).
- Extends field 125's own comment with this cycle's finding: this codebase already has the pieces the "map's own resolved encounter background" hypothesis needs (`Game::Backdrop.name_for`, `Scene::Map#terrain_backdrop`), but both need `Scene::Map`'s own compiled `@chipset`, which `Game::State#to_lsd` has no equivalent of — narrowing what a future cycle needs to wire up.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1158 checks passed (new check added for the database charset fallback)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks passed
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parsed cleanly
- [x] `ruby scripts/lcf_schema_coverage.rb` — every chunk in the test-bed data is named by the LCF schema
- [x] Verified directly against the genuine kk1.12 database that the fallback resolves the exact same values the genuine save capture carried

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB
