### PR TITLE
Hoist skip_to's terminator-code arrays to frozen constants

### DIFF
--- a/changelog.d/rpg2k-interpreter-skip-to-array-hoist.changed.md
+++ b/changelog.d/rpg2k-interpreter-skip-to-array-hoist.changed.md
@@ -1,0 +1,16 @@
+- **The RPG2000 event interpreter no longer allocates a throwaway Array on
+  every Conditional Branch, Choice, Shop, Inn or Battle-handler skip.**
+  `Game::Interpreter#skip_to`'s terminator-code lists were written as array
+  literals at each of its 12 call sites, so a false Conditional Branch check —
+  the standard shape of an always-on "poll a switch/variable in a Loop"
+  background common event — allocated and discarded one every single time.
+  Hoisted to frozen constants (`SKIP_TO_END_BRANCH`,
+  `SKIP_TO_ELSE_OR_END_BRANCH`, ...), reused across calls. Found via the new
+  `RGSS::Profiler.stats[:object_types]` per-type breakdown: on Nepheshel
+  (5 always-on background Parallel Process common events), this was the
+  single largest contributor to per-frame `Array` churn. Measured with a
+  temporary per-frame instrumentation pass: **~250 to ~86 Array allocations
+  per frame**, about a 65% cut. Verified against `scripts/rpg2k_command_soak.rb`
+  (184,166 real event commands from Nepheshel) and the existing RPG2000 logic
+  checks, all unaffected — this only changes what object backs the terminator
+  list, never which commands run or how far `skip_to` scans.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -149,6 +149,27 @@ module Game
       END_BRANCH_B             = 23311
     end
 
+    # #skip_to's terminator-code lists, hoisted to frozen constants rather than
+    # written as array literals at each call site below. #skip_to only ever
+    # reads them (Array#include?), so sharing one instance per shape is safe --
+    # and it matters here: every one of these call sites sits on the event
+    # command dispatch path (#execute, #do_conditional and friends), which
+    # background Parallel Process common events re-enter every frame they have
+    # steps left to spend. A Conditional Branch that evaluates false calls
+    # #skip_to once per check, so a game with a handful of always-on polling
+    # common events (switch/variable checks in a Loop, a very common RPG2000
+    # idiom) was allocating one of these throwaway arrays per check, per frame,
+    # per process -- profiled as the single largest contributor to per-frame
+    # Array churn (RGSS::Profiler.stats[:object_types], see docs/profiling.md).
+    SKIP_TO_CHOICE_END = [Cmd::CHOICE_END].freeze
+    SKIP_TO_END_BATTLE = [Cmd::END_BATTLE].freeze
+    SKIP_TO_SHOP_END = [Cmd::SHOP_END].freeze
+    SKIP_TO_INN_END = [Cmd::INN_END].freeze
+    SKIP_TO_END_BRANCH = [Cmd::END_BRANCH].freeze
+    SKIP_TO_END_BRANCH_B = [Cmd::END_BRANCH_B].freeze
+    SKIP_TO_ELSE_OR_END_BRANCH = [Cmd::ELSE_BRANCH, Cmd::END_BRANCH].freeze
+    SKIP_TO_ELSE_OR_END_BRANCH_B = [Cmd::ELSE_BRANCH_B, Cmd::END_BRANCH_B].freeze
+
     # Move-command ids inside a Move Event that carry extra parameters (every
     # other id is a bare command). Mirrors LCF's move-route parameter layout.
     module MoveCmd
@@ -931,23 +952,23 @@ module Game
       when Cmd::MESSAGE_OPTIONS  then do_message_options cmd
       when Cmd::CHANGE_FACE      then do_change_face cmd
       when Cmd::SHOW_CHOICES     then do_show_choices cmd
-      when Cmd::CHOICE_OPTION    then skip_to([Cmd::CHOICE_END], cmd.indent); consume
+      when Cmd::CHOICE_OPTION    then skip_to(SKIP_TO_CHOICE_END, cmd.indent); consume
       when Cmd::CHOICE_END       then nil
       when Cmd::INPUT_NUMBER     then do_input_number cmd
       when Cmd::KEY_INPUT_PROC   then do_key_input cmd
       when Cmd::ENEMY_ENCOUNTER  then do_enemy_encounter cmd
-      when Cmd::VICTORY_HANDLER  then skip_to([Cmd::END_BATTLE], cmd.indent); consume
-      when Cmd::ESCAPE_HANDLER   then skip_to([Cmd::END_BATTLE], cmd.indent); consume
-      when Cmd::DEFEAT_HANDLER   then skip_to([Cmd::END_BATTLE], cmd.indent); consume
+      when Cmd::VICTORY_HANDLER  then skip_to(SKIP_TO_END_BATTLE, cmd.indent); consume
+      when Cmd::ESCAPE_HANDLER   then skip_to(SKIP_TO_END_BATTLE, cmd.indent); consume
+      when Cmd::DEFEAT_HANDLER   then skip_to(SKIP_TO_END_BATTLE, cmd.indent); consume
       when Cmd::END_BATTLE       then nil
       when Cmd::OPEN_SHOP        then do_open_shop cmd
-      when Cmd::SHOP_TRANSACTION    then skip_to([Cmd::SHOP_END], cmd.indent); consume
-      when Cmd::SHOP_NO_TRANSACTION then skip_to([Cmd::SHOP_END], cmd.indent); consume
+      when Cmd::SHOP_TRANSACTION    then skip_to(SKIP_TO_SHOP_END, cmd.indent); consume
+      when Cmd::SHOP_NO_TRANSACTION then skip_to(SKIP_TO_SHOP_END, cmd.indent); consume
       when Cmd::SHOP_END         then nil
       when Cmd::NAME_INPUT       then do_name_input cmd
       when Cmd::SHOW_INN         then do_show_inn cmd
-      when Cmd::INN_STAY         then skip_to([Cmd::INN_END], cmd.indent); consume
-      when Cmd::INN_NO_STAY      then skip_to([Cmd::INN_END], cmd.indent); consume
+      when Cmd::INN_STAY         then skip_to(SKIP_TO_INN_END, cmd.indent); consume
+      when Cmd::INN_NO_STAY      then skip_to(SKIP_TO_INN_END, cmd.indent); consume
       when Cmd::INN_END          then nil
       when Cmd::CONTROL_SWITCHES then do_control_switches cmd
       when Cmd::CONTROL_VARS     then do_control_vars cmd
@@ -975,7 +996,7 @@ module Game
       when Cmd::SET_VEHICLE_LOCATION then do_set_vehicle_location cmd
       when Cmd::ENTER_EXIT_VEHICLE then @vehicle_toggle_requested = true
       when Cmd::CONDITIONAL      then do_conditional cmd
-      when Cmd::ELSE_BRANCH      then skip_to([Cmd::END_BRANCH], cmd.indent); consume
+      when Cmd::ELSE_BRANCH      then skip_to(SKIP_TO_END_BRANCH, cmd.indent); consume
       when Cmd::END_BRANCH       then nil
       when Cmd::JUMP_TO_LABEL    then do_jump_label cmd
       when Cmd::LOOP             then nil # marker; body runs, END_LOOP loops back
@@ -1049,7 +1070,7 @@ module Game
       when Cmd::CHANGE_BATTLE_BG         then do_change_battle_bg cmd
       when Cmd::SHOW_BATTLE_ANIM_B       then do_show_battle_animation_b cmd
       when Cmd::CONDITIONAL_B            then do_conditional_battle cmd
-      when Cmd::ELSE_BRANCH_B    then skip_to([Cmd::END_BRANCH_B], cmd.indent); consume
+      when Cmd::ELSE_BRANCH_B    then skip_to(SKIP_TO_END_BRANCH_B, cmd.indent); consume
       when Cmd::END_BRANCH_B     then nil
       when Cmd::TERMINATE_BATTLE then do_terminate_battle cmd
       else nil # blank editor lines (codes 0 / 10) and RPG2003-only commands
@@ -2970,7 +2991,7 @@ module Game
     # test 5 already threads.
     def do_conditional_battle(cmd)
       return if eval_battle_condition(cmd)
-      skip_to([Cmd::ELSE_BRANCH_B, Cmd::END_BRANCH_B], cmd.indent)
+      skip_to(SKIP_TO_ELSE_OR_END_BRANCH_B, cmd.indent)
       consume
     end
 
@@ -3084,7 +3105,7 @@ module Game
     def do_conditional(cmd)
       @last_condition_matched = eval_condition(cmd)
       return if @last_condition_matched # fall through into the true branch
-      skip_to([Cmd::ELSE_BRANCH, Cmd::END_BRANCH], cmd.indent)
+      skip_to(SKIP_TO_ELSE_OR_END_BRANCH, cmd.indent)
       consume # step past the else/end marker to run the else body (or continue)
     end
 


### PR DESCRIPTION
## Summary
- `Game::Interpreter#skip_to`'s 12 call sites (Conditional Branch, Choice, Shop, Inn, Battle-handler skips) each wrote their terminator codes as a fresh array literal — cheap in isolation, but `skip_to` sits on the event command dispatch path, and a false Conditional Branch check (the standard shape of an always-on "poll a switch/variable in a Loop" background common event) hits it every single time.
- Found via the new `RGSS::Profiler.stats[:object_types]` per-type breakdown (#1423): on Nepheshel (5 always-on background Parallel Process common events), this was the single largest contributor to per-frame `Array` churn.
- Hoisted each distinct terminator-code shape to a frozen class constant (`SKIP_TO_END_BRANCH`, `SKIP_TO_ELSE_OR_END_BRANCH`, ...), reused across calls — `skip_to` only ever reads the list (`Array#include?`), so sharing one instance is safe.
- Measured with a temporary per-frame instrumentation pass (not part of this diff): **~250 → ~86 Array allocations per frame, about a 65% cut**.

## Test plan
- [x] `ctest -R mruby_test` (native mrbtest suite) passes
- [x] `ruby scripts/rpg2k_command_soak.rb data/Nepheshel206beta/Nepheshel206Rbeta` — all 184,166 real event commands run clean, no raises, no gaps
- [x] `ruby scripts/rpg2k_logic_check.rb` and `ruby scripts/rpg2k_testbed_logic_check.rb` pass unaffected
- [x] Re-measured per-frame Array allocation before/after with the same instrumentation approach — confirms the ~65% drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117pag6Su2mrNWMN3QByEA3

---
_Generated by [Claude Code](https://claude.ai/code/session_0117pag6Su2mrNWMN3QByEA3)_