### PR TITLE
Persist the hero's own in-flight Flash Sprite through Save/Continue

### DIFF
--- a/changelog.d/flash-sprite-persistence.fixed.md
+++ b/changelog.d/flash-sprite-persistence.fixed.md
@@ -1,0 +1,17 @@
+- **The hero's own in-flight Flash Sprite (or a map-triggered battle-
+  animation pulse targeting the hero) now survives Save/Continue.**
+  Previously tracked only as `Scene::Map`'s own transient `@player_flash`
+  instance variable, invisible to both save formats — a save taken mid-flash
+  and continued silently dropped it instead of resuming the fade. Promoted
+  onto `Game::State#player_flash`, round-tripped through both the portable
+  Marshal save (`#to_h`/`#load_h`) and a genuine `.lsd` (`#to_lsd`/`.from_lsd`,
+  chunk 104's own `flash_red`/`_green`/`_blue`/`_current_level`/`_time_left`,
+  liblcf's generator/csv/fields.csv fields 0x51-0x55/81-85). Confirmed
+  against a genuine kk1.12 save under wine for the *not flashing* case: the
+  RGB triple is present as an explicit 0 (not the schema's own -1 generator
+  default, and not absent), while the current-level/time-left pair stays
+  absent. The *flashing* case's own exact decay curve (whether
+  `flash_current_level`'s interpolation matches this codebase's own linear
+  one) has not been independently confirmed against genuine RPG_RT — a save
+  resumed mid-flash restarts its own decay from the already-decayed current
+  level, one frame short of exactly reproducing the original fade.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1235,6 +1235,29 @@ module LCF
       # sprite_id co-occurring without its paired sprite_name ever would.
       73 => { name: :charset_name, type: :string },
       74 => { name: :charset_index, type: :int },
+      # liblcf's own generator/csv/fields.csv (0x51-0x55 == 81-85): an
+      # in-flight Flash Sprite (11320), or a map-triggered battle-animation
+      # flash reusing the same mechanism (see Game::State#player_flash's own
+      # citation in game.rb). `flash_current_level` is declared a `Double`
+      # (not an Int32 like its siblings) -- liblcf tracks the *current*,
+      # already-decayed strength directly rather than recomputing it from
+      # `flash_power`/`flash_time_left` each frame, so `#to_lsd` derives an
+      # equivalent value from this codebase's own `power * frames / total`
+      # decay math (`Scene::Map#flash_tone`'s own formula). Confirmed against
+      # a genuine kk1.12 save under wine, for the *not flashing* case only:
+      # flash_red/_green/_blue present as an explicit 0 (not the schema's own
+      # -1 generator default, and not absent either) while
+      # flash_current_level/_time_left stayed absent -- so RPG_RT always
+      # writes the RGB triple, defaulting to 0 rather than -1, and only adds
+      # the level/time_left pair while a flash is actually in progress. The
+      # *flashing* case's exact byte values (in particular whether
+      # `flash_current_level`'s own decay curve matches this codebase's
+      # linear one) has not been confirmed against genuine RPG_RT.
+      81 => { name: :flash_red, type: :int },
+      82 => { name: :flash_green, type: :int },
+      83 => { name: :flash_blue, type: :int },
+      84 => { name: :flash_current_level, type: :double },
+      85 => { name: :flash_time_left, type: :int },
       # liblcf's own `SaveVehicleLocation` struct (generator/csv/fields.csv,
       # 0x65 == 101, name `vehicle`) -- a boat/ship/airship-only field this
       # shared SAVE_MOVABLE table otherwise has no equivalent for (the hero's
@@ -1250,21 +1273,20 @@ module LCF
     # carries a lot more of liblcf's full `SaveMapEventBase` struct
     # (generator/csv/fields.csv) than this table models: a full in-progress
     # `move_route` (`MoveRoute` chunk, 0x29/41 -- the hero had a live custom
-    # route recorded in that capture), `through` (0x33/51),
-    # `stop_count`/`anim_count`/`max_stop_count` (0x34-36/52-54,
-    # movement/animation frame timers), `begin_jump_x`/`_y` (0x3E-3F/62-63),
-    # `processed` (0x4B/75, already noted above), and
-    # `flash_red`/`_green`/`_blue`/`_current_level`/`_time_left`
-    # (0x51-55/81-85, a live Flash Sprite in progress). None of these are
-    # modelled here: several need genuine new state this codebase's own
-    # `Game::State`/`Game::Character` don't track for the hero at all
-    # (an in-flight custom move route or Flash Sprite survives a save only
-    # by chance today, via whatever the interpreter re-derives), and the
-    # movement/animation timers are pure per-frame scheduling this engine
-    # already recomputes fresh rather than resuming byte-for-byte. Left as a
-    # known, larger gap for a future cycle -- see this table's own field 43
-    # comment for the `move_route_index` piece, and field 33's own comment
-    # for `layer`, already covered.
+    # route recorded in that capture), `through` (0x33/51), and
+    # `stop_count`/`anim_count`/`max_stop_count` (0x34-36/52-54, movement/
+    # animation frame timers). None of these are modelled here: the move
+    # route needs genuine new state this codebase's own `Game::State`/
+    # `Game::Character` don't track for the hero at all (an in-flight custom
+    # move route survives a save only by chance today, via whatever the
+    # interpreter re-derives), and the movement/animation timers are pure
+    # per-frame scheduling this engine already recomputes fresh rather than
+    # resuming byte-for-byte. Left as a known, larger gap for a future cycle
+    # -- see this table's own field 43 comment for the `move_route_index`
+    # piece, field 33's own comment for `layer`, and fields 81-85's own
+    # comment for `flash_red`/`_green`/`_blue`/`_current_level`/`_time_left`,
+    # already covered. `begin_jump_x`/`_y` (0x3E-3F/62-63) and `processed`
+    # (0x4B/75, already noted above) remain unmodeled too.
     #
     # https://w.atwiki.jp/rpg2kpsp/pages/21.html
     #

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14741,6 +14741,18 @@ module Game
     # promoted onto Game::State so #to_h/#load_h and #to_lsd/.from_lsd can
     # round-trip it like #current_bgm above.
     attr_accessor :pre_vehicle_bgm, :pre_battle_bgm
+    # The hero's own in-flight Flash Sprite (11320) or map-triggered battle-
+    # animation flash, a `{ red:, green:, blue:, power:, frames:, total: }`
+    # hash (see Scene::Map's own "Flash Sprite" section) or nil when nothing
+    # is flashing -- previously tracked only as Scene::Map's own transient
+    # `@player_flash`, invisible to both save formats, so a save taken mid-
+    # flash and continued silently dropped it instead of resuming the fade.
+    # Promoted onto Game::State so #to_h/#load_h and #to_lsd/.from_lsd can
+    # round-trip it, wiring up chunk 104's own flash_red/_green/_blue/
+    # _current_level/_time_left (liblcf's own generator/csv/fields.csv,
+    # 0x51-0x55/81-85) -- see #to_lsd's own citation for exactly what is and
+    # is not confirmed against genuine RPG_RT here.
+    attr_accessor :player_flash
     # Whether the current BGM has wrapped back to its start at least once — the
     # "BGM played once" conditional-branch test (12010 type 9). Cleared whenever
     # a new BGM starts; set by Scene::Map, which watches `RGSS::Audio.bgm_pos`
@@ -15025,6 +15037,7 @@ module Game
       @memorized_bgm = nil
       @pre_vehicle_bgm = nil
       @pre_battle_bgm = nil
+      @player_flash = nil
       @bgm_looped = false
       @bgm_stopping = false
       @player_transparent = false
@@ -15301,6 +15314,7 @@ module Game
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
         pre_vehicle_bgm: @pre_vehicle_bgm, pre_battle_bgm: @pre_battle_bgm,
+        player_flash: @player_flash,
         player_transparent: @player_transparent, weather: @weather.to_h,
         screen: @screen.to_h,
         pictures: @pictures.each_with_object({}) { |(id, p), out| out[id] = p.to_h },
@@ -15430,6 +15444,23 @@ module Game
       # page can be pinned below/above characters), so 1 is a true constant
       # here, not a live value with a default to elide at.
       hero[33] = 1
+      # Fields 81-85 (flash_red/_green/_blue/_current_level/_time_left): see
+      # SAVE_MOVABLE's own schema.rb comment for the full citation. The RGB
+      # triple is written unconditionally (0 when nothing is flashing,
+      # confirmed against genuine RPG_RT under wine -- not the schema's own
+      # -1 generator default); the level/time_left pair only while
+      # #player_flash is actually live, `flash_current_level` derived from
+      # this codebase's own linear decay (`power * frames / total.to_f`,
+      # matching Scene::Map#flash_tone) rather than independently confirmed.
+      pf = @player_flash
+      hero[81] = pf ? pf[:red] : 0
+      hero[82] = pf ? pf[:green] : 0
+      hero[83] = pf ? pf[:blue] : 0
+      if pf && pf[:frames] && pf[:frames] > 0
+        total = pf[:total] && pf[:total] > 0 ? pf[:total] : pf[:frames]
+        hero[84] = pf[:power].to_f * pf[:frames] / total
+        hero[85] = pf[:frames]
+      end
       # Set Transparent Flag's own override (Player Visibility, 11310) --
       # liblcf's own "0 or 3" convention for this field (see schema.rb's
       # SAVE_MOVABLE comment on why it lives here, on the hero's own movable
@@ -16439,6 +16470,25 @@ module Game
       # liblcf's "0 or 3" convention on the hero's own movable record (see
       # #to_lsd's own citation on why this lives here, not the system chunk).
       state.player_transparent = (hero.transparency || 0) != 0
+      # Fields 81-85 (flash_red/_green/_blue/_current_level/_time_left): see
+      # #to_lsd's own citation. A flash is only "live" once time_left is
+      # actually present and positive -- the RGB triple alone (0 or a stale
+      # colour) carries no flash of its own without it. `power` is
+      # recovered from `current_level` at its own peak strength (frames ==
+      # total, the instant it starts) since liblcf has no separate field for
+      # the original peak; a save resumed mid-decay therefore restarts that
+      # decay from its own already-decayed current level, one frame short of
+      # exactly reproducing genuine RPG_RT's own remaining fade -- close
+      # enough that the visual difference is a single frame, not a
+      # citation this codebase can make stronger without a wine capture of
+      # an actual in-progress flash to compare against.
+      if hero.flash_time_left && hero.flash_time_left > 0
+        frames = hero.flash_time_left
+        level = hero.flash_current_level || 0.0
+        state.player_flash = { red: hero.flash_red || 0, green: hero.flash_green || 0,
+                               blue: hero.flash_blue || 0, power: level.round, frames: frames,
+                               total: frames }
+      end
       # Vehicle locations (chunks 105 boat / 106 ship / 107 airship), each a
       # SAVE_MOVABLE; an absent chunk leaves that vehicle unplaced.
       state.vehicle(:boat).load_movable(save.boat)
@@ -16896,6 +16946,7 @@ module Game
       state.memorized_bgm = h[:memorized_bgm]
       state.pre_vehicle_bgm = h[:pre_vehicle_bgm]
       state.pre_battle_bgm = h[:pre_battle_bgm]
+      state.player_flash = h[:player_flash]
       state.player_transparent = h[:player_transparent] ? true : false
       state.weather.load_h(h[:weather])
       state.screen.load_h(h[:screen])

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4094,7 +4094,7 @@ class RPG2k
         return nil if flash[:frames] <= 0
         case r[:target]
         when MOVE_TARGET_PLAYER
-          @player_flash = flash
+          @state.player_flash = flash
           @last_frame = nil # force the hero's cached frame to be re-toned
           flash
         when 0, MOVE_TARGET_THIS
@@ -4127,15 +4127,15 @@ class RPG2k
         # Invalidate the hero's cached frame whenever a flash was running this
         # tick — including the tick it ends on, so the last toned frame is
         # replaced by the plain one instead of staying baked in.
-        @last_frame = nil if @player_flash
-        @player_flash = tick_flash(@player_flash)
+        @last_frame = nil if @state.player_flash
+        @state.player_flash = tick_flash(@state.player_flash)
         @events.each { |e| e[:flash] = tick_flash(e[:flash]) if e[:flash] }
         # A vehicle-target Flash Sprite has no CharSet-tone hash of its own to
         # decay here (its visuals are the native sprite #update_vehicle_flashes
         # already drives) -- @flash_wait's `:vehicle` marker is only ever set
         # by #apply_sprite_flash's own vehicle branch, so this can never
-        # double-decay the identical object the @player_flash/event lines
-        # above already tick.
+        # double-decay the identical object the @state.player_flash/event
+        # lines above already tick.
         @flash_wait = tick_flash(@flash_wait) if @flash_wait && @flash_wait[:vehicle]
       end
 
@@ -7617,8 +7617,8 @@ class RPG2k
         end
       end
 
-      # The map-triggered half: drop @player_flash / an @events entry's own
-      # [:flash] back to nil, the same "no flash in flight" state #tick_flash's
+      # The map-triggered half: drop @state.player_flash / an @events entry's
+      # own [:flash] back to nil, the same "no flash in flight" state #tick_flash's
       # own decay already leaves behind, mirroring #fire_map_target_flash's own
       # arm call. A vehicle target clears the native RGSS flash
       # #fire_map_target_flash armed on `@vehicle_sprites[type]` directly,
@@ -7632,8 +7632,8 @@ class RPG2k
           spr = @vehicle_sprites && @vehicle_sprites[target]
           spr.flash(nil, 0) if spr
         elsif target == :player
-          @last_frame = nil if @player_flash
-          @player_flash = nil
+          @last_frame = nil if @state.player_flash
+          @state.player_flash = nil
         else
           target[:flash] = nil
         end
@@ -7938,7 +7938,7 @@ class RPG2k
       # {red:, green:, blue:, power:, frames:, total:} hash #apply_sprite_flash
       # builds and #flash_tone/#update_sprite_flashes already drive every frame
       # (see the "Flash Sprite" section above): `target` (from
-      # #map_animation_flash_target) is either `:player` (-> @player_flash) or
+      # #map_animation_flash_target) is either `:player` (-> @state.player_flash) or
       # an `@events` entry (-> its `[:flash]`). A vehicle target (one of
       # `Game::Vehicle::TYPES`) instead pulses `@vehicle_sprites[type]`
       # directly with the native RGSS `Sprite#flash` primitive #fire_target_flash
@@ -7970,7 +7970,7 @@ class RPG2k
                   blue: (t.flash_blue || 0) * 8, power: (t.flash_power || 0) * 8,
                   frames: ANIM_FLASH_FRAMES, total: ANIM_FLASH_FRAMES }
         if target == :player
-          @player_flash = flash
+          @state.player_flash = flash
           @last_frame = nil # force the hero's cached frame to be re-toned
         else
           target[:flash] = flash
@@ -10364,7 +10364,7 @@ class RPG2k
       # rebuild that reorders or resizes the list reads as dirty -- always safe,
       # merely sometimes conservative.
       def events_dirty?
-        return true if @player_flash || @events.any? { |e| e[:flash] }
+        return true if @state.player_flash || @events.any? { |e| e[:flash] }
         sigs = @events.map { |e| event_draw_sig(e) }
         dirty = sigs != @event_draw_sigs
         @event_draw_sigs = sigs
@@ -10681,7 +10681,7 @@ class RPG2k
         # A Flash Sprite aimed at the hero tones the frame as it is laid down
         # (update_sprite_flashes invalidates @last_frame each frame it runs, so
         # the fading colour is re-applied rather than baked in once).
-        toned = @player_flash && flashed_charset(charset, src, @player_flash)
+        toned = @state.player_flash && flashed_charset(charset, src, @state.player_flash)
         @player_bmp.clear
         if toned
           blt_bushed @player_bmp, 0, 0, toned,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4632,6 +4632,50 @@ check 'to_lsd writes chunk 104/105-107 field 33 (layer) as the constant 1, ' \
   eq 1, saved[107].layer, 'the airship'
 end
 
+check 'to_lsd/from_lsd round-trips the hero\'s own in-flight Flash Sprite ' \
+      '(chunk 104 fields 81-85)' do
+  # Confirmed against a genuine kk1.12 save under wine, for the *not
+  # flashing* case: flash_red/_green/_blue present as an explicit 0 (not
+  # the schema's own -1 generator default), flash_current_level/_time_left
+  # both absent -- see SAVE_MOVABLE's own schema.rb comment for the fuller
+  # citation, including what is *not* confirmed (the exact decay curve
+  # while a flash is actually live).
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq nil, st.player_flash
+
+  saved = st.to_lsd[104]
+  eq 0, saved.flash_red, 'the RGB triple is an explicit 0, not the schema default (-1) or absent'
+  eq 0, saved.flash_green
+  eq 0, saved.flash_blue
+  ok !saved.key?(84), 'flash_current_level stays absent while nothing is flashing'
+  ok !saved.key?(85), 'flash_time_left stays absent while nothing is flashing'
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq nil, round.player_flash
+
+  # A live flash (Flash Sprite / a map-triggered battle-animation pulse)
+  # survives a real Save/Continue, not just this engine's own Marshal
+  # format -- previously tracked only as Scene::Map's own transient
+  # @player_flash, dropped silently by any save.
+  st.player_flash = { red: 200, green: 50, blue: 10, power: 24, frames: 8, total: 12 }
+  saved2 = st.to_lsd[104]
+  eq 200, saved2.flash_red
+  eq 50, saved2.flash_green
+  eq 10, saved2.flash_blue
+  eq 8, saved2.flash_time_left
+  eq 24.0 * 8 / 12, saved2.flash_current_level
+
+  round2 = Game::State.from_lsd(db, st.to_lsd)
+  pf = round2.player_flash
+  ok pf, 'the live flash round-trips as still in progress'
+  eq 200, pf[:red]
+  eq 50, pf[:green]
+  eq 10, pf[:blue]
+  eq 8, pf[:frames]
+  eq 8, pf[:total], 'no separate peak-duration field on the wire -- resumes decaying from here'
+end
+
 check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrides' do
   # do_change_system_bgm/_sfx (interpreter.rb) stash overrides in
   # @state.system_bgm/@state.system_sfx, keyed by slot -- the same slots

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5949,7 +5949,7 @@ check "Flash Sprite's own wait flag blocks a Parallel Process's own interpreter,
   st = scene.instance_variable_get(:@state)
 
   scene.update # runs Flash Sprite -> suspends on :sprite_flash
-  ok scene.instance_variable_get(:@player_flash), 'the hero is flashing'
+  ok st.player_flash, 'the hero is flashing'
   ok !st.switches[1], 'the Parallel Process must wait too, not resume immediately'
 
   4.times { scene.update } # still mid-flash (6-frame duration)
@@ -10033,11 +10033,10 @@ check 'A Character Flash concurrent with a Show Battle Animation targeting the s
   saw_the_flash_at_all = false
   40.times do
     scene.update
-    pf = scene.instance_variable_get(:@player_flash)
+    pf = st.player_flash
     saw_the_flash_at_all ||= !pf.nil?
     anim = scene.instance_variable_get(:@map_animation)
-    stomped_at_frame_0 ||= (anim && anim[:frame_i] == 0 &&
-                            scene.instance_variable_get(:@player_flash).nil?)
+    stomped_at_frame_0 ||= (anim && anim[:frame_i] == 0 && st.player_flash.nil?)
     break if st.switches[6]
   end
   ok saw_the_flash_at_all, 'the independently-fired Flash Sprite command did take effect at some point'
@@ -10178,7 +10177,7 @@ end
 # #fire_target_flash's battle-only enemy-sprite mechanism, which a map scene
 # (no @battle_ui at all) can never populate, so the flash simply never fired.
 # #fire_map_target_flash reuses the Flash Sprite command's own CharSet-tone
-# mechanism (@player_flash / an @events entry's [:flash]) instead of
+# mechanism (@state.player_flash / an @events entry's [:flash]) instead of
 # inventing a second one. Animation 9 in the fake db carries a flash_scope 1
 # timing (see the fake-db comment above) rather than id 8's flash_scope 2, so
 # this is isolated from the screen-flash check above.
@@ -10194,7 +10193,7 @@ check "a map-triggered Show Battle Animation's target-scope flash pulses the pla
   seen = false
   40.times do
     scene.update
-    pf = scene.instance_variable_get(:@player_flash)
+    pf = st.player_flash
     seen ||= (pf && pf[:red] == 248 && pf[:green] == 0 && pf[:blue] == 0)
     break if st.switches[6]
   end
@@ -10267,7 +10266,7 @@ check "a map-triggered Show Battle Animation's target-scope flash pulses the nam
     scene.update
     ev2 = event_hashes(scene)[2]
     seen_target ||= (ev2[:flash] && ev2[:flash][:red] == 248)
-    seen_player ||= !scene.instance_variable_get(:@player_flash).nil?
+    seen_player ||= !st.player_flash.nil?
     break if st.switches[6]
   end
   ok seen_target, "the targeted map event's own flash was armed"
@@ -14435,10 +14434,10 @@ check 'Flash Sprite on the hero holds a waiting event until it decays' do
   st = scene.instance_variable_get(:@state)
   scene.instance_variable_get(:@interpreter).start(cmds)
   scene.update
-  ok scene.instance_variable_get(:@player_flash), 'the hero is flashing'
+  ok st.player_flash, 'the hero is flashing'
   eq 0, st.variables[5], 'the event is held while the flash runs'
   10.times { scene.update }
-  ok !scene.instance_variable_get(:@player_flash), 'the flash decayed away'
+  ok !st.player_flash, 'the flash decayed away'
   eq 1, st.variables[5], 'the event resumed once the flash finished'
 end
 
@@ -14452,7 +14451,7 @@ check 'Flash Sprite on the hero with an instant (zero-duration) flash still ' \
   st = scene.instance_variable_get(:@state)
   scene.instance_variable_get(:@interpreter).start(cmds)
   scene.update
-  ok !scene.instance_variable_get(:@player_flash), 'nothing left to flash, it was instant'
+  ok !st.player_flash, 'nothing left to flash, it was instant'
   eq 0, st.variables[5], 'the event is still held right after the flash is queued'
   scene.update
   eq 1, st.variables[5], 'the event resumed the very next frame -- matching RPG_RT, whose ' \


### PR DESCRIPTION
## Summary
- **The hero's own in-flight Flash Sprite (or a map-triggered battle-animation pulse targeting the hero) now survives Save/Continue.** `Game::State#player_flash` promotes `Scene::Map`'s own transient `@player_flash` instance variable (the shared `{red:,green:,blue:,power:,frames:,total:}` hash both Flash Sprite (11320) and a map-triggered battle-animation flash already use) onto the state, wiring up chunk 104 (SAVE_MOVABLE) fields 81-85 (`flash_red`/`_green`/`_blue`/`_current_level`/`_time_left`, liblcf's own generator/csv/fields.csv 0x51-0x55) for `#to_lsd`/`.from_lsd` and `#to_h`/`#load_h`. Previously a save taken mid-flash and continued silently dropped it instead of resuming the fade.
- Confirmed against a genuine kk1.12 save under wine for the *not flashing* case: the RGB triple is present as an explicit 0 (not the schema's own -1 generator default, and not absent either), while `flash_current_level`/`_time_left` stay absent.
- The *flashing* case's own exact decay curve is **not independently confirmed** — documented honestly in both `schema.rb` and `game.rb`'s own citations. `flash_current_level` is derived from this codebase's own linear `power * frames / total` decay math rather than a wine capture of an actual in-progress flash; a save resumed mid-flash restarts its own decay from the already-decayed current level, one frame short of exactly reproducing the original fade.
- Updated every `rpg2k_scene_check.rb` assertion that introspected the old `@player_flash` ivar directly to read `scene.state.player_flash` instead.

This is the first of the two "heavier" architectural items flagged earlier this session (the interpreter execution-state work for chunks 113/114 was independently picked up and merged by another session as #1431 while this was in progress).

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 1170 checks passed (new round-trip check added)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 929 checks passed (existing Flash Sprite checks updated for the new state location)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 173 checks passed
- [x] `ruby scripts/lcf_testbed_check.rb` — all test-bed data parsed cleanly
- [x] `ruby scripts/lcf_schema_coverage.rb` — every chunk in the test-bed data is named by the LCF schema
- [x] `ruby scripts/rpg2k_command_soak.rb` — every event command ran without raising or reporting a gap
- [x] Verified directly against the genuine kk1.12 save: loading and re-exporting reproduces the not-flashing case byte-for-byte

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcLJ1KsXVzLsfwfTg9rZpB)_