### PR TITLE
Add per-type mruby object counts to the profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@
   line to stderr, e.g.:
 
   ```
-  [profiler] fps=60.0 frame(work) avg=3.21ms max=8.40ms n=60 | mem rss=45.20MB lv_used=1.83MB lv_frag=12% live_blocks=48213 allocs/s=91234 | sections: scene.update avg=1.90ms max=6.10ms n=60 (59%) gfx.lvgl avg=0.80ms max=1.20ms n=60 (25%) gfx.zorder avg=0.20ms max=0.90ms n=17 (6%)
+  [profiler] fps=60.0 frame(work) avg=3.21ms max=8.40ms n=60 | mem rss=45.20MB lv_used=1.83MB lv_frag=12% live_blocks=48213 allocs/s=91234 | types: String=18234 Array=9021 Object=4110 Hash=812 | sections: scene.update avg=1.90ms max=6.10ms n=60 (59%) gfx.lvgl avg=0.80ms max=1.20ms n=60 (25%) gfx.zorder avg=0.20ms max=0.90ms n=17 (6%)
   ```
 
 - `frame(work)` is per-frame CPU time (the frame span minus the fps-cap sleep);
@@ -665,7 +665,15 @@
   the **top eight** sections fit on the line, so use the Chrome trace below to
   see the cheap ones. The memory
   fields cover process RSS, the LVGL heap pool and mruby allocation churn (live
-  blocks and allocations/sec; the allocation counters need the native build)
+  blocks and allocations/sec; the allocation counters need the native build).
+  `types` is the mruby heap broken down by object type (Ruby class), most-live
+  first and also capped at eight — a live population count straight off the
+  GC's own per-type counters (`patches/mruby-gc-type-live-counts.patch`), not
+  a sampled walk: no extra GC pass and no extra heap scan, so it costs nothing
+  beyond the existing `--profile` overhead. `RGSS::Profiler.stats` exposes the
+  uncapped breakdown as `:object_types` (a Hash of class name to `:live` and
+  cumulative `:allocs`), and a Chrome trace mirrors it as a `mruby_types`
+  counter series
 - Game/engine Ruby code can time its own hot spots with
   `RGSS::Profiler.section("name") { ... }`, and read the live numbers back as a
   Hash with `RGSS::Profiler.stats`

--- a/changelog.d/profiler-mruby-object-type-counts.added.md
+++ b/changelog.d/profiler-mruby-object-type-counts.added.md
@@ -1,0 +1,10 @@
+- **The built-in profiler now reports live mruby objects by type.** A new
+  vendored patch (`patches/mruby-gc-type-live-counts.patch`) adds a per-type
+  live/allocation counter pair to mruby's GC, kept current by a single
+  increment in `mrb_obj_alloc()` and a single decrement in the sweep phase's
+  `obj_free()` — unlike `ObjectSpace.count_objects`, which forces a full GC
+  before every call, this costs nothing beyond an O(30) memcpy to read. The
+  `--profile` stderr summary line gains a `types:` field (top eight, most-live
+  first), `RGSS::Profiler.stats` exposes the full breakdown as `:object_types`
+  (class name to `:live`/`:allocs`), and a Chrome trace (`--profile_trace`)
+  mirrors it as a `mruby_types` counter series.

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -148,6 +148,25 @@ function(rpg2k_add_mruby)
   set(mruby_nomem_patch
       "${ARG_REPO_ROOT}/patches/mruby-nomemoryerror-reentrant-alloc.patch")
 
+  # Vendored mruby has no way to see what a live heap is made of by type --
+  # the stock answer, the mruby-objectspace mrbgem's ObjectSpace.count_objects,
+  # forces a full mrb_full_gc() before every walk (patches/mruby-gc-type-
+  # live-counts.patch's own preamble has the full trail), which is the exact
+  # stop-the-world cost this project's profiler exists to watch for, so it
+  # cannot be the thing that watches for it. This patch instead adds a
+  # per-mrb_vtype live/allocation counter pair to mrb_gc, kept current by a
+  # single increment already-executing mrb_obj_alloc() and a single decrement
+  # in the sweep phase's obj_free() -- no extra heap walk, no extra GC pass --
+  # plus mrb_gc_type_counts() to read them out, which mruby-rgss/src/
+  # profiler.cxx uses to report per-type object counts through
+  # RGSS::Profiler.stats. Unlike the other patches here this is a project-
+  # owned addition rather than an upstream bug fix, so it is not expected to
+  # ever land upstream and stays permanently. Same patch-in-place treatment as
+  # the rest of this file, for the same reason (no fork of upstream
+  # mruby/mruby this project controls).
+  set(mruby_gc_type_counts_patch
+      "${ARG_REPO_ROOT}/patches/mruby-gc-type-live-counts.patch")
+
   # Point mruby's rake at the vendored mgem-list (the mgem index) via symlinks
   # in its repos/ dir so it resolves gems locally instead of cloning from
   # GitHub. Both repos/host and repos/<TARGET_NAME> are linked: a cross build
@@ -168,6 +187,8 @@ function(rpg2k_add_mruby)
             "${mruby_defined_keyword_patch}"
     COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
             "${mruby_nomem_patch}"
+    COMMAND "${ARG_REPO_ROOT}/scripts/apply_mruby_patch.bash" "${mruby_prefix}"
+            "${mruby_gc_type_counts_patch}"
     COMMAND
       mkdir -p ${mruby_build_dir}/repos/host
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME} && ln -sfn
@@ -178,7 +199,7 @@ function(rpg2k_add_mruby)
     WORKING_DIRECTORY "${mruby_prefix}"
     DEPENDS "${ARG_REPO_ROOT}/build_config.rb" "${mruby_colon3_patch}"
             "${mruby_dollar_bang_patch}" "${mruby_defined_keyword_patch}"
-            "${mruby_nomem_patch}" ${mrb_files})
+            "${mruby_nomem_patch}" "${mruby_gc_type_counts_patch}" ${mrb_files})
   add_custom_target(mruby_build DEPENDS "${libmruby_a}")
   add_dependencies(mruby mruby_build)
 

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -148,22 +148,21 @@ function(rpg2k_add_mruby)
   set(mruby_nomem_patch
       "${ARG_REPO_ROOT}/patches/mruby-nomemoryerror-reentrant-alloc.patch")
 
-  # Vendored mruby has no way to see what a live heap is made of by type --
-  # the stock answer, the mruby-objectspace mrbgem's ObjectSpace.count_objects,
+  # Vendored mruby has no way to see what a live heap is made of by type -- the
+  # stock answer, the mruby-objectspace mrbgem's ObjectSpace.count_objects,
   # forces a full mrb_full_gc() before every walk (patches/mruby-gc-type-
   # live-counts.patch's own preamble has the full trail), which is the exact
   # stop-the-world cost this project's profiler exists to watch for, so it
   # cannot be the thing that watches for it. This patch instead adds a
   # per-mrb_vtype live/allocation counter pair to mrb_gc, kept current by a
-  # single increment already-executing mrb_obj_alloc() and a single decrement
-  # in the sweep phase's obj_free() -- no extra heap walk, no extra GC pass --
-  # plus mrb_gc_type_counts() to read them out, which mruby-rgss/src/
-  # profiler.cxx uses to report per-type object counts through
-  # RGSS::Profiler.stats. Unlike the other patches here this is a project-
-  # owned addition rather than an upstream bug fix, so it is not expected to
-  # ever land upstream and stays permanently. Same patch-in-place treatment as
-  # the rest of this file, for the same reason (no fork of upstream
-  # mruby/mruby this project controls).
+  # single increment already-executing mrb_obj_alloc() and a single decrement in
+  # the sweep phase's obj_free() -- no extra heap walk, no extra GC pass -- plus
+  # mrb_gc_type_counts() to read them out, which mruby-rgss/src/ profiler.cxx
+  # uses to report per-type object counts through RGSS::Profiler.stats. Unlike
+  # the other patches here this is a project- owned addition rather than an
+  # upstream bug fix, so it is not expected to ever land upstream and stays
+  # permanently. Same patch-in-place treatment as the rest of this file, for the
+  # same reason (no fork of upstream mruby/mruby this project controls).
   set(mruby_gc_type_counts_patch
       "${ARG_REPO_ROOT}/patches/mruby-gc-type-live-counts.patch")
 
@@ -197,9 +196,13 @@ function(rpg2k_add_mruby)
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME}/mgem-list && ${mrb_opts} rake
       -v
     WORKING_DIRECTORY "${mruby_prefix}"
-    DEPENDS "${ARG_REPO_ROOT}/build_config.rb" "${mruby_colon3_patch}"
-            "${mruby_dollar_bang_patch}" "${mruby_defined_keyword_patch}"
-            "${mruby_nomem_patch}" "${mruby_gc_type_counts_patch}" ${mrb_files})
+    DEPENDS "${ARG_REPO_ROOT}/build_config.rb"
+            "${mruby_colon3_patch}"
+            "${mruby_dollar_bang_patch}"
+            "${mruby_defined_keyword_patch}"
+            "${mruby_nomem_patch}"
+            "${mruby_gc_type_counts_patch}"
+            ${mrb_files})
   add_custom_target(mruby_build DEPENDS "${libmruby_a}")
   add_dependencies(mruby mruby_build)
 

--- a/mruby-rgss/src/profiler.cxx
+++ b/mruby-rgss/src/profiler.cxx
@@ -3,6 +3,7 @@
 #include "terminal.hxx"
 
 #include <mruby.h>
+#include <mruby/gc.h>
 #include <mruby/hash.h>
 #include <mruby/string.h>
 
@@ -47,6 +48,62 @@ uint64_t g_interval_ns = 1'000'000'000ULL;  // 1s default
 profiler_allocf_t g_downstream_allocf = nullptr;
 int64_t g_live_blocks = 0;
 int64_t g_alloc_calls = 0;
+
+// ---- Per-type object counts -----------------------------------------------
+//
+// mrb_gc_type_counts() (patches/mruby-gc-type-live-counts.patch) reads out two
+// counters the GC itself now maintains per mrb_vtype: live objects and
+// cumulative allocations. Both are kept current by a single increment in
+// mrb_obj_alloc() and a single decrement in the sweep phase's obj_free(), so
+// reading them here is an O(MRB_TT_MAXDEFINE) memcpy -- no heap walk, no GC
+// triggered (unlike ObjectSpace.count_objects, which forces a full GC before
+// every call; see that patch's preamble for why that ruled it out here).
+//
+// report() and the trace writer below run off the C++ main loop, not a Ruby
+// call, so they have no mrb_state of their own; profiler_init() stashes the
+// one this project ever opens here, matching how g_downstream_allocf is
+// installed once and reused for the life of the process.
+mrb_state* g_mrb = nullptr;
+
+constexpr size_t kNumTypes = MRB_TT_MAXDEFINE;
+
+// Ruby class names for every mrb_vtype, built from mruby's own
+// MRB_VTYPE_FOREACH (mruby/value.h) so this can never drift out of sync with
+// the enum -- adding a type upstream (or via a future patch) grows this table
+// for free.
+const char* const kTypeNames[] = {
+#define RPG2K_VTYPE_NAME(tt, type, name) name,
+    MRB_VTYPE_FOREACH(RPG2K_VTYPE_NAME)
+#undef RPG2K_VTYPE_NAME
+};
+static_assert(sizeof(kTypeNames) / sizeof(kTypeNames[0]) == MRB_TT_MAXDEFINE,
+              "kTypeNames must cover every mrb_vtype in order");
+
+struct TypeCount {
+  const char* name;
+  size_t live;
+  size_t allocs;
+};
+
+// Non-zero (live or ever-allocated) types, hottest (most live) first. Reads
+// straight off the GC's own counters; empty (not an error) before
+// profiler_init() has run or once profiling never touched a real mrb_state.
+std::vector<TypeCount> live_type_snapshot() {
+  std::vector<TypeCount> out;
+  if (!g_mrb)
+    return out;
+  size_t live[kNumTypes] = {};
+  size_t allocs[kNumTypes] = {};
+  mrb_gc_type_counts(g_mrb, live, allocs);
+  for (size_t i = 0; i < kNumTypes; ++i) {
+    if (live[i] != 0 || allocs[i] != 0)
+      out.push_back(TypeCount{kTypeNames[i], live[i], allocs[i]});
+  }
+  std::sort(out.begin(), out.end(), [](const TypeCount& a, const TypeCount& b) {
+    return a.live > b.live;
+  });
+  return out;
+}
 
 // ---- Per-interval aggregation --------------------------------------------
 
@@ -276,6 +333,19 @@ void report(uint64_t now) {
                 static_cast<long long>(g_live_blocks), alloc_rate);
   line += buf;
 
+  // Object types, most live first, capped so the line stays readable -- the
+  // full breakdown is in RGSS::Profiler.stats and the trace.
+  const std::vector<TypeCount> types = live_type_snapshot();
+  if (!types.empty()) {
+    line += " | types:";
+    const size_t top = std::min<size_t>(types.size(), 8);
+    for (size_t i = 0; i < top; ++i) {
+      std::snprintf(buf, sizeof(buf), " %s=%llu", types[i].name,
+                    static_cast<unsigned long long>(types[i].live));
+      line += buf;
+    }
+  }
+
   // Sections, hottest first (by total time), capped so the line stays readable.
   std::vector<std::pair<std::string, SectionAgg>> secs_v(g_sections.begin(),
                                                          g_sections.end());
@@ -312,6 +382,18 @@ void report(uint64_t now) {
     std::snprintf(args, sizeof(args), "\"live\":%lld",
                   static_cast<long long>(g_live_blocks));
     trace_counter("mruby_blocks", now, args);
+    if (!types.empty()) {
+      std::string type_args;
+      for (const TypeCount& t : types) {
+        if (!type_args.empty())
+          type_args += ',';
+        type_args += "\"";
+        type_args += json_escape(t.name);
+        type_args += "\":";
+        type_args += std::to_string(t.live);
+      }
+      trace_counter("mruby_types", now, type_args);
+    }
     std::fflush(g_trace_file);
   }
 
@@ -561,6 +643,27 @@ mrb_value prof_stats(mrb_state* M, mrb_value) {
                  sh);
   }
   mrb_hash_set(M, h, mrb_symbol_value(mrb_intern_lit(M, "sections")), sections);
+
+  // Object type breakdown -- straight off the GC's own per-type counters
+  // (mrb_gc_type_counts, patches/mruby-gc-type-live-counts.patch), not the
+  // top-eight-capped subset the stderr summary line shows.
+  mrb_value object_types = mrb_hash_new(M);
+  size_t live[kNumTypes] = {};
+  size_t allocs[kNumTypes] = {};
+  mrb_gc_type_counts(M, live, allocs);
+  for (size_t i = 0; i < kNumTypes; ++i) {
+    if (live[i] == 0 && allocs[i] == 0)
+      continue;
+    mrb_value th = mrb_hash_new(M);
+    mrb_hash_set(M, th, mrb_symbol_value(mrb_intern_lit(M, "live")),
+                 mrb_fixnum_value(static_cast<mrb_int>(live[i])));
+    mrb_hash_set(M, th, mrb_symbol_value(mrb_intern_lit(M, "allocs")),
+                 mrb_fixnum_value(static_cast<mrb_int>(allocs[i])));
+    mrb_hash_set(M, object_types, mrb_str_new_cstr(M, kTypeNames[i]), th);
+  }
+  mrb_hash_set(M, h, mrb_symbol_value(mrb_intern_lit(M, "object_types")),
+               object_types);
+
   return h;
 }
 
@@ -602,6 +705,7 @@ mrb_value prof_tracing_p(mrb_state* M, mrb_value) {
 }  // namespace
 
 void profiler_init(mrb_state* M) {
+  g_mrb = M;
   RClass* rgss = mrb_module_get(M, "RGSS");
   RClass* prof = mrb_define_module_under(M, rgss, "Profiler");
   mrb_define_module_function(M, prof, "enabled?", prof_enabled_p,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1515,6 +1515,21 @@ assert "RGSS::Profiler aggregates frames and sections when enabled" do
     assert_equal 3, sections["work"][:calls]
     assert_true sections["work"][:avg_ms] >= 0.0
 
+    # object_types comes straight off the GC's own per-type counters (see
+    # patches/mruby-gc-type-live-counts.patch), not a sampled/capped subset --
+    # the mruby heap is never empty (the interpreter's own bootstrap objects
+    # alone guarantee at least one live Object/Class/String), so this must be
+    # non-empty even though the "work" block itself never touches the heap.
+    object_types = st[:object_types]
+    assert_true object_types.is_a?(Hash)
+    assert_true object_types.size > 0, "expected at least one live object type"
+    object_types.each do |name, counts|
+      assert_true name.is_a?(String)
+      assert_true counts[:live] >= 0
+      assert_true counts[:allocs] >= counts[:live],
+                  "#{name}: cumulative allocs must be >= current live count"
+    end
+
     # report and reset must not raise; reset clears the interval.
     RGSS::Profiler.report
     RGSS::Profiler.reset

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1516,13 +1516,15 @@ assert "RGSS::Profiler aggregates frames and sections when enabled" do
     assert_true sections["work"][:avg_ms] >= 0.0
 
     # object_types comes straight off the GC's own per-type counters (see
-    # patches/mruby-gc-type-live-counts.patch), not a sampled/capped subset --
-    # the mruby heap is never empty (the interpreter's own bootstrap objects
-    # alone guarantee at least one live Object/Class/String), so this must be
-    # non-empty even though the "work" block itself never touches the heap.
+    # patches/mruby-gc-type-live-counts.patch), not a sampled/capped subset.
+    # Under real mruby this is never empty -- the interpreter's own bootstrap
+    # objects alone guarantee at least one live Object/Class/String -- but
+    # this same file also runs under the CRuby compat harness
+    # (scripts/rgss_cruby_compat.rb), which has no equivalent GC introspection
+    # and stubs it as {}, so only the shape is asserted unconditionally; the
+    # per-entry invariants below still exercise real data on a native build.
     object_types = st[:object_types]
     assert_true object_types.is_a?(Hash)
-    assert_true object_types.size > 0, "expected at least one live object type"
     object_types.each do |name, counts|
       assert_true name.is_a?(String)
       assert_true counts[:live] >= 0

--- a/patches/mruby-gc-type-live-counts.patch
+++ b/patches/mruby-gc-type-live-counts.patch
@@ -1,0 +1,99 @@
+mruby has no built-in way to see what a live mruby heap is made of --
+neither "how many Strings/Arrays/Hashes/... are alive right now" nor "which
+type is producing the allocation churn." The only stock answer is the
+mruby-objectspace mrbgem's ObjectSpace.count_objects, and it does not fit
+this project's always-on profiler (docs/profiling.md; mruby-rgss/src/
+profiler.cxx): mrb_objspace_each_objects() (src/gc.c) calls mrb_full_gc()
+before every walk, then iterates every slot of every heap page (live and
+dead). Sampling object-type stats once a second this way would mean forcing
+a full stop-the-world mark-and-sweep once a second -- the exact class of
+pause docs/profiling.md's map-render optimization (350k allocs/s -> 10k/s)
+was written to get rid of, self-inflicted by the very tool meant to watch
+for it.
+
+Every heap object of every type already funnels through one function,
+mrb_obj_alloc() (src/gc.c), which already switches on ttype before handing
+back a slot; and mruby's own incremental sweep already visits every dead
+object exactly once, in obj_free() (src/gc.c), which already has obj->tt
+in hand before it gets stomped to MRB_TT_FREE. This patch adds a
+size_t[MRB_TT_MAXDEFINE] pair to mrb_gc (include/mruby/gc.h) -- tt_live
+(currently-live objects, by mrb_vtype) and tt_allocs (cumulative
+allocations, by mrb_vtype) -- and one increment in mrb_obj_alloc, one
+decrement in obj_free, to keep them current. Both are single array-index
+updates on paths that already run for every object; no extra heap walk, no
+extra GC pass, and (unlike ObjectSpace.count_objects) no measurement-
+induced GC pressure. A new accessor, mrb_gc_type_counts(), copies both
+arrays out for a caller (mruby-rgss/src/profiler.cxx) to report, e.g.
+through RGSS::Profiler.stats -- an O(MRB_TT_MAXDEFINE) memcpy, cheap enough
+to call every frame if wanted.
+
+This is a project-owned addition, not an upstream mruby bug fix, so unlike
+the other patches in this directory it will never land upstream and this
+patch stays permanently (or until this project's own mruby pin gains
+something equivalent). Same patch-in-place treatment as the rest of this
+directory, for the same reason (no fork of upstream mruby/mruby this
+project controls).
+
+--- a/include/mruby/gc.h
++++ b/include/mruby/gc.h
+@@ -48,6 +48,8 @@ typedef struct mrb_gc {
+   mrb_bool gray_overflow:1;        /* gray stack overflowed; needs heap rescan */
+   size_t live;                     /* count of live objects */
+   size_t live_after_mark;          /* old generation objects */
++  size_t tt_live[MRB_TT_MAXDEFINE];   /* live objects, by mrb_vtype */
++  size_t tt_allocs[MRB_TT_MAXDEFINE]; /* cumulative allocations, by mrb_vtype */
+   size_t threshold;                /* threshold to start GC */
+   size_t oldgen_threshold;         /* threshold to kick major GC */
+   mrb_gc_state state;              /* current state of gc */
+@@ -72,6 +74,17 @@ typedef struct mrb_gc {
+ MRB_API mrb_bool mrb_object_dead_p(struct mrb_state *mrb, struct RBasic *object);
+ MRB_API int mrb_gc_add_region(struct mrb_state *mrb, void *start, size_t size);
+
++/*
++ * Snapshot the GC's per-type live/allocation counters into caller-owned
++ * arrays of MRB_TT_MAXDEFINE size_t entries each (index by enum mrb_vtype,
++ * e.g. MRB_TT_STRING). live_out reports currently-live objects of that type;
++ * alloc_out reports cumulative allocations since mrb_open(). Either pointer
++ * may be NULL to skip that half. O(MRB_TT_MAXDEFINE) -- no heap walk, no GC
++ * triggered: the counters are maintained incrementally by mrb_obj_alloc()
++ * and the sweep phase's obj_free(), so this is safe to call every frame.
++ */
++MRB_API void mrb_gc_type_counts(struct mrb_state *mrb, size_t *live_out, size_t *alloc_out);
++
+ #define MRB_GC_RED 7
+
+ MRB_END_DECL
+--- a/src/gc.c
++++ b/src/gc.c
+@@ -602,6 +602,8 @@ mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
+   }
+
+   gc->live++;
++  gc->tt_live[ttype]++;
++  gc->tt_allocs[ttype]++;
+   gc_protect(mrb, gc, &p->as.basic);
+   *p = RVALUE_zero;
+   p->as.basic.tt = ttype;
+@@ -613,6 +615,14 @@ mrb_obj_alloc(mrb_state *mrb, enum mrb_vtype ttype, struct RClass *cls)
+   return &p->as.basic;
+ }
+
++MRB_API void
++mrb_gc_type_counts(mrb_state *mrb, size_t *live_out, size_t *alloc_out)
++{
++  mrb_gc *gc = &mrb->gc;
++  if (live_out) memcpy(live_out, gc->tt_live, sizeof(gc->tt_live));
++  if (alloc_out) memcpy(alloc_out, gc->tt_allocs, sizeof(gc->tt_allocs));
++}
++
+ static inline void
+ add_gray_list(mrb_gc *gc, struct RBasic *obj)
+ {
+@@ -851,6 +861,7 @@ static void
+ obj_free(mrb_state *mrb, struct RBasic *obj, mrb_bool end)
+ {
+   DEBUG(fprintf(stderr, "obj_free(%p,tt=%d)\n",obj,obj->tt));
++  mrb->gc.tt_live[obj->tt]--;
+   switch (obj->tt) {
+   case MRB_TT_OBJECT:
+     mrb_gc_free_iv(mrb, (struct RObject*)obj);

--- a/scripts/rgss_cruby_compat.rb
+++ b/scripts/rgss_cruby_compat.rb
@@ -2373,7 +2373,12 @@ module RGSS
           rss_bytes: 0,
           live_blocks: 0,
           lv_used_bytes: 0,
-          sections: sections
+          sections: sections,
+          # The native profiler (mruby-rgss/src/profiler.cxx) reads this from
+          # mruby's own GC counters (patches/mruby-gc-type-live-counts.patch),
+          # which have no CRuby equivalent -- stubbed empty like the other
+          # native-only fields above rather than omitted.
+          object_types: {}
         }
       end
 


### PR DESCRIPTION
ObjectSpace.count_objects forces a full mrb_full_gc() before every walk,
which is exactly the stop-the-world cost the profiler exists to watch
for -- unfit for a sampler that runs once a second. Instead, patch
vendored mruby (patches/mruby-gc-type-live-counts.patch) to maintain a
per-mrb_vtype live/allocation counter pair as a byproduct of paths every
object already goes through: one increment in mrb_obj_alloc(), one
decrement in the sweep phase's obj_free(). Reading them back is an
O(MRB_TT_MAXDEFINE) memcpy, no extra heap walk or GC pass.

Wire the new mrb_gc_type_counts() into RGSS::Profiler: a `types:` field
on the stderr summary line, the full breakdown as `:object_types` in
RGSS::Profiler.stats, and a `mruby_types` Chrome trace counter series.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0117pag6Su2mrNWMN3QByEA3