### PR TITLE
Persist the vehicle/battle BGM restore point through Save/Continue

### DIFF
--- a/changelog.d/vehicle-battle-bgm-restore-point.fixed.md
+++ b/changelog.d/vehicle-battle-bgm-restore-point.fixed.md
@@ -1,0 +1,19 @@
+- `Game::State#to_lsd`/`.from_lsd` now round-trip the vehicle/battle BGM
+  restore point (chunk 101 fields 76/77, liblcf's own `before_vehicle_music`/
+  `before_battle_music`) through a genuine Save/Continue. Previously tracked
+  only as a transient `Scene::Map` instance variable
+  (`#restore_pre_vehicle_bgm`/`#restore_pre_battle_bgm`'s own stash), so a
+  save taken mid-vehicle-ride or mid-battle and then continued would resume
+  whatever was already playing rather than remembering the field/vehicle
+  track to restore on disembark or after the fight — now promoted onto
+  `Game::State` (`#pre_vehicle_bgm`/`#pre_battle_bgm`) and persisted through
+  both save formats. Confirmed against a genuine kk1.12 save under wine
+  (taken outside any vehicle/battle): both fields are always present, "(OFF)"
+  — RPG_RT's own placeholder — standing in for "nothing to restore" rather
+  than the field going absent.
+- Fixed `Game::State.bgm_from_chunk` (the save-side BGM decoder) to treat the
+  literal file name `"(OFF)"` the same as an absent or blank one — matching
+  `#play_bgm_or_stop`'s existing fix for live playback. A Change System BGM
+  override (or either restore point above) explicitly left at `"(OFF)"`
+  previously decoded as a genuine request to play a file literally named
+  `"(OFF)"` instead of "nothing here, use whatever otherwise applies".

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1821,15 +1821,12 @@ module LCF
       # genuine kk1.12 save under wine (taken outside any vehicle/battle):
       # both decode as a BGM struct whose own `file` (field 1) is the
       # literal string "(OFF)" -- RPG_RT's own placeholder name for "no
-      # track", rather than either field being absent outright. Not wired
-      # into `Game::State#to_lsd`/`.from_lsd` yet: this codebase's own
-      # counterpart to each restore point (`Scene::Map#restore_pre_vehicle_bgm`
-      # and its battle equivalent) is transient scene-layer state, not
-      # anything `Game::State` itself tracks, so `#to_lsd` has nothing to
-      # source these two from today -- and writing the "(OFF)" placeholder
-      # unconditionally would be actively wrong the instant a real session
-      # boards a vehicle or fights a battle before saving. Left for a future
-      # cycle that promotes that scene-layer state onto `Game::State` first.
+      # track", rather than either field being absent outright. Wired into
+      # `Game::State#to_lsd`/`.from_lsd` via `Game::State#pre_vehicle_bgm`/
+      # `#pre_battle_bgm`, promoted off `Scene::Map`'s own transient
+      # `@pre_vehicle_bgm`/`@pre_battle_bgm` instance variables (see that
+      # class's own citation in game.rb) so the restore point survives a
+      # genuine Save/Continue too, not just the current visit.
       76 => { name: :before_vehicle_music, type: :Array1D, elements: BGM },
       77 => { name: :before_battle_music, type: :Array1D, elements: BGM },
       78 => { name: :stored_bgm, type: :Array1D, elements: BGM },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14467,6 +14467,20 @@ module Game
     # each nil or a `{ name:, volume:, tempo: }` hash. Play Memorized BGM (11540)
     # restores the stash. Persisted in the save so the memory survives a reload.
     attr_accessor :current_bgm, :memorized_bgm
+    # The BGM #play_vehicle_bgm/#play_battle_bgm (Scene::Map) stash right
+    # before boarding a vehicle or a fight opens, so #restore_pre_vehicle_bgm/
+    # #restore_pre_battle_bgm can bring it back on disembark/after the fight --
+    # nil the rest of the time (no ride or fight in progress). Confirmed
+    # against a genuine kk1.12 save under wine: chunk 101 (SAVE_SYSTEM) fields
+    # 76/77 (liblcf's own before_vehicle_music/before_battle_music) were both
+    # present, as a BGM struct whose own `file` read the literal "(OFF)" --
+    # RPG_RT's own placeholder for "nothing to restore", not either field
+    # being absent -- confirmed in a session that never boarded a vehicle or
+    # fought a battle, i.e. both nil here. Previously tracked only as a
+    # transient Scene::Map instance variable, invisible to both save formats;
+    # promoted onto Game::State so #to_h/#load_h and #to_lsd/.from_lsd can
+    # round-trip it like #current_bgm above.
+    attr_accessor :pre_vehicle_bgm, :pre_battle_bgm
     # Whether the current BGM has wrapped back to its start at least once — the
     # "BGM played once" conditional-branch test (12010 type 9). Cleared whenever
     # a new BGM starts; set by Scene::Map, which watches `RGSS::Audio.bgm_pos`
@@ -14683,6 +14697,8 @@ module Game
       @escape_access = true
       @current_bgm = nil
       @memorized_bgm = nil
+      @pre_vehicle_bgm = nil
+      @pre_battle_bgm = nil
       @bgm_looped = false
       @bgm_stopping = false
       @player_transparent = false
@@ -14955,6 +14971,7 @@ module Game
         message_config: @message_config.to_h,
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
+        pre_vehicle_bgm: @pre_vehicle_bgm, pre_battle_bgm: @pre_battle_bgm,
         player_transparent: @player_transparent, weather: @weather.to_h,
         screen: @screen.to_h,
         pictures: @pictures.each_with_object({}) { |(id, p), out| out[id] = p.to_h },
@@ -15229,6 +15246,16 @@ module Game
       # 72-82. Written unconditionally to match.
       sys[71] = bgm_chunk({})
       sys[75] = bgm_chunk(@current_bgm) if @current_bgm
+      # Fields 76/77 (before_vehicle_music/before_battle_music) are the
+      # restore point #restore_pre_vehicle_bgm/#restore_pre_battle_bgm
+      # (Scene::Map) bring back on disembark/after a fight -- unlike the
+      # Change System BGM override slots just below, RPG_RT always writes a
+      # real value here, "(OFF)" standing in for "nothing to restore" rather
+      # than the field going absent. Confirmed against a genuine kk1.12 save
+      # under wine, taken outside any vehicle/battle: both present, decoding
+      # as a BGM struct whose own `file` read the literal "(OFF)".
+      sys[76] = bgm_chunk(@pre_vehicle_bgm || { name: '(OFF)' })
+      sys[77] = bgm_chunk(@pre_battle_bgm || { name: '(OFF)' })
       sys[78] = bgm_chunk(@memorized_bgm) if @memorized_bgm
       # Change System BGM (10660) overrides (SYSTEM_BGM_SAVE_FIELD above) --
       # like field 71 and the SFX slots below, all seven are written
@@ -16002,6 +16029,11 @@ module Game
       # Overridden BGM playback state; an empty file name means "none".
       state.current_bgm = bgm_from_chunk(sys.current_bgm)
       state.memorized_bgm = bgm_from_chunk(sys.stored_bgm)
+      # The vehicle/battle BGM restore point -- "(OFF)" (RPG_RT's own
+      # placeholder, see #to_lsd's own citation) reads back as nil, the same
+      # as an empty file name, via #bgm_from_chunk's own sentinel handling.
+      state.pre_vehicle_bgm = bgm_from_chunk(sys.before_vehicle_music)
+      state.pre_battle_bgm = bgm_from_chunk(sys.before_battle_music)
       # Change System BGM (10660) / Change System SFX (10670) overrides, read
       # back by the same slot -> field map #to_lsd wrote them with. A slot the
       # save left un-overridden is simply absent from the hash, matching
@@ -16319,12 +16351,19 @@ module Game
 
     # Rebuild our `{ name:, volume:, tempo:, balance: }` BGM hash from a
     # parsed BGM chunk (an LCF::Array1D over the BGM schema). Returns nil for
-    # an absent chunk or an empty file name (the "use the database value"
-    # sentinel).
+    # an absent chunk, an empty file name (the "use the database value"
+    # sentinel), or the literal file name "(OFF)" -- liblcf's own Music-struct
+    # schema default, and RPG_RT's own "play nothing" placeholder wherever a
+    # BGM slot is left unset (#play_bgm_or_stop's own comment already
+    # documents this same literal for live playback; a save round-trip
+    # carries the identical sentinel and needs the same treatment, or an
+    # editor-set-to-"(OFF)" override, or a before_vehicle_music/
+    # before_battle_music restore point with nothing to restore, would
+    # decode as a real request to play a file literally named "(OFF)").
     def self.bgm_from_chunk(chunk)
       return nil unless chunk
       name = chunk.file
-      return nil if name.nil? || name.empty?
+      return nil if name.nil? || name.empty? || name == '(OFF)'
       { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100,
         balance: chunk.balance || 50 }
     end
@@ -16365,6 +16404,8 @@ module Game
       state.save_access = h[:save_access] unless h[:save_access].nil?
       state.current_bgm = h[:current_bgm]
       state.memorized_bgm = h[:memorized_bgm]
+      state.pre_vehicle_bgm = h[:pre_vehicle_bgm]
+      state.pre_battle_bgm = h[:pre_battle_bgm]
       state.player_transparent = h[:player_transparent] ? true : false
       state.weather.load_h(h[:weather])
       state.screen.load_h(h[:screen])

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -394,7 +394,6 @@ class RPG2k
         # One digit-cell sprite per timer (RPG2003 has two); built lazily when
         # first shown (see #draw_timer).
         @timer_sprites = [nil, nil]
-        @pre_vehicle_bgm = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
         # a Move Event targeting "this event" can be resolved. nil for common
@@ -2734,7 +2733,7 @@ class RPG2k
       # airship music — remembering the BGM that was playing so
       # #restore_pre_vehicle_bgm can bring it back on disembark.
       def play_vehicle_bgm(type)
-        @pre_vehicle_bgm = @state.current_bgm
+        @state.pre_vehicle_bgm = @state.current_bgm
         play_bgm_or_stop(vehicle_bgm(type))
       rescue StandardError => e
         $stderr.puts "[RPG2k] vehicle BGM failed: #{e.message}"
@@ -2742,8 +2741,8 @@ class RPG2k
 
       # Restore the BGM that was playing before the party boarded (the map BGM).
       def restore_pre_vehicle_bgm
-        bgm = @pre_vehicle_bgm
-        @pre_vehicle_bgm = nil
+        bgm = @state.pre_vehicle_bgm
+        @state.pre_vehicle_bgm = nil
         play_bgm_or_stop(bgm)
       rescue StandardError => e
         $stderr.puts "[RPG2k] restoring BGM failed: #{e.message}"
@@ -2765,7 +2764,7 @@ class RPG2k
       def play_battle_bgm
         music = battle_bgm
         return unless music
-        @pre_battle_bgm = @state.current_bgm
+        @state.pre_battle_bgm = @state.current_bgm
         play_bgm(music)
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle BGM failed: #{e.message}"
@@ -2843,8 +2842,8 @@ class RPG2k
       # it. Harmless to call for an escape or a defeat too: there is no ME
       # active then, so it is a no-op.
       def restore_pre_battle_bgm
-        bgm = @pre_battle_bgm
-        @pre_battle_bgm = nil
+        bgm = @state.pre_battle_bgm
+        @state.pre_battle_bgm = nil
         return unless bgm && bgm[:name] && !bgm[:name].empty?
         RGSS::Audio.me_stop
         play_bgm(bgm)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4466,6 +4466,23 @@ check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrid
   eq nil, round.system_sfx[1], 'an untouched SFX slot round-trips as absent, not an empty override'
 end
 
+check 'Game::State.bgm_from_chunk treats the literal file name "(OFF)" the ' \
+      'same as an absent/blank one, not a real track to play' do
+  # liblcf's own Music-struct schema default is the literal string "(OFF)",
+  # not a blank name -- #play_bgm_or_stop (Scene::Map) already treats this
+  # exact literal as "play nothing" for live playback (see its own comment),
+  # but #bgm_from_chunk, the save round-trip's decoder, never got the same
+  # fix: a Change System BGM override (or a before_vehicle_music/
+  # before_battle_music restore point, see the check above) explicitly left
+  # at "(OFF)" decoded as a genuine request to play a file literally named
+  # "(OFF)" instead of the "nothing here" it actually means.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.system_bgm[0] = { name: '(OFF)', volume: 90, tempo: 110, balance: 20 }
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq nil, round.system_bgm[0], '"(OFF)" round-trips as no override, not a literal "(OFF)" file'
+end
+
 check 'to_lsd writes SAVE_SYSTEM fields 71-82/91-102 (title/battle/etc. ' \
       'BGM and every system SE slot) unconditionally, blank when untouched' do
   # Confirmed against a genuine kk1.12 save under wine: every one of
@@ -4541,6 +4558,40 @@ check 'to_lsd/from_lsd round-trips the current and memorized BGM\'s balance, ' \
   eq 30, round.current_bgm[:balance], 'and its balance round-trips too'
   eq 'field', round.memorized_bgm[:name], 'memorized BGM round-trips'
   eq 60, round.memorized_bgm[:balance], 'and its balance round-trips too'
+end
+
+check 'to_lsd/from_lsd round-trips the vehicle/battle BGM restore point ' \
+      '(chunk 101 fields 76/77), "(OFF)" when nothing to restore' do
+  # Confirmed against a genuine kk1.12 save under wine, taken outside any
+  # vehicle/battle: both fields present, decoding as a BGM struct whose own
+  # `file` is the literal "(OFF)" -- RPG_RT's own placeholder, not either
+  # field being absent. Game::State#pre_vehicle_bgm/#pre_battle_bgm were
+  # promoted off Scene::Map's own transient same-named instance variables so
+  # #to_lsd would have something to source these two fields from at all.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq nil, st.pre_vehicle_bgm, 'nothing to restore by default'
+  eq nil, st.pre_battle_bgm
+
+  saved = st.to_lsd
+  eq true, saved[101].key?(76), 'always present, unlike an ordinary omit-at-default field'
+  eq true, saved[101].key?(77)
+  eq '(OFF)', saved[101][76].file
+  eq '(OFF)', saved[101][77].file
+
+  round = Game::State.from_lsd(db, saved)
+  eq nil, round.pre_vehicle_bgm, '"(OFF)" reads back as nil, not a literal track named "(OFF)"'
+  eq nil, round.pre_battle_bgm
+
+  # A live restore point (mid-ride/mid-fight at save time) survives a real
+  # Save/Continue, not just this engine's own Marshal format.
+  st.pre_vehicle_bgm = { name: 'town', volume: 80, tempo: 100, balance: 30 }
+  st.pre_battle_bgm = { name: 'field', volume: 70, tempo: 90, balance: 60 }
+  round2 = Game::State.from_lsd(db, st.to_lsd)
+  eq 'town', round2.pre_vehicle_bgm[:name]
+  eq 30, round2.pre_vehicle_bgm[:balance]
+  eq 'field', round2.pre_battle_bgm[:name]
+  eq 60, round2.pre_battle_bgm[:balance]
 end
 
 check 'to_lsd/from_lsd round-trips bgm_stopping (liblcf SaveSystem field ' \


### PR DESCRIPTION
## Summary
- `Game::State#to_lsd`/`.from_lsd` now round-trip the vehicle/battle BGM restore point (chunk 101 fields 76/77, liblcf's own `before_vehicle_music`/`before_battle_music`) through a genuine Save/Continue. Previously tracked only as a transient `Scene::Map` instance variable (`#restore_pre_vehicle_bgm`/`#restore_pre_battle_bgm`'s own stash) — a save taken mid-vehicle-ride or mid-battle and then continued would resume whatever was already playing instead of remembering the field/vehicle track to restore afterward. Promoted onto `Game::State` (`#pre_vehicle_bgm`/`#pre_battle_bgm`) and persisted through both save formats (`#to_h`/`#load_h` too).
- Confirmed against a genuine kk1.12 save under wine (taken outside any vehicle/battle): both fields are always present, `"(OFF)"` (RPG_RT's own placeholder) standing in for "nothing to restore" rather than the field going absent.
- Fixes `Game::State.bgm_from_chunk` (the save-side BGM decoder) to treat the literal file name `"(OFF)"` the same as an absent/blank one — matching `#play_bgm_or_stop`'s existing fix for live playback. A Change System BGM override (or either restore point) explicitly left at `"(OFF)"` previously decoded as a genuine request to play a file literally named `"(OFF)"`.

This is the natural next step after #1417, which documented these two fields as blocked on exactly this promotion.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1160 checks passed (two new checks: the restore-point round-trip, and the "(OFF)" sentinel fix)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks passed
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parsed cleanly
- [x] `ruby scripts/lcf_schema_coverage.rb` — every chunk in the test-bed data is named by the LCF schema
- [x] `ruby scripts/rpg2k_command_soak.rb` — every event command ran without raising or reporting a gap, across all four test-bed projects
- [x] Verified directly against the genuine kk1.12 save: loading and re-exporting reproduces fields 76/77 byte-for-byte ("(OFF)" both ways)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_