### PR TITLE
Scale RPG2000 bitmap cache budgets with --render_fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,13 @@
   Defaults to `60` (every frame renders); values outside `1..60` are clamped
   with a warning.
 
+- For RPG Maker 2000/2003, a low `--render_fps` also shrinks the map scene's
+  decoded-bitmap cache budgets (named graphics and toned-picture variants) by
+  roughly the same ratio, evicting the least-recently-used entry sooner in
+  exchange for real RAM saved on a constrained device — see
+  [`docs/adr/0063-render-fps-scaled-bitmap-caches.md`](docs/adr/0063-render-fps-scaled-bitmap-caches.md).
+  No effect at the default `60`.
+
 ### Build natively without Nix
 
 - The supported build is the Nix flake (`nix develop`), which pins every

--- a/changelog.d/render-fps-scaled-bitmap-caches.added.md
+++ b/changelog.d/render-fps-scaled-bitmap-caches.added.md
@@ -1,0 +1,6 @@
+- RPG2000's named-graphic bitmap caches and picture tone-effect cache now
+  scale their memory budgets down with `--render_fps` (e.g. `--render_fps=10`
+  roughly sixths them), so a constrained device set to a low render rate
+  (the PSP/Wio-class ports) also holds a smaller working set of decoded
+  bitmaps in exchange for more cache-miss reloads. No effect at the default
+  `--render_fps=60`.

--- a/docs/adr/0063-render-fps-scaled-bitmap-caches.md
+++ b/docs/adr/0063-render-fps-scaled-bitmap-caches.md
@@ -1,0 +1,69 @@
+# 63. Scale RPG2000 bitmap cache budgets with --render_fps
+
+Date: 2026-08-27
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0047 sized `Scene::Map`'s seven named-graphic `LRUBitmapCache` budgets
+(`mruby-rpg2k/mrblib/scene/map.rb`, `CHARSET_CACHE_BYTES` and siblings, 6.25 MB
+combined at their base values) and the picture tone-effect cache
+(`PICTURE_TONE_CACHE_MAX`, up to 16 same-size decoded bitmaps) as "a
+conservative first cut, not a measured budget" — fixed constants, the same on
+every target, because nothing in the engine distinguished "this is a
+constrained device" from "this is a desktop" at the point those caches are
+built.
+
+ADR 0062 gave the engine exactly that signal for a different purpose:
+`--render_fps` (threaded into mruby as the `RENDER_FPS` constant) exists
+because a device may need to trade visible smoothness for less CPU/GPU/memory
+work, and the PSP/Wio-class ports are the concrete targets it names. A game
+launched with a low `--render_fps` is, by construction, running on hardware
+where memory is also worth economizing — the same signal, unused for the
+memory side of that trade.
+
+## Decision
+
+Add `RGSS::Graphics.render_fps` (`mruby-rgss/mrblib/lib.rb`), a thin reader
+over the `RENDER_FPS` constant with the same "undefined means uncapped (60)"
+fallback `--no_render_wait`'s own constant already uses, so game code never
+needs to know whether it's running under the native binary or a host-side
+check harness.
+
+`RPG2k::Scene::Map#constrained_scale(base)` scales a byte budget or entry
+count by the `render_fps`/60 ratio — `--render_fps=30` roughly halves it, `10`
+roughly sixths it — floored at `base / CONSTRAINED_SCALE_FLOOR_DIVISOR` (8) so
+a very low setting still leaves a small working set rather than none, and
+returns `base` unchanged at the default 60 (a pure opt-in, no behaviour
+change). Every `LRUBitmapCache.new` call in `#initialize` and the picture
+tone-cache's eviction check in `#toned_picture_src` route their base constant
+through it.
+
+This is deliberately *only* a smaller eviction threshold, not a change to
+what is cached or when: a scaled-down cache just evicts its least-recently-used
+entry sooner, and anything evicted is transparently reloaded (and re-cached)
+the next time its name comes up — the same cost the caches already pay on a
+cold miss, just paid more often. No game logic, timing, or drawn output
+changes at any setting, matching ADR 0062's own scope decision for
+`--render_fps` itself.
+
+## Consequences
+
+- A PSP/Wio-class run launched at a low `--render_fps` now also holds a
+  proportionally smaller working set of decoded named-graphic bitmaps and
+  toned-picture variants, at the cost of more re-decodes on a cache miss —
+  real RAM saved in exchange for CPU a constrained device already has less
+  competition for once it is also rendering less often.
+- An ordinary desktop run (`--render_fps=60`, the default) is byte-for-byte
+  unaffected: `constrained_scale` returns `base` unchanged.
+- `RGSS::Graphics.render_fps` is now available to any game-side Ruby code
+  (mruby-rpg2k or otherwise) that wants to scale back optional, purely-visual
+  or memory-costly work the same way — not something this ADR requires
+  elsewhere, just a reusable hook now that it exists.
+- The seven cache budgets and the tone-cache count remain "a conservative
+  first cut, not a measured budget" per ADR 0047; real on-device measurement
+  once a project actually runs on PSP hardware may still argue for different
+  base values or a different floor, independent of this scaling mechanism.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1365,6 +1365,23 @@ module RGSS
         @height = height
       end
 
+      # --render_fps (src/main.cxx): how many of every 60 real-time
+      # Graphics.update calls actually redraw the screen, set once at boot --
+      # unlike frame_rate above, a real-time redraw cadence the engine
+      # enforces, not a value scripts declare for their own timing math. Game
+      # code can read this to scale back purely-visual, memory-costly work
+      # (bitmap cache budgets, particle counts) on a device picked for a low
+      # render rate, without touching anything that affects game timing.
+      # Defaults to 60 (every frame renders) wherever the native RENDER_FPS
+      # constant isn't defined, e.g. the per-gem `rake test` binary, which
+      # never runs main.cxx -- same fallback main.cxx documents for
+      # NO_RENDER_WAIT.
+      def render_fps
+        RENDER_FPS
+      rescue StandardError
+        60
+      end
+
       # Run `duration` frames. Real behaviour, not a stub: the scripts use it to
       # hold a scene (fade-ins, message waits), and each update is a real frame.
       def wait(duration)

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -271,6 +271,42 @@ class RPG2k
       BATTLECHARSET_CACHE_BYTES = 500_000
       SYSTEM2_CACHE_BYTES = 250_000
 
+      # A scaled-down budget never shrinks past base/this, so a cache always
+      # keeps some working set (one still-oversized entry, per
+      # LRUBitmapCache#evict_lru_until_within_budget, would otherwise never
+      # evict anything else at all, and the picture tone cache -- see
+      # #toned_picture_src -- would stop caching entirely).
+      CONSTRAINED_SCALE_FLOOR_DIVISOR = 8
+
+      # Scale a named-graphic cache's byte budget (or the picture tone
+      # cache's entry count, see #toned_picture_src) down when --render_fps
+      # (src/main.cxx) signals a constrained device: a target picked for a
+      # low real-time render rate -- the PSP/Wio-class ports this flag exists
+      # for -- is RAM-constrained too, so it is worth evicting decoded
+      # graphics more eagerly (a re-decode-on-next-use cost) to hold a
+      # smaller working set. Scaled by the fps ratio rather than a single
+      # on/off cut -- --render_fps=30 roughly halves a budget, 10 roughly
+      # sixths it -- and floored at CONSTRAINED_SCALE_FLOOR_DIVISOR so a very
+      # low setting still leaves a small working set rather than none. An
+      # ordinary run (render_fps 60, the default) always returns base
+      # unchanged.
+      #
+      # RGSS::Graphics.render_fps rescued rather than called bare: the
+      # host-side scene checks (scripts/rpg2k_scene_check.rb) load this file
+      # under plain CRuby against their own minimal Graphics stub, which has
+      # no render_fps method -- same "missing means uncapped" fallback
+      # RGSS::Graphics.render_fps itself uses for the native constant it
+      # reads.
+      def constrained_scale(base)
+        fps = RGSS::Graphics.render_fps
+        return base if fps >= 60
+        scaled = base * fps / 60
+        floor = base / CONSTRAINED_SCALE_FLOOR_DIVISOR
+        scaled > floor ? scaled : floor
+      rescue StandardError
+        base
+      end
+
       def initialize parent, state, apply_access: true
         super parent
         @state = state
@@ -286,21 +322,22 @@ class RPG2k
         # now only the most-recently-used ones survive past each cache's own
         # byte budget, and anything evicted is simply reloaded (and re-cached)
         # the next time its name comes up.
-        @charset_cache = LRUBitmapCache.new(CHARSET_CACHE_BYTES)
+        @charset_cache = LRUBitmapCache.new(constrained_scale(CHARSET_CACHE_BYTES))
                                # CharSet/<name> -- event graphics and the
                                # party leader's own graphic share this, since
                                # both load the same files.
-        @picture_cache = LRUBitmapCache.new(PICTURE_CACHE_BYTES)
+        @picture_cache = LRUBitmapCache.new(constrained_scale(PICTURE_CACHE_BYTES))
                                # Picture/<name>, keyed by [name, transparent]
-        @backdrop_cache = LRUBitmapCache.new(BACKDROP_CACHE_BYTES)
+        @backdrop_cache = LRUBitmapCache.new(constrained_scale(BACKDROP_CACHE_BYTES))
                                # Backdrop/<name> (battle background)
-        @monster_cache = LRUBitmapCache.new(MONSTER_CACHE_BYTES)
+        @monster_cache = LRUBitmapCache.new(constrained_scale(MONSTER_CACHE_BYTES))
                                # Monster/<name> (battler graphics)
-        @animation_cache = LRUBitmapCache.new(ANIMATION_CACHE_BYTES)
+        @animation_cache = LRUBitmapCache.new(constrained_scale(ANIMATION_CACHE_BYTES))
                                # Battle/<name> (battle animation sheets)
-        @battlecharset_cache = LRUBitmapCache.new(BATTLECHARSET_CACHE_BYTES)
+        @battlecharset_cache =
+          LRUBitmapCache.new(constrained_scale(BATTLECHARSET_CACHE_BYTES))
                                # BattleCharSet/<name> (RPG2003 actor battler sprites)
-        @system2_cache = LRUBitmapCache.new(SYSTEM2_CACHE_BYTES)
+        @system2_cache = LRUBitmapCache.new(constrained_scale(SYSTEM2_CACHE_BYTES))
                                # System2/<name> (RPG2003 gauge card sprite sheet)
         apply_map_access if apply_access
         # Same Continue-only split as #apply_map_access just above: a fresh
@@ -9823,10 +9860,12 @@ class RPG2k
                         # neutral becomes positive desaturation.
                         Scene::Map.tone_channel(pic.saturation) * -1)
         scratch.tone_blt src, tone
-        # Bounded so a picture cycling through tones cannot grow it without end;
-        # the oldest entry goes first.
+        # Bounded so a picture cycling through tones cannot grow it without
+        # end; the oldest entry goes first. See #constrained_scale: each
+        # cached entry is a same-size decoded bitmap, so this shrinks under
+        # --render_fps the same way the named-graphic caches above do.
         @picture_tone_cache.delete(@picture_tone_cache.keys.first) if
-          @picture_tone_cache.size >= PICTURE_TONE_CACHE_MAX
+          @picture_tone_cache.size >= constrained_scale(PICTURE_TONE_CACHE_MAX)
         @picture_tone_cache[key] = scratch
       rescue StandardError => e
         $stderr.puts "[RPG2k] picture ##{pic.id} tone failed, drawn untinted: #{e.message}"


### PR DESCRIPTION
## Summary

A device launched at a low `--render_fps` (the PSP/Wio-class ports this flag exists for, see ADR 0062) is RAM-constrained, not just CPU/GPU-constrained. This PR uses that same signal to shrink `Scene::Map`'s decoded-bitmap cache budgets proportionally, reducing memory footprint on constrained hardware.

## Key Changes

- **`RGSS::Graphics.render_fps`** (`mruby-rgss/mrblib/lib.rb`): a defensive reader over the native `RENDER_FPS` constant, defaulting to 60 wherever it's undefined (host-side check harnesses, per-gem test binaries) — mirrors the existing fallback pattern for `NO_RENDER_WAIT`.

- **`RPG2k::Scene::Map#constrained_scale(base)`** (`mruby-rpg2k/mrblib/scene/map.rb`): scales a byte budget or entry count by the `render_fps`/60 ratio — `--render_fps=30` roughly halves it, `10` roughly sixths it — floored at 1/8 of the base so a cache never shrinks to uselessness. Returns `base` unchanged at the default 60, so ordinary desktop play is byte-for-byte unaffected.

- Routed through every named-graphic `LRUBitmapCache` budget (charset, picture, backdrop, monster, animation, battlecharset, system2 — 6.25 MB combined at base) and the picture tone-effect cache's eviction bound.

- **Documentation**: ADR 0063 explaining the design rationale and its relationship to ADR 0047 (PSP memory budget) and ADR 0062 (`--render_fps`); README addition under the existing Performance section; changelog fragment.

## Implementation Details

- Deliberately *only* a smaller eviction threshold, not a change to what is cached or when: a scaled-down cache just evicts its least-recently-used entry sooner, and anything evicted is transparently reloaded (and re-cached) the next time its name comes up — the same cost the cache already pays on a cold miss, just paid more often.
- No change to game logic, timing, or drawn output at any setting, matching ADR 0062's own scope decision for `--render_fps` itself.
- `RGSS::Graphics.render_fps` is now available to any game-side Ruby code that wants to scale back other optional, memory-costly work the same way.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 929 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] Full native build (`scripts/native-build-without-nix.bash`) + `ctest` — all suites green
- [x] Direct smoke test confirming the scaling math (e.g. `render_fps=10` → `1,000,000` → `166,666`; `render_fps=1` → floored at `125,000`)
- [x] Real RPG2000 project boot check (`scripts/rpg2k_boot_check.bash`) passes both at the default `--render_fps=60` and with `--render_fps=10` active

https://claude.ai/code/session_018F6qJM4LL2Xv9yqBxD6XZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018F6qJM4LL2Xv9yqBxD6XZV)_