### PR TITLE
Resolve chunk 101 field 125 (battle background); write field 33 (layer) as a constant

### DIFF
--- a/changelog.d/battle-background-field-125.fixed.md
+++ b/changelog.d/battle-background-field-125.fixed.md
@@ -1,0 +1,15 @@
+- `Game::State#to_lsd` now writes chunk 101 (SAVE_SYSTEM) field 125 (liblcf's
+  own `background`, this schema's `:battle_background`) when given a database
+  and map tree: the current map's resolved encounter background, off the
+  same `Game::Backdrop.name_for` map-tree walk `Scene::Battle#
+  encounter_backdrop` already uses for a fight's own backdrop, with a
+  `Game::ChipSet`/terrain lookup built from the party's current tile.
+  Previously undecoded and unwritten — field 125's own meaning had been an
+  open question across several prior cycles. Confirmed byte-for-byte against
+  a genuine kk1.12 save under wine, taken during ordinary map exploration:
+  loading it and re-exporting reproduces "草原" (grassland) exactly. Omitted
+  when no database/map tree is given (tests, tools) or this state has no map
+  loaded, matching the prior behavior for those cases. Does not yet account
+  for a live Change Map Tileset override (`Scene::Map`'s own transient
+  `@tileset_id`), which this codebase does not persist anywhere — a separate,
+  pre-existing gap.

--- a/changelog.d/hero-vehicle-layer-field.fixed.md
+++ b/changelog.d/hero-vehicle-layer-field.fixed.md
@@ -1,0 +1,8 @@
+- `Game::State#to_lsd` now writes chunk 104/105-107's field 33 (liblcf's own
+  `layer`) as the constant 1 ("same as characters") for the hero and every
+  vehicle. Confirmed present with exactly this value on a genuine kk1.12
+  save under wine, on the hero's own record and every vehicle's alike — this
+  codebase has no "Change Hero/Vehicle Layer" concept to source a live value
+  from (RPG2000/2003 never offers one outside a map event's own page), so
+  the field is a true constant, one more piece of the larger `SaveMapEventBase`
+  gap documented in `mruby-lcf/mrblib/schema.rb`'s `SAVE_MOVABLE` comment.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1948,19 +1948,15 @@ module LCF
       # map's own default backdrop" hypothesis directly); left for whoever
       # picks this back up, alongside cycle #167's own note above.
       #
-      # This codebase already has every *piece* the "map's own resolved
-      # encounter background" hypothesis needs -- `Game::Backdrop.name_for`
-      # (the map-tree backdrop_type walk) and `Scene::Map#terrain_backdrop`
-      # (the tile's own terrain background) together compute exactly this
-      # for `Scene::Battle#encounter_backdrop` -- but both live on
-      # `Scene::Map`/`Scene::Battle`, not `Game::State`: `#terrain_backdrop`
-      # needs `Scene::Map`'s own compiled `@chipset` (tile id -> terrain id)
-      # to resolve the party's current tile, which `Game::State#to_lsd` has
-      # no equivalent of at all. Wiring field 125 up for real needs that
-      # chipset/terrain lookup (or an equivalent) threaded into `#to_lsd`
-      # first, the same kind of database/scene-layer handle `#to_lsd`'s own
-      # vehicle-location comment (mrblib/game.rb) already flags as missing
-      # for a different field.
+      # Wired into `Game::State#to_lsd` off the same `Game::Backdrop.name_for`
+      # map-tree walk `Scene::Battle#encounter_backdrop` uses, plus a
+      # `Game::ChipSet`/terrain lookup built straight from the optional `db`/
+      # `map_tree` arguments (see `#to_lsd`'s own citation in game.rb) --
+      # `Game::ChipSet` already lives in the `Game` namespace, not
+      # `Scene::Map`-only as this comment previously assumed, so no new
+      # scene-layer dependency was needed after all. Not accounted for: a
+      # live Change Map Tileset override (`Scene::Map`'s own `@tileset_id`),
+      # which this codebase does not persist anywhere yet.
       125 => { name: :battle_background, type: :string },
        131 => { name: :save_count, type: :int },
       # The file slot this save was written to. Confirmed against genuine

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1180,6 +1180,14 @@ module LCF
       # write-only mirror, the same shape as chunk 104's own 73/74
       # (`charset_name`/`charset_index`) sprite mirror.
       21 => { name: :sprite_direction, type: :int },
+      # liblcf's own `layer` (generator/csv/fields.csv, 0x21 == 33): confirmed
+      # present as the constant 1 ("same as characters") on a genuine kk1.12
+      # save under wine, on the hero's own record and every vehicle's alike
+      # (chunks 104-107) -- RPG2000/2003 has no "Change Hero/Vehicle Layer"
+      # command (only a map *event* page can be pinned below/above
+      # characters), so this codebase's own `#to_lsd` writes it as a true
+      # constant rather than tracking any live state for it.
+      33 => { name: :layer, type: :int },
       # liblcf's `SaveMapEventBase.transparency` (generator/csv/fields.csv,
       # 0x18 == 24): "0 or 3 - Transparency level of the current event page".
       # On the *hero's* own record (chunk 104) this is Set Transparent Flag's
@@ -1241,10 +1249,10 @@ module LCF
 
     # A genuine kk1.12 save's own chunk 104 (the hero's SAVE_MOVABLE record)
     # carries a lot more of liblcf's full `SaveMapEventBase` struct
-    # (generator/csv/fields.csv) than this table models: `layer` (0x21/33),
-    # a full in-progress `move_route` (`MoveRoute` chunk, 0x29/41 -- the
-    # hero had a live custom route recorded in that capture), `through`
-    # (0x33/51), `stop_count`/`anim_count`/`max_stop_count` (0x34-36/52-54,
+    # (generator/csv/fields.csv) than this table models: a full in-progress
+    # `move_route` (`MoveRoute` chunk, 0x29/41 -- the hero had a live custom
+    # route recorded in that capture), `through` (0x33/51),
+    # `stop_count`/`anim_count`/`max_stop_count` (0x34-36/52-54,
     # movement/animation frame timers), `begin_jump_x`/`_y` (0x3E-3F/62-63),
     # `processed` (0x4B/75, already noted above), and
     # `flash_red`/`_green`/`_blue`/`_current_level`/`_time_left`
@@ -1256,7 +1264,8 @@ module LCF
     # movement/animation timers are pure per-frame scheduling this engine
     # already recomputes fresh rather than resuming byte-for-byte. Left as a
     # known, larger gap for a future cycle -- see this table's own field 43
-    # comment for the one piece (`move_route_index`) already covered.
+    # comment for the `move_route_index` piece, and field 33's own comment
+    # for `layer`, already covered.
     #
     # https://w.atwiki.jp/rpg2kpsp/pages/21.html
     #

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15093,6 +15093,14 @@ module Game
       # schema.rb comment for the genuine-save evidence and why this
       # codebase has no separate value to give it.
       hero[21] = hero[22]
+      # Field 33 (liblcf's own `layer`): confirmed present as the constant 1
+      # ("same as characters") on a genuine kk1.12 save under wine, on both
+      # the hero's own record and every vehicle's (see the vehicle-writing
+      # loop below) -- this codebase has no "Change Hero/Vehicle Layer"
+      # concept at all (RPG2000/2003 never offers one; only a map *event*
+      # page can be pinned below/above characters), so 1 is a true constant
+      # here, not a live value with a default to elide at.
+      hero[33] = 1
       # Set Transparent Flag's own override (Player Visibility, 11310) --
       # liblcf's own "0 or 3" convention for this field (see schema.rb's
       # SAVE_MOVABLE comment on why it lives here, on the hero's own movable
@@ -15146,6 +15154,9 @@ module Game
         dir_row = CharSet::DIR_ROW[v.direction] || 2
         mv[21] = dir_row
         mv[22] = dir_row
+        # Field 33 (layer): a true constant, see the hero's own field-33
+        # citation just above.
+        mv[33] = 1
         mv[35] = 0
         mv[37] = Vehicle::DEFAULT_MOVE_SPEED[type]
         if v.charset_name && !v.charset_name.empty?

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15041,13 +15041,15 @@ module Game
     # LCF::Schema::SAVE_INVENTORY's timer1_*/timer2_*,
     # battles/defeats/escapes/victories/steps/turns fields and
     # SAVE_PARTY_ACTOR's actor_name/title), so this is a near-parity export.
-    # `db`, when given, is only consulted for the same database System
-    # boat/ship/airship_name/_index fallback Scene::Map's own
-    # #vehicle_charset/#vehicle_charset_index (mrblib/scene/map.rb) already
-    # apply for rendering an uncustomized vehicle -- see the vehicle-writing
-    # loop below. Every other caller (tests, tools) omits it and gets the
-    # prior behavior (73/74 simply absent for an uncustomized vehicle).
-    def to_lsd(save_count = 1, timestamp = nil, save_slot = 1, db = nil)
+    # `db`, when given, is consulted for the same database System boat/ship/
+    # airship_name/_index fallback Scene::Map's own #vehicle_charset/
+    # #vehicle_charset_index (mrblib/scene/map.rb) already apply for
+    # rendering an uncustomized vehicle -- see the vehicle-writing loop
+    # below -- and, together with `map_tree`, for SAVE_SYSTEM field 125 (see
+    # that field's own citation further down). Every other caller (tests,
+    # tools) omits either and gets the prior behavior (73/74 simply absent
+    # for an uncustomized vehicle; field 125 omitted entirely).
+    def to_lsd(save_count = 1, timestamp = nil, save_slot = 1, db = nil, map_tree = nil)
       timestamp = State.ole_now if timestamp.nil?
       save = LCF::SaveData.new
 
@@ -15311,6 +15313,37 @@ module Game
       sys[122] = false unless @escape_access
       sys[123] = false unless @save_access
       sys[124] = false unless @menu_access
+      # Field 125 ("background" in liblcf's own generator/csv/fields.csv --
+      # this schema's own :battle_background name was a disproven guess, see
+      # SAVE_SYSTEM's own comment for the full history): the current map's
+      # resolved encounter background, standing on whatever terrain the
+      # party currently occupies -- the same `Game::Backdrop.name_for` walk
+      # plus terrain lookup `Scene::Battle#encounter_backdrop` already uses
+      # to pick a fight's own backdrop. Needs both `db` (a chipset to
+      # resolve the tile's terrain id, and the terrain table's own
+      # background_name) and `map_tree` (the map-tree's own backdrop_type
+      # walk) to compute -- omitted when either is absent (tests, tools), or
+      # this state has no map loaded (a fresh, unplayed save). Does not
+      # account for a live Change Map Tileset override
+      # (Scene::Map#apply_tileset_request's own `@tileset_id`), which this
+      # codebase does not persist anywhere yet -- a separate, pre-existing
+      # gap.
+      if db && map_tree && self.map
+        begin
+          props = map_tree.respond_to?(:map_properties) ? map_tree.map_properties : nil
+          terrain_name = ''
+          if db.respond_to?(:chipset) && db.respond_to?(:terrain) && self.map.in_bounds?(@x, @y)
+            chipset = ChipSet.new(db, self.map.chipset_id)
+            tid = chipset.terrain(self.map.lower(@x, @y))
+            row = db.terrain[tid]
+            terrain_name = row.background_name.to_s if row && row.respond_to?(:background_name)
+          end
+          name = Backdrop.name_for(map_id, props, terrain_name)
+          sys[125] = name unless name.nil? || name.empty?
+        rescue StandardError => e
+          $stderr.puts "[RPG2k] battle background lookup failed: #{e.message}"
+        end
+      end
       # Screen-transition slots 0..5 map to chunks 111..116 in order.
       @screen_transitions.each_with_index { |style, i| sys[111 + i] = style || 0 }
       # System windowskin / font override (Change System Graphics). Font id

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -933,7 +933,7 @@ class RPG2k
   # Write a real Save<slot>.lsd next to the Marshal save. Best-effort: any error
   # is logged and swallowed so it cannot break the primary save.
   def export_lsd state, slot = 1
-    state.to_lsd(state.save_count, nil, slot, @db).save_to(lsd_path(slot))
+    state.to_lsd(state.save_count, nil, slot, @db, @map_tree).save_to(lsd_path(slot))
   rescue StandardError => e
     $stderr.puts "[RPG2k] .lsd export failed for slot #{slot}: #{e.message}"
   end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3916,6 +3916,11 @@ end
 class FakeActorDB
   attr_reader :player, :system, :item, :skill, :job, :situation, :property, :battlecommands,
               :enemy_group, :battleranimations, :term
+  # Writable (unlike the others above): nil by default, matching a database
+  # with no chipset/terrain chunk at all -- set directly on an instance by
+  # the handful of checks that need Game::ChipSet/#terrain resolution (e.g.
+  # SAVE_SYSTEM field 125's own database-backed lookup).
+  attr_accessor :chipset, :terrain
   # `enemy_group` defaults to "every id exists" (Hash.new(true)) since most
   # checks using this fixture have nothing to do with troop validity; pass an
   # explicit hash (e.g. {}) to exercise the missing-troop-id diagnostic path.
@@ -22458,6 +22463,33 @@ check 'an unindexable tile reads the first lower tile' do
   td = Array.new(162, 3)
   td[0] = 7
   eq 7, chipset_with(td).terrain(-1)
+end
+
+check 'to_lsd resolves SAVE_SYSTEM field 125 (battle background) off the ' \
+      'map tree/terrain when given a database and map tree' do
+  # Confirmed byte-for-byte against a genuine kk1.12 save under wine: loading
+  # it and re-exporting via #to_lsd(..., db, map_tree) reproduces field 125
+  # ("草原", grassland) exactly. Game::Backdrop.name_for's own checks above
+  # already cover the map-tree backdrop_type walk in detail -- this one is
+  # about #to_lsd actually wiring db/map_tree into it end to end.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  db.chipset = { 1 => FakeChipsetRow.new('cs', 'cs', nil, nil, [7], 0, 0) }
+  db.terrain = { 7 => Struct.new(:background_name).new('Grassland') }
+  map_tree = Struct.new(:map_properties).new({ 5 => FakeMapNode.new(1, '') }) # type 1: use terrain
+
+  st = Game::State.new(Game::Party.new(db), 5, 0, 0)
+  st.map = Game::Map.new(5, FakeMapUnit.new(1, 1, 1, [0], []))
+
+  eq false, st.to_lsd[101].key?(125), 'omitted with no db/map_tree given (tests, tools)'
+
+  saved = st.to_lsd(1, nil, 1, db, map_tree)
+  eq 'Grassland', saved[101][125]
+
+  # backdrop_type 2 (the map's own specific file) overrides the terrain
+  # entirely, the same as Game::Backdrop.name_for's own already-tested rule.
+  map_tree.map_properties[5].backdrop_type = 2
+  map_tree.map_properties[5].backdrop_file = 'boss'
+  eq 'boss', st.to_lsd(1, nil, 1, db, map_tree)[101][125]
 end
 
 # -- chipset directional passability ------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4438,6 +4438,22 @@ check 'to_lsd mirrors chunk 104 field 21 (liblcf\'s own "direction") off ' \
   eq hero[22], hero[21], 'field 21 mirrors field 22 exactly'
 end
 
+check 'to_lsd writes chunk 104/105-107 field 33 (layer) as the constant 1, ' \
+      'for the hero and every vehicle alike' do
+  # Confirmed against a genuine kk1.12 save under wine: present as 1 ("same
+  # as characters") on the hero's own record and every vehicle's -- this
+  # codebase has no "Change Hero/Vehicle Layer" concept to source a live
+  # value from (RPG2000/2003 never offers one outside a map event's own
+  # page), so it is a true constant, not an omit-at-default field.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  saved = st.to_lsd
+  eq 1, saved[104].layer, "the hero's own record"
+  eq 1, saved[105].layer, 'the boat'
+  eq 1, saved[106].layer, 'the ship'
+  eq 1, saved[107].layer, 'the airship'
+end
+
 check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrides' do
   # do_change_system_bgm/_sfx (interpreter.rb) stash overrides in
   # @state.system_bgm/@state.system_sfx, keyed by slot -- the same slots


### PR DESCRIPTION
## Summary
- `Game::State#to_lsd` now accepts an optional `map_tree` argument alongside `db`, and together resolves chunk 101 (SAVE_SYSTEM) field 125 (liblcf's own `background`, this schema's long-standing `:battle_background` guess) the same way `Scene::Battle#encounter_backdrop` already picks a fight's own backdrop: `Game::Backdrop.name_for`'s map-tree `backdrop_type` walk, falling back to the party's current tile's own terrain via a `Game::ChipSet` built straight from `db`/`map_tree`.
- `Game::ChipSet` already lives in the `Game` namespace rather than `Scene::Map`-only, so no new scene-layer dependency was needed to wire this up — just the `db`/`map_tree` handles `#to_lsd` didn't have before. `main.rb`'s own save export passes `@map_tree` through alongside `@db`.
- Field 125's own meaning had been an open question across several prior cycles. Confirmed byte-for-byte against a genuine kk1.12 save under wine, taken during ordinary map exploration: loading it and re-exporting reproduces field 125 ("草原", grassland) exactly.
- **Also**: `#to_lsd` now writes chunk 104/105-107's field 33 (liblcf's own `layer`) as the constant 1 ("same as characters") for the hero and every vehicle — confirmed present with exactly this value on the same genuine save capture. RPG2000/2003 has no "Change Hero/Vehicle Layer" command, so this is a true constant, not live state — one more piece of the larger `SaveMapEventBase` gap this schema documents.

This closes the last of the three follow-ups flagged in #1417/#1419 (vehicle charset done, BGM restore points done, this closes the third), plus a small additional constant-field fix found along the way.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1162 checks passed (two new checks: field-125 database/map-tree wiring, and the field-33 constant)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks passed
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parsed cleanly
- [x] `ruby scripts/lcf_schema_coverage.rb` — every chunk in the test-bed data is named by the LCF schema
- [x] `ruby scripts/rpg2k_command_soak.rb` — every event command ran without raising or reporting a gap, across all four test-bed projects
- [x] Verified directly against the genuine kk1.12 save: loading and re-exporting reproduces fields 125 and 33 byte-for-byte

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB
