### PR TITLE
Cycle #194: restore a Parallel Process's mid-Key-Input-Proc wait through .lsd

### DIFF
--- a/changelog.d/key-input-proc-save-restore.fixed.md
+++ b/changelog.d/key-input-proc-save-restore.fixed.md
@@ -1,0 +1,15 @@
+- **A Common Event or Map Event Parallel Process genuinely mid a waiting Key
+  Input Proc (11610) now survives a genuine `.lsd` Save/Continue**, instead
+  of silently resuming past the wait with the requested variable stuck at 0.
+  Follow-up to cycle #193's own investigation, which found this is the one
+  wait kind a Parallel Process can be saved mid — every other Show
+  Message/Choices/Input Number wait is unreachable for a save at all, since
+  they all set the same scene-wide state that blocks the Save menu
+  regardless of which interpreter raised them, but `#event_busy?` never
+  inspects a Parallel Process's own wait state. `Game::Interpreter
+  #call_stack_snapshot` now rewinds this one specific wait kind's own
+  `current_command` by one, so `#restore_call_stack` naturally re-executes
+  the Key Input Proc command from scratch on the next tick — a pure
+  function of its own parameters, and exactly what genuine RPG_RT itself
+  already does every frame it re-checks a still-pending one. Covered by a
+  new check in `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14971,6 +14971,59 @@ following this paragraph as the original record.
   confirmed unreachable above, and a plain Wait/`:wait_key_enter` already
   round-trip correctly per cycle #191), a real but narrow follow-up left for
   a future cycle rather than built speculatively here.
+- ✅ **Follow-up (cycle #194, 2026-08-28): restored the Key Input Proc
+  mid-wait case cycle #193 left open**, closing the one narrow gap that
+  cycle's own investigation confirmed reachable. Simpler than that cycle's
+  own writeup anticipated: rather than carrying `@key_input_request`/
+  `@wait_kind`/`@waiting` explicitly through the snapshot (what cycle #193's
+  own entry speculated would be needed, and what `SAVE_EVENT_EXEC_STATE`'s
+  schema-only `keyinput_*` cluster would back), `Game::Interpreter
+  #call_stack_snapshot` now rewinds the innermost frame's own
+  `current_command` by one specifically when `@waiting && @wait_kind ==
+  :key_input` -- capturing the Key Input Proc command itself rather than
+  `@index`'s own usual "just past it" position. `#restore_call_stack`
+  needed no changes at all: rebuilding `@call_stack`/`@list`/`@index` at
+  that rewound position means the very next `#update` naturally re-executes
+  `#do_key_input` from scratch, which is a pure function of the command's
+  own literal parameters (`var_id`, `wait`, the accepted-keys flags) --
+  re-deriving `@key_input_request`/`@wait_kind`/`@waiting` exactly as they
+  were, with no explicit serialization needed. The one side effect
+  (resetting the requested variable to 0) is not a compromise: genuine
+  RPG_RT itself already does that same reset every single frame it
+  re-evaluates a still-pending Key Input Proc (`#do_key_input`'s own
+  existing comment), so replaying the command is not a workaround, it is
+  what would have happened on the very next frame regardless. This reuses
+  the same rewind-and-retry idiom `#block_pending_key_input_command`
+  already applies for its own "message window still open" case -- just
+  triggered by the save/snapshot path instead of by the interpreter's own
+  next tick.
+
+  Deliberately scoped to only this one confirmed-reachable case: Show
+  Message/Choices/Input Number stay correctly untouched (cycle #193 already
+  confirmed a save can never actually happen mid one), and the
+  `SAVE_EVENT_EXEC_STATE` `keyinput_*` field cluster remains schema-only --
+  it was never the mechanism this fix needed, so it is left exactly as
+  cycle #191 declared it (read-fidelity only, not written/restored).
+
+  **Verified**: new `scripts/rpg2k_logic_check.rb` check building an
+  interpreter that parks on a waiting Key Input Proc (Decision-only,
+  `wait` flag set), confirming `#call_stack_snapshot` captures
+  `current_command` one earlier than `@index`, restoring into a fresh
+  interpreter, confirming the very next `#update` re-enters the identical
+  `:key_input` wait (same accepted-keys mask, same `wait` flag) rather than
+  silently skipping past it, and finally confirming a Decision key input
+  afterward still completes the proc and runs the following command --
+  proving the restored state is genuinely live, not just decoded data.
+  `ruby -c` clean; full check-suite baselines unchanged except the one new
+  check (`rpg2k_scene_check.rb`=931, `rpg2k_logic_check.rb`=1175 (+1),
+  `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0,
+  `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known
+  pre-existing failures); `ctest -R mruby_test` passes after a clean
+  rebuild. No `data/` fixtures touched. No genuine wine-saved fixture
+  exercising this exact scenario was available, so this is a from-scratch
+  round-trip verification, not a wine-confirmed one -- the same honestly-
+  labeled limitation cycles #191-193 already carry for their own new
+  mechanisms.
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -753,7 +753,32 @@ module Game
     # SAVE_COMMON_EVENT's own schema.rb comments for when it is not).
     def call_stack_snapshot
       return nil unless @running
-      frames = @call_stack + [[@list, @index, @call_frame_event_id || @event_id || 0]]
+      # A Key Input Proc's own wait (@wait_kind == :key_input -- cycle #193's
+      # own confirmed-reachable case: a Parallel Process can be genuinely mid
+      # this specific wait, with no message window open, while a Save is
+      # still reachable, unlike every other message/choice/number wait that
+      # cycle #193 confirmed a Save can never interrupt) is captured one
+      # command EARLIER than @index's own usual "just past the command that
+      # raised the wait" convention. By the time #do_key_input sets
+      # @wait_kind, @index has already advanced past the Key Input Proc
+      # command itself (it committed -- reset the requested variable to 0,
+      # computed the accepted-keys mask -- and is now waiting for a genuine
+      # key press the scene feeds back later), which #restore_call_stack has
+      # no way to reconstruct on its own (it only rebuilds @call_stack/@list/
+      # @index, never @waiting/@wait_kind/@key_input_request -- see its own
+      # comment). Re-running #do_key_input from scratch instead reproduces
+      # the exact same wait state deterministically, since it is a pure
+      # function of the command's own literal parameters -- even its one
+      # side effect (resetting the requested variable to 0) is exactly what
+      # genuine RPG_RT itself already does every single frame it re-checks a
+      # still-pending Key Input Proc (see #do_key_input's own comment), so
+      # replaying it on restore is not a workaround, it is what would have
+      # happened on the very next frame regardless. This reuses the same
+      # rewind-and-retry idiom #block_pending_key_input_command already
+      # applies for its own "message window still open" case, just triggered
+      # here instead of by the interpreter's own next #update.
+      live_index = (@waiting && @wait_kind == :key_input) ? @index - 1 : @index
+      frames = @call_stack + [[@list, live_index, @call_frame_event_id || @event_id || 0]]
       frames.each_with_index.map do |(list, index, event_id), i|
         {
           commands: list,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2095,6 +2095,56 @@ check '#restore_call_stack is a no-op for a nil/empty snapshot' do
   ok !it.running?, 'same for an empty frames array'
 end
 
+# Cycle #194: cycle #193's own investigation confirmed a Parallel Process's
+# own waiting Key Input Proc (Cmd::KEY_INPUT_PROC, wait flag set) is the one
+# wait kind a genuine Save can interrupt without a message window blocking it
+# first (#event_busy? never inspects a parallel process's own wait_kind) --
+# every other message/choice/number wait is unreachable for a save, since all
+# three set the same scene-wide state #event_busy? already gates on. Unlike
+# those, #call_stack_snapshot/#restore_call_stack did not restore this one's
+# own wait state at all before this cycle: @index already sits just past the
+# Key Input Proc command by the time it starts waiting (the same general
+# convention every other wait kind's capture already relies on), so a naive
+# restore would silently resume PAST the wait, leaving the requested variable
+# at 0 forever and the proc effectively skipped. See #call_stack_snapshot's
+# own comment for the fix (rewinding this one specific wait kind's own
+# current_command by one, so restoring naturally re-executes the Key Input
+# Proc command from scratch -- a pure function of its own parameters, and
+# exactly what genuine RPG_RT itself already does every frame it re-checks a
+# pending one).
+check '#call_stack_snapshot rewinds a mid-Key-Input-Proc wait so #restore_call_stack re-derives it' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::KEY_INPUT_PROC, [3, 1, 0, 1, 0, 0, 0, 0, 0, 0]), # var 3, wait, decision only
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok it.waiting?, 'parked on the Key Input Proc'
+  eq :key_input, it.wait_kind
+  eq 0, st.variables[3], 'the requested variable was already reset to 0'
+
+  frames = it.call_stack_snapshot
+  eq 1, frames.size
+  eq 0, frames[0][:current_command],
+     'rewound to the Key Input Proc command itself, not past it (@index was already 1)'
+
+  it2 = Game::Interpreter.new(new_state)
+  it2.restore_call_stack(frames)
+  ok !it2.waiting?, 'not waiting yet -- #restore_call_stack never re-executes anything on its own'
+  it2.update
+  ok it2.waiting?, 'the very next #update re-ran the Key Input Proc command from its rewound position'
+  eq :key_input, it2.wait_kind
+  eq true, it2.key_input_request[:wait], 'the wait flag survived re-execution'
+  eq true, it2.key_input_request[:accepted][:decision], 're-derived deterministically from the command\'s own params'
+  eq false, it2.key_input_request[:accepted][:cancel]
+
+  # And it genuinely still functions afterward -- not just decoding as inert
+  # state: a Decision key input completes the proc and the command after it
+  # runs, the same as an interpreter that was never saved/restored at all.
+  it2.resume_key_input(it2.key_input_result([:decision]))
+  it2.update
+  eq true, it2.instance_variable_get(:@state).switches[1], 'the command after the proc ran'
+end
+
 # LCF::Schema::SAVE_EVENT_EXEC_STATE/_FRAME's own encode/decode round trip
 # (Game::State.build_event_exec_state/.read_event_exec_frames), through
 # genuine chunk bytes (Array1D#to_lcf / LCF::Array1D.new) rather than just


### PR DESCRIPTION
## Summary

Closes the one narrow gap cycle #193's own investigation (#1434) confirmed reachable: a Parallel Process's own waiting Key Input Proc (11610, no message window open) is the one wait kind a genuine Save can interrupt, since `#event_busy?` never inspects a parallel process's own wait state (every other Show Message/Choices/Input Number wait is unreachable for a save at all, confirmed by that same cycle).

Simpler fix than that cycle's own writeup anticipated: rather than threading `@key_input_request`/`@wait_kind`/`@waiting` explicitly through the snapshot, `Game::Interpreter#call_stack_snapshot` now rewinds the innermost frame's own `current_command` by one specifically when `@waiting && @wait_kind == :key_input`, capturing the Key Input Proc command itself instead of `@index`'s own usual "just past it" position. `#restore_call_stack` needed no changes: the very next `#update` naturally re-executes `#do_key_input` from scratch — a pure function of the command's own parameters — re-deriving the exact same wait state. The one side effect (resetting the requested variable to 0) is exactly what genuine RPG_RT itself already does every frame it re-checks a pending one. Reuses the same rewind-and-retry idiom `#block_pending_key_input_command` already applies for its own "message window still open" case.

Deliberately scoped to only this one confirmed-reachable case — Show Message/Choices/Input Number stay untouched, and `SAVE_EVENT_EXEC_STATE`'s `keyinput_*` cluster remains schema-only, unneeded by this fix.

## Verification

- New `scripts/rpg2k_logic_check.rb` check: parks an interpreter on a waiting Key Input Proc (Decision-only, wait flag set), confirms `#call_stack_snapshot` captures `current_command` one earlier than `@index`, restores into a fresh interpreter, confirms the very next `#update` re-enters the identical `:key_input` wait, then confirms a Decision key input afterward still completes the proc and runs the following command.
- `ruby -c` clean.
- All check-suite baselines unchanged except the one new check: `rpg2k_scene_check.rb`=931, `rpg2k_logic_check.rb`=1175 (+1), `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0, `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known pre-existing failures.
- `ctest -R mruby_test` passes after a clean rebuild.
- No `data/` files touched.

See `docs/TODO.md`'s cycle #194 entry for the full writeup.

## Changelog

`changelog.d/key-input-proc-save-restore.fixed.md` — genuine behavioral fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_