### PR TITLE
Cycle #191: decode LCF save chunks 113/114 as a real interpreter call stack

### DIFF
--- a/changelog.d/event-exec-state-save-chunks.added.md
+++ b/changelog.d/event-exec-state-save-chunks.added.md
@@ -1,0 +1,18 @@
+- LCF save chunks 113 (`SAVE_FOREGROUND_EVENT`) and 114 (`SAVE_COMMON_EVENT`)
+  now decode a genuine interpreter **call-stack snapshot** (liblcf's own
+  `SaveEventExecState`/`SaveEventExecFrame`) instead of an opaque blob, and
+  `Game::State#to_lsd`/`.from_lsd` wire them to `Game::Interpreter`'s real
+  live state: `#call_stack_snapshot`/`#restore_call_stack` capture and
+  restore the full `@call_stack` (every nested Call Event frame, each with
+  its own commands/cursor), a strict superset of the older
+  `#resumable_index`/`#start_at` cursor, which could not survive a save taken
+  mid a nested call. A Common Event Parallel Process now resumes through this
+  richer mechanism first (falling back to the old cursor for an older save),
+  and a map event or Auto-Start common event mid-execution in the shared
+  foreground interpreter — reachable via the event's own Open Save Menu
+  command — now genuinely survives a Save/Continue too, not just within one
+  session. `subcommand_path` (Show Choices branch identity) is a documented,
+  deliberate no-op: this engine's own resume is cursor-based and does not
+  need it. Verified by a from-scratch round trip (schema encode/decode plus a
+  restored interpreter running to completion), not against a genuine
+  wine-saved mid-event `.lsd`. See docs/TODO.md's cycle #191 entry.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14607,6 +14607,105 @@ following this paragraph as the original record.
   pinning that a map event's own parallel process still gets a brand-new
   interpreter, restarting at index 0, on every visit), all confirmed to fail
   against the pre-fix code before the fix.
+- ✅ **Follow-up (cycle #191, 2026-08-27): decoded LCF save chunks 113
+  (`SAVE_FOREGROUND_EVENT`)/114 (`SAVE_COMMON_EVENT`) for real and wired them
+  to a genuine `Game::Interpreter` call-stack snapshot**, closing the gap the
+  previous bullet flagged as a standing follow-up. `LCF::Schema` gained
+  `SAVE_EVENT_EXEC_FRAME`/`SAVE_EVENT_EXEC_STATE` (liblcf's own
+  `SaveEventExecFrame`/`SaveEventExecState`, field ids taken straight off
+  `generator/csv/fields.csv`), and both chunks' field 1 (`execution_state`)
+  changed from an opaque `:int8_array` to `:Array1D, elements:
+  SAVE_EVENT_EXEC_STATE` — a genuine interpreter call stack, not just a
+  resume index: each stack frame carries its OWN full `commands` list
+  (reusing the existing `:event` schema type MAP_EVENT_PAGE already uses, so
+  a Call Event's own called page round-trips its exact bytes rather than a
+  reference to re-resolve), plus `current_command`, `event_id` and
+  `triggered_by_decision_key`.
+
+  `Game::Interpreter` gained `#call_stack_snapshot`/`#restore_call_stack`
+  (interpreter.rb), a strict superset of the older `#resumable_index`/
+  `#start_at` pair the previous bullet added: unlike `#resumable_index`,
+  which returns nil whenever `@call_stack` is non-empty (mid a nested Call
+  Event), `#call_stack_snapshot` captures `@call_stack + [[@list, @index]]`
+  whole, outermost frame first, and stays capturable while `#waiting?` too
+  (a save taken mid a Wait/Show Message/Open Save Menu/etc. — the position
+  is still valid to resume from, only the UI-facing wait itself is not
+  restored, the same scope `#resumable_index` already had).
+
+  `Game::State` gained two attributes wiring this into `#to_lsd`/`.from_lsd`:
+  `#foreground_event_exec` (chunk 113 — whatever event currently occupies
+  `Scene::Map`'s single shared foreground interpreter, snapshotted every
+  frame by the new `Scene::Map#record_foreground_event_exec` and restored
+  once, at Continue time, by the new `#restore_foreground_event_exec`) and
+  `#common_event_exec` (chunk 114 — one snapshot per running Common Event
+  Parallel Process, keyed by common-event id, snapshotted every tick by the
+  extended `#record_parallel_progress` and consumed by `#new_parallel`,
+  which now tries this first and only falls back to the older
+  `#common_event_progress` cursor when this has nothing for a given id).
+  `#common_event_progress` itself is unchanged and still exactly what the
+  portable Marshal save (`#to_h`/`.load`) round-trips — the new mechanism is
+  deliberately `.lsd`-only, so the two save formats keep two
+  different-but-documented fidelity levels rather than silently
+  disagreeing.
+
+  Investigated, and deliberately left as a documented simplification rather
+  than implemented: `subcommand_path` (liblcf's own per-nesting-level "which
+  Show Choice branch was taken" byte array) is always written empty.
+  Reading `#do_show_choices`/`#find_choice_option`/`#choose` confirmed this
+  engine's own resume is purely `current_command`-cursor-based — once a
+  branch is chosen, `@index` already sits inside that branch's own
+  commands, so replaying from there alone reaches the right code with no
+  separate branch-identity lookup needed, unlike genuine RPG_RT's own
+  jump-to-matching-Case mechanism. This is a genuine simplification for this
+  engine's own internal round-trip fidelity (its own Continue), not an
+  attempt at interop with genuine RPG_RT reading our `.lsd` (or the
+  reverse) — a real save captured mid an unanswered Show Choices prompt
+  would need the field decoded to resume identically. Also left
+  schema-only (declared for read-fidelity against a genuine third-party
+  `.lsd`, never written or restored by this engine): `SaveEventExecState`'s
+  `show_message`/`abort_on_escape`/`wait_movement`/the whole keyinput_*
+  cluster/`wait_time`/`wait_key_enter` — only `stack` (the call stack
+  itself, this cycle's actual subject) is genuinely round-tripped. Each
+  frame's own `event_id`/`triggered_by_decision_key` are mirrored from the
+  whole interpreter's single `#event_id`/`#triggered_by_decision_key` on
+  every frame alike, since `#do_call_event` does not track which event a
+  called list's commands originally belonged to — a documented
+  simplification of what this engine can honestly reconstruct, not a claim
+  it matches genuine RPG_RT's own per-frame bookkeeping.
+
+  Verified by a from-scratch round trip, NOT against a genuine wine-saved
+  mid-event `.lsd` (no such fixture — a save taken mid a nested Call Event
+  or a running Parallel Process — was available to compare byte-for-byte):
+  new `scripts/rpg2k_logic_check.rb` checks cover the plain
+  `#call_stack_snapshot`/`#restore_call_stack` interpreter contract (a
+  clean mid-list position, a nested Call Event, the finished/nil case, a
+  nil/empty restore no-op), the schema's own encode/decode round trip
+  through genuine chunk bytes (`Game::State.build_event_exec_state`/
+  `.read_event_exec_frames`, confirming a decoded snapshot's
+  commands/cursor/event_id/flag survive, and that a fresh
+  `Game::Interpreter` restored from it actually finishes correctly, not
+  just decodes as inert data), and the `Game::State#to_lsd`/`.from_lsd`
+  wiring for both chunks together. The existing native
+  `mruby-lcf/test/lcf_test.rb` chunk-113/114 decode test (which pinned the
+  *old* opaque-blob shape) was rewritten to build genuine nested
+  `SAVE_EVENT_EXEC_STATE` bytes instead. All of the full check-suite
+  baselines (`rpg2k_scene_check.rb`=929, `rpg2k_logic_check.rb`=1169 — up
+  from 1163, all new checks — `rpg2k_render_check.rb`=41,
+  `rpg2k3_battle_row_check.rb`=19/0, `rpg2k3_battle_gauge_check.rb`=15/0,
+  `rpg2k_save_load_check.rb`'s 3 known pre-existing failures unchanged) and
+  the `mruby_test` ctest suite stay green.
+
+  Deliberately left open: no genuine wine-saved fixture was captured to
+  confirm the exact byte layout against real RPG_RT (the frame-array
+  numbering in particular — this engine's own 1-based, outer-to-inner
+  convention is not confirmed against a real multi-frame save); a Map
+  Event's own parallel process is still excluded from any of this (matching
+  `#common_event_progress`'s own pre-existing, deliberate "always restarts
+  fresh" scope, which this cycle did not revisit); and the foreground
+  restore path's `@active_event` re-resolution is best-effort (a saved
+  event id whose page conditions have since changed just runs with no map
+  character, the same fallback an ordinary Auto-Start common event already
+  has).
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1693,52 +1693,159 @@ module LCF
       42 => { name: :steps, type: :int },
     }
 
-    # Saved common-event execution state (chunk 114): an Array2D indexed by
-    # common-event id -- 505 entries in a real Nepheshel save. Each entry's
-    # field 1 is that event's interpreter execution state, kept as an opaque blob
-    # (like SAVE_MAP_EVENT's tile replacements) until its grammar is documented.
+    # One stack frame of an interpreter's own call stack (liblcf's
+    # `SaveEventExecFrame`), nested inside SAVE_EVENT_EXEC_STATE's own `stack`
+    # field below. Each frame carries its OWN full `commands` list (0x02,
+    # `Vector<EventCommand>` -- reusing the existing `:event` schema type, the
+    # same one MAP_EVENT_PAGE's own `event_commands` uses, which already
+    # round-trips through `LCF.parse_event_commands`/`encode_event_commands`),
+    # i.e. the exact command page being executed, not just a reference to one
+    # -- a Call Event pushes a frame whose commands come from the called
+    # event, so a nested call round-trips without needing to re-resolve
+    # anything (see `Game::Interpreter#call_stack_snapshot`/
+    # `#restore_call_stack`, mruby-rpg2k/mrblib/interpreter.rb). Field 0x01
+    # (`command_size`) mirrors field 0x02's own encoded byte length exactly,
+    # the same size-field convention `MAP_EVENT_PAGE`'s own
+    # `event_command_size` (field 51) already established -- see that field's
+    # own comment for why a stale length hangs genuine RPG_RT.exe; this
+    # codebase's own writer (`Game::State#to_lsd`) recomputes it the same way.
     #
-    # liblcf's own generator/csv/fields.csv (not yet decoded field-by-field
-    # here) names field 1 (0x01) `parallel_event_execstate`, a
-    # `SaveEventExecState` struct -- NOT a simple resume index like this
-    # codebase's own `Game::State#common_event_progress` (a command-list
-    # cursor per running Common Event). It is a genuine interpreter call-
-    # stack snapshot: `stack` (0x01, `Array<SaveEventExecFrame>`), each frame
-    # carrying its OWN full `commands` list (0x02, `Vector<EventCommand>`,
-    # i.e. the exact command page being executed, not just an id — a Call
-    # Event pushes a frame whose commands come from the called event, so
-    # nested calls round-trip correctly), `current_command` (0x0B, the
-    # index into that frame's own commands), `event_id` (0x0C, 0 for a
-    # common event or one belonging to another map), a
-    # `triggered_by_decision_key` flag (0x0D), and `subcommand_path` (0x15
-    # count / 0x16 data) -- one byte per nesting level, the chosen Show
-    # Choice branch id at that level (255 once taken, per liblcf's own
-    # comment on the field). `SaveEventExecState` itself also carries
-    # `show_message` (0x04), `abort_on_escape` (0x0B), `wait_movement`
-    # (0x0D), a `wait_time` countdown (0x1F), and a whole keyinput_* cluster
-    # (0x15-0x2A) for a live Wait For Key Input / mouse-input pause.
-    # `SaveMapEvent`'s own 0x6C field and `SaveCommonEvent`'s 0x01 both point
-    # at this same struct. Implementing this for real means snapshotting
-    # `Game::Interpreter`'s actual call stack (command list + cursor per
-    # frame, not just the coarser resume-index this codebase tracks today)
-    # -- a genuine feature addition, not a small field fix, so it stays
-    # undecoded here; `Game::State#common_event_progress`'s own comment
-    # tracks this as a standing gap.
-    SAVE_COMMON_EVENT = {
-      1 => { name: :execution_state, type: :int8_array },
+    # `event_id` (0x0C, "0 if it's common event or in other map" per liblcf's
+    # own comment) and `triggered_by_decision_key` (0x0D) are written from
+    # this whole interpreter's own single `#event_id`/
+    # `#triggered_by_decision_key` on every frame alike -- this codebase's own
+    # Call Event (`#do_call_event`) does not track which event a called
+    # list's commands originally belonged to (a "this event" reference
+    # inside a call always resolves to the outermost caller's own id, never
+    # the callee's -- see `#character_ref`'s own comment), so there is no
+    # richer per-frame value to honestly give here than the one id/flag the
+    # whole interpreter already carries. A genuine RPG_RT `.lsd` may carry a
+    # different value per frame; this is a documented simplification of what
+    # this engine can honestly reconstruct from its own live state, not a
+    # claim that every frame's `event_id` matches genuine RPG_RT's own
+    # per-frame bookkeeping.
+    #
+    # `subcommand_path` (0x15 count / 0x16 data, one byte per nesting level --
+    # the chosen Show Choice branch id at that level, 255 once taken, per
+    # liblcf's own comment on the field) is always written empty here. This
+    # engine's own Show Choices (`#do_show_choices`/`#find_choice_option`)
+    # resumes purely off the flat `current_command` cursor: once a branch is
+    # chosen, `@index` already points inside that branch's own commands (see
+    # `#choose`), so replaying from `current_command` alone reaches the right
+    # code with no separate "which Case was taken" lookup needed, unlike
+    # genuine RPG_RT's own jump-to-matching-Case mechanism, which is what
+    # `subcommand_path` exists to drive. Verified by reading (not by a wine
+    # capture) that nothing else in this engine's interpreter ever consults a
+    # branch identity beyond command position. This is a genuine, deliberate
+    # simplification for this engine's own internal round-trip fidelity (its
+    # own Continue), not an attempt at full interop with genuine RPG_RT.exe
+    # reading our `.lsd` files (or the reverse) -- a real save captured mid a
+    # Show Choices prompt would need this field decoded to resume the exact
+    # same way genuine RPG_RT would.
+    SAVE_EVENT_EXEC_FRAME = {
+      1  => { name: :command_size, type: :int, default: 0 },
+      2  => { name: :commands, type: :event, default: [] },
+      11 => { name: :current_command, type: :int, default: 0 },
+      12 => { name: :event_id, type: :int, default: 0 },
+      13 => { name: :triggered_by_decision_key, type: :bool, default: false },
+      21 => { name: :subcommand_path_size, type: :int, default: 0 },
+      22 => { name: :subcommand_path, type: :int8_array, default: [] },
     }
 
-    # Foreground (map / parallel) event interpreter state (chunk 113): the event
-    # that was mid-execution when the game was saved. A save taken from an
-    # on-screen choice keeps that choice's option strings inside this blob, which
-    # is how the section was identified; its inner grammar is left opaque for now.
+    # An interpreter's full execution state (liblcf's `SaveEventExecState`):
+    # `stack` (0x01, `Array<SaveEventExecFrame>` -- see SAVE_EVENT_EXEC_FRAME
+    # just above) is the genuine call stack, outermost frame first, matching
+    # `Game::Interpreter#call_stack_snapshot`'s own `@call_stack + [[@list,
+    # @index]]` order (this codebase's own writer/reader convention for the
+    # frame's own array index within `stack`, 1-based ascending outer to
+    # inner -- not confirmed against a genuine multi-frame capture, since none
+    # was available; only that a single-frame `stack` round-trips against
+    # this codebase's own reading of the field table). `SaveMapEvent`'s own
+    # 0x6C field and `SaveCommonEvent`'s own field 1 both point at this same
+    # struct (`generator/csv/fields.csv`'s `Save.foreground_event_execstate`
+    # field, 0x71 at the top-level Save struct, is the same struct again).
     #
-    # Same `SaveEventExecState` struct as SAVE_COMMON_EVENT's own field 1 --
-    # see that table's own comment for liblcf's full field breakdown
-    # (`generator/csv/fields.csv`'s `Save.foreground_event_execstate` field,
-    # 0x71 at the top-level Save struct).
+    # Everything below `stack` -- `show_message`, `abort_on_escape`,
+    # `wait_movement`, the whole keyinput_* cluster, `wait_time`, and
+    # `wait_key_enter` -- is declared here for read-fidelity (so a genuine
+    # third-party `.lsd` carrying them decodes cleanly instead of raising on
+    # an unknown field), but is schema-only: this engine's own writer
+    # (`Game::State#to_lsd`) never populates them (they are always absent,
+    # reading back at their liblcf defaults below), and its own reader never
+    # feeds them into any live interpreter wait state. Only `stack` is
+    # genuinely round-tripped end to end. See `Game::Interpreter
+    # #call_stack_snapshot`'s own comment for exactly what capturing "mid a
+    # blocking wait" (Show Message/Choices/Key Input/etc.) does and does not
+    # preserve today -- the call-stack position survives, the UI-facing wait
+    # itself does not.
+    SAVE_EVENT_EXEC_STATE = {
+      1  => { name: :stack, type: :Array2D, elements: SAVE_EVENT_EXEC_FRAME },
+      4  => { name: :show_message, type: :bool, default: false },
+      11 => { name: :abort_on_escape, type: :bool, default: false },
+      13 => { name: :wait_movement, type: :bool, default: false },
+      21 => { name: :keyinput_wait, type: :bool, default: false },
+      22 => { name: :keyinput_variable, type: :uint8, default: 0 },
+      23 => { name: :keyinput_all_directions, type: :bool, default: false },
+      24 => { name: :keyinput_decision, type: :int, default: 0 },
+      25 => { name: :keyinput_cancel, type: :int, default: 0 },
+      26 => { name: :keyinput_2kshift_2k3numbers, type: :int, default: 0 },
+      27 => { name: :keyinput_2kdown_2k3operators, type: :int, default: 0 },
+      28 => { name: :keyinput_2kleft_2k3shift, type: :int, default: 0 },
+      29 => { name: :keyinput_2kright, type: :int, default: 0 },
+      30 => { name: :keyinput_2kup, type: :int, default: 0 },
+      31 => { name: :wait_time, type: :int, default: 0 },
+      32 => { name: :keyinput_time_variable, type: :int, default: 0 },
+      35 => { name: :keyinput_2k3down, type: :int, default: 0 },
+      36 => { name: :keyinput_2k3left, type: :int, default: 0 },
+      37 => { name: :keyinput_2k3right, type: :int, default: 0 },
+      38 => { name: :keyinput_2k3up, type: :int, default: 0 },
+      41 => { name: :keyinput_timed, type: :bool, default: false },
+      42 => { name: :wait_key_enter, type: :bool, default: false },
+    }
+
+    # Saved common-event execution state (chunk 114): an Array2D indexed by
+    # common-event id -- 505 entries in a real Nepheshel save (this codebase's
+    # own writer only ever writes entries for a Common Event actually running
+    # a Parallel Process at save time -- see `Game::State#common_event_exec`'s
+    # own comment for why the full 505-entry shape is not reproduced). Each
+    # entry's field 1 is that common event's own SAVE_EVENT_EXEC_STATE --
+    # NOT a simple resume index like this codebase's own, older
+    # `Game::State#common_event_progress` (a command-list cursor per running
+    # Common Event, still used as the `.lsd`-absent/Marshal-only fallback --
+    # see that attribute's own comment). Cycle #191 wires this field to a
+    # genuine `Game::Interpreter` call-stack snapshot end to end (schema
+    # decode plus `Game::State#to_lsd`/`.from_lsd` plus
+    # `Scene::Map#new_parallel`/`#record_parallel_progress`); verified by a
+    # from-scratch round trip (encode a captured snapshot, decode it back,
+    # confirm a fresh interpreter resumes and finishes identically -- see
+    # `scripts/rpg2k_logic_check.rb`), not against a genuine wine-saved
+    # mid-Parallel-Process `.lsd`, since none was available to compare
+    # byte-for-byte against.
+    SAVE_COMMON_EVENT = {
+      1 => { name: :execution_state, type: :Array1D, elements: SAVE_EVENT_EXEC_STATE },
+    }
+
+    # Foreground (map / parallel) event interpreter state (chunk 113): the
+    # event that was mid-execution when the game was saved. A save taken from
+    # an on-screen choice keeps that choice's option strings inside this
+    # blob, which is how the section was identified. Same
+    # `SaveEventExecState` struct as SAVE_COMMON_EVENT's own field 1 above --
+    # see that table's own comment for liblcf's full field breakdown and this
+    # cycle's own verification method.
+    #
+    # "Foreground" is this codebase's own single shared interpreter
+    # (`Scene::Map#@interpreter`), which runs either a map event (trigger 0
+    # action key / 1 touch / Auto-Start) or an Auto-Start Common Event --
+    # both share the one interpreter, matching real RPG_RT's own single
+    # foreground slot. The ordinary player-driven Save menu can only ever
+    # open between events (`Scene::Map#try_open_menu` bails out whenever
+    # `#event_busy?`), so the one reachable way a genuine save actually
+    # captures this chunk with something in it is an event's own Open Save
+    # Menu command (`Cmd::OPEN_SAVE_MENU`, 11910), which parks the
+    # interpreter on a `:save_menu` wait rather than stopping it -- see
+    # `Game::State#foreground_event_exec`'s own comment.
     SAVE_FOREGROUND_EVENT = {
-      1 => { name: :execution_state, type: :int8_array },
+      1 => { name: :execution_state, type: :Array1D, elements: SAVE_EVENT_EXEC_STATE },
     }
 
     SAVE_SYSTEM = {

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -521,11 +521,24 @@ assert "LCF::SaveData decodes the inventory, common-event and foreground-event c
                            lcf_field(13, "\x03\x01"),
                            lcf_field(14, "\x00\x00"),
                            lcf_int_field(21, 100)])
-  # Common-event state (chunk 114): Array2D indexed by common-event id, each an
-  # opaque per-event execution-state blob.
-  common = lcf_array2d([[1, lcf_array1d([lcf_field(1, "\x01\x01\x00\x00")])]])
-  # Foreground event (chunk 113): the running event's opaque exec-state blob.
-  foreground = lcf_array1d([lcf_field(1, "\xab\xcd")])
+  # Common-event state (chunk 114) and foreground event (chunk 113, cycle
+  # #191): each is a SAVE_EVENT_EXEC_STATE (field 1: `stack`, an Array2D of
+  # SAVE_EVENT_EXEC_FRAME -- see mruby-lcf/mrblib/schema.rb's own comment on
+  # these two tables), no longer an opaque blob. One single-frame stack per
+  # chunk here, with an empty `commands` list (field 2, the `:event` type,
+  # already covered end-to-end by the "decodes an event command list" test
+  # elsewhere in this file) -- current_command/event_id/
+  # triggered_by_decision_key are the fields this test is actually pinning.
+  ce_frame = lcf_array1d([lcf_int_field(1, 0), lcf_field(2, ''),
+                          lcf_int_field(11, 3), lcf_int_field(12, 7),
+                          lcf_field(13, "\x01")])
+  ce_state = lcf_array1d([lcf_field(1, lcf_array2d([[1, ce_frame]]))])
+  common = lcf_array2d([[1, lcf_array1d([lcf_field(1, ce_state)])]])
+  fg_frame = lcf_array1d([lcf_int_field(1, 0), lcf_field(2, ''),
+                          lcf_int_field(11, 5), lcf_int_field(12, 0),
+                          lcf_field(13, "\x00")])
+  fg_state = lcf_array1d([lcf_field(1, lcf_array2d([[1, fg_frame]]))])
+  foreground = lcf_array1d([lcf_field(1, fg_state)])
   body = lcf_array1d([lcf_field(109, inventory),
                       lcf_field(113, foreground),
                       lcf_field(114, common)])
@@ -535,8 +548,18 @@ assert "LCF::SaveData decodes the inventory, common-event and foreground-event c
   assert_equal [1, 451], save.inventory.item_ids
   assert_equal [3, 1], save.inventory.item_counts
   assert_equal 100, save.inventory.gold
-  assert_equal [0x01, 0x01, 0x00, 0x00], save.common_events[1].execution_state
-  assert_equal [0xab, 0xcd], save.foreground_event.execution_state
+
+  ce = save.common_events[1].execution_state.stack[1]
+  assert_equal [], ce.commands
+  assert_equal 3, ce.current_command
+  assert_equal 7, ce.event_id
+  assert_equal true, ce.triggered_by_decision_key
+
+  fg = save.foreground_event.execution_state.stack[1]
+  assert_equal [], fg.commands
+  assert_equal 5, fg.current_command
+  assert_equal 0, fg.event_id
+  assert_equal false, fg.triggered_by_decision_key
 end
 
 assert "LCF::SaveData decodes per-actor level/exp/skills/HP/MP (chunk 108)" do

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14885,9 +14885,74 @@ module Game
     # all: Scene::Map#build_parallels keeps the live Game::Interpreter object
     # across it, which preserves full fidelity (call stack, in-flight wait
     # timer, everything), not just this coarser checkpoint. Persisted in the
-    # portable Marshal save; not yet in `.lsd` (chunks 113/114 are still
-    # opaque, see LCF::Schema::SAVE_FOREGROUND_EVENT / SAVE_COMMON_EVENT).
+    # portable Marshal save (#to_h/.load); not persisted through `.lsd` at
+    # all any more as of cycle #191 -- #common_event_exec below is the richer
+    # mechanism that now backs chunk 114, and #new_parallel only ever falls
+    # back to this cursor when that has nothing for a given common event id
+    # (an older save, or one written by a build that predates cycle #191).
+    # Kept, rather than replaced outright, because it is still exactly what
+    # the portable Marshal save round-trips -- see #common_event_exec's own
+    # comment for why that path was deliberately left alone.
     attr_accessor :common_event_progress
+    # Full `Game::Interpreter` call-stack snapshot (see
+    # Game::Interpreter#call_stack_snapshot) of whichever event currently
+    # occupies the single shared foreground interpreter (Scene::Map's own
+    # @interpreter) -- a map event (trigger 0 action key / 1 touch /
+    # Auto-Start) or an Auto-Start Common Event, both of which run on that
+    # one shared interpreter (see Scene::Map#start_autostart). A Hash
+    # `{ event_id:, frames: }` (`frames` is #call_stack_snapshot's own return
+    # value; `event_id` is the map event id it belongs to, or 0 for a common
+    # event / no map character) when there is something mid-execution there,
+    # nil otherwise -- true the overwhelming majority of the time a save
+    # actually happens: an ordinary player-driven Save can only ever open
+    # between events (Scene::Map#try_open_menu bails out on #event_busy?),
+    # so the one reachable way to reach a non-nil value here is an event's
+    # own Open Save Menu command (Cmd::OPEN_SAVE_MENU, 11910), which parks
+    # the interpreter on a :save_menu wait rather than stopping it. Restoring
+    # the wait itself (so the save menu would reopen the instant Continue
+    # resumes) is deliberately out of scope, same as every other blocking-UI
+    # wait #call_stack_snapshot's own comment already excludes -- the event
+    # simply carries on with its very next command once resumed, which for
+    # a completed Open Save Menu is exactly right (the menu already served
+    # its purpose: writing this very save).
+    #
+    # Snapshotted every frame by Scene::Map#record_foreground_event_exec;
+    # consumed once, at Continue time, by Scene::Map#initialize via
+    # Scene::Map#restore_foreground_event_exec (Game::Interpreter
+    # #restore_call_stack). Not persisted through the portable Marshal save
+    # (#to_h/.load) -- see #common_event_exec's own comment for why. Round-
+    # trips through a real `.lsd`'s chunk 113 (LCF::Schema::
+    # SAVE_FOREGROUND_EVENT), as of cycle #191.
+    attr_accessor :foreground_event_exec
+    # Full `Game::Interpreter` call-stack snapshots of every currently-
+    # running Common Event Parallel Process (Scene::Map's own @parallels,
+    # the `common_event_id`-non-nil entries only -- a Map Event's own
+    # parallel process is excluded, matching #common_event_progress's
+    # identical scope and its own "always restarts fresh" reasoning): common
+    # event id => Game::Interpreter#call_stack_snapshot's own return value.
+    #
+    # Snapshotted every tick by Scene::Map#record_parallel_progress
+    # (superseding #common_event_progress for anything that has ever
+    # actually run one full tick: unlike #resumable_index,
+    # #call_stack_snapshot also captures a process mid a nested Call Event,
+    # not only a clean between-commands cursor), consumed by
+    # Scene::Map#new_parallel via Game::Interpreter#restore_call_stack,
+    # falling back to #common_event_progress only when this hash has
+    # nothing for a given id.
+    #
+    # Kept as a *separate* hash rather than folded into
+    # #common_event_progress since the two round-trip through different save
+    # formats by design: this one is `.lsd`-only (chunk 114, LCF::Schema::
+    # SAVE_COMMON_EVENT), deliberately never added to the portable Marshal
+    # save (#to_h/.load) -- that path already has full fidelity for free
+    # within one process (a Transfer Player keeps the live
+    # Game::Interpreter objects themselves, per #common_event_progress's own
+    # comment above) and gets by with the coarser cursor otherwise, exactly
+    # as it always has; Marshal-dumping a whole command-list snapshot (an
+    # Array of LCF::EventCommand objects) every tick, for every running
+    # Parallel Process, is unnecessary weight that path's own callers (dev
+    # tooling, this test suite's own round-trip checks) have no need for.
+    attr_accessor :common_event_exec
     # The current map's own live event positions, event id => [x, y, direction],
     # snapshotted every frame by Scene::Map#record_map_event_positions. Real
     # RPG_RT's SaveMapEvent chunk carries exactly this (plus a move-route index,
@@ -14975,6 +15040,8 @@ module Game
       @teleport_targets = {}
       @escape_target = nil
       @common_event_progress = {}
+      @foreground_event_exec = nil
+      @common_event_exec = {}
       @map_event_positions = {}
       @map_event_route_index = {}
       @tile_substitutions = [{}, {}]
@@ -16051,6 +16118,37 @@ module Game
         save[111] = mapev
       end
 
+      # Chunk 113 (SAVE_FOREGROUND_EVENT): the shared foreground
+      # interpreter's own live call stack, when something is actually
+      # mid-execution there at save time -- see #foreground_event_exec's own
+      # comment for when that is genuinely reachable. Absent otherwise,
+      # matching every other "nothing to restore" chunk in this method.
+      if @foreground_event_exec && @foreground_event_exec[:frames]
+        fg = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_FOREGROUND_EVENT })
+        fg[1] = self.class.build_event_exec_state(@foreground_event_exec[:frames])
+        save[113] = fg
+      end
+
+      # Chunk 114 (SAVE_COMMON_EVENT): one entry per currently-running Common
+      # Event Parallel Process -- see #common_event_exec's own comment. A
+      # genuine RPG_RT save writes one entry per common event *in the
+      # database* (505 of them on a real Nepheshel capture, see
+      # LCF::Schema::SAVE_COMMON_EVENT's own comment); this only ever writes
+      # the ones this engine actually has live state for, since nothing here
+      # ever reads the rest back and this method has no reliable way to
+      # enumerate "every common event id in the database" without a `db`
+      # argument it is not always given.
+      running_common = @common_event_exec.select { |_, frames| frames && !frames.empty? }
+      unless running_common.empty?
+        ce = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_COMMON_EVENT })
+        running_common.each do |id, frames|
+          entry = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_COMMON_EVENT })
+          entry[1] = self.class.build_event_exec_state(frames)
+          ce[id] = entry
+        end
+        save[114] = ce
+      end
+
       save
     end
 
@@ -16076,6 +16174,58 @@ module Game
       h = {}
       bytes.each_with_index { |v, i| h[i] = v if v != i }
       h
+    end
+
+    # Build a SAVE_EVENT_EXEC_STATE chunk (an LCF::Array1D) from a
+    # Game::Interpreter#call_stack_snapshot-shaped `frames` array -- shared by
+    # #to_lsd's chunk 113 and 114 writers above (class methods, not instance,
+    # for the same reason .tile_replacement_bytes/_hash are just above: both
+    # #to_lsd and .from_lsd need to reach them). `stack`'s own array ids are
+    # 1-based, ascending outer to inner -- see SAVE_EVENT_EXEC_STATE's own
+    # schema.rb comment on why that particular numbering, not a confirmed
+    # genuine-file convention (nothing to check it against was available).
+    def self.build_event_exec_state(frames)
+      state = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_EVENT_EXEC_STATE })
+      stack = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_EVENT_EXEC_FRAME })
+      frames.each_with_index do |f, i|
+        frame = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_EVENT_EXEC_FRAME })
+        cmds = f[:commands] || []
+        # Mirrors field 2's own encoded byte length exactly, the same
+        # size-field convention MAP_EVENT_PAGE's own event_command_size
+        # (field 51) already established -- see that field's own comment.
+        frame[1] = LCF.encode_event_commands(cmds).bytesize
+        frame[2] = cmds
+        frame[11] = f[:current_command] || 0
+        frame[12] = f[:event_id] || 0
+        frame[13] = !!f[:triggered_by_decision_key]
+        stack[i + 1] = frame
+      end
+      state[1] = stack
+      state
+    end
+
+    # The inverse of .build_event_exec_state: decode a SAVE_EVENT_EXEC_STATE
+    # Array1D (chunk 113/114's own field 1) back into a
+    # Game::Interpreter#call_stack_snapshot-shaped frames array, outermost
+    # frame first (`stack`'s own #each already yields ascending by array id,
+    # which .build_event_exec_state always writes in that same
+    # outer-to-inner order). nil for an absent chunk, or one whose own stack
+    # is absent or empty -- both mean "nothing to restore" to
+    # Scene::Map#restore_foreground_event_exec/#new_parallel alike.
+    def self.read_event_exec_frames(exec_state)
+      return nil unless exec_state
+      stack = exec_state.stack
+      return nil unless stack
+      frames = []
+      stack.each do |_, frame|
+        frames << {
+          commands: frame.commands || [],
+          current_command: frame.current_command || 0,
+          event_id: frame.event_id || 0,
+          triggered_by_decision_key: !!frame.triggered_by_decision_key,
+        }
+      end
+      frames.empty? ? nil : frames
     end
 
     # Build a BGM chunk (an LCF::Array1D over the BGM schema) from our stored
@@ -16542,6 +16692,30 @@ module Game
                            sx: map_events.parallax_horz_speed,
                            auto_y: !!map_events.parallax_vert_auto,
                            sy: map_events.parallax_vert_speed)
+      end
+      # Chunk 113 (SAVE_FOREGROUND_EVENT): whatever event was mid-execution
+      # in the shared foreground interpreter at save time -- see
+      # #foreground_event_exec's own comment for when a genuine save
+      # actually carries one. Absent on the overwhelming majority of saves
+      # (nothing to restore, matching every save taken between events), and
+      # on any save written before cycle #191. Consumed once, at Continue
+      # time, by Scene::Map#restore_foreground_event_exec -- this method
+      # itself only decodes the chunk onto Game::State, it does not touch a
+      # live interpreter (there is none to touch here).
+      fg_state = save[113] && save[113].execution_state
+      fg_frames = read_event_exec_frames(fg_state)
+      state.foreground_event_exec = fg_frames && { event_id: fg_frames.first[:event_id], frames: fg_frames }
+      # Chunk 114 (SAVE_COMMON_EVENT): one entry per currently-running Common
+      # Event Parallel Process -- see #common_event_exec's own comment.
+      # Absent, or missing individual ids, on a save written before cycle
+      # #191; Scene::Map#new_parallel falls back to #common_event_progress
+      # (or a fresh #start) for any id this does not cover.
+      common_events = save[114]
+      if common_events
+        common_events.each do |id, entry|
+          frames = read_event_exec_frames(entry.execution_state)
+          state.common_event_exec[id] = frames if frames
+        end
       end
       state
     end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -659,6 +659,88 @@ module Game
       { index: @index, size: @list.size, call_depth: @call_stack.size }
     end
 
+    # Full call-stack snapshot, suitable for a genuine `.lsd`'s
+    # SaveEventExecState/SaveEventExecFrame (LCF::Schema::
+    # SAVE_EVENT_EXEC_STATE/_FRAME, mruby-lcf/mrblib/schema.rb) -- unlike
+    # #resumable_index (a single command-list cursor, only capturable with
+    # @call_stack empty), this captures every frame Call Event has pushed,
+    # outermost first, plus the innermost currently-executing one, so a save
+    # taken mid a nested Call Event resumes at the exact right command in the
+    # exact right list once restored via #restore_call_stack. It also stays
+    # capturable while #waiting? (parked on a Show Message/Wait/Open Save
+    # Menu/etc. request): @waiting only stops execution from *advancing*
+    # further, it does not make @call_stack/@list/@index any less valid a
+    # position to resume at than #resumable_index already treats a clean
+    # between-commands pause -- @index always sits just past the command
+    # that raised the wait either way (see #resumable_index's own comment).
+    #
+    # Each returned frame is a Hash: `commands` (the frame's own command
+    # list, an Array of LCF::EventCommand-alikes -- exactly what
+    # LCF.encode_event_commands/#restore_call_stack both expect),
+    # `current_command` (the cursor into it), `event_id` and
+    # `triggered_by_decision_key`, both mirrored from this whole
+    # interpreter's own #event_id/#triggered_by_decision_key rather than
+    # tracked per frame -- #do_call_event does not record which event a
+    # called list's commands originally belonged to (a "this event"
+    # reference always resolves through the outermost caller's own id, see
+    # #character_ref), so there is no richer per-frame value available to
+    # give honestly. Only the outermost frame's own `triggered_by_decision_key`
+    # can genuinely be true: a Call Event's own nested frame was never itself
+    # started by the action key, whatever launched the outer event.
+    #
+    # Returns nil for an interpreter with nothing to capture (never started,
+    # or already finished) -- the overwhelming common case a save actually
+    # happens in, matching real RPG_RT (see SAVE_FOREGROUND_EVENT/
+    # SAVE_COMMON_EVENT's own schema.rb comments for when it is not).
+    def call_stack_snapshot
+      return nil unless @running
+      frames = @call_stack + [[@list, @index]]
+      frames.each_with_index.map do |(list, index), i|
+        {
+          commands: list,
+          current_command: index,
+          event_id: @event_id || 0,
+          triggered_by_decision_key: i.zero? && !!@triggered_by_decision_key,
+        }
+      end
+    end
+
+    # Restore a previously #call_stack_snapshot-captured stack (or the
+    # equivalent decoded fresh off a genuine `.lsd`'s SAVE_EVENT_EXEC_STATE),
+    # replacing whatever this interpreter was running. Rebuilds
+    # @call_stack/@list/@index exactly, outermost frame first (matching
+    # #call_stack_snapshot's own order), restores the outermost frame's own
+    # #event_id/#triggered_by_decision_key (0/false read back as "nothing to
+    # restore", the same as a fresh interpreter already starts with), and
+    # marks the interpreter running again via #start -- which also resets
+    # every other per-run flag (@waiting included) a fresh #start already
+    # resets, since nothing here attempts to restore a mid-wait UI request
+    # (a Show Message/Choices window, a Key Input prompt, ...), only the
+    # command-list position underneath it -- see #call_stack_snapshot's own
+    # comment on that same scope limit, which #resumable_index/#start_at
+    # already share.
+    #
+    # The caller still owns #resolver/#map_info the same way #start's own
+    # callers already do (Scene::Map's #start_autostart/#new_parallel/the
+    # decision-key trigger path) -- this only rebuilds the execution
+    # position, not the surrounding wiring a fresh interpreter also needs.
+    #
+    # A blank/nil `frames` is a no-op, leaving the interpreter exactly as it
+    # was (unstarted, most likely) -- there is nothing here to fall back to
+    # instead, so the caller is expected to check first, same as every
+    # existing #resumable_index/#start_at call site already does.
+    def restore_call_stack(frames)
+      return if frames.nil? || frames.empty?
+      innermost = frames.last
+      start(innermost[:commands] || [])
+      idx = innermost[:current_command]
+      @index = idx if idx && idx >= 0 && idx <= @list.size
+      @call_stack = frames[0...-1].map { |f| [f[:commands] || [], f[:current_command] || 0] }
+      outer = frames.first
+      @event_id = outer[:event_id] if outer[:event_id] && outer[:event_id] != 0
+      @triggered_by_decision_key = !!outer[:triggered_by_decision_key]
+    end
+
     # Start (or restart) at a previously #resumable_index-captured position
     # instead of the top of the list. `commands` must be the same command list
     # (or an equivalent rebuild of it, e.g. the same common event reloaded from

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -406,6 +406,15 @@ class RPG2k
         # a Move Event targeting "this event" can be resolved. nil for common
         # events (which have no map character).
         @active_event = nil
+        # Resume whatever event was mid-execution in the shared foreground
+        # interpreter at save time, if the state we were built from carries
+        # one -- see #restore_foreground_event_exec's own comment. Placed
+        # here, after @active_event's own plain-nil init just above (which
+        # would otherwise wipe out a restore run any earlier) and after
+        # #build_events/#build_resolver already ran, but before anything
+        # else in this method or its caller gets a chance to start a
+        # *different* event on the one shared interpreter.
+        restore_foreground_event_exec
         # A forced move route applied to the player by a Move Event, with its own
         # character mirror and step timer; nil when the player moves by input.
         @player_route = nil
@@ -668,6 +677,7 @@ class RPG2k
           end
         end
         record_map_event_positions
+        record_foreground_event_exec
         record_tile_substitutions
         RGSS::Profiler.section("map.animate_events") { animate_events }
         RGSS::Profiler.section("map.render") { render }
@@ -1491,6 +1501,49 @@ class RPG2k
         end
       end
 
+      # Snapshot the shared foreground @interpreter's own live call stack onto
+      # Game::State every frame -- see Game::State#foreground_event_exec's
+      # own comment for exactly when this is non-nil (in practice: only
+      # while an event's own Open Save Menu command has it parked on a
+      # :save_menu wait, since the ordinary player-driven Save menu can only
+      # ever open between events). Cleared back to nil the instant nothing is
+      # mid-execution there, so a save taken between events -- the
+      # overwhelming majority of the time -- carries no stale chunk 113 at
+      # all when #to_lsd runs, matching genuine RPG_RT.
+      def record_foreground_event_exec
+        frames = @interpreter.call_stack_snapshot
+        @state.foreground_event_exec =
+          frames && { event_id: @active_event ? @active_event[:id] : 0, frames: frames }
+      end
+
+      # Resume whatever event was mid-execution in the shared foreground
+      # interpreter at save time (Game::State#foreground_event_exec, decoded
+      # from a real .lsd's chunk 113 by Game::State.from_lsd, or carried over
+      # from #record_foreground_event_exec's own last snapshot when this
+      # Scene::Map was instead built straight from a live State without going
+      # through .lsd at all). A no-op the overwhelming majority of the time
+      # (see #record_foreground_event_exec's own comment on when this is ever
+      # non-nil). Called once, from #initialize, before anything else gets a
+      # chance to start a *different* event on the one shared interpreter.
+      #
+      # A saved event id that no longer resolves to a live map event here
+      # (its page's own conditions changed since, e.g. a switch flipped
+      # elsewhere, or it belonged to a common event Auto-Start, id 0) still
+      # resumes the raw command list -- each frame carries its own full
+      # commands, not just a reference to a page -- it just has no map
+      # character to answer a "this event" reference with, same as an
+      # ordinary Auto-Start common event running on this same shared
+      # interpreter today (#start_autostart's own `@active_event = nil`).
+      def restore_foreground_event_exec
+        saved = @state.foreground_event_exec
+        frames = saved && saved[:frames]
+        return unless frames && !frames.empty?
+        @interpreter.restore_call_stack(frames)
+        return unless @interpreter.running?
+        ev_id = saved[:event_id]
+        @active_event = (ev_id && ev_id != 0) ? @events.find { |e| e[:id] == ev_id } : nil
+      end
+
       # Snapshot the current map's live Tile Substitution table onto
       # Game::State every frame, the same "survives a Save/Continue on this
       # map, resets on an ordinary re-visit" pattern #record_map_event_positions
@@ -1877,15 +1930,28 @@ class RPG2k
       # `common_event_id` is that common event's own id, nil for a map event --
       # it keys both the teleport-time reuse in #build_parallels above and the
       # save-file continuation this seeds from below.
+      #
+      # Genuine full-fidelity continuation (Game::State#common_event_exec,
+      # driven from a real .lsd's chunk 114 -- see that attribute's own
+      # comment) is tried first: unlike the older #common_event_progress
+      # cursor, it also covers a process saved mid a nested Call Event.
+      # #common_event_progress only ever gets a look-in when this has
+      # nothing for the id (an older save, or one written before cycle
+      # #191).
       def new_parallel(commands, gate_switch, event, common_event_id)
         it = Game::Interpreter.new(@state)
         it.resolver = @interpreter.resolver
         it.map_info = self
-        resume_at = common_event_id && @state.common_event_progress[common_event_id]
-        if resume_at
-          it.start_at(commands, resume_at)
+        saved_frames = common_event_id && @state.common_event_exec[common_event_id]
+        if saved_frames && !saved_frames.empty?
+          it.restore_call_stack(saved_frames)
         else
-          it.start(commands)
+          resume_at = common_event_id && @state.common_event_progress[common_event_id]
+          if resume_at
+            it.start_at(commands, resume_at)
+          else
+            it.start(commands)
+          end
         end
         it.event_id = event && event[:id]
         { interp: it, commands: commands, gate_switch: gate_switch,
@@ -2024,17 +2090,29 @@ class RPG2k
       # Snapshot a Common Event Parallel Process's current position onto
       # Game::State, so a fresh Scene::Map built later from this state (a
       # genuine save/load, not a Transfer Player -- see #build_parallels) can
-      # resume it instead of restarting at the top. Only overwrites the stored
-      # checkpoint when the interpreter's position is cleanly capturable right
-      # now (see Game::Interpreter#resumable_index); a tick that returns nil
-      # (mid a nested Call Event) simply leaves the last known-good checkpoint
-      # in place rather than clearing it. A no-op for a map event's own
-      # parallel process (p[:common_event_id] is nil there), which never gets a
-      # checkpoint at all -- it always restarts fresh, unchanged.
+      # resume it instead of restarting at the top. A no-op for a map event's
+      # own parallel process (p[:common_event_id] is nil there), which never
+      # gets a checkpoint at all -- it always restarts fresh, unchanged.
+      #
+      # Records two things, cycle #191 having added the second on top of the
+      # pre-existing first:
+      #   - Game::State#common_event_progress (Game::Interpreter
+      #     #resumable_index): only overwrites the stored checkpoint when the
+      #     interpreter's position is cleanly capturable right now; a tick
+      #     that returns nil (mid a nested Call Event) simply leaves the last
+      #     known-good checkpoint in place rather than clearing it. Still the
+      #     only mechanism the portable Marshal save (#to_h/.load) carries.
+      #   - Game::State#common_event_exec (Game::Interpreter
+      #     #call_stack_snapshot): the fuller call-stack snapshot a real
+      #     `.lsd`'s chunk 114 now backs, captured whenever the interpreter is
+      #     running at all -- including mid a nested Call Event, unlike
+      #     #resumable_index above.
       def record_parallel_progress(p)
         return unless p[:common_event_id]
         idx = p[:interp].resumable_index
         @state.common_event_progress[p[:common_event_id]] = idx if idx
+        frames = p[:interp].call_stack_snapshot
+        @state.common_event_exec[p[:common_event_id]] = frames if frames
       end
 
       def drive_parallel_wait(p, it)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1927,6 +1927,147 @@ check '#start_at falls back to the top for an out-of-range index' do
   eq true, st.switches[1], 'an out-of-range index is ignored, same as a fresh #start'
 end
 
+# Cycle #191: #call_stack_snapshot/#restore_call_stack back the richer
+# LCF::Schema::SAVE_EVENT_EXEC_STATE/_FRAME `.lsd` continuation (chunks
+# 113/114, wired through Game::State#foreground_event_exec/
+# #common_event_exec -- see scripts/rpg2k_scene_check.rb for the end-to-end
+# version through an actual map/save round trip once one exists). These pin
+# the plain interpreter-level contract in isolation, the same way the
+# #resumable_index/#start_at checks just above pin the older, coarser one.
+check '#call_stack_snapshot captures a clean mid-list position; #restore_call_stack resumes there' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  commands = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0]),
+              FakeCmd.new(IC::WAIT, [1]),
+              FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0])]
+  ok it.call_stack_snapshot.nil?, 'nothing captured before the process even starts'
+  it.start(commands)
+  it.event_id = 7
+  it.triggered_by_decision_key = true
+  it.update # switch 1 on, then parks at the Wait
+  eq true, st.switches[1]
+
+  frames = it.call_stack_snapshot
+  eq 1, frames.size, 'a single frame -- no Call Event pushed anything'
+  eq 2, frames[0][:current_command], 'parked right after the Wait, at the next command'
+  eq 7, frames[0][:event_id]
+  eq true, frames[0][:triggered_by_decision_key]
+
+  it2 = Game::Interpreter.new(new_state)
+  it2.restore_call_stack(frames)
+  st2 = it2.instance_variable_get(:@state)
+  eq 7, it2.event_id, 'event_id restored from the outermost (only) frame'
+  eq true, it2.triggered_by_decision_key
+  it2.update
+  eq false, st2.switches[1], '#restore_call_stack does not replay commands before the captured index'
+  eq true, st2.switches[2], 'it resumes exactly at the captured index'
+end
+
+check '#call_stack_snapshot captures a process mid a nested Call Event too, unlike #resumable_index' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0]),
+            FakeCmd.new(IC::WAIT, [1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 10, 10, 0])]
+  it.resolver = FakeResolver.new(common: { 5 => called })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update # enters the call, runs its first command, parks on its own Wait
+  eq true, st.switches[9]
+  ok it.resumable_index.nil?, 'not capturable the old, coarser way -- mid a nested call'
+
+  frames = it.call_stack_snapshot
+  eq 2, frames.size, 'the suspended caller frame plus the called frame'
+  eq 1, frames[0][:current_command], 'the caller is parked right after its own Call Event'
+  eq 2, frames[1][:current_command], 'the called frame is parked right after its own Wait'
+
+  it2 = Game::Interpreter.new(new_state)
+  it2.resolver = FakeResolver.new(common: { 5 => called })
+  it2.restore_call_stack(frames)
+  st2 = it2.instance_variable_get(:@state)
+  it2.resume # clear the restored Wait, same as the scene driving its timer to zero would
+  it2.update
+  eq false, st2.switches[9], '#restore_call_stack does not replay the called frame\'s own already-run command'
+  eq true, st2.switches[10], 'the called frame resumes past its own Wait, not from the top'
+  eq true, st2.switches[1], 'control correctly returns to the outer, suspended caller'
+  ok !it2.running?, 'the whole call stack unwinds to completion'
+end
+
+check '#call_stack_snapshot is nil once the process has finished' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.running?
+  ok it.call_stack_snapshot.nil?, 'nothing to resume once the list is exhausted'
+end
+
+check '#restore_call_stack is a no-op for a nil/empty snapshot' do
+  it = Game::Interpreter.new(new_state)
+  it.restore_call_stack(nil)
+  ok !it.running?, 'nil frames leave the interpreter exactly as it was'
+  it.restore_call_stack([])
+  ok !it.running?, 'same for an empty frames array'
+end
+
+# LCF::Schema::SAVE_EVENT_EXEC_STATE/_FRAME's own encode/decode round trip
+# (Game::State.build_event_exec_state/.read_event_exec_frames), through
+# genuine chunk bytes (Array1D#to_lcf / LCF::Array1D.new) rather than just
+# in-memory Ruby Hashes -- this is a from-scratch round-trip check, NOT
+# verified against a genuine wine-saved mid-event `.lsd`, since no such
+# fixture (a save taken mid a nested Call Event or a Common Event Parallel
+# Process) was available to compare byte-for-byte against. See
+# LCF::Schema::SAVE_EVENT_EXEC_STATE's own schema.rb comment.
+check 'SAVE_EVENT_EXEC_STATE round-trips a captured call-stack snapshot through raw .lsd bytes' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0]),
+            FakeCmd.new(IC::WAIT, [1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 10, 10, 0])]
+  it.resolver = FakeResolver.new(common: { 5 => called })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.event_id = 3
+  it.triggered_by_decision_key = true
+  it.update
+  frames = it.call_stack_snapshot
+  eq 2, frames.size
+
+  exec_state = Game::State.build_event_exec_state(frames)
+  bytes = exec_state.to_lcf # genuine chunk bytes, terminator included
+  decoded = LCF::Array1D.new(bytes, { elements: LCF::Schema::SAVE_EVENT_EXEC_STATE })
+  round = Game::State.read_event_exec_frames(decoded)
+  eq frames.size, round.size, 'both frames survived the round trip'
+
+  round.each_index do |i|
+    eq frames[i][:current_command], round[i][:current_command], "frame #{i} current_command"
+    eq frames[i][:event_id], round[i][:event_id], "frame #{i} event_id"
+    eq frames[i][:triggered_by_decision_key], round[i][:triggered_by_decision_key],
+       "frame #{i} triggered_by_decision_key"
+    eq frames[i][:commands].size, round[i][:commands].size, "frame #{i} command count"
+    frames[i][:commands].each_index do |j|
+      eq frames[i][:commands][j].code, round[i][:commands][j].code, "frame #{i} command #{j} code"
+      eq frames[i][:commands][j].parameters, round[i][:commands][j].parameters,
+         "frame #{i} command #{j} parameters"
+    end
+  end
+  eq true, round[0][:triggered_by_decision_key], 'only the outermost frame carries the trigger flag'
+  eq false, round[1][:triggered_by_decision_key], 'a Call Event\'s own nested frame never does'
+
+  # And the round-tripped frames genuinely drive a fresh Game::Interpreter to
+  # completion, not just decode as inert data.
+  it2 = Game::Interpreter.new(new_state)
+  it2.resolver = FakeResolver.new(common: { 5 => called })
+  it2.restore_call_stack(round)
+  st2 = it2.instance_variable_get(:@state)
+  it2.resume
+  it2.update
+  eq false, st2.switches[9], 'the already-run command before the captured index was not replayed'
+  eq true, st2.switches[10], 'the called frame ran the rest of its own commands'
+  eq true, st2.switches[1], 'and control returned to the outer caller, which ran to completion'
+  ok !it2.running?, 'the whole restored call stack unwound correctly'
+end
+
 # A resolver that counts every Call Event lookup instead of answering with
 # real commands, so a Call Event round trip stays a one-command no-op (the
 # empty-target early return in do_call_event) whose count is still visible.
@@ -10668,6 +10809,74 @@ check 'common_event_progress (a Parallel Process interpreter checkpoint) round-t
   legacy = st.to_h
   legacy.delete(:common_event_progress)
   eq({}, Game::State.load(db, legacy).common_event_progress)
+end
+
+# Cycle #191: chunks 113 (SAVE_FOREGROUND_EVENT) and 114 (SAVE_COMMON_EVENT)
+# now round-trip a genuine Game::Interpreter call-stack snapshot through
+# to_lsd/from_lsd, not just the coarser common_event_progress cursor above --
+# see Game::State#foreground_event_exec/#common_event_exec's own comments.
+# This exercises the same to_lsd/from_lsd path scripts/rpg2k_scene_check.rb
+# drives end to end through an actual Scene::Map; this check pins the
+# Game::State-level contract in isolation, the same relationship the
+# #call_stack_snapshot checks in this file bear to Scene::Map's own
+# #record_foreground_event_exec/#record_parallel_progress.
+check 'to_lsd/from_lsd round-trips a foreground and a common-event call-stack snapshot (chunks 113/114)' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+
+  fg_it = Game::Interpreter.new(st)
+  fg_it.resolver = FakeResolver.new
+  fg_it.start([FakeCmd.new(IC::WAIT, [1]), FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  fg_it.event_id = 42
+  fg_it.triggered_by_decision_key = true
+  fg_it.update # parks on the Wait
+  st.foreground_event_exec = { event_id: 42, frames: fg_it.call_stack_snapshot }
+
+  ce_it = Game::Interpreter.new(Game::State.new(Game::Party.new(db), 1, 0, 0))
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0]), FakeCmd.new(IC::WAIT, [1])]
+  ce_it.resolver = FakeResolver.new(common: { 5 => called })
+  ce_it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0])])
+  ce_it.update # enters the call, parks mid a nested Call Event
+  ok ce_it.resumable_index.nil?, 'sanity: not capturable the old, coarser way'
+  st.common_event_exec[7] = ce_it.call_stack_snapshot
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+
+  fg = round.foreground_event_exec
+  ok !fg.nil?, 'chunk 113 came back'
+  eq 42, fg[:event_id]
+  eq 1, fg[:frames].size
+  eq 1, fg[:frames][0][:current_command], 'parked right after the Wait'
+  eq true, fg[:frames][0][:triggered_by_decision_key]
+
+  ce_frames = round.common_event_exec[7]
+  ok !ce_frames.nil?, 'chunk 114 carries an entry for common event 7'
+  eq 2, ce_frames.size, 'the suspended caller frame plus the called frame, not collapsed'
+  eq 2, ce_frames[1][:current_command], 'the called frame is parked right after its own Wait'
+  ok round.common_event_exec[12].nil?, 'no entry at all for a common event nothing ran'
+
+  # Absent when nothing was mid-execution -- the overwhelming common case --
+  # matching every other "nothing to restore" chunk in #to_lsd.
+  bare = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  bare_round = Game::State.from_lsd(db, bare.to_lsd)
+  ok bare_round.foreground_event_exec.nil?, 'chunk 113 is absent, not an empty stub'
+  eq({}, bare_round.common_event_exec)
+
+  # The portable Marshal save (#to_h/.load) never carries either field at all
+  # -- deliberately, see #common_event_exec's own comment -- so loading one
+  # restores the same "nothing to resume" state a fresh Game::State starts
+  # with, whatever #foreground_event_exec/#common_event_exec held before it
+  # was dumped.
+  st.foreground_event_exec = { event_id: 42, frames: fg_it.call_stack_snapshot }
+  st.common_event_exec[7] = [{ commands: [], current_command: 0, event_id: 0,
+                                triggered_by_decision_key: false }]
+  via_marshal = Game::State.load(db, st.to_h)
+  ok via_marshal.foreground_event_exec.nil?, 'not carried by #to_h at all'
+  eq({}, via_marshal.common_event_exec)
 end
 
 check 'shown pictures round-trip through this engine\'s own internal Marshal-style ' \


### PR DESCRIPTION
## Summary

Directed by the user: compare today's coarse, Marshal-only event-resume bookkeeping (`Game::State#common_event_progress`) against what a genuine `.lsd` save needs to actually persist an interpreter's execution state, and close that gap for real.

Replaces the opaque `int8_array` field 1 on `SAVE_FOREGROUND_EVENT`/`SAVE_COMMON_EVENT` (chunks 113/114) with liblcf's actual `SaveEventExecState`/`SaveEventExecFrame` structs (new `LCF::Schema::SAVE_EVENT_EXEC_FRAME`/`SAVE_EVENT_EXEC_STATE`, field ids taken from `generator/csv/fields.csv`), and wires them end to end:

- `Game::Interpreter#call_stack_snapshot`/`#restore_call_stack` capture and restore the full `@call_stack` (every nested Call Event frame with its own commands/cursor) — a strict superset of the older `#resumable_index`/`#start_at` cursor, which returns nil whenever a save happens mid a nested call.
- `Game::State#foreground_event_exec`/`#common_event_exec` snapshot the shared foreground interpreter and every running Common Event Parallel Process each frame/tick; `Game::State#to_lsd`/`.from_lsd` read/write them as chunks 113/114. `#common_event_progress` is kept as-is for the portable Marshal save and as a fallback for older `.lsd` files.
- `Scene::Map` gains `#record_foreground_event_exec`/`#restore_foreground_event_exec`, and `#new_parallel`/`#record_parallel_progress` prefer the richer snapshot over the older cursor when available.

`subcommand_path` is deliberately always written empty (documented: this engine's own resume is cursor-based and never needs it, unlike genuine RPG_RT's jump-to-Case mechanism). The keyinput_* cluster and a few other `SaveEventExecState` fields are schema-only for read-fidelity, not yet written or restored.

## Verification

- Verified by a from-scratch round trip (new `scripts/rpg2k_logic_check.rb` checks: the plain interpreter contract including a nested Call Event, schema encode/decode through real chunk bytes, and `Game::State#to_lsd`/`.from_lsd` wiring) — **not** against a genuine wine-saved mid-event `.lsd`, since no such fixture was available to compare byte-for-byte.
- Updated `mruby-lcf/test/lcf_test.rb`'s chunk 113/114 decode test to build genuine nested bytes instead of the old opaque blob.
- All check-suite baselines unchanged, independently re-verified: `rpg2k_scene_check.rb`=929, `rpg2k_logic_check.rb`=1169 (1163+6 new), `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0, `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known pre-existing failures unchanged.
- `ctest -R mruby_test` passes.
- No `data/` files touched.

See `docs/TODO.md`'s cycle #191 entry for the full writeup, including everything deliberately left open (per-frame `event_id`/`triggered_by_decision_key` fidelity, `subcommand_path`, the keyinput_* cluster, no genuine wine-saved multi-frame fixture).

## Changelog

`changelog.d/event-exec-state-save-chunks.added.md` — genuine behavioral/feature addition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_