### PR TITLE
Cycle #189: full manual re-read of the two largest citation-swept scripts/ files

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6643,6 +6643,126 @@ The work below is roughly ordered by the critical path to a walkable game
   formally close this out, that re-read plus a scripted multi-line-window
   scan of `game.rb` (rather than this cycle's manual read-through) would be
   the way to get a provable rather than believed-complete result.
+  ✅ **Follow-up (cycle #189, 2026-08-27): the line-by-line re-read of
+  `rpg2k_logic_check.rb`/`rpg2k_scene_check.rb` cycle #188 flagged as never
+  having happened since cycle #185.** Explicitly a lighter-weight cycle -- no
+  wine/Xvfb, comment editing only. **Method:** read both files in full,
+  section by section, specifically hunting cycle #188's own split-citation
+  shape (an EasyRPG class/method name on one comment line, a `src/*.cpp|h`
+  file path on a different line) plus any other undisclosed-citation shape a
+  human read could catch that the grep patterns from cycles #174-188 could
+  not (a bare filename with no `src/` prefix, a filename glob like
+  `scene_battle*.cpp`, or simply "EasyRPG's `Foo::Bar` does X" stated as fact
+  with no disclaimer anywhere in the same check). A scripted pass (group the
+  file into per-`check`-block sections including each block's own leading
+  comment, flag any section mentioning EasyRPG with no disclaimer phrase
+  anywhere in it) narrowed several thousand lines down to roughly 90
+  candidates per file, each then read by hand in context to separate genuine
+  violations from false positives (a disclaimer phrased differently than "NOT
+  independently confirmed", e.g. "Independently re-verified under wine" or a
+  hyphenated "not-independently-confirmed"; a citation deferring to another
+  spot in `mrblib/game.rb` or `mrblib/scene/map.rb` that was checked and
+  does carry its own honest disclosure; a benign self-consistency check like
+  "matches EasyRPG CheckTurns/DrawNumberSystem2 exactly" that ports a literal
+  transcription of an EasyRPG algorithm and tests the Ruby port against that
+  transcription, never claiming RPG_RT confirmation; a historical-correction
+  paragraph that already says the EasyRPG-sourced claim does not match
+  genuine RPG_RT; or independent evidence -- genuine wine confirmation, a
+  citation to this codebase's own already-disclosed comment, or community
+  デフォ戦bot/2000_battle_bot/yado.tk trivia -- already present, which was kept
+  while only the illegitimate EasyRPG-source framing was dropped).
+  **Found and fixed, `rpg2k_logic_check.rb` (69 edited spots):** the exact
+  cycle-#188 split-line shape did turn up (`Scene_Battle::EndBattle`'s class
+  name on one comment line, `` `src/\n  # scene_battle.cpp`` `` split onto the
+  next, in `rpg2k_scene_check.rb` -- see below), but this file's own
+  dominant miss was different and larger: dozens of "EasyRPG's `Foo::Bar`
+  does X" / "ported from EasyRPG's `Foo::Bar`" statements presented as flat
+  behavioral fact with no disclaimer anywhere nearby, several using the
+  outright illegitimate "**Confirmed against EasyRPG's** ..." / "**Verified
+  against RPG_RT's actual behavior via EasyRPG Player's own C++ source**"
+  framing cycle #188 flagged as the most serious violation shape (e.g. the
+  airship-boarding-facing check's "fetched live" framing, which also
+  presented an EasyRPG source comment's own claim -- "RPG_RT ignores the
+  lock\_facing flag here!" -- as if it were this codebase's own verified
+  finding; the self-destruction-basic-action check's "verified against
+  EasyRPG" title; several "class\_set is ignored"/"Row case"/"crit-chance
+  truncation"/"escape-chance rounding"/"weapon-swing count" battle-math
+  paragraphs). Every one rewritten to the established "ported from EasyRPG
+  Player's source, NOT independently confirmed against genuine RPG_RT under
+  wine" framing, preserving the technical description and any independent
+  evidence already present (e.g. the self-destruct check kept its
+  2000\_battle\_bot/デフォ戦bot trivia and only lost the "verified against
+  EasyRPG" wrapper). **Found and fixed, `rpg2k_scene_check.rb` (67 edited spots):**
+  the same "confirmed/verified against EasyRPG" and bare undisclosed-citation
+  shapes throughout the battle scene, menu, equip, and field-map sections,
+  plus three genuine split/evasion shapes the prior file-path grep could
+  never have caught: `Scene_Battle::EndBattle`'s citation split exactly like
+  cycle #188's `game.rb` finds (class name one line, `` `src/\n  #
+  scene_battle.cpp`` `` the next); two bare filenames with no `src/` prefix
+  at all (`` `Game_Battler::EvadesAllPhysicalAttacks (game_battler.cpp)` ``
+  and `` `Skill::IsReflected (game_battlealgorithm.cpp)` ``, both inside
+  `rpg2k_logic_check.rb`); and a glob-style reference (`` `src/
+  scene_battle*.cpp` ``) that a literal-path regex can never match. Also
+  corrected two mislabelling shapes cycle #188 specifically warned about --
+  citing "RPG\_RT's own `GetParameterChangeMessage`/`GetAttributeShiftMessage`"
+  when those are EasyRPG's own function names, and "confirmed against
+  EasyRPG's" phrasing on several Scene\_Menu/Scene\_Equip/Scene\_Skill
+  checks -- to the honest "ported from ..., NOT independently confirmed"
+  framing throughout. Left two citations pointing at `mruby-rpg2k/mrblib/
+  scene/map.rb` doc comments (`#hold_animation_screen_flash`/
+  `#hold_animation_target_flash`) that themselves still read as
+  "corroborated independently against EasyRPG's own C++ source" with no
+  disclaimer of their own -- `scene_check.rb`'s own two citing comments were
+  rewritten to disclose honestly regardless, but `scene/map.rb` itself is
+  out of this cycle's scope (only `scripts/rpg2k_logic_check.rb`/
+  `rpg2k_scene_check.rb` were assigned) and still needs its own pass.
+  **`mruby-rpg2k/mrblib/interpreter.rb` spot-check:** re-read with the same
+  scripted narrowing (100 EasyRPG mentions total, 6 candidates after
+  filtering); all 6 already read as honest on inspection -- two used a
+  hyphenated "ported-from-EasyRPG, not-independently-confirmed" disclaimer
+  the regex's exact-phrase match missed, one is a `~~struck-through~~`
+  historical correction immediately followed by a lengthy genuine
+  RPG\_RT.exe-under-wine confirmation (cycle #181's Teleport facing-parameter
+  splice, run against two distinct genuine binaries), and one is a design-
+  rationale analogy ("like EasyRPG on a platform whose window cannot change
+  mode") with no RPG\_RT behavioral claim at all. Confirms cycles #177/#186's
+  "already honest" assessment still holds; **no edits made** to this file.
+  **Verification:** `ruby -c` clean on both edited files. Comment-only,
+  checked per file with `git diff -- <file> | grep -E '^[+-]' | grep -vE
+  '^(\+\+\+|---)' | grep -vE '^[+-][[:space:]]*#' | grep -vE
+  '^[+-][[:space:]]*$'`: for `rpg2k_logic_check.rb`, only 3 rewritten
+  check-title strings ever showed (never an assertion line); for
+  `rpg2k_scene_check.rb`, only 6 rewritten check-title/assertion-message
+  strings showed. Before/after check counts, both matching the pre-cycle
+  baselines this cycle confirmed first: `rpg2k_logic_check.rb` 1163 checks
+  passed, `rpg2k_scene_check.rb` 929 checks passed, identical before and
+  after every edit. `cd build && ctest -R mruby_test` passed (7.90s). No
+  wine/Xvfb/matchbox process started this cycle, no save file touched. No
+  changelog fragment: comment-only documentation work, not a behavioral fix.
+  **Is the sweep complete now?** For these two files specifically: believed
+  complete under both the file-path grep and a full manual read for
+  undisclosed/mislabelled EasyRPG citations -- this cycle read every line of
+  both files, not just the post-narrowing candidate set (the candidate
+  narrowing was cross-checked, not solely relied on). What is **not**
+  provably complete: (1) `mruby-rpg2k/mrblib/scene/map.rb`, newly identified
+  above as carrying at least two "corroborated independently against
+  EasyRPG's own C++ source" citations with no disclaimer of their own --
+  never in scope for any prior citation-hygiene cycle and not fixed here
+  either, since this cycle's assignment was the two `scripts/*.rb` files;
+  (2) `mruby-rpg2k/mrblib/game.rb` itself, ~16,600 lines, cycle #188's own
+  closing note already flagged as not exhaustively provable and untouched
+  this cycle; (3) the handful of `scripts/*.rb` files with a low EasyRPG
+  count that no cycle has re-read line-by-line since cycle #187's blanket
+  sweep (only spot-checked there, not read in full); and (4) this cycle's own
+  scripted narrowing heuristic (disclaimer-phrase-anywhere-in-the-same-
+  `check`-block) is itself an approximation -- a disclaimer worded
+  unusually enough to dodge the regex *and* missed by this cycle's own manual
+  read remains a theoretical gap, though the full manual read of both files
+  makes that considerably less likely than after cycles #185/#187's
+  narrower automated passes alone. Net assessment: the two largest,
+  longest-unread files in the sweep are now the most thoroughly checked, and
+  the specific cycle-#188 blind spot (a citation split across lines) is
+  confirmed either absent or fixed in both.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -681,9 +681,10 @@ check "Game::EventGraphic.frame draws a fixed-direction event's live facing, " \
   # character's own #direction (the check above), the render layer threw it
   # away and drew the stale page facing regardless. Covers all three
   # fixed_direction? kinds, FIXED_GRAPHIC ("never animates") included --
-  # EasyRPG only special-cases it for the *walk-frame column* (a fixed
-  # graphic's own pattern column never advances, still true here via
-  # #animated?), never for GetFacing()/its move-route Face handling.
+  # ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: it only special-cases it for the *walk-frame
+  # column* (a fixed graphic's own pattern column never advances, still true
+  # here via #animated?), never for GetFacing()/its move-route Face handling.
   eg = Game::EventGraphic
   dir, col = eg.frame(eg::FIXED_NON_CONTINUOUS, 2, 1, 8, 0, false)
   eq [8, 1], [dir, col], 'char_dir (an explicit Face Up), not base_dir (2, south)'
@@ -5501,10 +5502,11 @@ end
 
 check "Party#toggle_actor_row flips an actor's row and refuses to empty the front row" do
   # RPG2003's field-menu Row command (scene/menu.rb's :row branch) --
-  # EasyRPG's own `Scene_Menu::UpdateActorSelection` Row case, restated:
-  # blocks only the toggle that would leave every live party member in the
-  # back row (no `IsDirectionFlipped` term here -- that quirk is specific to
-  # the in-battle `Scene_Battle_Rpg2k3::RowSelected`, see
+  # ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Scene_Menu::UpdateActorSelection` Row
+  # case, restated, blocks only the toggle that would leave every live party
+  # member in the back row (no `IsDirectionFlipped` term here -- that quirk
+  # is specific to the in-battle `Scene_Battle_Rpg2k3::RowSelected`, see
   # Game::Battle#can_leave_front_row?).
   players = (1..3).to_h { |i| [i, FakePlayerRow.new("Actor#{i}", '', 0, 1, max_hp: 10)] }
   db = FakeActorDB.new(players, [1, 2, 3])
@@ -8387,8 +8389,9 @@ end
 
 # Under the *default* "by Actor" setting (equipment_setting left at 0, or a
 # fixture that never sets it at all), class_set is ignored entirely and
-# actor_set decides, even in an RPG2003 database with classes -- matching
-# EasyRPG's own `if` branch, which only switches to class_set once
+# actor_set decides, even in an RPG2003 database with classes -- ported from
+# EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine: its own `if` branch only switches to class_set once
 # `equipment_setting == EquipmentSetting_class`.
 check 'class_set is ignored under the default "by Actor" equipment setting' do
   items = { 4 => fake_item(type: 6, rhp: 40, actor_set: [true, false],
@@ -9204,10 +9207,12 @@ check 'party#has_item? counts a copy equipped on any member, not just the bag' d
 end
 
 # The shop status panel's "equipped" row (Scene::Map#draw_shop_status) sums
-# every slot on every party member holding the item -- EasyRPG's
-# Game_Party::GetEquippedItemCount / Game_Actor::GetItemCount, a plain slot
-# equality scan, so two members (or two slots on one member) each holding a
-# copy count as two, and it moves independently of the bag count.
+# every slot on every party member holding the item -- ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine: its `Game_Party::GetEquippedItemCount` / `Game_Actor::GetItemCount`
+# is a plain slot equality scan, so two members (or two slots on one member)
+# each holding a copy count as two, and it moves independently of the bag
+# count.
 check "party#equipped_item_count sums a held item across every member's " \
       'equipment slots' do
   items = { 7 => fake_item(atk: 15, type: 1) }   # weapon -> slot 0
@@ -11390,8 +11395,9 @@ check 'Weather Effects keeps an RPG2003-only weather type on an RPG2003 database
   eq 3, st.weather.type, 'an RPG2003 database keeps the higher type'
 end
 
-# `int strength = std::min(str, 2);` in the same EasyRPG function, applied
-# unconditionally on every edition.
+# `int strength = std::min(str, 2);` in the same EasyRPG function as above
+# (also NOT independently confirmed against genuine RPG_RT under wine),
+# applied unconditionally on every edition.
 check 'Weather Effects clamps strength to at most 2 on any edition' do
   st = party_state
   it = Game::Interpreter.new(st)
@@ -11644,7 +11650,8 @@ check "an RPG2003 database widens the EXP cap to 9999999" do
 end
 
 check "an RPG2003 database's EXP curve is RPG2003's own linear formula, not RPG2000's" do
-  # EasyRPG's CalculateExp branches entirely on edition
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its CalculateExp branches entirely on edition
   # (`Player::IsRPG2k() ? 1 : 2`) -- RPG2003's own curve sums
   # `base + i*inflation + correction` linearly over the level index, a
   # structurally different formula from RPG2000's compounding
@@ -12316,7 +12323,9 @@ check 'Troop#drops rolls the drop probability on the given RNG' do
   ok results.any?(&:empty?), 'and sometimes misses'
 end
 
-check 'Troop EXP/gold/drops exclude a member still hidden at victory time (yado.tk, EasyRPG game_enemyparty.cpp)' do
+check 'Troop EXP/gold/drops exclude a member still hidden at victory time (yado.tk; ' \
+      'ported from EasyRPG Player\'s game_enemyparty.cpp, NOT independently confirmed ' \
+      'against genuine RPG_RT under wine)' do
   # A never-revealed Show-Hidden-Monster member: victory can fire while it's
   # still flagged invisible (Game::Battle#incapacitated? treats hidden the
   # same as dead for win/loss purposes), yet it never actually fell.
@@ -13011,13 +13020,14 @@ check 'to_lsd encodes a character\'s facing in liblcf\'s 0..3 convention, ' \
   eq 4, round.vehicle(:boat).direction, 'and the boat reads back numpad left too'
 end
 
-# EasyRPG models an actor's and an enemy's own "state id the target's
-# state_ranks array doesn't cover" case (routine -- liblcf/RPG_RT truncate
-# trailing default bytes off it) as two distinct functions with two distinct
-# defaults: Game_Actor::GetStateProbability defaults to C (rank 2, 60%),
-# Game_Enemy::GetStateProbability to B (rank 1, 80%) -- not one shared
-# default. #ally? (a live Combatant#actor vs nil) is the same tell Battle
-# already uses elsewhere to distinguish the two.
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: it models an actor's and an enemy's own "state
+# id the target's state_ranks array doesn't cover" case (routine --
+# liblcf/RPG_RT truncate trailing default bytes off it) as two distinct
+# functions with two distinct defaults: Game_Actor::GetStateProbability
+# defaults to C (rank 2, 60%), Game_Enemy::GetStateProbability to B (rank 1,
+# 80%) -- not one shared default. #ally? (a live Combatant#actor vs nil) is
+# the same tell Battle already uses elsewhere to distinguish the two.
 check "an enemy's own missing state-rank entry defaults to B (80%), an actor's to C (60%)" do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.actor = Object.new # a live actor -- #ally? true
@@ -13091,8 +13101,10 @@ end
 check "on RPG2003, a defensive item's reverse_state_effect flag grants no resistance either" do
   # reverse_state_effect only ever means something on a *weapon's own* states
   # (flips inflict to heal, #weapon_states) or a curative item; it has no
-  # meaning on defensive gear's state_set, matching EasyRPG's own
-  # `!(Player::IsRPG2k3() && item->reverse_state_effect)` guard excluding it.
+  # meaning on defensive gear's state_set -- ported from EasyRPG Player's
+  # source, NOT independently confirmed against genuine RPG_RT under wine:
+  # its own `!(Player::IsRPG2k3() && item->reverse_state_effect)` guard
+  # excludes it.
   items = { 5 => fake_item(type: 5, state_set: [0, 0, 1], state_chance: 50,
                             reverse_state: true) }
   st = skill_party({}, items, rpg2003: true)
@@ -13227,9 +13239,10 @@ check 'battle: a critical hit triples the damage when the fight rolls one' do
 end
 
 check "battle: a critical's damage multiplier now applies before variance, not after" do
-  # EasyRPG's CalcNormalAttackEffect applies the critical/charge multiplier
-  # and only then spreads the result by VarianceAdjustEffect -- not the other
-  # way round. #varied's own spread (`var*base/10`) scales with its input, so
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its CalcNormalAttackEffect applies the
+  # critical/charge multiplier and only then spreads the result by
+  # VarianceAdjustEffect -- not the other way round. #varied's own spread (`var*base/10`) scales with its input, so
   # rolling variance on the pre-crit base and tripling the *result* afterward
   # can only ever land on a multiple of 3 away from the tripled base (each
   # ±1 unit of pre-crit noise becomes ±3 once multiplied) -- a strictly
@@ -13303,10 +13316,12 @@ def crit_party(items)
 end
 
 check 'Actor#crit_chance: the row rate alone, truncated to a whole percent' do
-  # EasyRPG's Algo::CalcCriticalHitChance truncates the actor's own float rate
-  # to a whole int percent before ever rolling (`static_cast<int>(chance *
-  # 100.0)`, fed straight to `Rand::PercentChance(int)`'s plain 0..99 roll) --
-  # a 1-in-30 rate is a flat 3%, not 3.33%.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Algo::CalcCriticalHitChance truncates the
+  # actor's own float rate to a whole int percent before ever rolling
+  # (`static_cast<int>(chance * 100.0)`, fed straight to
+  # `Rand::PercentChance(int)`'s plain 0..99 roll) -- a 1-in-30 rate is a flat
+  # 3%, not 3.33%.
   st = crit_party({})
   eq 3, st.party.actor_by_id(1).crit_chance, '1-in-30 truncates to 3%'
   eq 0, st.party.actor_by_id(2).crit_chance, 'an actor that never crits'
@@ -13314,8 +13329,10 @@ end
 
 check 'Actor#crit_chance: an equipped weapon adds its own percentage' do
   # RPG_RT adds the weapon's rate to the wielder's, which no 1-in-N denominator
-  # can express -- but the *sum*, not the base rate, is what EasyRPG truncates,
-  # so 3% + 20% lands on the same 23% either way the truncation is ordered.
+  # can express -- but per the same EasyRPG-ported CalcCriticalHitChance
+  # reading above (NOT independently confirmed against genuine RPG_RT under
+  # wine), the *sum*, not the base rate, is what gets truncated, so 3% + 20%
+  # lands on the same 23% either way the truncation is ordered.
   items = { 7 => fake_item(type: 1, atk: 5, critical_hit: 20) }
   st = crit_party(items)
   a = st.party.actor_by_id(1)
@@ -13477,8 +13494,10 @@ check 'Appear Randomly never re-rolls a member already individually flagged ' \
 end
 
 check 'battle: the crit roll is read against a whole-percent scale' do
-  # A rate of N must crit on a roll of N-1 and not on N -- EasyRPG's
-  # Rand::PercentChance(int rate), `GetRandomNumber(0, 99) < rate`.
+  # A rate of N must crit on a roll of N-1 and not on N -- ported from
+  # EasyRPG Player's source, NOT independently confirmed against genuine
+  # RPG_RT under wine: its Rand::PercentChance(int rate) is
+  # `GetRandomNumber(0, 99) < rate`.
   [[49, true], [50, false], [51, false]].each do |roll, want|
     hero = combatant('Hero', 40, 0, 20, 100)
     hero.crit_chance = 50
@@ -13716,7 +13735,9 @@ check 'battle: RPG2003 lets a negative attribute rate scale damage directly, and
      'falls to the milder rate (not a multiply) when only one side is negative' do
   # Same single-attribute setup as the RPG2000 check above, but with the
   # `rpg2003:` flag on: unlike RPG2000, RPG2003 keeps EasyRPG's `INT_MIN`
-  # (no) floor, so the lone negative-rate side still applies directly.
+  # (no) floor (ported from EasyRPG Player's source, NOT independently
+  # confirmed against genuine RPG_RT under wine), so the lone negative-rate
+  # side still applies directly.
   props = { 1 => RateRow.new(200, 150, 100, 50, -100, 0) }
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.atk_attrs = [1]
@@ -13773,9 +13794,10 @@ end
 
  # A "physical" failure message (failure_message == 3) on an enemy-scope skill
  # switches its to-hit from the flat `skill.hit` to the agility-adjusted,
- # evasion-aware physical formula (EasyRPG Algo::CalcSkillToHit) -- the
- # CalcSkillToHit edge case docs/TODO.md left unimplemented. See Game::Battle#
- # skill_to_hit.
+ # evasion-aware physical formula (EasyRPG Algo::CalcSkillToHit, ported from
+ # EasyRPG Player's source and NOT independently confirmed against genuine
+ # RPG_RT under wine) -- the CalcSkillToHit edge case docs/TODO.md left
+ # unimplemented. See Game::Battle# skill_to_hit.
  check 'a physical-flagged enemy-scope skill uses the agility-adjusted hit formula' do
    skills = { 7 => fake_skill(name: 'Punch', scope: 0, hit: 90, failure_message: 3) }
    st = skill_party(skills)
@@ -13838,9 +13860,11 @@ end
  end
 
  # `hit == -1` is a sentinel meaning "use the caster's own weapon-based hit
- # chance" -- EasyRPG's Algo::CalcSkillToHit reads it unconditionally, as its
- # very first line, for every skill (not gated behind any EasyRPG-only
- # extension flag, unlike the row terms). Previously read literally: -1 as a
+ # chance" -- ported from EasyRPG Player's source, NOT independently
+ # confirmed against genuine RPG_RT under wine: its Algo::CalcSkillToHit
+ # reads it unconditionally, as its very first line, for every skill (not
+ # gated behind any EasyRPG-only extension flag, unlike the row terms).
+ # Previously read literally: -1 as a
  # flat percent compares false against every possible `@rng.random(100)`
  # roll (0..99), so such a skill missed unconditionally instead of using the
  # caster's real hit rate.
@@ -13923,9 +13947,10 @@ end
 
 check "battle: a basic Attack rolls its weapon's own state-infliction chance" do
   # A "Poison Dagger" -- state_set flags state 3, state_chance 100 -- ported
-  # from EasyRPG's Game_BattleAlgorithm::Normal::vExecute weapon block, which
-  # this codebase previously left entirely unbuilt: only Skills/Items rolled
-  # state infliction, never a plain Attack.
+  # from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_BattleAlgorithm::Normal::vExecute
+  # weapon block, which this codebase previously left entirely unbuilt: only
+  # Skills/Items rolled state infliction, never a plain Attack.
   items = { 7 => fake_item(type: 1, atk: 10, state_set: [0, 0, 1], state_chance: 100) }
   st = skill_party({}, items)
   a = st.party.actor_by_id(1)
@@ -13941,10 +13966,11 @@ end
 
 check "battle: an RPG2003 weapon's reverse_state_effect heals instead of inflicts" do
   # Same weapon, `reverse_state_effect` set: on RPG2003 this flips the weapon
-  # from inflicting its named states to curing them (EasyRPG's
-  # `is2k3 && w->reverse_state_effect` branch) -- a weapon-only flip; the
-  # identical field on a *medicine* item is dead in the real engine (see
-  # `Game::Party#item_cured_states`'s own comment).
+  # from inflicting its named states to curing them (ported from EasyRPG
+  # Player's source, NOT independently confirmed against genuine RPG_RT
+  # under wine: its `is2k3 && w->reverse_state_effect` branch) -- a
+  # weapon-only flip; the identical field on a *medicine* item is dead in
+  # the real engine (see `Game::Party#item_cured_states`'s own comment).
   items = { 7 => fake_item(type: 1, atk: 10, state_set: [0, 0, 1],
                             state_chance: 100, reverse_state: true) }
   st = skill_party({}, items, rpg2003: true)
@@ -13963,7 +13989,9 @@ end
 check "battle: on RPG2000, a weapon's reverse_state_effect has no effect -- it still inflicts" do
   # The exact same weapon/scenario as the RPG2003 heal check above, but on an
   # RPG2000 database: `reverse_state_effect` only flips a weapon's polarity on
-  # RPG2003 (EasyRPG's `is2k3 &&` guard), so the state still inflicts here.
+  # RPG2003, per the same EasyRPG-ported `is2k3 &&` guard cited above (NOT
+  # independently confirmed against genuine RPG_RT under wine), so the state
+  # still inflicts here.
   items = { 7 => fake_item(type: 1, atk: 10, state_set: [0, 0, 1],
                             state_chance: 100, reverse_state: true) }
   st = skill_party({}, items) # rpg2003 defaults to false
@@ -14027,10 +14055,11 @@ check 'Battle#escape_chance scales with the agility ratio, clamped 0..100' do
 end
 
 check 'Battle#escape_chance still counts a fallen battler, per GetAverageAgility' do
-  # EasyRPG's Game_Party_Base::GetAverageAgility sums over GetBattlers (every
-  # member) rather than GetActiveBattlers (the not-dead subset), so a party
-  # that has already lost someone still divides by the whole roster and adds
-  # the fallen member's own agility in.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_Party_Base::GetAverageAgility sums
+  # over GetBattlers (every member) rather than GetActiveBattlers (the
+  # not-dead subset), so a party that has already lost someone still
+  # divides by the whole roster and adds the fallen member's own agility in.
   hero = combatant('Hero', 0, 0, 20, 10)      # alive, agi 20
   squire = combatant('Squire', 0, 0, 0, 0)    # already down, agi 0
   slime = combatant('Slime', 0, 0, 10, 10)    # agi 10
@@ -14042,9 +14071,11 @@ check 'Battle#escape_chance still counts a fallen battler, per GetAverageAgility
 end
 
 check 'Battle#escape_chance rounds the agility ratio to the nearest percent' do
-  # EasyRPG's InitEscapeChance finishes with Utils::RoundTo<int> (std::lrint),
-  # not a truncating integer divide -- unlike this same class's #to_hit
-  # agility term, which RPG_RT computes in `float` and truncates instead.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its InitEscapeChance finishes with
+  # Utils::RoundTo<int> (std::lrint), not a truncating integer divide --
+  # unlike this same class's #to_hit agility term, which RPG_RT computes in
+  # `float` and truncates instead.
   hero = combatant('Hero', 0, 0, 7, 10)
   slime = combatant('Slime', 0, 0, 10, 10)
   b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
@@ -14058,8 +14089,10 @@ check 'Battle#escape_chance rounds an exact tie to even, not always up' do
   # Utils::RoundTo<int> is std::lrint under the default IEEE 754 FE_TONEAREST
   # mode -- round-half-to-*even*, not round-half-up (`Float#round`'s own
   # half-away-from-zero rule). Party average agility 200, enemy average 101:
-  # 100*101/200 = 50.5 exactly. EasyRPG rounds to 50 (already even) -> escape
-  # 150-50 = 100; round-half-up would land on 51 -> escape 99.
+  # 100*101/200 = 50.5 exactly. Per the same EasyRPG-ported RoundTo/lrint
+  # reading above (NOT independently confirmed against genuine RPG_RT under
+  # wine), it rounds to 50 (already even) -> escape 150-50 = 100;
+  # round-half-up would land on 51 -> escape 99.
   hero = combatant('Hero', 0, 0, 200, 10)
   slime = combatant('Slime', 0, 0, 101, 10)
   b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
@@ -14067,9 +14100,11 @@ check 'Battle#escape_chance rounds an exact tie to even, not always up' do
 end
 
 check 'Battle#escape_chance is fixed at battle start, not re-derived per attempt' do
-  # EasyRPG calls InitEscapeChance() exactly once, from Scene_Battle::Start;
-  # TryEscape only ever adds +10 to that one starting value on a failure, and
-  # nothing re-reads the agilities once the fight is under way.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: it calls InitEscapeChance() exactly once, from
+  # Scene_Battle::Start; TryEscape only ever adds +10 to that one starting
+  # value on a failure, and nothing re-reads the agilities once the fight is
+  # under way.
   states = { 1 => fake_state(affect_type: 0, affect_agility: true) } # 0 = halve
   hero = combatant('Hero', 0, 0, 20, 10)
   slime = combatant('Slime', 0, 0, 10, 10)
@@ -14774,14 +14809,19 @@ check 'Battle#apply_to_party ignores combatants with no source actor' do
   ok true, 'write-back skipped bare combatants without error'
 end
 
-check "Battle#apply_to_party carries a survivor's active-time gauge into the next fight, matching RPG_RT (2026-08-18)" do
-  # EasyRPG's Game_Battler::ResetBattle deliberately does not reset the ATB
-  # gauge -- "ATB gauge is not reset here. This is on purpose because RPG_RT
-  # will freeze the gauge and carry it between battles if
-  # !CanActOrRecoverable()" -- only Knockout (AddState's own kDeathID
-  # branch) zeroes it. Combatant.from_actor previously never seeded #gauge
-  # from anything persistent, so every fight started every actor's gauge at
-  # 0 regardless of how charged they were when the last one ended.
+check "Battle#apply_to_party carries a survivor's active-time gauge into the next " \
+      "fight, per EasyRPG Player's source (2026-08-18, NOT independently confirmed " \
+      "against genuine RPG_RT under wine)" do
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_Battler::ResetBattle deliberately
+  # does not reset the ATB gauge -- that source's own comment there claims
+  # this is "on purpose because RPG_RT will freeze the gauge and carry it
+  # between battles if !CanActOrRecoverable()", a claim this codebase has
+  # not itself verified against the genuine engine -- only Knockout
+  # (AddState's own kDeathID branch) zeroes it. Combatant.from_actor
+  # previously never seeded #gauge from anything persistent, so every fight
+  # started every actor's gauge at 0 regardless of how charged they were
+  # when the last one ended.
   st = party_state
   hero = st.party.actor_by_id(1)
   eq 0, hero.atb_gauge, 'a fresh actor has never charged'
@@ -15143,8 +15183,10 @@ check 'an attack skill that computes to 0 damage still reads as an attack, not a
   eq 100, tough_foe.hp, 'the target neither took damage nor was healed'
 end
 
-# Ported from EasyRPG's Game_BattleAlgorithm::Skill::vExecute (algo.cpp's
-# CalcSkillEffect + game_battlealgorithm.cpp): an enemy-scope attack skill's
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Game_BattleAlgorithm::Skill::vExecute
+# (algo.cpp's CalcSkillEffect + game_battlealgorithm.cpp): an enemy-scope
+# attack skill's
 # `affect_hp`/`affect_sp` flags each independently gate whether the skill's
 # one shared `effect` value (the same number, not two separately-rolled
 # amounts) lands on the target's HP and/or SP. #battle_skill_command's enemy
@@ -15179,11 +15221,12 @@ end
 
 check 'an offensive skill halves its HP effect against a defending target, ' \
       'but leaves the SP effect untouched' do
-  # EasyRPG's Skill::vExecute: `hp_effect = IsPositive() ? effect :
-  # Algo::AdjustDamageForDefend(effect, *target)` -- an enemy-scope skill's HP
-  # branch gets the same defend-halving a plain Attack already gets, but the
-  # SP branch (and the ATK/DEF/SPI/AGI stat-mod branches) read the raw
-  # `effect` with no such adjustment.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Skill::vExecute has `hp_effect =
+  # IsPositive() ? effect : Algo::AdjustDamageForDefend(effect, *target)` --
+  # an enemy-scope skill's HP branch gets the same defend-halving a plain
+  # Attack already gets, but the SP branch (and the ATK/DEF/SPI/AGI
+  # stat-mod branches) read the raw `effect` with no such adjustment.
   skills = { 7 => fake_skill(name: 'Drain Fire', scope: 0, sp_cost: 6, power: 20,
                              mrate: 40, hp: true, sp: true) }
   st = skill_party(skills)
@@ -15231,11 +15274,13 @@ end
 
 check "a dual HP+SP attack skill's killing blow leaves SP untouched -- HP " \
       'reaching 0 blocks the SP damage on the same swing' do
-  # EasyRPG's own ordering: `if (!is_dead && GetTarget()->GetHp() +
-  # this->GetAffectedHp() <= 0) return IsSuccess();` runs right after the
-  # affect_hp block and *before* affect_sp's -- so a lethal HP hit skips SP
-  # entirely on that swing, matching デフォ戦bot's own trivia: "ＨＰとＭＰに
-  # ダメージを与える技能でＨＰがゼロになった場合、ＭＰは減らない".
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine (though the general behavior matches
+  # デフォ戦bot's own community trivia: "ＨＰとＭＰにダメージを与える技能で
+  # ＨＰがゼロになった場合、ＭＰは減らない"): its own ordering,
+  # `if (!is_dead && GetTarget()->GetHp() + this->GetAffectedHp() <= 0)
+  # return IsSuccess();`, runs right after the affect_hp block and *before*
+  # affect_sp's -- so a lethal HP hit skips SP entirely on that swing.
   skills = { 7 => fake_skill(name: 'Drain Fire', scope: 0, sp_cost: 6, power: 20,
                              mrate: 40, hp: true, sp: true) }
   st = skill_party(skills)
@@ -15259,8 +15304,9 @@ end
 
 check 'a skill flagged "attribute defence up/down" picks direction from ' \
       'the skill\'s own scope, not reverse_state_effect' do
-  # Ported from EasyRPG's Game_BattleAlgorithm::Skill::vExecute: `auto shift
-  # = IsPositive() ? 1 : -1;`, where IsPositive() comes from
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_BattleAlgorithm::Skill::vExecute has
+  # `auto shift = IsPositive() ? 1 : -1;`, where IsPositive() comes from
   # Algo::SkillTargetsAllies(skill) -- purely the skill's own `scope` field.
   # reverse_state_effect never enters into it, unlike this codebase's old,
   # explicitly-unconfirmed guess that it did. Every scope/reverse_state_effect
@@ -15299,8 +15345,10 @@ end
 check 'on an RPG2000 database, a self/ally-scoped skill\'s own state_effects ' \
       'cure in battle, ignoring reverse_state_effect (an enemy-scoped one ' \
       'still inflicts)' do
-  # EasyRPG's Game_BattleAlgorithm::Skill::vExecute: `heals_states =
-  # IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`, and
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_BattleAlgorithm::Skill::vExecute has
+  # `heals_states = IsPositive() ^ (Player::IsRPG2k3() &&
+  # skill.reverse_state_effect)`, and
   # `IsPositive()` is `Algo::SkillTargetsAllies(skill)` -- true for every scope
   # but Scope_enemy(0)/Scope_enemies(1). On an RPG2000 database the XOR's
   # right-hand term is always false (`Player::IsRPG2k3()` false), so
@@ -15338,8 +15386,10 @@ check 'on an RPG2003 database, reverse_state_effect flips a skill\'s own ' \
   # The gap this closes: #battle_skill_command used to apply the plain
   # scope-only rule (ally cures / enemy inflicts) unconditionally, the same
   # simplification #skill_attr_shift's own sibling formula settled for good
-  # reason -- but unlike attribute-defence direction, EasyRPG's `heals_states`
-  # line does gate on `Player::IsRPG2k3()`, so a real RPG2003 database with
+  # reason -- but unlike attribute-defence direction, per the same
+  # EasyRPG-ported `heals_states` reading above (NOT independently
+  # confirmed against genuine RPG_RT under wine), that line does gate on
+  # `Player::IsRPG2k3()`, so a real RPG2003 database with
   # `reverse_state_effect` set can invert either scope: an ally/self skill
   # inflicts its listed states on its own side (a self-scoped Berserk that
   # confuses its own caster), and an enemy skill cures its target's states
@@ -15498,10 +15548,12 @@ check 'battle: an actor added to the live party mid-fight joins the next round' 
 end
 
 # Corrects an initial reading of this fix's own community-trivia source
-# ("swap out then back in still lets the queued command execute"), checked
-# directly against EasyRPG's real `Scene_Battle_Rpg2k::ProcessSceneActionBattle`:
-# its `ePreAction` substate rechecks `battler->Exists()` (which folds in
-# `IsInParty()`, `game_battler.h`) immediately before running *each* queued
+# ("swap out then back in still lets the queued command execute"), against
+# a closer reading of EasyRPG Player's source -- ported from that source,
+# NOT independently confirmed against genuine RPG_RT under wine:
+# `Scene_Battle_Rpg2k::ProcessSceneActionBattle`'s `ePreAction` substate
+# rechecks `battler->Exists()` (which folds in `IsInParty()`,
+# `game_battler.h`) immediately before running *each* queued
 # action and drops the ones that fail, not only the ones for the *next*
 # round's queue. #step_action ports that same recheck (see its own comment) --
 # a turn already resolved before the removal stands (nothing rewinds `@log`),
@@ -15574,8 +15626,10 @@ end
 # agility) -- a skill's own per-battle ATK/DEF/SPI/AGI modifier, distinct from
 # both attribute-defence rank shifting (above) and a *state*'s halve/double
 # (Game::Battle#stat_mode / #adjust_stat, "stat-halving state" checks nearby).
-# Ported from EasyRPG's Game_Battler::atk_modifier and CanChangeAtkModifier
-# (and its DEF/SPI/AGI siblings) -- this codebase used to parse these four
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Game_Battler::atk_modifier and
+# CanChangeAtkModifier (and its DEF/SPI/AGI siblings) -- this codebase used
+# to parse these four
 # skill flags into FakeSkill/the LCF schema and then read none of them
 # anywhere, so a "raise/lower ATK/DEF/SPI/AGI" skill silently did nothing at
 # all beyond whatever incidental affect_hp/affect_sp damage/heal it also
@@ -15679,9 +15733,11 @@ end
 check 'ability-value decrease rounds toward zero (up) on an odd base, not ' \
       'a Ruby-style floor' do
   # -(5 / 2) truncates toward zero to -2 in both this Ruby code (dividing the
-  # positive base first, then negating) and EasyRPG's C++ `-base / 2` -- a
-  # floor-toward-negative-infinity reading (Ruby's own `-base / 2`, base
-  # negated first) would instead land one step lower, at -3.
+  # positive base first, then negating) and EasyRPG Player's C++ `-base / 2`
+  # (ported from that source, NOT independently confirmed against genuine
+  # RPG_RT under wine) -- a floor-toward-negative-infinity reading (Ruby's
+  # own `-base / 2`, base negated first) would instead land one step lower,
+  # at -3.
   weaken = fake_skill(name: 'Weaken', scope: 0, sp_cost: 0, power: 100, prate: 0,
                       mrate: 0, affect_attack: true)
   st = skill_party({ 7 => weaken })
@@ -15763,9 +15819,10 @@ end
 
 # -- Battle skill/item effect accuracy (Game::Battle#skill_effect_hits?) -----
 #
-# Ported from EasyRPG's Game_BattleAlgorithm::Skill::vExecute: each of
-# affect_hp/affect_sp/affect_attack/affect_defense/affect_spirit/
-# affect_agility is gated behind its own Rand::PercentChance(to_hit) roll.
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Game_BattleAlgorithm::Skill::vExecute has
+# each of affect_hp/affect_sp/affect_attack/affect_defense/affect_spirit/
+# affect_agility gated behind its own Rand::PercentChance(to_hit) roll.
 # Previously #apply_skill_hit applied a skill's core HP/SP/stat effect
 # unconditionally -- only state infliction (#roll_inflict) ever consulted
 # cmd[:chance] -- so an offensive or buff skill with hit < 100 landed its
@@ -16049,11 +16106,12 @@ check "battle: a heal on a still-standing target is unaffected by the " \
 end
 
 check "battle: a skill/spell attack now rolls its own critical hit too" do
-  # EasyRPG's Game_BattleAlgorithm::Skill::vExecute rolls
-  # Algo::CalcCriticalHitChance(source, target, WeaponAll, ...) -- the exact
-  # same weapon-inclusive rate #deal_attack's own #critical? already reads --
-  # and Algo::CalcSkillEffect triples the result the same way a basic
-  # attack's own CalcNormalAttackEffect does. Previously nothing in
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_BattleAlgorithm::Skill::vExecute
+  # rolls Algo::CalcCriticalHitChance(source, target, WeaponAll, ...) -- the
+  # exact same weapon-inclusive rate #deal_attack's own #critical? already
+  # reads -- and Algo::CalcSkillEffect triples the result the same way a
+  # basic attack's own CalcNormalAttackEffect does. Previously nothing in
   # #apply_skill_hit ever rolled a skill/spell critical at all: every
   # offensive skill's damage was capped at its non-critical value on every
   # single cast.
@@ -16092,9 +16150,11 @@ check 'battle: no skill/spell critical when the fight has criticals off' do
 end
 
 check "battle: an attack skill's own physical_rate shakes loose a status on a landed hit" do
-  # EasyRPG's Skill::vExecute calls BattlePhysicalStateHeal(skill.physical_rate
-  # * 10, ...) inside the same affect_hp/to_hit-gated block the HP change
-  # itself is in -- previously #apply_skill_hit never called this at all, so
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Skill::vExecute calls
+  # BattlePhysicalStateHeal(skill.physical_rate * 10, ...) inside the same
+  # affect_hp/to_hit-gated block the HP change itself is in -- previously
+  # #apply_skill_hit never called this at all, so
   # even a fully melee/physical attack skill never shook a status loose.
   states = { 8 => fake_state(release_by_attack: 100) }
   hero = combatant('Hero', 40, 0, 20, 100)
@@ -16563,10 +16623,12 @@ check 'battle_items lists battle medicines; battle_item_command recovers' do
      st.party.battle_item_command(st.party.db_item(5), target))
 end
 
-# A 蘇生専用 (`ko_only`) item cast from the battle Item menu: EasyRPG's
-# `Game_BattleAlgorithm::Item::vExecute` returns before either the HP/SP
-# recovery or the state cure is ever computed once `item.ko_only &&
-# !GetTarget()->IsDead()`, so a revive item aimed at a target still standing
+# A 蘇生専用 (`ko_only`) item cast from the battle Item menu: ported from
+# EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine: its `Game_BattleAlgorithm::Item::vExecute` returns
+# before either the HP/SP recovery or the state cure is ever computed once
+# `item.ko_only && !GetTarget()->IsDead()`, so a revive item aimed at a
+# target still standing
 # does nothing at all -- not even the percentage HP restore or the cure. The
 # field-menu path (`#use_medicine`) already honoured this; `#battle_item_
 # command` had not.
@@ -16826,10 +16888,12 @@ end
 
 # デフォ戦bot: "once afflicted with a 'cannot act' state, curing it before your
 # turn comes up still doesn't let you act that turn; likewise Silence cured
-# before your turn still blocks magic." Checked directly against EasyRPG's
-# real source rather than trusted from the trivia alone (`SelectNextActor`/
-# `CreateEnemyActions`, `PrepareBattleAction`, `Game_Battler::AddState`, all
-# in `src/scene_battle*.cpp`/`game_battler.cpp`): a do-nothing restriction
+# before your turn still blocks magic." That general behavior is community
+# trivia; the specific mechanism below is ported from EasyRPG Player's
+# source, NOT independently confirmed against genuine RPG_RT under wine
+# (`SelectNextActor`/`CreateEnemyActions`, `PrepareBattleAction`,
+# `Game_Battler::AddState`, all in `src/scene_battle*.cpp`/
+# `game_battler.cpp`): a do-nothing restriction
 # (`!CanAct()`) locks an actor's queued algorithm to `Game_BattleAlgorithm::
 # None` the moment it is decided -- at `SelectNextActor`/`CreateEnemyActions`
 # (queue-build time) if already restricted then, or live via `AddState`'s own
@@ -16888,9 +16952,11 @@ check 'battle: a do-nothing state inflicted after queueing still blocks the turn
   eq 'Healthy', first[:attacker]
 
   # Something in the round (an earlier ally/enemy action, a troop page) puts
-  # Victim to sleep before its own queued turn comes up -- EasyRPG's
-  # Game_Battler::AddState overrides an already-queued action to None the
-  # moment this happens, live, not only at the round's original queue-build.
+  # Victim to sleep before its own queued turn comes up -- per the same
+  # EasyRPG-ported `AddState` reading above (NOT independently confirmed
+  # against genuine RPG_RT under wine), its Game_Battler::AddState overrides
+  # an already-queued action to None the moment this happens, live, not
+  # only at the round's original queue-build.
   victim.states = [8]
 
   entries = []
@@ -17053,8 +17119,10 @@ check 'battle: a fully-Stoned enemy troop, still at full HP, does not end the fi
 end
 
 # yado.tk's "unrecoverable input-blocking state lock" case, next to the
-# empty/all-KO'd-party fix: EasyRPG's Scene_Battle_Rpg2k::SelectNextActor
-# skips the Fight/Skill/Defend/Item prompt entirely for a "do nothing"
+# empty/all-KO'd-party fix: ported from EasyRPG Player's source, NOT
+# independently confirmed against genuine RPG_RT under wine: its
+# Scene_Battle_Rpg2k::SelectNextActor skips the Fight/Skill/Defend/Item
+# prompt entirely for a "do nothing"
 # restriction (asleep/paralysed, !CanAct()) and a forced attack-ally/
 # attack-enemy restriction (confused/berserk, GetSignificantRestriction() !=
 # Restriction_normal) rather than asking the player to pick a command that
@@ -17309,9 +17377,11 @@ check 'battle: a self-destruct also reads state-adjusted ATK / DEF' do
 end
 
 check "battle: a self-destruct's 強力防御 halves a defending target's blow twice" do
-  # EasyRPG's SelfDestruct::vExecute calls the identical AdjustDamageForDefend
-  # a basic attack (#deal_attack) already applies -- not a self-destruct-
-  # specific halving rule. A prior version of this method only ever halved
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its SelfDestruct::vExecute calls the identical
+  # AdjustDamageForDefend a basic attack (#deal_attack) already applies --
+  # not a self-destruct-specific halving rule. A prior version of this
+  # method only ever halved
   # once, for plain Defend, ignoring the second halving a 強力防御 (strong
   # defence) target's own gear/class adds.
   bomber = combatant('Bomber', 50, 0, 5, 1)
@@ -17349,8 +17419,10 @@ check "battle: a self-destruct's defend-halving carries no floor either, matchin
 end
 
 check 'battle: a self-destruct shakes loose a survivor\'s status the same as a basic attack' do
-  # EasyRPG's SelfDestruct::vExecute calls the same BattlePhysicalStateHeal(100,
-  # ...) Normal::vExecute does -- previously unmodelled here, so a blinded
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its SelfDestruct::vExecute calls the same
+  # BattlePhysicalStateHeal(100, ...) Normal::vExecute does -- previously
+  # unmodelled here, so a blinded
   # survivor of a self-destruct stayed blind no matter how hard the blast hit,
   # where a plain attack for the same damage would have had a shot at curing it.
   states = { 8 => fake_state(release_by_attack: 100) }
@@ -17973,10 +18045,11 @@ end
 
 check 'battle: an "Avoid Attacks" (RPG2003) state dodges every basic attack unconditionally' do
   # Parsed (mruby-lcf/mrblib/schema.rb state field 36, avoid_attacks) but never
-  # read anywhere in Game::Battle before this fix -- EasyRPG's
-  # Game_Battler::EvadesAllPhysicalAttacks (game_battler.cpp) forces
-  # CalcNormalAttackToHit to 0 the instant the target carries one, ahead of
-  # every other term, so the state did nothing at all here.
+  # read anywhere in Game::Battle before this fix -- ported from EasyRPG
+  # Player's source, NOT independently confirmed against genuine RPG_RT
+  # under wine: its Game_Battler::EvadesAllPhysicalAttacks (game_battler.cpp)
+  # forces CalcNormalAttackToHit to 0 the instant the target carries one,
+  # ahead of every other term, so the state did nothing at all here.
   states = { 12 => fake_state(avoid_attacks: true), 13 => fake_state }
   attacker = combatant('Attacker', 20, 0, 10, 100) # a fast, hard-hitting attacker
   dodger = combatant('Dodger', 0, 0, 1, 100)        # slow, so agi alone would favour a hit
@@ -18001,9 +18074,11 @@ check 'battle: an "Avoid Attacks" (RPG2003) state dodges every basic attack unco
 end
 
 check 'battle: a "do nothing"-restricted target always gets hit' do
-  # EasyRPG's CalcNormalAttackToHit: `if (!target.CanAct()) return 100;` --
-  # the next term down from avoid_attacks, ahead of every ordinary accuracy
-  # roll. An asleep/paralysed target (state restriction 1) was previously
+  # Per the same EasyRPG-ported CalcNormalAttackToHit reading above (NOT
+  # independently confirmed against genuine RPG_RT under wine): `if
+  # (!target.CanAct()) return 100;` -- the next term down from
+  # avoid_attacks, ahead of every ordinary accuracy roll. An asleep/paralysed
+  # target (state restriction 1) was previously
   # rolled through the normal hit-rate/agility math like anyone else.
   states = { 5 => fake_state(restriction: Game::Battle::RESTRICTION_DO_NOTHING) }
   # A slow, low-hit-rate attacker against a fast target: agility alone would
@@ -18025,8 +18100,10 @@ end
 
 check "battle: a state's reduce_hit_ratio folds into the base hit rate before " \
       'the agility term, not after' do
-  # EasyRPG: `to_hit = to_hit * GetHitChanceModifierFromStates() / 100;` runs
-  # *before* `CalcToHitAgiAdjustment`, so the AGI term's own nonlinear
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: `to_hit = to_hit *
+  # GetHitChanceModifierFromStates() / 100;` runs *before*
+  # `CalcToHitAgiAdjustment`, so the AGI term's own nonlinear
   # `100 - (100 - to_hit) * (src + tgt) / (2 * src)` shape is applied to the
   # already-blinded hit rate, not to the unblinded base with the state
   # discount multiplied on afterward -- the two orders disagree whenever
@@ -18045,9 +18122,11 @@ end
 
 check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its own caster' do
   # Parsed (mruby-lcf/mrblib/schema.rb state field 37, reflect_magic) but never
-  # read anywhere in Game::Battle before this fix -- EasyRPG's
-  # Game_BattleAlgorithm::Skill::IsReflected (game_battlealgorithm.cpp) redirects
-  # a Skill's target onto its own caster the instant the intended target carries
+  # read anywhere in Game::Battle before this fix -- ported from EasyRPG
+  # Player's source, NOT independently confirmed against genuine RPG_RT
+  # under wine: its Game_BattleAlgorithm::Skill::IsReflected
+  # (game_battlealgorithm.cpp) redirects a Skill's target onto its own
+  # caster the instant the intended target carries
   # one, checked by Scene_Battle_Rpg2k::ProcessBattleActionAnimationImpl right
   # before the action's own Execute() step -- so the skill still rolls its own
   # damage/accuracy/variance normally afterward, just against the new target.
@@ -18090,8 +18169,10 @@ check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its o
   eq 75, caster_foe.hp
 
   # A skill's own reflect check requires a genuine skill cast (cmd[:skill_id]) --
-  # an item-cast effect (EasyRPG's own "item" guard in Skill::IsReflected) never
-  # reflects even against the identical warded target, and neither does a skill
+  # an item-cast effect (per the same EasyRPG-ported IsReflected "item" guard
+  # above, NOT independently confirmed against genuine RPG_RT under wine)
+  # never reflects even against the identical warded target, and neither
+  # does a skill
   # whose target starts on the *same* side as its caster (an ally/self-scoped
   # skill never legitimately reaches the opposing side to begin with).
   bare = Game::Battle.new([mage], [warded_foe], Game::Rng.new(1), states)
@@ -18107,8 +18188,10 @@ check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its o
 end
 
 check "battle: an all-enemy Skill's own reflect redirects the whole volley onto the caster's entire party" do
-  # EasyRPG's AlgorithmBase::ReflectTargets (game_battlealgorithm.cpp), for the
-  # `party_target` (all-enemies/all-allies scope) shape the single-target
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its AlgorithmBase::ReflectTargets
+  # (game_battlealgorithm.cpp), for the `party_target` (all-enemies/
+  # all-allies scope) shape the single-target
   # reflect fix's own comment names as a "materially different shape" left
   # unaddressed: `AddTargets(&source->GetParty(), true)` both adds every
   # member of the caster's own party as new targets *and* repoints the
@@ -18260,8 +18343,9 @@ end
 
 # 攻撃の回数 (weapon field 70's per-actor Battle Animation table, RPG2003
 # only): a basic Attack's swing count is now multiplied by
-# `Actor#weapon_attack_multiplier`, matching EasyRPG's `Algo::
-# GetNumberOfAttacks` (`cba[actor_id - 1].attacks + 1`). Previously
+# `Actor#weapon_attack_multiplier`, ported from EasyRPG Player's source
+# (NOT independently confirmed against genuine RPG_RT under wine): its
+# `Algo::GetNumberOfAttacks` (`cba[actor_id - 1].attacks + 1`). Previously
 # `Actor#strike_count` ported only the `dual_attack` term of that same
 # function, never reading `attack_times` at all (docs/TODO.md).
 check 'battle: RPG2003 攻撃の回数 multiplies a basic Attack\'s swing count' do
@@ -18291,9 +18375,11 @@ check 'battle: RPG2003 攻撃の回数 multiplies a basic Attack\'s swing count'
   eq 1, hero2000.strike_count, 'RPG2000: the same row is never consulted at all'
 
   # A two-weapon (#double_hand?) actor: each weapon's own multiplier scales
-  # only its own term before the two are summed -- EasyRPG's `Normal::Init`
-  # sums `GetNumberOfAttacks(WeaponPrimary) + GetNumberOfAttacks
-  # (WeaponSecondary)`, each already including its own `cba_hits`.
+  # only its own term before the two are summed -- ported from EasyRPG
+  # Player's source, NOT independently confirmed against genuine RPG_RT
+  # under wine: its `Normal::Init` sums `GetNumberOfAttacks(WeaponPrimary) +
+  # GetNumberOfAttacks(WeaponSecondary)`, each already including its own
+  # `cba_hits`.
   items2 = { 7 => fake_item(type: 1, atk: 5, animation_data: { 1 => FakeCbaRow.new(2) }), # 3 hits
              9 => fake_item(type: 1, atk: 5, dual_attack: true) } # 2 hits, no row
   db2 = FakeActorDB.new({ 1 => row }, [1], items2, {}, {}, nil, nil, rpg2003: true)
@@ -18304,7 +18390,8 @@ check 'battle: RPG2003 攻撃の回数 multiplies a basic Attack\'s swing count'
 end
 
 # 消費SP (weapon field 16): a basic Attack now spends the equipped weapon's
-# own SP cost, matching EasyRPG's `Normal::vStart`
+# own SP cost, ported from EasyRPG Player's source (NOT independently
+# confirmed against genuine RPG_RT under wine): its `Normal::vStart`
 # (`source->ChangeSp(-source->CalculateWeaponSpCost(weapon))`, unconditional
 # every action, hit or miss). Previously unwired entirely -- `Actor#half_sp_cost?`
 # only ever discounted a *skill's* SP, and no weapon-side accessor existed at
@@ -18511,8 +18598,10 @@ check 'battle: a 全体化 weapon spreads a basic Attack across the whole enemy 
 end
 
 check 'battle: 全体化 spreads a forced (confused) attack across the whole ally side too' do
-  # EasyRPG's Normal::vStart spreads across whichever side the already-
-  # resolved single target belongs to -- confusion resolves that target from
+  # Per the same EasyRPG-ported Normal::vStart reading above (NOT
+  # independently confirmed against genuine RPG_RT under wine), it spreads
+  # across whichever side the already-resolved single target belongs to --
+  # confusion resolves that target from
   # the attacker's own side, so a 全体化 weapon spreads across allies here,
   # the attacker included (AddTargets pushes the whole party with no
   # self-exclusion).
@@ -18602,8 +18691,10 @@ check 'battle: 強力防御 halves damage a second time' do
 end
 
 check 'MP消費半分 gear halves a fixed cost rounding up, a percent cost rounding down' do
-  # EasyRPG's Algo::CalcSkillCost rounds the two sp_type branches differently
-  # when half-cost gear is worn: a fixed cost gets a `+1` before halving (so
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Algo::CalcSkillCost rounds the two
+  # sp_type branches differently when half-cost gear is worn: a fixed cost
+  # gets a `+1` before halving (so
   # a 1-SP skill still costs 1), a percent cost gets no such `+1` and simply
   # floors. Applying one shared `(cost + 1) / 2` to whichever cost came out
   # (a prior version of this method) silently overcharged the percent branch
@@ -18802,9 +18893,11 @@ check 'Simulated Attack does not hard-cap damage the way a real battle-popup ' \
 end
 
 check "Simulated Attack's variance uses RPG_RT's real spread, not a coarser percent model" do
-  # EasyRPG's CommandSimulatedAttack rolls Algo::VarianceAdjustEffect(result,
-  # var) -- the exact same formula Game::Battle#varied already applies to a
-  # normal attack/skill/self-destruct's own damage. A prior version of this
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its CommandSimulatedAttack rolls
+  # Algo::VarianceAdjustEffect(result, var) -- the exact same formula
+  # Game::Battle#varied already applies to a normal attack/skill/
+  # self-destruct's own damage. A prior version of this
   # method modelled the spread as a flat +/-(var*5) *percent* of the base
   # instead (its own doc comment incorrectly attributed that to EasyRPG's
   # source): the two formulas' outer bounds happen to coincide (base +/-
@@ -19378,8 +19471,10 @@ end
 # -- the per-battler source: BattlePage checks at an action boundary -----------
 #
 # A per-battler check runs *for* a concrete battler -- the scene passes the
-# battle's #acting_battler. Port of EasyRPG's AreConditionsMet(source, ...):
-# the source gates turn_enemy/turn_actor (a page checked at one battler's turn
+# battle's #acting_battler. Ported from EasyRPG Player's source, NOT
+# independently confirmed against genuine RPG_RT under wine: its
+# AreConditionsMet(source, ...) has the source gate turn_enemy/turn_actor
+# (a page checked at one battler's turn
 # never fires off a different battler's counter) and command_actor (needs a
 # source at all, and that source must be the named actor, whose chosen command
 # is then compared against the condition).
@@ -19415,7 +19510,9 @@ check 'a turn_enemy / turn_actor condition is gated on the source being that bat
   eq true, BP.active?(econd, st.switches, st.variables, b2003, foe),
      'checked at the foe\'s own turn, its counter fires'
   # Checked at the hero's boundary (the hero is the source): the foe's
-  # counter must not answer -- EasyRPG's `if (source && source != enemy)`.
+  # counter must not answer -- per the same EasyRPG-ported AreConditionsMet
+  # reading above (NOT independently confirmed against genuine RPG_RT under
+  # wine): `if (source && source != enemy)`.
   eq false, BP.active?(econd, st.switches, st.variables, b2003, hero),
      'checked at a different battler\'s turn, the foe\'s counter does not fire'
 
@@ -19520,10 +19617,12 @@ check 'Battle#fatigue weights HP two thirds and SP one third' do
 end
 
 check 'Battle#fatigue rounds an exact tie to even, not always up' do
-  # EasyRPG's Utils::RoundTo<int> is std::lrint under the default IEEE 754
-  # FE_TONEAREST mode -- round-half-to-*even*, not round-half-up. max_hp 16,
-  # hp 3, no SP (total_sp forced to 1) computes exactly 12.5 before rounding:
-  # EasyRPG rounds to 12 (already even), landing fatigue at 88, not 87.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Utils::RoundTo<int> is std::lrint under
+  # the default IEEE 754 FE_TONEAREST mode -- round-half-to-*even*, not
+  # round-half-up. max_hp 16, hp 3, no SP (total_sp forced to 1) computes
+  # exactly 12.5 before rounding: it rounds to 12 (already even), landing
+  # fatigue at 88, not 87.
   tied = combatant('Hero', 10, 0, 10, 16)
   tied.hp = 3
   b = Game::Battle.new([tied], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1))
@@ -20032,8 +20131,10 @@ end
 
 # `Game::Battle#deal_attack` mutates a Combatant's hp directly (`target.hp
 # -= dmg`) with no matching `#inflict_state(target, DEATH_ID)` call, unlike
-# EasyRPG's own `Game_Battler::ChangeHp` (which folds `AddState(kDeathID)`
-# into every HP-zeroing path) -- so `#dead?`, an explicit HP check, has to
+# EasyRPG Player's own `Game_Battler::ChangeHp` (which folds
+# `AddState(kDeathID)` into every HP-zeroing path -- ported from that
+# source, NOT independently confirmed against genuine RPG_RT under wine) --
+# so `#dead?`, an explicit HP check, has to
 # be tested alongside the do-nothing-restriction scan in
 # `#battle_actor_condition`/`#battle_enemy_condition` rather than assumed
 # subsumed by it the way it safely is for `Game::Actor` (whose own
@@ -20692,8 +20793,10 @@ end
 
 check 'a charged enemy is forced to a single Attack even when its pattern ' \
       'would otherwise choose Attack Twice' do
-  # EasyRPG's EnemyAi::SetStateRestrictedAction forces a hardcoded
-  # MakeAttack(source, 1) while charged -- a fixed one-hit repeat count, not
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its EnemyAi::SetStateRestrictedAction forces
+  # a hardcoded MakeAttack(source, 1) while charged -- a fixed one-hit
+  # repeat count, not
   # whatever #enemy.GetEnemyAi() would have picked -- so a charged enemy
   # can never reach a genuine "Attack Twice" pattern action either, the same
   # way it can never reach Defend (see the check above). A dual attack
@@ -20745,8 +20848,10 @@ check 'an escaping enemy leaves the fight without counting as a kill' do
 end
 
 check 'self-destruction hits the party for atk - def/2 and hides the caster, ' \
-      'not kills it (2000_battle_bot / デフォ戦bot trivia, verified against ' \
-      'EasyRPG: Game_BattleAlgorithm::SelfDestruct::vExecute sets the ' \
+      'not kills it (2000_battle_bot / デフォ戦bot trivia; the specific ' \
+      'mechanism is ported from EasyRPG Player\'s source, NOT independently ' \
+      'confirmed against genuine RPG_RT under wine: ' \
+      'Game_BattleAlgorithm::SelfDestruct::vExecute sets the ' \
       'affected HP on the target only, and ApplyCustomEffect reacts to the ' \
       'caster with SetHidden(true) alone, no HP write)' do
   hero = combatant('Hero', 40, 10, 20, 500)
@@ -21178,8 +21283,10 @@ check 'Game::Actor#force_ai? reads the row (or its RPG2003 class) exactly like #
   ok !st.party.actor_by_id(2).force_ai?, 'an unflagged actor reads false'
 end
 
-# Ports EasyRPG's `Algo::CalcSkillCost` edition gate (`Player::IsRPG2k3() &&
-# skill.sp_type == SpType_percent`), reached via `CalcSkillCostAutoBattle`'s
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Algo::CalcSkillCost` edition gate
+# (`Player::IsRPG2k3() && skill.sp_type == SpType_percent`), reached via
+# `CalcSkillCostAutoBattle`'s
 # own `emulate_bugs: true` path (`AutoBattle::RpgRtCompat` always calls it
 # that way) -- the exact same gate `Game::Party#skill_cost` already applies
 # for the SP actually charged once the action is queued. Without it, a stray
@@ -21320,9 +21427,11 @@ check 'battle: a Forced-AI actor picks a clearly-better Skill over Attack, with 
 end
 
 check 'battle: a Forced-AI actor revives a downed ally instead of attacking' do
-  # The "downed target" half of #auto_battle_heal_rank (EasyRPG's
-  # CalcSkillHealAutoBattleTargetRank checking skill.state_effects[0], state
-  # id 1 == Game::Actor::DEATH_STATE) -- its own `power/1000.0 + 1.0` rank
+  # The "downed target" half of #auto_battle_heal_rank -- ported from
+  # EasyRPG Player's source, NOT independently confirmed against genuine
+  # RPG_RT under wine: its CalcSkillHealAutoBattleTargetRank checks
+  # skill.state_effects[0], state id 1 == Game::Actor::DEATH_STATE -- its
+  # own `power/1000.0 + 1.0` rank
   # has no cost penalty or cap, so a revive skill with any real `power` value
   # comfortably clears an ordinary Attack's own ranking ceiling (well under
   # 2.0 even at its own best-case jitter roll) regardless of seed.
@@ -21585,9 +21694,11 @@ end
 # -- field Teleport/Escape access resolution (map tree fields 31, 32) --------
 #
 # The identical tri-state walk as Save above (field 33), just read off a
-# different pair of fields -- confirmed against EasyRPG's Game_Map::Setup,
-# which re-derives Game_System::AllowTeleport/AllowEscape from these two
-# fields on every map load exactly as it does AllowSave. Since #allowed? is
+# different pair of fields -- ported from EasyRPG Player's source, NOT
+# independently confirmed against genuine RPG_RT under wine: its
+# Game_Map::Setup re-derives Game_System::AllowTeleport/AllowEscape from
+# these two fields on every map load exactly as it does AllowSave. Since
+# #allowed? is
 # shared with #save_allowed? and its walk (inherit, loop, unknown map, root,
 # a field-less node) is already exhaustively covered above, these checks only
 # have to show each method reads its own field rather than borrowing #save's.
@@ -21749,9 +21860,10 @@ end
 # The critical-hit line is a bare term with no battler name in front — unlike
 # every predicate above, it stands alone the same way `using_message2` does —
 # and which term speaks is keyed on the *target* taking the crit, matching
-# `actor_damaged` / `enemy_damaged`'s own side rule (EasyRPG's
-# GetCriticalHitMessage: `target.GetType() == Type_Ally ? actor_critical :
-# enemy_critical`), not on which side dealt the blow.
+# `actor_damaged` / `enemy_damaged`'s own side rule -- ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine: its GetCriticalHitMessage is `target.GetType() == Type_Ally ?
+# actor_critical : enemy_critical`, not on which side dealt the blow.
 check 'a critical-hit line is the bare term, keyed on the target taking it' do
   t = fake_terms
   eq '会心の一撃！！', BT.critical(t, true), 'a party member took the crit'
@@ -22138,8 +22250,10 @@ check 'equipping from the bag returns the emptied hand to the bag' do
   eq 0, st.party.item_count(2)
 end
 
-# Restoring a saved loadout is not an equip action: RPG_RT stores what it stores,
-# and EasyRPG enforces the rule only in ChangeEquipment.
+# Restoring a saved loadout is not an equip action: RPG_RT stores what it
+# stores, and EasyRPG Player's source enforces the rule only in
+# ChangeEquipment (ported from that source, NOT independently confirmed
+# against genuine RPG_RT under wine).
 check 'a bulk equip restores a saved pair as-is' do
   st = two_handed_party
   hero = st.party.actor_by_id(1)
@@ -22379,7 +22493,8 @@ check "battle: an RPG2003 two-weapon actor's swing on a genuine 0%-hit " \
   # covers (see "a weapon with its own genuine 0% hit rate is used as-is,
   # not treated as unequipped" above), now for the per-swing #swing_weapon_
   # data/#weapon_roll_data path a two-weapon RPG2003 actor's second swing
-  # goes through. Confirmed against the same EasyRPG source: `Game_Actor::
+  # goes through. Per the same EasyRPG-ported source cited above (NOT
+  # independently confirmed against genuine RPG_RT under wine): `Game_Actor::
   # GetHitChance`'s `ForEachEquipment<true,false>(..., weapon)` call visits
   # exactly one slot for a single-weapon query, so `hit = std::max(INT_MIN,
   # item.hit) == item.hit` verbatim -- the `INT_MIN` fallback to 90 only
@@ -22412,8 +22527,9 @@ check 'battle: #swing actually lands three attacks when strike_count is three, '
   # then a second only if strike_count >= 2) -- a limit that happened to
   # match every *previous* strike_count value (1 or 2, #dual_attack?'s own
   # binary range), so it went unnoticed until a two-weapon actor with one
-  # dual_attack weapon could report 3 (or 4). EasyRPG's own SetRepeat takes
-  # the summed hit count as-is, with no such cap.
+  # dual_attack weapon could report 3 (or 4). Ported from EasyRPG Player's
+  # source, NOT independently confirmed against genuine RPG_RT under wine:
+  # its own SetRepeat takes the summed hit count as-is, with no such cap.
   items = { 1 => fake_item(type: 1, atk: 5, hit: 100, dual_attack: true), # 2 swings
             2 => fake_item(type: 1, atk: 5, hit: 100) }                  # 1 swing
   row = FakePlayerRow.new('Hero', '', 0, 5,
@@ -22522,9 +22638,11 @@ end
 
 # -- 装備固定 actors (equipment_fixed) -----------------------------------------
 # An actor (or RPG2003 class) trait meaning the field cannot change their
-# equipment at all. EasyRPG gates this at the equip *scene* -- confirming a
-# slot refuses to even open the item list for such an actor -- rather than in
-# Game_Actor::ChangeEquipment or Game_Party's bag-swapping helpers, which
+# equipment at all. Ported from EasyRPG Player's source, NOT independently
+# confirmed against genuine RPG_RT under wine: it gates this at the equip
+# *scene* -- a slot refuses to even open the item list for such an actor --
+# rather than in Game_Actor::ChangeEquipment or Game_Party's bag-swapping
+# helpers, which
 # neither check it (a Change Equipment event command, unlike the menu, is not
 # gated by this at all). So Game::Party's own equip API stays usable here on
 # purpose; #equipment_fixed? exists for Scene::EquipMenu to read before
@@ -22561,8 +22679,10 @@ check 'equipment_fixed? does not itself block Party#equip_from_bag / #unequip_to
 end
 
 # -- 呪い states lock equipment too (Actor#equipment_fixed?/#state_cursed?) ---
-# The RPG2003 state field EasyRPG's own `IsEquipmentFixed(true)` folds into the
-# same predicate as the row's `equipment_fixed` trait -- see the fuller
+# The RPG2003 state field folds into the same predicate as the row's
+# `equipment_fixed` trait -- ported from EasyRPG Player's own
+# `IsEquipmentFixed(true)`, NOT independently confirmed against genuine
+# RPG_RT under wine -- see the fuller
 # writeup at #equipment_fixed? above. Distinct from #slot_cursed? (a property
 # of the *item*, checked further below): this one is a property of whatever
 # states the actor currently carries, so it comes and goes with the state

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5673,8 +5673,10 @@ check "a wandered map event's position and facing survive a save/load, but " \
   # (reset to their default page-1 placement)" -- but the same list's "does
   # not survive a save/load specifically" half never names event positions,
   # meaning they are expected to survive one, matching real RPG_RT's own
-  # SaveMapEvent chunk (x/y/direction, confirmed against EasyRPG's
-  # Game_Event -- see Game::State#map_event_positions). This codebase had no
+  # SaveMapEvent chunk (x/y/direction; the field shape is ported from
+  # EasyRPG Player's Game_Event, NOT independently confirmed against
+  # genuine RPG_RT under wine -- see Game::State#map_event_positions). This
+  # codebase had no
   # mechanism at all for the save/load half: Scene::Map#build_event always
   # built a fresh Game::Character from the map's own ev.x/ev.y, so even a
   # same-map Save-then-Continue snapped every wandered NPC back to its
@@ -7323,7 +7325,8 @@ check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Vi
   ok !st.switches[2], 'the Escape handler was skipped'
 end
 
-# EasyRPG's own EXP-granting loop (Scene_Battle_Rpg2k::
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its own EXP-granting loop (Scene_Battle_Rpg2k::
 # ProcessSceneActionVictory) iterates Game_Party_Base::GetActiveBattlers, not
 # the raw party roster, and GetActiveBattlers excludes anyone failing
 # Game_Battler::Exists() (`!IsHidden() && !IsDead() && IsInParty()`) -- a
@@ -7442,10 +7445,12 @@ check 'Enemy Encounter scene: opening a battle narrates each visible enemy with 
      'both troop members are named, once each, using the database term'
 end
 
-# `ProcessSceneActionStart`'s `eFirstStrike` substate pushes `terms.
-# special_combat` (no subject, a fixed line) *after* every per-enemy
-# `encounter` line, only when the encounter is a first-strike ambush -- it is
-# appended to the same narration, not a replacement for it.
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `ProcessSceneActionStart`'s `eFirstStrike`
+# substate pushes `terms.special_combat` (no subject, a fixed line) *after*
+# every per-enemy `encounter` line, only when the encounter is a
+# first-strike ambush -- it is appended to the same narration, not a
+# replacement for it.
 check 'Enemy Encounter scene: a first-strike encounter appends the special_combat ' \
       'line after the per-enemy encounter lines' do
   ic = Game::Interpreter::Cmd
@@ -7775,9 +7780,10 @@ check 'Enemy Encounter scene: a game-over defeat returns to the title' do
   ok parent.game_over_shown, 'a game-over defeat puts up the Game Over screen'
 end
 
-# The real RPG2k Battle/Auto Battle/Escape options window (EasyRPG's
-# `scene_battle_rpg2k.cpp`, `State_SelectOption` /
-# `ProcessSceneActionFightAutoEscape`), traced verbatim in docs/TODO.md's
+# The real RPG2k Battle/Auto Battle/Escape options window -- ported from
+# EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine: its `scene_battle_rpg2k.cpp`, `State_SelectOption` /
+# `ProcessSceneActionFightAutoEscape` -- traced verbatim in docs/TODO.md's
 # "SelectPreviousActor" writeup: shown automatically once per battle, right
 # after the encounter/turn-0-event messages resolve
 # (`ProcessSceneActionStart`'s final substate: unconditional
@@ -7890,8 +7896,10 @@ check 'Enemy Encounter scene: selecting Escape from the options window runs Esca
   ok st.switches[2], 'the Escape handler ran'
 end
 
-# EasyRPG's Scene_Battle::TryEscape checks its own `first_strike` flag first,
-# before ever touching `escape_chance` -- so a first-strike encounter's
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Scene_Battle::TryEscape checks its own
+# `first_strike` flag first, before ever touching `escape_chance` -- so a
+# first-strike encounter's
 # opening Escape always succeeds, even against enemies fast enough to floor
 # the roll at 0%. Scene::Battle#try_battle_escape used to call
 # Game::Battle#attempt_escape with no argument at all (defaulting `preemptive`
@@ -7997,8 +8005,9 @@ check 'Enemy Encounter scene: a game-over defeat returns to the title' do
   RGSS::Input.triggered = []
   ok parent.game_over_shown, 'a game-over defeat reached the Game Over screen'
   ok !st.switches[5], 'the rest of the event never ran'
-  # Confirmed against EasyRPG's `Scene_Battle::EndBattle` (`src/
-  # scene_battle.cpp`): the "Other" battle counters are bumped there,
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Scene_Battle::EndBattle` (`src/
+  # scene_battle.cpp`) bumps the "Other" battle counters there,
   # unconditionally, before the Game Over dispatch that can follow a
   # defeat -- a game-over-ending defeat still counts, even though the event
   # that opened the fight is abandoned and never resumed.
@@ -9507,13 +9516,15 @@ end
 
 check 'boarding and landing the airship snaps the hero to face left, matching RPG_RT ' \
       '(2026-08-18)' do
-  # Verified against RPG_RT's actual behavior via EasyRPG Player's own C++
-  # source, fetched live: Game_Player::GetOnVehicle's airship branch (src/
-  # game_player.cpp) calls SetFacing(Left) unconditionally the instant
-  # boarding begins ("RPG_RT ignores the lock_facing flag here!"), and
-  # GetOffVehicle's own InAirship branch does the identical SetFacing(Left)
-  # right before StartDescent() -- the boat/ship branches have no equivalent
-  # call at all, so this is airship-specific.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: Game_Player::GetOnVehicle's airship branch
+  # (src/game_player.cpp) calls SetFacing(Left) unconditionally the instant
+  # boarding begins (that source's own comment there claims "RPG_RT ignores
+  # the lock_facing flag here!", a claim this codebase has not itself
+  # verified against the genuine engine), and GetOffVehicle's own InAirship
+  # branch does the identical SetFacing(Left) right before StartDescent() --
+  # the boat/ship branches have no equivalent call at all, so this is
+  # airship-specific.
   scene = new_scene({}, player: [0, 0], airship_land: true)
   st = scene.instance_variable_get(:@state)
   st.direction = 2 # facing down beforehand
@@ -9536,8 +9547,10 @@ check 'boarding and landing the airship snaps the hero to face left, matching RP
 end
 
 check 'boarding a boat/ship does not force any particular facing' do
-  # Control for the airship-specific check above: EasyRPG's boat/ship
-  # boarding branch never calls SetFacing on the player at all.
+  # Control for the airship-specific check above: per the same
+  # EasyRPG-ported source (NOT independently confirmed against genuine
+  # RPG_RT under wine), its boat/ship boarding branch never calls SetFacing
+  # on the player at all.
   scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)
   st.direction = 2 # face down, toward the boat
@@ -9870,8 +9883,10 @@ end
 
 # #missing_animation_wait's own two branches, pinned directly (see its own
 # doc comment in mruby-rpg2k/mrblib/scene/map.rb): an invalid/unknown
-# animation id waits 0 real frames -- no one-frame floor, matching
-# EasyRPG's Game_Interpreter wait_time == 0 fallthrough -- while a valid row
+# animation id waits 0 real frames -- no one-frame floor, ported from
+# EasyRPG Player's source (NOT independently confirmed against genuine
+# RPG_RT under wine): its Game_Interpreter wait_time == 0 fallthrough --
+# while a valid row
 # with real frame data waits that row's own real duration regardless of
 # whether its graphic sheet loads (the sheet is never consulted here at
 # all).
@@ -9951,8 +9966,9 @@ check 'Show Battle Animation with the wait flag off still plays, without blockin
   ok !spr.visible, 'the animation sprite is hidden once it finishes'
 end
 
-# yado.tk (corroborated independently against EasyRPG's own C++ source, see
-# #hold_animation_screen_flash's comment): Screen Flash is capped to 1/30s of
+# yado.tk trivia; the specific mechanism is ported from EasyRPG Player's
+# source, NOT independently confirmed against genuine RPG_RT under wine
+# (see #hold_animation_screen_flash's comment): Screen Flash is capped to 1/30s of
 # display while a Battle Animation is playing, since the animation
 # continuously re-asserts its own per-frame flash state -- overwriting an
 # unrelated, still-ticking Screen Flash the very next real frame, regardless
@@ -9990,8 +10006,9 @@ check 'A Screen Flash concurrent with a Show Battle Animation is capped to the c
 end
 
 # yado.tk's own "Character Flash" half of the same claim, capped the same way
-# and for the same reason (corroborated independently against EasyRPG's own
-# C++ source, see #hold_animation_target_flash's comment):
+# and for the same reason; the specific mechanism is ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine (see #hold_animation_target_flash's comment):
 # `BattleAnimation::Update` calls `UpdateTargetFlash()` unconditionally right
 # alongside `UpdateScreenFlash()` on every real frame, and it always ends in
 # an unconditional `FlashTargets(r, g, b, p)` the same way `FlashOnce` is for
@@ -10841,9 +10858,11 @@ check 'the airship floats above a ground shadow; a boat casts none' do
   # the airship sprite's own y is drawn CharSet::HEIGHT - TILE pixels above
   # that already (every vehicle/character sprite's own feet-alignment,
   # unrelated to floating), plus AIRSHIP_ALTITUDE on top of that -- a full
-  # tile (16px), not half. EasyRPG's own Game_Vehicle::GetAltitude() is
-  # SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE / TILE_SIZE) once fully airborne,
-  # 256 / (256 / 16) = 16 with RPG_RT's own real constants.
+  # tile (16px), not half. Ported from EasyRPG Player's source, NOT
+  # independently confirmed against genuine RPG_RT under wine: its own
+  # Game_Vehicle::GetAltitude() is SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE /
+  # TILE_SIZE) once fully airborne, 256 / (256 / 16) = 16 with those
+  # constants.
   base_offset = Game::CharSet::HEIGHT - Game::TILE
   eq 16, shadow.y - sprites[:airship].y - base_offset,
      "the airship floats a full 16px tile above its shadow, not half"
@@ -11215,9 +11234,10 @@ end
 
 check 'auto-relocation uses RPG_RT\'s real 112px/160px zone thresholds and ' \
       'the feet position, not the earlier SCREEN_H/2 approximation' do
-  # Confirmed against EasyRPG's own Game_Message::GetRealPosition() (fetched
-  # verbatim): the zone boundaries are 16*7=112 and 16*10=160 real pixels --
-  # not this build's old SCREEN_H/2=120 guess -- measured off the hero's
+  # Ported from EasyRPG Player's own Game_Message::GetRealPosition(), NOT
+  # independently confirmed against genuine RPG_RT under wine: the zone
+  # boundaries are 16*7=112 and 16*10=160 real pixels -- not this build's
+  # old SCREEN_H/2=120 guess -- measured off the hero's
   # *feet* (Game_Character::GetScreenY(), the tile's bottom edge), not its
   # centre. A map exactly one screen tall (15 tiles * 16px = 240px) never
   # scrolls, so #hero_screen_y tracks `st.y * 16 + 16` directly with no
@@ -11442,8 +11462,10 @@ check 'the timer drops to the bottom edge once a message resolves to the ' \
   scene.update
   eq RPG2k::Scene::Map::SCREEN_H - 20, spr.y,
      'the timer slides down to keep clear of the top-parked message'
-  # Closing the message does not undo it -- EasyRPG's own Window_Message#y
-  # is never reset on FinishMessageProcessing either.
+  # Closing the message does not undo it -- ported from EasyRPG Player's
+  # source, NOT independently confirmed against genuine RPG_RT under wine:
+  # its own Window_Message#y is never reset on FinishMessageProcessing
+  # either.
   scene.send(:close_message, animate: false)
   scene.update
   eq RPG2k::Scene::Map::SCREEN_H - 20, spr.y,
@@ -11894,9 +11916,10 @@ check 'Enemy Encounter scene: using an Item heals and consumes one from the bag'
   ok RGSS::Audio.se_calls.any? { |c| c[0] == 'ItemUse' }, 'the item SE played too'
 end
 
-# SFX_ENEMY_ATTACK (Scene::Base::DB_SE_FIELD slot 6): confirmed against
-# EasyRPG Player's source (scene_battle_rpg2k.cpp's ProcessBattleActionUsage)
-# to fire once, at the very start of an *enemy's* plain Attack action, never
+# SFX_ENEMY_ATTACK (Scene::Base::DB_SE_FIELD slot 6): ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT
+# under wine (scene_battle_rpg2k.cpp's ProcessBattleActionUsage) -- it
+# fires once, at the very start of an *enemy's* plain Attack action, never
 # for a skill/item hit or for an ally's own Attack -- see the doc comment on
 # `SFX_ENEMY_ATTACK` in mruby-rpg2k/mrblib/scene/base.rb.
 check 'Enemy Encounter scene: the enemy-attack SE plays for an enemy Attack, ' \
@@ -11932,9 +11955,10 @@ check 'Enemy Encounter scene: the enemy-attack SE plays for an enemy Attack, ' \
      "and the enemy's own Attack plays the enemy-attack SE"
 end
 
-# The battle command/target/skill/item flow's own system SE -- confirmed
-# against EasyRPG Player's source the same way the field menu and title
-# screen already were (Scene_Battle::AttackSelected/DefendSelected/
+# The battle command/target/skill/item flow's own system SE -- ported from
+# EasyRPG Player's source the same way the field menu and title screen
+# already were, NOT independently confirmed against genuine RPG_RT under
+# wine (Scene_Battle::AttackSelected/DefendSelected/
 # ItemSelected/SkillSelected, Window_Selectable::Update() for cursor moves,
 # ProcessSceneActionCommand/EnemyTarget/Escape for Cancel/Buzzer/Escape).
 check 'Enemy Encounter scene: the command/skill/target flow plays cursor, ' \
@@ -12314,7 +12338,9 @@ check 'Enemy Encounter scene: the command menu is drawn Attack / Skill / Defend 
   ui = battle_to_command(scene)
   labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
   eq %w[Attack Skill Defend Item], labels,
-     "EasyRPG's own CreateBattleCommandWindow order, not Item ahead of Defend"
+     "EasyRPG's own CreateBattleCommandWindow order (ported from that " \
+     "source, NOT independently confirmed against genuine RPG_RT under " \
+     "wine), not Item ahead of Defend"
 end
 
 check 'Enemy Encounter scene: cmd 2 commits Defend at once (not the Item list)' do
@@ -12425,7 +12451,8 @@ check "Enemy Encounter scene: a reordered Defense command still commits at once,
 end
 
 check 'selecting a battle command records its command id on the acting Combatant, ' \
-      'the way EasyRPG sets SetLastBattleAction' do
+      'the way EasyRPG sets SetLastBattleAction (ported from that source, ' \
+      'NOT independently confirmed against genuine RPG_RT under wine)' do
   # The fixed four map to EasyRPG's default command ids 1..4 (attack, skill,
   # defense, item) -- what the RPG2003 battle combo (Enable Combo) and the
   # `command_actor` page condition compare against. This pins the recording,
@@ -12461,8 +12488,9 @@ end
 
 check "Enemy Encounter scene: a Special battle command draws a row and forfeits the actor's turn" do
   # RPG2003's Special (type 6) command resolves to a turn that does nothing --
-  # EasyRPG's `Scene_Battle_Rpg2k3::SpecialSelected` queues
-  # `Game_BattleAlgorithm::DoNothing`. It must be offered as a menu row (this
+  # ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its `Scene_Battle_Rpg2k3::SpecialSelected`
+  # queues `Game_BattleAlgorithm::DoNothing`. It must be offered as a menu row (this
   # engine used to skip it along with Escape) and, once chosen, commit at once
   # like Defend -- no target/skill/item submenu -- and pass the actor's turn
   # with no action: `Game::Battle#command_skip` sets the Combatant's skip
@@ -13123,11 +13151,13 @@ check 'Enemy Encounter scene: the alternative/gauge layout draws a positioned Id
   ok spr.z < 300, 'sits below the UI windows (z >= 300)'
 end
 
-# EasyRPG's Sprite_Actor::DoIdleAnimation resolves a monster's Knockout state
-# straight to AnimationState_Dead rather than hiding it; a party member is
-# treated the same way here (#build_actor_sprite's `dead:` keyword, Pose id
-# 4) -- so a member already KO'd the instant the fight opens gets that pose
-# rather than no sprite at all, the gap this check pins.
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Sprite_Actor::DoIdleAnimation resolves a
+# monster's Knockout state straight to AnimationState_Dead rather than
+# hiding it; a party member is treated the same way here
+# (#build_actor_sprite's `dead:` keyword, Pose id 4) -- so a member already
+# KO'd the instant the fight opens gets that pose rather than no sprite at
+# all, the gap this check pins.
 check "Enemy Encounter scene: a party member already KO'd going into the fight draws the Dead pose, not no sprite" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
@@ -13389,8 +13419,9 @@ end
 # 2000_battle_bot / デフォ戦bot trivia: 自爆した敵は、経験値・お金・アイテムを落と
 # さない。しかもデータ内部では逃走した状態と同じ扱いになっており、敵ＨＰを変数に
 # 代入してみると0になっていない。更に自爆後にイベントコマンド「敵キャラの出現」で
-# 指定すると何喰わぬ顔で元に戻る。Verified against EasyRPG Player's actual C++
-# source (see Game::Battle#enemy_autodestruct's own comment in mrblib/game.rb):
+# 指定すると何喰わぬ顔で元に戻る。The specific mechanism is ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine (see Game::Battle#enemy_autodestruct's own comment in mrblib/game.rb):
 # Game_BattleAlgorithm::SelfDestruct never writes the caster's own HP, only
 # SetHidden(true) -- so this scene-level check exercises the same "hidden, not
 # killed" path a real self-destruct takes through #refresh_battle_sprites, and
@@ -13427,12 +13458,15 @@ check 'Enemy Encounter scene: a self-destructed monster drops no reward and ' \
 end
 
 # yado.tk's own text on the "airborne" enemy flag names no pixel offset or
-# animation shape, only that it "changes its Y position on screen" -- but
-# EasyRPG's `Game_Enemy::GetFlyingOffset` supplies both the missing magnitude
+# animation shape, only that it "changes its Y position on screen" -- the
+# specific magnitude, period and edition gate below are ported from EasyRPG
+# Player's source, NOT independently confirmed against genuine RPG_RT under
+# wine: its `Game_Enemy::GetFlyingOffset` supplies both the missing magnitude
 # (+/-4px) and period (256 frames) *and* an edition gate the site never
-# mentions at all: real RPG2000 never renders it ("2k does not support
-# flying, albeit mentioned in the help file" -- their comment), only RPG2003
-# does. Troop 2 (Bats) is the lone-`levitate`-member fixture these exercise;
+# mentions at all: that source's own comment claims real RPG2000 never
+# renders it ("2k does not support flying, albeit mentioned in the help
+# file"), only RPG2003 does -- a claim this codebase has not itself verified
+# against the genuine engine. Troop 2 (Bats) is the lone-`levitate`-member fixture these exercise;
 # troop 1's two Slimes (neither flagged) are untouched by any of this, which
 # the existing battler-sprite checks above already pin.
 check 'Scene::Map#flying_offset: RPG2003 + levitate is a +/-4px, 256-frame sine bob' do
@@ -13791,7 +13825,8 @@ end
 # Scene::Title's own `continue_available?` (ADR 0012, extended by ADR 0045 to
 # cover every slot rather than just slot 1). The cursor can still reach the
 # grayed-out entry, and confirming it is not silent -- it plays Buzzer
-# (confirmed against EasyRPG's own Scene_Title::CommandContinue) rather than
+# (ported from EasyRPG Player's own Scene_Title::CommandContinue, NOT
+# independently confirmed against genuine RPG_RT under wine) rather than
 # doing nothing at all, but still never opens the file-select screen.
 
 check 'no save data: Continue is flagged unavailable and reachable by the cursor' do
@@ -14691,9 +14726,10 @@ check 'a command_actor troop page fires at the acting battler\'s turn in a gauge
 end
 
 # The Special command in a gauge fight: choosing it forfeits the ready actor's
-# turn (EasyRPG's DoNothing), spending the held gauge and returning to the ATB
-# idle loop without any action -- the active-time counterpart to the round-
-# based Special check above.
+# turn (per the same EasyRPG-ported DoNothing reading in the round-based
+# Special check above, NOT independently confirmed against genuine RPG_RT
+# under wine), spending the held gauge and returning to the ATB idle loop
+# without any action -- the active-time counterpart to that check.
 check "a gauge battle: the Special command spends the ready actor's turn and returns to the ATB loop" do
   scene, st = battle_scene_with_pages({}, rpg2003: true,
                                       battlecommands: OpenStruct.new(battle_type: 2, placement: 1))
@@ -14811,8 +14847,10 @@ check 'the Row command moves an automatic-placement actor sprite by row_x_offset
 end
 
 check 'a defending actor draws the Defend pose, reverting to Idle once the round ends' do
-  # EasyRPG's Sprite_Actor::DoIdleAnimation checks IsDefending() before
-  # anything else -- ported as #build_actor_sprite's `defending:` keyword
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Sprite_Actor::DoIdleAnimation checks
+  # IsDefending() before anything else -- ported as #build_actor_sprite's
+  # `defending:` keyword
   # (Pose id 7), driven by #reposition_actor_sprite right when Defend
   # commits and again once Game::Battle#end_round clears the flag.
   poses = { 0 => battle_pose(battler_name: 'Party', battler_index: 0),
@@ -14952,9 +14990,11 @@ end
 # only #dead?) used to still open the ordinary Attack/Skill/Defend/Item prompt
 # for one, waiting on a choice that #apply_turn_states/#strike (see
 # Game::Battle#command_restricted?) discard or override regardless of what
-# gets picked. EasyRPG's Scene_Battle_Rpg2k::SelectNextActor recurses straight
-# past exactly these two cases (`!CanAct()` / `GetSignificantRestriction() !=
-# Restriction_normal`) with no manual prompt shown at all.
+# gets picked. Ported from EasyRPG Player's source, NOT independently
+# confirmed against genuine RPG_RT under wine: its Scene_Battle_Rpg2k::
+# SelectNextActor recurses straight past exactly these two cases
+# (`!CanAct()` / `GetSignificantRestriction() != Restriction_normal`) with
+# no manual prompt shown at all.
 check 'an asleep ally is skipped straight to the next commandable one, no command prompt for it' do
   scene, st = battle_scene_with_pages({})
   st.party.instance_variable_set(:@actors, [BattleStubActor.new(id: 1, states: [4]),
@@ -14993,9 +15033,11 @@ end
 
 # 強制AI (mruby-lcf/mrblib/schema.rb, player/job field 23, force_ai) --
 # parsed but never read anywhere in mruby-rpg2k before this fix. Mirrors the
-# two restricted-actor checks directly above: EasyRPG's own
-# `Scene_Battle_Rpg2k::SelectNextActor` checks `GetAutoBattle()` right after
-# the CanAct()/forced-restriction gates and, if set, queues an action via the
+# two restricted-actor checks directly above: ported from EasyRPG Player's
+# source, NOT independently confirmed against genuine RPG_RT under wine:
+# its own `Scene_Battle_Rpg2k::SelectNextActor` checks `GetAutoBattle()`
+# right after the CanAct()/forced-restriction gates and, if set, queues an
+# action via the
 # default AutoBattle algorithm instead of ever opening `State_SelectCommand`
 # -- see `Game::Battle#choose_auto_battle_command`'s own header comment for
 # the full port. `BattleStubActor#force_ai?` here has no skills at all
@@ -15082,10 +15124,11 @@ check 'a battle page with no condition ticked at all never fires' do
   ok !st.switches[15], 'RPG_RT reads an unticked condition box as never, not always'
 end
 
-# EasyRPG's CheckBattleEndAndScheduleEvents runs "before each battler acts and
-# also right after the last battler acts", not just once between rounds --
-# Scene::Map#drive_battle_animate now checks between every acting battler
-# (see @battle_ui[:battler_boundary]).
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its CheckBattleEndAndScheduleEvents runs
+# "before each battler acts and also right after the last battler acts",
+# not just once between rounds -- Scene::Map#drive_battle_animate now
+# checks between every acting battler (see @battle_ui[:battler_boundary]).
 check 'a battle page conditioned on enemy HP fires mid-round, before the round settles' do
   ic = Game::Interpreter::Cmd
   # True only once the first troop member's HP falls to half or less -- which
@@ -15250,9 +15293,11 @@ end
 # screen during a fight at all -- the Backdrop/<name> image is the whole
 # background. This port runs the fight inline on Scene::Map, and #render used
 # to keep compositing the map every frame underneath it: the backdrop sprite's
-# z 5 (EasyRPG's Priority_Background) is outranked by @map_viewport (z 100) and
-# @upper_viewport (z 200), and the lower tile layer is opaque, so the correctly
-# resolved backdrop was drawn entirely behind the map graphics.
+# z 5 (ported from EasyRPG Player's own Priority_Background constant, NOT
+# independently confirmed against genuine RPG_RT under wine) is outranked by
+# @map_viewport (z 100) and @upper_viewport (z 200), and the lower tile layer
+# is opaque, so the correctly resolved backdrop was drawn entirely behind
+# the map graphics.
 check 'the map is hidden while the battle screen is up, so the backdrop actually shows' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }
@@ -15578,9 +15623,10 @@ check "a battle page's Show Battle Animation target-scope flash pulses the named
 end
 
 # RPG2003's Ally/Enemy target-type flag on Show Battle Animation
-# (Interpreter#do_show_battle_animation_b's param3, matching EasyRPG's
-# `Game_Interpreter_Battle::CommandShowBattleAnimation`) used to be dropped
-# entirely: an "Ally #1" target still indexed straight into
+# (Interpreter#do_show_battle_animation_b's param3, ported from EasyRPG
+# Player's `Game_Interpreter_Battle::CommandShowBattleAnimation`, NOT
+# independently confirmed against genuine RPG_RT under wine) used to be
+# dropped entirely: an "Ally #1" target still indexed straight into
 # `@ui[:enemy_sprites]` -- the troop's own *second* monster in any troop
 # with 2+ members, not any party member at all. Fixed by carrying the flag
 # through to #start_battle_page_animation, which now falls back to the same
@@ -16690,9 +16736,10 @@ check 'Enemy Encounter scene: a successful Flee shows the database escape_succes
      'a successful escape also plays the dedicated Escape SE'
 end
 
-# EasyRPG's `Game_BattleAlgorithm::Escape::GetStartSe` (src/
-# game_battlealgorithm.cpp) returns `SFX_Escape` whenever the algorithm's
-# own *source* is an enemy (an ally's own Escape defers to the base
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_BattleAlgorithm::Escape::GetStartSe`
+# (src/game_battlealgorithm.cpp) returns `SFX_Escape` whenever the
+# algorithm's own *source* is an enemy (an ally's own Escape defers to the base
 # class's silent default instead, played separately by the check just
 # above) -- a distinct trigger from the party's own successful-escape SE.
 # `entry[:fled]` (`Game::Battle#enemy_basic_action`'s BASIC_ESCAPE arm) is
@@ -16713,11 +16760,14 @@ check "an enemy's own AI-chosen Escape basic action plays the dedicated " \
   RGSS::Audio.reset_se
   battle.send(:play_battle_action_se, { attacker: 'Slime', fled: true })
   ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Escape1' },
-     "matches RPG_RT's own Escape::GetStartSe for an enemy source"
+     "matches the EasyRPG-ported Escape::GetStartSe for an enemy source " \
+     "(NOT independently confirmed against genuine RPG_RT under wine)"
 end
 
-# EasyRPG's `Game_BattleAlgorithm::SelfDestruct::GetStartSe` (src/
-# game_battlealgorithm.cpp) is `return &GetSystemSE(SFX_EnemyKill);` --
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_BattleAlgorithm::SelfDestruct::
+# GetStartSe` (src/game_battlealgorithm.cpp) is
+# `return &GetSystemSE(SFX_EnemyKill);` --
 # unconditional, unlike the ordinary post-hit death SE just above
 # (`entry[:defeated] && !entry[:target_ally]`), which can never fire for a
 # self-destruct entry at all since every target is a party member.
@@ -17227,8 +17277,10 @@ end
 # Each animation cell carries its own `transparency` (LCF battle_anime chunk
 # 19's per-cell field 10 -- mruby-lcf/mrblib/schema.rb), decoded all along and
 # never read, so every cell drew fully opaque no matter what its author asked
-# for. #animation_cell_opacity is the pure-logic half, mirroring EasyRPG's own
-# `BattleAnimation::DrawAt`: `SetOpacity(255 * (100 - cell.transparency) / 100)`.
+# for. #animation_cell_opacity is the pure-logic half, ported from EasyRPG
+# Player's own `BattleAnimation::DrawAt` (NOT independently confirmed
+# against genuine RPG_RT under wine): `SetOpacity(255 * (100 -
+# cell.transparency) / 100)`.
 check 'animation_cell_opacity converts a cell transparency percentage to a blit opacity' do
   scene, = battle_at_command
   op = ->(t) { scene.send(:animation_cell_opacity, OpenStruct.new(cell_id: 0, transparency: t)) }
@@ -17286,9 +17338,11 @@ check 'the battle status window shows each ally condition, or the normal term' d
   scene.instance_variable_get(:@battle).send(:refresh_battle_status)
   texts = window_texts(ui[:status_win])
   ok texts.include?('Sleep'), 'the afflicted ally shows its state'
-  # RPG2000 is front-view: EasyRPG's Scene_Battle_Rpg2k builds exactly one
-  # Window_BattleStatus, defaulted to `enemy: false` -- the troop is never
-  # listed on this panel, only shown through its battler sprites.
+  # RPG2000 is front-view: ported from EasyRPG Player's source, NOT
+  # independently confirmed against genuine RPG_RT under wine: its
+  # Scene_Battle_Rpg2k builds exactly one Window_BattleStatus, defaulted to
+  # `enemy: false` -- the troop is never listed on this panel, only shown
+  # through its battler sprites.
   ok !texts.include?(ui[:foes][0].name), "the enemy troop has no row here"
 end
 
@@ -17403,9 +17457,11 @@ end
 
 check 'the status panel swaps sides with whichever 76px window is showing beside it' do
   battle_mod = RPG2k::Scene::Battle
-  # During the top-level Battle/Auto Battle/Escape choice, EasyRPG's
-  # SetCommandWindowsX lays the options window at x=0 and pushes the status
-  # window to its right (BATTLE_CMD_W); the per-actor command window (off
+  # During the top-level Battle/Auto Battle/Escape choice, ported from
+  # EasyRPG Player's source (NOT independently confirmed against genuine
+  # RPG_RT under wine): its SetCommandWindowsX lays the options window at
+  # x=0 and pushes the status window to its right (BATTLE_CMD_W); the
+  # per-actor command window (off
   # screen here) would take the *far* right slot instead, past the status
   # window.
   scene, = battle_scene_with_pages(nil, party: BattleStubParty.new)
@@ -17446,8 +17502,9 @@ end
 # specifically for battle_type 2, distinct from `#alternate_battle_layout?`
 # (true for both 1 and 2) -- see #refresh_battle_status's own comment,
 # scene/map.rb. These checks exercise the dispatch and the card's own
-# drawing, ported from EasyRPG's real `Window_BattleStatus::Refresh`/
-# `RefreshGauge`/`DrawGaugeSystem2`/`DrawNumberSystem2`.
+# drawing, ported from EasyRPG Player's real `Window_BattleStatus::Refresh`/
+# `RefreshGauge`/`DrawGaugeSystem2`/`DrawNumberSystem2`, NOT independently
+# confirmed against genuine RPG_RT under wine.
 
 check 'battle_type 0 (no gauge layout) still draws the plain text status row' do
   scene, ui = battle_at_command
@@ -17670,8 +17727,10 @@ check 'a ready but restricted (asleep) party member\'s gauge fires a silent no-o
   ui = battle_until_phase(scene, :atb, 150)
   ok ui, 'the battle opened to the active-time idle loop'
   hero = ui[:battle].all_combatants.first
-  # The restricted ally never *charges* under the real fill curve (EasyRPG's
-  # CanAct() gate -- the new rpg2k3_battle_gauge_check.rb check pins that), so
+  # The restricted ally never *charges* under the real fill curve (ported
+  # from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its CanAct() gate -- the new
+  # rpg2k3_battle_gauge_check.rb check pins that), so
   # seed its gauge directly: a full gauge it somehow holds still fires its
   # turn, and the restriction resolves it to a silent no-op, never a prompt.
   hero.gauge = Game::Battle::GAUGE_MAX
@@ -17688,8 +17747,10 @@ end
 # menu's Wait command -- *not* a Battle Commands database field, correcting
 # the ADR's own premise. In active mode (raw 0, the default) the gauges keep
 # filling while any command menu is open and a ready non-controllable
-# combatant's action interrupts the menu (EasyRPG's
-# `ProcessSceneActionCommand`'s `GetAtbMode() == active && IsBattleActionPending()`
+# combatant's action interrupts the menu (ported from EasyRPG Player's
+# source, NOT independently confirmed against genuine RPG_RT under wine:
+# its `ProcessSceneActionCommand`'s
+# `GetAtbMode() == active && IsBattleActionPending()`
 # gate); in wait mode (raw 1) they freeze -- confirmed against liblcf's own
 # generated `AtbMode` enum (`AtbMode_atb_active = 0, AtbMode_atb_wait = 1`),
 # the opposite of an earlier, uncited pass here that had the two raw values
@@ -17961,7 +18022,8 @@ check 'leaving and rejoining the same fight reuses the same Combatant (and ' \
 end
 
 check 'actor sprite Z stays collision-free across a remove-then-add cycle, ' \
-      'matching EasyRPG\'s ResetAllBattlerZ' do
+      'per EasyRPG Player\'s ResetAllBattlerZ (ported from that source, NOT ' \
+      'independently confirmed against genuine RPG_RT under wine)' do
   hero = BattleStubActor.new(id: 1, name: 'Hero', battler_animation_id: 5)
   ally = BattleStubActor.new(id: 2, name: 'Ally', battler_animation_id: 5)
   third = BattleStubActor.new(id: 3, name: 'Third', battler_animation_id: 5)
@@ -18098,10 +18160,12 @@ end
 #
 # An affect_attack/defense/spirit/agility skill (Game::Battle#apply_stat_mods)
 # and an affect_attr_defence skill (Game::Battle#apply_attr_shift) both already
-# moved the target's numbers with no line ever announcing it -- RPG_RT's own
-# GetParameterChangeMessage / GetAttributeShiftMessage read `term.
-# parameter_increase` / `_decrease` and `term.resistance_increase` / `_decrease`
-# for exactly this, matching every other landed-condition sentence above.
+# moved the target's numbers with no line ever announcing it -- ported from
+# EasyRPG Player's source, NOT independently confirmed against genuine
+# RPG_RT under wine: its GetParameterChangeMessage / GetAttributeShiftMessage
+# read `term.parameter_increase` / `_decrease` and `term.resistance_increase`
+# / `_decrease` for exactly this, matching every other landed-condition
+# sentence above.
 
 check 'an affect_attack/defense/spirit/agility skill announces the stat rise ' \
       'or drop, in the game\'s own words' do
@@ -18131,7 +18195,8 @@ end
 
 check 'an affect_attr_defence skill announces which way the target\'s ' \
       'resistance moved, by the attribute\'s own name -- no magnitude, ' \
-      'matching EasyRPG\'s GetAttributeShiftMessage' do
+      'per the same EasyRPG-ported GetAttributeShiftMessage reading above ' \
+      '(NOT independently confirmed against genuine RPG_RT under wine)' do
   scene, = battle_at_command
   raised = scene.instance_variable_get(:@battle).send(:battle_state_lines,
                       { target: 'Hero', target_ally: true,
@@ -18685,9 +18750,11 @@ check 'Scene::Menu: the main command cursor wraps around' do
   eq 0, scene.instance_variable_get(:@index), 'Down from the last command wraps to the first'
 end
 
-# EasyRPG's Window_Selectable::Update (the base every real RPG2000 command
-# list is built on) falls through to Input::IsRepeated right after its own
-# IsTriggered check, so holding Down/Up auto-scrolls the cursor after the
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Window_Selectable::Update (the base every
+# RPG2000 command list is modelled on there) falls through to
+# Input::IsRepeated right after its own IsTriggered check, so holding
+# Down/Up auto-scrolls the cursor after the
 # initial delay -- see Scene::SaveLoad's identical fix for the fuller
 # writeup. `RGSS::Input.repeated` (distinct from `.triggered`) lets this
 # check hold a key across frames without it also reading as a fresh
@@ -18723,8 +18790,9 @@ end
 
 check 'Scene::Menu: choosing Skill/Equip hands focus to the party-status panel, ' \
       'a second confirm there opens the scene for the picked actor' do
-  # Confirmed against EasyRPG's own Scene_Menu::UpdateCommand /
-  # UpdateActorSelection: Skill/Equipment/Status don't open immediately --
+  # Ported from EasyRPG Player's own Scene_Menu::UpdateCommand /
+  # UpdateActorSelection, NOT independently confirmed against genuine
+  # RPG_RT under wine: Skill/Equipment/Status don't open immediately --
   # the command list goes inactive, the party-status panel goes active, and
   # only confirming an actor there pushes the real scene (constructed with
   # that actor's index, the third constructor argument).
@@ -18787,8 +18855,9 @@ end
 
 check 'Scene::Menu: a restricted actor cannot be given the Skill command, ' \
       'unlike Equip' do
-  # Confirmed against EasyRPG's own Scene_Menu::UpdateActorSelection: its
-  # Skill case alone gates on actor->CanAct(); Equipment/Status do not.
+  # Ported from EasyRPG Player's own Scene_Menu::UpdateActorSelection, NOT
+  # independently confirmed against genuine RPG_RT under wine: its Skill
+  # case alone gates on actor->CanAct(); Equipment/Status do not.
   st = wrap_menu_state
   st.party.actors.first.can_act_flag = false
   scene = menu_scene(RPG2k::Scene::Menu, st)
@@ -18894,8 +18963,9 @@ check 'Scene::Menu: RPG2000 (no rpg2003? flag) never offers Status at all' do
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
   keys = scene.instance_variable_get(:@commands).map(&:first)
   eq [:item, :skill, :equip, :save, :end_game], keys,
-     'the fixed RPG2000 five, matching EasyRPG\'s Player::IsRPG2k() branch -- ' \
-     'no Status, since a real RPG2000 database never customizes the menu'
+     'the fixed RPG2000 five, per the EasyRPG-ported Player::IsRPG2k() ' \
+     'branch (NOT independently confirmed against genuine RPG_RT under ' \
+     'wine) -- no Status, since a real RPG2000 database never customizes the menu'
 end
 
 check 'Scene::Menu: an RPG2003 database drives the command list from ' \
@@ -18907,8 +18977,9 @@ check 'Scene::Menu: an RPG2003 database drives the command list from ' \
   # (`Game::Party#toggle_actor_row`); Wait (8) -- the ATB toggle -- flips the
   # save-system `atb_mode` field (ADR 0054's follow-up) and is offered with
   # its current-mode label; Order (7) has no battle-system dependency at all,
-  # just party reordering; End Game is appended unconditionally, matching
-  # EasyRPG's own unconditional Quit push outside the customized loop.
+  # just party reordering; End Game is appended unconditionally, ported from
+  # EasyRPG Player's own unconditional Quit push outside the customized
+  # loop (NOT independently confirmed against genuine RPG_RT under wine).
   db = fake_db(rpg2003: true, menu_commands: [1, 2, 3, 4, 5, 6, 7, 8])
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)
   keys = scene.instance_variable_get(:@commands).map(&:first)
@@ -18969,7 +19040,8 @@ end
 check 'Scene::Menu: choosing Order pushes Scene::Order directly, no actor-' \
       'selection step' do
   # Unlike Skill/Equip/Status, Order acts on the whole party at once --
-  # confirmed against EasyRPG's own Scene_Menu::UpdateCommand, whose `case
+  # ported from EasyRPG Player's own Scene_Menu::UpdateCommand, NOT
+  # independently confirmed against genuine RPG_RT under wine: its `case
   # Order:` pushes Scene_Order straight away, the same shape as Item/Save,
   # not the Skill/Equipment/Status/Row actor-selection branch.
   db = fake_db(rpg2003: true, menu_commands: [1, 7])
@@ -18988,11 +19060,13 @@ end
 check 'Scene::Menu: choosing Row hands focus to the actor-selection panel, ' \
       'and confirming an actor toggles their row with no scene pushed' do
   # Unlike Order, Row shares Skill/Equipment/Status' actor-selection shape
-  # (the class comment, and EasyRPG's own UpdateCommand grouping) -- but
-  # unlike those three, confirming an actor never opens anything: the toggle
-  # happens right on the panel and focus falls straight back to the command
-  # list (EasyRPG's UpdateActorSelection Row case ends with the same
-  # SetActive/SetIndex(-1) every other case does).
+  # (the class comment, and EasyRPG Player's own UpdateCommand grouping,
+  # ported from that source and NOT independently confirmed against
+  # genuine RPG_RT under wine) -- but unlike those three, confirming an
+  # actor never opens anything: the toggle happens right on the panel and
+  # focus falls straight back to the command list (its UpdateActorSelection
+  # Row case ends with the same SetActive/SetIndex(-1) every other case
+  # does).
   db = fake_db(rpg2003: true, menu_commands: [6])
   st = wrap_menu_state
   scene = menu_scene(RPG2k::Scene::Menu, st, db)
@@ -19016,8 +19090,9 @@ end
 
 check 'Scene::Menu: Order refuses a single-member party with the buzzer, ' \
       'no scene pushed' do
-  # Confirmed against EasyRPG's own Scene_Menu::UpdateCommand's `Order`
-  # branch, which gates on `GetActors().size() <= 1` rather than the plain
+  # Ported from EasyRPG Player's own Scene_Menu::UpdateCommand's `Order`
+  # branch, NOT independently confirmed against genuine RPG_RT under wine:
+  # it gates on `GetActors().size() <= 1` rather than the plain
   # empty-party check every other command here uses -- reordering a single
   # member is meaningless.
   db = fake_db(rpg2003: true, menu_commands: [7])
@@ -19031,8 +19106,9 @@ end
 
 # -- Scene::Order: RPG2003's party-reordering screen --------------------------
 #
-# Confirmed against EasyRPG Player's own `Scene_Order::UpdateOrder`/
-# `UpdateConfirm`/`Redo`/`Confirm`: the player picks party members one at a
+# Ported from EasyRPG Player's own `Scene_Order::UpdateOrder`/
+# `UpdateConfirm`/`Redo`/`Confirm`, NOT independently confirmed against
+# genuine RPG_RT under wine: the player picks party members one at a
 # time from a left column (building a right column in the picked order), then
 # confirms or redoes the whole pick from a two-option prompt. This is *not* a
 # swap or drag-drop -- see mruby-rpg2k/mrblib/scene/order.rb's own class
@@ -19272,7 +19348,8 @@ check 'Scene::Menu: choosing Save opens Scene::SaveLoad in :save mode' do
 end
 
 check 'Scene::Menu: Save access forbidden refuses the selection silently, no message' do
-  # Confirmed against EasyRPG's own Scene_Menu::UpdateCommand: a disabled
+  # Ported from EasyRPG Player's own Scene_Menu::UpdateCommand, NOT
+  # independently confirmed against genuine RPG_RT under wine: a disabled
   # Save command just refuses the selection (plays a buzzer SE this engine
   # does not yet model any menu SE for), no message of any kind -- unlike
   # this screen's old hardcoded English "You cannot save right now.".
@@ -19735,7 +19812,9 @@ end
 
 # The scroll indicator: two independent blinking arrow sprites, not a
 # scrollbar -- see the class comment above Scene::SaveLoad::VISIBLE_SLOTS.
-# Confirmed against EasyRPG's own Scene_File (MakeArrowSprite/UpdateArrows).
+# Ported from EasyRPG Player's own Scene_File
+# (MakeArrowSprite/UpdateArrows), NOT independently confirmed against
+# genuine RPG_RT under wine.
 check 'Scene::SaveLoad: at the top of the list, only the down arrow can show, ' \
       'blinking on a 20-frame cycle' do
   scene, = save_load_scene(:load)
@@ -20184,11 +20263,12 @@ check 'Scene::ItemMenu: Right/Left cross a row boundary rather than ' \
      'Left from a row\'s first cell flows back into the previous row\'s last cell'
 end
 
-# EasyRPG's Window_Selectable::Update (the base every real RPG2000 list is
-# built on) falls through to Input::IsRepeated for all four directions
-# right after its own IsTriggered check, so holding a direction
-# auto-repeats the cursor after the initial delay -- see Scene::SaveLoad's
-# identical fix for the fuller writeup. `RGSS::Input.repeated` (distinct
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Window_Selectable::Update (the base every
+# RPG2000 list is modelled on there) falls through to Input::IsRepeated for
+# all four directions right after its own IsTriggered check, so holding a
+# direction auto-repeats the cursor after the initial delay -- see
+# Scene::SaveLoad's identical fix for the fuller writeup. `RGSS::Input.repeated` (distinct
 # from `.triggered`) lets this check hold a key across frames without it
 # also reading as a fresh trigger, exercising the `#repeat?` half of the
 # gate on its own.
@@ -20865,8 +20945,9 @@ check 'Scene::SkillMenu: the skill grid cursor does not wrap, caster is fixed, '
       'the target cursor does wrap' do
   scene = menu_scene(RPG2k::Scene::SkillMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@skill_index), 'starts on the first skill'
-  # The skill list is a two-column grid (confirmed against EasyRPG's own
-  # Window_Skill, see Scene::SkillMenu::COLUMN_MAX): with only two skills,
+  # The skill list is a two-column grid (ported from EasyRPG Player's own
+  # Window_Skill, NOT independently confirmed against genuine RPG_RT under
+  # wine, see Scene::SkillMenu::COLUMN_MAX): with only two skills,
   # both sit in the same row, so UP/DOWN have no cell to move to.
   RGSS::Input.triggered = [RGSS::Input::UP]
   scene.update
@@ -20885,8 +20966,9 @@ check 'Scene::SkillMenu: the skill grid cursor does not wrap, caster is fixed, '
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@skill_index), 'Left moves back onto the first skill'
 
-  # There is no way to switch caster inside this screen -- confirmed
-  # against EasyRPG's own Scene_Skill, whose actor_index is fixed at
+  # There is no way to switch caster inside this screen -- ported from
+  # EasyRPG Player's own Scene_Skill, NOT independently confirmed against
+  # genuine RPG_RT under wine: its actor_index is fixed at
   # construction (see the class comment); LEFT/RIGHT above are grid
   # navigation now, not a caster switch.
   eq 0, scene.instance_variable_get(:@caster_index), 'caster stays fixed regardless of LEFT/RIGHT'
@@ -21052,8 +21134,9 @@ check 'Scene::SkillMenu: a Teleport skill opens a destination list and queues th
   parent = fake_parent(fake_db)
   state = escape_teleport_state
   scene = RPG2k::Scene::SkillMenu.new(parent, state)
-  # The skill list is a two-column grid (confirmed against EasyRPG's own
-  # Window_Skill, see Scene::SkillMenu::COLUMN_MAX): with only two skills,
+  # The skill list is a two-column grid (ported from EasyRPG Player's own
+  # Window_Skill, NOT independently confirmed against genuine RPG_RT under
+  # wine, see Scene::SkillMenu::COLUMN_MAX): with only two skills,
   # the second sits beside the first in the same row, reached by RIGHT.
   RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto Teleport
   scene.update
@@ -21143,8 +21226,9 @@ check 'Scene::SkillMenu: cancelling the destination list returns to the skill li
   parent = fake_parent(fake_db)
   state = escape_teleport_state
   scene = RPG2k::Scene::SkillMenu.new(parent, state)
-  # The skill list is a two-column grid (confirmed against EasyRPG's own
-  # Window_Skill, see Scene::SkillMenu::COLUMN_MAX): with only two skills,
+  # The skill list is a two-column grid (ported from EasyRPG Player's own
+  # Window_Skill, NOT independently confirmed against genuine RPG_RT under
+  # wine, see Scene::SkillMenu::COLUMN_MAX): with only two skills,
   # the second sits beside the first in the same row, reached by RIGHT.
   RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto Teleport
   scene.update
@@ -22368,7 +22452,8 @@ class TwoHandedEquipParty < MenuStubParty
   def equip_candidates(_slot, _actor = nil); [[2, 1]]; end
 end
 
-# Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
+# Ported from EasyRPG Player's actual C++ source, NOT independently
+# confirmed against genuine RPG_RT under wine: `Scene_Equip::
 # UpdateStatusWindow` also subtracts the *other* hand's item when either it
 # or the candidate is 両手持ち, since equipping either one forces the
 # opposite slot empty -- the exact side effect `Actor#equip_item` /
@@ -22841,7 +22926,8 @@ check 'harmless ground takes nothing' do
 end
 
 check 'a negative terrain damage heals every tile instead of hurting' do
-  # Confirmed against EasyRPG's actual C++ source: Game_Player::Move applies
+  # Ported from EasyRPG Player's actual C++ source, NOT independently
+  # confirmed against genuine RPG_RT under wine: Game_Player::Move applies
   # `hero->ChangeHp(-terrain->damage, ...)` regardless of sign, so a terrain
   # row with a negative `damage` field (a "recovery floor") heals rather than
   # hurts -- `-(-3) = +3`. Party#apply_terrain_damage's own doc comment is the
@@ -22855,7 +22941,9 @@ check 'a negative terrain damage heals every tile instead of hurting' do
 end
 
 check '地形ダメージ無効 gear does NOT block a healing tile -- only a damaging one' do
-  # EasyRPG's own gate is `terrain->damage < 0 || !hero->PreventsTerrainDamage()`
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its own gate is
+  # `terrain->damage < 0 || !hero->PreventsTerrainDamage()`
   # -- a negative damage value short-circuits the immunity check entirely, so
   # gear that blocks a damage floor does not also block a recovery floor.
   hero = SlipActor.new([], 70)
@@ -22866,8 +22954,10 @@ check '地形ダメージ無効 gear does NOT block a healing tile -- only a dam
 end
 
 check 'a healing tile never flashes the screen, unlike a damaging one' do
-  # EasyRPG's Game_Player::Move only sets `red_flash` for positive `damage`
-  # (`if (terrain->damage > 0) red_flash = true`) -- a heal never flashes.
+  # Ported from EasyRPG Player's source, NOT independently confirmed against
+  # genuine RPG_RT under wine: its Game_Player::Move only sets `red_flash`
+  # for positive `damage` (`if (terrain->damage > 0) red_flash = true`) --
+  # a heal never flashes.
   hero = SlipActor.new([], 70)
   scene = new_scene({}, player: [0, 0], members: [hero], terrain_damage: -3)
   walk(scene, 1)
@@ -22877,10 +22967,11 @@ end
 
 # -- footstep SE (RPG2003 歩行音, ADR 0034 follow-up) --------------------------
 #
-# EasyRPG's Game_Player::Move plays terrain->footstep behind a
-# Player::IsRPG2k3() gate -- RPG2000 never plays it -- and on_damage_se
-# repurposes the same field into a damage-tick-only SE instead of an
-# ordinary per-step one: `!terrain->on_damage_se || red_flash`. See
+# Ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its Game_Player::Move plays terrain->footstep
+# behind a Player::IsRPG2k3() gate -- RPG2000 never plays it -- and
+# on_damage_se repurposes the same field into a damage-tick-only SE instead
+# of an ordinary per-step one: `!terrain->on_damage_se || red_flash`. See
 # #play_terrain_footstep_se's comment (mruby-rpg2k/mrblib/scene/map.rb).
 
 check 'RPG2003 terrain footstep plays every ordinary step onto that tile' do
@@ -22945,8 +23036,10 @@ check 'on_damage_se withholds the footstep on a harmless step, and plays it on a
 end
 
 # Riding the airship skips terrain damage and the footstep SE entirely --
-# EasyRPG's `Game_Player::Move` returns via `InAirship()`'s own early check
-# *before* it ever looks up the stepped-on tile's terrain row, so neither
+# ported from EasyRPG Player's source, NOT independently confirmed against
+# genuine RPG_RT under wine: its `Game_Player::Move` returns via
+# `InAirship()`'s own early check *before* it ever looks up the
+# stepped-on tile's terrain row, so neither
 # fires while airborne. `InAirship()` alone, not a general `boarded?`
 # check: a boat/ship still sails the water layer's own terrain and is not
 # exempted (`check_random_encounter`'s own "riding the airship skips the
@@ -23646,8 +23739,10 @@ end
 # (Game::Battle#enemy_transform_action), but the troop's own Enemy object at
 # the same slot -- the one #total_exp/#total_gold/#drops actually read
 # exp/gold/drop_id/drop_prob from -- is a separate object nothing else keeps
-# in sync. EasyRPG's own Game_Enemy::Transform repoints a single backing
-# data pointer, so reward accessors read the new monster too; this port's
+# in sync. Per EasyRPG Player's own Game_Enemy::Transform (ported from that
+# source, NOT independently confirmed against genuine RPG_RT under wine),
+# it repoints a single backing data pointer, so reward accessors read the
+# new monster too; this port's
 # parallel Combatant/Troop::Enemy split needs an explicit mirror, which
 # #refresh_battle_sprites now performs (#sync_troop_member_rewards) right
 # alongside its existing battler-swap detection.
@@ -23814,8 +23909,10 @@ end
 
 check 'a forced move route does not roll for a random encounter' do
   # A Move Event route driving the player is a forced step (@player_forced_step),
-  # not ordinary input-driven walking -- EasyRPG's UpdateEncounterSteps only
-  # ever runs from the latter (see the comment on @player_forced_step).
+  # not ordinary input-driven walking -- ported from EasyRPG Player's
+  # source, NOT independently confirmed against genuine RPG_RT under wine:
+  # its UpdateEncounterSteps only ever runs from the latter (see the
+  # comment on @player_forced_step).
   ic = Game::Interpreter::Cmd
   tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

Cycle #188 discovered a blind spot no automated grep pattern used so far can catch: a citation where the EasyRPG class/method name and its `src/` file path are split across separate comment lines, so neither single line matches. `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb` were only ever swept by cycle #185's automated (single-line) pass, before this blind spot was known — so they were read in full by hand this cycle.

Method: a scripted pre-pass grouped each file into per-`check`-block sections and flagged any block mentioning "EasyRPG" with no disclaimer phrase anywhere in it, narrowing ~300 EasyRPG mentions per file down to ~90 candidates each; every candidate was then read in its actual source context to separate genuine violations from false positives.

- `rpg2k_logic_check.rb`: **69 fixed** (mostly bare "EasyRPG's `Foo::Bar` does X" stated as fact, plus a few outright "Confirmed/Verified against EasyRPG" framings).
- `rpg2k_scene_check.rb`: **67 fixed**, including one genuine split-line case (`Scene_Battle::EndBattle`, the same shape cycle #188 found in `game.rb`) and two bare filenames with no `src/` prefix (`game_battler.cpp`, `game_battlealgorithm.cpp`) that the file-path grep never had a chance to match.
- `interpreter.rb` was spot-checked — already fully honest, no edits needed.

Both files are now believed genuinely complete under both the grep pattern and a full manual read.

**Left open**: `mruby-rpg2k/mrblib/scene/map.rb` was found to carry at least two undisclosed "corroborated independently against EasyRPG's own C++ source" citations of its own (out of this cycle's scope) — the check-title citing them was fixed, but the root comment was not.

Comment/check-title-only.

## Verification

- Confirmed every changed line in both files is a check-title/descriptive string, never an assertion: `git diff -- scripts/rpg2k_logic_check.rb scripts/rpg2k_scene_check.rb | grep -E "^[+-]" | grep -vE "^(\+\+\+|---)" | grep -vE "^[+-][[:space:]]*#" | grep -vE "^[+-][[:space:]]*$"`.
- `ruby -c` clean on both files.
- Re-ran both check scripts: exact same counts as before (`rpg2k_logic_check.rb` 1163, `rpg2k_scene_check.rb` 929) — confirms no assertions altered.
- `ctest -R mruby_test` passed.
- No `data/` files touched, no wine/Xvfb processes started.
- No upstream drift to reconcile (branch was already at the fresh `origin/master` tip).

## Changelog

None — comment-only, no shipped behavioral change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_