### PR TITLE
Write chunk 101 field 78 (memorized BGM) unconditionally, "(OFF)" default

### DIFF
--- a/changelog.d/memorized-bgm-off-placeholder.fixed.md
+++ b/changelog.d/memorized-bgm-off-placeholder.fixed.md
@@ -1,0 +1,12 @@
+- `Game::State#to_lsd` now writes chunk 101 (SAVE_SYSTEM) field 78
+  (`stored_bgm`, Memorize BGM's own stash) unconditionally, "(OFF)" when
+  nothing has been memorized — the same convention fields 76/77
+  (before_vehicle_music/before_battle_music) already follow, not the
+  "omit when nil" this field used before. Confirmed against a genuine
+  kk1.12 save under wine: field 78 was present even though that session
+  never ran Memorize BGM, decoding as a BGM struct whose own `file` read
+  the literal "(OFF)". A recent fix to `Game::State.bgm_from_chunk` (treating
+  the "(OFF)" placeholder as nil, matching `#play_bgm_or_stop`'s existing
+  live-playback fix) exposed this: previously "(OFF)" round-tripped as a
+  truthy value by accident, masking that genuine RPG_RT never actually
+  omits this field at all.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -15269,7 +15269,13 @@ module Game
       # as a BGM struct whose own `file` read the literal "(OFF)".
       sys[76] = bgm_chunk(@pre_vehicle_bgm || { name: '(OFF)' })
       sys[77] = bgm_chunk(@pre_battle_bgm || { name: '(OFF)' })
-      sys[78] = bgm_chunk(@memorized_bgm) if @memorized_bgm
+      # Field 78 (stored_bgm/Memorize BGM's own stash, 11530) follows the
+      # exact same "always present, (OFF) when nothing to hold" convention
+      # as 76/77 above, not the "omit at default" this field used before --
+      # confirmed against the same genuine kk1.12 save under wine: present
+      # even though that session never ran Memorize BGM, decoding as a BGM
+      # struct whose own `file` read the literal "(OFF)".
+      sys[78] = bgm_chunk(@memorized_bgm || { name: '(OFF)' })
       # Change System BGM (10660) overrides (SYSTEM_BGM_SAVE_FIELD above) --
       # like field 71 and the SFX slots below, all seven are written
       # unconditionally (blank when unset), confirmed against the same

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4581,6 +4581,28 @@ check 'to_lsd/from_lsd round-trips the current and memorized BGM\'s balance, ' \
   eq 60, round.memorized_bgm[:balance], 'and its balance round-trips too'
 end
 
+check 'to_lsd writes chunk 101 field 78 (stored_bgm/Memorize BGM) ' \
+      'unconditionally, "(OFF)" when nothing memorized' do
+  # Confirmed against a genuine kk1.12 save under wine: field 78 was present
+  # even though that session never ran Memorize BGM (11530), decoding as a
+  # BGM struct whose own `file` read the literal "(OFF)" -- the same
+  # "always present, (OFF) as placeholder" convention fields 76/77 already
+  # follow, not the "omit when nil" this field used before (a bug the
+  # bgm_from_chunk "(OFF)" sentinel fix exposed: previously "(OFF)" round-
+  # tripped as a truthy value by accident, masking that this field was never
+  # actually omitted by genuine RPG_RT at all).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq nil, st.memorized_bgm
+
+  saved = st.to_lsd
+  eq true, saved[101].key?(78), 'always present, unlike an ordinary omit-at-default field'
+  eq '(OFF)', saved[101][78].file
+
+  round = Game::State.from_lsd(db, saved)
+  eq nil, round.memorized_bgm, '"(OFF)" reads back as nil, not a literal track named "(OFF)"'
+end
+
 check 'to_lsd/from_lsd round-trips the vehicle/battle BGM restore point ' \
       '(chunk 101 fields 76/77), "(OFF)" when nothing to restore' do
   # Confirmed against a genuine kk1.12 save under wine, taken outside any


### PR DESCRIPTION
## Summary
- `Game::State#to_lsd` now writes chunk 101 (SAVE_SYSTEM) field 78 (`stored_bgm`, Memorize BGM's own stash) unconditionally, `"(OFF)"` when nothing has been memorized — the same convention fields 76/77 (`before_vehicle_music`/`before_battle_music`) already follow, not the "omit when nil" this field used before.
- Confirmed against a genuine kk1.12 save under wine: field 78 was present even though that session never ran Memorize BGM, decoding as a BGM struct whose own `file` read the literal `"(OFF)"`.
- Found via a full re-diff against the genuine save after the recent `bgm_from_chunk` `"(OFF)"` sentinel fix (#1419): that fix made `.from_lsd` correctly read a genuine `"(OFF)"` stash as nil, which then exposed that `#to_lsd`'s own conditional write (`if @memorized_bgm`) had been silently relying on the old bug to round-trip this field at all.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1163 checks passed (new check added)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks passed
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parsed cleanly
- [x] `ruby scripts/lcf_schema_coverage.rb` — every chunk in the test-bed data is named by the LCF schema
- [x] `ruby scripts/rpg2k_command_soak.rb` — every event command ran without raising or reporting a gap
- [x] Verified directly against the genuine kk1.12 save: field 78 now matches exactly; only remaining chunk 101 diffs are `frame_count` and `event_message_active`, both expected artifacts of the synthetic (non-gameplay) reconstruction used for diffing, not real bugs

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_