### PR TITLE
Add --render_fps flag to cap screen redraw rate independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,24 @@
   rate (SDL_mixer already mixes on its own thread; only asset load blocks the
   game loop)
 
+### Performance
+
+- `--render_fps=N` caps how many of every 60 `Graphics.update` calls actually
+  repaint the screen — `30`, `15` or `10` redraw the screen that many times a
+  second instead of 60, to cut rendering CPU/GPU work and the memory
+  bandwidth it costs on constrained hardware (handhelds, older phones, the
+  PSP/Wio Terminal ports). Game logic, `Graphics.frame_count`, animation
+  timers, message speed and `Wait` all keep running every call at the normal
+  rate — the game plays and times identically at every setting, it just
+  visibly updates less often:
+
+  ```sh
+  ./rpg_maker_clone --render_fps=30 --game_dir path/to/game
+  ```
+
+  Defaults to `60` (every frame renders); values outside `1..60` are clamped
+  with a warning.
+
 ### Build natively without Nix
 
 - The supported build is the Nix flake (`nix develop`), which pins every

--- a/changelog.d/render-fps-cap.added.md
+++ b/changelog.d/render-fps-cap.added.md
@@ -1,0 +1,6 @@
+- Added `--render_fps=N` (e.g. `30`/`15`/`10`) to cap how often the screen
+  actually redraws, cutting rendering CPU/GPU work and memory bandwidth on
+  constrained hardware. Game logic, `Graphics.frame_count`, animation timers
+  and `Wait` keep running at the normal rate every call — only the LVGL
+  redraw itself is skipped on the frames a lower rate does not need, so the
+  game plays and times identically, just visibly updating less often.

--- a/docs/adr/0062-render-fps-cap.md
+++ b/docs/adr/0062-render-fps-cap.md
@@ -1,0 +1,89 @@
+# 62. Cap render rate independently of game-logic rate
+
+Date: 2026-08-27
+
+## Status
+
+Accepted
+
+## Context
+
+`RGSS::Graphics.update` (`mruby-rgss/src/lib.cxx`, `gfx_update`) is the single
+per-frame pump for every maker: one call advances `Graphics.frame_count`,
+drives input, runs the interpreter's own timed things (walk cycles, message
+reveal, `Wait`), reorders/invalidates the LVGL display tree and then calls
+`lv_timer_handler`/`lv_task_handler` to actually redraw and present, before
+sleeping to the next 1/60s deadline (see ADR 21's frame-pacing note in the
+same function). Logic and rendering are the same call — there is no separate
+fixed-timestep-simulation-vs-variable-render split the way many engines have.
+
+That coupling is exactly why lowering the frame rate for constrained hardware
+(older phones, the PSP/Wio Terminal ports, battery saving in general) is not a
+free choice: naively pacing the whole loop to, say, 30Hz would also halve
+every frame_count-driven timer, since nothing here reads a wall-clock delta —
+speeds are expressed in frames. A "low FPS mode" that changes how fast the
+game plays is a different, much larger feature (it would need every timed
+thing ported to a delta-time model) and was explicitly not what was wanted:
+the ask was to cut rendering cost for devices that need it, without changing
+game feel.
+
+The `docs/android-perf-followups.md` / `app/android/README.md` work already
+cuts rendering cost by skipping redraw *whose output would not change*
+(`Scene::Map`'s per-layer dirty tracking, `Sprite#opacity=`/`x=`/`y=` no-oping
+on an unchanged value). That is complementary but orthogonal: it saves work
+when nothing moved, and does nothing when something did — walking across a
+panorama map, or standing in a busy battle, still redraws every single frame.
+There was no existing lever for "redraw less often than every frame,
+regardless of what's on screen," which is what a device that is simply too
+slow (or wants to save battery) actually needs.
+
+## Decision
+
+Add `--render_fps=N` (`src/main.cxx`, threaded into mruby as the `RENDER_FPS`
+constant the same way `--no_render_wait` threads `NO_RENDER_WAIT`). `gfx_update`
+gates only the render-heavy tail of the frame — z-reorder, bitmap-dirty
+invalidation and the `lv_timer_handler`/`lv_task_handler` draw/present — behind
+a `render_due()` check; everything before it (input poll via `Input.update`,
+`Graphics.frame_count`, the interpreter's own per-frame work) and the 1/60s
+wall-clock pacing sleep after it are untouched. So the game still advances,
+times and paces at 60 logical frames a second at every `--render_fps` setting;
+only how often the screen actually repaints changes.
+
+`render_due()` spreads the rendered frames evenly across each 60-call window
+with the same accumulator technique the pacing sleep already uses for its
+17/17/16ms step (`g_period_acc`) rather than rendering in bursts: `--render_fps
+30` renders every other call, `15` every fourth, `10` every sixth. A frame that
+is skipped does not clear the z/bitmap-dirty flags it would otherwise have
+cleared, so the next frame that does render still picks up everything that
+changed while it waited — nothing is silently dropped, just deferred to the
+next visible repaint. Default is `60` (render every frame; the flag is a pure
+opt-in with no behaviour change).
+
+Deliberately scoped to *redraw*, not input latency or logic responsiveness: a
+skipped frame still polls input and runs the interpreter, so `Input.update`
+still sees every real transition — only the visible update lags by up to
+`60/render_fps - 1` frames, same trade-off a display's own refresh cap would
+make.
+
+## Consequences
+
+- A constrained device (or a player who wants to save battery) gets a real
+  CPU/GPU/bandwidth reduction proportional to how much of the frame's cost was
+  actually in `gfx.zorder`/`gfx.invalidate`/`gfx.lvgl` (see `--profile`'s
+  section breakdown) — `docs/profiling.md`'s baseline numbers are the ones to
+  compare against on a given target.
+- Game speed, save timing and any script relying on `Graphics.frame_count`
+  are unaffected at any setting — there is no game-visible difference besides
+  the screen repainting less often, which is the trade-off asked for.
+- Android's own on-screen virtual pad (`src/android_vpad_ui.cxx`) hangs its
+  press-highlight redraw off the same `lv_timer_handler` pump, so at a low
+  `--render_fps` its visual feedback lags by the same skipped frames as the
+  game picture. This was accepted rather than special-cased, since it is a
+  visual-only overlay and the whole point of the flag is fewer visual
+  updates per second.
+- This is a coarser, always-on lever than the existing per-object dirty
+  skipping (`Scene::Map`, `Sprite#opacity=`/`x=`/`y=`); the two compose —
+  dirty skipping still avoids redundant work on the frames that do render.
+- A future genuine delta-time mode (game logic itself pacing to a lower rate)
+  remains a separate, much larger change if ever wanted; this ADR only covers
+  the redraw-rate cap.

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -3155,6 +3155,12 @@ uint32_t g_next_frame = 0;
 uint32_t g_period_acc = 0;
 bool g_paced = false;
 
+// --render_fps (src/main.cxx): duty-cycle accumulator deciding which of every
+// 60 Graphics.update calls actually reach the LVGL redraw below (same
+// Bresenham-style technique as g_period_acc above, just spreading renders
+// instead of milliseconds evenly across the 60 calls-per-second baseline).
+uint32_t g_render_acc = 0;
+
 // RGSS Graphics.frame_reset: "resets the screen refresh timing", called after
 // something slow so the game does not then run fast catching up. The pacing
 // below carries an absolute deadline forward, so after a long stall it owes a
@@ -3170,6 +3176,32 @@ mrb_value gfx_frame_reset(mrb_state* M, mrb_value self) {
   (void)M;
   g_paced = false;
   return self;
+}
+
+// Whether *this* Graphics.update call should reach the LVGL redraw, per
+// --render_fps (src/main.cxx). Game logic runs every call regardless -- this
+// only gates the z-reorder/bitmap-invalidate/LVGL draw work below, so a lower
+// setting redraws the screen less often without changing how fast the game
+// itself runs. Undefined (e.g. the per-gem `rake test` binary, which never
+// runs main.cxx) means "render every frame", same fallback as NO_RENDER_WAIT.
+bool render_due(mrb_state* M) {
+  int32_t render_fps = 60;
+  if (mrb_const_defined(M, mrb_obj_value(M->object_class),
+                        mrb_intern_lit(M, "RENDER_FPS"))) {
+    const mrb_value v = mrb_const_get(M, mrb_obj_value(M->object_class),
+                                      mrb_intern_lit(M, "RENDER_FPS"));
+    mrb_assert(mrb_fixnum_p(v));
+    render_fps = static_cast<int32_t>(mrb_fixnum(v));
+  }
+  if (render_fps >= 60)
+    return true;
+  if (render_fps <= 0)
+    return false;
+  g_render_acc += static_cast<uint32_t>(render_fps);
+  if (g_render_acc < 60)
+    return false;
+  g_render_acc -= 60;
+  return true;
 }
 
 mrb_value gfx_update(mrb_state* M, mrb_value self) {
@@ -3194,73 +3226,81 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
     }
   }
 
-  // Reapply z ordering when something changed since the last frame. LVGL draws
-  // siblings in child order, so within each LVGL parent we sort that parent's
-  // z-managed objects by `z` and move them to the foreground from lowest to
-  // highest, leaving the greatest `z` on top. Grouping by parent means sprites
-  // that live inside a Viewport are ordered among themselves, while the
-  // Viewport (and top-level sprites) are ordered against each other on the
-  // screen. Disposed objects (null DATA_PTR) are dropped from the set here so
-  // it does not grow unbounded.
-  if (mrb_bool(mrb_iv_get(M, rgss_mod, mrb_intern_lit(M, "_z_updated")))) {
-    ProfilerScope _zscope("gfx.zorder");
-    const mrb_value objs = zorder_objs(M);
-    const mrb_value live = mrb_ary_new(M);
-    std::map<lv_obj_t*, std::multimap<mrb_int, lv_obj_t*>> by_parent;
-    for (mrb_int i = 0; i < RARRAY_LEN(objs); ++i) {
-      const mrb_value v = RARRAY_PTR(objs)[i];
-      if (!DATA_PTR(v))
-        continue;
-      mrb_ary_push(M, live, v);
-      lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(v));
-      const mrb_value z = mrb_iv_get(M, v, mrb_intern_lit(M, "@z"));
-      mrb_assert(mrb_fixnum_p(z));
-      by_parent[lv_obj_get_parent(obj)].insert({mrb_fixnum(z), obj});
+  // --render_fps (src/main.cxx): on a skipped frame, leave the z/dirty flags
+  // set rather than touching them, so the next frame that does render picks
+  // up everything that changed while it waited -- no dropped update, just a
+  // deferred repaint.
+  if (render_due(M)) {
+    // Reapply z ordering when something changed since the last frame. LVGL
+    // draws siblings in child order, so within each LVGL parent we sort that
+    // parent's z-managed objects by `z` and move them to the foreground from
+    // lowest to highest, leaving the greatest `z` on top. Grouping by parent
+    // means sprites that live inside a Viewport are ordered among
+    // themselves, while the Viewport (and top-level sprites) are ordered
+    // against each other on the screen. Disposed objects (null DATA_PTR) are
+    // dropped from the set here so it does not grow unbounded.
+    if (mrb_bool(mrb_iv_get(M, rgss_mod, mrb_intern_lit(M, "_z_updated")))) {
+      ProfilerScope _zscope("gfx.zorder");
+      const mrb_value objs = zorder_objs(M);
+      const mrb_value live = mrb_ary_new(M);
+      std::map<lv_obj_t*, std::multimap<mrb_int, lv_obj_t*>> by_parent;
+      for (mrb_int i = 0; i < RARRAY_LEN(objs); ++i) {
+        const mrb_value v = RARRAY_PTR(objs)[i];
+        if (!DATA_PTR(v))
+          continue;
+        mrb_ary_push(M, live, v);
+        lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(v));
+        const mrb_value z = mrb_iv_get(M, v, mrb_intern_lit(M, "@z"));
+        mrb_assert(mrb_fixnum_p(z));
+        by_parent[lv_obj_get_parent(obj)].insert({mrb_fixnum(z), obj});
+      }
+      mrb_const_set(M, rgss_mod, mrb_intern_lit(M, "_zobjs"), live);
+      for (const auto& group : by_parent)
+        for (const auto& order : group.second)
+          lv_obj_move_foreground(order.second);
+      mrb_iv_set(M, rgss_mod, mrb_intern_lit(M, "_z_updated"),
+                 mrb_false_value());
     }
-    mrb_const_set(M, rgss_mod, mrb_intern_lit(M, "_zobjs"), live);
-    for (const auto& group : by_parent)
-      for (const auto& order : group.second)
-        lv_obj_move_foreground(order.second);
-    mrb_iv_set(M, rgss_mod, mrb_intern_lit(M, "_z_updated"), mrb_false_value());
-  }
 
-  // Bitmap mutators write straight into the shared pixel buffer, which LVGL
-  // does not observe. Walk the live sprites and invalidate any whose bitmap has
-  // been touched since the last frame so LVGL repaints them below. Flags are
-  // cleared only after the whole sweep so a bitmap shared by several sprites
-  // invalidates all of them.
-  {
-    ProfilerScope _iscope("gfx.invalidate");
-    const mrb_value roots = zorder_objs(M);
-    const mrb_sym bitmap_sym = mrb_intern_lit(M, "@bitmap");
-    for (mrb_int i = 0; i < RARRAY_LEN(roots); ++i) {
-      const mrb_value v = RARRAY_PTR(roots)[i];
-      lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(v));
-      if (!obj)
-        continue;
-      const mrb_value bmpv = mrb_iv_get(M, v, bitmap_sym);
-      if (mrb_nil_p(bmpv) || !DATA_PTR(bmpv))
-        continue;
-      Bitmap* b = reinterpret_cast<Bitmap*>(DATA_PTR(bmpv));
-      if (b->dirty)
-        lv_obj_invalidate(obj);
+    // Bitmap mutators write straight into the shared pixel buffer, which LVGL
+    // does not observe. Walk the live sprites and invalidate any whose bitmap
+    // has been touched since the last frame so LVGL repaints them below.
+    // Flags are cleared only after the whole sweep so a bitmap shared by
+    // several sprites invalidates all of them.
+    {
+      ProfilerScope _iscope("gfx.invalidate");
+      const mrb_value roots = zorder_objs(M);
+      const mrb_sym bitmap_sym = mrb_intern_lit(M, "@bitmap");
+      for (mrb_int i = 0; i < RARRAY_LEN(roots); ++i) {
+        const mrb_value v = RARRAY_PTR(roots)[i];
+        lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(v));
+        if (!obj)
+          continue;
+        const mrb_value bmpv = mrb_iv_get(M, v, bitmap_sym);
+        if (mrb_nil_p(bmpv) || !DATA_PTR(bmpv))
+          continue;
+        Bitmap* b = reinterpret_cast<Bitmap*>(DATA_PTR(bmpv));
+        if (b->dirty)
+          lv_obj_invalidate(obj);
+      }
+      // Second pass: clear the flags now that every referencing sprite is
+      // marked.
+      for (mrb_int i = 0; i < RARRAY_LEN(roots); ++i) {
+        const mrb_value v = RARRAY_PTR(roots)[i];
+        if (!DATA_PTR(v))
+          continue;
+        const mrb_value bmpv = mrb_iv_get(M, v, bitmap_sym);
+        if (mrb_nil_p(bmpv) || !DATA_PTR(bmpv))
+          continue;
+        reinterpret_cast<Bitmap*>(DATA_PTR(bmpv))->dirty = false;
+      }
     }
-    // Second pass: clear the flags now that every referencing sprite is marked.
-    for (mrb_int i = 0; i < RARRAY_LEN(roots); ++i) {
-      const mrb_value v = RARRAY_PTR(roots)[i];
-      if (!DATA_PTR(v))
-        continue;
-      const mrb_value bmpv = mrb_iv_get(M, v, bitmap_sym);
-      if (mrb_nil_p(bmpv) || !DATA_PTR(bmpv))
-        continue;
-      reinterpret_cast<Bitmap*>(DATA_PTR(bmpv))->dirty = false;
-    }
-  }
 
-  {
-    ProfilerScope _lvscope("gfx.lvgl");
-    lv_timer_handler();
-    lv_task_handler();
+    {
+      ProfilerScope _lvscope("gfx.lvgl");
+      lv_timer_handler();
+      lv_task_handler();
+    }
   }
 
   // Advance Graphics.frame_count, matching RGSS semantics.

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -1,4 +1,5 @@
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -73,6 +74,17 @@ DEFINE_bool(
     "the wall clock, so this only removes idle wall-clock wait -- it does "
     "not change what any frame does. Used by the MV/MZ/RPG2k/XP boot-check "
     "smokes, which only need the frames to happen, not to happen on time.");
+DEFINE_int32(
+    render_fps,
+    60,
+    "Cap how many of every 60 Graphics.update calls actually repaint the "
+    "screen (e.g. 30, 15 or 10), to cut rendering CPU/GPU work and the "
+    "memory bandwidth it costs on constrained devices. Game logic, "
+    "Graphics.frame_count, animation timers and Wait all still run every "
+    "call at the normal rate -- only the LVGL redraw itself is skipped on "
+    "the frames a lower rate does not need, so the game plays and times "
+    "identically at every setting, just visibly updating less often. "
+    "Clamped to 1..60; 60 (the default) renders every frame");
 DEFINE_bool(
     rpg2k_new_game,
     false,
@@ -1563,6 +1575,17 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "NO_RENDER_WAIT"),
                 mrb_bool_value(FLAGS_no_render_wait));
+  // See --render_fps above: read once here, the same way NO_RENDER_WAIT is,
+  // by RGSS::Graphics.update (mruby-rgss/src/lib.cxx) to decide which frames
+  // actually reach the LVGL redraw.
+  if (FLAGS_render_fps < 1 || FLAGS_render_fps > 60) {
+    LOG(ERROR) << "--render_fps=" << FLAGS_render_fps
+               << " is out of range; clamping to 1..60";
+    FLAGS_render_fps = std::clamp(FLAGS_render_fps, 1, 60);
+  }
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RENDER_FPS"),
+                mrb_fixnum_value(FLAGS_render_fps));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RPG2K_NEW_GAME"),
                 mrb_bool_value(FLAGS_rpg2k_new_game));


### PR DESCRIPTION
## Summary

This PR adds a `--render_fps` command-line flag that allows capping how often the screen actually redraws, independent of the game logic frame rate. The game continues running at 60 logical frames per second, but the expensive LVGL rendering work is skipped on frames that don't need to be displayed, reducing CPU/GPU load on constrained hardware.

## Key Changes

- **New `render_due()` function** in `mruby-rgss/src/lib.cxx`: Implements a Bresenham-style accumulator (similar to existing `g_period_acc`) to evenly distribute rendered frames across the 60-call window. For example, `--render_fps=30` renders every other frame, `15` renders every fourth frame, etc.

- **Gated rendering work** in `gfx_update()`: The z-reorder, bitmap-dirty invalidation, and LVGL draw/present operations are now wrapped in a `render_due()` check. Skipped frames preserve the z/dirty flags so the next rendered frame picks up all accumulated changes.

- **New global accumulator** `g_render_acc`: Tracks render frame distribution across the 60-call baseline, mirroring the existing pacing accumulator pattern.

- **Command-line flag** in `src/main.cxx`: Added `--render_fps` (default 60, clamped to 1..60) that threads the value into mruby as the `RENDER_FPS` constant, matching how `--no_render_wait` works.

- **Documentation**: Added ADR 0062 explaining the design rationale, consequences, and interaction with existing dirty-tracking optimizations. Updated README with usage examples.

## Implementation Details

- Game logic, input polling, `Graphics.frame_count`, animation timers, and `Wait` all continue running every frame at 60 Hz — only the visual redraw is throttled
- Frames are skipped evenly using an accumulator technique rather than in bursts, providing smooth visual degradation
- Undefined `RENDER_FPS` (e.g., in test binaries that don't run `main.cxx`) defaults to "render every frame" for backward compatibility
- The flag is purely opt-in with no behavior change at the default setting of 60
- Complements existing per-object dirty-tracking optimizations; both mechanisms compose

https://claude.ai/code/session_018F6qJM4LL2Xv9yqBxD6XZV