### PR TITLE
Cycle #193: persist a map event's own Parallel Process; investigate save-mid-wait reachability

### DIFF
--- a/changelog.d/map-event-parallel-process-persistence.fixed.md
+++ b/changelog.d/map-event-parallel-process-persistence.fixed.md
@@ -1,0 +1,24 @@
+- **A Map Event's own Parallel Process now survives a genuine Save/Continue
+  on the same map**, instead of always restarting from the top — the one gap
+  cycles #191/#192's own foreground/Common-Event-Parallel-Process call-stack
+  persistence deliberately left open (a Map Event's own Parallel Process,
+  distinct from a Common Event's, had no persistence mechanism at all, not
+  even the older, coarser `Game::Interpreter#resumable_index`-style cursor,
+  since no such cursor ever existed for one). `LCF::Schema::SAVE_MOVABLE`
+  gained field 108 (`parallel_event_execstate`, liblcf's own `SaveMapEvent`
+  field), the same `SAVE_EVENT_EXEC_STATE` struct chunks 113/114 already use,
+  nested inside chunk 111's own per-event `Array2D`. `Game::State` gained
+  `#map_event_exec` (a `{event id => call-stack frames}` Hash mirroring
+  `#common_event_exec`'s own shape, but — unlike it — scoped to the currently
+  loaded map only and reset on every `#perform_teleport`, since a map event's
+  own id repeats across maps). `Scene::Map#record_parallel_progress` (which
+  used to no-op outright for a map event's own Parallel Process) now
+  snapshots it there every tick, and `#new_parallel` consults it the same way
+  it already consults `#common_event_exec`. An ordinary Transfer Player still
+  always restarts a map event's own Parallel Process fresh, unchanged — only
+  a genuine `.lsd` Save/Continue on the same map reaches the new mechanism.
+  Covered by new checks in `scripts/rpg2k_logic_check.rb` (the schema-level
+  `to_lsd`/`from_lsd` round trip, mid a nested Call Event) and
+  `scripts/rpg2k_scene_check.rb` (a fresh `Scene::Map` genuinely resuming
+  from the captured call stack rather than restarting). See docs/TODO.md's
+  cycle #193 entry.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14707,6 +14707,12 @@ following this paragraph as the original record.
   character, the same fallback an ordinary Auto-Start common event already
   has).
 
+  **Superseded by cycle #193, 2026-08-28, on the Map Event exclusion
+  specifically**: the paragraph just above says a Map Event's own parallel
+  process "is still excluded from any of this" — true when written; cycle
+  #193 closed exactly that gap (`Game::State#map_event_exec`, SAVE_MOVABLE
+  field 108). See cycle #193's own entry below.
+
   **Superseded by cycle #192, 2026-08-27, on one specific point**: this
   entry's own writeup above (and `LCF::Schema::SAVE_EVENT_EXEC_FRAME`'s
   schema.rb comment as it read at the time) claimed each frame's `event_id`/
@@ -14801,6 +14807,170 @@ following this paragraph as the original record.
   per-frame `event_id` values) is verified by a fresh-state round trip, not
   a genuine wine-saved multi-frame `.lsd`, same open point cycle #191 itself
   already carried forward.
+- ✅ **Follow-up (cycle #193, 2026-08-28): a Map Event's own Parallel Process
+  now persists through a genuine `.lsd` Save/Continue too**, closing the one
+  gap cycles #191/#192 both left open on purpose (see cycle #191's own entry
+  above, now annotated). A Common Event's own Parallel Process
+  (`Game::State#common_event_exec`, chunk 114) and the shared foreground
+  interpreter (`#foreground_event_exec`, chunk 113) already had full
+  call-stack persistence; a Map Event whose own page trigger is Parallel
+  Process — a distinct thing from a Common Event's Parallel Process — had
+  none at all, not even the older, coarser `Game::Interpreter
+  #resumable_index`-style cursor `#common_event_progress` gives common
+  events, since no such cursor ever existed for a map event's own process in
+  the first place.
+
+  `LCF::Schema::SAVE_MOVABLE` (the per-map-event record chunk 111's own field
+  11 `Array2D` elements are, shared with the hero/vehicle chunks 104-107)
+  gained field 108 (`0x6C`, liblcf's own `SaveMapEvent.
+  parallel_event_execstate`, generator/csv/fields.csv): `type: :Array1D,
+  elements: SAVE_EVENT_EXEC_STATE`, the identical struct chunks 113/114
+  already use. Declared after `SAVE_EVENT_EXEC_STATE`'s own definition
+  further down `schema.rb`, not inline in `SAVE_MOVABLE`'s own literal
+  (`SAVE_MOVABLE[108] = {...}`), since that struct did not exist yet at
+  `SAVE_MOVABLE`'s own point in the file — a plain forward-reference, not a
+  design choice. Two of liblcf's other `SaveMapEvent` fields the same brief
+  flagged were deliberately left out: field 101 (`waiting_execution`) already
+  means something else entirely in this same shared table (`SaveVehicleLocation
+  .vehicle`, chunks 105-107's own boat/ship/airship ordinal) — giving one
+  field id two meanings in one shared table is not possible without
+  splitting `SAVE_MOVABLE` into per-chunk tables, out of scope here; fields
+  102/103 (`original_move_route_index`/`triggered_by_decision_key`) are real
+  and uncontested but this codebase has no distinct "route before an
+  override" concept to source the former from, and the latter is already
+  carried per-frame inside `stack`'s own outermost `SAVE_EVENT_EXEC_FRAME`
+  field 13 — left for a future cycle alongside `SAVE_MOVABLE`'s own other
+  already-catalogued gaps (the hero's unmodelled move-route chunk, `through`,
+  movement timers).
+
+  `Game::State` gained `#map_event_exec`, a `{map event id => call-stack
+  frames}` Hash mirroring `#common_event_exec`'s own shape and consumed the
+  same way, but scoped differently in one deliberate respect:
+  `#common_event_exec` is safe to carry across an ordinary Transfer Player
+  (a common event id is global), while `#map_event_exec` is NOT (a map event
+  id repeats across maps, the same hazard `#map_event_positions` already
+  has) — so `Scene::Map#perform_teleport` resets it to `{}` on every map
+  change, alongside `#map_event_positions`/`#map_event_route_index`. This is
+  exactly what keeps a Map Event's own Parallel Process still always
+  restarting fresh across an ordinary same-session Transfer Player, matching
+  the pre-existing, deliberate behaviour `#build_parallels`'s own comment
+  documents — the new mechanism is reachable only through a genuine
+  Save/Continue on the SAME map, the one channel `#perform_teleport`'s reset
+  does not touch. `Scene::Map#record_parallel_progress` (which used to
+  `return unless p[:common_event_id]`, a documented no-op for a map event's
+  own process) now snapshots the `p[:event]`-non-nil half too, keyed by the
+  owning map event's own id; `#new_parallel` consults `#map_event_exec[event
+  [:id]]` the same way it already consults `#common_event_exec
+  [common_event_id]`, with no older-cursor fallback to fall back to (none
+  ever existed). `#to_lsd`/`.from_lsd`'s chunk 111 writer/reader were
+  extended to carry field 108 alongside the pre-existing position/route-index
+  fields, keyed by the union of `#map_event_positions`' and
+  `#map_event_exec`'s own ids (the two are recorded independently, though in
+  practice always together, by `#record_map_event_positions`/
+  `#record_parallel_progress` alike).
+
+  Verified the same way cycle #191 verified chunks 113/114 (a from-scratch
+  round trip, not a genuine wine-saved fixture — none was available):
+  `scripts/rpg2k_logic_check.rb` gained a `to_lsd`/`from_lsd` round-trip
+  check at the `Game::State` level, built around a map event Calling a
+  *different* map event's page and parking mid that nested call's own Wait
+  (mirroring cycle #191's own common-event check, confirming per-frame
+  `event_id`s 5/6 read back correctly, not collapsed or swapped);
+  `scripts/rpg2k_scene_check.rb` gained an end-to-end check building a real
+  `Scene::Map`, capturing the same mid-nested-call snapshot from a live
+  `#step_parallel` tick, then building a *second*, brand-new `Scene::Map`
+  from a fresh `Game::State` carrying only `#map_event_exec` (no live
+  `Game::Interpreter` object, standing in for a genuine Continue) and
+  confirming it resumes exactly where the snapshot left off — the called
+  frame's own follow-up command runs, then control returns to the caller's
+  trailing command, all without either of the two markers that ran *before*
+  the snapshot ever re-running — rather than restarting both map events from
+  the top. The pre-existing "Transfer Player ... always rebuilds a map
+  event's [interpreter]" check (cycle #191) needed no change and still
+  passes unmodified, confirming the two channels (live Transfer Player vs.
+  genuine Continue) stay correctly distinguished. Full check-suite baselines
+  after this cycle: `rpg2k_scene_check.rb`=931 (up from 929: +1 for this
+  part's own resume check, +1 for the part-2 Key Input Proc reachability
+  check below), `rpg2k_logic_check.rb`=1174 (up from 1173 — note: cycle
+  #192's own entry recorded 1172 as its final total, but the actual
+  pre-cycle-#193 baseline measured directly against this branch's own HEAD
+  was 1173, one higher than documented; not investigated further, harmless
+  either way since this cycle's own +1 is verified against the real,
+  measured baseline rather than the possibly-stale documented one),
+  `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0,
+  `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known
+  pre-existing failures unchanged, and the `mruby_test` ctest suite passes
+  after a clean rebuild.
+
+  Deliberately left open, matching cycle #191/#192's own carried-forward
+  points: no genuine wine-saved fixture confirms the exact byte layout
+  against real RPG_RT; and the same per-frame `event_id`/`triggered_by_decision_key`
+  simplifications cycles #191/#192 already documented for chunks 113/114
+  apply identically here, since field 108 reuses the exact same
+  `SAVE_EVENT_EXEC_STATE`/`SAVE_EVENT_EXEC_FRAME` structs and
+  `Game::Interpreter#call_stack_snapshot`/`#restore_call_stack` machinery,
+  unchanged by this cycle.
+- ✅ **Investigated (cycle #193, 2026-08-28): is saving mid a Show
+  Message/Choices/Key Input wait reachable?** Following up on cycle #191's
+  own "restoring a mid-wait UI request is out of scope" note (`#call_stack_
+  snapshot` captures the command-list position but not `@waiting`/
+  `@wait_kind`/etc.), this asked whether that gap is even reachable at all,
+  for any interpreter — the shared foreground one, a Common Event Parallel
+  Process, or (after this same cycle's own part above) a Map Event's own
+  Parallel Process.
+
+  **Confirmed unreachable for Show Message/Show Choices/Input Number,
+  specifically**: `Scene::Map#event_busy?` (which gates `#try_open_menu`,
+  the only path to an ordinary player-driven Save) checks `@message`/
+  `@number_input` — genuinely scene-wide state, not per-interpreter. Traced
+  `#drive_parallel_wait`'s own `:message`/`:choice`/`:number` cases: a
+  Parallel Process's own Show Message/Show Choices/Input Number opens the
+  *exact same* `@message`/`@number_input` `#open_message`/
+  `#open_number_input` already write for the foreground (confirmed by
+  reading the call sites directly, not inferred) — matching
+  `#message_window_open?`'s own comment, "anywhere in the scene, including a
+  still-running parallel process". So a genuine Save is unreachable while
+  ANY interpreter, foreground or parallel, sits on one of these three
+  specific waits — the gap `#call_stack_snapshot`'s own scope limit
+  describes is real but never actually exercised for them, the same
+  "investigated, confirmed unreachable" verdict this project's culture
+  prefers over leaving the question open.
+
+  **Confirmed reachable for a Key Input Proc's own wait (Cmd::KEY_INPUT_PROC,
+  11610), when issued from a Parallel Process specifically**: `#event_busy?`
+  only ever inspects the single shared foreground `@interpreter`'s own
+  `#waiting?`/`#running?` plus the scene-wide `@message`/`@number_input`/
+  `@battle` — it never looks at any `@parallels` entry's own `#wait_kind` at
+  all. A waiting Key Input Proc (`wait` param set) first blocks-and-retries
+  behind a genuinely open message window (`#block_pending_key_input_
+  command`), but once past that guard (no message window open anywhere) it
+  parks the issuing interpreter on a bare `:key_input` wait with nothing else
+  in the scene reflecting it. For the FOREGROUND interpreter this is already
+  covered — `@interpreter.waiting?` alone makes `#event_busy?` true — but a
+  Common Event's (or, after this cycle's own part 1, a Map Event's) own
+  Parallel Process parked there sets none of `#event_busy?`'s own conditions,
+  so the ordinary Cancel-key menu shortcut — and with it, a genuine Save —
+  stays reachable. Confirmed with a new `scripts/rpg2k_scene_check.rb` check:
+  a Common Event Parallel Process genuinely parked on `:key_input` (Decision
+  only accepted, so the Cancel key used to open the menu cannot also resolve
+  the proc itself) still lets `#try_open_menu` push `Scene::Menu`.
+
+  Judged out of scope to actually restore this cycle, and left as a
+  documented follow-up rather than silently dropped: the call-stack position
+  itself is already captured/restored correctly regardless (a save taken
+  here still resumes at the right command) — only the live request itself
+  (target variable id, accepted-key flags) has no restore path, so a save
+  taken here today silently resumes past the Wait For Key Input entirely,
+  leaving the requested variable at 0 (its own "reset every retried frame"
+  default) rather than a genuine key code. `SAVE_EVENT_EXEC_STATE`'s
+  `keyinput_*` field cluster already exists schema-only for exactly this
+  (see that struct's own schema.rb comment) — restoring it for real would
+  need `#call_stack_snapshot`/`#restore_call_stack` to also carry
+  `@key_input_request`/`@wait_kind`/`@waiting` for the `:key_input` case
+  specifically (and only that case — Show Message/Choices/Input Number are
+  confirmed unreachable above, and a plain Wait/`:wait_key_enter` already
+  round-trip correctly per cycle #191), a real but narrow follow-up left for
+  a future cycle rather than built speculatively here.
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1267,6 +1267,17 @@ module LCF
       # ever been boarded that session -- see SAVE_DATA's own 105-107
       # comment for the larger discovery this field was found alongside.
       101 => { name: :vehicle, type: :int },
+      # Field 108 (0x6C, `parallel_event_execstate` -- liblcf's own
+      # `SaveMapEvent`, generator/csv/fields.csv) is added just below
+      # SAVE_EVENT_EXEC_STATE's own definition further down this file, not
+      # inline here: its `elements:` is that very struct, which is not
+      # defined yet at this point in the file (SAVE_MOVABLE is one of the
+      # earliest tables declared; SAVE_EVENT_EXEC_STATE, added by cycle #191,
+      # comes much later). See that assignment's own comment for the field
+      # itself, and for why fields 101 (already spoken for, above) and
+      # 102/103 (liblcf's own `waiting_execution`/`original_move_route_index`
+      # /`triggered_by_decision_key` neighbours) are deliberately left
+      # unmodelled here.
     }
 
     # A genuine kk1.12 save's own chunk 104 (the hero's SAVE_MOVABLE record)
@@ -1832,6 +1843,52 @@ module LCF
       41 => { name: :keyinput_timed, type: :bool, default: false },
       42 => { name: :wait_key_enter, type: :bool, default: false },
     }
+
+    # SAVE_MOVABLE field 108 (0x6C, liblcf's own `SaveMapEvent.
+    # parallel_event_execstate`, generator/csv/fields.csv) -- a map event's
+    # OWN Parallel Process's full call-stack snapshot, the identical
+    # SAVE_EVENT_EXEC_STATE struct chunk 111's own sibling chunks 113/114
+    # (SAVE_FOREGROUND_EVENT/SAVE_COMMON_EVENT) already use. Assigned here,
+    # after SAVE_EVENT_EXEC_STATE's own definition just above, rather than
+    # inline in SAVE_MOVABLE's own literal further up this file -- see that
+    # table's own field-108 comment for why (a forward-reference: this
+    # struct did not exist yet at that point in the file).
+    #
+    # Cycle #193 closes the one gap cycle #191/#192's own foreground/
+    # common-event call-stack persistence deliberately left open: a Map
+    # Event's own Parallel Process (trigger Parallel Process on the event's
+    # own page, distinct from a Common Event's Parallel Process, already
+    # covered by SAVE_COMMON_EVENT) previously had no persistence at all --
+    # not even the older, coarser #resumable_index-style cursor
+    # `Game::State#common_event_progress` gives common events, since no such
+    # cursor ever existed for map events (`Scene::Map#build_parallels`'s own
+    # comment: "a real 'visit' gives a map event's own parallel process no
+    # id that means anything on the map being left"). See
+    # `Game::State#map_event_exec`'s own comment (game.rb) for the full
+    # engine-side wiring this field now backs, and why -- unlike
+    # `#common_event_exec` -- it is scoped to the currently-loaded map only,
+    # matching `#map_event_positions`.
+    #
+    # liblcf's own two neighbouring fields on `SaveMapEvent` --
+    # `waiting_execution` (0x65/101, "this event is waiting for foreground
+    # execution") and `original_move_route_index` (0x66/102) /
+    # `triggered_by_decision_key` (0x67/103) -- are deliberately left
+    # unmodelled: 101 collides with this same shared SAVE_MOVABLE table's
+    # pre-existing, differently-typed `:vehicle` field (chunks 105-107's own
+    # boat/ship/airship ordinal, write-only byte parity with no reader), so
+    # giving it a second meaning here is not possible without splitting
+    # SAVE_MOVABLE into per-chunk tables -- out of scope for this cycle,
+    # which only needs field 108. 102/103 are real, uncontested fields this
+    # codebase's own `Game::State` simply has no distinct "original route
+    # before an override"/"triggered by decision key" concept to source for
+    # a map event specifically (the latter is already carried per-frame
+    # inside `stack`'s own outermost `SAVE_EVENT_EXEC_FRAME`, field 13, which
+    # is what this codebase's reader actually consults) -- left for a future
+    # cycle alongside SAVE_MOVABLE's own already-catalogued larger gaps (see
+    # that table's own comment on the hero's unmodelled move-route chunk/
+    # `through`/movement timers).
+    SAVE_MOVABLE[108] = { name: :parallel_event_execstate, type: :Array1D,
+                          elements: SAVE_EVENT_EXEC_STATE }
 
     # Saved common-event execution state (chunk 114): an Array2D indexed by
     # common-event id -- 505 entries in a real Nepheshel save (this codebase's

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -14939,9 +14939,11 @@ module Game
     # Full `Game::Interpreter` call-stack snapshots of every currently-
     # running Common Event Parallel Process (Scene::Map's own @parallels,
     # the `common_event_id`-non-nil entries only -- a Map Event's own
-    # parallel process is excluded, matching #common_event_progress's
-    # identical scope and its own "always restarts fresh" reasoning): common
-    # event id => Game::Interpreter#call_stack_snapshot's own return value.
+    # parallel process has its own, separate #map_event_exec below, added by
+    # cycle #193; this comment previously read "excluded... matching
+    # #common_event_progress's identical scope", true when cycle #191 wrote
+    # it, no longer true as of #map_event_exec's own addition): common event
+    # id => Game::Interpreter#call_stack_snapshot's own return value.
     #
     # Snapshotted every tick by Scene::Map#record_parallel_progress
     # (superseding #common_event_progress for anything that has ever
@@ -14964,7 +14966,60 @@ module Game
     # Array of LCF::EventCommand objects) every tick, for every running
     # Parallel Process, is unnecessary weight that path's own callers (dev
     # tooling, this test suite's own round-trip checks) have no need for.
+    #
+    # Unlike #map_event_exec below, a common event id is global (unique
+    # across the whole database, not per-map), so this hash is safe to carry
+    # forward across an ordinary Transfer Player untouched -- though in
+    # practice #new_parallel never actually needs to for that case, since
+    # #build_parallels already keeps the live Game::Interpreter object
+    # itself across a same-session teleport (see its own comment); this hash
+    # only ever gets a real look-in at Continue time, when there is no live
+    # object to inherit from at all.
     attr_accessor :common_event_exec
+    # Full `Game::Interpreter` call-stack snapshots of every currently-
+    # running Map Event Parallel Process (a map event whose own page trigger
+    # is Parallel Process -- distinct from #common_event_exec just above,
+    # which is a Common Event's own Parallel Process): map event id =>
+    # Game::Interpreter#call_stack_snapshot's own return value. Added by
+    # cycle #193, closing the gap cycles #191/#192 both left open (a Map
+    # Event's own Parallel Process previously had no persistence mechanism
+    # at all -- not even the older, coarser #resumable_index-style cursor
+    # #common_event_progress gives common events, since no such cursor ever
+    # existed for map events in the first place -- see
+    # Scene::Map#record_parallel_progress's own comment, which used to
+    # document this as a deliberate no-op).
+    #
+    # Snapshotted every tick by the same Scene::Map#record_parallel_progress
+    # that maintains #common_event_exec (the `p[:event]`, `p[:common_event_id]`-
+    # nil entries of @parallels), consumed by Scene::Map#new_parallel via
+    # Game::Interpreter#restore_call_stack exactly the same way, keyed by
+    # the owning map event's own id instead of a common event id.
+    #
+    # Scoped to the single currently-loaded map only, UNLIKE
+    # #common_event_exec: a map event's own id is per-map, not global (ids
+    # repeat across maps -- see #map_event_positions' own comment on the
+    # identical hazard), so carrying a stale entry across a genuine map
+    # change risks feeding a same-numbered but wholly unrelated event on the
+    # destination map someone else's captured call stack. Scene::Map
+    # #perform_teleport clears this to `{}` for exactly that reason,
+    # alongside #map_event_positions/#map_event_route_index (see there) --
+    # which also means, unlike a Common Event's own Parallel Process, a Map
+    # Event's own Parallel Process still always restarts fresh across an
+    # ordinary Transfer Player (the pre-existing, deliberate behaviour
+    # #build_parallels' own comment documents: "a real 'visit' gives a map
+    # event's own parallel process no id that means anything on the map
+    # being left"); this hash's full-fidelity resume is reachable only
+    # through a genuine Save/Continue on the SAME map, the one channel
+    # #perform_teleport's own reset does not touch.
+    #
+    # `.lsd`-only, the same rationale #common_event_exec's own comment gives
+    # (round-trips through chunk 111's own SAVE_MOVABLE field 108,
+    # LCF::Schema::SAVE_MOVABLE, one entry per live map event, nested inside
+    # the same Array2D #map_event_positions/#map_event_route_index already
+    # share -- see #to_lsd/.from_lsd) -- never added to the portable Marshal
+    # save (#to_h/.load), which already gets full fidelity for free within
+    # one process exactly the way #common_event_exec's own comment explains.
+    attr_accessor :map_event_exec
     # The current map's own live event positions, event id => [x, y, direction],
     # snapshotted every frame by Scene::Map#record_map_event_positions. Real
     # RPG_RT's SaveMapEvent chunk carries exactly this (plus a move-route index,
@@ -15055,6 +15110,7 @@ module Game
       @common_event_progress = {}
       @foreground_event_exec = nil
       @common_event_exec = {}
+      @map_event_exec = {}
       @map_event_positions = {}
       @map_event_route_index = {}
       @tile_substitutions = [{}, {}]
@@ -16092,11 +16148,12 @@ module Game
 
       # Chunk 111 (SAVE_MAP_EVENT/SAVE_MOVABLE) is the currently-loaded map's
       # own live event table, mirrored straight from #map_event_positions/
-      # #map_event_route_index, plus its Tile Substitution table
-      # (#tile_substitutions, fields 21/22), a live Change Encounter Rate
-      # override (#encounter_rate, field 3), a live Change Parallax
+      # #map_event_route_index/#map_event_exec (the last added by cycle
+      # #193, field 108 -- see its own comment), plus its Tile Substitution
+      # table (#tile_substitutions, fields 21/22), a live Change Encounter
+      # Rate override (#encounter_rate, field 3), a live Change Parallax
       # Background override (#parallax, fields 32-38), and the camera scroll
-      # (fields 1/2) -- all six scoped to the current map only, see their own
+      # (fields 1/2) -- all scoped to the current map only, see their own
       # doc comments above. Camera scroll is the view's top-left pixel in
       # 1/16 pixel, computed the same way `Scene::Map#camera_position` does
       # every frame (`Game.camera_offset` against the hero's pixel centre and
@@ -16109,8 +16166,8 @@ module Game
       # with no map loaded (e.g. a fresh, unplayed save), the same "absent
       # means nothing to restore" rule the unplaced-vehicle chunks above use.
       lower_subs, upper_subs = @tile_substitutions
-      if self.map || !@map_event_positions.empty? || !lower_subs.empty? ||
-         !upper_subs.empty? || @encounter_rate || @parallax
+      if self.map || !@map_event_positions.empty? || !@map_event_exec.empty? ||
+         !lower_subs.empty? || !upper_subs.empty? || @encounter_rate || @parallax
         mapev = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MAP_EVENT })
         if self.map
           hero_px = @x * TILE + TILE / 2
@@ -16120,16 +16177,29 @@ module Game
           mapev[1] = cam_x * LCF::Schema::SCROLL_UNITS_PER_PIXEL
           mapev[2] = cam_y * LCF::Schema::SCROLL_UNITS_PER_PIXEL
         end
-        unless @map_event_positions.empty?
+        # The union of #map_event_positions' and #map_event_exec's own ids:
+        # in practice every map event with a live Parallel Process call-stack
+        # snapshot also has a position (both are recorded every frame, by
+        # #record_map_event_positions/#record_parallel_progress, for as long
+        # as the event has a live Game::Character at all), but the two are
+        # deliberately not assumed to stay in lockstep here -- an id present
+        # in only one still gets its own entry, with just that one field set.
+        unless @map_event_positions.empty? && @map_event_exec.empty?
           events = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
-          @map_event_positions.each do |id, pos|
-            x, y, direction = pos
+          ids = @map_event_positions.keys | @map_event_exec.keys
+          ids.each do |id|
             e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
-            e[12] = x
-            e[13] = y
-            e[22] = CharSet::DIR_ROW[direction] || 2
-            idx = @map_event_route_index[id]
-            e[43] = idx if idx
+            pos = @map_event_positions[id]
+            if pos
+              x, y, direction = pos
+              e[12] = x
+              e[13] = y
+              e[22] = CharSet::DIR_ROW[direction] || 2
+              idx = @map_event_route_index[id]
+              e[43] = idx if idx
+            end
+            frames = @map_event_exec[id]
+            e[108] = self.class.build_event_exec_state(frames) if frames && !frames.empty?
             events[id] = e
           end
           mapev[11] = events
@@ -16687,27 +16757,41 @@ module Game
       # before this landed, or one taken before any battle ever finished.
       state.last_battle_turns = inv.turns unless inv.turns.nil?
       # The currently-loaded map's own live event table (chunk 111,
-      # #to_lsd's write above): position/facing into #map_event_positions and
-      # a page's custom-route cursor (field 43) into #map_event_route_index.
-      # An absent chunk (a save written before this landed, or a state that
-      # never recorded any positions) leaves the constructor's empty {}
-      # defaults in place; an entry with no field 43 restores its position
-      # but nothing for #map_event_route_index, matching build_event's
-      # existing "no saved index means start the custom route from the top"
-      # fallback.
+      # #to_lsd's write above): position/facing into #map_event_positions, a
+      # page's custom-route cursor (field 43) into #map_event_route_index,
+      # and (cycle #193) a map event's own Parallel Process call-stack
+      # snapshot (field 108, SAVE_EVENT_EXEC_STATE) into #map_event_exec --
+      # see that attribute's own comment. An absent chunk (a save written
+      # before this landed, or a state that never recorded any positions)
+      # leaves the constructor's empty {} defaults in place; an entry with no
+      # field 43 restores its position but nothing for
+      # #map_event_route_index, matching build_event's existing "no saved
+      # index means start the custom route from the top" fallback; an entry
+      # with no field 108 (the overwhelming majority -- most map events run
+      # no Parallel Process at all) simply gets no #map_event_exec entry,
+      # matching #new_parallel's own "nothing to restore" fallback to a
+      # fresh start. Field 108 is read independently of whether `mv.x`/`mv.y`
+      # are present, unlike positions/route_index just below -- see
+      # #map_event_exec's own comment on why the two are not assumed to
+      # always co-occur.
       map_events = save[111]
       saved_events = map_events && map_events.events
       if saved_events
         positions = {}
         route_index = {}
+        exec_snapshots = {}
         saved_events.each do |id, mv|
-          next unless mv.x && mv.y
-          positions[id] = [mv.x, mv.y, EventGraphic.numpad_direction(mv.direction)]
-          idx = mv.move_route_index
-          route_index[id] = idx unless idx.nil?
+          if mv.x && mv.y
+            positions[id] = [mv.x, mv.y, EventGraphic.numpad_direction(mv.direction)]
+            idx = mv.move_route_index
+            route_index[id] = idx unless idx.nil?
+          end
+          frames = read_event_exec_frames(mv.parallel_event_execstate)
+          exec_snapshots[id] = frames if frames
         end
         state.map_event_positions = positions
         state.map_event_route_index = route_index
+        state.map_event_exec = exec_snapshots
       end
       # The same chunk's Tile Substitution table (fields 21/22): absent on a
       # save that never rewrote a tile, or one written before this landed.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1697,6 +1697,40 @@ class RPG2k
 
       # -- event execution ----------------------------------------------------
 
+      # Cycle #193 investigation (docs/TODO.md, following up on cycle #191's
+      # own "restoring a mid-wait UI request is out of scope" note): every
+      # entry here except `@interpreter.waiting?` is either the single shared
+      # FOREGROUND interpreter or genuinely scene-wide state
+      # (@message/@number_input, set identically whichever interpreter --
+      # foreground or any @parallels entry -- raised the Show Message/Show
+      # Choices/Input Number that opened them, see #message_window_open?'s
+      # own comment; @battle, similarly shared regardless of which
+      # interpreter opened it, just above). Confirmed by tracing
+      # #drive_parallel_wait's own :message/:choice/:number cases
+      # (mruby-rpg2k/mrblib/scene/map.rb): a Parallel Process's own Show
+      # Message/Choices/Input Number opens the exact same @message/
+      # @number_input #open_message/#open_number_input already write for the
+      # foreground, not a per-interpreter mechanism of its own -- so a
+      # genuine Save is unreachable while ANY interpreter sits on one of
+      # those three specific waits, not merely the foreground's own.
+      #
+      # This method never inspects any @parallels entry's own #waiting?/
+      # #wait_kind directly, though -- so a wait kind that neither sets
+      # @message/@number_input nor opens @battle is NOT covered when it is a
+      # *parallel* process (not the foreground) sitting on it. The one such
+      # wait kind reachable without a message window already blocking it
+      # first: a waiting Key Input Proc (Cmd::KEY_INPUT_PROC, 11610, wait
+      # flag set) issued from a Common Event's or a Map Event's own Parallel
+      # Process -- see scripts/rpg2k_scene_check.rb's own check proving this
+      # reachable (a Parallel Process genuinely parked on Key Input, no
+      # message window up anywhere, still lets #try_open_menu's ordinary
+      # Cancel-key shortcut open the menu). Judged out of scope to restore
+      # this cycle (a documented follow-up, not silently dropped) --
+      # #call_stack_snapshot's own "does not restore a mid-wait UI request"
+      # scope limit already covers what actually happens: the save still
+      # resumes at the right command, just past the Wait For Key Input
+      # entirely, with the requested variable left holding 0 rather than a
+      # genuine key code.
       def event_busy?
         @message || @number_input || @interpreter.running? || @interpreter.waiting? ||
           # A battle a Parallel Process opened (#drive_parallel_wait's :battle
@@ -1864,7 +1898,16 @@ class RPG2k
       # Player, or the very first build for this scene), matching the existing
       # per-visit-reset behaviour: a real "visit" gives a map event's own
       # parallel process no id that means anything on the map being left, so
-      # there is nothing sound to reuse.
+      # there is nothing sound to reuse. This still holds after cycle #193:
+      # #new_parallel now *can* resume a map event's own Parallel Process
+      # from a captured call stack (Game::State#map_event_exec), but only
+      # across a genuine Save/Continue on the SAME map -- #perform_teleport
+      # deliberately clears #map_event_exec on every map change for the
+      # identical reason it already clears #map_event_positions (a map
+      # event's own id is per-map, not global, so a stale entry would
+      # misapply to an unrelated same-numbered event on the destination map)
+      # -- so an ordinary Transfer Player still finds nothing there to
+      # resume from and rebuilds fresh, exactly as before.
       #
       # `preserve_map_events:` is the one exception, passed only by
       # #rebuild_events_preserving_positions: that call does not change maps at
@@ -1886,12 +1929,15 @@ class RPG2k
       #
       # On the very first build for this scene (a brand new game, or the fresh
       # Scene::Map Continue/#initialize builds from a loaded save), there is no
-      # previous @parallels to reuse from, so #new_parallel instead
-      # fast-forwards a fresh interpreter to whatever position #step_parallel
-      # last recorded on Game::State before the game was last saved (see
-      # Game::State#common_event_progress) -- a coarser, index-only
-      # continuation, since nothing was kept alive across a save to resume with
-      # full fidelity.
+      # previous @parallels to reuse from, so #new_parallel instead consults
+      # whatever Game::State carries from the save it was built from: for a
+      # common event, #common_event_exec's own full call-stack snapshot first,
+      # falling back to the coarser, index-only #common_event_progress cursor
+      # only when that has nothing; for a map event (cycle #193), the
+      # identically-shaped #map_event_exec -- there is no older coarse-cursor
+      # fallback to fall back to here, since none ever existed for a map
+      # event's own Parallel Process before this.
+      #
       def build_parallels(preserve_map_events: false)
         previous_common = {}
         previous_map = {}
@@ -1968,18 +2014,25 @@ class RPG2k
       # it keys both the teleport-time reuse in #build_parallels above and the
       # save-file continuation this seeds from below.
       #
-      # Genuine full-fidelity continuation (Game::State#common_event_exec,
-      # driven from a real .lsd's chunk 114 -- see that attribute's own
-      # comment) is tried first: unlike the older #common_event_progress
-      # cursor, it also covers a process saved mid a nested Call Event.
-      # #common_event_progress only ever gets a look-in when this has
-      # nothing for the id (an older save, or one written before cycle
-      # #191).
+      # Genuine full-fidelity continuation is tried first: Game::State
+      # #common_event_exec (driven from a real .lsd's chunk 114) for a common
+      # event, or -- cycle #193 -- Game::State#map_event_exec (chunk 111
+      # field 108) for a map event's own Parallel Process, keyed by `event`'s
+      # own id rather than `common_event_id` since a map event has none.
+      # Unlike the older #common_event_progress cursor, either one also
+      # covers a process saved mid a nested Call Event. #common_event_progress
+      # only ever gets a look-in when this has nothing for the id (an older
+      # save, or one written before cycle #191); there is no equivalent
+      # fallback for a map event, since no such cursor ever existed for one.
       def new_parallel(commands, gate_switch, event, common_event_id)
         it = Game::Interpreter.new(@state)
         it.resolver = @interpreter.resolver
         it.map_info = self
-        saved_frames = common_event_id && @state.common_event_exec[common_event_id]
+        saved_frames = if common_event_id
+                         @state.common_event_exec[common_event_id]
+                       elsif event
+                         @state.map_event_exec[event[:id]]
+                       end
         if saved_frames && !saved_frames.empty?
           it.restore_call_stack(saved_frames)
         else
@@ -2124,32 +2177,47 @@ class RPG2k
         nil
       end
 
-      # Snapshot a Common Event Parallel Process's current position onto
-      # Game::State, so a fresh Scene::Map built later from this state (a
-      # genuine save/load, not a Transfer Player -- see #build_parallels) can
-      # resume it instead of restarting at the top. A no-op for a map event's
-      # own parallel process (p[:common_event_id] is nil there), which never
-      # gets a checkpoint at all -- it always restarts fresh, unchanged.
+      # Snapshot a Parallel Process's current position onto Game::State, so a
+      # fresh Scene::Map built later from this state (a genuine save/load,
+      # not a Transfer Player -- see #build_parallels) can resume it instead
+      # of restarting at the top. Handles both halves of @parallels:
       #
-      # Records two things, cycle #191 having added the second on top of the
-      # pre-existing first:
-      #   - Game::State#common_event_progress (Game::Interpreter
-      #     #resumable_index): only overwrites the stored checkpoint when the
-      #     interpreter's position is cleanly capturable right now; a tick
-      #     that returns nil (mid a nested Call Event) simply leaves the last
-      #     known-good checkpoint in place rather than clearing it. Still the
-      #     only mechanism the portable Marshal save (#to_h/.load) carries.
-      #   - Game::State#common_event_exec (Game::Interpreter
-      #     #call_stack_snapshot): the fuller call-stack snapshot a real
-      #     `.lsd`'s chunk 114 now backs, captured whenever the interpreter is
-      #     running at all -- including mid a nested Call Event, unlike
-      #     #resumable_index above.
+      #   - A Common Event's own Parallel Process (`p[:common_event_id]`
+      #     non-nil) records two things, cycle #191 having added the second
+      #     on top of the pre-existing first:
+      #       - Game::State#common_event_progress (Game::Interpreter
+      #         #resumable_index): only overwrites the stored checkpoint when
+      #         the interpreter's position is cleanly capturable right now; a
+      #         tick that returns nil (mid a nested Call Event) simply leaves
+      #         the last known-good checkpoint in place rather than clearing
+      #         it. Still the only mechanism the portable Marshal save
+      #         (#to_h/.load) carries.
+      #       - Game::State#common_event_exec (Game::Interpreter
+      #         #call_stack_snapshot): the fuller call-stack snapshot a real
+      #         `.lsd`'s chunk 114 now backs, captured whenever the
+      #         interpreter is running at all -- including mid a nested Call
+      #         Event, unlike #resumable_index above.
+      #   - A Map Event's own Parallel Process (`p[:event]` non-nil,
+      #     `p[:common_event_id]` nil -- cycle #193) records only the fuller
+      #     snapshot, into Game::State#map_event_exec, keyed by the owning
+      #     map event's own id: there is no #common_event_progress-style
+      #     coarse cursor to maintain in parallel here, since none ever
+      #     existed for a map event's own Parallel Process before this (see
+      #     #map_event_exec's own comment). Previously this method returned
+      #     immediately for this case (`return unless p[:common_event_id]`)
+      #     -- a map event's own Parallel Process got no checkpoint
+      #     whatsoever and always restarted fresh; see this method's own
+      #     history in docs/TODO.md for why.
       def record_parallel_progress(p)
-        return unless p[:common_event_id]
-        idx = p[:interp].resumable_index
-        @state.common_event_progress[p[:common_event_id]] = idx if idx
-        frames = p[:interp].call_stack_snapshot
-        @state.common_event_exec[p[:common_event_id]] = frames if frames
+        if p[:common_event_id]
+          idx = p[:interp].resumable_index
+          @state.common_event_progress[p[:common_event_id]] = idx if idx
+          frames = p[:interp].call_stack_snapshot
+          @state.common_event_exec[p[:common_event_id]] = frames if frames
+        elsif p[:event]
+          frames = p[:interp].call_stack_snapshot
+          @state.map_event_exec[p[:event][:id]] = frames if frames
+        end
       end
 
       def drive_parallel_wait(p, it)
@@ -8243,9 +8311,20 @@ class RPG2k
         # applies to a saved custom-route cursor: dropped alongside so a
         # destination event beginning its own page's route starts at the top,
         # not part-way through wherever a same-numbered event on the map being
-        # left happened to be.
+        # left happened to be. And (cycle #193) to a saved map-event Parallel
+        # Process call-stack snapshot (#map_event_exec): dropped for the
+        # identical reason -- without this, a destination map's own event
+        # sharing the same numeric id as one still mid a Parallel Process on
+        # the map being left could pick up that unrelated snapshot's captured
+        # command list, running the wrong event's bytecode entirely rather
+        # than merely mispositioning a sprite. This is exactly why a map
+        # event's own Parallel Process still always restarts fresh across an
+        # ordinary Transfer Player (see #build_parallels' own comment) even
+        # though #new_parallel now knows how to resume one -- this reset is
+        # what keeps that true.
         @state.map_event_positions = {}
         @state.map_event_route_index = {}
+        @state.map_event_exec = {}
         # Tiles #warn_stale_terrain has already reported are per-visit too, same
         # reasoning as the tables above -- a stale reference on the map being
         # left says nothing about the destination.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11008,6 +11008,61 @@ check 'to_lsd/from_lsd round-trips a foreground and a common-event call-stack sn
   eq({}, via_marshal.common_event_exec)
 end
 
+# Cycle #193: chunk 111's own SAVE_MOVABLE field 108 (parallel_event_execstate)
+# now round-trips a genuine Game::Interpreter call-stack snapshot for a MAP
+# event's own Parallel Process, the identical mechanism the check just above
+# already proves for chunks 113/114 -- see Game::State#map_event_exec's own
+# comment for why this needed its own separate hash/field (a map event's own
+# id is per-map, not global, unlike a common event's). This exercises the
+# Game::State-level contract in isolation; scripts/rpg2k_scene_check.rb's own
+# "a fresh Scene::Map genuinely resumes a saved map event's own Parallel
+# Process" check drives the same mechanism end to end through #new_parallel.
+check "to_lsd/from_lsd round-trips a map event's own Parallel Process " \
+      'call-stack snapshot (chunk 111 field 108)' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+
+  # Map event 5's own Parallel Process Calls map event 6's page 1 (Call
+  # Event mode 1: [mode, event_ref, page]), which itself parks on a Wait --
+  # mid a nested Call Event, the same shape cycle #191's own common-event
+  # check above exercises, not merely a clean between-commands cursor.
+  me_it = Game::Interpreter.new(Game::State.new(Game::Party.new(db), 1, 0, 0))
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0]), FakeCmd.new(IC::WAIT, [1])]
+  me_it.resolver = FakeResolver.new(maps: { 6 => { 1 => called } })
+  me_it.start([FakeCmd.new(IC::CALL_EVENT, [1, 6, 1])])
+  me_it.event_id = 5
+  me_it.update # enters the call, parks mid the nested Call Event's own Wait
+  ok me_it.resumable_index.nil?, 'sanity: not capturable the old, coarser way'
+  st.map_event_exec[5] = me_it.call_stack_snapshot
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  frames = round.map_event_exec[5]
+  ok !frames.nil?, "chunk 111 field 108 came back for map event 5's own entry"
+  eq 2, frames.size, 'the suspended caller frame plus the called frame, not collapsed'
+  eq 5, frames[0][:event_id], "the outer frame is this Parallel Process's own event, 5"
+  eq 6, frames[1][:event_id], 'the called frame is map event 6, the Call Event target'
+  eq 2, frames[1][:current_command], 'the called frame is parked right after its own Wait'
+  ok round.map_event_exec[12].nil?, 'no entry at all for a map event nothing ever ran'
+
+  # Absent when nothing was mid-execution -- the overwhelming common case --
+  # matching every other "nothing to restore" chunk in #to_lsd.
+  bare = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  bare_round = Game::State.from_lsd(db, bare.to_lsd)
+  eq({}, bare_round.map_event_exec)
+
+  # The portable Marshal save (#to_h/.load) never carries this field at all
+  # either -- deliberately, see #map_event_exec's own comment -- so loading
+  # one restores "nothing to resume", whatever #map_event_exec held before
+  # it was dumped.
+  st.map_event_exec[5] = me_it.call_stack_snapshot
+  via_marshal = Game::State.load(db, st.to_h)
+  eq({}, via_marshal.map_event_exec)
+end
+
 check 'shown pictures round-trip through this engine\'s own internal Marshal-style ' \
       'save (Game::State#to_h/.load), not just through a genuine .lsd (#to_lsd/.from_lsd)' do
   # Cycle #158: #to_h never mentioned @pictures at all, so any picture on screen

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2720,6 +2720,83 @@ check "Transfer Player reuses a common event's Parallel Process interpreter " \
      "the rebuilt map event's parallel process starts over at the top"
 end
 
+# Cycle #193: a map event's own Parallel Process now DOES survive a genuine
+# Save/Continue on the same map -- Game::State#map_event_exec (chunk 111
+# field 108), consulted by #new_parallel exactly the way #common_event_exec
+# already is for a common event's own Parallel Process. This is deliberately
+# NOT in tension with the check just above: that one pins an ordinary
+# Transfer Player (a live, same-session #perform_teleport, which still
+# always rebuilds a map event's process fresh -- #perform_teleport clears
+# #map_event_exec on every map change specifically to keep that true); this
+# one pins the OTHER channel, a brand new Scene::Map built from a state that
+# only carries the captured snapshot, standing in for a genuine Continue.
+check "a fresh Scene::Map genuinely resumes a saved map event's own Parallel " \
+      'Process from its captured call stack (mid a nested Call Event), not ' \
+      'from the top' do
+  ic = Game::Interpreter::Cmd
+  caller_page = page(trigger: 4) # Parallel Process
+  caller_page.event_commands = [add_var_cmd(3), ECmd.new(ic::CALL_EVENT, [1, 6, 1]),
+                                 add_var_cmd(4)]
+  # Never auto-runs on its own (action-key trigger, the `page` default) --
+  # reached only via the Call Event above, so it contributes nothing to
+  # @parallels itself and cannot be confused with event 5's own entry.
+  callee_page = page(trigger: 0)
+  callee_page.event_commands = [add_var_cmd(5), ECmd.new(ic::WAIT, [1]), add_var_cmd(6)]
+  events = { 5 => event(2, 2, caller_page), 6 => event(3, 3, callee_page) }
+  db = fake_db(nil)
+
+  scene = new_scene(events)
+  st = scene.instance_variable_get(:@state)
+  scene.update # marker 3, enters the call, marker 5, parks on the called Wait
+  eq 1, st.variables[3]
+  eq 1, st.variables[5]
+  eq 0, st.variables[4], 'has not returned from the call yet'
+  eq 0, st.variables[6], "hasn't reached the Wait's own follow-up yet"
+
+  p = scene.instance_variable_get(:@parallels).find { |pp| pp[:event] && pp[:event][:id] == 5 }
+  frames = p[:interp].call_stack_snapshot
+  ok frames && frames.size == 2, 'sanity: genuinely captured mid a nested Call Event'
+
+  # A brand new Game::State/Scene::Map, standing in for Continue: no live
+  # Game::Interpreter object carries over (unlike the ordinary-Transfer-
+  # Player check above), only the captured snapshot on #map_event_exec --
+  # exactly what a real .lsd's chunk 111 field 108 would decode into (see
+  # the Game::State-level round trip in scripts/rpg2k_logic_check.rb for
+  # that half of the mechanism).
+  fresh_state = Game::State.new(fake_party, 1, 0, 0)
+  fresh_state.map = fake_map(1, events)
+  fresh_state.map_event_exec[5] = frames
+  parent = FakeParent.new(db) { |id| fake_map(id, events) }
+  fresh_scene = RPG2k::Scene::Map.new(parent, fresh_state)
+
+  new_p = fresh_scene.instance_variable_get(:@parallels)
+                      .find { |pp| pp[:event] && pp[:event][:id] == 5 }
+  restored_it = new_p[:interp]
+  ok !restored_it.instance_variable_get(:@call_stack).empty?,
+     'restored with the caller frame still on the call stack, not a fresh empty one'
+  eq 0, fresh_state.variables[3],
+     "marker 3 must not re-run on this fresh state -- it belongs to the OLD " \
+     "state's own history, not this resume"
+  eq 0, fresh_state.variables[5], 'nor marker 5 -- both already ran before the save'
+
+  # #restore_call_stack's own restored cursor already sits just PAST the
+  # Wait command (matching #call_stack_snapshot's own "@index always sits
+  # just past the command that raised the wait" contract) -- there is no
+  # in-flight countdown left to restore (the same documented scope limit
+  # every other captured-mid-a-wait case has), so the very next tick runs
+  # straight through the called frame's own follow-up, back out of the call,
+  # and to the caller's own trailing command, all in one #update. Checked
+  # after exactly one tick, before the process has any chance to finish and
+  # loop back to the top for a second lap (which would genuinely re-run
+  # markers 3/5, a real but unrelated, pre-existing "parallel processes loop
+  # forever" behaviour -- see the Transfer Player check further below).
+  fresh_scene.update
+  eq 1, fresh_state.variables[6], "the called frame's own follow-up ran, past the restored Wait"
+  eq 1, fresh_state.variables[4], "control returned to the caller's own trailing command"
+  eq 0, fresh_state.variables[3], 'marker 3 still never re-ran -- this was a resume, not a restart'
+  eq 0, fresh_state.variables[5], 'nor marker 5'
+end
+
 check "a common event's Parallel Process's own Transfer Player command " \
       'actually warps the party, then keeps running on the new map' do
   ic = Game::Interpreter::Cmd
@@ -3651,6 +3728,70 @@ check 'Key Input Proc (RPG2003 Numbers layout) ignores a digit key when Numbers 
   eq 5, st.variables[1]
   scene.update
   ok st.switches[5]
+end
+
+# Cycle #193 investigation (docs/TODO.md, following up on cycle #191's own
+# "restoring a mid-wait UI request is out of scope" note): every OTHER
+# blocking wait a Show Message/Show Choices/Input Number can raise sets the
+# scene-wide @message/@number_input (#message_window_open?'s own comment:
+# "anywhere in the scene, ... including a still-running parallel process"),
+# which #event_busy? already checks and #try_open_menu already gates on --
+# confirming a genuine Save simply cannot happen while any interpreter,
+# foreground or parallel, sits on one of those three. A Parallel Process's
+# own waiting Key Input Proc (Cmd::KEY_INPUT_PROC, 11610, wait flag set) is
+# different: #event_busy? only ever inspects the single FOREGROUND
+# @interpreter's own #waiting?/@battle plus the scene-wide @message/
+# @number_input -- it never looks at any entry in @parallels at all. So
+# nothing gates the ordinary Cancel-key menu shortcut (and with it, a
+# genuine Save) while a Common Event's -- or, after this same cycle's own
+# map-event Parallel Process persistence, a Map Event's -- own Parallel
+# Process sits fully parked on a Wait For Key Input, with no message window
+# involved anywhere in the scene. #event_busy?'s own mechanism draws no
+# distinction between @parallels entries by `common_event_id`/`event`, so
+# this reachability is identical for both; only a Common Event is exercised
+# below; a Map Event's own entry would fail the same assertions for the
+# identical reason (see Scene::Map#event_busy?'s own comment for this).
+#
+# Judged out of scope to actually restore for this cycle (kept as a
+# documented follow-up rather than silently dropped, per docs/TODO.md):
+# unlike the call-stack position itself (already captured and restored
+# unconditionally by #call_stack_snapshot/#restore_call_stack, so a save
+# taken here still resumes at the right command), the live Key Input Proc
+# request itself (target variable id, which buttons were accepted) has no
+# field on SAVE_EVENT_EXEC_STATE this codebase's own writer populates
+# (`keyinput_*`, schema-only -- see that struct's own schema.rb comment) and
+# no restore path back into a freshly-restored interpreter's own
+# @key_input_request/@wait_kind/@waiting. A save taken here today resumes
+# past the Wait For Key Input entirely, silently: the requested variable is
+# simply left holding whatever #do_key_input's own "reset every retried
+# frame" default (0) wrote before the wait parked, per #call_stack_snapshot's
+# own "does not restore a mid-wait UI request" scope limit, which already
+# covers this the same way it covers Show Message/Wait/Open Save Menu.
+check "a Common Event Parallel Process's own waiting Key Input Proc leaves " \
+      "#event_busy?/#try_open_menu completely unguarded, unlike a message " \
+      "window or the foreground interpreter's own wait" do
+  ic = Game::Interpreter::Cmd
+  # Decision only accepted (cancel param 0) -- so the Cancel-key press used
+  # below to open the menu can never also be read as the very key this proc
+  # is itself waiting for, keeping the two concerns cleanly separated.
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 0, 0, 0, 0])])
+  scene = new_scene({}, common: { 7 => ce })
+  parent = scene.instance_variable_get(:@parent)
+  scene.update # the Parallel Process arms the wait -- genuinely parked, no message window up
+  p = scene.instance_variable_get(:@parallels).find { |pp| pp[:common_event_id] == 7 }
+  eq :key_input, p[:interp].wait_kind,
+     'genuinely parked on Key Input (no message window to block-and-retry against)'
+  ok !scene.send(:event_busy?),
+     "#event_busy? never looks at a parallel process's own wait_kind at all"
+
+  RGSS::Input.triggered = [RGSS::Input::B] # the field map's own Cancel-key menu shortcut
+  scene.update
+  eq :key_input, p[:interp].wait_kind,
+     "the proc's own wait is unaffected -- Cancel is not among its accepted keys"
+  eq 1, parent.pushed.length,
+     "yet the menu opened anyway -- a real Save is reachable while this " \
+     "Parallel Process's own Wait For Key Input is still live"
 end
 
 check 'parallel processes keep running while a message window is open (yado.tk)' do


### PR DESCRIPTION
## Summary

Picking up the two smaller items left open by cycles #191/#192 (#1431, #1433), per user direction ("go on from smaller").

**Part 1 — a Map Event's own Parallel Process now survives a genuine Save/Continue on the same map.** Distinct from a Common Event's own Parallel Process (already covered by #191/#192), a map event's own Parallel Process previously had *no* persistence mechanism at all — not even the older, coarser `#resumable_index`-style cursor `common_event_progress` gives common events, since no such cursor ever existed for map events. Adds `LCF::Schema::SAVE_MOVABLE` field 108 (`parallel_event_execstate`, liblcf's own `SaveMapEvent` field — the same `SAVE_EVENT_EXEC_STATE` struct chunks 113/114 already use), `Game::State#map_event_exec` (mirroring `#common_event_exec` but scoped to the currently-loaded map, since a map event's own id repeats across maps — reset on every `#perform_teleport` for exactly that reason), and wires `Scene::Map#record_parallel_progress`/`#new_parallel` to snapshot/restore it the same way the common-event mechanism already works. An ordinary Transfer Player still always restarts a map event's own Parallel Process fresh, unchanged.

Note: field 101 on the shared `SAVE_MOVABLE` table already means something unrelated (`SaveVehicleLocation.vehicle`, write-only byte parity for the vehicle chunks) — deliberately left untouched; only field 108 was needed for this goal.

**Part 2 — investigated whether saving mid a Show Message/Choices/Input Number or Key Input Proc wait is reachable at all**, for any interpreter (not just the foreground one #191 already covered). Confirmed **unreachable** for Show Message/Choices/Input Number: traced `#drive_parallel_wait`'s own `:message`/`:choice`/`:number` cases — any interpreter's request opens the exact same scene-wide `@message`/`@number_input` that `#event_busy?`/`#try_open_menu` already gate on, regardless of which interpreter raised it. Confirmed **reachable** for a Parallel Process's own waiting Key Input Proc (11610) with no message window open — `#event_busy?` never inspects a parallel process's own wait state at all. Judged out of scope to build restoration for this small cycle; documented as a follow-up rather than silently dropped.

## Verification

Independently re-verified before shipping (including after merging in unrelated concurrent master activity — a profiler change with no file overlap):
- `ruby -c` clean on all touched files.
- `rpg2k_scene_check.rb`=931 (was 929, +2 new), `rpg2k_logic_check.rb`=1174 (was 1173 as actually measured on this branch — one higher than #192's own documented 1172, from unrelated concurrent activity; +1 new), `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0, `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known pre-existing failures — all unchanged.
- `ctest -R mruby_test` passes after a clean rebuild.
- No `data/` files touched.

See `docs/TODO.md`'s cycle #193 entry for the full writeup.

## Changelog

`changelog.d/map-event-parallel-process-persistence.fixed.md` — genuine behavioral fix (part 1); part 2 is investigation-only, no changelog entry needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_