### PR TITLE
Cycle #192: give each call-stack frame its own real event_id

### DIFF
--- a/changelog.d/call-stack-frame-event-id.fixed.md
+++ b/changelog.d/call-stack-frame-event-id.fixed.md
@@ -1,0 +1,19 @@
+- `Game::Interpreter#call_stack_snapshot`'s `.lsd`-bound call-stack frames
+  (cycle #191's `LCF::Schema::SAVE_EVENT_EXEC_FRAME`/`SAVE_EVENT_EXEC_STATE`,
+  chunks 113/114) now carry each frame's own genuine `event_id` instead of
+  mirroring the whole interpreter's single `#event_id` on every frame alike.
+  `#do_call_event` (Call Event, 12330) now records, at the moment it pushes a
+  frame, the concrete target map-event id `#resolve_call`/`#map_event_call`
+  already resolved to fetch that frame's own commands — or `0` for a common
+  event, matching liblcf's own "0 if it's common event or in other map"
+  field comment (Call Event's own command format never names a different
+  map, so that distinction collapses into the same `0` case here). Only the
+  outermost frame still carries the interpreter's own root `#event_id`, same
+  as before. This is purely save-fidelity: live "this event" resolution
+  (`#character_ref`) is unchanged and still deliberately root-scoped, not
+  per-frame. Covered by new `scripts/rpg2k_logic_check.rb` checks (a called
+  common-event frame reads back `0`; a called map-event frame reads back its
+  own target id, not the caller's; a self-call to "this event" reads back
+  the same id as the caller; `#return_from_call` correctly restores the
+  caller's own identity so it does not leak into a later, unrelated call).
+  See docs/TODO.md's cycle #192 entry.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14707,6 +14707,101 @@ following this paragraph as the original record.
   character, the same fallback an ordinary Auto-Start common event already
   has).
 
+  **Superseded by cycle #192, 2026-08-27, on one specific point**: this
+  entry's own writeup above (and `LCF::Schema::SAVE_EVENT_EXEC_FRAME`'s
+  schema.rb comment as it read at the time) claimed each frame's `event_id`/
+  `triggered_by_decision_key` were "mirrored from this whole interpreter's
+  own single `#event_id`/`#triggered_by_decision_key`... since `#do_call_event`
+  does not track which event a called list's commands originally belonged
+  to". That was true when written; cycle #192 closed exactly that gap for
+  `event_id` (`triggered_by_decision_key` was already correct — only the
+  outermost frame ever carries it true — and needed no change). See cycle
+  #192's own entry below for what changed and why this historical bullet is
+  left as-is otherwise.
+- ✅ **Follow-up (cycle #192, 2026-08-27): `#call_stack_snapshot`'s saved
+  call-stack frames now carry each frame's own genuine `event_id`**, closing
+  the one-line gap cycle #191 flagged and documented honestly rather than
+  fixing (quoted just above). `Game::Interpreter#do_call_event` (Call Event,
+  12330) now records, at the exact moment it pushes a frame onto
+  `@call_stack`, the target event's own identity: `#resolve_call` was
+  extended to return `[commands, event_id]` instead of just `commands` (and
+  `#map_event_call` likewise `[commands, id]`) — 0 for a common-event target
+  (`param(0) == 0`), the concrete map-event id `#character_ref` already
+  resolves for a same-map target (`param(0) == 1` or `2`). `@call_stack`'s
+  own entries grew a third element (`[list, index, event_id]`) to carry it;
+  every read/write site was updated to match: `#do_call_event`'s own push,
+  `#return_from_call`'s pop, `#call_stack_snapshot`, `#restore_call_stack`,
+  and every `@call_stack = []` reset site (`#initialize`, `#start`, `#stop`,
+  `#resume_battle`, `#skip_invalid_troop`, `#do_terminate_battle`) gained a
+  matching `@call_frame_event_id = nil` reset. A new `@call_frame_event_id`
+  ivar tracks "the event_id of whichever list `@list` currently holds" live,
+  updated by `#do_call_event` on every push and restored by
+  `#return_from_call` on every pop, entirely separate from `#event_id`
+  itself (see below).
+
+  The RPG2003 battle page's own Call Common Event (1005,
+  `#do_call_common_event`) shares the same `@call_stack`/`#return_from_call`
+  mechanism but was deliberately left out of scope (per the original
+  cycle-#192 brief): its push now writes a literal `0` third element purely
+  so the shared array shape stays uniform for `#return_from_call` to pop —
+  battle interpreters were never part of cycle #191's save mechanism
+  (`Game::State#foreground_event_exec`/`#common_event_exec` only ever
+  snapshot map/common-event interpreters), so no real per-frame identity
+  tracking was added there.
+
+  liblcf's own field comment ("0 if it's common event or in other map")
+  raised the question of whether a distinct "in other map" case needed
+  modelling separately from "common event". Investigated and concluded no:
+  Call Event's own command format (`param(0)` 0/1/2, see `#do_call_event`'s
+  own comment) never names a map at all, only a common-event id or a
+  same-map event id/page — this codebase's own model has no path to a
+  "different map" target for `#resolve_call` to ever produce, so `0` was
+  kept as the one case covering both, documented explicitly rather than
+  inventing an unreachable branch.
+
+  Also investigated, per the original brief's own prompt, whether
+  `#event_id` itself (the live "this event" resolution `#character_ref`
+  reads) needed a matching per-frame restore in `#return_from_call` — i.e.
+  whether resuming an outer, suspended caller frame needs its own identity
+  restored the way `@call_frame_event_id` now is. Concluded no, and left
+  `#event_id` untouched: `#do_call_event` never mutates `#event_id` when
+  entering a call in the first place (this codebase's own pre-existing,
+  deliberate design — a "this event" reference inside a nested call
+  resolves to the outermost caller's own id throughout, never switching to
+  the callee's, predating this cycle and not revisited here), so there is
+  nothing for `#return_from_call` to restore: the value was never disturbed.
+  Changing that live resolution semantic (making "this event" inside a
+  called page mean the callee instead) would be a genuine RPG_RT behavior
+  question needing its own citable evidence, out of scope for a save-
+  fidelity cycle — `#event_id`'s own attr comment (interpreter.rb) now
+  spells this reasoning out explicitly so a future cycle does not
+  rediscover the same question from scratch.
+
+  `LCF::Schema::SAVE_EVENT_EXEC_FRAME`'s own schema.rb comment was rewritten
+  to describe what is now actually implemented (it previously described the
+  gap this cycle closed as a permanent simplification).
+
+  Verified with 4 new `scripts/rpg2k_logic_check.rb` checks (a called
+  common-event frame reads back `event_id` 0, not the caller's; a called
+  map-event frame reads back its own target id, not the caller's; a Call
+  Event self-call to "this event" reads back the SAME id as the caller,
+  since it genuinely is the same event; and `#return_from_call` correctly
+  restores the caller's own identity after a call fully returns, so it does
+  not leak into a later, sequential, unrelated call) plus extended
+  assertions on cycle #191's own nested-call-stack check — total
+  `rpg2k_logic_check.rb` now 1172 (up from 1169). All other check-suite
+  baselines unchanged (`rpg2k_scene_check.rb`=929,
+  `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0,
+  `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known
+  pre-existing failures unchanged), and the `mruby_test` ctest suite passes.
+
+  Deliberately left open: the round-trip fidelity of `@call_frame_event_id`
+  through `#restore_call_stack` (so a restored interpreter, re-snapshotted
+  immediately without running another command, reproduces the exact same
+  per-frame `event_id` values) is verified by a fresh-state round trip, not
+  a genuine wine-saved multi-frame `.lsd`, same open point cycle #191 itself
+  already carried forward.
+
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
   `do_wait`/`drive_wait` in interpreter.rb / map.rb.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1711,19 +1711,27 @@ module LCF
     # codebase's own writer (`Game::State#to_lsd`) recomputes it the same way.
     #
     # `event_id` (0x0C, "0 if it's common event or in other map" per liblcf's
-    # own comment) and `triggered_by_decision_key` (0x0D) are written from
-    # this whole interpreter's own single `#event_id`/
-    # `#triggered_by_decision_key` on every frame alike -- this codebase's own
-    # Call Event (`#do_call_event`) does not track which event a called
-    # list's commands originally belonged to (a "this event" reference
-    # inside a call always resolves to the outermost caller's own id, never
-    # the callee's -- see `#character_ref`'s own comment), so there is no
-    # richer per-frame value to honestly give here than the one id/flag the
-    # whole interpreter already carries. A genuine RPG_RT `.lsd` may carry a
-    # different value per frame; this is a documented simplification of what
-    # this engine can honestly reconstruct from its own live state, not a
-    # claim that every frame's `event_id` matches genuine RPG_RT's own
-    # per-frame bookkeeping.
+    # own comment): cycle #192 gave each frame its own genuine value.
+    # `Game::Interpreter#do_call_event` now records, at the moment it pushes
+    # each frame, the concrete map-event id that frame's own `commands` list
+    # actually belongs to (via `#resolve_call`/`#map_event_call`, which
+    # already resolve exactly that to look the list up in the first place),
+    # or 0 when the call target was a common event -- see
+    # `#call_stack_snapshot`'s own comment for exactly how each frame's
+    # value is derived (the outermost frame is always this whole
+    # interpreter's own `#event_id`; every frame beneath it carries its own
+    # Call Event's resolved target). "...or in other map" does not name a
+    # distinct, reachable case here: Call Event's own command format (param0
+    # 0/1/2, see `#do_call_event`'s own comment) never names a map at all,
+    # only a common-event id or a same-map event id/page, so this codebase's
+    # own model has no "different map" target to ever resolve into a frame
+    # -- 0 covers both the common-event case and (vacuously) that one.
+    # `triggered_by_decision_key` (0x0D) is still written from this whole
+    # interpreter's single `#triggered_by_decision_key`, true only for the
+    # outermost frame (index 0): a Call Event's own nested frame was never
+    # itself started by the action key, whatever launched the outer event --
+    # this part was already correct as of cycle #191 and cycle #192 left it
+    # untouched.
     #
     # `subcommand_path` (0x15 count / 0x16 data, one byte per nesting level --
     # the chosen Show Choice branch id at that level, 255 once taken, per
@@ -1756,10 +1764,10 @@ module LCF
     # `stack` (0x01, `Array<SaveEventExecFrame>` -- see SAVE_EVENT_EXEC_FRAME
     # just above) is the genuine call stack, outermost frame first, matching
     # `Game::Interpreter#call_stack_snapshot`'s own `@call_stack + [[@list,
-    # @index]]` order (this codebase's own writer/reader convention for the
-    # frame's own array index within `stack`, 1-based ascending outer to
-    # inner -- not confirmed against a genuine multi-frame capture, since none
-    # was available; only that a single-frame `stack` round-trips against
+    # @index, event_id]]` order (this codebase's own writer/reader convention
+    # for the frame's own array index within `stack`, 1-based ascending outer
+    # to inner -- not confirmed against a genuine multi-frame capture, since
+    # none was available; only that a single-frame `stack` round-trips against
     # this codebase's own reading of the field table). `SaveMapEvent`'s own
     # 0x6C field and `SaveCommonEvent`'s own field 1 both point at this same
     # struct (`generator/csv/fields.csv`'s `Save.foreground_event_execstate`

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -190,6 +190,11 @@ module Game
       @index = 0
       @running = false
       @call_stack = []
+      # The event_id a Call Event resolved for the list @list currently holds,
+      # tracked purely so #call_stack_snapshot can report each stack frame's
+      # own genuine identity -- see its declaration further down (searched for
+      # "@call_frame_event_id" everywhere it is touched) for the full story.
+      @call_frame_event_id = nil
       @resolver = nil
       @move_route_requests = []
       @location_requests = []
@@ -286,13 +291,56 @@ module Game
     # is stepping. The read-side ones — Conditional Branch orientation, the
     # Control Variables character operand and a Call Event naming a map event —
     # are answered here, so they need the id too.
+    #
+    # Deliberately NOT frame-scoped: a nested Call Event (#do_call_event)
+    # never touches #event_id, so a "this event" reference inside a called
+    # page still resolves to whichever event/common-event originally started
+    # THIS interpreter (the outermost caller), not to the map event the Call
+    # Event actually jumped into. This is this codebase's own pre-existing,
+    # deliberate design (predating cycle #192), not something introduced or
+    # revisited here — cycle #192 only teaches #call_stack_snapshot to record
+    # each frame's own real target-event identity for the *save file*
+    # (@call_frame_event_id below), and deliberately leaves this live
+    # resolution semantic alone: changing what "this event" means mid a
+    # nested call would be a genuine RPG_RT behavior question of its own,
+    # needing its own citable evidence, not a side effect of a save-fidelity
+    # cycle. Because #event_id is never mutated by entering a call in the
+    # first place, #return_from_call correctly has nothing to restore here
+    # either -- see #return_from_call's own comment.
     attr_accessor :event_id
+
+    # The event_id a Call Event resolved when it pushed the list @list is
+    # currently running (0 for a common event, matching liblcf's own
+    # SaveEventExecFrame#event_id comment "0 if it's common event or in
+    # other map" -- see LCF::Schema::SAVE_EVENT_EXEC_FRAME's own comment for
+    # why "in other map" collapses into the same 0 case here). Tracked
+    # entirely separately from #event_id above: this is per-CALL-FRAME
+    # identity, purely so #call_stack_snapshot can give each frame its own
+    # honest value instead of mirroring the whole interpreter's single
+    # #event_id on every frame alike (cycle #191's original simplification).
+    # #character_ref/#event_id's own "this event" resolution never reads
+    # this -- it is inert for live command execution, exactly like the
+    # `commands`/`current_command` a stack frame also carries are inert
+    # until a return actually unwinds to them.
+    #
+    # nil at depth 0 (no Call Event has run yet this interpreter run) --
+    # #call_stack_snapshot then falls back to #event_id for that frame,
+    # which is exactly correct since depth 0 IS the interpreter's own root
+    # frame. #do_call_event sets it to the callee's resolved id on every
+    # push (after first stashing the outgoing value into the pushed
+    # @call_stack entry's own third element), and #return_from_call restores
+    # it from that same third element on every pop, so it always names
+    # whichever list @list currently holds, all the way back up.
+    attr_reader :call_frame_event_id
 
     def start(commands)
       @list = commands || []
       @index = 0
       @running = true
       @call_stack = []
+      # A fresh run starts back at depth 0, same reasoning as #event_id's own
+      # reset just below.
+      @call_frame_event_id = nil
       @move_route_requests = []
       @location_requests = []
       @sprite_flash_requests = []
@@ -615,10 +663,15 @@ module Game
     end
 
     # Resume the caller that a finished called-list returned to; returns false
-    # when there is no caller (the outermost list is done).
+    # when there is no caller (the outermost list is done). Also restores
+    # #call_frame_event_id from the popped frame's own third element, so it
+    # keeps naming whichever list @list holds now that we are back a level
+    # shallower -- #event_id itself needs no matching restore here: it was
+    # never touched by #do_call_event entering the call in the first place
+    # (see #event_id's own comment), so there is nothing to unwind.
     def return_from_call
       return false if @call_stack.empty?
-      @list, @index = @call_stack.pop
+      @list, @index, @call_frame_event_id = @call_stack.pop
       true
     end
 
@@ -678,15 +731,21 @@ module Game
     # list, an Array of LCF::EventCommand-alikes -- exactly what
     # LCF.encode_event_commands/#restore_call_stack both expect),
     # `current_command` (the cursor into it), `event_id` and
-    # `triggered_by_decision_key`, both mirrored from this whole
-    # interpreter's own #event_id/#triggered_by_decision_key rather than
-    # tracked per frame -- #do_call_event does not record which event a
-    # called list's commands originally belonged to (a "this event"
-    # reference always resolves through the outermost caller's own id, see
-    # #character_ref), so there is no richer per-frame value available to
-    # give honestly. Only the outermost frame's own `triggered_by_decision_key`
-    # can genuinely be true: a Call Event's own nested frame was never itself
-    # started by the action key, whatever launched the outer event.
+    # `triggered_by_decision_key`.
+    #
+    # `event_id` is each frame's own genuine target identity (cycle #192):
+    # the outermost frame (index 0) always carries this whole interpreter's
+    # own #event_id -- that one was never pushed by a Call Event, it is
+    # whatever the owning scene set before this run started, and stays the
+    # only source of truth for it (see #event_id's own comment on why it is
+    # deliberately NOT frame-scoped for live execution). Every frame beneath
+    # it carries the map-event id (or 0 for a common event -- see
+    # #do_call_event/#resolve_call) that the Call Event pushing it actually
+    # resolved, tracked live via #call_frame_event_id and threaded through
+    # each @call_stack entry's own third element. Only the outermost frame's
+    # own `triggered_by_decision_key` can genuinely be true: a Call Event's
+    # own nested frame was never itself started by the action key, whatever
+    # launched the outer event.
     #
     # Returns nil for an interpreter with nothing to capture (never started,
     # or already finished) -- the overwhelming common case a save actually
@@ -694,12 +753,12 @@ module Game
     # SAVE_COMMON_EVENT's own schema.rb comments for when it is not).
     def call_stack_snapshot
       return nil unless @running
-      frames = @call_stack + [[@list, @index]]
-      frames.each_with_index.map do |(list, index), i|
+      frames = @call_stack + [[@list, @index, @call_frame_event_id || @event_id || 0]]
+      frames.each_with_index.map do |(list, index, event_id), i|
         {
           commands: list,
           current_command: index,
-          event_id: @event_id || 0,
+          event_id: (i.zero? ? @event_id : event_id) || 0,
           triggered_by_decision_key: i.zero? && !!@triggered_by_decision_key,
         }
       end
@@ -720,6 +779,24 @@ module Game
     # comment on that same scope limit, which #resumable_index/#start_at
     # already share.
     #
+    # Each restored @call_stack entry also gets back its own frame's
+    # `event_id` (cycle #192) as its third element, and #call_frame_event_id
+    # is set to the innermost frame's own value when there is any nesting at
+    # all (#start above already reset it to nil, the correct depth-0 value,
+    # for the no-nesting case). None of this changes what actually executes
+    # -- #character_ref/#event_id's own "this event" resolution only ever
+    # reads #event_id (restored just below, from the OUTERMOST frame, same
+    # as before), never a frame's own per-call identity or
+    # #call_frame_event_id -- it exists purely so that immediately
+    # re-snapshotting a freshly-restored interpreter (before it runs another
+    # command) reproduces the exact same per-frame `event_id` values the
+    # original snapshot had, i.e. so the round trip is stable. A suspended
+    # caller frame's own event_id is genuinely dormant data until
+    # #return_from_call eventually pops back to it; #return_from_call
+    # already restores #call_frame_event_id from that same third element at
+    # that point (see its own comment), so nothing here needs to anticipate
+    # that -- only the record has to survive the round trip.
+    #
     # The caller still owns #resolver/#map_info the same way #start's own
     # callers already do (Scene::Map's #start_autostart/#new_parallel/the
     # decision-key trigger path) -- this only rebuilds the execution
@@ -735,10 +812,13 @@ module Game
       start(innermost[:commands] || [])
       idx = innermost[:current_command]
       @index = idx if idx && idx >= 0 && idx <= @list.size
-      @call_stack = frames[0...-1].map { |f| [f[:commands] || [], f[:current_command] || 0] }
+      @call_stack = frames[0...-1].map do |f|
+        [f[:commands] || [], f[:current_command] || 0, f[:event_id] || 0]
+      end
       outer = frames.first
       @event_id = outer[:event_id] if outer[:event_id] && outer[:event_id] != 0
       @triggered_by_decision_key = !!outer[:triggered_by_decision_key]
+      @call_frame_event_id = (innermost[:event_id] || 0) if frames.size > 1
     end
 
     # Start (or restart) at a previously #resumable_index-captured position
@@ -767,6 +847,7 @@ module Game
       @running = false
       @index = @list.size
       @call_stack = []
+      @call_frame_event_id = nil
       @pending_messages = []
       reset_waits
     end
@@ -910,6 +991,7 @@ module Game
       if result == :escape && @battle_escape_aborts
         @index = @list.size
         @call_stack = []
+        @call_frame_event_id = nil
         reset_waits
         return
       end
@@ -1152,23 +1234,43 @@ module Game
     # A missing target is a logged no-op (see #resolve_call/#map_event_call); an
     # empty (but resolved) target is a silent no-op, since that page/event
     # genuinely has nothing to run. Recursion is bounded by MAX_CALL_DEPTH.
+    #
+    # Before diving in, stashes the OUTGOING #call_frame_event_id (cycle
+    # #192 -- this frame's own genuine identity, whatever list @list held
+    # before this call) onto the pushed @call_stack entry's own third
+    # element, then updates #call_frame_event_id to the callee's own newly-
+    # resolved identity, so it always names whichever list @list currently
+    # holds -- see #call_frame_event_id's own comment for the full
+    # bookkeeping story and #return_from_call for the matching pop-side
+    # restore.
     def do_call_event(cmd)
       return unless @resolver
-      cmds = resolve_call(cmd)
+      cmds, target_event_id = resolve_call(cmd)
       return if cmds.nil? || cmds.empty?
       return if @call_stack.size >= MAX_CALL_DEPTH
-      @call_stack.push [@list, @index]
+      @call_stack.push [@list, @index, @call_frame_event_id || @event_id || 0]
       @list = cmds
       @index = 0
+      @call_frame_event_id = target_event_id
     end
 
+    # Resolves a Call Event's target, returning `[commands, event_id]` (both
+    # nil on any failure) -- `event_id` (cycle #192) is the concrete map-event
+    # id #do_call_event's pushed frame should carry for the list about to run,
+    # 0 for a common event, matching liblcf's own SaveEventExecFrame#event_id
+    # comment "0 if it's common event or in other map" (see
+    # LCF::Schema::SAVE_EVENT_EXEC_FRAME's own comment on why "in other map"
+    # is not a distinct, reachable case in this codebase's own model: Call
+    # Event's own command format -- param0 0/1/2 above -- never names a map
+    # at all, only a common-event id or a same-map event id/page, so there is
+    # no "different map" target for this engine to ever resolve here).
     def resolve_call(cmd)
       case cmd.param(0)
       when 0
         id = cmd.param(1)
         cmds = @resolver.common_event_commands(id)
         $stderr.puts "[RPG2k] Call Event: common event #{id} not found" if cmds.nil?
-        cmds
+        [cmds, 0]
       when 1 then map_event_call(cmd.param(1), cmd.param(2))
       when 2 then map_event_call(variables[cmd.param(1)],
                                  variables[cmd.param(2)])
@@ -1184,7 +1286,9 @@ module Game
     # stale event id or page number resolves to no commands either -- both are
     # reported here rather than left a silent no-op, matching real RPG_RT's
     # error dialog for the same targets (see docs/TODO.md's runtime error
-    # catalog).
+    # catalog). Returns `[commands, id]` on success (see #resolve_call), a
+    # bare nil on failure -- #do_call_event/#resolve_call already bail out on
+    # `cmds.nil?` before ever consulting the second value in that case.
     def map_event_call(event_ref, page)
       id = character_ref(event_ref)
       if id.nil?
@@ -1194,7 +1298,7 @@ module Game
       end
       cmds = @resolver.map_event_commands(id, page)
       $stderr.puts "[RPG2k] Call Event: map event #{id} page #{page} not found" if cmds.nil?
-      cmds
+      [cmds, id]
     end
 
     # Translate a command's character reference into the map event id the scene
@@ -1615,6 +1719,7 @@ module Game
       if @battle_escape_aborts
         @index = @list.size
         @call_stack = []
+        @call_frame_event_id = nil
         return
       end
       target = @battle_has_handlers && find_battle_option(:escape)
@@ -2973,12 +3078,22 @@ module Game
     # NOT independently confirmed against genuine RPG_RT under wine, the
     # same `IsRPG2k3Commands()` gate
     # as Force Flee/Enable Combo above.
+    #
+    # The pushed entry's third element (cycle #192's per-frame event_id, see
+    # #do_call_event's own comment) is always a literal 0 here, matching the
+    # only kind of target this command ever has -- kept purely so
+    # @call_stack's own shape stays uniform for the shared #return_from_call
+    # to pop, NOT a claim that battle interpreters participate in
+    # #call_stack_snapshot's save mechanism: they do not (see
+    # #call_stack_snapshot's own scope, Game::State#foreground_event_exec/
+    # #common_event_exec), per-frame identity there is deliberately out of
+    # scope for this cycle.
     def do_call_common_event(cmd)
       return unless @resolver && @state.party.rpg2003?
       cmds = common_event_commands(cmd.param(0))
       return if cmds.nil? || cmds.empty?
       return if @call_stack.size >= MAX_CALL_DEPTH
-      @call_stack.push [@list, @index]
+      @call_stack.push [@list, @index, 0]
       @list = cmds
       @index = 0
     end
@@ -3023,6 +3138,7 @@ module Game
       @battle.terminate
       @index = @list.size
       @call_stack = []
+      @call_frame_event_id = nil
     end
 
     # Conditional Branch (battle form, 13310). param0 selects the test:

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1972,6 +1972,7 @@ check '#call_stack_snapshot captures a process mid a nested Call Event too, unli
   it.resolver = FakeResolver.new(common: { 5 => called })
   it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),
             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.event_id = 3 # the caller's own identity -- must NOT leak into the called frame below
   it.update # enters the call, runs its first command, parks on its own Wait
   eq true, st.switches[9]
   ok it.resumable_index.nil?, 'not capturable the old, coarser way -- mid a nested call'
@@ -1980,6 +1981,12 @@ check '#call_stack_snapshot captures a process mid a nested Call Event too, unli
   eq 2, frames.size, 'the suspended caller frame plus the called frame'
   eq 1, frames[0][:current_command], 'the caller is parked right after its own Call Event'
   eq 2, frames[1][:current_command], 'the called frame is parked right after its own Wait'
+  # Cycle #192: a Call Event targeting a COMMON event reads back event_id 0
+  # on its own frame (liblcf's own "0 if it's common event or in other
+  # map"), never the outer caller's own id -- the outermost frame alone
+  # still carries the interpreter's own root #event_id.
+  eq 3, frames[0][:event_id], 'the outermost frame is still this interpreter\'s own root event_id'
+  eq 0, frames[1][:event_id], 'a called common event\'s own frame reads back 0, not the caller\'s 3'
 
   it2 = Game::Interpreter.new(new_state)
   it2.resolver = FakeResolver.new(common: { 5 => called })
@@ -1991,6 +1998,84 @@ check '#call_stack_snapshot captures a process mid a nested Call Event too, unli
   eq true, st2.switches[10], 'the called frame resumes past its own Wait, not from the top'
   eq true, st2.switches[1], 'control correctly returns to the outer, suspended caller'
   ok !it2.running?, 'the whole call stack unwinds to completion'
+end
+
+check "#call_stack_snapshot's called frame carries the target map event's own event_id, not the caller's" do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0]),
+            FakeCmd.new(IC::WAIT, [1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 10, 10, 0])]
+  it.resolver = FakeResolver.new(maps: { 12 => { 2 => called } })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [1, 12, 2]), # call map event 12, page 2
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.event_id = 7 # the caller's own identity -- distinct from the target, 12
+  it.update # enters the call, runs its first command, parks on its own Wait
+  eq true, st.switches[9]
+
+  frames = it.call_stack_snapshot
+  eq 2, frames.size
+  eq 7, frames[0][:event_id], 'the outermost (suspended caller) frame is the interpreter\'s own root identity'
+  eq 12, frames[1][:event_id],
+     'the called frame carries the TARGET map event\'s own id (12), not the caller\'s (7)'
+
+  # A re-snapshot after a full restore reproduces the exact same per-frame
+  # event_ids -- #call_frame_event_id round-trips through #restore_call_stack
+  # even though nothing about live execution needs it (see
+  # Game::Interpreter#restore_call_stack's own comment).
+  it2 = Game::Interpreter.new(new_state)
+  it2.resolver = FakeResolver.new(maps: { 12 => { 2 => called } })
+  it2.restore_call_stack(frames)
+  eq 7, it2.event_id, 'event_id restored from the outermost frame, same as before'
+  round = it2.call_stack_snapshot
+  eq frames.map { |f| f[:event_id] }, round.map { |f| f[:event_id] },
+     'restoring then re-snapshotting reproduces the exact same per-frame event_ids'
+
+end
+
+check '#return_from_call restores the caller\'s own event_id -- it does not leak into a later, unrelated call' do
+  # Two SEQUENTIAL (not nested) Call Events from the same root event, each
+  # to a different map event: once the first call fully returns,
+  # #call_frame_event_id must read back the root's own identity (7) again,
+  # not stay stuck on the first callee's (12) -- otherwise the SECOND call's
+  # own pushed frame would record the wrong caller identity.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  first_called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])] # finishes immediately, no Wait
+  second_called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 10, 10, 0]), FakeCmd.new(IC::WAIT, [1])]
+  it.resolver = FakeResolver.new(maps: { 12 => { 2 => first_called }, 20 => { 3 => second_called } })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [1, 12, 2]),
+            FakeCmd.new(IC::CALL_EVENT, [1, 20, 3])])
+  it.event_id = 7
+  it.update # runs+returns from the first call, then enters the second and parks on its Wait
+  eq true, st.switches[9], 'the first call ran and returned'
+  eq true, st.switches[10], 'the second call ran up to its own Wait'
+
+  frames = it.call_stack_snapshot
+  eq 2, frames.size, 'the suspended root caller plus the second called frame'
+  eq 7, frames[0][:event_id], 'the caller\'s own identity, not leaked from the first call\'s target (12)'
+  eq 20, frames[1][:event_id], 'the second call\'s own frame correctly carries its own target (20)'
+end
+
+check '#call_stack_snapshot on a Call Event to "this event" gives the called frame the SAME id as the caller' do
+  # Self-calling another page of the event already running is genuinely the
+  # same event throughout -- unlike calling a DIFFERENT map event (checked
+  # above), the called frame's own event_id must equal the caller's, not
+  # read back as a distinct id.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  page2 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0]), FakeCmd.new(IC::WAIT, [1])]
+  it.resolver = FakeResolver.new(maps: { 7 => { 2 => page2 } })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [1, 10005, 2]), # "this event", page 2
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.event_id = 7 # the list belongs to map event 7
+  it.update
+  eq true, st.switches[9]
+
+  frames = it.call_stack_snapshot
+  eq 2, frames.size
+  eq 7, frames[0][:event_id]
+  eq 7, frames[1][:event_id], 'the called frame is genuinely the same event (7), not a distinct callee id'
 end
 
 check '#call_stack_snapshot is nil once the process has finished' do


### PR DESCRIPTION
## Summary

Small follow-up to #1431 (cycle #191, merged). That cycle's own `docs/TODO.md` entry honestly flagged a simplification: each saved call-stack frame's `event_id`/`triggered_by_decision_key` were mirrored from the whole interpreter's single value, since `Game::Interpreter#do_call_event` never recorded which event a called command list actually belonged to when it pushed a frame.

This closes that gap. `#do_call_event` now records, at push time, the concrete target `event_id` `#resolve_call`/`#map_event_call` already resolve to fetch that frame's own commands (0 for a common event, matching liblcf's own `SaveEventExecFrame#event_id` comment "0 if it's common event or in other map"). `@call_stack` entries grew a third element (`[list, index, event_id]`); every push/pop/reset site was updated to match, threaded through a new `@call_frame_event_id` ivar tracked entirely separately from `#event_id` itself (which stays root-scoped for live "this event" resolution — investigated and deliberately left untouched, since `#do_call_event` never mutates it entering a call in the first place, so `#return_from_call` needs no matching restore for it either).

`#do_call_common_event` (the RPG2003 battle page's own Call Common Event, 1005) is out of scope — battle interpreters aren't part of the `foreground_event_exec`/`common_event_exec` save mechanism cycle #191 built — it keeps `@call_stack`'s shape uniform with a literal `0` third element.

Also confirmed: liblcf's "...or in other map" case doesn't name a distinct, reachable case in this codebase's model — Call Event's own command format never names a different map, only a common-event id or a same-map event id/page — documented rather than fabricating a case for it.

## Verification

Independently re-verified before shipping:
- `ruby -c` clean on all touched files.
- `rpg2k_logic_check.rb`=1172 (was 1169, +3 new checks: a common-event call reads back 0 not the caller's id, a map-event call reads back its own target id not the caller's, sequential-not-nested calls don't leak identity, and a "this event" self-call reads back the same id as the caller).
- `rpg2k_scene_check.rb`=929, `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0, `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known pre-existing failures — all unchanged.
- `ctest -R mruby_test` passes after a clean rebuild.
- No `data/` files touched.

See `docs/TODO.md`'s cycle #192 entry for the full writeup.

## Changelog

`changelog.d/call-stack-frame-event-id.fixed.md` — genuine correctness fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_