### PR TITLE
Cycle #185: finish EasyRPG-citation sweep on scripts/ check files (267 fixed)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6340,6 +6340,80 @@ The work below is roughly ordered by the critical path to a walkable game
   another pass. The two flagged-tractable wine-verification items (move-route
   Speed Up/Down ceiling's exact value, RPG2003 Teleport facing on a genuine
   RPG2003 database) remain untouched, as expected for a comment-only cycle.
+  ✅ **Follow-up (cycle #185, 2026-08-27): finished the EasyRPG-citation sweep
+  cycle #184 left open (item (3) above) -- explicitly a lighter-weight
+  cycle, no wine/Xvfb work, comment editing only.** **Method:** re-verified
+  the count with cycle #184's own grep first, then noticed it undercounts:
+  `src/[a-z_]+\.(cpp|h)` requires letters/underscore only, so a filename with
+  a digit (`scene_battle_rpg2k.cpp`, `scene_battle_rpg2k3.cpp`,
+  `window_shopnumber.cpp`, `game_interpreter_control_variables.cpp`, ...)
+  silently escapes it -- widened to `src/[a-z0-9_]+\.(cpp|h)` for this
+  cycle's own counting and swept both files against the wider pattern.
+  Worked `rpg2k_logic_check.rb`'s own remaining ~94 first (the smaller,
+  more self-contained battle-algorithm section, per this cycle's own
+  priority), read top-to-bottom in ~150-300 line chunks rather than
+  grep-hopping, then continued into `rpg2k_scene_check.rb`'s own back half.
+  Every fix followed the established rule: where a comment already carried
+  independent evidence (a wine confirmation, this codebase's own
+  schema/liblcf generator citation, or established community trivia sources
+  such as yado.tk/デフォ戦bot already used elsewhere in this codebase), the
+  EasyRPG citation was dropped and the independent evidence kept untouched
+  (several dozen such comments, mostly the already-honest historical
+  corrections from cycles #154-#184 and the liblcf-schema citations, were
+  left alone entirely); everywhere else, rewritten to "ported from EasyRPG
+  Player's source, NOT independently confirmed against genuine RPG_RT under
+  wine" (or an equivalent phrasing fitted to the sentence), preserving the
+  underlying technical description of what the ported mechanism actually
+  does. A handful of check *titles* (not their `ok`/`eq` assertion calls)
+  also carried the same misattribution ("matching RPG_RT", "(RPG_RT)") and
+  got the same honest-downgrade treatment. Two same-comment cases mixed a
+  legitimate liblcf schema/field-id citation with an illegitimate EasyRPG
+  behavioral one in the same paragraph (`rpg2k_logic_check.rb`'s Change
+  Encounter Rate/Parallax Background save round-trip citations,
+  `rpg2k_scene_check.rb`'s terrain-footstep Sound-field citation) -- the
+  liblcf half was kept, only the EasyRPG behavioral half was downgraded.
+  **Net result:** re-counted with the widened pattern before touching
+  anything -- `rpg2k_logic_check.rb` actually carried 99 citations (not 94;
+  5 had names with digits the narrow pattern missed), `rpg2k_scene_check.rb`
+  178 (not 177; 1 digit-named miss). `rpg2k_logic_check.rb` went from 99 to
+  2 real remaining (both cycle #169's own already-honest historical
+  corrections, not violations) -- 97 fixed. `rpg2k_scene_check.rb` went from
+  178 to 8 real remaining, all of which are pre-existing, already-honest
+  historical-correction/wine-confirmation comments (cycle #169's Set
+  Transparent Flag/actor-graphic Transparent-flag corrections, cycle #123's
+  SaveLoad recency citation, and similar) that legitimately mention an
+  EasyRPG path only to say it was wrong or superseded -- verified by reading
+  each of the 8 in full before leaving it alone -- 170 fixed. Combined: 267
+  citations fixed across both files in this cycle, clearing every
+  illegitimate citation this sweep set out to find in
+  `scripts/rpg2k_logic_check.rb` and `rpg2k_scene_check.rb`, a fully
+  exhaustive pass rather than a partial one.
+  **Verification:** `ruby -c` clean on both files. Comment-only: `git diff
+  -- scripts/rpg2k_logic_check.rb scripts/rpg2k_scene_check.rb | grep -E
+  '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-][[:space:]]*#' |
+  grep -vE '^[+-][[:space:]]*$'` returned only check-title string lines
+  (68 total across both files), never an `ok`/`eq`/assertion line. `ruby
+  scripts/rpg2k_logic_check.rb` (1150) and `ruby scripts/rpg2k_scene_check.rb`
+  (929) both passed at their existing pre-cycle baselines exactly,
+  confirming no assertion was touched. `cd build && ctest -R mruby_test`
+  passed (3.97s) -- unaffected, as expected, since no `mrblib` file was
+  touched. No wine/Xvfb/matchbox process was started this cycle. No new
+  EasyRPG source was consulted for any behavioral claim -- existing
+  citations were read only to identify and rewrite them, per every prior
+  cycle in this sweep's own ground rule. No changelog fragment: this is
+  comment-only documentation work, not a behavioral fix.
+  **Left open for a future cycle:** none from this specific sweep --
+  `scripts/rpg2k_logic_check.rb` and `rpg2k_scene_check.rb` are both clear
+  of illegitimate EasyRPG-source citations now, down to only pre-existing
+  honest historical corrections. The two flagged-tractable wine-verification
+  items cycle #184 also left open (move-route Speed Up/Down ceiling's exact
+  value, RPG2003 Teleport facing on a genuine RPG2003 database) remain
+  untouched, as expected for a comment-only cycle -- a future cycle with
+  wine/Xvfb available should pick those up. A prior cycle should re-run the
+  same widened `src/[a-z0-9_]+\.(cpp|h)` + bare-EasyRPG-mention scan against
+  the rest of the codebase (`mrblib/*.rb`, other `scripts/*.rb` check files)
+  before assuming the whole citation-sweep effort is complete -- this cycle
+  only scoped the two files named in its own instructions.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5480,8 +5480,9 @@ check 'Party#reorder applies a picked front-to-back permutation, ' \
       'and can change the leader' do
   # RPG2003's Order menu command -- see Scene::Order (mruby-rpg2k/mrblib/
   # scene/order.rb), which builds exactly this kind of permutation one pick
-  # at a time and hands it to #reorder. Confirmed against EasyRPG's own
-  # `Scene_Order::Confirm`, which has the same net effect (remove every
+  # at a time and hands it to #reorder. Per EasyRPG Player's source (NOT
+  # independently confirmed against genuine RPG_RT under wine), its
+  # `Scene_Order::Confirm` has the same net effect (remove every
   # member, then re-add them in the picked order).
   players = (1..4).to_h { |i| [i, FakePlayerRow.new("Actor#{i}", '', 0, 1, max_hp: 10)] }
   db = FakeActorDB.new(players, [1, 2, 3, 4])
@@ -12530,8 +12531,9 @@ check 'a random encounter reports and skips a missing troop id without arming th
   eq :battle, it.wait_kind
 end
 
-# Ports EasyRPG's own `Game_Battle::HasDeathHandler`/
-# `GetDeathHandlerCommonEvent`/`GetDeathHandlerTeleport` (src/game_battle.cpp):
+# Ported from EasyRPG Player's source (its HasDeathHandler/
+# GetDeathHandlerCommonEvent/GetDeathHandlerTeleport equivalents), NOT
+# independently confirmed against genuine RPG_RT under wine:
 # `Player::IsRPG2k3() && db.death_handler` gates all three. A scripted Battle
 # Processing command's own [Defeat] handler (`defeat_game_over: cmd.param(4)
 # == 0`, above) is unaffected either way -- this only changes a *random*
@@ -12619,11 +12621,11 @@ def combatant_mp(name, atk, dfn, agi, hp, mp)
   c
 end
 
-# The Actor-side checks above cover the field-side prune/cure paths; every
-# `Game_BattleAlgorithm` subclass's own state mutation
-# (src/game_battlealgorithm.cpp) threads the identical
-# `target->GetPermanentStates()` into every in-battle `State::Add`/
-# `State::Remove` too -- `Game::Battle#inflict_state`/`#cure_state` had no
+# The Actor-side checks above cover the field-side prune/cure paths; ported
+# from EasyRPG Player's source (every `Game_BattleAlgorithm` subclass's own
+# state mutation threads the identical `target->GetPermanentStates()` into
+# every in-battle State::Add/State::Remove too), NOT independently confirmed
+# against genuine RPG_RT under wine -- `Game::Battle#inflict_state`/`#cure_state` had no
 # such wiring at all, so the exact same cursed state that already survived
 # a lethal hit and resisted Full Recovery on the field could still be
 # stripped by a lethal in-battle hit, or cured outright by a curative
@@ -12759,9 +12761,10 @@ check 'to_lsd/from_lsd round-trips a live Change Encounter Rate override ' \
   # Real RPG_RT's SaveMapInfo.encounter_steps (liblcf generator/csv/
   # fields.csv: `SaveMapInfo,encounter_steps,f,Int32,0x03,-1,...`) restores a
   # Save/Continue on the same map to whatever Change Encounter Rate (11740)
-  # had overridden -- Game_Map::PrepareSave/SetEncounterSteps
-  # (src/game_map.cpp) confirmed directly against EasyRPG's own live source;
-  # #to_lsd/.from_lsd previously never touched field 3 at all, so the
+  # had overridden -- Game_Map::PrepareSave/SetEncounterSteps, ported from
+  # EasyRPG Player's source and NOT independently confirmed against genuine
+  # RPG_RT under wine (the field id/type above is the independently-verified
+  # part, from liblcf's own schema); #to_lsd/.from_lsd previously never touched field 3 at all, so the
   # override silently reverted to the map's own default the moment a real
   # save was reloaded.
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
@@ -12797,8 +12800,10 @@ check 'to_lsd/from_lsd round-trips a live Change Parallax Background ' \
   # parallax_name,f,String,0x20,...` through `...,parallax_vert_speed,f,
   # Int32,0x26,...`) restore a Save/Continue on the same map to whatever
   # Change Parallax Background (11720) had overridden --
-  # Game_Map::Parallax::ChangeBG/GetParallaxParams (src/game_map.cpp)
-  # confirmed directly against EasyRPG's own live source, the same `map_info`
+  # Game_Map::Parallax::ChangeBG/GetParallaxParams, ported from EasyRPG
+  # Player's source and NOT independently confirmed against genuine RPG_RT
+  # under wine (the field ids/types above are the independently-verified
+  # part, from liblcf's own schema); the same `map_info`
   # struct `SetupFromSave` restores wholesale before ChangeBG re-derives the
   # live panorama from it. #to_lsd/.from_lsd previously never touched these
   # fields at all, so the override silently reverted to the map's own
@@ -12834,10 +12839,11 @@ end
 
 check 'to_lsd/from_lsd round-trips Set Teleport Target / Set Escape Target ' \
       '(chunk 110)' do
-  # Confirmed directly against RPG_RT's live source: `Scene_Save::Prepare`/
-  # `Player::LoadSavegame` (`src/scene_save.cpp`/`src/player.cpp`) round-trip
-  # `save.targets` via `Game_Targets::GetSaveData`/`SetSaveData`
-  # (`src/game_targets.cpp`) unconditionally on every save -- the escape
+  # Ported from EasyRPG Player's source (`Scene_Save::Prepare`/
+  # `Player::LoadSavegame` round-trip `save.targets` via
+  # `Game_Targets::GetSaveData`/`SetSaveData`), NOT independently confirmed
+  # against genuine RPG_RT under wine -- claimed to round-trip
+  # unconditionally on every save -- the escape
   # target always at array id 0, every teleport target keyed by its own
   # destination map id. #to_lsd/.from_lsd previously never touched chunk 110
   # at all (only this engine's own portable Marshal save round-tripped these
@@ -13028,8 +13034,9 @@ check "an enemy's own missing state-rank entry defaults to B (80%), an actor's t
   eq 100, bat.send(:state_susceptibility, slime, 2), "state 2 is explicitly rank A (100%) for the enemy too"
 end
 
-# Ports EasyRPG's `Game_Actor::GetStateProbability` (src/game_actor.cpp): a
-# shield/armor/helmet/accessory that flags a state in its own `state_set`
+# Ported from EasyRPG Player's source (its Game_Actor::GetStateProbability
+# equivalent), NOT independently confirmed against genuine RPG_RT under
+# wine: a shield/armor/helmet/accessory that flags a state in its own `state_set`
 # resists it landing at all, by `100 - state_chance` percent, on top of the
 # target's A-E rank. `Game_Enemy::GetStateProbability` never scans equipment
 # at all (monsters equip nothing), so only an ally is affected.
@@ -13182,10 +13189,11 @@ check 'battle: a crit chance is paid out at the rate it states' do
      "a 1-in-20 chance crit #{crits} times in #{trials}, wanted about #{want.round}"
 end
 
-check 'battle: critical? draws from the RNG even at an exact 0% crit chance, matching RPG_RT (2026-08-18)' do
-  # EasyRPG's Rand::PercentChance(crit_chance) rolls unconditionally, even
-  # when crit_chance is exactly 0 -- Game_BattleAlgorithm's vExecute call
-  # sites (src/game_battlealgorithm.cpp, both the basic-attack and skill
+check 'battle: critical? draws from the RNG even at an exact 0% crit chance, per EasyRPG Player (2026-08-18, NOT independently confirmed against genuine RPG_RT under wine)' do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Rand::PercentChance(crit_chance) rolls
+  # unconditionally, even when crit_chance is exactly 0 -- its
+  # Game_BattleAlgorithm's vExecute call sites (both the basic-attack and skill
   # ones) carry no `crit_chance > 0` guard around the roll. So a battler with
   # no crit ability at all (the common case: most enemies, and any actor
   # before equipping a crit-capable weapon) still burns one draw from the
@@ -13371,8 +13379,9 @@ end
 
 # ランダムに出現 (Appear Randomly, chunk 15 field 6): parsed but never read
 # before this fix -- every troop with the box checked behaved exactly like
-# one without it. Ports EasyRPG's actual C++ source, `Game_EnemyParty
-# ::ResetBattle` (src/game_enemyparty.cpp): a per-member
+# one without it. Ported from EasyRPG Player's source (its
+# `Game_EnemyParty::ResetBattle` equivalent), NOT independently confirmed
+# against genuine RPG_RT under wine: a per-member
 # `Rand::PercentChance(40)` roll in member order, stopping the instant only
 # one member is left visible.
 AppearRandomRow = Struct.new(:name, :members, :appear_randomly)
@@ -13668,8 +13677,9 @@ check 'battle: two attributes of the same type keep the strongest rate, not mult
   eq 40, bat.step_action[:damage] # base 20 * 200%, not 200% * 200%
 end
 
-check 'battle: RPG2000 drops a negative-rate attribute instead of healing (yado.tk / ' \
-     'EasyRPG src/attribute.cpp)' do
+check 'battle: RPG2000 drops a negative-rate attribute instead of healing (yado.tk; ' \
+     'ported from EasyRPG Player\'s source, NOT independently confirmed against ' \
+     'genuine RPG_RT under wine)' do
   # Rank E (index 4) set to a deliberate -100% -- a plain signed database
   # field, not something the editor forbids.
   props = { 1 => RateRow.new(200, 150, 100, 50, -100, 0) } # weapon-type
@@ -13797,8 +13807,9 @@ end
    eq 90, c[:chance]                            # no agility term, just skill.hit
  end
 
- # 3 (Switch): EasyRPG's `Game_BattleAlgorithm::Skill::vExecute`
- # (`src/game_battlealgorithm.cpp`) special-cases a switch skill before any of
+ # 3 (Switch): per EasyRPG Player's source (NOT independently confirmed
+ # against genuine RPG_RT under wine), its `Game_BattleAlgorithm::Skill::vExecute`
+ # special-cases a switch skill before any of
  # the ordinary hit/damage/state logic -- `SetAffectedSwitch(skill.switch_id);
  # return SetIsSuccess();` -- so casting one in a fight, exactly like on the
  # field (`#cast_switch_skill`), only ever spends its SP and flips its switch.
@@ -14102,10 +14113,11 @@ check 'Battle#first_strike? is true only for the opening ambush round, ' \
   # `@rounds` is 0 for the whole of round 1's command phase (before
   # #begin_round has ever run -- Scene::Battle only calls it once every
   # actor already has a command, including a possible Escape) and 1 or
-  # higher for every round after, mirroring EasyRPG's own `first_strike`
-  # flag: set for the whole of round 1 and cleared right before round 2's
+  # higher for every round after, mirroring EasyRPG Player's own `first_strike`
+  # flag (NOT independently confirmed against genuine RPG_RT under wine):
+  # set for the whole of round 1 and cleared right before round 2's
   # command phase opens (`Scene_Battle_Rpg2k::ProcessSceneActionOption`'s
-  # `ePost` substate, src/scene_battle_rpg2k.cpp).
+  # `ePost` substate).
   hero = combatant('Hero', 40, 0, 5, 100)
   foe = combatant('Slime', 30, 0, 20, 100)
   fs = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false, false, true)
@@ -14433,12 +14445,13 @@ end
 # -- RPG2003 battle combo (Enable Combo / 1007) --------------------------------
 #
 # A combo armed by Enable Combo (event 1007) makes the named battle command hit
-# `multiple` times. Port of EasyRPG's ProcessBattleActionCombo
-# (src/scene_battle_rpg2k3.cpp): the armed combo applies only when `command_id`
+# `multiple` times. Ported from EasyRPG Player's source (its
+# ProcessBattleActionCombo), NOT independently confirmed against genuine
+# RPG_RT under wine: the armed combo applies only when `command_id`
 # is the command the actor actually chose this turn (Combatant#last_battle_action,
 # recorded by the scene's #select_battle_command) and only to attack / skill /
-# subskill commands -- never Defend, Item or Escape. Like EasyRPG the combo is
-# not decremented by a use; it stays armed for the whole fight.
+# subskill commands -- never Defend, Item or Escape. Like that reference the
+# combo is not decremented by a use; it stays armed for the whole fight.
 
 # A party whose battle-commands table carries the fixed four (attack 1, skill
 # 2, defend 3, item 4 -- EasyRPG's GetDefaultBattleCommands ids) so a combo's
@@ -14557,14 +14570,12 @@ end
 
 check 'battle_skill_command carries the skill elemental attributes on its heal branch too, ' \
      'and a target that partly resists them heals for less than the raw base' do
-  # EasyRPG's `Algo::CalcSkillEffect` runs `Attribute::
-  # ApplyAttributeSkillMultiplier` unconditionally -- no heal-vs-damage branch
-  # gates it -- so a healing skill tagged with an elemental attribute (a real
-  # RPG2000/2003 database trick: tag a heal with a custom attribute and set a
+  # No heal-vs-damage branch gates the elemental-attribute multiplier -- so a
+  # healing skill tagged with an elemental attribute (a real RPG2000/2003
+  # database trick: tag a heal with a custom attribute and set a
   # character's own resistance to it to make them harder/easier to heal) scales
   # its recovery by the target's resistance exactly like an attack skill's own
-  # `attributes:` already does. Verified directly against EasyRPG Player's
-  # `src/algo.cpp` and independently by @2000_battle_bot/デフォ戦bot trivia.
+  # `attributes:` already does, per @2000_battle_bot/デフォ戦bot trivia.
   skills = { 8 => fake_skill(name: 'Cure', scope: 3, power: 30, hp: true,
                              attribute_effects: [false, false, true]) } # element 3
   st = skill_party(skills)
@@ -14698,8 +14709,10 @@ check 'Battle: a defending ally takes half damage and does not attack' do
   eq 90, hero.hp, 'took half of 20 = 10'
 end
 
-check "battle: defend-halving carries no floor of its own, matching RPG_RT's AdjustDamageForDefend (2026-08-18)" do
-  # EasyRPG's AdjustDamageForDefend (src/algo.cpp) is a bare `dmg /= 2` (twice
+check "battle: defend-halving carries no floor of its own, per EasyRPG Player's " \
+      "AdjustDamageForDefend (2026-08-18, NOT independently confirmed against genuine RPG_RT under wine)" do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its AdjustDamageForDefend is a bare `dmg /= 2` (twice
   # for strong defence), with no std::max of any kind -- unlike the base
   # damage formula's own std::max(0, atk/2 - def/4) floor (already correctly
   # ported as Battle.attack_damage's own 0 floor). A defending target facing
@@ -14794,10 +14807,10 @@ check 'Battle#apply_to_party zeroes the active-time gauge for an ally who ended 
   eq 0, ally.atb_gauge, 'a knocked-out ally does not carry a charge into the next fight'
 end
 
-# Confirmed against EasyRPG's actual C++ source, fetched live:
-# `Game_Battler::AddState`'s Knockout branch (src/game_battler.cpp) is
-# `if (state_id == kDeathID) { SetAtbGauge(0); SetHp(0); ... }`, fired the
-# instant Death lands -- and `Game_Battler::ChangeHp` calls
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Battler::AddState`'s Knockout branch
+# is `if (state_id == kDeathID) { SetAtbGauge(0); SetHp(0); ... }`, fired the
+# instant Death lands -- and its `Game_Battler::ChangeHp` calls
 # `AddState(kDeathID, true)` itself the moment `new_hp <= 0`, so *every*
 # ordinary lethal hit zeroes the gauge mid-fight, not merely once the
 # fight ends (the already-fixed `Battle#apply_to_party` cross-*battle*
@@ -14805,7 +14818,7 @@ end
 # this, an ally charged to near-full gauge who dies and is then revived
 # by an ordinary Full Heal/revival item within the same fight would
 # resume acting from that stale pre-death charge instead of empty, like
-# anyone else newly readying up -- a real, exploitable pacing difference
+# anyone else newly readying up -- a plausible, exploitable pacing difference
 # in any RPG2003 project using the Gauge battle system.
 check "a lethal attack zeroes the target's active-time gauge immediately, not " \
       'merely once the fight ends' do
@@ -14819,17 +14832,18 @@ check "a lethal attack zeroes the target's active-time gauge immediately, not " 
 
   # An ordinary revival effect (a Full Heal/revival item raising HP back
   # above 0) does not restore the stale pre-death charge -- nothing
-  # recharges a dead battler's gauge in between, matching real RPG_RT,
-  # which never re-zeroes on revival because it was already zeroed the
-  # moment death landed.
+  # recharges a dead battler's gauge in between (per EasyRPG Player's source,
+  # NOT independently confirmed against genuine RPG_RT under wine, which never
+  # re-zeroes on revival because it was already zeroed the moment death
+  # landed).
   foe.hp = 10
   ok !foe.dead?, 'revived'
   eq 0, foe.gauge, 'revival does not restore the pre-death charge'
 end
 
-# Confirmed against EasyRPG's actual C++ source, fetched live:
-# `Game_Battler::AddState`'s Knockout branch (src/game_battler.cpp) also
-# resets `SetAtkModifier(0)`/`SetDefModifier(0)`/`SetSpiModifier(0)`/
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Battler::AddState`'s Knockout branch
+# also resets `SetAtkModifier(0)`/`SetDefModifier(0)`/`SetSpiModifier(0)`/
 # `SetAgiModifier(0)` and clears `attribute_shift` the instant Death
 # lands -- the exact same branch the gauge check just above already
 # proved this codebase now honours for `#gauge`, but the fix that added
@@ -14839,9 +14853,10 @@ end
 # #apply_attr_shift) have no other reset path once a fight is under way,
 # so an ally buffed (or debuffed) mid-fight, then killed, then revived by
 # an ordinary Full Heal/revival item within the same fight kept fighting
-# with the stale pre-death modifier still active -- real RPG_RT gives a
+# with the stale pre-death modifier still active -- EasyRPG's Player gives a
 # revived battler a clean slate on every one of these fields, not just
-# the gauge.
+# the gauge, but this has not been independently confirmed against genuine
+# RPG_RT under wine.
 check 'a lethal attack also resets stat modifiers and attribute-rank shifts, ' \
       'the same Knockout branch the gauge fix above already covers' do
   hero = combatant('Hero', 999, 0, 5, 100)
@@ -14863,15 +14878,16 @@ check 'a lethal attack also resets stat modifiers and attribute-rank shifts, ' \
   eq 0, foe.agi_mod
   eq({}, foe.attr_ranks, 'the attribute shift was cleared too, not just the raw stat mods')
 
-  # Revival does not restore any of it either, matching the gauge above.
+  # Revival does not restore any of it either, matching the gauge above
+  # (per EasyRPG Player's source, not independently confirmed under wine).
   foe.hp = 10
   ok !foe.dead?
   eq 0, foe.atk_mod, 'a revived ally does not keep its stale pre-death buff'
 end
 
-# Confirmed against EasyRPG's actual C++ source, fetched live:
-# `Game_Battler::AddState`'s Knockout branch (src/game_battler.cpp) also
-# fires `SetIsDefending(false)`/`SetCharged(false)` the instant Death
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Battler::AddState`'s Knockout branch
+# also fires `SetIsDefending(false)`/`SetCharged(false)` the instant Death
 # lands, the same statement group as the gauge/stat-modifier resets the two
 # checks above already cover -- `apply_knockout_reset`'s own doc comment
 # had claimed these two fields were "deliberately not ported" because "this
@@ -14884,8 +14900,9 @@ end
 # attack. An enemy that Defends (or Charges), then dies, then is revived
 # before its own next turn comes up kept the stale flag -- wrongly halving
 # incoming damage from other battlers (`#defending`) or wrongly doubling
-# its own next attack (`#charged`) -- something real RPG_RT's immediate,
-# unconditional reset at death never allows.
+# its own next attack (`#charged`) -- something EasyRPG Player's immediate,
+# unconditional reset at death never allows, though this has not been
+# independently confirmed against genuine RPG_RT under wine.
 check 'a lethal attack also clears a defending or charged enemy\'s stance, ' \
       'the same Knockout branch the gauge/stat-mod fixes above already cover' do
   hero = combatant('Hero', 999, 0, 5, 100)
@@ -14909,13 +14926,13 @@ check 'a lethal attack also clears a defending or charged enemy\'s stance, ' \
   eq false, defender.defending, 'a revived enemy does not keep its stale pre-death Defend stance'
 end
 
-check "Battle#apply_to_party clears a battle combo Enable Combo armed, matching RPG_RT (2026-08-19)" do
-  # Confirmed against EasyRPG's actual C++ source, fetched live:
-  # `Game_Battler::ResetBattle` (src/game_battler.cpp) is `battle_combo_
+check "Battle#apply_to_party clears a battle combo Enable Combo armed, per EasyRPG Player " \
+      "(2026-08-19, NOT independently confirmed against genuine RPG_RT under wine)" do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Game_Battler::ResetBattle` is `battle_combo_
   # command_id = -1; battle_combo_times = 1;`, called for every actor at
   # both a battle's start and its end (`Game_Battle::Init`/`Quit`, via
-  # `Game_Actors::ResetBattle`, src/game_battle.cpp / src/game_actors.cpp)
-  # -- so a combo armed by one battle-event page for one specific fight
+  # `Game_Actors::ResetBattle`) -- so a combo armed by one battle-event page for one specific fight
   # never carries into the next. #set_battle_combo's own doc comment
   # already claimed the combo stays armed "until battle end", but nothing
   # ever actually cleared it: an Enable Combo fired for a scripted boss
@@ -15624,11 +15641,12 @@ end
 # Attack (`Battle#effective_atk`), but a *second Skill* cast against the same
 # already-buffed/debuffed battler still computed its own damage/defence term
 # off the battler's unmodified base stat, as if no buff or debuff were
-# active at all -- confirmed against EasyRPG's actual C++ source: `Algo::
-# CalcSkillEffect` (`src/algo.cpp`) reads `source.GetAtk()`/`target.GetDef()`/
-# `GetSpi()`, the exact same `Game_Battler` accessors (`src/game_battler.cpp`)
-# a basic Attack's own `CalcNormalAttackEffect` reads -- there is no
-# separate, unmodified accessor for a Skill at all in the reference.
+# active at all -- per EasyRPG Player's source (NOT independently confirmed
+# against genuine RPG_RT under wine), its `Algo::CalcSkillEffect` reads
+# `source.GetAtk()`/`target.GetDef()`/`GetSpi()`, the exact same
+# `Game_Battler` accessors a basic Attack's own `CalcNormalAttackEffect`
+# reads -- there is no separate, unmodified accessor for a Skill at all in
+# that reference.
 check "a target's own per-battle DEF modifier (already lowered by an " \
       "earlier skill) now reduces a later attack skill's own defence term " \
       'too, matching Battle#effective_def' do
@@ -15811,10 +15829,11 @@ check 'battle: a heal skill restoring both HP and SP rolls each independently' d
   eq 10, hero.mp
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Algo::CalcSkillEffect`
-# (src/algo.cpp) computes one `effect` local -- attribute multiplier, then
-# `VarianceAdjustEffect`, each applied exactly once -- and `Skill::vExecute`
-# (src/game_battlealgorithm.cpp) reads that identical raw number into every
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Algo::CalcSkillEffect` computes one
+# `effect` local -- attribute multiplier, then
+# `VarianceAdjustEffect`, each applied exactly once -- and its `Skill::vExecute`
+# reads that identical raw number into every
 # `affect_hp`/`affect_sp`/`affect_attack`/etc. branch it takes, each still
 # gated by its own independent `Rand::PercentChance(to_hit)` roll (the
 # check above, unaffected by this one). The *magnitude* itself is never
@@ -15838,7 +15857,8 @@ check "battle: a heal skill restoring both HP and SP shares one variance " \
   eq 85, hero.mp
 end
 
-# RPG_RT's `Game_BattleAlgorithm::Skill::vExecute` (src/game_battlealgorithm.cpp)
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Game_BattleAlgorithm::Skill::vExecute`
 # gates every state a skill would cure behind its own `Rand::PercentChance(
 # to_hit_states)` roll -- the same fresh-per-field idiom `#skill_effect_hits?`
 # already gives HP/SP/stat-mod effects -- while `Item::vExecute`'s own cure
@@ -15910,8 +15930,8 @@ end
 
 check "battle: an attribute-defence shift rolls its own hit chance per " \
       "attribute id, not once for the whole skill" do
-  # RPG_RT (Game_BattleAlgorithm::Skill::vExecute,
-  # src/game_battlealgorithm.cpp) rolls an independent
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Game_BattleAlgorithm::Skill::vExecute rolls an independent
   # `Rand::PercentChance(to_hit_attribute_shift)` inside the `for` loop over
   # every targeted attribute id, even though they all share the same
   # skill-wide to-hit -- so a multi-attribute shift skill can land on some
@@ -15932,8 +15952,9 @@ check "battle: an attribute-defence shift rolls its own hit chance per " \
   eq 2, foe.attr_ranks[2], 'attribute 2 kept its rank -- its own roll missed'
 end
 
-# RPG_RT's own two-step mechanism for a revival skill/item (`AlgorithmBase::
-# ApplyHpEffect`/`ApplyStateEffect`, src/game_battlealgorithm.cpp):
+# EasyRPG Player's own two-step mechanism for a revival skill/item
+# (`AlgorithmBase::ApplyHpEffect`/`ApplyStateEffect`), ported here and NOT
+# independently confirmed against genuine RPG_RT under wine:
 # ApplyHpEffect is a hard no-op on an already-dead target
 # (`if (target->IsDead()) return 0;`), so the heal never lands against the
 # target's raw HP total (nothing floors HP at 0 mid-fight -- an overkill hit
@@ -15976,7 +15997,8 @@ check 'battle: a revival skill with no heal configured still lands the ' \
   eq 1, foe.hp
 end
 
-# RPG_RT's `Skill::vExecute` (src/game_battlealgorithm.cpp) reads a
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Skill::vExecute` reads a
 # *percentage* of max HP for a revival whose Affect HP flag is off, instead
 # of the flat-1 floor a flat-amount reviver (Affect HP on) lands on: `if
 # (IsRevived() && effect > 0) { if (skill.affect_hp) {
@@ -15987,7 +16009,7 @@ end
 # used to always floor such a skill to 1 HP, identical to a skill/item with
 # no heal configured at all.
 check 'battle: a revival skill with Affect HP off heals a percentage of ' \
-      'max HP, not a flat 1 (RPG_RT)' do
+      'max HP, not a flat 1 (per EasyRPG Player, not independently confirmed under wine)' do
   hero = combatant('Hero', 40, 0, 20, 100)
   foe = combatant('Foe', 0, 0, 5, 100)
   foe.max_hp = 100
@@ -16096,8 +16118,9 @@ check "battle: a purely magical skill's physical_rate of 0 never shakes a status
   ok foe.state?(8), 'physical_rate 0 never rolls, matching a magical spell'
 end
 
-check 'battle: shake_off_states still draws from the RNG when release_by_attack*rate/100 rounds down to 0, matching RPG_RT (2026-08-18)' do
-  # EasyRPG's BattlePhysicalStateHeal (src/game_battlealgorithm.cpp) only
+check 'battle: shake_off_states still draws from the RNG when release_by_attack*rate/100 rounds down to 0, per EasyRPG Player (2026-08-18, NOT independently confirmed against genuine RPG_RT under wine)' do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its BattlePhysicalStateHeal only
   # gates the roll on release_by_damage > 0 (the `base > 0` check below) --
   # once past that outer gate it calls Rand::ChanceOf(release_chance, 100)
   # unconditionally, even when release_chance itself (release_by_damage *
@@ -16258,10 +16281,11 @@ end
 check 'battle: Knockout (state 1) is scaled by state_ranks like any other ' \
       'state -- rank E blocks it' do
   # RPG2000 has no separate instant-death mechanic; a skill's state-effect
-  # list names Knockout (id 1, Game::Actor::DEATH_STATE) directly. RPG_RT's
-  # own Game_Actor::GetStateProbability (src/game_actor.cpp) has no
-  # state_id == kDeathID special case, and Game_BattleAlgorithm's infliction
-  # loops (src/game_battlealgorithm.cpp) call GetStateProbability uniformly
+  # list names Knockout (id 1, Game::Actor::DEATH_STATE) directly. Per
+  # EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Game_Actor::GetStateProbability has no
+  # state_id == kDeathID special case, and its Game_BattleAlgorithm's infliction
+  # loops call GetStateProbability uniformly
   # for every flagged state id, Knockout included.
   foe = combatant('Foe', 0, 0, 5, 100)
   foe.state_ranks = { Game::Actor::DEATH_STATE => 4 } # rank E -> 0%
@@ -16449,8 +16473,9 @@ check 'Battle command_skill fizzles on a fallen target, sparing the SP' do
   eq 0, downed.hp, 'the fallen ally stayed down'
 end
 
-# RPG_RT's own per-algorithm `IsTargetValid` override
-# (`Game_BattleAlgorithm::Item::IsTargetValid`, src/game_battlealgorithm.cpp)
+# EasyRPG Player's own per-algorithm `IsTargetValid` override
+# (`Game_BattleAlgorithm::Item::IsTargetValid`), ported here and NOT
+# independently confirmed against genuine RPG_RT under wine --
 # ignores the target entirely for a medicine/switch item -- `return
 # item.type == Type_medicine || item.type == Type_switch;` -- always valid,
 # dead or alive -- re-checked at resolution time by
@@ -16647,8 +16672,9 @@ check 'battle poison slips HP each turn (fixed val + percent of max)' do
 end
 
 check 'battle poison (percent of max) floors at 1 HP -- slip damage alone cannot knock the battler out' do
-  # Verified against EasyRPG's own Game_Battler::ApplyConditions
-  # (src/game_battler.cpp): it calls ChangeHp(src_hp, /* lethal = */ false),
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Game_Battler::ApplyConditions
+  # calls ChangeHp(src_hp, /* lethal = */ false),
   # which floors at 1 regardless of how large the computed slip is -- state
   # slip damage can wear a battler down but never itself end its turn in
   # death, the same non-lethal rule the map-side field-poison drain already
@@ -16669,15 +16695,16 @@ check 'battle poison (percent of max) floors at 1 HP -- slip damage alone cannot
 end
 
 check 'battle poison slip damage is not clamped to the damage-popup cap' do
-  # Confirmed against EasyRPG's actual C++ source, fetched live:
-  # `Game_Battler::ApplyConditions` (src/game_battler.cpp) computes each
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine:
+  # its `Game_Battler::ApplyConditions` computes each
   # afflicted state's `src_hp` and hands it straight to `ChangeHp(src_hp,
   # /* lethal = */ false)` -- no `Utils::Clamp(..., -MaxDamageValue(),
   # MaxDamageValue())` anywhere in that path. The popup hard-cap exists at
-  # exactly three call sites in the whole codebase, all inside
-  # `game_battlealgorithm.cpp`'s Normal/Skill/SelfDestruct algorithms (see
+  # exactly three call sites in the whole reference source, all inside
+  # its Normal/Skill/SelfDestruct algorithms (see
   # "Simulated Attack does not hard-cap damage..." below for the same
-  # citation) -- `ApplyConditions` is not one of them. A prior version of
+  # caveat) -- `ApplyConditions` is not one of them. A prior version of
   # this codebase clamped the HP slip here to Game::Battle#damage_cap
   # anyway, on an uncited assumption that the popup limit "applies to slip
   # damage too"; it does not.
@@ -16725,19 +16752,20 @@ check 'battle: a "do nothing" state (restriction 1) skips the turn' do
   eq 100, slime.hp                                   # the asleep hero never struck
 end
 
-# Confirmed against EasyRPG's actual C++ source: Scene_Battle_Rpg2k::
-# ProcessBattleActionBegin (src/scene_battle_rpg2k.cpp) scans every state id
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Scene_Battle_Rpg2k::
+# ProcessBattleActionBegin scans every state id
 # the battler either still carries or just had auto-cured this turn (not
-# Game_Battler::GetSignificantState/State::GetSignificantState -- confirmed
-# these are two genuinely distinct functions in EasyRPG's own source, the
+# Game_Battler::GetSignificantState/State::GetSignificantState -- these are
+# two genuinely distinct functions in that source, the
 # latter special-casing Knockout and never considering a just-healed state),
 # keeping whichever has the highest `priority` (ties to the higher id), and
 # shows that state's own message_affected (still held) or message_recovery
 # (just healed) at the very start of the battler's turn, before its action.
 # This codebase's own docs/TODO.md had claimed the opposite -- that
 # message_affected is "deliberately still unread" because "EasyRPG ...
-# never calls it from either battle scene" -- which is simply wrong against
-# current live EasyRPG source.
+# never calls it from either battle scene" -- which does not match that
+# reference's current source.
 check 'battle: a still-afflicted state opens the battler\'s turn with its own ' \
       'message_affected line' do
   states = { 3 => fake_state(priority: 50, affected_msg: 'は毒に苦しんでいる！') } # poison, no restriction
@@ -16918,13 +16946,14 @@ check 'battle state at 0% auto_release_prob never wears off on its own' do
   eq true, hero.state?(5)                            # 0% -> stays for the whole fight
 end
 
-# EasyRPG's Game_Battler::BattleStateHeal (src/game_battler.cpp) always rolls
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Game_Battler::BattleStateHeal always rolls
 # Rand::ChanceOf(auto_release_prob, 100) once state_turns exceeds hold_turn --
-# Rand::ChanceOf (src/rand.cpp) is GetRandomNumber(1, m) <= n and always draws,
+# its Rand::ChanceOf is GetRandomNumber(1, m) <= n and always draws,
 # whatever n is; C++'s && only short-circuits on the hold_turn test, never on
 # the probability. A 0%-chance state must still burn that RNG draw every turn
-# once eligible, or this build's shared RNG stream desyncs from a real seeded
-# RPG_RT run for the rest of the fight.
+# once eligible, or this build's shared RNG stream would desync from a real
+# seeded RPG_RT run for the rest of the fight, per that reference's own logic.
 check 'battle state auto-release always consumes an RNG draw once eligible, even at 0% chance' do
   states = { 5 => FakeStateDef.new(0, 0, 0, 0, 0, 0, 0) } # hold_turn 0, prob 0
   hero = combatant('Hero', 40, 0, 20, 100)
@@ -16943,10 +16972,11 @@ end
 
 check 'battle: curing a state resets its turn-held counter, so a ' \
       'reinflicted state does not inherit a stale duration' do
-  # RPG_RT's own State::Add/State::Remove (src/state.cpp) share one literal
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its State::Add/State::Remove share one literal
   # field for "state present" and "turns held" -- Add sets it to 1, Remove
   # sets it to 0 -- so a cured-then-reinflicted state can never carry a
-  # stale duration into BattleStateHeal's (src/game_battler.cpp) hold_turn
+  # stale duration into BattleStateHeal's hold_turn
   # check. #cure_state used to remove the state from `states` without ever
   # clearing the matching #apply_turn_states entry in this codebase's own
   # separate `state_turns` hash, which #inflict_state never resets either.
@@ -17003,13 +17033,14 @@ check 'battle: one incapacitated ally among others is not a party wipe' do
   ok !bat.finished?, 'a still-able ally keeps the party in the fight'
 end
 
-# RPG_RT's own Game_Battle::CheckWin/CheckLose (src/game_battle.cpp) are two
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Game_Battle::CheckWin/CheckLose are two
 # genuinely different tests, not one shared symmetric one: CheckWin is a bare
 # dead-or-hidden check (!IsAnyActive(), bottoming out in Exists()), with no
 # restriction/recovery concept at all -- only CheckLose widens to
 # CanActOrRecoverable(). A fully-Stoned enemy troop, unlike a fully-Stoned
-# party, does not end the fight on its own: the player can always keep
-# attacking a restricted-but-alive enemy, so real RPG_RT keeps the battle
+# party, would not end the fight on its own by that logic: the player can always keep
+# attacking a restricted-but-alive enemy, so this assumes RPG_RT keeps the battle
 # running until the enemies are actually reduced to 0 HP or hidden/removed.
 check 'battle: a fully-Stoned enemy troop, still at full HP, does not end the fight' do
   states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) } # do-nothing, 0% auto-release
@@ -17069,10 +17100,11 @@ check 'battle: a berserk battler (restriction 2) attacks despite defending' do
   eq 80, slime.hp                                         # ...but berserk forced a 20 hit
 end
 
-# デフォ戦bot (@2000_battle_bot) trivia, confirmed against EasyRPG's own
-# State::GetSignificantRestriction (src/state.cpp): "同時に暴走と混乱の状態に
+# デフォ戦bot (@2000_battle_bot) trivia: "同時に暴走と混乱の状態に
 # なった場合、暴走が優先されて敵を攻撃する" -- Berserk (attack-enemy) beats
-# Confusion (attack-ally) when both are inflicted simultaneously. That C++
+# Confusion (attack-ally) when both are inflicted simultaneously. Per EasyRPG
+# Player's source (NOT independently confirmed against genuine RPG_RT under
+# wine, though consistent with that trivia), its State::GetSignificantRestriction
 # resolves a *fixed priority hierarchy* by restriction type (do_nothing >
 # attack_enemy > attack_ally > normal) while scanning every afflicted state,
 # not a numeric max of the raw restriction constants -- RESTRICTION_ATTACK_ALLY
@@ -17109,12 +17141,13 @@ end
 # first'." The confusion half (attack_all still spreading, hit-twice/必中
 # unaffected either way) was already covered by the 全体化/必中 checks above.
 # The berserk-collapses-attack_all half of that same uncited claim does not
-# hold up against RPG_RT's own live source, though: `Scene_Battle_Rpg2k::
-# SelectNextActor` (`src/scene_battle_rpg2k.cpp`) constructs an identical
+# hold up against EasyRPG Player's source, though (NOT independently
+# confirmed against genuine RPG_RT under wine): its `Scene_Battle_Rpg2k::
+# SelectNextActor` constructs an identical
 # single-target `Game_BattleAlgorithm::Normal` for both the attack-ally
 # (confusion) and attack-enemy (berserk) restrictions -- the same switch just
 # picks which side `GetRandomActiveBattler()` draws from -- and
-# `Normal::vStart()` (`src/game_battlealgorithm.cpp`) then unconditionally
+# `Normal::vStart()` then unconditionally
 # re-expands *any* single-target Normal algorithm to the whole side once the
 # weapon carries attack_all, with no restriction check anywhere in that path.
 check 'battle: a berserk battler with an attack_all weapon still hits every ' \
@@ -17245,8 +17278,9 @@ end
 
 check 'battle: turn order rolls a random Agility jitter each round, instead of ' \
       'sorting by raw Agility alone' do
-  # Confirmed against EasyRPG's own Scene_Battle_Rpg2k::CreateExecutionOrder
-  # (src/scene_battle_rpg2k.cpp): each battler rolls `agi + Rand(0, agi / 4 +
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Scene_Battle_Rpg2k::CreateExecutionOrder
+  # has each battler roll `agi + Rand(0, agi / 4 +
   # 3)` fresh, once per round, before the sort ("must be done outside of the
   # sort function... so the sort is consistent", per that function's own
   # comment) -- two battlers with identical Agility do not act in a fixed
@@ -17329,7 +17363,8 @@ check 'battle: a self-destruct shakes loose a survivor\'s status the same as a b
   eq [8], entry[:woke]
 end
 
-# RPG_RT's own `SelfDestruct::GetStartSe` (src/game_battlealgorithm.cpp)
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `SelfDestruct::GetStartSe`
 # plays the explosion SE unconditionally, once per action, the instant it
 # starts -- not once per target hit. `Scene::Battle#play_battle_action_se`
 # reads `entry[:autodestruct_se]` for this, which must therefore ride on
@@ -17426,8 +17461,8 @@ check 'States.prune: states sharing the top priority all survive' do
   eq [2, 3], Game::States.prune([2, 3, 5], table)
 end
 
-# Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
-# source rather than assumed: `State::Add` (src/state.cpp) computes
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `State::Add` computes
 # `sig_state = GetSignificantState(states)` *after* inserting the new id,
 # then clears every state whose own priority sits 10+ below
 # `sig_state->priority`. Death is not exempt from this at all -- when
@@ -17477,10 +17512,11 @@ def party_state_with_states(states, skills = {})
     Game::Party.new(FakeActorDB.new(players, [1, 2], {}, skills, {}, states)), 1, 0, 0)
 end
 
-# Confirmed against EasyRPG's live source, `ControlVariables::Actor`
-# (`src/game_interpreter_control_variables.cpp`): its Attack/Defence/
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `ControlVariables::Actor`
+# Attack/Defence/
 # Intelligence/Agility cases (6-9) call straight through `Game_Actor::
-# GetAtk`/`GetDef`/`GetSpi`/`GetAgi` (`src/game_battler.cpp`), each routed
+# GetAtk`/`GetDef`/`GetSpi`/`GetAgi`, each routed
 # through `AdjustParam` -- the same halve/double-by-active-state mechanism
 # ported here as `Game::Party#effective_atk`/`#effective_def`/`#effective_int`/
 # `#effective_agi`, already used elsewhere (Simulated Attack, the Status
@@ -17569,8 +17605,8 @@ check "a battle attack skill inflicting a state prunes the target's state set" d
   eq [3], foe.states, 'the battle-inflicted Petrify displaced the held Poison'
 end
 
-# Verified against RPG_RT's actual behavior via EasyRPG's own
-# Game_Battler::AddState (src/game_battler.cpp): inflicting state 1
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Game_Battler::AddState: inflicting state 1
 # (Knockout) forces HP to 0 as an unconditional side effect of the state
 # landing at all -- the same function every battle-time infliction path
 # routes through (a skill's own state-effect list included) -- not
@@ -17714,8 +17750,10 @@ check 'States.map_step_drain is type-aware: GAIN heals, NOTHING does nothing' do
   # RPG2003's hp_change_type/sp_change_type (Game::States::CHANGE_TYPE_*):
   # a "regen"-style field state (GAIN) returns a positive delta instead of a
   # negative one, and NOTHING returns 0 despite a nonzero configured amount --
-  # verified against EasyRPG's own lcf::rpg::State::ChangeType enum and
-  # Game_Party::ApplyStateDamage (src/game_party.cpp).
+  # the enum values themselves come from liblcf's own schema
+  # (lcf::rpg::State::ChangeType); the GAIN/NOTHING behavior itself is
+  # ported from EasyRPG Player's source (its Game_Party::ApplyStateDamage),
+  # NOT independently confirmed against genuine RPG_RT under wine.
   regen = { 4 => fake_state(name: 'Regen', hp_map_steps: 2, hp_map_val: 5,
                              hp_change_type: Game::States::CHANGE_TYPE_GAIN,
                              sp_map_steps: 2, sp_map_val: 3,
@@ -17780,8 +17818,9 @@ check 'map slip damage cannot kill: it floors at 1 HP' do
   eq 1, hero.hp, 'and walking on keeps it there'
   eq false, st.party.all_dead?
 
-  # A member already down is not skipped outright -- EasyRPG's
-  # `Game_Party::ApplyStateDamage` iterates every actor with no alive/dead
+  # A member already down is not skipped outright -- per EasyRPG Player's
+  # source (NOT independently confirmed against genuine RPG_RT under wine),
+  # its `Game_Party::ApplyStateDamage` iterates every actor with no alive/dead
   # filter, and only `ChangeHp` (not the caller) has its own dead-guard, so a
   # dead member's affliction is still reported as "hit" even though the HP
   # loss itself silently no-ops via #change_hp.
@@ -17792,7 +17831,8 @@ check 'map slip damage cannot kill: it floors at 1 HP' do
   eq 0, ally.hp, 'the HP loss itself still no-ops on a dead member'
 end
 
-# Ports EasyRPG's `Game_Battler::ChangeSp` (`src/game_battler.cpp`), which --
+# Ported from EasyRPG Player's source (its `Game_Battler::ChangeSp`), NOT
+# independently confirmed against genuine RPG_RT under wine -- which --
 # unlike `ChangeHp` -- carries no `IsDead()` guard at all: a map-step state's
 # SP component keeps applying to a KO'd member exactly as it would to a
 # living one, even though that same member's HP component is silently
@@ -17833,7 +17873,8 @@ check 'map slip damage: a GAIN-type state heals instead of draining, clamped to 
   eq [hero.max_mp, before_mp + 30].min, hero.mp
 end
 
-# Ports EasyRPG's `Game_Party::ApplyStateDamage` (src/game_party.cpp): its
+# Ported from EasyRPG Player's source (its `Game_Party::ApplyStateDamage`),
+# NOT independently confirmed against genuine RPG_RT under wine: its
 # `damage` bool is only ever set inside a `ChangeType_lose` branch, never a
 # `ChangeType_gain` one -- #apply_map_step_damage's own return value reports
 # every actor who changed either way, but #map_step_damaged? is the one the
@@ -18663,10 +18704,11 @@ end
 
 check "Simulated Attack reads the target's state-adjusted Defence/Spirit, " \
       'not its raw base stat' do
-  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
-  # CommandSimulatedAttack` (`src/game_interpreter.cpp`) computes `atk -
-  # actor->GetDef() * def / 400 - actor->GetSpi() * spi / 800`, and
-  # `Game_Battler::GetDef`/`GetSpi` (`src/game_battler.cpp`) both route
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Game_Interpreter::
+  # CommandSimulatedAttack` computes `atk -
+  # actor->GetDef() * def / 400 - actor->GetSpi() * spi / 800`, and its
+  # `Game_Battler::GetDef`/`GetSpi` both route
   # through `AdjustParam`, which folds in a currently-afflicted state's own
   # halve/double Defence flag -- the same accessor every other damage
   # formula reads, in or out of battle. A target whose Defence is halved by
@@ -18706,10 +18748,11 @@ end
 
 check 'Simulated Attack leaves its result variable untouched when the ' \
       'target actor id is invalid, instead of zeroing it' do
-  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
-  # CommandSimulatedAttack` (`src/game_interpreter.cpp`) writes the result
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Game_Interpreter::
+  # CommandSimulatedAttack` writes the result
   # variable *inside* its own `for (const auto& actor : GetActors(...))`
-  # loop, never reached at all when that loop is empty -- and `GetActors`
+  # loop, never reached at all when that loop is empty -- and its `GetActors`
   # returns an empty vector, without ever touching the variable, when a
   # fixed actor id names a database row that does not exist (`if (!actor)
   # { ...; return actors; }`). A stale value already sitting in the
@@ -18727,11 +18770,12 @@ end
 # to Game::Battle::DAMAGE_CAP, by analogy with the normal-attack/skill/
 # self-destruct/slip-damage popup cap -- a plausible-sounding but
 # unverified inference, not something read off this command's own source.
-# Confirmed against EasyRPG's actual C++ source, fetched live:
-# `Game_Interpreter::CommandSimulatedAttack` (src/game_interpreter.cpp)
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine:
+# `Game_Interpreter::CommandSimulatedAttack`
 # applies no clamp at all. `Utils::Clamp(effect, -MaxDamageValue(),
-# MaxDamageValue())` exists in exactly three places in the entire real
-# codebase, all inside `game_battlealgorithm.cpp`'s `Normal`/`Skill`/
+# MaxDamageValue())` exists in exactly three places in that reference
+# source, all inside `game_battlealgorithm.cpp`'s `Normal`/`Skill`/
 # `SelfDestruct` -- the battle actions that actually draw the fixed-width
 # damage-popup animation the cap exists for. Simulated Attack is a silent
 # map-side HP change with no popup at all: it calls `Algo::
@@ -18850,10 +18894,11 @@ check 'Fade Out BGM fades the music but keeps the current-BGM record intact' do
   # against its "Duration in ms" doc comment and every real call site, all
   # bare millisecond literals).
   #
-  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
-  # CommandFadeOutBGM` (`src/game_interpreter.cpp`) calls `Game_System::
-  # BgmFade(fadeout)` with a single argument, and `Game_System::BgmFade`
-  # (`src/game_system.h`/`.cpp`) only clears `data.current_music` when its
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Game_Interpreter::
+  # CommandFadeOutBGM` calls `Game_System::
+  # BgmFade(fadeout)` with a single argument, and its `Game_System::BgmFade`
+  # only clears `data.current_music` when its
   # second parameter, `clear_current_music`, is explicitly `true` --
   # defaulted `false`, so the event command never clears it. A save taken
   # (or a Memorize BGM issued) right after a Fade Out BGM must still see
@@ -18913,8 +18958,9 @@ check 'Tile Substitution rewrites a tile on the map and flags a redraw' do
   eq false, it.take_tiles_changed, 'the flag is one-shot'
 end
 
-# Confirmed against RPG_RT's own live source: `Game_Map::DoSubstitute`
-# (`src/game_map.cpp`) scans its persistent substitution table by *current*
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Map::DoSubstitute`
+# scans its persistent substitution table by *current*
 # value every call (`for (i) if (tiles[i] == old_id) tiles[i] = new_id;`),
 # not by each tile's original chipset id -- so a later substitution chains
 # through an earlier one whenever its `old_id` matches the earlier `new_id`,
@@ -19077,8 +19123,10 @@ check 'Game::EventPage.active? tests the Timer (0x20) condition against Timer1 s
   vars = st.variables
   party = FakeEventPageParty.new([], [])
 
-  # RPG_RT's AreConditionsMet: "if (secs > condition.timer_sec) return false"
-  # -- active once Timer1 has counted down to timer_sec seconds or below.
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its AreConditionsMet: "if (secs > condition.timer_sec)
+  # return false" -- active once Timer1 has counted down to timer_sec seconds
+  # or below.
   cond = event_cond(Game::EventPage::TIMER, timer_sec: 30)
   eq false, Game::EventPage.active?(cond, sw, vars, party, 60), 'well above the threshold'
   eq false, Game::EventPage.active?(cond, sw, vars, party, 31), 'one second above the threshold'
@@ -19096,8 +19144,9 @@ check 'Game::EventPage.active? tests the Timer (0x20) condition against Timer1 s
 end
 
 check 'Game::EventPage.active? tests the Timer2 (0x40) condition, RPG2003 only' do
-  # Confirmed against EasyRPG's actual C++ source: Game_Event::
-  # AreConditionsMet (src/game_event.cpp) gates Timer2 on
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_Event::
+  # AreConditionsMet gates Timer2 on
   # Player::IsRPG2k3Commands() -- an RPG2000 database ignores the bit
   # entirely, even if it happens to be set. Same "counted down to timer2_sec
   # or below" rule as Timer1, against Timer2's own seconds (the method's
@@ -19122,10 +19171,11 @@ end
 
 check "Game::EventPage.active?'s variable condition reads RPG2003's own " \
       'compare_operator instead of a hardcoded >=' do
-  # Confirmed against EasyRPG's actual C++ source: AreConditionsMet branches
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its AreConditionsMet branches
   # on Player::IsRPG2k() -- RPG2000 always compares >=, but everything else
-  # (RPG2003) reads condition.compare_operator through CheckOperator
-  # (src/game_interpreter_shared.h): 0 == 1 >= 2 <= 3 > 4 < 5 !=. These are
+  # (RPG2003) reads condition.compare_operator through CheckOperator:
+  # 0 == 1 >= 2 <= 3 > 4 < 5 !=. These are
   # genuinely different rules per edition, not a shared comparison with an
   # edition-gated constant.
   st = new_state
@@ -19377,9 +19427,10 @@ check 'a turn_enemy / turn_actor condition is gated on the source being that bat
      'but not at the foe\'s boundary'
 end
 
-# turn_enemy / turn_actor / fatigue are RPG2003-only page conditions --
-# EasyRPG's own Game_Interpreter_Battle::AreConditionsMet
-# (src/game_interpreter_battle.cpp) gates all three behind
+# turn_enemy / turn_actor / fatigue are RPG2003-only page conditions -- per
+# EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Game_Interpreter_Battle::AreConditionsMet
+# gates all three behind
 # Player::IsRPG2k3Commands(), the same way Game::EventPage.active? already
 # gates a map event page's TIMER2 condition on rpg2003?. An RPG2000 database
 # has no editor control for any of these three condition types at all, so a
@@ -19560,8 +19611,9 @@ check 'Change Monster HP heals, reads a variable and a percentage' do
   eq 45, b.enemy(0).hp
 
   # percentage operand (2): 10% of the target's *current* hp (45, not max_hp
-  # 100) = 4, per EasyRPG's CommandChangeMonsterHP (src/
-  # game_interpreter_battle.cpp), which reads `hp = enemy->GetHp()` and
+  # 100) = 4, per EasyRPG Player's source (NOT independently confirmed
+  # against genuine RPG_RT under wine), its CommandChangeMonsterHP, which
+  # reads `hp = enemy->GetHp()` and
   # computes the percentage from that captured value, not GetMaxHp().
   it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 2, 10, 1])])
   it.update
@@ -19573,8 +19625,9 @@ check 'Change Monster HP heals, reads a variable and a percentage' do
   eq 100, b.enemy(0).hp
 end
 
-# Verified against EasyRPG's own CommandChangeMonsterHP
-# (src/game_interpreter_battle.cpp): `if (enemy->IsDead()) return true;` runs
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its CommandChangeMonsterHP:
+# `if (enemy->IsDead()) return true;` runs
 # before anything else -- direction, amount source (param2/param3) and the
 # lethal flag (param4) are never even read once the target is already dead.
 # A further *hit* on a 0-HP target used to fall through to `hp = 0 + amount`,
@@ -19598,9 +19651,10 @@ check 'Change Monster HP leaves an already-downed target untouched entirely' do
   eq 0, b.enemy(0).hp, 'a heal on a downed target is still a no-op'
 end
 
-# RPG_RT routes this command through Game_Battler::ChangeHp, which itself
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), this command routes through Game_Battler::ChangeHp, which itself
 # calls AddState(kDeathID, true) the instant HP reaches 0
-# (src/game_battler.cpp) -- the same Knockout branch that already zeroes
+# -- the same Knockout branch that already zeroes
 # the ATB gauge, ATK/DEF/SPI/AGI modifiers and attribute-rank shifts for
 # every other lethal-HP path in this codebase (#deal_attack_with_current_
 # weapon, #apply_skill_hit, #enemy_autodestruct, Change Monster
@@ -19659,15 +19713,16 @@ check 'Change Monster Condition inflicts and cures a status' do
   ok !b.enemy(0).state?(4), 'and it was cured'
 end
 
-# Verified against RPG_RT's actual behavior via EasyRPG's own
-# Game_Battler::AddState/RemoveState (src/game_battler.cpp): state 1
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine:
+# its Game_Battler::AddState/RemoveState: state 1
 # (Knockout) is not mere states-list bookkeeping -- inflicting it forces HP
 # to 0 as an explicit, unconditional side effect (`if (state_id ==
 # kDeathID) { SetHp(0); ... }`), and curing it while downed revives to 1
 # (the shared `RemoveStates` helper's own `if (is_dead != check_dead())
 # SetHp(1)`). Change Monster Condition routes through those same two
-# functions in real RPG_RT (`CommandChangeMonsterCondition`, src/
-# game_interpreter_battle.cpp: `enemy->AddState(...)`/`enemy->
+# functions in that reference (`CommandChangeMonsterCondition`:
+# `enemy->AddState(...)`/`enemy->
 # RemoveState(...)`), so inflicting/curing state 1 through this command
 # must carry the identical HP side effect -- before this fix it only
 # pushed/deleted the id from the states array, leaving HP (and #dead?)
@@ -19755,9 +19810,10 @@ check 'the battle Conditional Branch tests switches, variables and battlers' do
   eq 2, st.variables[1], 'an actor not in the fight fails'
 end
 
-# デフォ戦bot trivia, verified against EasyRPG's real
-# Game_Interpreter_Battle::CommandConditionalBranchBattle / Game_Battler::CanAct
-# (src/game_interpreter_battle.cpp, src/game_battler.cpp): actor sub-test 3
+# デフォ戦bot trivia, and per EasyRPG Player's source (NOT independently
+# confirmed against genuine RPG_RT under wine), its
+# Game_Interpreter_Battle::CommandConditionalBranchBattle / Game_Battler::CanAct:
+# actor sub-test 3
 # ("can use battle command") is true unless the ally carries a "do nothing"
 # restriction (asleep/paralysed) -- it does NOT fail for a Berserk
 # (attack_enemy) or Confusion (attack_ally) restriction, since such an ally
@@ -19862,12 +19918,13 @@ end
 
 # Test 4 ("the currently-targeted troop member is param1") was previously
 # left unimplemented (see #do_conditional_battle's own citation), falling
-# straight to `else false` regardless of actual battle state. Confirmed
-# against EasyRPG's actual C++ source: `Game_Interpreter_Battle::
+# straight to `else false` regardless of actual battle state. Ported from
+# EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine: its `Game_Interpreter_Battle::
 # CommandConditionalBranchBattle` case 4, `result = (targets_single_enemy
 # && target_enemy_index == com.parameters[1]);`, where both fields are set
-# in `Scene_Battle_Rpg2k3::ProcessBattleActionBegin` (src/
-# scene_battle_rpg2k3.cpp) from the acting ally's own `GetOriginalSingle
+# in `Scene_Battle_Rpg2k3::ProcessBattleActionBegin` from the acting ally's
+# own `GetOriginalSingle
 # Target()` -- the target chosen at command time -- only when that target
 # is itself an enemy. `Game::Battle#target_enemy_index` is this port's own
 # counterpart, reusing the identical `battle_source` plumbing test 5
@@ -19927,9 +19984,10 @@ check 'battle Conditional Branch test 4 (troop member is the current ' \
   eq 2, st.variables[1], 'a command aimed at an ally is not a troop member'
 end
 
-# Confirmed against EasyRPG's actual C++ source, fetched live:
-# `Game_Interpreter_Battle::CommandConditionalBranchBattle`
-# (src/game_interpreter_battle.cpp) reads only `com.parameters[1]` for its
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine:
+# its `Game_Interpreter_Battle::CommandConditionalBranchBattle`
+# reads only `com.parameters[1]` for its
 # actor (case 2) and enemy (case 3) branches -- `result = actor->CanAct();`
 # / `result = enemy->CanAct();`. `parameters[2]`/`[3]` are never read at
 # all: the real editor's Actor/Enemy tab offers a single "can act"
@@ -20014,8 +20072,9 @@ check 'troop-member numbering stays stable when a middle member dies or is hidde
   # docs/TODO.md's render-order fix left this "still open": does killing or
   # hiding troop member 1 (the middle of three) shift member 2 down into
   # slot 1, silently repointing anything that names it by its original
-  # index? Confirmed against EasyRPG's Game_EnemyParty::ResetBattle /
-  # GetEnemy (src/game_enemyparty.cpp) that it does not -- `@enemies` here
+  # index? Per EasyRPG Player's source (NOT independently confirmed against
+  # genuine RPG_RT under wine), its Game_EnemyParty::ResetBattle /
+  # GetEnemy say it does not -- `@enemies` here
   # mirrors its fixed-size `enemies` vector exactly: built once, never
   # erased or resized mid-battle, with `dead?`/`hidden` in-place flags on
   # each entry rather than removal.
@@ -20167,9 +20226,9 @@ end
 # `Interpreter#identity_target`'s own doc comment), which all resolve
 # through the roster alone so an away companion is still affected, Enable
 # Combo additionally requires the named actor to be a *current* party
-# member. Confirmed directly against RPG_RT's live source:
-# `Game_Interpreter_Battle::CommandEnableCombo` (`src/
-# game_interpreter_battle.cpp`) is `if (!Main_Data::game_party->
+# member. Ported from EasyRPG Player's source, NOT independently confirmed
+# against genuine RPG_RT under wine:
+# `Game_Interpreter_Battle::CommandEnableCombo` is `if (!Main_Data::game_party->
 # IsActorInParty(actor_id)) { return true; }`, checked before
 # `Game_Actors::GetActor` is even consulted -- `IsActorInParty` appears in
 # exactly one other place in the whole reference (the Conditional Branch
@@ -20208,9 +20267,10 @@ check 'Call Common Event runs the common event and returns to the page' do
   eq true, st.switches[1], 'and control came back'
 end
 
-# Ports EasyRPG's own `Game_Interpreter_Battle::CommandForceFlee`/
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Interpreter_Battle::CommandForceFlee`/
 # `CommandEnableCombo`/`CommandCallCommonEvent`
-# (src/game_interpreter_battle.cpp): all three open with `if (!Player::
+# all three open with `if (!Player::
 # IsRPG2k3Commands()) { return true; }` -- the RPG2003 battle event editor
 # is the only one with any of these three commands at all, so a genuine
 # RPG2000 database's own battle page should never carry one, but an
@@ -20275,10 +20335,10 @@ check 'Open Load Menu and Exit Game raise their scene requests' do
   eq :exit_game, it2.wait_kind
 end
 
-# Confirmed against RPG_RT's own live source: all five 2k3e system commands
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: all five 2k3e system commands
 # (`CommandOpenLoadMenu`/`CommandExitGame`/`CommandToggleAtbMode`/
-# `CommandToggleFullscreen`/`CommandOpenVideoOptions`, `src/
-# game_interpreter.cpp`/`game_interpreter_map.cpp`) open with `if (!Player::
+# `CommandToggleFullscreen`/`CommandOpenVideoOptions`) open with `if (!Player::
 # IsRPG2k3ECommands()) { return true; }` -- a hard no-op, not merely
 # discarding some other effect, on an RPG2000-compatible database.
 check 'all five 2k3e system commands are RPG2000 no-ops' do
@@ -20314,8 +20374,9 @@ check 'all five 2k3e system commands are RPG2000 no-ops' do
   eq '', logged5, "Open Video Options doesn't either"
 end
 
-# Ports EasyRPG's own `Game_Interpreter::CommandWait`
-# (src/game_interpreter.cpp): a param1 mode byte the RPG2003 editor's Wait
+# Ported from EasyRPG Player's source (its `Game_Interpreter::CommandWait`),
+# NOT independently confirmed against genuine RPG_RT under wine: a param1
+# mode byte the RPG2003 editor's Wait
 # dialog adds -- 0 (or absent, an RPG2000 project) the plain timed wait,
 # nonzero "wait until the Decision key is pressed" instead, which ignores
 # param0 entirely (`if (com.parameters.size() <= 1 || (!maniac &&
@@ -20392,8 +20453,9 @@ check 'Show Battle Animation (battle form) waits like the map form' do
   eq true, it.battle_animation[:battle]
 end
 
-# Ports EasyRPG's own `Game_Interpreter_Battle::CommandShowBattleAnimation`
-# (src/game_interpreter_battle.cpp): `allies = com.parameters[3] != 0`, read
+# Ported from EasyRPG Player's source (its
+# `Game_Interpreter_Battle::CommandShowBattleAnimation`), NOT independently
+# confirmed against genuine RPG_RT under wine: `allies = com.parameters[3] != 0`, read
 # only `if (Player::IsRPG2k3() && com.parameters.size() > 3)` -- the same
 # trailing-RPG2003-parameter gate already used for Flash/Shake Screen.
 check 'Show Battle Animation (battle form) reads the RPG2003 Ally/Enemy target-type flag' do
@@ -20596,19 +20658,20 @@ end
 
 check 'a charged enemy is forced to attack, never running a pattern action ' \
       'like Defend even when the pattern would otherwise choose it' do
-  # EasyRPG's EnemyAi::SetStateRestrictedAction (src/enemyai.cpp) checks
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its EnemyAi::SetStateRestrictedAction checks
   # source.IsCharged() right after its attack_ally/attack_enemy restriction
   # branches and, if set, calls MakeAttack(source, 1) and returns *before*
   # SetEnemyAiAction (the rating-weighted pattern picker) is ever consulted
-  # (scene_battle_rpg2k.cpp's `if (!SetStateRestrictedAction(*enemy)) ...
+  # (its `if (!SetStateRestrictedAction(*enemy)) ...
   # SetEnemyAiAction(...)`) -- so a charged enemy can never end up Defending
   # (or casting a Skill, self-destructing, ...); it is guaranteed exactly one
   # doubled Attack. #strike now skips #choose_enemy_action outright while
   # charged, matching that gate -- it used to run the pattern normally, so a
   # single-entry Defend pattern would win the draw and spend the charge for
-  # nothing (Game_BattleAlgorithm::AlgorithmBase::Start()'s own unconditional
-  # SetCharged(false) still fires for *any* algorithm once one actually runs,
-  # confirmed against game_battlealgorithm.cpp and ported by
+  # nothing (that reference's own Game_BattleAlgorithm::AlgorithmBase::Start()
+  # unconditional SetCharged(false) still fires for *any* algorithm once one
+  # actually runs, and is ported by
   # #perform_enemy_action -- that part was already correct, it just used to
   # be reachable by the wrong action kind).
   foe = combatant('Slime', 40, 0, 5, 500)
@@ -20760,8 +20823,9 @@ check 'a switch-gated action is invalid with no AI env to ask' do
   ok enemy_entry([act], nil)[:defend].nil?, 'falls back to attacking'
 end
 
-# "Enemies" in the editor's own condition list -- EasyRPG's IsActionValid
-# (src/enemyai.cpp) reads game_enemyparty's own GetActiveBattlers here, never
+# "Enemies" in the editor's own condition list -- per EasyRPG Player's
+# source (NOT independently confirmed against genuine RPG_RT under wine),
+# its IsActionValid reads game_enemyparty's own GetActiveBattlers here, never
 # game_party, so this ranges over the acting monster's own living troop-mates,
 # not the player party's headcount.
 check 'an actor-count action ranges over the living enemy troop, not the party' do
@@ -20810,11 +20874,12 @@ check 'a party-level action reads the average level through the AI env' do
   ok enemy_entry([miss], ai)[:defend].nil?, 'outside it'
 end
 
-check 'an out-of-range condition type still fires, matching RPG_RT\'s own ' \
-      'default: return true' do
-  # Confirmed directly against RPG_RT's live source: `EnemyAi::
+check "an out-of-range condition type still fires, per EasyRPG Player's own " \
+      "default: return true (NOT independently confirmed under wine)" do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `EnemyAi::
   # IsActionValid`'s own `switch (action.condition_type)`
-  # (`src/enemyai.cpp`) ends `default: return true;` -- a condition_type
+  # ends `default: return true;` -- a condition_type
   # past the eight it recognises (e.g. a hand-edited or non-standard-tool
   # database byte) reads as unconditionally eligible, not excluded.
   act = enemy_action(kind: 0, basic: 2, condition_type: 99)
@@ -20874,12 +20939,13 @@ check 'an enemy casts an attack skill from its pattern' do
   ok e[:damage] > 0, 'and it hurt'
 end
 
-# Confirmed directly against RPG_RT's live source: `EnemyAi::IsActionValid`
-# (`src/enemyai.cpp`) rejects a `Kind_skill` action outright when
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `EnemyAi::IsActionValid`
+# rejects a `Kind_skill` action outright when
 # `!source.IsSkillUsable(action.skill_id)` -- before the action's own weight
-# is ever computed, not merely zeroed out afterward. `Algo::IsSkillUsable`
-# (`src/algo.cpp`), which `Game_Battler::IsSkillUsable`
-# (`src/game_battler.cpp`) reaches in battle, is unconditionally false for a
+# is ever computed, not merely zeroed out afterward. Its `Algo::IsSkillUsable`,
+# which `Game_Battler::IsSkillUsable`
+# reaches in battle, is unconditionally false for a
 # Teleport- or Escape-type skill, and gated on the skill's own
 # `occasion_battle` flag for a Switch-type one -- an enemy's own action
 # pattern is bound by the exact same rules a field/battle actor cast is.
@@ -21005,7 +21071,8 @@ end
 # -- skill effectiveness gates the AI's own weighted choice --------------------
 
 check "an enemy's own state-cure skill is excluded from the running when it has nothing to cure" do
-  # EasyRPG's EnemyAi::IsSkillEffectiveOnAnyTarget (src/enemyai.cpp): unlike an
+  # Ported from EasyRPG Player's source (its EnemyAi::IsSkillEffectiveOnAnyTarget),
+  # NOT independently confirmed against genuine RPG_RT under wine: unlike an
   # HP/SP/stat-affecting skill (always considered worth trying against a live
   # target -- the real engine never actually computes the effect before
   # choosing), a *pure* state-effect skill only counts as effective once some
@@ -21056,9 +21123,10 @@ check "an enemy's own state-cure skill still fires once a target actually needs 
 end
 
 check "an ineffective skill's own high rating still crowds out a lower-rated action via max_prio" do
-  # EasyRPG computes max_prio from every action's raw rating first, then
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), it computes max_prio from every action's raw rating first, then
   # zeroes an ineffective skill's own draw in a *separate* later pass
-  # (src/enemyai.cpp's SelectEnemyAiActionRpgRtCompat) -- it does not drop
+  # (its SelectEnemyAiActionRpgRtCompat) -- it does not drop
   # the ineffective skill before max_prio is found and recompute the other
   # actions' weights against a lower max. So a much lower-rated action a
   # naive "exclude it up front" fix would let back into the draw (49 is
@@ -21136,11 +21204,12 @@ end
 
 check 'battle: auto_battle_attack_target_rank includes the RPG2003 attacker ' \
       "row bonus, matching the real attack's own formula" do
-  # Confirmed directly against RPG_RT's live source: `Calc
-  # NormalAttackAutoBattleTargetRank` (`src/autobattle.cpp`) computes its own
-  # `base_effect` via `Algo::CalcNormalAttackEffect` (`src/algo.cpp`) -- the
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Calc
+  # NormalAttackAutoBattleTargetRank` computes its own
+  # `base_effect` via `Algo::CalcNormalAttackEffect` -- the
   # *identical* function `Game_BattleAlgorithm::Normal::Execute`
-  # (`src/game_battlealgorithm.cpp`) calls to resolve the real swing -- so a
+  # calls to resolve the real swing -- so a
   # front-row attacker's ranking must include the same +25% bonus its real
   # attack deals, not merely the raw, unadjusted damage. Two otherwise-
   # identical battles seeded identically isolate the row difference from the
@@ -21180,9 +21249,10 @@ end
 
 check 'battle: auto_battle_attack_target_rank reads the target\'s ' \
       'state-adjusted Defence, not its raw base stat' do
-  # Same citation as the row check above -- `CalcNormalAttackAutoBattleTarget
+  # Same source as the row check above (EasyRPG Player's, NOT independently
+  # confirmed against genuine RPG_RT under wine) -- `CalcNormalAttackAutoBattleTarget
   # Rank` shares `Algo::CalcNormalAttackEffect` with the real attack, and
-  # `Game_Battler::GetDef` (`src/game_battler.cpp`) folds in a currently-
+  # `Game_Battler::GetDef` folds in a currently-
   # afflicted state's own halve/double Defence flag. A target whose Defence
   # is halved by an active state must rank as easier to damage than an
   # identical, unafflicted one.
@@ -21312,7 +21382,8 @@ end
 
 # A "true form" boss trick -- transforming into a form with a *smaller* max
 # HP/SP than the current values must not full-heal-then-clamp them down.
-# EasyRPG's `Game_Enemy::Transform` (src/game_enemy.cpp) only ever repoints
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Game_Enemy::Transform` only ever repoints
 # the `enemy` database row and refreshes the sprite; it never touches hp/sp
 # at all (those are set to the max exactly once, in the constructor, on the
 # enemy's very first spawn). `Game_BattleAlgorithm::Transform`'s own
@@ -21340,10 +21411,11 @@ check 'a transformation carries current HP/SP over unchanged, not reclamped to t
   eq 40, foe.mp, 'current SP carries over unchanged too'
 end
 
-# EasyRPG's own attribute-rank shift is a persistent delta (Game_Battler::
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its attribute-rank shift is a persistent delta (Game_Battler::
 # attribute_shift, clamped to +-1 total) added onto a *live* base
 # (Game_Enemy::GetBaseAttributeRate reads straight off the currently-
-# transformed `enemy` row, src/game_enemy.cpp) -- a Transform can never make
+# transformed `enemy` row) -- a Transform can never make
 # it stale, there being only the one pointer. This port instead snapshots the
 # base once (Combatant#attr_base_ranks, set at spawn) to cap an absolute
 # rank value, so a Transform has to explicitly re-seed it -- exactly the
@@ -21857,7 +21929,8 @@ check 'the same item revives an ally who is down, HP and all' do
   ok !hero.dead?, 'back on their feet'
   # Standing up puts them on 1 HP first (the existing revive path), and the
   # item's 25% of 100 lands on top of that -- but one HP short of the raw
-  # 25, since RPG_RT's `Game_Battler::UseItem` (`src/game_battler.cpp`)
+  # 25, since (per EasyRPG Player's source, NOT independently confirmed
+  # against genuine RPG_RT under wine) its `Game_Battler::UseItem`
   # applies `ChangeHp(hp_change - revived, false)` on top of the cure's own
   # floor-to-1, not the full `hp_change`.
   eq 25, hero.hp, 'with the 25% the item restores, one short of the raw 25'
@@ -21877,8 +21950,9 @@ end
 check 'a medicine that does not cure Death does nothing at all to a downed ' \
       'target -- not even curing an unrelated state or restoring MP, and ' \
       'the item is not spent' do
-  # Confirmed against RPG_RT's own live source: `Game_Battler::UseItem`
-  # (src/game_battler.cpp) checks `IsDead()` before anything else and
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Game_Battler::UseItem`
+  # checks `IsDead()` before anything else and
   # returns `false` immediately -- no state-cure loop, no HP change, no SP
   # change run at all -- unless `item->state_set[0]` (state id 1, Death) is
   # flagged. An Antidote-style item that cures some other state (Poison,
@@ -22122,8 +22196,9 @@ check 'equipping a second weapon from the bag lands it in the shield slot' do
   eq 95, hero.attack_hit_rate, 'the better of the two weapons\' hit rates'
   eq 20, hero.weapon_crit_bonus, 'the dagger\'s crit bonus, the sword carrying none'
   eq 10 + 20 + 15, hero.atk, 'both weapons\' attack bonuses are summed in, like any slot'
-  # Confirmed against EasyRPG's actual C++ source: Game_BattleAlgorithm::
-  # Normal::Init (src/game_battlealgorithm.cpp) sums each weapon's own hit
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_BattleAlgorithm::
+  # Normal::Init sums each weapon's own hit
   # count (GetNumberOfAttacks) once both GetWeapon() and Get2ndWeapon() hold
   # a real weapon, rather than taking the higher of the two the way the
   # single-weapon case (Game_Actor::GetNumberOfAttacks's own max-over-
@@ -22134,8 +22209,8 @@ end
 
 check 'a weapon with its own genuine 0% hit rate is used as-is, not treated ' \
       'as unequipped' do
-  # Confirmed against EasyRPG's actual C++ source: Game_Actor::GetHitChance
-  # (src/game_actor.cpp) uses INT_MIN as its own "nothing equipped" sentinel
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_Actor::GetHitChance uses INT_MIN as its own "nothing equipped" sentinel
   # (`hit = std::max(hit, item.hit)`, `if (hit != INT_MIN) return hit;`), so
   # a "cursed" weapon whose own `hit` field is a genuine 0 -- intentionally
   # unable to land a hit, not a missing field -- is returned as 0, not
@@ -22179,15 +22254,16 @@ end
 
 check "battle: an RPG2003 two-weapon actor's swings each roll their own " \
       "weapon's to-hit, not a merged max" do
-  # Confirmed against EasyRPG's actual C++ source: Game_BattleAlgorithm::
-  # Normal::GetDefaultStyle (src/game_battlealgorithm.cpp) only picks
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_BattleAlgorithm::
+  # Normal::GetDefaultStyle only picks
   # Style_MultiHit -- the style whose Init sets weapon_style and so lets
   # GetWeapon resolve a specific slot instead of WeaponAll -- when
-  # Feature::HasRpg2k3BattleSystem() (src/feature.cpp: !HasRpg2kBattleSystem,
+  # Feature::HasRpg2k3BattleSystem() (!HasRpg2kBattleSystem,
   # true whenever the game isn't Player::IsRPG2k()). Under that style, each
   # swing resolves to exactly one weapon (the primary weapon's own hit count
-  # worth of swings, then the secondary's), and Game_Actor::GetHitChance's own
-  # ForEachEquipment (src/game_actor.cpp) excludes the *other* weapon's slot
+  # worth of swings, then the secondary's), and its Game_Actor::GetHitChance's own
+  # ForEachEquipment excludes the *other* weapon's slot
   # entirely -- never a merge/max across both. hit 100 always lands (its own
   # agi term collapses to zero regardless of either side's Agility); a low
   # hit rate against a much nimbler target clamps to a guaranteed miss (the
@@ -22223,8 +22299,8 @@ check "battle: an RPG2003 two-weapon actor's swings each carry their own " \
   # Same Style_MultiHit/GetWeapon/ForEachEquipment exclusion as the to-hit
   # check above, but for Attribute::ApplyAttributeNormalAttackMultiplier and
   # the weapon-state block of Normal::vExecute (both also gated on that
-  # swing's own resolved weapon, per EasyRPG's src/attribute.cpp and
-  # src/game_battlealgorithm.cpp). Both weapons hit 100 so accuracy never
+  # swing's own resolved weapon, per EasyRPG Player's source, NOT
+  # independently confirmed against genuine RPG_RT under wine). Both weapons hit 100 so accuracy never
   # interferes; element 1 is immune (rank 4 -> 0%) and element 2 is normal
   # (rank 2 -> 100%) on the target. The weapon states are 3 and 4,
   # deliberately not 1: state id 1 is always Knockout (Game::States::
@@ -22261,13 +22337,14 @@ end
 
 check "battle: an RPG2000 two-weapon actor's swings both roll the merged " \
       "max to-hit, never one weapon's own low roll" do
-  # Confirmed against EasyRPG's actual C++ source: Game_BattleAlgorithm::
-  # Normal::GetDefaultStyle (src/game_battlealgorithm.cpp) picks
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_BattleAlgorithm::
+  # Normal::GetDefaultStyle picks
   # Style_Combined -- not Style_MultiHit -- whenever
   # !Feature::HasRpg2k3BattleSystem() (a non-2003 database), and Init only
   # ever sets weapon_style under Style_MultiHit; left at its initial -1,
   # GetWeapon always returns WeaponAll, so Game_Actor::GetHitChance's
-  # ForEachEquipment (src/game_actor.cpp) folds in *both* equipped weapons'
+  # ForEachEquipment folds in *both* equipped weapons'
   # hit fields for *every* swing (`hit = std::max(hit, item.hit)`), never one
   # specific slot's own roll. Same fixture as the RPG2003 check above (a
   # hit-100 and a hit-10 weapon against a much nimbler target -- the low hit
@@ -22382,8 +22459,9 @@ end
 # The Change Equipment event command (#equip_item_from_bag) bypasses
 # #equip_candidates/#equip_candidate_for? entirely -- it names no slot at
 # all, unlike the equip menu -- so it needs its own dual-wield handling.
-# Confirmed against RPG_RT's own live source: `Game_Interpreter::
-# CommandChangeEquipment` (src/game_interpreter.cpp) special-cases
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Interpreter::
+# CommandChangeEquipment` special-cases
 # `HasTwoWeapons()` before its own `ChangeEquipment` call: a shield-type
 # item is a complete no-op, and a weapon-type item redirects into the
 # shield slot when the weapon slot already holds a non-two-handed weapon

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5565,10 +5565,11 @@ end
 
 check 'Proceed With Movement resumes the command right after it the same ' \
       'real frame the forced route finishes, not one frame later' do
-  # RPG_RT's own `Game_Interpreter::Update` loop does not unconditionally
-  # `break` on `_state.wait_movement` either -- `if (_state.wait_movement) {
-  # if (Game_Map::IsAnyMovePending()) break; _state.wait_movement = false; }`
-  # (`src/game_interpreter.cpp`) -- once every targeted route finishes, that
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Game_Interpreter::Update` loop does not
+  # unconditionally `break` on `_state.wait_movement` either -- `if
+  # (_state.wait_movement) { if (Game_Map::IsAnyMovePending()) break;
+  # _state.wait_movement = false; }` -- once every targeted route finishes, that
   # same `Update` call falls straight through into whatever command follows.
   # A freshly-armed forced route's own `move_timer` starts at 0
   # (#force_event_route), so its very first step fires on the first frame
@@ -6231,9 +6232,10 @@ end
 
 check 'Tint Screen resumes the command right after it the same real frame the ' \
       'tint settles, not one frame later' do
-  # RPG_RT implements Tint Screen's own wait flag with the identical
-  # `_state.wait_time` countdown the plain Wait command uses (`SetupWait`,
-  # `src/game_interpreter.cpp`), not a "poll until still animating"
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), Tint Screen's own wait flag uses the identical
+  # `_state.wait_time` countdown the plain Wait command uses (`SetupWait`),
+  # not a "poll until still animating"
   # mechanism -- its own `Update` loop falls straight through into whatever
   # command follows the instant that countdown clears, costing no further
   # frame. 1 tenth (6 frames): the interpreter starts on frame 1, the tint
@@ -6412,8 +6414,9 @@ check 'a continuous-animation event advances even while standing still' do
   ok e[:anim_phase] != 0, 'but its walk animation kept cycling'
 end
 
-# Confirmed against EasyRPG's live source, `Game_Character::
-# GetContinuousAnimFrames` (`src/game_character.h`): an idling Continuous
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Character::
+# GetContinuousAnimFrames`: an idling Continuous
 # event's own cadence (ANIM_CONTINUOUS_FRAMES[2] = 10 at the default
 # move_speed) is slower than the sliding/stationary cadence
 # (ANIM_STATIONARY_FRAMES[2] = 8) the same event would use while actually
@@ -6433,8 +6436,9 @@ check 'a continuous-animation event standing still cycles on its own, ' \
 end
 
 # Same distinction, for a Spin-type event's own facing-rotation cadence
-# (ANIM_SPIN_FRAMES[2] = 12) -- confirmed against EasyRPG's `Game_Character::
-# GetSpinAnimFrames` (`src/game_character.h`), read unconditionally by
+# (ANIM_SPIN_FRAMES[2] = 12) -- per EasyRPG Player's source (NOT
+# independently confirmed against genuine RPG_RT under wine), its `Game_Character::
+# GetSpinAnimFrames`, read unconditionally by
 # `UpdateAnimation`'s `IsSpinning()` branch, whether the event is moving or
 # not.
 check 'a spin-type event rotates its facing on its own, slower cadence ' \
@@ -6492,10 +6496,11 @@ end
 # #build_field_background), a message window is not a scene push and does not
 # blank the screen -- it is itself a z=300 Window sitting above the z=250
 # picture layer (see the "below the message window" assertion just above).
-# RPG_RT's own Draw() carries no message-window check for pictures either
-# (verified against EasyRPG Player's Sprite_Picture::Draw and Scene_Map --
-# `Priority_PictureOld` sits below `Priority_Window` in src/drawable.h, and
-# neither file gates picture visibility on message state), so an already-shown
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine): its Draw() carries no message-window check for pictures
+# either -- its Sprite_Picture::Draw and Scene_Map --
+# `Priority_PictureOld` sits below `Priority_Window`, and
+# neither gates picture visibility on message state -- so an already-shown
 # picture keeps compositing and animating under an open message window exactly
 # like it does under any other window; the window's own z-order is what covers
 # it, the same way it covers the map tiles beneath it.
@@ -6553,9 +6558,10 @@ check 'pictures composite in ascending id order, independent of show order' do
      'lower id drawn first, higher id drawn last (on top), regardless of show order'
 end
 
-# RPG_RT's `ShowParams` (src/game_pictures.h) defaults every picture's
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `ShowParams` defaults every picture's
 # `affected_by_shake` flag on (RPG2000/pre-1.12 RPG2003 games have no way to
-# turn it off at all), and `Sprite_Picture::Draw` (src/sprite_picture.cpp)
+# turn it off at all), and its `Sprite_Picture::Draw`
 # applies the shake offset to a picture's screen position unconditionally of
 # `fixed_to_map`: `if (data.flags.affected_by_shake) { x -=
 # GetShakeOffsetX(); ... }`. A picture NOT fixed to the map used to hold
@@ -6563,7 +6569,8 @@ end
 # the view -- only a map-fixed picture's own scroll subtraction happened to
 # fold the shake in too, as a side effect of #camera_position already
 # including it.
-check 'a picture not fixed to the map still shakes with Shake Screen (RPG_RT)' do
+check 'a picture not fixed to the map still shakes with Shake Screen ' \
+      '(per EasyRPG Player, not independently confirmed under wine)' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)
   st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
@@ -6791,8 +6798,9 @@ check 'Open Shop scene: buying then leaving runs the Transaction branch' do
   eq 400, st.party.gold, 'one Potion bought'
   eq 1, st.party.item_count(3)
   # The "purchased" confirmation only leaves once its own 60-frame timer
-  # expires -- Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) never
-  # reads Input::, so a button press does not skip it.
+  # expires -- per EasyRPG Player's source (NOT independently confirmed
+  # against genuine RPG_RT under wine), its Scene_Shop::vUpdate's Bought case
+  # never reads Input::, so a button press does not skip it.
   60.times { scene.update }
   RGSS::Input.triggered = [RGSS::Input::B] # leave the shop
   scene.update
@@ -6828,9 +6836,10 @@ end
 # key across frames without it also reading as a fresh trigger.
 check 'Open Shop scene: holding a direction auto-repeats the buy list ' \
       'cursor, not just a fresh press' do
-  # Confirmed against RPG_RT's own live source: `Window_Shop::Update`
-  # (src/window_shop.cpp, the command list) and `Window_Selectable::Update`
-  # (src/window_selectable.cpp, the buy/sell item lists) both move the
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Window_Shop::Update`
+  # (the command list) and `Window_Selectable::Update`
+  # (the buy/sell item lists) both move the
   # cursor on a held (repeated) Down/Up, not only a fresh trigger.
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
@@ -6900,9 +6909,9 @@ check 'Open Shop scene: the counter steps by one on the horizontal axis and ' \
 end
 
 check 'Open Shop scene: the counter steps by ten on the vertical axis' do
-  # Confirmed against EasyRPG's Window_ShopNumber::Update
-  # (src/window_shopnumber.cpp): RIGHT/LEFT step by one, UP/DOWN by ten -- the
-  # tens step is vertical, not horizontal.
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Window_ShopNumber::Update: RIGHT/LEFT step by
+  # one, UP/DOWN by ten -- the tens step is vertical, not horizontal.
   scene, _st = shop_quantity_scene(999_999)
   shop = scene.instance_variable_get(:@shop)
   eq 99, shop[:quantity][:max], 'rich enough to hit the item cap'
@@ -6918,8 +6927,8 @@ end
 # key across frames without it also reading as a fresh trigger.
 check 'Open Shop scene: holding a direction auto-repeats the quantity counter, ' \
       'not just a fresh press' do
-  # Confirmed against RPG_RT's own live source: Window_ShopNumber::Update
-  # (src/window_shopnumber.cpp) gates all four directions on
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Window_ShopNumber::Update gates all four directions on
   # Input::IsRepeated, not IsTriggered -- the same repeat-while-held cursor
   # semantics every other in-game list uses.
   scene, _st = shop_quantity_scene(999_999)
@@ -6946,8 +6955,9 @@ check 'Open Shop scene: confirming the counter buys the whole stack at once' do
   eq 3, st.party.item_count(3), 'three bought in one confirm'
   shop = scene.instance_variable_get(:@shop)
   eq :purchased, shop[:screen], 'the "purchased" confirmation shows first'
-  # RPG_RT auto-dismisses the confirmation after a flat one-second (60 frame)
-  # timer -- Scene_Shop::vUpdate's Bought/Sold cases (src/scene_shop.cpp)
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), it auto-dismisses the confirmation after a flat
+  # one-second (60 frame) timer -- Scene_Shop::vUpdate's Bought/Sold cases
   # never read Input:: at all -- so a button press alone does nothing here.
   press(scene, RGSS::Input::C)
   shop = scene.instance_variable_get(:@shop)
@@ -7001,10 +7011,11 @@ check 'Open Shop scene: an unaffordable good never opens the counter' do
 end
 
 check 'Open Shop scene: the command list plays the RPG_RT system SE' do
-  # Confirmed against EasyRPG's Window_Shop::Update (src/window_shop.cpp):
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Window_Shop::Update:
   # Cursor on every move, Decision on any of Buy/Sell/Leave (all three
   # always succeed, so there is no Buzzer case here); Cancel on B
-  # (Scene_Shop::UpdateCommandSelection, src/scene_shop.cpp).
+  # (Scene_Shop::UpdateCommandSelection).
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0), # buy+sell
@@ -7033,8 +7044,9 @@ check 'Open Shop scene: the command list plays the RPG_RT system SE' do
 end
 
 check 'Open Shop scene: the buy list plays cursor/decision SE, buzzer for an unaffordable good' do
-  # Confirmed against EasyRPG's Scene_Shop::UpdateBuySelection
-  # (src/scene_shop.cpp): Decision opens the quantity counter for an
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Scene_Shop::UpdateBuySelection: Decision opens
+  # the quantity counter for an
   # affordable good, Buzzer instead the moment `buy_window->CheckEnable`
   # fails -- #open_shop_quantity's own `max < 1` guard is that same check.
   ic = Game::Interpreter::Cmd
@@ -7063,10 +7075,10 @@ check 'Open Shop scene: the buy list plays cursor/decision SE, buzzer for an una
 end
 
 check 'Open Shop scene: the quantity counter plays cursor/decision/cancel SE' do
-  # Confirmed against EasyRPG's Window_ShopNumber::Update
-  # (src/window_shopnumber.cpp, cursor only when the count actually
-  # changed) and Scene_Shop::UpdateNumberInput (src/scene_shop.cpp,
-  # decision on commit, cancel on B).
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Window_ShopNumber::Update (cursor only when the
+  # count actually
+  # changed) and Scene_Shop::UpdateNumberInput (decision on commit, cancel on B).
   scene, = shop_quantity_scene(500)
 
   RGSS::Audio.reset_se
@@ -7119,8 +7131,9 @@ check 'Open Shop scene: leaving without buying runs the No Transaction branch' d
   ok st.switches[2], 'the No Transaction branch ran'
 end
 
-# EasyRPG's `Game_Interpreter_Map::CommandOpenShop`
-# (src/game_interpreter_map.cpp) is the exact same method for the foreground
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Game_Interpreter_Map::CommandOpenShop`
+# is the exact same method for the foreground
 # and every Parallel Process's own interpreter -- gated only on
 # `Game_Message::IsMessageActive()`, no "foreground only" restriction. Before
 # this fix, `Scene::Map#drive_parallel_wait` had no `:shop` branch at all, so
@@ -7159,8 +7172,9 @@ check 'Open Shop issued from a Parallel Process opens the shop screen too' do
   eq 400, st.party.gold, 'one Potion bought'
   eq 1, st.party.item_count(3)
   # The "purchased" confirmation only leaves once its own 60-frame timer
-  # expires -- Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) never
-  # reads Input::, so a button press does not skip it.
+  # expires -- per EasyRPG Player's source (NOT independently confirmed
+  # against genuine RPG_RT under wine), its Scene_Shop::vUpdate's Bought case
+  # never reads Input::, so a button press does not skip it.
   60.times { scene.update }
   RGSS::Input.triggered = [RGSS::Input::B] # leave the shop
   scene.update
@@ -7186,16 +7200,17 @@ def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil, troop_id:
   ]
 end
 
-# Enemy Encounter's own param2 selects the battle backdrop's source, verified
-# against EasyRPG Player's actual C++ source rather than assumed:
-# `Game_Interpreter_Map::CommandEnemyEncounter` (`src/game_interpreter_map.cpp`)
+# Enemy Encounter's own param2 selects the battle backdrop's source. Ported
+# from EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine:
+# `Game_Interpreter_Map::CommandEnemyEncounter`
 # `switch`es on it -- 0 (the only case previously modelled) leaves the ordinary
 # map/terrain default in place; 1 names an explicit background image directly
 # on the command (its own free-text `string` field, entirely separate from
 # every numeric param); 2 names an explicit terrain id instead (param8), read
 # off that terrain's own row directly rather than wherever the party happens
-# to be standing (`Background(int terrain_id)`, `src/background.cpp` --
-# confirmed to bypass the map-tree walk `Game_Map::SetupBattle` uses for the
+# to be standing (`Background(int terrain_id)` --
+# which bypasses the map-tree walk `Game_Map::SetupBattle` uses for the
 # param2==0 default entirely). `Interpreter#do_enemy_encounter` used to read
 # neither at all, so a scripted encounter always fell back to the map/terrain
 # default regardless of what the event author actually chose.
@@ -7355,7 +7370,8 @@ check 'Enemy Encounter scene: finish_battle captures the round count as last_bat
      "(got #{st.last_battle_turns.inspect})"
 end
 
-# RPG_RT's own `Scene_Battle` constructor (src/scene_battle.cpp) plays the
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Scene_Battle` constructor plays the
 # database's Battle Start system SE (`SFX_BeginBattle`) as its very first act,
 # unconditionally, before even swapping to the battle BGM -- `Scene::Map
 # #open_battle` (mruby-rpg2k/mrblib/scene/map.rb) already had every other
@@ -7403,8 +7419,9 @@ check 'Enemy Encounter scene: a Change System SFX battle-start override wins ove
      'the database default is fully superseded, not layered alongside it'
 end
 
-# EasyRPG Player's `Scene_Battle_Rpg2k::ProcessSceneActionStart`
-# (`src/scene_battle_rpg2k.cpp`) narrates the encounter before the party is
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Scene_Battle_Rpg2k::ProcessSceneActionStart`
+# narrates the encounter before the party is
 # ever asked for a command: `GetActiveBattlers` (not dead or hidden) feeds one
 # `PushWithSubject(terms.encounter, enemy->GetName())` per visible member --
 # stock RPG2000's `PushWithSubject` concatenates `subject + message`, no
@@ -8111,7 +8128,8 @@ end
 
 check "Game Over's very first #update already honours a Decision trigger " \
       '-- there is no arming delay' do
-  # EasyRPG's Scene_Gameover::vUpdate (src/scene_gameover.cpp) is a bare
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Scene_Gameover::vUpdate is a bare
   # `if (Input::IsTriggered(Input::DECISION)) { ReturnToTitleScene(); }` --
   # no arming/pending state of any kind. An earlier version here required a
   # key-released frame first, on the theory that the key which dismissed
@@ -8122,7 +8140,9 @@ check "Game Over's very first #update already honours a Decision trigger " \
   # point that iteration's own `Input.update` has already cleared the old
   # trigger. That scenario can never reach this screen's very first
   # `#update` call through the real engine loop, so a fresh Decision
-  # trigger dismisses it immediately, exactly like the reference.
+  # trigger dismisses it immediately, matching that reference's own logic
+  # (though this itself has not been independently confirmed against
+  # genuine RPG_RT under wine).
   parent = fake_parent(fake_db)
   Input.reset
   scene = RPG2k::Scene::GameOver.new(parent)
@@ -8217,8 +8237,9 @@ end
 
 check "a Common Event Parallel Process's own Battle Processing is blocked " \
       '(not run) while a message window is open, and retries once it closes' do
-  # Confirmed directly against RPG_RT's live source: `Game_Interpreter_Map::
-  # CommandEnemyEncounter` (`src/game_interpreter_map.cpp`, code 10710) opens
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Game_Interpreter_Map::
+  # CommandEnemyEncounter` (code 10710) opens
   # with `if (Game_Message::IsMessageActive()) { return false; }`,
   # unconditionally -- the identical block-and-retry shape already ported for
   # Show/Move/Erase Picture and Transfer Player/Recall to Location, see
@@ -8340,8 +8361,9 @@ check 'Enter Hero Name: typing on the grid and confirming renames the actor' do
   ok st.switches[5], 'the event resumed after entry'
 end
 
-# Confirmed against RPG_RT's own live source: `Scene_Name::vUpdate`'s DONE
-# branch (`src/scene_name.cpp`) is `if (name_window->Get().empty()) {
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Name::vUpdate`'s DONE
+# branch is `if (name_window->Get().empty()) {
 # name_window->Set(ToString(actor.GetName())); name_window->Refresh(); }
 # else { actor.SetName(...); Scene::Pop(); }` -- an empty typed name resets
 # the field to the actor's current name and leaves the screen open, rather
@@ -8385,10 +8407,11 @@ check 'Enter Hero Name: confirming a blank name refills it and stays open, ' \
 end
 
 check 'Enter Hero Name plays the RPG_RT system SE on every interaction' do
-  # Confirmed against EasyRPG's Scene_Name::vUpdate (src/scene_name.cpp,
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its Scene_Name::vUpdate (
   # Cursor on every grid move, Decision unconditionally on every C press
-  # before dispatching on the highlighted cell), Window_Name::Append (src/
-  # window_name.cpp, Buzzer when a character would overflow the field) and
+  # before dispatching on the highlighted cell), Window_Name::Append (
+  # Buzzer when a character would overflow the field) and
   # the same vUpdate's Cancel branch (Cancel with a character to erase,
   # Buzzer with none) -- this widget used to play nothing at all.
   ic = Game::Interpreter::Cmd
@@ -8432,8 +8455,9 @@ check 'Enter Hero Name plays the RPG_RT system SE on every interaction' do
   eq RPG2k::Scene::Map::NAME_MAX, ui[:name].length, 'the character was not appended'
 end
 
-# EasyRPG's `Game_Interpreter_Map::CommandEnterHeroName`
-# (src/game_interpreter_map.cpp) is the exact same method for the foreground
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Game_Interpreter_Map::CommandEnterHeroName`
+# is the exact same method for the foreground
 # and every Parallel Process's own interpreter -- gated only on
 # `Game_Message::IsMessageActive()`, no "foreground only" restriction. Before
 # this fix, `Scene::Map#drive_parallel_wait` had no `:name_input` branch at
@@ -8547,8 +8571,9 @@ end
 # key across frames without it also reading as a fresh trigger.
 check 'Enter Hero Name: holding a direction auto-repeats the character grid ' \
       'cursor, not just a fresh press' do
-  # Confirmed against RPG_RT's own live source: `Window_Keyboard::Update`
-  # (src/window_keyboard.cpp) gates all four grid directions on
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Window_Keyboard::Update`
+  # gates all four grid directions on
   # `Input::IsRepeated` alone, which fires on both the first pressed frame
   # and every later repeat tick.
   ic = Game::Interpreter::Cmd
@@ -8725,14 +8750,15 @@ check 'Enter Hero Name: confirming a blank kana name refills it and stays ' \
   ok st.switches[5], 'and the event resumed'
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Window_Keyboard::
-# layouts[]` (`src/window_keyboard.cpp`), the real RPG_RT keyboard table --
-# the ま row's small-kana columns are っゃゅょゎ (small-tsu, then small-ya/
-# yu/yo, then small-wa), and the last row's "vu" cell is katakana ヴ even
-# on the hiragana page (hiragana has no glyph of its own there in the
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_Keyboard::
+# layouts[]` -- the ま row's small-kana columns are っゃゅょゎ (small-tsu, then
+# small-ya/yu/yo, then small-wa), and the last row's "vu" cell is katakana ヴ
+# even on the hiragana page (hiragana has no glyph of its own there in that
 # reference table).
-check 'Enter Hero Name: the ま row and "vu" cell match RPG_RT\'s own keyboard ' \
-      'table, not a scrambled small-kana order' do
+check 'Enter Hero Name: the ま row and "vu" cell match EasyRPG Player\'s own ' \
+      'keyboard table (not independently confirmed under wine), not a ' \
+      'scrambled small-kana order' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = [ECmd.new(ic::NAME_INPUT, [1, 0, 0], indent: 0)]
@@ -8949,8 +8975,9 @@ end
 check "a common event's Parallel Process's own show-message Change Level " \
       'command is blocked (not applied) while a message window is open, and ' \
       'retries once it closes' do
-  # Confirmed directly against RPG_RT's live source: `Game_Interpreter::
-  # CommandChangeExp`/`CommandChangeLevel` (`src/game_interpreter.cpp`) both
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Game_Interpreter::
+  # CommandChangeExp`/`CommandChangeLevel` both
   # open with `bool show_msg = com.parameters[5]; if (show_msg &&
   # !Game_Message::CanShowMessage(true)) { return false; }`, guarding the
   # entire command -- the actor's level itself, not just the level-up
@@ -9017,9 +9044,9 @@ check 'boarding a boat and disembarking onto the shore' do
   eq [0, 1], [boat.x, boat.y], 'the boat stayed where the party left it'
 end
 
-# Confirmed against EasyRPG's live source: `Game_Player::GetOffVehicle`
-# (`src/game_player.cpp`) calls `Game_Map::CanDisembarkShip` (`src/
-# game_map.cpp`), which only ever tests the *landing* tile's own passability
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Game_Player::GetOffVehicle`
+# calls `Game_Map::CanDisembarkShip`, which only ever tests the *landing* tile's own passability
 # (`GetPassableMask(x, y, player.GetX(), player.GetY())` derives a single
 # direction bit at `(x, y)` alone) -- unlike an ordinary step's own two-sided
 # `#passable?`, the water tile the party is leaving is never consulted.
@@ -9037,7 +9064,8 @@ check 'a boat disembark only tests the landing tile\'s own passability, ' \
   eq 1, calls.size, 'exactly one tile is asked about passability -- the landing tile alone'
 end
 
-# Confirmed against EasyRPG's live source: `Game_Map::CanDisembarkShip` has
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), `Game_Map::CanDisembarkShip` has
 # no equivalent of `#vehicle_blocks?` at all -- unlike `Game_Map::
 # CanLandAirship`, a few lines above it in the same file, which does loop
 # `{ Boat, Ship }` explicitly to block a landing -- so a different boat/ship
@@ -9072,8 +9100,9 @@ end
 
 check 'each vehicle type has exactly one boarding trigger: the airship only ' \
       'by standing on it, a boat/ship only by facing it' do
-  # Confirmed against RPG_RT's own live source: `Game_Player::GetOnVehicle`
-  # (src/game_player.cpp) checks the Airship only against the player's own
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Game_Player::GetOnVehicle`
+  # checks the Airship only against the player's own
   # tile (`GetX()`/`GetY()`), in an `if` whose `else` branch is the only
   # place the faced tile is computed at all -- the Airship is never
   # considered there, and Ship/Boat are never considered against the
@@ -9107,11 +9136,12 @@ end
 
 check 'a boarded boat glides straight through a below-characters event, ' \
       'the same as the walking hero' do
-  # Confirmed against EasyRPG's live source, not a divergence from the hero's
-  # own rule: `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) routes a
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), not a divergence from the hero's
+  # own rule: `Game_Map::CheckOrMakeWayEx` routes a
   # moving boat/ship's collision through the exact same generic `WouldCollide`
   # every other mover uses, whose own layer test is `self.GetLayer() ==
-  # other.GetLayer()`; `Game_Vehicle`'s constructor (`src/game_vehicle.cpp`)
+  # other.GetLayer()`; `Game_Vehicle`'s constructor
   # sets `SetLayer(Layers_same)` unconditionally, for every vehicle type. So a
   # LAYER_BELOW event never matches a boat's own LAYER_SAME and is a
   # decoration it glides straight through, exactly as the walking hero does
@@ -9197,8 +9227,9 @@ end
 
 check "a vehicle's forced Move Route frequency reverts once the (non-" \
       "repeating) route finishes, not stuck forever" do
-  # Confirmed against RPG_RT's own live source: `Game_Character::
-  # ForceMoveRoute` (src/game_character.cpp) snapshots the frequency in
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Game_Character::
+  # ForceMoveRoute` snapshots the frequency in
   # effect before the route starts (`if (!IsMoveRouteOverwritten())
   # original_move_frequency = GetMoveFrequency();`), and `CancelMoveRoute`
   # restores it (`SetMoveFrequency(original_move_frequency)`) the instant a
@@ -9238,7 +9269,8 @@ check "a boat's move route is blocked by terrain the same way ordinary sailing i
   eq 0, boat.x, 'terrain blocked it before it ever moved'
 end
 
-# EasyRPG's own Game_Player::MakeWay (src/game_player.cpp) unconditionally
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Game_Player::MakeWay unconditionally
 # delegates to the ridden vehicle's own MakeWay whenever IsAboard(), with no
 # separate branch for move-route-driven movement vs. ordinary input
 # movement -- #try_move (the input path) already reads #vehicle_passable?
@@ -9277,8 +9309,9 @@ end
 check 'a move route runs consecutive effect-only sub-commands in the same ' \
       'frame as the Move that follows them, only the Move itself spending ' \
       "the route's own pacing delay" do
-  # Confirmed against RPG_RT's own live source: `Game_Character::
-  # UpdateMoveRoute` (src/game_character.cpp) only calls
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Game_Character::
+  # UpdateMoveRoute` only calls
   # `SetMaxStopCountFor{Step,Turn,Wait}` for a Move/Turn/Wait/Jump
   # sub-command; every other sub-command (Switch On/Off, Speed/Frequency
   # Up/Down, Change Graphic, Play Sound, Through Mode, Stop/Start
@@ -9323,8 +9356,9 @@ check 'a Move Route request targeting a currently-ridden vehicle is ignored' do
      'the route request was dropped rather than fighting #follow_vehicle'
 end
 
-# EasyRPG's own Game_Interpreter::CommandMoveEvent (code 11330,
-# src/game_interpreter.cpp): "If the event is a vehicle in use, push the
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Game_Interpreter::CommandMoveEvent (code 11330):
+# "If the event is a vehicle in use, push the
 # commands to the player instead" -- a Move Event targeting a boat the party
 # is currently riding drives the *player*, which the ridden boat already
 # mirrors every frame (#follow_vehicle), producing a scripted "sail the boat
@@ -9355,7 +9389,8 @@ check 'Move Event targeting a currently-ridden vehicle redirects onto the ' \
      'no separate vehicle-character route was ever armed for the boat itself'
 end
 
-# EasyRPG's own CommandSetVehicleLocation (src/game_interpreter.cpp): "Check
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its CommandSetVehicleLocation: "Check
 # if the party is in the current vehicle and transfer the party together with
 # it" -- boarding the boat and issuing Set Vehicle Location for the *same*
 # vehicle, on the current map, moves the whole party there too, not just the
@@ -9518,8 +9553,9 @@ check 'boarding a boat/ship does not force any particular facing' do
 end
 
 check 'boarding the airship doubles the party\'s per-frame slide speed; boat/ship do not' do
-  # Confirmed against EasyRPG's actual C++ source: Game_Vehicle's constructor
-  # (src/game_vehicle.cpp) gives Boat/Ship `MoveSpeed_normal` -- identical to
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: Game_Vehicle's constructor
+  # gives Boat/Ship `MoveSpeed_normal` -- identical to
   # the player's own on-foot default -- but the Airship `MoveSpeed_double`,
   # twice the per-frame step. #player_slide_speed is the port target.
   scene = new_scene({}, player: [0, 0])
@@ -9540,7 +9576,8 @@ check 'Move Speed is no longer dead: it drives the per-frame slide, jump and ani
   # walk_slide_step/jump_slide_step/anim_frame_period take the *internal*
   # (real RPG_RT Move Speed - 1) scale -- see #page_move_speed. Internal 0..5
   # maps to real Move Speed 1..6, giving frames/tile 64,32,16,8,4,2 (matching
-  # EasyRPG's `1 << (1 + GetMoveSpeed())`, src/game_character.cpp, exactly).
+  # EasyRPG Player's source, `1 << (1 + GetMoveSpeed())`, exactly -- not
+  # independently confirmed against genuine RPG_RT under wine).
   # Internal 3 (real 4, the player's own default) keeps the prior hardcoded
   # 8-frames/tile baseline unchanged; internal 0 (real 1, the slowest) used
   # to be unreachable (clamp_speed floored at 1, i.e. real 2).
@@ -9554,8 +9591,9 @@ check 'Move Speed is no longer dead: it drives the per-frame slide, jump and ani
   # Animation cadence is move_speed-dependent; internal 3 keeps the prior 6.
   eq 6,  scene.send(:anim_frame_period, 3)
   eq 4,  scene.send(:anim_frame_period, 5)
-  # Confirmed against EasyRPG's live source, `Game_Character::
-  # GetContinuousAnimFrames` / `GetSpinAnimFrames` (`src/game_character.h`):
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its `Game_Character::
+  # GetContinuousAnimFrames` / `GetSpinAnimFrames`:
   # an idling Continuous/Fixed-Continuous event and a Spin event's own
   # facing-rotation each use their own, slower table -- not the stationary
   # one reused.
@@ -9631,8 +9669,9 @@ check 'the airship cannot land on a tile a map event occupies, Through ' \
   # (#vehicle_passable?'s airship branch never reads @event_tiles), so the
   # airship can cruise -- and be boarded -- directly over a below-characters
   # event a walking hero would just as happily overlap; landing there must
-  # still refuse it. Confirmed against RPG_RT's own live source:
-  # `Game_Map::CanLandAirship` (`src/game_map.cpp`) is a standalone loop
+  # still refuse it. Ported from EasyRPG Player's source, NOT independently
+  # confirmed against genuine RPG_RT under wine:
+  # `Game_Map::CanLandAirship` is a standalone loop
   # over every event's `IsInPosition`/`IsActive`/`GetActivePage`, entirely
   # separate from `WouldCollide`/`CheckOrMakeWayEx` (the function
   # #vehicle_passable?'s own boat/ship rule reads Through Mode from) -- it
@@ -9667,7 +9706,8 @@ check 'the airship cannot land on a tile a map event occupies, Through ' \
 end
 
 check 'an unridden boat/ship blocks the hero on foot, but an unridden airship does not' do
-  # Verified against EasyRPG Player's actual C++ source: Game_Map::
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine): its Game_Map::
   # CheckOrMakeWayEx blocks every character type (the player included) on a
   # parked Boat/Ship's own tile, but only checks the Airship when
   # self.GetType() != Player -- a walking hero passes clean over one.
@@ -9694,7 +9734,8 @@ end
 
 check 'an unridden boat/ship/airship all block a map event\'s own custom-route movement' do
   # Unlike the hero (checked above), an event's own movement has no Player
-  # exemption for the Airship: EasyRPG's CheckOrMakeWayEx only skips the
+  # exemption for the Airship: per EasyRPG Player's source (NOT independently
+  # confirmed against genuine RPG_RT under wine), its CheckOrMakeWayEx only skips the
   # Airship check when self.GetType() == Player, so every other mover -- a
   # map event's autonomous/custom route, and the player's own forced Set
   # Move Route mirror -- is blocked by all three vehicle types alike.
@@ -9729,9 +9770,9 @@ end
 # #airship_landable? never checked at all before this fix: neither ever
 # consulted another vehicle's own position, so a party riding a Boat could
 # sail straight through a parked Ship or a grounded Airship, and a landing
-# Airship could set down right on top of a parked Boat/Ship. Verified
-# against RPG_RT's actual behavior via EasyRPG Player's own C++ source
-# (src/game_map.cpp): `Game_Map::CheckOrMakeWayEx` loops `{ Boat, Ship }` for
+# Airship could set down right on top of a parked Boat/Ship. Ported from
+# EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine: `Game_Map::CheckOrMakeWayEx` loops `{ Boat, Ship }` for
 # any non-Airship mover, then also checks a grounded Airship whenever the
 # mover is not the on-foot Player -- true for a ridden Boat/Ship, which
 # moves as its own `Vehicle`-typed character, never `Player` -- and
@@ -9873,8 +9914,9 @@ check 'Show Battle Animation plays: an animation sprite shows and a flash fires'
   ok !spr.visible, 'the animation sprite is hidden once it finishes'
 end
 
-# EasyRPG's own Game_Interpreter_Map::CommandShowBattleAnimation
-# (src/game_interpreter_map.cpp) always starts the animation through
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its own Game_Interpreter_Map::CommandShowBattleAnimation
+# always starts the animation through
 # Game_Screen::ShowBattleAnimation regardless of the wait flag -- the flag only
 # gates whether the interpreter's own wait_time is set afterwards. This
 # codebase used to only ever start an animation from the :animation wait
@@ -10028,11 +10070,13 @@ end
 # #start_map_animation can hand #animation_position_offset a real height
 # unconditionally, unlike the battle path's ally-side "no sprite" fallback.
 # That height is ANIM_MAP_TARGET_HEIGHT (24), not Game::CharSet::HEIGHT
-# (32) -- confirmed against EasyRPG's own BattleAnimationMap::DrawSingle
-# (`const int character_height = 24;`, src/battle_animation.cpp), a
+# (32) -- per EasyRPG Player's source (NOT independently confirmed against
+# genuine RPG_RT under wine), its BattleAnimationMap::DrawSingle uses
+# `const int character_height = 24;`, a
 # hardcoded constant unrelated to the actual CharSet frame's pixel height
 # despite reading like it should be the same thing.
-check "a map-triggered Show Battle Animation carries RPG_RT's own 24px map-target height" do
+check "a map-triggered Show Battle Animation carries EasyRPG Player's own 24px " \
+      "map-target height (not independently confirmed under wine)" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = [
@@ -10054,11 +10098,12 @@ end
 
 check "Show Battle Animation's Whole Screen option (param3) tiles the animation " \
       'across the screen, not just over the target character' do
-  # Confirmed against EasyRPG's actual C++ source, fetched live:
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine:
   # `Game_Interpreter_Map::CommandShowBattleAnimation`
-  # (src/game_interpreter_map.cpp) reads `bool global = com.parameters[3] >
-  # 0;` and threads it through to `BattleAnimationMap::DrawGlobal`
-  # (src/battle_animation.cpp), which draws the animation nine times in a
+  # reads `bool global = com.parameters[3] >
+  # 0;` and threads it through to `BattleAnimationMap::DrawGlobal`,
+  # which draws the animation nine times in a
   # 3x3 grid offset by a full screen width/height in each direction --
   # covering the whole visible screen regardless of where the camera
   # happens to sit. A prior version of this codebase never read param3 at
@@ -10143,9 +10188,9 @@ end
 
 # screen_shaking (LCF database field 8 on an animation timing: 0 none / 1
 # target / 2 screen, decoded by mruby-lcf/mrblib/schema.rb) was decoded but
-# never read by #fire_animation_flashes at all. Verified against EasyRPG
-# Player's actual C++ source, `BattleAnimation::ProcessAnimationTiming`
-# (src/battle_animation.cpp, fetched verbatim): screen_shaking 2 fires
+# never read by #fire_animation_flashes at all. Ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine: `BattleAnimation::ProcessAnimationTiming`, screen_shaking 2 fires
 # `screen->ShakeOnce(3, 5, 32)` from the shared base class, with no
 # `ma[:battle]` gate the way the target case just below needs one -- so a
 # map-triggered Show Battle Animation shakes the whole screen exactly the
@@ -10166,14 +10211,17 @@ check 'a map-context screen-scope animation shake triggers the same Game::Screen
 end
 
 # screen_shaking 1 ("target") on a map-triggered Show Battle Animation is a
-# genuine no-op, not a dropped feature: EasyRPG's own `BattleAnimationMap::
-# ShakeTargets` (src/battle_animation.cpp, fetched verbatim) is an empty
+# genuine no-op per EasyRPG Player's source (NOT independently confirmed
+# against genuine RPG_RT under wine), not a dropped feature: its `BattleAnimationMap::
+# ShakeTargets` is an empty
 # method body -- `void BattleAnimationMap::ShakeTargets(int, int, int) {}` --
 # unlike `BattleAnimationBattle`/`BattleAnimationBattler`'s real per-battler
 # shake (see the battle-round check further down). #fire_animation_flashes
 # only calls #fire_target_shake when `ma[:battle]`, matching that real split
 # rather than treating the map path as an oversight to fill in.
-check 'a map-context target-scope animation shake is a real no-op, matching BattleAnimationMap::ShakeTargets' do
+check 'a map-context target-scope animation shake is a real no-op, matching ' \
+      'EasyRPG Player\'s BattleAnimationMap::ShakeTargets (not independently ' \
+      'confirmed under wine)' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)
   timing = OpenStruct.new(frame: 0, screen_shaking: 1)
@@ -10240,13 +10288,14 @@ end
 
 # A map-triggered Show Battle Animation's flash_scope-1 timing aimed at a
 # vehicle now actually pulses that vehicle's own on-screen sprite, instead of
-# being silently dropped as an "unsupported target." Verified against EasyRPG
-# Player's actual C++ source rather than assumed unsupported:
-# Game_Character::GetCharacter (src/game_character.cpp) resolves
+# being silently dropped as an "unsupported target." Ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine (previously assumed unsupported without checking that source at all):
+# Game_Character::GetCharacter resolves
 # CharBoat/CharShip/CharAirship straight to the live Game_Vehicle object -- a
 # Game_Character subclass -- so BattleAnimationMap::FlashTargets's own
-# target->Flash(...) call (src/battle_animation.cpp) reaches a vehicle exactly
-# like it reaches the player or a map event; nothing in real RPG_RT exempts
+# target->Flash(...) call reaches a vehicle exactly
+# like it reaches the player or a map event; nothing in that reference exempts
 # it. Unlike the player/event case (a CharSet tint mixed into the drawn
 # frame), a vehicle already draws through a real Sprite (#draw_vehicles), so
 # #fire_map_target_flash reaches @vehicle_sprites[:boat] directly with the
@@ -10360,9 +10409,10 @@ check "a Common Event Parallel Process's Show Battle Animation draws a sprite an
 end
 
 # yado.tk: only one Battle Animation is ever on screen, and a *second* one
-# forcibly cuts the first off rather than queueing behind it -- confirmed
-# against EasyRPG Player's actual C++ source (Game_Screen::ShowBattleAnimation,
-# src/game_screen.cpp, a bare unconditional unique_ptr::reset()), see
+# forcibly cuts the first off rather than queueing behind it -- consistent
+# with EasyRPG Player's source (Game_Screen::ShowBattleAnimation, a bare
+# unconditional unique_ptr::reset(); NOT independently confirmed against
+# genuine RPG_RT under wine), see
 # #drive_map_animation's own comment. Before this fix a second request while
 # the shared slot was held simply sat there doing nothing every frame until
 # the first one finished naturally -- never cutting it off, and (worse) had
@@ -10575,9 +10625,10 @@ end
 
 # docs/TODO.md's own "still open" note on the chained-animation fixes above:
 # this codebase's own extra, structural one-frame startup latency was not
-# touched by either one. Settled against EasyRPG's actual C++ source rather
-# than left a guess: `Game_Interpreter_Map::CommandShowBattleAnimation`
-# (src/game_interpreter_map.cpp) always calls `Game_Screen::ShowBattleAnimation`
+# touched by either one. Ported from EasyRPG Player's source rather
+# than left a guess, NOT independently confirmed against genuine RPG_RT
+# under wine: `Game_Interpreter_Map::CommandShowBattleAnimation`
+# always calls `Game_Screen::ShowBattleAnimation`
 # in-line -- building the animation -- *before* it ever touches its own
 # wait_time, so a waited-for play's sprite is visible the exact same real
 # frame the command runs. `Game::Interpreter#do_show_battle_animation` only
@@ -10645,11 +10696,12 @@ check "a Common Event Parallel Process's own waited-for Show Battle Animation sh
   ok !st.switches[5], "the process is still held on its own wait that same frame, not resumed already"
 end
 
-# Confirmed against RPG_RT's own live source: `Game_Interpreter_Map::
-# CommandShowBattleAnimation` (src/game_interpreter_map.cpp) calls
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Game_Interpreter_Map::
+# CommandShowBattleAnimation` calls
 # `GetCharacter(evt_id, ...)` unconditionally, before it ever reads `global`
 # or computes a frame count, and returns outright when that comes back null
-# -- `GetCharacter` (src/game_interpreter.cpp) is null for "This Event" (0)
+# -- `GetCharacter` is null for "This Event" (0)
 # when the calling interpreter has no owning map event, exactly what a
 # common event's own Parallel Process is. `_state.wait_time = frames` is
 # never reached in that case, so a "wait until finished" request falls
@@ -11031,9 +11083,10 @@ end
 # key across frames without it also reading as a fresh trigger.
 check 'the choice window cursor auto-repeats while a direction is held, ' \
       'not just a fresh press' do
-  # Confirmed against RPG_RT's own live source: `Window_Message` (`src/
-  # window_message.h`) is a plain `Window_Selectable` subclass, and
-  # `Window_Message::Update` (`src/window_message.cpp`) calls the base
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Window_Message` is a plain
+  # `Window_Selectable` subclass, and
+  # `Window_Message::Update` calls the base
   # `Window_Selectable::Update()` unconditionally every frame before its
   # own choice-specific dispatch -- so a held Down/Up scrolls the choice
   # cursor exactly like any other list window.
@@ -11219,7 +11272,8 @@ check 'Weather draws a particle overlay when active and hides it when clear' do
   st.weather.set(1, 2) # heavy rain
   scene.update
   ok wsp.visible, 'rain draws an overlay'
-  # EasyRPG's own num_rain_or_snow_particles table (src/weather.cpp) is the
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its num_rain_or_snow_particles table is the
   # literal { 20, 60, 100 } for strength 0/1/2 -- a real, non-uniform step
   # (+40, +40), not a fixed multiple of the lightest strength's own count.
   eq 100, scene.send(:weather_particle_count, st.weather), 'strength 2 (heavy)'
@@ -11235,10 +11289,12 @@ check 'Weather draws a particle overlay when active and hides it when clear' do
   ok !wsp.visible, 'clearing weather hides the overlay'
 end
 
-check 'Weather rain falls and drifts at RPG_RT\'s own per-frame rate, and ' \
+check 'Weather rain falls and drifts at EasyRPG Player\'s own per-frame rate ' \
+      '(not independently confirmed under wine), and ' \
       'snow only ever drifts left, never bounces back right' do
-  # Confirmed against RPG_RT's own live source: Game_Screen::UpdateRain/
-  # UpdateSnow (src/game_screen.cpp) -- rain falls 4px down and 1px left
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: Game_Screen::UpdateRain/
+  # UpdateSnow -- rain falls 4px down and 1px left
   # every frame it's alive (`p.y += 4; p.x -= 1`), snow drifts leftward
   # only, never rightward (`p.x -= Rand::GetRandomNumber(0, 1)`).
   scene = new_scene({})
@@ -11286,7 +11342,8 @@ check 'the timer draws M:SS as digit-sprite cells cut from the System graphic, a
   eq 4, spr.x, 'parked at the screen'"'"'s left edge'
   eq 4, spr.y, 'parked at the top outside of battle'
   # 75 s = 1:15 -> cells [0, 1, :, 1, 5], each an 8x16 blit from the System
-  # graphic's digit row (Sprite_Timer::Draw, src/sprite_timer.cpp).
+  # graphic's digit row (per EasyRPG Player's Sprite_Timer::Draw, not
+  # independently confirmed against genuine RPG_RT under wine).
   calls = spr.bitmap.blt_calls
   eq [[0, 0, 32, 32, 8, 16], [8, 0, 40, 32, 8, 16], [16, 0, 112, 32, 8, 16],
       [24, 0, 40, 32, 8, 16], [32, 0, 72, 32, 8, 16]],
@@ -11492,8 +11549,9 @@ check 'boarding a vehicle plays a Change System BGM override instead of the data
 end
 
 check 'boarding a vehicle with no configured BGM stops the field music instead of leaving it ' \
-      'playing, matching RPG_RT (2026-08-18)' do
-  # EasyRPG's Game_System::BgmPlay (src/game_system.cpp) is unconditional --
+      'playing, per EasyRPG Player (2026-08-18, NOT independently confirmed against genuine RPG_RT under wine)' do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_System::BgmPlay is unconditional --
   # a blank/"(OFF)" track still hits its own `else { BgmStop(); }` branch
   # ("(OFF) means play nothing"), silencing whatever was already playing.
   # Boarding a vehicle whose database BGM field is blank (and no Change
@@ -11524,8 +11582,9 @@ end
 check 'disembarking back onto a map with no field BGM stops the vehicle music the same way ' \
       '(2026-08-18)' do
   # The mirror image of the check just above: #restore_pre_vehicle_bgm ports
-  # the identical unconditional `BgmPlay(GetBeforeVehicleMusic())` call
-  # (`src/game_player.cpp`), so a pre-boarding field with no BGM playing at
+  # the identical unconditional `BgmPlay(GetBeforeVehicleMusic())` call from
+  # EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), so a pre-boarding field with no BGM playing at
   # all must silence the vehicle's own track on disembark, not leave it
   # running now that the party is back on foot.
   scene = new_scene({}, player: [0, 0])
@@ -11556,11 +11615,12 @@ end
 check 'a failed boat disembark (blocked by a shore NPC) falls through to the ' \
       'action-trigger check on that tile, instead of just swallowing the ' \
       'button press' do
-  # RPG_RT's own `Game_Player::Update` only skips `CheckActionEvent` when
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its `Game_Player::Update` only skips `CheckActionEvent` when
   # `GetOnOffVehicle` actually succeeds (`if (!GetOnOffVehicle())
-  # CheckActionEvent();`, src/game_player.cpp) -- and disembarking a boat/
+  # CheckActionEvent();`) -- and disembarking a boat/
   # ship fails outright when an active same-layer event occupies the
-  # landing tile (`Game_Map::CanDisembarkShip`, src/game_map.cpp, loops
+  # landing tile (`Game_Map::CanDisembarkShip` loops
   # `GetEvents()` for exactly that before ever checking terrain
   # passability). A failed disembark press must therefore fall through to
   # the ordinary action-trigger check on that same tile, the same way it
@@ -13091,8 +13151,8 @@ check "Enemy Encounter scene: a party member already KO'd going into the fight d
      'the living member still gets the Idle pose'
 end
 
-# Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
-# source: `Sprite_Actor::DoIdleAnimation` (src/sprite_actor.cpp) does not
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Sprite_Actor::DoIdleAnimation` does not
 # stop at Defend/Dead -- once neither applies, it reads the battler's
 # significant active state (`GetSignificantState`) and shows *that state's
 # own* configured pose (`state->battler_animation_id`), not plain Idle.
@@ -13211,8 +13271,9 @@ end
 # The "Appear Transparent" flag (field 10, `Game::Enemy#transparent`) was
 # parsed by the schema but read nowhere in mruby-rpg2k -- the same
 # "parsed but unused" shape as the `levitate` flag above, and every enemy
-# battler sprite drew fully opaque regardless. Verified against EasyRPG
-# Player's actual C++ source: `Sprite_Enemy::Draw` (`src/sprite_enemy.cpp`)
+# battler sprite drew fully opaque regardless. Ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine: `Sprite_Enemy::Draw`
 # computes `alpha = 160 * alpha / 255` whenever `Game_Enemy::IsTransparent`
 # is set, with no accuracy/evasion effect of any kind -- purely cosmetic,
 # like `levitate`. Troop 3's lone Ghost (enemy id 4) is the dedicated
@@ -13253,10 +13314,11 @@ end
 # unused" shape as `levitate`/`transparent` above, so a game reusing one
 # Monster/<name> bitmap for several palette-swapped monsters (a common
 # RPG2000 authoring trick) always drew every one of them in the file's own
-# unshifted colour. Verified against EasyRPG Player's actual C++ source:
-# `Game_Enemy::GetHue` (`src/game_enemy.h`) is a bare `enemy->battler_hue`
+# unshifted colour. Ported from EasyRPG Player's source, NOT independently
+# confirmed against genuine RPG_RT under wine:
+# `Game_Enemy::GetHue` is a bare `enemy->battler_hue`
 # passthrough, and `Sprite_Enemy::OnMonsterSpriteReady`/`Refresh`
-# (`src/sprite_enemy.cpp`) rotate the decoded bitmap through
+# rotate the decoded bitmap through
 # `Bitmap::HueChangeBlit` whenever it is nonzero and rebuild whenever either
 # the sprite name or the hue changes. Troop 4's lone Red Slime (enemy id 5,
 # reusing Slime's own "Slime" battler file at hue 120) is the dedicated
@@ -13769,11 +13831,12 @@ check 'no save data: pressing the selection key on Continue plays Buzzer and ope
   eq 1, scene.instance_variable_get(:@selected_index), 'the selection is left untouched'
 end
 
-# EasyRPG's Window_Command::DrawItem (src/window_command.cpp) draws every
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Window_Command::DrawItem draws every
 # command through the windowskin's own system-colour palette, chosen by
-# Font::ColorDisabled (index 3, src/font.h) once Scene_Title disables
-# Continue (command_window->SetItemEnabled(1, continue_enabled),
-# src/scene_title.cpp) -- never a hardcoded flat gray. A custom windowskin
+# Font::ColorDisabled (index 3) once Scene_Title disables
+# Continue (command_window->SetItemEnabled(1, continue_enabled))
+# -- never a hardcoded flat gray. A custom windowskin
 # whose disabled swatch is tinted shows that tint on real RPG_RT, with the
 # same drop-shadow every other label gets.
 check 'no save data, with a windowskin loaded: the disabled Continue label ' \
@@ -13810,10 +13873,11 @@ check 'a save exists: Continue is flagged available and its selection key opens 
   eq :load, pushed.instance_variable_get(:@mode), 'opened in :load mode'
 end
 
-# `Scene_Title::Refresh` (src/scene_title.cpp) calls `command_window->SetIndex(1)`
-# whenever a save exists, unconditionally alongside `SetItemEnabled` -- the
-# cursor starts on Continue, not New Game, so a returning player does not have
-# to move down manually before resuming.
+# EasyRPG Player's own `Scene_Title::Refresh` calls `command_window->SetIndex(1)`
+# whenever a save exists, unconditionally alongside `SetItemEnabled` -- which
+# would put the cursor on Continue, not New Game, on boot whenever a save
+# exists. The check right below found this does NOT match genuine RPG_RT
+# under wine -- see its own comment for the correction.
 check 'a save exists: the title cursor still starts on New Game, not Continue' do
   # Confirmed against a genuine RPG_RT.exe (Nepheshel, under wine): booted
   # three separate times against a valid, working save (Continue enabled and
@@ -13835,12 +13899,13 @@ check 'no save data: the title cursor still starts on New Game' do
      'with nothing to resume, the cursor starts on New Game as before'
 end
 
-check 'selecting New Game fades the title BGM (800ms), matching RPG_RT, ' \
-      'not a hard stop' do
-  # Confirmed directly against RPG_RT's live source: `Player::SetupNewGame`
-  # (`src/player.cpp`) is `Main_Data::game_system->BgmFade(800, true); ...`
+check 'selecting New Game fades the title BGM (800ms), per EasyRPG Player ' \
+      '(not independently confirmed under wine), not a hard stop' do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Player::SetupNewGame`
+  # is `Main_Data::game_system->BgmFade(800, true); ...`
   # -- an 800ms fade, not `BgmStop()`'s immediate cut (`Game_System::
-  # BgmFade`/`BgmStop`, `src/game_system.cpp`, are genuinely different
+  # BgmFade`/`BgmStop` are genuinely different
   # calls). A prior version of this method ran a blanket `Audio.bgm_stop`
   # before every title selection, this one included.
   parent = TitleParent.new(fake_db, nil, false, false)
@@ -13856,9 +13921,11 @@ check 'selecting New Game fades the title BGM (800ms), matching RPG_RT, ' \
 end
 
 check "the headless --rpg2k_continue auto-select fades the title BGM " \
-      "(800ms) before resuming, matching RPG_RT's LoadSavegame" do
-  # Confirmed directly against RPG_RT's live source: `Player::LoadSavegame`
-  # (`src/player.cpp`) is `if (!load_on_map) { Main_Data::game_system->
+      "(800ms) before resuming, per EasyRPG Player's LoadSavegame " \
+      "(not independently confirmed under wine)" do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Player::LoadSavegame`
+  # is `if (!load_on_map) { Main_Data::game_system->
   # BgmFade(800); ... }` -- true from the title screen, the only path this
   # headless single-slot shortcut ever takes (the interactive
   # Scene::SaveLoad picker is a separate, deliberately-unfaded path -- see
@@ -14148,8 +14215,9 @@ check 'mosaic transitions resample the capture through a shrinking/growing block
   RGSS::Graphics.snapshot = snap
 
   # Erase (MOSAIC_OUT): starts sharp (block size 1) and gets chunkier --
-  # EasyRPG's `m_size = current_frame + 1`, confirmed against
-  # src/transition.cpp's TransitionMosaicOut case.
+  # per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), `m_size = current_frame + 1` in its
+  # TransitionMosaicOut case.
   st.screen.erase(Game::Transition::MOSAIC_OUT)
   fade.bitmap.clear_mosaic_calls
   scene.update
@@ -14199,7 +14267,8 @@ check 'wave transitions resample the capture through the depth/phase ramp' do
   RGSS::Graphics.snapshot = snap
 
   # Erase (WAVE_OUT): depth/phase grow as the screen prepares to vanish --
-  # EasyRPG's `p = current_frame + 1`, confirmed against src/transition.cpp's
+  # per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), `p = current_frame + 1` in its
   # TransitionWaveOut case (itself Bitmap::WaverBlit's depth/phase args).
   st.screen.erase(Game::Transition::WAVE_OUT)
   fade.bitmap.clear_wave_calls
@@ -14358,12 +14427,13 @@ end
 
 check 'Flash Sprite targeting a vehicle (Boat) pulses the native sprite flash ' \
       'and decays, instead of silently dropping the target' do
-  # Confirmed against RPG_RT's own live source: `Game_Character::
-  # GetCharacter` (src/game_character.cpp) resolves CharBoat/CharShip/
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Game_Character::
+  # GetCharacter` resolves CharBoat/CharShip/
   # CharAirship (10002-10004) to the live Game_Vehicle object exactly like
   # CharPlayer/CharThisEvent, so `Game_Interpreter_Map::
   # CommandFlashSprite`'s `event->Flash(...)` call reaches a vehicle just
-  # as it reaches the player or a map event -- nothing in real RPG_RT
+  # as it reaches the player or a map event -- nothing in that reference
   # exempts it, unlike this codebase's prior "vehicle target = unresolved,
   # flashes nothing" behaviour.
   cmds = [ECmd.new(IC2::FLASH_SPRITE, [10002, 31, 0, 0, 31, 2, 0])] # boat, r g b power, 2 tenths, wait=0
@@ -14449,8 +14519,9 @@ check 'Tile Substitution survives a Save/Continue on the same map, unlike an ord
 end
 
 check 'Enter/Exit Vehicle boards the vehicle the party faces' do
-  # `Game_Interpreter_Map::CommandEnterExitVehicle` (code 10840,
-  # src/game_interpreter_map.cpp) just calls `Game_Player::GetOnOffVehicle`
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), `Game_Interpreter_Map::CommandEnterExitVehicle`
+  # (code 10840) just calls `Game_Player::GetOnOffVehicle`
   # -- the identical function the action button drives -- so a Boat/Ship
   # boards only by facing it from an adjacent tile, never by standing on it
   # (see "board_vehicle applies the wrong boarding trigger" above); only the
@@ -14484,8 +14555,9 @@ check 'Open Main Menu pushes the field menu and resumes when it closes' do
   eq 1, st.variables[6], 'the event resumed after the menu closed'
 end
 
-# EasyRPG's `Game_Interpreter_Map::CommandOpenMainMenu`
-# (src/game_interpreter_map.cpp) is gated only on
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Game_Interpreter_Map::CommandOpenMainMenu`
+# is gated only on
 # `Game_Message::IsMessageActive()`, no `main_flag` restriction, so a
 # Parallel Process can trigger it exactly like the foreground can. Before
 # this fix, `Scene::Map#drive_parallel_wait` had no `:menu` branch, so it
@@ -14644,7 +14716,8 @@ end
 
 # -- automatic battler placement (`battlecommands.placement == 1`) -------------
 #
-# Port of EasyRPG's Calculate2k3BattlePosition (src/game_battle.cpp): a
+# Ported from EasyRPG Player's source (its Calculate2k3BattlePosition), NOT
+# independently confirmed against genuine RPG_RT under wine: a
 # placement-1 database computes each party member's battle sprite position
 # from a grid keyed by party index/size and the encounter terrain, instead of
 # the manual battle_x/battle_y. The fixture terrain (fake_db's tile tag 42)
@@ -15247,8 +15320,9 @@ check 'Terminate Battle matches neither Win/Escape/Defeat and only bumps the bat
   eq 0, st.defeat_count
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Scene_Battle::EndBattle`
-# (`src/scene_battle.cpp`) only ever bumps `IncBattleCount()` there, at
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Battle::EndBattle`
+# only ever bumps `IncBattleCount()` there, at
 # battle *end* -- not when the encounter is first armed, well before the
 # fight screen has even opened.
 check "the battle-entry count does not tick until the fight actually ends, " \
@@ -15309,14 +15383,15 @@ check 'a page can wound a monster through Change Monster HP' do
   eq foe.max_hp - 7, foe.hp, 'the page took 7 HP off the first troop member'
 end
 
-# RPG_RT's own `CommandChangeMonsterHP` (src/game_interpreter_battle.cpp)
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `CommandChangeMonsterHP`
 # plays the enemy-kill system SE directly the instant its own `IsDead()`
 # check goes true, the same cue an ordinary lethal Attack/Skill already gets
 # via `#play_battle_action_se`'s `entry[:defeated]` check -- a check this
 # event-command path never produces, so a scripted kill (a damage-over-time
 # battle-event page, say) used to fell a monster in total silence.
 check 'a page killing a monster through Change Monster HP plays the ' \
-      'enemy-kill SE (RPG_RT)' do
+      'enemy-kill SE (per EasyRPG Player, not independently confirmed under wine)' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::CHANGE_MONSTER_HP, [0, 1, 0, 9999, 1])]) }
   scene, _st = battle_scene_with_pages(pages)
@@ -15397,8 +15472,9 @@ check "a battle page's Show Battle Animation actually holds the page, not resumi
   ok st.switches[21], 'the page ran on once the animation actually finished'
 end
 
-# Confirmed against RPG_RT's own live source: `Game_Interpreter_Battle::
-# CommandShowBattleAnimation` (src/game_interpreter_battle.cpp) leaves
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Game_Interpreter_Battle::
+# CommandShowBattleAnimation` leaves
 # `battler_target` null -- and so never calls `ShowBattleAnimation` at all --
 # for an Ally index (1-based, `target -= 1` first) outside
 # `0...GetBattlerCount()`, or an Enemy index outside `0...GetBattlerCount()`.
@@ -15612,12 +15688,13 @@ check 'a battle page shows its message in a battle panel and waits for a key' do
      'the panel closed with the message'
 end
 
-# Confirmed against RPG_RT's own live source: `Game_Message::
-# GetRealPosition` (`src/game_message.cpp`) is `if (Game_Battle::
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Game_Message::
+# GetRealPosition` is `if (Game_Battle::
 # IsBattleRunning()) { return Feature::HasRpg2kBattleSystem() ? 2 : 0; }` --
 # position 2 (bottom) for an RPG2000 database, position 0 (top) for
 # RPG2003 -- overriding any Message-Options position outright while a
-# battle is running. `Feature::HasRpg2kBattleSystem` (`src/feature.cpp`) is
+# battle is running. `Feature::HasRpg2kBattleSystem` is
 # a pure database-edition check, unrelated to `battle_type`/gauge mode.
 check 'a battle-event page message sits at the bottom for RPG2000, the ' \
       'top for RPG2003' do
@@ -15821,11 +15898,12 @@ check 'Open Shop scene: the command menu\'s own cursor lives in the prompt ' \
      'the list window carries no cursor rect while on the command menu'
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Window_Shop`
-# (`src/window_shop.cpp`) sets `index = 1` (the Buy row) exactly once, in
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_Shop`
+# sets `index = 1` (the Buy row) exactly once, in
 # its constructor; neither `Refresh()` nor `SetMode()` (called by
 # `Scene_Shop::UpdateBuySelection`/`UpdateSellSelection`'s own Cancel
-# branch, `src/scene_shop.cpp`, to return to `BuySellLeave2`) ever touches
+# branch, to return to `BuySellLeave2`) ever touches
 # `index` again. So the command menu's own cursor persists across a trip
 # into Buy or Sell and back, rather than always snapping back to the first
 # row (Buy).
@@ -15892,10 +15970,11 @@ check 'Open Shop scene: buying shows the shop_purchased confirmation, then retur
   ok window_texts(shop[:prompt]).any? { |t| t.include?('毎度あり！') },
      'the confirmation line uses the database shop_purchased term'
 
-  # Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) is a bare
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), Scene_Shop::vUpdate's Bought case is a bare
   # `timer--; if (timer == 0) SetMode(Buy);` with no Input:: read at all, so
   # a button press does nothing here -- only the flat 60-frame timer (armed
-  # by SetMode, DEFAULT_FPS in src/options.h) dismisses it.
+  # by SetMode, DEFAULT_FPS) dismisses it.
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.triggered = []
@@ -15937,7 +16016,8 @@ check 'Open Shop scene: selling shows the shop_sold confirmation, then returns '
   ok window_texts(shop[:prompt]).any? { |t| t.include?('毎度！') },
      'the confirmation line uses the database shop_sold term'
 
-  # Scene_Shop::vUpdate's Sold case (src/scene_shop.cpp) never reads Input::
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), Scene_Shop::vUpdate's Sold case never reads Input::
   # either -- B does not dismiss it early any more than C does.
   RGSS::Input.triggered = [RGSS::Input::B]
   scene.update
@@ -15951,13 +16031,14 @@ check 'Open Shop scene: selling shows the shop_sold confirmation, then returns '
                            'same as EasyRPG\'s Sold -> Sell'
 end
 
-# Confirmed against RPG_RT's own live source: `Window_ShopSell`
-# (`src/window_shopsell.cpp`) inherits `Window_Item::CheckInclude`/
-# `Refresh` (`src/window_item.cpp`) unchanged -- a plain `item_id > 0`
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_ShopSell`
+# inherits `Window_Item::CheckInclude`/
+# `Refresh` unchanged -- a plain `item_id > 0`
 # filter, no price check -- and only overrides `CheckEnable` (`item->price
-# > 0`), which `Scene_Shop::UpdateSellSelection` (`src/scene_shop.cpp`)
+# > 0`), which `Scene_Shop::UpdateSellSelection`
 # reads to Buzz instead of opening the quantity counter. A price-0 (key)
-# item the party holds stays on screen in real RPG_RT, just refuses the sale.
+# item the party holds stays on screen in that reference, just refuses the sale.
 check 'Open Shop scene: a price-0 (key) item stays listed on the sell ' \
       'screen, but selecting it just buzzes' do
   ic = Game::Interpreter::Cmd
@@ -16066,7 +16147,8 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   RGSS::Input.triggered = []
   shop = scene.instance_variable_get(:@shop)
   eq :quantity, shop[:screen]
-  # Scene_Shop::SetMode (src/scene_shop.cpp) keeps the right-hand panels
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), Scene_Shop::SetMode keeps the right-hand panels
   # visible through BuyHowMany/Bought just like Buy itself -- the panel
   # still describes the item the counter was opened for, not "no panel".
   ok !shop[:status].nil?, 'the quantity counter keeps the status panel visible, for the same item'
@@ -16085,7 +16167,8 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
      'the purchase confirmation keeps the status panel visible too (Scene_Shop::SetMode\'s Bought case)'
 
   # The confirmation only leaves once its own 60-frame timer runs out --
-  # Scene_Shop::vUpdate's Bought case (src/scene_shop.cpp) never reads
+  # per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), Scene_Shop::vUpdate's Bought case never reads
   # Input:: at all.
   60.times { scene.update } # the timer expires, back to the buy list
   shop = scene.instance_variable_get(:@shop)
@@ -16100,7 +16183,8 @@ check 'Open Shop scene: the status panel shows the highlighted item\'s possessed
   ok shop[:status].nil?, 'the command menu still shows no panel'
 end
 
-# Scene_Shop::SetMode's own right-hand-panel switch (src/scene_shop.cpp)
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), Scene_Shop::SetMode's own right-hand-panel switch
 # hides the party/status/gold panels for BuySellLeave and Sell alike, and
 # shows them for Buy, BuyHowMany/SellHowMany and Bought/Sold -- the gold
 # panel follows the exact same visible/hidden set as the status panel
@@ -16746,9 +16830,10 @@ check 'a target-scope animation flash pulses the hit enemy, not the screen or a 
   eq nil, spr.flash_color, 'the flash faded out after its duration'
 end
 
-# screen_shaking 2 ("screen") on a battle-round animation. Verified against
-# EasyRPG Player's actual C++ source, `BattleAnimation::ProcessAnimationTiming`
-# (src/battle_animation.cpp, fetched verbatim): `screen->ShakeOnce(3, 5, 32)`
+# screen_shaking 2 ("screen") on a battle-round animation. Ported from
+# EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine: `BattleAnimation::ProcessAnimationTiming`'s
+# `screen->ShakeOnce(3, 5, 32)`
 # -- the exact same Game::Screen#shake call and (power, speed, frames)
 # argument order the Shake Screen event command (11050) already drives (see
 # the 'Shake Screen with a wait...' check above), so this reuses it rather
@@ -16782,9 +16867,10 @@ check 'a screen_shaking-0 (default) timing triggers no shake' do
   ok !st.screen.shaking?, 'screen_shaking 0 (the schema default) never touches the screen shake'
 end
 
-# screen_shaking 1 ("target"): EasyRPG's own `BattleAnimationBattle::
-# ShakeTargets`/`BattleAnimationBattler::ShakeTargets` (src/battle_animation.cpp,
-# fetched verbatim) shake every one of the animation's own battler targets
+# screen_shaking 1 ("target"): per EasyRPG Player's source (NOT
+# independently confirmed against genuine RPG_RT under wine), its
+# `BattleAnimationBattle::ShakeTargets`/`BattleAnimationBattler::ShakeTargets`
+# shake every one of the animation's own battler targets
 # with the same (3, 5, 32) triple as the screen case, via `battler->
 # ShakeOnce(...)` -- #fire_target_shake/#update_enemy_shakes port that to this
 # codebase's own per-sprite x, since there is no native per-sprite shake
@@ -16827,10 +16913,11 @@ check 'a target-scope shake with no resolvable target sprite is a silent no-op' 
   ok true, 'no exception targeting nothing'
 end
 
-# ANIM_FLASH_FRAMES itself, pinned against EasyRPG's actual C++ source rather
+# ANIM_FLASH_FRAMES itself, pinned against EasyRPG Player's source (NOT
+# independently confirmed against genuine RPG_RT under wine) rather
 # than against its own value (the checks above derive their expectations from
-# the constant, so a wrong constant would still "pass" them). EasyRPG's
-# `BattleAnimation::UpdateFlashGeneric` (src/battle_animation.cpp) computes
+# the constant, so a wrong constant would still "pass" them). Its
+# `BattleAnimation::UpdateFlashGeneric` computes
 # `delta_frames = GetFrame() - start_frame` and keeps a fired timing's own
 # colour/power alive for `delta_frames <= 10` -- 11 raw ticks (0 through 10
 # inclusive) from the tick it fires, not some other guess -- before
@@ -16841,7 +16928,8 @@ end
 # tick after) to land on delta_frames 10 and 11 without needing a full fixture
 # animation or 60 real `scene.update` calls.
 check 'a fired animation screen flash stays alive for exactly 11 real frames, matching ' \
-      "EasyRPG's UpdateFlashGeneric delta_frames <= 10" do
+      "EasyRPG Player's UpdateFlashGeneric delta_frames <= 10 (not independently " \
+      'confirmed under wine)' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)
   timing = OpenStruct.new(frame: 0, flash_scope: 2, flash_red: 31, flash_green: 0,
@@ -16978,7 +17066,8 @@ check 'the round waits for the animation instead of the banner timer' do
   ok !scene.instance_variable_get(:@battle).send(:battle_animation_playing?)
 end
 
-# Real RPG_RT (EasyRPG's BattleAnimation::Update, src/battle_animation.cpp)
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its BattleAnimation::Update
 # ticks an internal frame counter once per logical 60fps update and shows
 # `GetFrame() / 2` as the current cell -- so every real (LCF) animation frame
 # is held for exactly 2 ticks (1/30s), whether or not that frame's own cell
@@ -17072,8 +17161,9 @@ check 'animation_position_offset splits head/center/feet around the target sprit
   eq 0, scene.send(:animation_position_offset, { height: nil }, 0),
      'no known height (the ally-side screen-centre fallback) is never offset'
   # The real map-target value every #start_map_animation caller actually
-  # hands this (ANIM_MAP_TARGET_HEIGHT, 24 -- RPG_RT's own hardcoded
-  # constant, not the 32px CharSet frame), split at its own halves.
+  # hands this (ANIM_MAP_TARGET_HEIGHT, 24 -- EasyRPG Player's own hardcoded
+  # constant, not the 32px CharSet frame, per its source; not independently
+  # confirmed against genuine RPG_RT under wine), split at its own halves.
   eq(-12, scene.send(:animation_position_offset,
                      { height: RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT }, 0))
   eq 12, scene.send(:animation_position_offset,
@@ -17117,7 +17207,8 @@ end
 # (`Bitmap.new`'s second argument) the same way every other sprite sheet this
 # runtime loads is. `Battle/` was the one sheet directory asking for an opaque
 # decode, which made every cell blit a solid 96x96 rectangle of background over
-# its target. EasyRPG's own material table (`src/cache.cpp`) sets
+# its target. Per EasyRPG Player's source (NOT independently confirmed against
+# genuine RPG_RT under wine), its material table sets
 # `Spec::transparent` true for Battle, and false only for the four full-screen
 # backdrops this runtime already loads opaque.
 check 'the Battle/ animation sheet is loaded colour-keyed, like every other sprite sheet' do
@@ -18154,9 +18245,10 @@ check 'an item that did nothing keeps the composed line' do
      .first.include?('no effect')
 end
 
-# A special/use_skill battle item invoking a skill: verified against EasyRPG
-# Player's actual C++ source, `Game_BattleAlgorithm::Skill::GetStartMessage`
-# (`src/game_battlealgorithm.cpp`) -- `if (item && item->using_message == 0)
+# A special/use_skill battle item invoking a skill: ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine: `Game_BattleAlgorithm::Skill::GetStartMessage` --
+# `if (item && item->using_message == 0)
 # ... return BattleMessage::GetItemStartMessage2k(...)`, checked *before* ever
 # reading the skill's own `using_message1`/`using_message2`. The item
 # schema's own `using_message` field (`mruby-lcf/mrblib/schema.rb`, distinct
@@ -18521,8 +18613,9 @@ check 'the menu party list shows each member condition' do
   ok !texts.include?('Normal'), 'the normal term is replaced, not added to'
 end
 
-# RPG_RT's own `Window_Gold` on this screen -- confirmed against
-# `Scene_Menu::Start` (`src/scene_menu.cpp`), which creates one
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Window_Gold` on this screen --
+# `Scene_Menu::Start`, which creates one
 # unconditionally (88x32, bottom-left corner, no version/feature gate
 # anywhere in the file) for RPG2000 and RPG2003 alike, and
 # `Scene_Menu::Continue`, which refreshes it every time control returns from
@@ -18823,10 +18916,12 @@ check 'Scene::Menu: an RPG2003 database drives the command list from ' \
      'Status (id 5), Row (id 6), Order (id 7) and Wait (id 8) are all offered'
 end
 
-# Confirmed against liblcf's own generated `AtbMode` enum (`AtbMode_atb_active
-# = 0, AtbMode_atb_wait = 1`) and EasyRPG's `Scene_Menu` Wait row
-# (`src/scene_menu.cpp`): `GetAtbMode() == AtbMode_atb_wait ? wait_on :
-# wait_off` -- raw 0 (the default) is active mode and labels `wait_off`, raw
+# The enum values are confirmed against liblcf's own generated `AtbMode`
+# enum (`AtbMode_atb_active = 0, AtbMode_atb_wait = 1`); the label mapping
+# itself is ported from EasyRPG Player's source (its `Scene_Menu` Wait row:
+# `GetAtbMode() == AtbMode_atb_wait ? wait_on :
+# wait_off`), NOT independently confirmed against genuine RPG_RT under wine
+# -- raw 0 (the default) is active mode and labels `wait_off`, raw
 # 1 is wait mode and labels `wait_on`.
 check 'Scene::Menu: the Wait command shows the current atb_mode, and toggling ' \
       'it flips the field and relabels the row' do
@@ -19029,12 +19124,13 @@ check 'Scene::Order: picking every member opens the Confirm/Redo prompt, ' \
   ok scene.parent.pop_called, 'the screen closes on Confirm'
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Scene_Order::UpdateOrder`
-# (`src/scene_order.cpp`), once the last member is picked, calls
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Order::UpdateOrder`,
+# once the last member is picked, calls
 # `window_left->SetIndex(-1)` before `SetActive(false)` -- distinct from
 # simply going inactive. `Window_Selectable::UpdateCursorRect`
-# (`src/window_selectable.cpp`) special-cases a negative index to
-# `SetCursorRect(Rect())`, so real RPG_RT hides the left column's cursor
+# special-cases a negative index to
+# `SetCursorRect(Rect())`, so that reference hides the left column's cursor
 # entirely at this transition, rather than freezing it on the now-blank
 # final row the way an ordinary inactive window's cursor otherwise would
 # (see the `RPG2k::Window#draw_cursor` "freeze, don't hide" fix, which still
@@ -19089,7 +19185,8 @@ check 'Scene::Order: Redo clears every pick and returns to the left column, ' \
   eq original_order, state.party.actors.map(&:object_id), 'the party is untouched'
 end
 
-# EasyRPG's Scene_Order::vUpdate (src/scene_order.cpp) calls window_left->
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Scene_Order::vUpdate calls window_left->
 # Update()/window_confirm->Update() unconditionally, every frame -- both
 # genuine Window_Selectables whose own Update() drives the cursor
 # (trigger-then-repeat), before GetActive() ever gates which of
@@ -19126,10 +19223,11 @@ check 'Scene::Order: holding Down auto-repeats both the left-column pick ' \
      'a held (repeated, not triggered) Down still flips the prompt cursor to Redo'
 end
 
-# Confirmed directly against RPG_RT's live source: `Scene_Order::Confirm`
-# (`src/scene_order.cpp`) removes then re-adds every member through
-# `Game_Party::RemoveActor`/`AddActor` (`src/game_party.cpp`), and each of
-# those calls `Main_Data::game_player->ResetGraphic()` (`src/game_player.cpp`)
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Order::Confirm`
+# removes then re-adds every member through
+# `Game_Party::RemoveActor`/`AddActor`, and each of
+# those calls `Main_Data::game_player->ResetGraphic()`
 # as a side effect -- re-reading slot 0's (the new leader's) CharSet name
 # onto the map sprite. `Game::Party#reorder` applies the net effect of the
 # remove/re-add dance directly rather than replaying it, so this side effect
@@ -19191,12 +19289,13 @@ end
 
 check 'Scene::Menu: a disabled command reads the windowskin\'s own disabled ' \
       'swatch, not the default text colour' do
-  # Confirmed directly against RPG_RT's live source: `Scene_Menu::
-  # CreateCommandWindow` (`src/scene_menu.cpp`) disables Save on
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Scene_Menu::
+  # CreateCommandWindow` disables Save on
   # `!GetAllowSave()` and every other non-Order command on
   # `GetActors().empty()`; `Window_Command::SetItemEnabled`/`DrawItem`
-  # (`src/window_command.cpp`) then draws a disabled row through
-  # `Font::ColorDisabled` (swatch index 3, `src/font.h`), the same
+  # then draws a disabled row through
+  # `Font::ColorDisabled` (swatch index 3), the same
   # windowskin-blended path every row uses -- the same convention already
   # ported for Scene::Title's Continue and Scene::SaveLoad's file rows.
   db = fake_db
@@ -19327,8 +19426,9 @@ check 'Scene::SaveLoad: an occupied slot shows the leader, level and HP -- no go
                                               'reference capture, unlike this screen\'s old layout'
 end
 
-# Confirmed against RPG_RT's own live source: `Window_SaveFile::Refresh`
-# (src/window_savefile.cpp) draws the level and HP fields as four separate
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_SaveFile::Refresh`
+# draws the level and HP fields as four separate
 # `TextDraw` calls at fixed pixel columns (x=4, x=46), each number
 # `std::setw`-padded to a fixed width -- so the "HP" label never shifts
 # sideways depending on how many digits the level has, unlike a single
@@ -19363,10 +19463,11 @@ check 'Scene::SaveLoad: HP is space-padded to width 4 on RPG2003, not 3' do
   ok texts.include?('  80'), 'RPG2003 widens the HP field to 4 characters, not 3'
 end
 
-# EasyRPG's Window_SaveFile::Refresh (src/window_savefile.cpp) draws every
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Window_SaveFile::Refresh draws every
 # text element through TextDraw(x, y, fc, text) -- never a flat colour --
 # with `fc` itself `has_save ? Font::ColorDefault : Font::ColorDisabled`
-# (system-colour swatch index 0 or 3, src/font.h) for the file label. The
+# (system-colour swatch index 0 or 3) for the file label. The
 # same disabled-swatch convention Scene::Title's own Continue entry already
 # reads (see the title checks above).
 check 'Scene::SaveLoad: an empty slot\'s file label blends from the windowskin\'s ' \
@@ -19488,8 +19589,9 @@ check 'Scene::SaveLoad: a member with no FaceSet draws no thumbnail; only the fi
      'only members 2/3/4 (of 5) draw a face'
 end
 
-# Confirmed against RPG_RT's own live source: `Scene_Save::Action`
-# (`src/scene_save.cpp`) is just `Save(fs, index + 1); Scene::Pop();`,
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Save::Action`
+# is just `Save(fs, index + 1); Scene::Pop();`,
 # discarding `Save`'s own boolean result outright -- a save I/O failure
 # pops exactly the same as a success, no "Save failed." path exists at
 # all, and there is no confirmation banner of any kind either way.
@@ -19552,7 +19654,8 @@ check 'Scene::SaveLoad: Down/Up move the cursor and clamp, never wrap, at ' \
      'UP from the last slot moves up by one, same as any other slot'
 end
 
-# EasyRPG's Window_Selectable::Update (src/window_selectable.cpp) falls
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Window_Selectable::Update falls
 # through to Input::IsRepeated(DOWN/UP) right after its own IsTriggered
 # check, so holding a direction auto-scrolls the cursor after the initial
 # delay, not just once per tap. `RGSS::Input.repeated` (distinct from
@@ -19700,8 +19803,9 @@ check 'Open Save Menu pushes Scene::SaveLoad in :save mode and resumes the event
   eq 1, st.variables[7], 'the event resumed after the picker closed'
 end
 
-# EasyRPG's `Game_Interpreter_Map::CommandOpenSaveMenu`
-# (src/game_interpreter_map.cpp) is gated only on
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Game_Interpreter_Map::CommandOpenSaveMenu`
+# is gated only on
 # `Game_Message::IsMessageActive()`, no `main_flag` restriction, so a
 # Parallel Process can trigger it exactly like the foreground can. Before
 # this fix, `Scene::Map#drive_parallel_wait` had no `:save_menu` branch, so
@@ -20056,9 +20160,10 @@ end
 
 check 'Scene::ItemMenu: Right/Left cross a row boundary rather than ' \
       'stopping at the row edge' do
-  # Confirmed directly against RPG_RT's live source: `Window_Selectable::
-  # Update` (src/window_selectable.cpp) has no method actually named
-  # `CursorRight`/`CursorLeft` -- its real Right/Left branches are a flat
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Window_Selectable::
+  # Update` has no method actually named
+  # `CursorRight`/`CursorLeft` -- its Right/Left branches are a flat
   # `index +- 1` bounded only by the list's own absolute start/end, no
   # row-boundary check, structurally unlike Down/Up's genuine column-lock.
   scene = menu_scene(RPG2k::Scene::ItemMenu, three_item_wrap_state)
@@ -20152,9 +20257,10 @@ class MedicineItemStubParty < WrapMenuParty
 end
 
 check 'Scene::ItemMenu: a successful use stays on the target screen, ' \
-      'matching RPG_RT, instead of dropping back to the item list' do
-  # Confirmed against RPG_RT's own live source: `Scene_ActorTarget::
-  # UpdateItem` (src/scene_actortarget.cpp) never calls `Scene::Pop()` on
+      'per EasyRPG Player (not independently confirmed under wine), instead of dropping back to the item list' do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Scene_ActorTarget::
+  # UpdateItem` never calls `Scene::Pop()` on
   # Decision, success or failure alike -- only `vUpdate`'s own Cancel branch
   # does, and it never builds a message window either: only `SePlay`/
   # `Refresh`. A successful use lets the player keep using the same item on
@@ -20636,9 +20742,9 @@ check 'Scene::ItemMenu: a special item invoking Teleport opens a destination ' \
      'both registered destinations, ascending by map id (this fixture parent carries no map tree)'
   ok state.pending_teleport.nil?, 'opening the list does not warp yet'
 
-  # The destination list is itself a two-column grid (confirmed against
-  # genuine RPG_RT's live source: `Window_Teleport` sets `column_max = 2`,
-  # `src/window_teleport.cpp`) -- with only two destinations, DOWN is a
+  # The destination list is itself a two-column grid (per EasyRPG Player's
+  # source, NOT independently confirmed against genuine RPG_RT under wine:
+  # `Window_Teleport` sets `column_max = 2`) -- with only two destinations, DOWN is a
   # no-op (nothing in the row below) and RIGHT is what reaches the second
   # one, not DOWN.
   RGSS::Input.triggered = [RGSS::Input::DOWN]        # no cell below -- a no-op
@@ -20657,8 +20763,9 @@ end
 
 check 'Scene::ItemMenu: the Teleport destination list crosses a row ' \
       'boundary on Right/Left rather than stopping at the row edge' do
-  # Confirmed directly against RPG_RT's live source: `Window_Selectable::
-  # Update` (src/window_selectable.cpp) -- Right/Left are a flat `index +-
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Window_Selectable::
+  # Update` -- Right/Left are a flat `index +-
   # 1` bounded only by the list's own absolute start/end, no row-boundary
   # check, the same shape already fixed for the item/skill grids. A third
   # destination is needed here: with only two, both fit in the first row
@@ -20811,9 +20918,10 @@ end
 
 check 'Scene::SkillMenu: Right/Left cross a row boundary rather than ' \
       'stopping at the row edge' do
-  # Confirmed directly against RPG_RT's live source: `Window_Selectable::
-  # Update` (src/window_selectable.cpp) has no method actually named
-  # `CursorRight`/`CursorLeft` -- its real Right/Left branches are a flat
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Window_Selectable::
+  # Update` has no method actually named
+  # `CursorRight`/`CursorLeft` -- its Right/Left branches are a flat
   # `index +- 1` bounded only by the list's own absolute start/end, no
   # row-boundary check, structurally unlike Down/Up's genuine column-lock.
   scene = menu_scene(RPG2k::Scene::SkillMenu, three_skill_wrap_state)
@@ -20959,9 +21067,9 @@ check 'Scene::SkillMenu: a Teleport skill opens a destination list and queues th
      '(this fixture parent carries no map tree)'
   ok state.pending_teleport.nil?, 'opening the list does not warp yet'
 
-  # The destination list is itself a two-column grid (confirmed against
-  # genuine RPG_RT's live source: `Window_Teleport` sets `column_max = 2`,
-  # `src/window_teleport.cpp`) -- RIGHT is what reaches the second
+  # The destination list is itself a two-column grid (per EasyRPG Player's
+  # source, NOT independently confirmed against genuine RPG_RT under wine:
+  # `Window_Teleport` sets `column_max = 2`) -- RIGHT is what reaches the second
   # destination, not DOWN.
   RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second destination (map 20)
   scene.update
@@ -20975,8 +21083,9 @@ end
 
 check 'Scene::SkillMenu: the Teleport destination list crosses a row ' \
       'boundary on Right/Left rather than stopping at the row edge' do
-  # Confirmed directly against RPG_RT's live source: `Window_Selectable::
-  # Update` (src/window_selectable.cpp) -- Right/Left are a flat `index +-
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Window_Selectable::
+  # Update` -- Right/Left are a flat `index +-
   # 1` bounded only by the list's own absolute start/end, no row-boundary
   # check, the same shape already fixed for the item/skill grids. A third
   # destination is needed here: with only two, both fit in the first row
@@ -21119,9 +21228,10 @@ class NormalTargetSkillStubParty < WrapMenuParty
 end
 
 check 'Scene::SkillMenu: a successful cast stays on the target screen, ' \
-      'matching RPG_RT, instead of dropping back to the skill list' do
-  # Confirmed against RPG_RT's own live source: `Scene_ActorTarget::
-  # UpdateSkill` (src/scene_actortarget.cpp) never calls `Scene::Pop()` on
+      'per EasyRPG Player (not independently confirmed under wine), instead of dropping back to the skill list' do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Scene_ActorTarget::
+  # UpdateSkill` never calls `Scene::Pop()` on
   # Decision, success or failure alike -- only `vUpdate`'s own Cancel branch
   # does, and it never builds a message window either: only `SePlay`/
   # `Refresh`, playing the invoked skill's own `animation_id`-derived SE. A
@@ -21168,8 +21278,9 @@ check 'Scene::SkillMenu: a successful cast stays on the target screen, ' \
   eq :skills, scene.instance_variable_get(:@mode)
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Game_System::
-# SePlay(const RPG::Animation&)` (`src/game_system.cpp`) skips a timing
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Game_System::
+# SePlay(const RPG::Animation&)` skips a timing
 # whose sound name fails `IsStopSoundFilename` -- true for a genuinely
 # blank name *or* the literal "(OFF)" sentinel (liblcf's own "no sound set"
 # default), not blank alone -- and falls through to the next timing's own
@@ -21262,9 +21373,10 @@ check 'Scene::SkillMenu: the description banner and skill-list box both ' \
   eq RPG2k::Scene::SkillMenu::SCREEN_W, skill_win.width, 'Cancel: skill grid is back to full width'
 end
 
-# Confirmed against EasyRPG's actual C++ source:
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine:
 # `Game_Character::MoveTypeCustomCommand`'s `Code::play_sound_effect` case
-# (`src/game_character.cpp`) -- `if (move_command.parameter_string !=
+# -- `if (move_command.parameter_string !=
 # "(OFF)" && move_command.parameter_string != "(Brak)") { ...SePlay...; }`
 # -- a Move Route "Play SE" sub-command skips playback for either sentinel
 # string, not just a blank name. `RPG2k::Scene::MapWorld`/`VehicleWorld
@@ -21281,8 +21393,9 @@ check 'RPG2k::Scene::MapWorld#play_sound skips the "(OFF)"/"(Brak)" ' \
   eq [['bell', 90, 100]], RGSS::Audio.se_calls, 'a real name still plays normally'
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Game_System::
-# SePlay(const lcf::rpg::Sound&, bool)` (`src/game_system.cpp`) -- `if
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Game_System::
+# SePlay(const lcf::rpg::Sound&, bool)` -- `if
 # (se.name.empty()) { return; } else if (se.name == "(OFF)") { ...; return;
 # }` -- a system SFX slot (cursor/decision/cancel/buzzer) set to the
 # literal "(OFF)" sentinel plays nothing, the same as a genuinely blank
@@ -21297,11 +21410,12 @@ check 'Scene::Base#play_system_se treats a "(OFF)" system SFX slot as no ' \
   eq [], RGSS::Audio.se_calls, 'a "(OFF)" system SFX slot plays nothing'
 end
 
-# A party whose two field skills are self (2) and all-ally (4) scope -- real
-# RPG_RT (`Scene_Skill::vUpdate`'s `Algo::IsNormalOrSubskill` branch,
-# scope-independent, `src/scene_skill.cpp`) still pushes a target-confirm
+# A party whose two field skills are self (2) and all-ally (4) scope -- per
+# EasyRPG Player's source (`Scene_Skill::vUpdate`'s `Algo::IsNormalOrSubskill`
+# branch, scope-independent), NOT independently confirmed against genuine
+# RPG_RT under wine, it still pushes a target-confirm
 # screen for both, cursor locked to who the effect already lands on
-# (`Scene_ActorTarget::Start`, `src/scene_actortarget.cpp`), rather than
+# (`Scene_ActorTarget::Start`), rather than
 # applying on the very first Decision -- Game::Party's own scope-resolution
 # logic (#skill_targets) is covered by scripts/rpg2k_logic_check.rb; this
 # stub only has to hand the scene something that behaves the same way, so
@@ -21433,7 +21547,8 @@ check 'Scene::SkillMenu: the "MP cost" box shows the right cost for a ' \
 end
 
 # A party exposing a real #can_cast?, to prove Scene::SkillMenu now gates
-# Decision on it -- EasyRPG's `Scene_Skill::vUpdate` (`src/scene_skill.cpp`)
+# Decision on it -- per EasyRPG Player's source (NOT independently confirmed
+# against genuine RPG_RT under wine), its `Scene_Skill::vUpdate`
 # gates its whole Decision branch on `Window_Skill::CheckEnable`
 # (`IsSkillLearned && IsSkillUsable`) before playing any SE or opening the
 # target-confirm screen at all; the disabled case just buzzes and stays put.
@@ -21470,7 +21585,8 @@ class SkillGateStubParty < MenuStubParty
 end
 
 check 'Scene::SkillMenu: choosing a currently-unusable skill just buzzes and stays ' \
-      'on the list, matching RPG_RT\'s own CheckEnable gate' do
+      'on the list, matching EasyRPG Player\'s own CheckEnable gate ' \
+      '(not independently confirmed under wine)' do
   parent = fake_parent(fake_db)
   state = Game::State.new(SkillGateStubParty.new, 1, 0, 0)
   scene = RPG2k::Scene::SkillMenu.new(parent, state)
@@ -21529,8 +21645,9 @@ end
 # #apply_escape_skill's own `sound_effect` playback (schema.rb field 16) --
 # one Switch skill with a configured SE, one Switch skill with a blank one
 # (no filename set), one Switch skill that always fails (Buzzer only, no
-# skill SE), and an Escape skill with a configured SE. Confirmed against
-# EasyRPG's `Scene_Skill::Update`: Switch/Escape play `skill->sound_effect`
+# skill SE), and an Escape skill with a configured SE. Per EasyRPG Player's
+# source (NOT independently confirmed against genuine RPG_RT under wine),
+# its `Scene_Skill::Update`: Switch/Escape play `skill->sound_effect`
 # on a successful cast; Teleport does not (it keeps the ordinary decision SE
 # played earlier in #update_teleport_target, already covered above), so it
 # is not repeated here.
@@ -21593,8 +21710,9 @@ end
 
 check 'Scene::SkillMenu: a successful Switch skill closes the whole menu ' \
       'stack at once, with no confirmation message' do
-  # Confirmed against RPG_RT's own live source: `Scene_Skill::vUpdate`'s
-  # `Type_switch` arm (src/scene_skill.cpp) plays the skill's own sound
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `Scene_Skill::vUpdate`'s
+  # `Type_switch` arm plays the skill's own sound
   # effect and calls `Scene::PopUntil(Scene::Map)` on the very same Decision
   # press, with no confirmation message at all -- the identical shape as
   # `Type_escape`, not the ordinary target-mode cast's stay-open-and-show-a-
@@ -21661,7 +21779,8 @@ check 'Scene::SkillMenu: an Escape skill plays its own sound_effect on a success
      "the ordinary Decision SE then the skill's own sound_effect, before the warp closes the menu"
 end
 
-# EasyRPG's Window_Skill::UpdateHelp (src/window_skill.cpp) feeds the
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Window_Skill::UpdateHelp feeds the
 # database skill's own `description` straight to Scene_Skill's Window_Help
 # banner every time the selection changes -- the exact mechanism
 # Scene::ItemMenu/EquipMenu already reproduce for their own item description
@@ -21977,8 +22096,9 @@ end
 # The slot and candidate cursors live on genuine Window_Selectable
 # subclasses (Window_Equip/Window_EquipItem) whose own Update() auto-repeats
 # DOWN/UP the same as every other list -- see Scene::ItemMenu#update_items's
-# fuller writeup. The actor switch (RIGHT/LEFT) is confirmed NOT to: real
-# EasyRPG's Scene_Equip::UpdateEquipSelection (src/scene_equip.cpp) checks
+# fuller writeup. The actor switch (RIGHT/LEFT) is, per EasyRPG Player's
+# source (NOT independently confirmed against genuine RPG_RT under wine),
+# NOT auto-repeating: its Scene_Equip::UpdateEquipSelection checks
 # Input::IsTriggered(RIGHT/LEFT) only, no IsRepeated, since each switch
 # pushes a whole new Scene_Equip rather than moving a cursor.
 check 'Scene::EquipMenu: holding Down auto-repeats the slot and candidate ' \
@@ -22010,8 +22130,9 @@ check 'Scene::EquipMenu: holding Down auto-repeats the slot and candidate ' \
      'a held (repeated, not triggered) Down still moves the candidate cursor one row'
 end
 
-# Confirmed against RPG_RT's own live source: `Scene_Equip::
-# UpdateEquipSelection` (src/scene_equip.cpp) gates both the RIGHT and LEFT
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Equip::
+# UpdateEquipSelection` gates both the RIGHT and LEFT
 # branches on `actors.size() > 1`, not just the key trigger itself -- a solo
 # party's Equip screen plays no cursor SE and rebuilds nothing on either key.
 check 'Scene::EquipMenu: a solo party leaves Right/Left as silent no-ops' do
@@ -22087,12 +22208,13 @@ class EquipCompareParty < MenuStubParty
   def equip_candidates(_slot, _actor = nil); [[2, 1], [3, 1], [4, 1]]; end
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Window_EquipItem::
-# CheckInclude` (`src/window_equipitem.cpp`) and the inherited `Window_Item::
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_EquipItem::
+# CheckInclude` and the inherited `Window_Item::
 # DrawItem` draw only the item's name and stock count, no comparison glyph of
 # any kind -- the summed arrow this candidate list used to draw next to each
-# row (attributed to a fan wiki, yado.tk, rather than ever reading
-# `scene_equip.cpp` in full) never existed in real RPG_RT. The comparison
+# row (attributed to a fan wiki, yado.tk, rather than ever reading that
+# source in full) does not appear in EasyRPG Player's implementation. The comparison
 # lives entirely in the stats window instead, checked below.
 check 'Scene::EquipMenu: the candidate list draws only a name and count, no comparison glyph' do
   state = Game::State.new(EquipCompareParty.new, 1, 0, 0)
@@ -22109,16 +22231,17 @@ check 'Scene::EquipMenu: the candidate list draws only a name and count, no comp
      'no arrow glyph anywhere in the candidate list, and nothing drawn for Remove'
 end
 
-# Confirmed against EasyRPG's actual C++ source, fetched live:
-# `Window_EquipStatus::Refresh` (`src/window_equipstatus.cpp`) draws the
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine:
+# `Window_EquipStatus::Refresh` draws the
 # actor name once (`DrawActorName`) and then loops exactly the four battle
 # stats (`DrawParameter`, type 0-3: Attack/Defense/Spirit/Agility) at
 # `y_offset + ((12 + 4) * i)` -- a genuinely separate row per stat, with no
 # HP/MP field anywhere in the window at all. `Scene_Equip::Start`
-# (`src/scene_equip.cpp`) confirms this is the *only* status window on the
+# confirms this is the *only* status window on the
 # screen (alongside the plain slot list) -- there is no second window
 # showing HP/MP either. docs/TODO.md's own "Menu scene" entry used to claim
-# "Equip already shows the full stat block", which this source disproves.
+# "Equip already shows the full stat block", which this reference disagrees with.
 check 'Scene::EquipMenu: the stats window shows no HP/MP, and each battle ' \
       'stat is drawn on its own row' do
   state = Game::State.new(MenuStubParty.new, 1, 0, 0)
@@ -22143,10 +22266,11 @@ check 'Scene::EquipMenu: the stats window shows no HP/MP, and each battle ' \
      'each stat on its own row below the name row, one RPG2k::Scene::EquipMenu::LINE_H apart'
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
-# UpdateStatusWindow` (`src/scene_equip.cpp`) recomputes each of the four
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Equip::
+# UpdateStatusWindow` recomputes each of the four
 # battle stats independently and hands them to `Window_EquipStatus::
-# SetNewParameters`, which `DrawParameter` (`src/window_equipstatus.cpp`)
+# SetNewParameters`, which `DrawParameter`
 # draws as its own old -> new pair -- never folded into one net verdict, so
 # a candidate that trades Atk for Def shows both movements at once.
 check 'Scene::EquipMenu: the stats window previews each battle stat ' \
@@ -22180,10 +22304,10 @@ check 'Scene::EquipMenu: the stats window previews each battle stat ' \
   eq false, texts.include?('>'), 'back on the slot list, the preview arrow is gone entirely'
 end
 
-# Confirmed against RPG_RT's own live source: `Window_EquipStatus::
-# DrawParameter` (`src/window_equipstatus.cpp`) draws `actor.GetAtk()` (the
-# state-adjusted value), and `Scene_Equip::UpdateStatusWindow` (`src/
-# scene_equip.cpp`) computes its own "new" preview by rebuilding the raw
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_EquipStatus::
+# DrawParameter` draws `actor.GetAtk()` (the
+# state-adjusted value), and `Scene_Equip::UpdateStatusWindow` computes its own "new" preview by rebuilding the raw
 # base+equip total first, clamping to `MaxStatBaseValue()` (999), and only
 # then calling `actor.CalcValueAfterAtkStates` -- the state adjustment is
 # the last step in both the current and the preview column, not skipped or
@@ -22270,8 +22394,9 @@ check 'Scene::EquipMenu: a 両手持ち candidate previews Atk rising and Def ' 
   ok texts.include?('40'),
      'Atk rises: stub actor\'s own 20 + delta (claymore 40 - sword 20 = 20) = 40'
   # Def falls in the same preview: stub actor's own 12 + delta (0 -
-  # forced-off shield's 25 = -25) = -13 -- but RPG_RT clamps the new base
-  # total to 1..999 (`Utils::Clamp(atk, 1, limit)`, `src/scene_equip.cpp`)
+  # forced-off shield's 25 = -25) = -13 -- but per EasyRPG Player's source
+  # (NOT independently confirmed against genuine RPG_RT under wine), it
+  # clamps the new base total to 1..999 (`Utils::Clamp(atk, 1, limit)`)
   # *before* ever displaying it, the same clamp #draw_stat_row now applies,
   # so a negative preview floors to 1, not the raw negative sum.
   ok texts.include?('1'),
@@ -22280,7 +22405,8 @@ check 'Scene::EquipMenu: a 両手持ち candidate previews Atk rising and Def ' 
      'the raw, unclamped negative total should not be shown at all'
 end
 
-# EasyRPG's `Window_EquipStatus::DrawParameter` (`src/window_equipstatus.cpp`)
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Window_EquipStatus::DrawParameter`
 # colours the new value via `GetNewParameterColor` (0 unchanged / 2 up / 3
 # down), blended from the windowskin's own system-colour swatches -- the same
 # convention the disabled title-menu label and the shop status panel already
@@ -22314,8 +22440,10 @@ check "Scene::EquipMenu: browsing the shield slot with a 両手持ち weapon " \
       'already worn shows the same forced-unequip side effect' do
   # Symmetric case: any candidate landing in the shield slot forces the
   # weapon slot's own 両手持ち weapon off, even an ordinary (non-two-handed)
-  # shield candidate -- EasyRPG's guard is `other_old_item->two_handed ||
-  # current_item->two_handed`, either side qualifies.
+  # shield candidate -- per EasyRPG Player's source (NOT independently
+  # confirmed against genuine RPG_RT under wine), its guard is
+  # `other_old_item->two_handed || current_item->two_handed`, either side
+  # qualifies.
   state = Game::State.new(TwoHandedEquipParty.new, 1, 0, 0)
   actor = state.party.actors.first
   actor.equipment[0] = 2 # weapon slot: Claymore (two-handed), atk 40
@@ -22330,8 +22458,10 @@ end
 
 check "Scene::EquipMenu: Remove never triggers the 両手持ち forced-unequip " \
       'side effect' do
-  # EasyRPG's own guard is `current_item && ...` -- id 0 (Remove) has no
-  # candidate item at all, so the other hand is never touched by removing
+  # Per EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its own guard is `current_item && ...` -- id 0
+  # (Remove) has no candidate item at all, so the other hand is never touched
+  # by removing
   # this slot's own item.
   state = Game::State.new(TwoHandedEquipParty.new, 1, 0, 0)
   actor = state.party.actors.first
@@ -22369,8 +22499,9 @@ check 'Scene::EquipMenu: a dangling equipped item id logs once, not per rebuild,
   ok out2.empty?, "re-rendering the already-warned id must stay silent, got: #{out2.inspect}"
 end
 
-# Confirmed against RPG_RT's own live source: `Window_ActorInfo::DrawInfo`
-# (`src/window_actorinfo.cpp`) always draws a labelled Class/Profession row
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_ActorInfo::DrawInfo`
+# always draws a labelled Class/Profession row
 # (`TextDraw(..., "Class"); DrawActorClass(actor, ...)`), with no version
 # gate around it -- an RPG2000 database with no class table still gets the
 # row, just blank.
@@ -22390,10 +22521,10 @@ check 'the status screen shows a labelled Class row' do
   ok texts.include?('Class: Paladin'), "shows the class name, got: #{texts.inspect}"
 end
 
-# Confirmed against RPG_RT's own live source: `Window_ParamStatus::Refresh`
-# (`src/window_paramstatus.cpp`) draws `actor.GetAtk()`/`GetDef()`/
-# `GetSpi()`/`GetAgi()`, and `Game_Battler::GetAtk` et al. (`src/
-# game_battler.cpp`) run the base value through `AdjustParam`, which halves
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_ParamStatus::Refresh`
+# draws `actor.GetAtk()`/`GetDef()`/
+# `GetSpi()`/`GetAgi()`, and `Game_Battler::GetAtk` et al. run the base value through `AdjustParam`, which halves
 # or doubles it against whatever states the actor currently carries -- a
 # state that persists onto the map affects this screen too, not just battle
 # math.
@@ -22416,11 +22547,12 @@ check 'the status screen shows a battle stat halved by an active state, ' \
   ok !stat_line.match?(/\b20\b/), "the raw base Atk (20) should not still appear: #{stat_line.inspect}"
 end
 
-# Confirmed directly against RPG_RT's live source: `Window_ActorStatus::
-# DrawStatus` (`src/window_actorstatus.cpp`) draws the Exp row via
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_ActorStatus::
+# DrawStatus` draws the Exp row via
 # `DrawMinMax(90, 34, -1, -1)`, whose sentinel routes both halves through
 # `GetExpString`/`GetNextExpString` rather than a literal min/max pair;
-# `Game_Actor::GetNextExpString` (`src/game_actor.cpp`) stringifies
+# `Game_Actor::GetNextExpString` stringifies
 # `GetNextExp()` -- the absolute cumulative-total curve value for the next
 # level, not a subtraction against current EXP. `MenuStubActor` gives
 # `#next_level_exp`/`#exp_to_next` distinct values (420 vs 120) precisely so
@@ -22449,9 +22581,10 @@ check 'the status screen gives the condition a labelled row' do
   ok texts.include?('Down'), 'a downed actor reads as such, not merely HP 0'
 end
 
-# RPG_RT's own `Window_Gold` (`src/window_gold.cpp`), created unconditionally
-# by `Scene_Status::Start` (`src/scene_status.cpp`, no visibility gate
-# anywhere in the file) -- confirmed missing here entirely.
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Window_Gold`, created unconditionally
+# by `Scene_Status::Start` (no visibility gate
+# anywhere in the file) -- missing here entirely.
 check 'the status screen shows the party\'s own Gold' do
   st = menu_state
   st.party.instance_variable_set(:@gold, 1234)
@@ -22459,7 +22592,8 @@ check 'the status screen shows the party\'s own Gold' do
                          .instance_variable_get(:@window))
   ok texts.include?('1234G'), "Gold is drawn as its own line, got: #{texts.inspect}"
 
-  # RPG_RT's Window_Gold draws unconditionally, including at 0 -- not only
+  # Per EasyRPG Player's source (not independently confirmed under wine),
+  # its Window_Gold draws unconditionally, including at 0 -- not only
   # once the party has money.
   st.party.instance_variable_set(:@gold, 0)
   texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
@@ -22467,9 +22601,10 @@ check 'the status screen shows the party\'s own Gold' do
   ok texts.include?('0G'), "zero Gold still shows, got: #{texts.inspect}"
 end
 
-# `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`) additionally
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), `Window_ActorInfo::DrawInfo` additionally
 # draws "Front"/"Back" right-aligned at the top of the panel whenever
-# `Feature::HasRow()` (`src/feature.cpp`) holds -- which for a genuine,
+# `Feature::HasRow()` holds -- which for a genuine,
 # unmodified project reduces to "the database is RPG2003". An RPG2000
 # database never shows either label.
 check 'the status screen shows the RPG2003 battle row, gated on rpg2003?' do
@@ -22491,10 +22626,11 @@ check 'the status screen shows the RPG2003 battle row, gated on rpg2003?' do
   ok texts.include?('Back'), "back row shows once toggled, got: #{texts.inspect}"
 end
 
-# Confirmed directly against RPG_RT's live source: `Window_Base::
-# GetValueFontColor` (`src/window_base.cpp`), the shared routine behind
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Window_Base::
+# GetValueFontColor`, the shared routine behind
 # `DrawActorHp`/`DrawActorSp` (in turn used by `Window_ActorStatus::
-# DrawStatus`, `src/window_actorstatus.cpp`) -- the *current* HP/MP figure
+# DrawStatus`) -- the *current* HP/MP figure
 # alone recolors: knockout gray (index 5) at exactly 0 HP, critical
 # red/orange (index 4) at or below a quarter of max, the ordinary default
 # (index 0) otherwise. SP never shows the knockout colour even at 0
@@ -22533,18 +22669,20 @@ check 'Scene::StatusMenu: the actor cursor wraps around' do
   eq 0, scene.instance_variable_get(:@actor_index), 'Right from the last actor wraps to the first'
 end
 
-# Confirmed already correct, no code change needed -- checked while auditing
+# No code change needed here -- checked while auditing
 # this screen for the same key-repeat gap already fixed on every other menu
 # screen (see docs/TODO.md). Unlike a genuine cursor inside a
 # Window_Selectable list, this screen has no list at all: LEFT/RIGHT just
-# rebuild the whole panel for a different party member, and EasyRPG's real
-# Scene_Status::vUpdate (src/scene_status.cpp) checks
+# rebuild the whole panel for a different party member, and per EasyRPG
+# Player's source (NOT independently confirmed against genuine RPG_RT under
+# wine), its Scene_Status::vUpdate checks
 # Input::IsTriggered(RIGHT/LEFT) only -- no IsRepeated fallthrough anywhere
-# in the method -- so holding the key never auto-cycles members in the real
-# engine either. This check pins that as a checked invariant rather than an
-# unverified assumption.
+# in the method -- so holding the key never auto-cycles members in that
+# reference either. This check pins that as a ported assumption, not an
+# independently confirmed one.
 check 'Scene::StatusMenu: holding Right does NOT auto-cycle the actor -- ' \
-      'confirmed matching the real engine\'s own discrete-only gate' do
+      'matching EasyRPG Player\'s own discrete-only gate (not independently ' \
+      'confirmed under wine)' do
   scene = menu_scene(RPG2k::Scene::StatusMenu, wrap_menu_state)
   RGSS::Input.repeated = [RGSS::Input::RIGHT] # held, but not a fresh trigger
   scene.update
@@ -22553,8 +22691,9 @@ check 'Scene::StatusMenu: holding Right does NOT auto-cycle the actor -- ' \
      'a held (repeated, not triggered) Right does not cycle the actor'
 end
 
-# Confirmed against RPG_RT's own live source: `Scene_Status::vUpdate`
-# (src/scene_status.cpp) gates both the RIGHT and LEFT branches on
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Scene_Status::vUpdate`
+# gates both the RIGHT and LEFT branches on
 # `actors.size() > 1`, not just the key trigger itself -- a solo party's
 # Status screen plays no cursor SE and rebuilds nothing on either key.
 check 'Scene::StatusMenu: a solo party leaves Right/Left as silent no-ops' do
@@ -22638,7 +22777,8 @@ check 'walking slips HP from a poisoned member every fourth tile' do
   eq 99, hero.hp, 'the fourth tile slips 1 HP'
 end
 
-# Ports EasyRPG's `Game_Party::ApplyStateDamage` (src/game_party.cpp): its
+# Ported from EasyRPG Player's source (its `Game_Party::ApplyStateDamage`),
+# NOT independently confirmed against genuine RPG_RT under wine: its
 # `damage` bool is only ever set inside a `ChangeType_lose` branch, never a
 # `ChangeType_gain` one, and `Game_Player::UpdateNextMovementAction` gates the
 # red step-damage flash on exactly that bool. Regen's map-step tick heals, so
@@ -22751,13 +22891,13 @@ check 'RPG2003 terrain footstep plays every ordinary step onto that tile' do
   eq 3, RGSS::Audio.se_calls.count { |c| c[0] == 'Step1' }, 'one footstep per tile walked'
 end
 
-# Confirmed against EasyRPG's actual C++ source: liblcf's own
-# `generator/csv/fields.csv` (`Terrain,footstep,f,Sound,0x0F,...`) and
-# `src/generated/lcf/rpg/terrain.h` (`Sound footstep;`) -- the field is a
+# Confirmed against liblcf's own schema: `generator/csv/fields.csv`
+# (`Terrain,footstep,f,Sound,0x0F,...`) -- the field is a
 # full Sound struct (filename + volume + tempo + balance), not a bare
-# filename, the same shape `Game_System::SePlay(const lcf::rpg::Sound&,
-# bool)` (`src/game_system.cpp`) already reads for every other Sound-typed
-# database field.
+# filename. That it is read the same way `Game_System::SePlay(const
+# lcf::rpg::Sound&, bool)` already reads every other Sound-typed database
+# field is ported from EasyRPG Player's source, NOT independently confirmed
+# against genuine RPG_RT under wine.
 check 'RPG2003 terrain footstep plays with its own configured volume/pitch, ' \
       'not the schema defaults' do
   RGSS::Audio.reset_se
@@ -23262,13 +23402,15 @@ check 'a forced player jump arcs the hero the way it arcs an event' do
   eq 0, scene.send(:player_jump_offset), 'and the hero is back on it once landed'
 end
 
-# EasyRPG's own Game_Character::GetJumpHeight (src/game_character.cpp) is
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Game_Character::GetJumpHeight is
 # `jump_height &lt; 5 ? jump_height * 2 : jump_height &lt; 13 ? jump_height + 4 :
 # 16` -- doubled while small, offset by 4 through h < 13, and capped at a
 # flat 16 beyond that. #jump_offset_for used to mis-port this as an
-# uncapped `h + 5`, peaking at 21px instead of the real arc's own 16px
+# uncapped `h + 5`, peaking at 21px instead of that arc's own 16px
 # ceiling (a full tile, never past it).
-check "#jump_offset_for's piecewise arc matches EasyRPG's GetJumpHeight exactly" do
+check "#jump_offset_for's piecewise arc matches EasyRPG Player's " \
+      "GetJumpHeight exactly (not independently confirmed under wine)" do
   scene = new_scene({})
   jh = ->(move_count) { scene.send(:jump_offset_for, move_count) }
   eq 0, jh.call(0), 'move_count 0: the hop begins on the ground'
@@ -23350,8 +23492,8 @@ check 'a vehicle Change Graphic overrides its sprite without persisting to Game:
      'Transfer Player drops the mirror, reverting the override'
 end
 
-# EasyRPG Player's actual C++ source: Game_Vehicle::Game_Vehicle
-# (src/game_vehicle.cpp) seeds a fresh vehicle with
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine): its Game_Vehicle::Game_Vehicle seeds a fresh vehicle with
 # `SetSpriteGraphic(ToString(lcf::Data::system.boat_name), lcf::Data::system.
 # boat_index)` (and the ship_/airship_ equivalents) -- the database's System
 # boat_index/ship_index/airship_index seed the on-map CharSet cell exactly
@@ -23482,11 +23624,11 @@ check 'a transformed monster is redrawn with its new battler graphic' do
   ok !ui[:enemy_sprites][0].equal?(before), 'its sprite is rebuilt'
   eq 'Dragon', ui[:sprite_names][0], 'and tracked against the new battler'
   ok ui[:enemy_sprites][0].visible, 'still on the field'
-  # Confirmed against EasyRPG's actual C++ source, fetched live:
-  # `Game_BattleAlgorithm::Transform::ApplyCustomEffect`
-  # (src/game_battlealgorithm.cpp) calls `enemy->Flash(31,31,31,31,20)`
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine:
+  # `Game_BattleAlgorithm::Transform::ApplyCustomEffect` calls `enemy->Flash(31,31,31,31,20)`
   # unconditionally right after the swap -- the near-white "flash of
-  # light" every RPG_RT transformation shows, on the 0..31 raw scale this
+  # light" that reference's transformation shows, on the 0..31 raw scale this
   # codebase already multiplies by 8 elsewhere (Interpreter::FLASH_SCALE).
   new_spr = ui[:enemy_sprites][0]
   ok new_spr.flash_color, 'the transform flashes the new sprite'
@@ -23561,12 +23703,13 @@ check 'a random encounter opens a battle with the map-tree node\'s own troop' do
   eq 0, st.encounter_total, 'the accumulator resets once a fight actually starts'
 end
 
-# RPG2000's own 1/32 first-strike roll on a wandering encounter -- EasyRPG's
-# `Game_Map::PrepareEncounter` (`src/game_map.cpp`) is a hard `if (Feature::
+# RPG2000's own 1/32 first-strike roll on a wandering encounter -- per
+# EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its `Game_Map::PrepareEncounter` is a hard `if (Feature::
 # HasRpg2kBattleSystem()) { Rand::ChanceOf(1, 32) ... } else { /* 2003's
 # terrain-condition rolls */ }`, and `Feature::HasRpg2kBattleSystem()`
-# (`src/feature.cpp`) reduces to `Player::IsRPG2k()` for a genuine database --
-# so a real RPG2003 game never rolls this chance at all, and draws no random
+# reduces to `Player::IsRPG2k()` for a genuine database --
+# so an RPG2003 game per that reference never rolls this chance at all, and draws no random
 # number doing so either. Previously this build rolled it unconditionally
 # regardless of edition.
 check 'RPG2003 never rolls RPG2000\'s 1/32 first-strike chance on a wandering ' \
@@ -23589,7 +23732,7 @@ check 'RPG2003 never rolls RPG2000\'s 1/32 first-strike chance on a wandering ' 
   # `Game::Rng.new(0x2000)`) and run the identical code path up to the
   # first-strike line (troop-count roll, accumulator roll, troop selection),
   # so their `@rng` are in identical internal state right up to it -- the
-  # ONLY difference RPG_RT's own if/else makes is the 2000-only draw. Manually
+  # ONLY difference that reference's own if/else makes is the 2000-only draw. Manually
   # advancing the 2003 rng one more step must land exactly on the 2000 rng's
   # own post-call state, proving the roll was skipped outright rather than
   # merely made and discarded.
@@ -23608,8 +23751,8 @@ check 'an empty encounter list never starts a random battle' do
      'the roll succeeds but there is nothing to fight, so no battle opens'
 end
 
-# Confirmed against EasyRPG's live source, `Game_Map::GetEncountersAt`
-# (`src/game_map.cpp`): an "Area" map-tree node (field 4 `type` == 2, a
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: `Game_Map::GetEncountersAt`: an "Area" map-tree node (field 4 `type` == 2, a
 # rectangular sub-region the RPG2000/2003 editor lets an author carve out of
 # a map with its own independent encounter list, field 41) is a *direct
 # child* of its owning map (field 2 `parent_map_id`) and contributes its own
@@ -23723,14 +23866,15 @@ check 'standing on an Event Touch tile still rolls for a random encounter' do
 end
 
 check "a chipset cell whose terrain id has no database row never rolls for a random " \
-      "encounter, matching RPG_RT (2026-08-18)" do
-  # EasyRPG's Game_Player::UpdateEncounterSteps (src/game_player.cpp) returns
+      "encounter, per EasyRPG Player (2026-08-18, NOT independently confirmed against genuine RPG_RT under wine)" do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_Player::UpdateEncounterSteps returns
   # outright when the tile's terrain row can't be resolved at all --
   # `if (!terrain) { Output::Warning(...); return; }` -- no fallback rate, no
   # encounter_total increment, no roll, as if the step never happened. This
   # build's own #check_random_encounter used to fall through to a fabricated
   # rate of 100 instead, still rolling (and, with this guaranteed-roll setup,
-  # still starting) a fight real RPG_RT can never trigger from that tile.
+  # still starting) a fight that reference can never trigger from that tile.
   tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
   scene = new_scene({}, player: [0, 0], map_tree: tree)
   st = scene.instance_variable_get(:@state)
@@ -24080,7 +24224,8 @@ check 'B cancels the debug menu variable editor without changing the value' do
   eq 5, st.variables[1], 'cancelling left the variable untouched'
 end
 
-# EasyRPG's own Game_Variables::GetMaxDigits (src/game_variables.cpp) derives
+# Per EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine), its Game_Variables::GetMaxDigits derives
 # the debug menu's own Window_NumberInput width from the same edition-gated
 # range Game::Variables::MAX/RPG2003_MAX already carries -- 6 digits on
 # RPG2000, 7 on RPG2003, not a flat 6 regardless of database.


### PR DESCRIPTION
## Summary

Completes cycle #184's sweep exhaustively. Cycle #184's own grep (`src/[a-z_]+\.(cpp|h)`) undercounted — it requires letters/underscore only, so filenames with digits (`scene_battle_rpg2k.cpp`, `scene_battle_rpg2k3.cpp`, `window_shopnumber.cpp`, etc.) escaped it. Widened to `src/[a-z0-9_]+\.(cpp|h)`, which found the true baseline was 99 remaining in `rpg2k_logic_check.rb` (not 94) and 178 in `rpg2k_scene_check.rb` (not 177).

Read both files top-to-bottom and rewrote every illegitimate citation: where independent evidence already existed in the comment (genuine wine confirmation, a liblcf schema citation, or established community trivia like yado.tk), kept it and dropped the EasyRPG citation; everywhere else, rewrote to "ported from EasyRPG Player's source, NOT independently confirmed against genuine RPG_RT under wine" while preserving the technical description. Also fixed several check-title strings carrying the same misattribution ("matching RPG_RT", "(RPG_RT)").

- `rpg2k_logic_check.rb`: 99 → 2 remaining (97 fixed; the 2 left are pre-existing, already-honest historical-correction comments from cycle #169).
- `rpg2k_scene_check.rb`: 178 → 8 remaining (170 fixed; same situation).

**267 citations fixed total** — clears every illegitimate citation in both target files. A lighter, comment/check-title-only cycle: no wine/Xvfb used, no assertions changed.

Note: this branch was reconciled against unrelated upstream changes (two other PRs merged to master in the meantime, adding ~362 new lines/13 new checks to `rpg2k_logic_check.rb`) via a careful stash/fetch/pop — verified with `git diff` that the auto-merge introduced no conflicts and no unintended changes.

## Verification

- Confirmed every changed line vs. the current `origin/master` base is a check-title/descriptive string, never an assertion: `git diff origin/master -- scripts/rpg2k_logic_check.rb scripts/rpg2k_scene_check.rb | grep -E "^[+-]" | grep -vE "^(\+\+\+|---)" | grep -vE "^[+-][[:space:]]*#" | grep -vE "^[+-][[:space:]]*$"` shows only `check '...' do` strings.
- No merge-conflict markers anywhere (`grep -n '^<<<<<<<\|^=======$\|^>>>>>>>'` clean).
- `ruby -c` clean on both files.
- Re-ran both check scripts: `rpg2k_logic_check.rb` → 1163 checks passed, `rpg2k_scene_check.rb` → 929 checks passed — independently confirmed these exact counts already hold on `origin/master` alone (before this PR's changes), proving no assertions were altered.
- `rpg2k_render_check.rb` (41), `rpg2k3_battle_row_check.rb` (19), `rpg2k3_battle_gauge_check.rb` (15), `ctest -R mruby_test` all green.
- No `data/` files touched (no wine used this cycle).

## Changelog

None — comment/string-only, no shipped behavioral change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_