### PR TITLE
Add a minimal, non-mruby map-walking port for iPod nano 7th generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,29 @@
   `libEGL.so` doesn't export) — RPG2000/2003, XP and VX/VX Ace are
   unaffected. See the ADR.
 
+### iPod nano 7th generation (homebrew)
+
+- [`app/nano7/rpg2k_walk`](app/nano7/rpg2k_walk) walks a real RPG Maker
+  2000/2003 map on a jailbroken iPod nano 7th generation via the
+  [NanoApps](https://github.com/nfzerox/NanoApps) homebrew SDK. Unlike every
+  other port above, this is **not** the mruby/RGSS engine on a new display
+  backend — NanoApps caps a compiled app image at roughly 500 KB, far under
+  what this repo's mruby + RGSS/RPG2k gem stack needs, so it is instead a
+  small from-scratch C engine. A new host-side exporter
+  (`scripts/export_nano7_map.rb`) does the real LCF parsing and chipset/
+  autotile compositing once, on this repo's own pure-Ruby tooling, and writes
+  a compact binary the on-device app reads directly. See
+  [`docs/adr/0061-ipod-nano-7-homebrew-map-walk.md`](docs/adr/0061-ipod-nano-7-homebrew-map-walk.md)
+  for why, and the app's own README for build/install instructions.
+- **Scope: map walking, not the game.** Tile rendering (including autotiles,
+  frozen at their first animation frame) and grid movement with real
+  collision, for one static map — no events, battle or menus.
+- Verified on real hardware: `.hbapp` image ~4.5 KB (well under the ~500 KB
+  ceiling), installed via NanoApps on a jailbroken nano 7G, walking a real
+  exported map with working collision. One known issue: cells whose
+  lower-layer chip resolves to the chipset's transparent/placeholder region
+  render as solid magenta instead of being handled — see the ADR.
+
 ### Reporting an error
 
 When the engine dies on a Ruby exception it no longer just prints a backtrace

--- a/app/nano7/rpg2k_walk/Info.plist
+++ b/app/nano7/rpg2k_walk/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>	<string>org.rpg-maker-clone.rpg2k_walk</string>
+	<key>CFBundleName</key>		<string>RPG2k Walk</string>
+	<key>CFBundleExecutable</key>	<string>rpg2k_walk</string>
+	<key>HBAppKind</key>			<integer>1</integer>
+	<key>HBIconGlyph</key>		<string>map</string>
+	<key>HBIconColor</key>		<string>#3a7d44</string>
+</dict>
+</plist>

--- a/app/nano7/rpg2k_walk/Makefile
+++ b/app/nano7/rpg2k_walk/Makefile
@@ -1,0 +1,4 @@
+APP_NAME    := rpg2k_walk
+SRCS        := rpg2k_walk.c
+RAW_SURFACE := 1
+include ../../sdk/hb_app.mk

--- a/app/nano7/rpg2k_walk/README.md
+++ b/app/nano7/rpg2k_walk/README.md
@@ -1,0 +1,107 @@
+# rpg2k_walk — walk a real RPG2000/2003 map on iPod nano 7th gen
+
+A from-scratch, non-mruby homebrew app that reads one map exported from a
+real RPG Maker 2000/2003 project and lets you walk around it on a jailbroken
+**iPod nano 7th generation**, using the [NanoApps](https://github.com/nfzerox/NanoApps)
+homebrew SDK. See `docs/adr/0061-ipod-nano-7-homebrew-map-walk.md` for why
+this is a separate minimal engine rather than the mruby/RGSS engine the rest
+of this repo runs everywhere else, and for the full scope/limitations.
+
+**Scope**: tile rendering (including autotiles, frozen at their first
+animation frame) + grid movement + collision, for one static map. No events,
+no interpreter, no battle, no menus — this walks a map, it does not play the
+game.
+
+## What you need
+
+- A jailbroken iPod nano 7th generation with untethered code execution (e.g.
+  [Pixosn0w](https://github.com/IAmDazen/Pixosn0w) / `ipod_sun`) and a
+  [NanoApps](https://github.com/nfzerox/NanoApps) checkout set up per its own
+  README (`./start`, on a Linux machine the iPod is connected to).
+- A local checkout of this repo (`rpg-maker-clone`), to run the exporter and
+  supply this app's source.
+- Plain `ruby` (no mruby build needed — see below).
+
+This repo does not vendor NanoApps, and there is no CI job for this port:
+neither the toolchain conventions above nor the physical device are things
+CI can exercise (the same reasoning PSP's best-effort `psp-smoke` job
+documents, one step further — there is not even an emulator to boot this
+under). Build and install are entirely manual, on your own hardware.
+
+## 1. Export a map
+
+From this repo:
+
+```sh
+ruby scripts/export_nano7_map.rb GAME_DIR MAP_ID OUT_DIR
+```
+
+For example, using the Nepheshel test-bed this repo's own test suite already
+uses (`scripts/download-nepheshel.bash`):
+
+```sh
+ruby scripts/export_nano7_map.rb \
+  data/Nepheshel206beta/Nepheshel206Nbeta 1 /tmp/rpg2k_walk_out
+```
+
+writes `map.bin` + `tiles.bin` to `OUT_DIR`. `scripts/export_nano7_map_check.rb`
+round-trips the exporter's output against its own invariants (no mruby or
+device needed) — run it after touching the exporter or this app's binary
+format.
+
+The exporter rejects (does not truncate) a map bigger than 128×128 tiles or
+with more than 256 distinct on-screen tile ids — see the size-budget comment
+in `rpg2k_walk.c`. Pick a smaller map if your project's start map is larger.
+
+## 2. Build the app
+
+NanoApps builds apps from inside its own checkout. Copy (not symlink — a
+symlinked app directory resolves `../../sdk/hb_app.mk` against the physical
+path, which lands outside NanoApps and fails) this directory into
+`NanoApps/apps/`:
+
+```sh
+cp -r app/nano7/rpg2k_walk /path/to/NanoApps/apps/rpg2k_walk
+cd /path/to/NanoApps
+./start build rpg2k_walk
+```
+
+or, from inside `NanoApps/apps/rpg2k_walk` directly, plain `make` (needs
+`arm-none-eabi-gcc` and Python 3 with `pyelftools`, which `./start` installs
+for you the first time). The build's `.hbapp` should come out a few KB —
+`.bss` (the map/tile static buffers) is not part of that packed image, only
+code and constants are.
+
+## 3. Install the map data and the app
+
+With the iPod on its Home Screen (not "Connected" mode — see `hb_fs.c`'s
+precondition), copy the exported files to the app's data directory and
+install the app:
+
+```sh
+# from your NanoApps checkout, adjust the mount point ./start reports:
+cp /tmp/rpg2k_walk_out/map.bin /tmp/rpg2k_walk_out/tiles.bin \
+   /Volumes/IPOD/Apps/Data/RPG2kWalk/   # or wherever ./start mounted it
+./start install rpg2k_walk
+```
+
+`./start`'s own menu can do the device-copy step for you too; see its
+README. If the app opens to "no map.bin/tiles.bin", the data directory copy
+didn't land — re-check the mount point and path
+(`/Apps/Data/RPG2kWalk/map.bin` on the iPod's own filesystem).
+
+## Controls
+
+Touch anywhere and hold. The direction is whichever of up/down/left/right is
+furthest from the screen's center — a whole-screen virtual joystick, the same
+"zone" convention `apps/tetris`/`apps/paint` use. The player steps one tile
+at a time while held, blocked by the map's real passability data.
+
+## Known limitations
+
+- One static map per export; no map tree, no teleport/transitions.
+- Autotiles (water, terrain edges) render correctly but frozen at their
+  first animation frame — no water/ground animation on-device.
+- No events, message boxes, battle, or menus.
+- Map size capped at 128×128 tiles / 256 distinct tile ids (see `rpg2k_walk.c`);
+  a larger map is refused by the exporter rather than truncated.

--- a/app/nano7/rpg2k_walk/rpg2k_walk.c
+++ b/app/nano7/rpg2k_walk/rpg2k_walk.c
@@ -1,0 +1,228 @@
+/*
+ * rpg2k_walk -- walk a real RPG Maker 2000/2003 map on iPod nano 7th
+ * generation homebrew (NanoApps SDK, RAW_SURFACE).
+ *
+ * This is deliberately NOT the mruby/RGSS engine the rest of this repo runs
+ * everywhere else (PSP, Wio Terminal, Android, browser): NanoApps caps a
+ * compiled app image at roughly 500 KB, and this repo's mruby + RGSS/RPG2k
+ * gem stack is tens of MB even stripped -- see docs/adr/0061. Instead, all
+ * LCF parsing and chipset/autotile compositing happens once on the host via
+ * scripts/export_nano7_map.rb, which writes two flat files this app reads
+ * with hb_fs_read and indexes directly. No LCF, no BER, no autotile geometry
+ * on-device -- just array lookups and pixel blits.
+ *
+ * Scope (see docs/adr/0061 for the full rationale): one static map, no
+ * events/interpreter/battle/menus, tiles frozen at their first animation
+ * frame. This walks a real map; it does not play the game.
+ *
+ * Input: hold anywhere on screen. The direction is whichever of up/down/
+ * left/right is furthest from screen center (a whole-screen virtual
+ * joystick, the same "zone" input convention apps/tetris and apps/paint
+ * use), and the player steps one tile every STEP_INTERVAL_MS while held,
+ * blocked by the exported passability mask.
+ */
+#include "hb_raw_surface.h"
+#include "hb_sdk.h"
+
+#define TS 16 /* chipset tile size, matches scripts/export_nano7_map.rb */
+#define TILE_PIXELS (TS * TS)
+
+/* On-device caps, mirrored in scripts/export_nano7_map.rb's MAP_MAX_W/H and
+ * MAX_TILES. Sized to keep total .bss comfortably under the ~512 KB gap
+ * between BSS_VA and LINK_VA in sdk/hb_app.mk (0x09200000..0x09280000) --
+ * that gap is not documented as a hard per-app .bss ceiling, but nothing in
+ * the SDK says it is safe to exceed either, so this stays well under it
+ * rather than finding out on real hardware. Raise with caution. */
+#define MAP_MAX_W 128
+#define MAP_MAX_H 128
+#define MAX_TILES 256
+
+#define MAP_CELLS (MAP_MAX_W * MAP_MAX_H)
+/* map.bin layout: 18-byte header + cells*(u16 lower + u16 upper + u8 passable). */
+#define MAP_BIN_MAX_BYTES (18 + MAP_CELLS * 5)
+
+#define UPPER_NONE 0xFFFFu
+
+/* Matches DIR_BITS in scripts/export_nano7_map.rb (RPG2000's own numpad
+ * direction convention, Game::ChipSet::DIR_BIT in mruby-rpg2k/mrblib/game.rb). */
+#define DIR_DOWN_BIT 0x01
+#define DIR_LEFT_BIT 0x02
+#define DIR_RIGHT_BIT 0x04
+#define DIR_UP_BIT 0x08
+
+#define MAP_DATA_DIR "/Apps/Data/RPG2kWalk"
+
+#define STEP_INTERVAL_MS 160u
+
+static uint8_t s_map_raw[MAP_BIN_MAX_BYTES];
+static uint32_t s_tiles[MAX_TILES * TILE_PIXELS];
+
+static int s_map_w, s_map_h, s_tile_count;
+static const uint8_t *s_lower_base, *s_upper_base, *s_pass_base;
+
+static int s_player_x, s_player_y;
+static uint32_t s_last_step_ms;
+static int s_loaded;
+
+static uint16_t rd_u16(const uint8_t *p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+
+static uint16_t lower_at(int x, int y) { return rd_u16(s_lower_base + (long)(y * s_map_w + x) * 2); }
+static uint16_t upper_at(int x, int y) { return rd_u16(s_upper_base + (long)(y * s_map_w + x) * 2); }
+static uint8_t passable_at(int x, int y) { return s_pass_base[y * s_map_w + x]; }
+
+static int in_bounds(int x, int y) { return x >= 0 && y >= 0 && x < s_map_w && y < s_map_h; }
+
+static int load_map(void)
+{
+    uint32_t n = hb_fs_read(MAP_DATA_DIR "/map.bin", s_map_raw, sizeof(s_map_raw));
+    if (n < 18) return 0;
+    if (s_map_raw[0] != 'N' || s_map_raw[1] != '7' || s_map_raw[2] != 'W' || s_map_raw[3] != 'M') return 0;
+    if (s_map_raw[4] != 1) return 0; /* version */
+
+    int w = rd_u16(s_map_raw + 6);
+    int h = rd_u16(s_map_raw + 8);
+    int sx = rd_u16(s_map_raw + 10);
+    int sy = rd_u16(s_map_raw + 12);
+    int tile_count = rd_u16(s_map_raw + 14);
+    if (w <= 0 || h <= 0 || w > MAP_MAX_W || h > MAP_MAX_H) return 0;
+    if (tile_count > MAX_TILES) return 0;
+    if (sx < 0 || sy < 0 || sx >= w || sy >= h) return 0;
+
+    uint32_t cells = (uint32_t)w * (uint32_t)h;
+    uint32_t expected = 18 + cells * 5;
+    if (n < expected) return 0;
+
+    s_map_w = w;
+    s_map_h = h;
+    s_tile_count = tile_count;
+    s_player_x = sx;
+    s_player_y = sy;
+    s_lower_base = s_map_raw + 18;
+    s_upper_base = s_lower_base + cells * 2;
+    s_pass_base = s_upper_base + cells * 2;
+
+    uint32_t tiles_bytes = (uint32_t)tile_count * TILE_PIXELS * 4;
+    uint32_t got = hb_fs_read(MAP_DATA_DIR "/tiles.bin", s_tiles, sizeof(s_tiles));
+    if (got < tiles_bytes) return 0;
+
+    return 1;
+}
+
+/* Both halves of RPG2000's own movement check (mirrors
+ * Scene::Map#char_passable? in mruby-rpg2k/mrblib/scene/map.rb): the current
+ * cell must permit leaving in `dir`, AND the target cell must permit
+ * entering from the opposite direction. No event/blocker checks -- this
+ * slice has no events. */
+static int can_step(int dir_bit, int opp_bit, int nx, int ny)
+{
+    if (!in_bounds(nx, ny)) return 0;
+    if ((passable_at(s_player_x, s_player_y) & dir_bit) == 0) return 0;
+    if ((passable_at(nx, ny) & opp_bit) == 0) return 0;
+    return 1;
+}
+
+static void try_move(int dx, int dy)
+{
+    int dir_bit, opp_bit;
+    if (dx < 0) { dir_bit = DIR_LEFT_BIT; opp_bit = DIR_RIGHT_BIT; }
+    else if (dx > 0) { dir_bit = DIR_RIGHT_BIT; opp_bit = DIR_LEFT_BIT; }
+    else if (dy < 0) { dir_bit = DIR_UP_BIT; opp_bit = DIR_DOWN_BIT; }
+    else { dir_bit = DIR_DOWN_BIT; opp_bit = DIR_UP_BIT; }
+
+    int nx = s_player_x + dx, ny = s_player_y + dy;
+    if (can_step(dir_bit, opp_bit, nx, ny)) {
+        s_player_x = nx;
+        s_player_y = ny;
+    }
+}
+
+/* Whole-screen virtual joystick: the axis furthest from center wins, same
+ * "zone" input convention apps/tetris and apps/paint use. A small deadzone
+ * around center avoids jitter from an imprecise tap. */
+static void touch_direction(const hb_spoint_t *t, int *dx, int *dy)
+{
+    *dx = 0;
+    *dy = 0;
+    if (!t->down) return;
+    int cx = hb_raw_w() / 2, cy = hb_raw_h() / 2;
+    int ddx = t->x - cx, ddy = t->y - cy;
+    int adx = ddx < 0 ? -ddx : ddx;
+    int ady = ddy < 0 ? -ddy : ddy;
+    const int DEADZONE = 12;
+    if (adx < DEADZONE && ady < DEADZONE) return;
+    if (adx > ady) *dx = ddx > 0 ? 1 : -1;
+    else *dy = ddy > 0 ? 1 : -1;
+}
+
+static void draw_map(void)
+{
+    int view_w = hb_raw_w() / TS;
+    int view_h = hb_raw_h() / TS;
+
+    int cam_x = s_player_x - view_w / 2;
+    int cam_y = s_player_y - view_h / 2;
+    if (cam_x > s_map_w - view_w) cam_x = s_map_w - view_w;
+    if (cam_y > s_map_h - view_h) cam_y = s_map_h - view_h;
+    if (cam_x < 0) cam_x = 0;
+    if (cam_y < 0) cam_y = 0;
+
+    hb_raw_fill(HB_BLACK);
+
+    for (int ty = 0; ty < view_h; ty++) {
+        int my = cam_y + ty;
+        if (my >= s_map_h) break;
+        for (int tx = 0; tx < view_w; tx++) {
+            int mx = cam_x + tx;
+            if (mx >= s_map_w) break;
+            int px = tx * TS, py = ty * TS;
+
+            uint16_t lo = lower_at(mx, my);
+            if (lo < (uint16_t)s_tile_count)
+                hb_raw_blit(px, py, TS, TS, &s_tiles[(uint32_t)lo * TILE_PIXELS]);
+
+            uint16_t up = upper_at(mx, my);
+            if (up != UPPER_NONE && up < (uint16_t)s_tile_count)
+                hb_raw_blit(px, py, TS, TS, &s_tiles[(uint32_t)up * TILE_PIXELS]);
+        }
+    }
+
+    int ppx = (s_player_x - cam_x) * TS, ppy = (s_player_y - cam_y) * TS;
+    hb_raw_disc(ppx + TS / 2, ppy + TS / 2, TS / 2 - 1, HB_RGB(0xff, 0x40, 0x40));
+}
+
+void hb_raw_init(int w, int h)
+{
+    (void)w;
+    (void)h;
+    s_loaded = load_map();
+    s_last_step_ms = hb_time_uptime_ms();
+    if (s_loaded) {
+        draw_map();
+    } else {
+        hb_raw_fill(HB_BLACK);
+        hb_draw_str(8, 8, "no map.bin/tiles.bin", 2, HB_WHITE, HB_BLACK);
+        hb_draw_str(8, 32, "run export_nano7_map.rb,", 2, HB_WHITE, HB_BLACK);
+        hb_draw_str(8, 56, "copy to " MAP_DATA_DIR, 2, HB_WHITE, HB_BLACK);
+    }
+}
+
+void hb_raw_frame(const hb_spoint_t *touch)
+{
+    if (!s_loaded) return;
+
+    int dx, dy;
+    touch_direction(touch, &dx, &dy);
+
+    if (dx != 0 || dy != 0) {
+        uint32_t now = hb_time_uptime_ms();
+        if (now - s_last_step_ms >= STEP_INTERVAL_MS) {
+            try_move(dx, dy);
+            s_last_step_ms = now;
+            draw_map();
+        }
+    } else {
+        /* Released: next hold steps immediately rather than waiting out
+         * whatever fraction of the interval elapsed before release. */
+        s_last_step_ms = hb_time_uptime_ms() - STEP_INTERVAL_MS;
+    }
+}

--- a/changelog.d/nano7-map-walk.added.md
+++ b/changelog.d/nano7-map-walk.added.md
@@ -1,0 +1,8 @@
+- **iPod nano 7th generation (homebrew)**: a minimal, from-scratch map-walking
+  app (`app/nano7/rpg2k_walk`, see ADR 61) for jailbroken iPod nano 7G
+  hardware via the [NanoApps](https://github.com/nfzerox/NanoApps) SDK. A new
+  host-side exporter (`scripts/export_nano7_map.rb`) converts a real RPG
+  Maker 2000/2003 map — tiles, autotiles and passability — into a compact
+  binary the on-device app reads directly; this is a separate, non-mruby
+  engine (NanoApps' ~500 KB app-image ceiling rules out this repo's mruby/RGSS
+  stack), so it walks one static map with no events, battle or menus.

--- a/docs/adr/0061-ipod-nano-7-homebrew-map-walk.md
+++ b/docs/adr/0061-ipod-nano-7-homebrew-map-walk.md
@@ -1,0 +1,134 @@
+# 61. A minimal, non-mruby map-walking port for iPod nano 7th generation
+
+Date: 2026-08-27
+
+## Status
+
+Accepted
+
+## Context
+
+A core project goal (see ADR 1) is to run RPG Maker games "on any environment
+such like embedded boards." Every existing real-hardware port — Wio Terminal
+(ADR 7), PSP (ADR 10), Android (ADR 58) — follows the same shape: add a new
+LVGL display + input backend behind the seams `mruby-rgss` already exposes
+(`rgss_set_display`, the per-frame poll hooks in `gfx_update`), and run the
+*same* mruby interpreter and RGSS/RPG2k Ruby game logic this repo runs
+everywhere else. That pattern only works when the target can host a
+general-purpose interpreter and a few MB of compiled gem code.
+
+The **iPod nano 7th generation** cannot. As of 2026 there is a real,
+maintained homebrew scene for it:
+
+- [`ipod_sun`](https://freemyipod.org/wiki/Main_Page) /
+  [Pixosn0w](https://github.com/IAmDazen/Pixosn0w) give untethered code
+  execution on the device.
+- [NanoApps](https://github.com/nfzerox/NanoApps) is a public C SDK
+  (`hb_sdk.h`) for building Home-Screen apps, built on **LVGL** — the exact
+  display library the other ports already use.
+
+But NanoApps caps a homebrew app's **compiled, uploaded image** (`.text` +
+`.rodata`, what its resident loads and I-cache-invalidates before jumping to
+it) at roughly **500 KB**; past that, apps hang or crash on launch in ways
+that are easy to misread as unrelated bugs (`sdk/hb_app.mk`'s own comment on
+the ceiling). This repo's `libmruby.a` is 51–61 MB unstripped for every
+existing cross target, and the PSP's `EBOOT.PBP` — mruby + the RGSS/RPG2k
+gem stack + LVGL + engine — is 19 MB. Even after aggressive stripping and
+`--gc-sections`, that gem stack is not landing under 500 KB; the gap is
+40x+, not something `-Os` closes. Running the actual interpreter and Ruby
+game logic on this device is not feasible with this engine's current
+architecture.
+
+A critical mitigating detail, confirmed empirically (see Decision): the
+500 KB ceiling is specifically the **relocatable app blob** NanoApps' loader
+places into RAM — `.bss` and anything read from the iPod's own filesystem at
+runtime (`hb_fs_read`/`hb_bmp_load_to`) are outside it. So a large *runtime*
+data set is free; only the *code* has to be tiny.
+
+## Decision
+
+Add a **from-scratch, non-mruby map-walking app**
+(`app/nano7/rpg2k_walk/rpg2k_walk.c`) instead of a new mruby/RGSS backend.
+This is a deliberate departure from every other port's pattern: it is a
+different, much smaller engine, written directly in C against NanoApps'
+`RAW_SURFACE` (direct-framebuffer) surface — not an additive display backend
+to the existing interpreter. Scope is map walking only: tile rendering
+(including autotiles) + grid movement + collision, for one static map. No
+events, no interpreter, no battle/menus, no RGSS. It still renders real RPG
+Maker 2000/2003 map data, not synthetic test data.
+
+The pieces:
+
+- **Host-side exporter** (`scripts/export_nano7_map.rb`): plain CRuby,
+  loaded the same way `scripts/lcf_save_check.rb`/`lcf_testbed_check.rb`
+  already load `mruby-lcf/mrblib/{lcf,schema}.rb` under CRuby with no mruby
+  build. It also loads `mruby-rpg2k/mrblib/game.rb` for `Game::ChipsetLayout`
+  (the tile-id → chipset source-rect geometry, including the autotile
+  quarter-tile assembly — the exact module `scripts/rpg2k_render_check.rb`
+  already exercises standalone) and `Game::ChipSet` (passability), and
+  `scripts/rgss_cruby_compat.rb` for `RGSS::Bitmap`'s pure-Ruby PNG decoder.
+  All LCF parsing and chipset compositing happens once, on the host, using
+  the same logic the real engine uses — not a reimplementation of it.
+- **Output format**: `map.bin` (dimensions, start position, per-cell lower/
+  upper tile-atlas indices, and a precomputed 4-bit-per-cell passability
+  mask — both halves of `Scene::Map#char_passable?`'s check, "can this cell
+  be exited this way" and "can the target cell be entered from the
+  opposite side," baked in at export time) and `tiles.bin` (a flat XRGB8888
+  atlas, one 16×16 entry per distinct tile id the map actually uses, each
+  composited via `Game::ChipsetLayout.quads` at animation frame 0). The
+  on-device C code never parses LCF, never assembles a quarter-tile
+  autotile, and never computes passability — it reads two flat files and
+  indexes arrays.
+- **On-device app** (`app/nano7/rpg2k_walk/`): a `RAW_SURFACE` NanoApps app
+  (`hb_raw_init`/`hb_raw_frame`) that loads both files via `hb_fs_read` into
+  static `.bss` buffers, blits the visible viewport (lower then upper layer,
+  camera clamped to map bounds), and steps the player one tile at a time on
+  continuous zone-hold touch input (a whole-screen virtual joystick, the
+  input convention `apps/tetris`/`apps/paint` already use in NanoApps —
+  N7G has no D-pad).
+- **Size budget, verified**: `MAP_MAX_W`/`MAP_MAX_H` = 128, `MAX_TILES` = 256
+  (mirrored between the exporter and the C bounds, so an oversized map is
+  refused at export time rather than truncated or overflowed on-device).
+  Built for real against a scratch NanoApps checkout with `arm-none-eabi-gcc`
+  in this session: the linked `.text` is **4.3 KB**, `.bss` is **336 KB**,
+  and the packed `.hbapp` NanoApps' loader actually uploads is **4.5 KB** —
+  under 1% of the 500 KB ceiling, and `.bss` sits comfortably below the
+  ~512 KB gap between `BSS_VA` and `LINK_VA` in `sdk/hb_app.mk` (that gap is
+  not a documented hard cap, so the caps above deliberately leave headroom
+  rather than target it exactly).
+- **No CI job.** CI has no NanoApps toolchain and no iPod; unlike the PSP
+  port's best-effort `psp-smoke` job there is not even an emulator to boot
+  this under. `scripts/export_nano7_map_check.rb` (round-trips the exporter
+  against the real Nepheshel test-bed data already in `data/`, including a
+  positive check that an oversized map is refused) is the only automated
+  coverage; the on-device build and hardware behavior are manual, documented
+  in `app/nano7/rpg2k_walk/README.md`.
+
+## Consequences
+
+- This is the first port in the repo that does **not** extend the shared
+  mruby/RGSS engine — a reviewer comparing it to ADR 7/10/58 should expect a
+  different shape, not a missing display backend. Any future RPG2k feature
+  work (events, battle, ...) added to the main engine does not reach this
+  app; it would need its own, separate C implementation, which is a real
+  cost of this approach and the reason the README frames it plainly as
+  "walk a map," not "play the game."
+- Because chipset compositing happens at export time, adding **tile
+  animation** on-device would mean shipping multiple pre-composited frames
+  per animated tile id and cycling the atlas index in `rpg2k_walk.c` — a
+  bounded, scoped follow-up, not a re-architecture.
+- **Multiple maps / map transitions** would need either bundling several
+  `map.bin`/`tiles.bin` pairs and a simple on-device map-switch (still no
+  interpreter) or accepting a NanoApps relaunch per map; not attempted here.
+- Verified on a real jailbroken nano 7G: NanoApps installs the app, the
+  exporter's `map.bin`/`tiles.bin` load correctly via `hb_fs_read`, tile
+  rendering and grid movement/collision work, and touch-hold steps the
+  player as designed.
+- **Known bug, not yet fixed**: `composite_tile` in
+  `scripts/export_nano7_map.rb` copies chipset pixels for every referenced
+  tile id with no transparency handling. Cells whose tile id resolves to the
+  chipset's transparent/placeholder region (confirmed on real map data, not
+  just theoretical) render as solid magenta on-device instead of being
+  skipped or resolved to something sensible. Root cause not yet isolated to
+  a specific tile id or `Game::ChipsetLayout.quads` gap — tracked as
+  follow-up work, not fixed in this slice.

--- a/scripts/export_nano7_map.rb
+++ b/scripts/export_nano7_map.rb
@@ -1,0 +1,203 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Export one RPG Maker 2000/2003 map into the compact binary format the
+# iPod Nano 7th-gen homebrew app (app/nano7/rpg2k_walk) reads on-device.
+#
+# NanoApps (the N7G homebrew SDK, see docs/adr/0061) caps a compiled app
+# image at roughly 500 KB, which rules out running this engine's mruby/RGSS
+# interpreter on the device (see the ADR). This script instead does the LCF
+# parsing and chipset compositing *once, on the host*, using the exact same
+# pure-Ruby sources the rest of this repo already loads under plain CRuby:
+#
+#   * mruby-lcf/mrblib/{lcf,schema}.rb   -- the LCF/BER map+database reader,
+#     same loading pattern as scripts/lcf_save_check.rb / lcf_testbed_check.rb.
+#   * mruby-rpg2k/mrblib/game.rb         -- Game::ChipsetLayout (tile-id ->
+#     chipset source-rect geometry, including the autotile quarter-tile
+#     assembly) and Game::ChipSet (passability), the same pure-geometry module
+#     scripts/rpg2k_render_check.rb already exercises standalone.
+#   * scripts/rgss_cruby_compat.rb       -- RGSS::Bitmap's PNG decoder, to
+#     read the chipset PNG without a native build.
+#
+# so the on-device C code never parses LCF or composites autotiles: it reads
+# two flat files and indexes arrays.
+#
+# Limitations (see docs/adr/0061 for the full rationale):
+#   * one static map per export -- no map tree, no teleport/transitions.
+#   * one animation frame per tile id (abf=0, cf=0) -- water/ground/terrain
+#     autotiles render their first frame, never animate on-device.
+#   * events, message boxes, battle and everything interpreter-driven are out
+#     of scope entirely; this is a walkable map, not a playable game.
+#
+# Usage:
+#   ruby scripts/export_nano7_map.rb GAME_DIR MAP_ID OUT_DIR [START_X START_Y]
+#
+# GAME_DIR is an RPG2000/2003 project directory (containing RPG_RT.ldb/.lmt
+# and Map####.lmu files). MAP_ID is the numeric map id (e.g. 1 for
+# Map0001.lmu). OUT_DIR receives map.bin and tiles.bin. START_X/START_Y
+# override the player start position; with no override, the script uses the
+# map tree's own start position (RPG_RT.lmt initial_x/initial_y) when MAP_ID
+# is the project's configured start map, or the map's center otherwise.
+#
+# Exits non-zero (with a clear message) if the map's dimensions or distinct
+# on-screen tile count exceed the on-device caps (MAP_MAX_W/H, MAX_TILES
+# below, mirrored in app/nano7/rpg2k_walk/rpg2k_walk.c) -- no silent
+# truncation.
+
+require 'stringio'
+
+module LCF
+  # uni-algo stand-in, same shim scripts/lcf_save_check.rb and
+  # scripts/lcf_testbed_check.rb use to load the schema under plain CRuby.
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+  module_function :cp932_to_utf8
+
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+ROOT = File.expand_path('..', __dir__)
+load File.join(ROOT, 'mruby-lcf/mrblib/lcf.rb')
+load File.join(ROOT, 'mruby-lcf/mrblib/schema.rb')
+load File.join(ROOT, 'mruby-rpg2k/mrblib/game.rb')
+load File.join(ROOT, 'scripts/rgss_cruby_compat.rb')
+
+# Mirrored in app/nano7/rpg2k_walk/rpg2k_walk.c's static array bounds. Sized
+# to keep the on-device .bss well under the ~512 KB BSS_VA..LINK_VA gap in
+# NanoApps' sdk/hb_app.mk -- see the size-budget comment in rpg2k_walk.c.
+MAP_MAX_W = 128
+MAP_MAX_H = 128
+MAX_TILES = 256
+TS = Game::ChipsetLayout::TS # 16
+
+MAGIC = 'N7WM'
+UPPER_NONE = 0xFFFF
+
+DIR_DOWN = 2
+DIR_LEFT = 4
+DIR_RIGHT = 6
+DIR_UP = 8
+DIR_BITS = { DIR_DOWN => 0x01, DIR_LEFT => 0x02, DIR_RIGHT => 0x04, DIR_UP => 0x08 }.freeze
+
+def usage_abort(msg)
+  warn msg
+  warn 'Usage: ruby scripts/export_nano7_map.rb GAME_DIR MAP_ID OUT_DIR [START_X START_Y]'
+  exit 1
+end
+
+game_dir, map_id_arg, out_dir, start_x_arg, start_y_arg = ARGV
+usage_abort('missing arguments') if game_dir.nil? || map_id_arg.nil? || out_dir.nil?
+usage_abort("no such game dir: #{game_dir}") unless Dir.exist?(game_dir)
+
+map_id = Integer(map_id_arg)
+map_path = File.join(game_dir, format('Map%04d.lmu', map_id))
+usage_abort("no such map: #{map_path}") unless File.file?(map_path)
+
+db = LCF::Database.new(File.open(File.join(game_dir, 'RPG_RT.ldb'), 'rb'))
+lmu = LCF::MapUnit.new(File.open(map_path, 'rb'))
+
+width = lmu.width.to_i
+height = lmu.height.to_i
+if width <= 0 || height <= 0 || width > MAP_MAX_W || height > MAP_MAX_H
+  usage_abort("map #{width}x#{height} exceeds on-device bounds #{MAP_MAX_W}x#{MAP_MAX_H}")
+end
+
+lower_layer = lmu.lower_layer.to_a
+upper_layer = (lmu.upper_layer && lmu.upper_layer.to_a) || Array.new(width * height, 0)
+if lower_layer.size != width * height || upper_layer.size != width * height
+  usage_abort("map layer size mismatch: expected #{width * height} cells")
+end
+
+chipset = db.chipset[lmu.chipset_id]
+usage_abort("map ##{map_id} references chipset ##{lmu.chipset_id}, not found in database") if chipset.nil?
+
+chipset_path = File.join(game_dir, 'ChipSet', "#{chipset.chipset_name}.png")
+usage_abort("chipset image not found: #{chipset_path} (only PNG chipsets are supported)") unless File.file?(chipset_path)
+
+chipset_bmp = RGSS::Bitmap.allocate
+usage_abort("failed to decode chipset PNG: #{chipset_path}") unless chipset_bmp.send(:_init_file, chipset_path)
+
+cset = Game::ChipSet.new(db, lmu.chipset_id)
+
+# Start position: an explicit override, else the map tree's own start
+# position when this is the project's configured start map, else the map's
+# center as a reasonable default for previewing any other map.
+start_x = start_x_arg && Integer(start_x_arg)
+start_y = start_y_arg && Integer(start_y_arg)
+if start_x.nil? || start_y.nil?
+  lmt = LCF::MapTree.new(File.open(File.join(game_dir, 'RPG_RT.lmt'), 'rb'))
+  if lmt.initial.initial_map_id.to_i == map_id
+    start_x ||= lmt.initial.initial_x.to_i
+    start_y ||= lmt.initial.initial_y.to_i
+  else
+    start_x ||= width / 2
+    start_y ||= height / 2
+  end
+end
+
+# ---- build the deduplicated tile atlas -------------------------------------
+
+atlas_index = {} # tile id -> atlas slot
+atlas_pixels = [] # atlas slot -> 256 packed 0xRRGGBB pixels (top-left origin, row-major)
+
+def composite_tile(bmp, tile_id)
+  pixels = Array.new(TS * TS, 0)
+  Game::ChipsetLayout.quads(tile_id, 0, 0).each do |dx, dy, sx, sy, w, h|
+    h.times do |yy|
+      w.times do |xx|
+        r, g, b, = bmp.bmp_read(sx + xx, sy + yy)
+        pixels[(dy + yy) * TS + (dx + xx)] = (r << 16) | (g << 8) | b
+      end
+    end
+  end
+  pixels
+end
+
+def atlas_slot_for(tile_id, bmp, atlas_index, atlas_pixels)
+  slot = atlas_index[tile_id]
+  return slot if slot
+  usage_abort("map uses #{atlas_index.size + 1} distinct tiles, exceeding on-device cap #{MAX_TILES}") if atlas_index.size >= MAX_TILES
+  slot = atlas_index.size
+  atlas_index[tile_id] = slot
+  atlas_pixels << composite_tile(bmp, tile_id)
+  slot
+end
+
+lower_out = Array.new(width * height)
+upper_out = Array.new(width * height)
+passable_out = Array.new(width * height)
+
+(0...(width * height)).each do |i|
+  lo = lower_layer[i]
+  up = upper_layer[i]
+  lower_out[i] = atlas_slot_for(lo, chipset_bmp, atlas_index, atlas_pixels)
+  upper_out[i] = Game::ChipsetLayout.upper_blank?(up) ? UPPER_NONE : atlas_slot_for(up, chipset_bmp, atlas_index, atlas_pixels)
+
+  flags = 0
+  DIR_BITS.each do |dir, bit|
+    flags |= bit if cset.passable_tile?(lo, up, dir)
+  end
+  passable_out[i] = flags
+end
+
+# ---- write map.bin -----------------------------------------------------
+
+Dir.mkdir(out_dir) unless Dir.exist?(out_dir)
+
+File.open(File.join(out_dir, 'map.bin'), 'wb') do |f|
+  f.write(MAGIC)
+  f.write([1, 0].pack('CC'))
+  f.write([width, height, start_x, start_y, atlas_index.size, 0].pack('v6'))
+  f.write(lower_out.pack('v*'))
+  f.write(upper_out.pack('v*'))
+  f.write(passable_out.pack('C*'))
+end
+
+File.open(File.join(out_dir, 'tiles.bin'), 'wb') do |f|
+  atlas_pixels.each { |px| f.write(px.pack('V*')) }
+end
+
+puts "wrote #{out_dir}/map.bin (#{width}x#{height}, start #{start_x},#{start_y}) " \
+     "and #{out_dir}/tiles.bin (#{atlas_index.size} tiles)"

--- a/scripts/export_nano7_map_check.rb
+++ b/scripts/export_nano7_map_check.rb
@@ -1,0 +1,133 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Smoke-test scripts/export_nano7_map.rb against a real RPG2000 test-bed
+# project: runs the exporter, then re-parses map.bin/tiles.bin as plain
+# binary (independent of the exporter's own writer code) and checks the
+# invariants the on-device reader (app/nano7/rpg2k_walk/rpg2k_walk.c) relies
+# on -- so a mismatch between the exporter's format and the C reader's
+# expectations fails here instead of on real hardware.
+#
+# Usage:
+#   ruby scripts/export_nano7_map_check.rb [GAME_DIR [MAP_ID ...]]
+# With no GAME_DIR, uses data/Nepheshel206beta/Nepheshel206Nbeta (see
+# scripts/download-nepheshel.bash). With no MAP_ID, checks a small sample of
+# maps spread across the project. Exits non-zero on any failure.
+
+require 'tmpdir'
+require 'open3'
+
+ROOT = File.expand_path('..', __dir__)
+EXPORTER = File.join(ROOT, 'scripts/export_nano7_map.rb')
+
+MAP_MAX_W = 128
+MAP_MAX_H = 128
+MAX_TILES = 256
+UPPER_NONE = 0xFFFF
+VALID_PASSABLE_BITS = 0x0F # down|left|right|up -- see DIR_BITS in the exporter
+
+$failures = 0
+$checks = 0
+
+def check(name)
+  $checks += 1
+  yield
+rescue StandardError => e
+  $failures += 1
+  warn "  FAIL #{name}: #{e.class}: #{e.message}"
+end
+
+def ok(cond, msg)
+  raise msg unless cond
+end
+
+def read_map_bin(path)
+  bytes = File.binread(path)
+  magic = bytes[0, 4]
+  version, _pad = bytes[4, 2].unpack('CC')
+  width, height, start_x, start_y, tile_count, _pad2 = bytes[6, 12].unpack('v6')
+  off = 18
+  cells = width * height
+  lower = bytes[off, cells * 2].unpack('v*'); off += cells * 2
+  upper = bytes[off, cells * 2].unpack('v*'); off += cells * 2
+  passable = bytes[off, cells].unpack('C*'); off += cells
+  ok(off == bytes.bytesize, "map.bin has #{bytes.bytesize - off} trailing bytes")
+  {
+    magic: magic, version: version, width: width, height: height,
+    start_x: start_x, start_y: start_y, tile_count: tile_count,
+    lower: lower, upper: upper, passable: passable
+  }
+end
+
+def check_export(game_dir, map_id)
+  Dir.mktmpdir('n7export') do |out_dir|
+    stdout, stderr, status = Open3.capture3('ruby', EXPORTER, game_dir, map_id.to_s, out_dir)
+    check("#{game_dir} map #{map_id}: exporter exits 0") { ok status.success?, "exit #{status.exitstatus}: #{stderr}" }
+    next unless status.success?
+    puts "  #{stdout.strip}"
+
+    map = read_map_bin(File.join(out_dir, 'map.bin'))
+    tiles_bytes = File.binread(File.join(out_dir, 'tiles.bin'))
+
+    check("map #{map_id}: magic") { ok map[:magic] == 'N7WM', map[:magic].inspect }
+    check("map #{map_id}: version") { ok map[:version] == 1, map[:version] }
+    check("map #{map_id}: dimensions in bounds") do
+      ok map[:width].positive? && map[:height].positive?, 'non-positive dimensions'
+      ok map[:width] <= MAP_MAX_W && map[:height] <= MAP_MAX_H, "#{map[:width]}x#{map[:height]}"
+    end
+    check("map #{map_id}: tile_count in bounds") { ok map[:tile_count] <= MAX_TILES, map[:tile_count] }
+    check("map #{map_id}: start position inside map") do
+      ok map[:start_x] >= 0 && map[:start_x] < map[:width], "start_x #{map[:start_x]}"
+      ok map[:start_y] >= 0 && map[:start_y] < map[:height], "start_y #{map[:start_y]}"
+    end
+    check("map #{map_id}: tiles.bin size matches tile_count") do
+      expected = map[:tile_count] * 16 * 16 * 4
+      ok tiles_bytes.bytesize == expected, "#{tiles_bytes.bytesize} != #{expected}"
+    end
+    check("map #{map_id}: every lower-layer index resolves into the atlas") do
+      bad = map[:lower].reject { |i| i < map[:tile_count] }
+      ok bad.empty?, "#{bad.size} out-of-range indices, e.g. #{bad.first}"
+    end
+    check("map #{map_id}: every upper-layer index resolves or is NONE") do
+      bad = map[:upper].reject { |i| i == UPPER_NONE || i < map[:tile_count] }
+      ok bad.empty?, "#{bad.size} out-of-range indices, e.g. #{bad.first}"
+    end
+    check("map #{map_id}: passable bytes use only the four direction bits") do
+      bad = map[:passable].reject { |b| (b & ~VALID_PASSABLE_BITS).zero? }
+      ok bad.empty?, "#{bad.size} bytes with stray bits, e.g. 0x%02x" % (bad.first || 0)
+    end
+  end
+end
+
+def discover_default_maps(game_dir, sample = 5)
+  ids = Dir[File.join(game_dir, 'Map*.lmu')].map { |f| File.basename(f)[/\d+/].to_i }.sort
+  return ids if ids.size <= sample
+  step = ids.size / sample
+  ids.each_slice([step, 1].max).map(&:first).first(sample)
+end
+
+game_dir = ARGV[0] || File.join(ROOT, 'data/Nepheshel206beta/Nepheshel206Nbeta')
+unless Dir.exist?(game_dir)
+  warn "no test-bed game at #{game_dir} -- run scripts/download-nepheshel.bash first, or pass a GAME_DIR"
+  exit 0
+end
+
+map_ids = ARGV.drop(1).map(&:to_i)
+map_ids = discover_default_maps(game_dir) if map_ids.empty?
+
+map_ids.each { |id| check_export(game_dir, id) }
+
+# An oversized map (bigger than MAP_MAX_W/H) must be refused cleanly with a
+# non-zero exit and a clear message, not crash or silently truncate. Only
+# run this if the default test-bed game actually has one -- a GAME_DIR the
+# caller points at a different, all-small-maps project should not fail here.
+if game_dir == File.join(ROOT, 'data/Nepheshel206beta/Nepheshel206Nbeta')
+  check('oversized map is refused, not truncated') do
+    _stdout, stderr, status = Open3.capture3('ruby', EXPORTER, game_dir, '192', Dir.mktmpdir('n7export'))
+    ok !status.success?, 'exporter accepted a 230x50 map past the 128x128 cap'
+    ok stderr.include?('exceeds on-device bounds'), "unexpected message: #{stderr}"
+  end
+end
+
+puts "#{$checks} checks, #{$failures} failures"
+exit($failures.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary
- Adds `app/nano7/rpg2k_walk`, a small from-scratch C map-walking app for jailbroken iPod nano 7th generation, built against the [NanoApps](https://github.com/nfzerox/NanoApps) homebrew SDK — not an extension of this repo's mruby/RGSS engine, since NanoApps caps a compiled app image at ~500 KB (see ADR 61 for why that rules out the shared engine).
- Adds `scripts/export_nano7_map.rb`, a host-side CRuby exporter that reuses this repo's existing LCF parsing, chipset/autotile compositing and passability logic to convert a real RPG Maker 2000/2003 map into a compact binary (`map.bin` + `tiles.bin`) the on-device app reads directly via `hb_fs_read`.
- Scope is deliberately narrow: tile rendering + grid movement + real collision for one static map — no events, battle or menus.

## Verification
- `ruby scripts/export_nano7_map_check.rb` — 51 checks, 0 failures, round-tripping the exporter against real test-bed map data (including a positive check that an oversized map is refused rather than truncated).
- Built for real against a NanoApps toolchain: `.hbapp` image ~4.5 KB, well under the ~500 KB ceiling.
- **Verified end-to-end on a real jailbroken iPod nano 7G**: installed via NanoApps, loads a real exported map, renders tiles (including autotiles) and the player, and grid movement/collision work via touch-hold input.
- Known follow-up bug (documented in the ADR, not fixed here): cells whose chip resolves to the chipset's transparent/placeholder region render as solid magenta on-device, since `composite_tile` has no transparency handling yet.
- No CI job — CI has no NanoApps toolchain and no device; this is documented explicitly rather than pretending build coverage exists where it can't.

## Test plan
- [x] `ruby scripts/export_nano7_map_check.rb`
- [x] Build against a real NanoApps checkout, confirm size budget
- [x] Install and run on real jailbroken hardware

https://claude.ai/code/session_01Ptng9zDEnsziyUVDTd6Tpc