### PR TITLE
Cut per-frame Array/Proc/env churn in Scene::Map's draw path

### DIFF
--- a/changelog.d/scene-map-per-frame-object-churn.changed.md
+++ b/changelog.d/scene-map-per-frame-object-churn.changed.md
@@ -1,0 +1,39 @@
+- **`Scene::Map`'s per-frame draw path allocates fewer throwaway objects.**
+  Follow-up to the `skip_to` array-hoisting fix, driven by the same
+  `RGSS::Profiler.stats[:object_types]` per-type breakdown, this time aimed at
+  the render side rather than the interpreter:
+  - `#events_dirty?`/the tile-cache redraw's per-event signature check used to
+    rebuild an Array-of-Arrays (one outer Array plus one signature tuple per
+    on-screen event, each tuple itself built from two more arrays returned by
+    `Game::EventGraphic.frame` and `#event_pixel`) every time it ran, whether
+    or not anything had actually changed. Replaced with `#store_event_draw_sig`,
+    which writes each event's ten signature fields as scalars into a reused
+    flat buffer and diffs them in place — same positional dirty semantics
+    (a page rebuild that resizes or reorders `@events` still reads as dirty),
+    zero per-event allocation. `Game::EventGraphic.frame` and `#event_pixel`
+    gained `frame_dir`/`frame_col` and `event_pixel_x`/`event_pixel_y` scalar
+    siblings so the signature check can ask for just the two numbers it needs
+    instead of a pair wrapped in a throwaway Array; the original array-returning
+    methods are unchanged for their other callers. The redundant recompute after
+    `#draw_layers` redraws (previously always re-ran the full check even when
+    `#events_dirty?` had just computed the identical values) is now skipped
+    whenever `#events_dirty?` already ran that frame.
+  - `#render` and `#camera_position` both computed `#player_pixel` (one more
+    Array) every frame; `#camera_position` now takes the already-known
+    `px, py` as optional arguments instead of recomputing them.
+  - `#draw_timer`'s `2.times { |id| draw_one_timer(id, battle) }` allocated a
+    Proc (and its closure env) every frame to call a two-line method twice;
+    replaced with two direct calls.
+
+  Measured with a temporary per-frame instrumentation pass (`RGSS::Profiler`'s
+  cumulative alloc counters, sampled every 120 frames) against the same
+  deterministic 26s Nepheshel run, comparing the exact same input/timing with
+  and without these changes: **Array allocations 86.2 → 80.2 per frame, Proc
+  42.6 → 41.6, env 31.6 → 30.6** on this particular map's on-screen event count
+  — the `#events_dirty?` rewrite scales with the number of on-screen events, so
+  the win grows on more populated maps. Verified against
+  `scripts/rpg2k_command_soak.rb` (184,166 real event commands from Nepheshel),
+  `scripts/rpg2k_scene_check.rb` (which ticks the real `Scene::Map` render/update
+  path), and the rest of the RPG2000 logic/render checks, all unaffected — every
+  frame still redraws the exact same pixels; only what gets allocated to decide
+  that changed.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1228,15 +1228,24 @@ module Game
     # stays base_pattern by construction); the ordinary types walk (cycling
     # columns) while moving/continuous and rest on the page pattern when idle.
     def self.frame(anim_type, base_dir, base_pattern, char_dir, phase, moving)
+      [frame_dir(anim_type, char_dir, phase),
+       frame_col(anim_type, base_pattern, phase, moving)]
+    end
+
+    # The direction half of #frame, split out so a caller that only needs it
+    # (map.rb's per-event redraw signature, checked every event every frame)
+    # can skip building and immediately discarding the two-element array.
+    def self.frame_dir(anim_type, char_dir, phase)
+      anim_type == SPIN ? spin_direction(phase) : char_dir
+    end
+
+    # The column half of #frame, split out for the same reason as #frame_dir.
+    def self.frame_col(anim_type, base_pattern, phase, moving)
       case anim_type
-      when SPIN
-        [spin_direction(phase), base_pattern]
-      when FIXED_GRAPHIC
-        [char_dir, base_pattern]
+      when SPIN, FIXED_GRAPHIC
+        base_pattern
       else
-        col = (moving || continuous?(anim_type)) ? pattern_column(phase)
-                                                  : base_pattern
-        [char_dir, col]
+        (moving || continuous?(anim_type)) ? pattern_column(phase) : base_pattern
       end
     end
   end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3341,15 +3341,23 @@ class RPG2k
       # Current position of event `e` in map pixels, interpolated from its
       # display origin toward its logical tile while a slide is in progress.
       def event_pixel(e)
+        [event_pixel_x(e), event_pixel_y(e)]
+      end
+
+      # The two axes of #event_pixel split out so a caller that only needs one
+      # coordinate at a time (the per-event redraw signature, checked every
+      # event every frame) can skip building and immediately discarding the
+      # two-element array.
+      def event_pixel_x(e)
         cx = e[:char].x
+        return cx * TILE unless event_sliding?(e)
+        e[:disp_x] * TILE + (cx - e[:disp_x]) * e[:move_count]
+      end
+
+      def event_pixel_y(e)
         cy = e[:char].y
-        if event_sliding?(e)
-          t = e[:move_count]
-          [e[:disp_x] * TILE + (cx - e[:disp_x]) * t,
-           e[:disp_y] * TILE + (cy - e[:disp_y]) * t]
-        else
-          [cx * TILE, cy * TILE]
-        end
+        return cy * TILE unless event_sliding?(e)
+        e[:disp_y] * TILE + (cy - e[:disp_y]) * e[:move_count]
       end
 
       # -- Erase Event --------------------------------------------------------
@@ -9344,9 +9352,11 @@ class RPG2k
       # coordinate" operand can ask for it too; it is a pure function of the
       # hero position, the pan lock/offset and the shake, apart from `@locked_cam`
       # being captured the first frame the camera locks (which is idempotent, so
-      # an extra caller cannot move the view).
-      def camera_position
-        px, py = player_pixel
+      # an extra caller cannot move the view). `px`/`py` let #render, which
+      # already has #player_pixel's result, pass it straight through instead of
+      # recomputing (and re-allocating) it here.
+      def camera_position(px = nil, py = nil)
+        px, py = player_pixel if px.nil?
         screen = @state.screen
         hero_cx = Game.camera_offset(px + TILE / 2, SCREEN_W, @map.width * TILE)
         hero_cy = Game.camera_offset(py + TILE / 2, SCREEN_H, @map.height * TILE)
@@ -9447,7 +9457,7 @@ class RPG2k
 
       def render
         px, py = player_pixel
-        cam_x, cam_y = camera_position
+        cam_x, cam_y = camera_position(px, py)
 
         # The map itself never shows on the battle screen -- see
         # #set_map_layers_visible, which explains why the backdrop needs it gone
@@ -9549,7 +9559,8 @@ class RPG2k
       def draw_timer
         battle = !@battle.nil?
         @timer_sprites ||= [nil, nil]
-        2.times { |id| draw_one_timer(id, battle) }
+        draw_one_timer(0, battle)
+        draw_one_timer(1, battle)
       end
 
       def draw_one_timer(id, battle)
@@ -9973,11 +9984,14 @@ class RPG2k
           rebuilt = true
         end
 
-        if !rebuilt && !@layers_dirty &&
-           @drawn_ox == ox && @drawn_oy == oy &&
-           @drawn_party_y == @state.y && !events_dirty?
-          return
-        end
+        # Captured separately from the #events_dirty? call itself so the
+        # signature recompute after the redraw below (which only exists to
+        # cover the paths that skip #events_dirty?) knows when it can trust
+        # the freshly-stored signatures instead of redoing the same work.
+        events_checked = !rebuilt && !@layers_dirty &&
+                          @drawn_ox == ox && @drawn_oy == oy &&
+                          @drawn_party_y == @state.y
+        return if events_checked && !events_dirty?
         @layers_dirty = false
         @drawn_ox = ox
         @drawn_oy = oy
@@ -10004,42 +10018,90 @@ class RPG2k
         # The signatures must describe what was *just drawn*, not some earlier
         # frame: a compose forced by a rebuild or a flash may have drawn a state
         # whose signature was never stored, and a later frame that matches it
-        # has to be able to trust the skip.
-        @event_draw_sigs = @events.map { |e| event_draw_sig(e) }
+        # has to be able to trust the skip. When #events_dirty? already ran
+        # above, its signatures already describe this exact frame -- redoing
+        # it here would just be recomputing values that haven't changed since.
+        store_event_draw_sigs unless events_checked
+      end
+
+      # Number of scalar fields #store_event_draw_sig writes per event -- see
+      # its comment for what each one is.
+      EVENT_DRAW_SIG_FIELDS = 10
+
+      # Writes event `e`'s current draw signature into the flat `buf` at
+      # `base..base + EVENT_DRAW_SIG_FIELDS - 1`, covering exactly what
+      # #draw_event reads for it -- which CharSet cell (direction/column
+      # derived from the anim inputs), where it sits (pixel position, jump
+      # arc, bush depth), how it blends (translucency) and which buffer it
+      # lands in (page layer, and for the same-as-hero layer the y-sort
+      # against the party). Returns whether any field differs from what was
+      # there before, i.e. whether this event would composite differently
+      # from the last completed composition. Scalars written into a reused
+      # buffer, rather than an array-of-tuples rebuilt every call, so a frame
+      # with nothing to redraw costs no per-event allocation to find that out.
+      def store_event_draw_sig(e, buf, base)
+        ch = e[:char]
+        dir = Game::EventGraphic.frame_dir(e[:anim_type], ch.direction, e[:anim_phase])
+        col = Game::EventGraphic.frame_col(e[:anim_type], e[:base_pattern],
+                                           e[:anim_phase], e[:moving])
+        epx = event_pixel_x(e)
+        epy = event_pixel_y(e)
+        translucent = e[:translucent]
+        jump = event_jump_offset(e)
+        bush = event_bush_depth(e)
+        upper = event_target_buffer(e).equal?(@upper_bmp)
+
+        changed = buf[base] != ch.graphic_name || buf[base + 1] != ch.graphic_index ||
+                  buf[base + 2] != dir || buf[base + 3] != col ||
+                  buf[base + 4] != epx || buf[base + 5] != epy ||
+                  buf[base + 6] != translucent || buf[base + 7] != jump ||
+                  buf[base + 8] != bush || buf[base + 9] != upper
+
+        buf[base] = ch.graphic_name
+        buf[base + 1] = ch.graphic_index
+        buf[base + 2] = dir
+        buf[base + 3] = col
+        buf[base + 4] = epx
+        buf[base + 5] = epy
+        buf[base + 6] = translucent
+        buf[base + 7] = jump
+        buf[base + 8] = bush
+        buf[base + 9] = upper
+        changed
+      end
+
+      # Refreshes @event_draw_sigs to the current frame's actual values,
+      # resizing the buffer first if the event count changed (a page rebuild
+      # swapping entries in or out).
+      def store_event_draw_sigs
+        needed = @events.size * EVENT_DRAW_SIG_FIELDS
+        unless @event_draw_sigs && @event_draw_sigs.size == needed
+          @event_draw_sigs = Array.new(needed)
+        end
+        @events.each_with_index do |e, i|
+          store_event_draw_sig(e, @event_draw_sigs, i * EVENT_DRAW_SIG_FIELDS)
+        end
       end
 
       # Whether any event would composite differently from the last completed
-      # composition. One signature per event covering exactly what #draw_event
-      # reads -- which CharSet cell (direction/column derived from the anim
-      # inputs), where it sits (pixel position, jump arc, bush depth), how it
-      # blends (translucency) and which buffer it lands in (page layer, and for
-      # the same-as-hero layer the y-sort against the party). A frame where
-      # every signature repeats redraws the same pixels into the same buffers,
-      # so the composition as a whole can keep last frame's output. An event
-      # mid-Flash recomposes every frame by the global flash check in
-      # #events_dirty? -- its tone changes per frame, cheaper to over-draw than
-      # to fingerprint.
-      def event_draw_sig(e)
-        ch = e[:char]
-        dir, col = Game::EventGraphic.frame(e[:anim_type], e[:base_dir],
-                                            e[:base_pattern], ch.direction,
-                                            e[:anim_phase], e[:moving])
-        epx, epy = event_pixel(e)
-        [ch.graphic_name, ch.graphic_index, dir, col, epx, epy,
-         e[:translucent], event_jump_offset(e), event_bush_depth(e),
-         event_target_buffer(e).equal?(@upper_bmp)]
-      end
-
-      # Whether any event's #event_draw_sig differs from the last composed
-      # frame's, or the event set itself changed (page rebuilds swap the
-      # entries). Signatures are stored positionally, matching @events, so a
-      # rebuild that reorders or resizes the list reads as dirty -- always safe,
-      # merely sometimes conservative.
+      # composition, or the event set itself changed size (page rebuilds swap
+      # the entries). Signatures are stored positionally, matching @events, so
+      # a rebuild that reorders or resizes the list reads as dirty -- always
+      # safe, merely sometimes conservative. An event mid-Flash recomposes
+      # every frame by the global flash check below -- its tone changes per
+      # frame, cheaper to over-draw than to fingerprint.
       def events_dirty?
         return true if @player_flash || @events.any? { |e| e[:flash] }
-        sigs = @events.map { |e| event_draw_sig(e) }
-        dirty = sigs != @event_draw_sigs
-        @event_draw_sigs = sigs
+        needed = @events.size * EVENT_DRAW_SIG_FIELDS
+        unless @event_draw_sigs && @event_draw_sigs.size == needed
+          store_event_draw_sigs
+          return true
+        end
+        dirty = false
+        @events.each_with_index do |e, i|
+          base = i * EVENT_DRAW_SIG_FIELDS
+          dirty = true if store_event_draw_sig(e, @event_draw_sigs, base)
+        end
         dirty
       end
 


### PR DESCRIPTION
## Summary

Follow-up to #1436 (the `skip_to` array-hoisting fix), using the same `RGSS::Profiler.stats[:object_types]` per-type breakdown to find further per-frame allocation waste — this time on the render side rather than the interpreter:

- **`#events_dirty?`** / the tile-cache redraw's per-event signature check used to rebuild an Array-of-Arrays every time it ran (one outer Array, one signature tuple per on-screen event, each tuple itself built from two more arrays returned by `Game::EventGraphic.frame` and `#event_pixel`) — regardless of whether anything had actually changed. Replaced with `#store_event_draw_sig`, which writes each event's ten signature fields as scalars into a reused flat buffer and diffs them in place. Same positional dirty semantics (a page rebuild that resizes or reorders `@events` still reads as dirty), zero per-event allocation. `Game::EventGraphic.frame` and `#event_pixel` gained scalar `frame_dir`/`frame_col` and `event_pixel_x`/`event_pixel_y` siblings so the signature check can ask for just the number it needs instead of a pair wrapped in a throwaway Array — the original array-returning methods are unchanged for their other callers. The redundant recompute after `#draw_layers` redraws (previously always re-ran the full check even when `#events_dirty?` had just computed the identical values) is now skipped whenever `#events_dirty?` already ran that frame.
- **`#render`/`#camera_position`** both computed `#player_pixel` every frame; `#camera_position` now takes the already-known `px, py` as optional arguments instead of recomputing them.
- **`#draw_timer`**'s `2.times { |id| draw_one_timer(id, battle) }` allocated a Proc (and its closure env) every frame to call a two-line method twice; replaced with two direct calls.

Left `interpreter.rb`'s `range(cmd)` (`[a, b]` return, used by Control Switches/Variables) alone — it fires per-command, not per-frame, and touching it risks the documented indirect-addressing edge case for `mode == 2`. Not worth the risk for the payoff.

## Measurements

Via a temporary per-frame instrumentation pass (reverted before commit), A/B on the identical deterministic ~26s Nepheshel run, same input/timing with and without these changes:

| | before | after |
| --- | ---: | ---: |
| Array allocs/frame | 86.2 | 80.2 |
| Proc allocs/frame | 42.6 | 41.6 |
| env allocs/frame | 31.6 | 30.6 |

Smaller than the `skip_to` fix's ~65% cut since this run's starting area has few on-screen events — the `#events_dirty?` rewrite scales with on-screen event count, so the win grows on more populated maps.

## Test plan

- [x] `ctest -R mruby_test`
- [x] `scripts/rpg2k_command_soak.rb` — 368,332 real event commands across both Nepheshel variants, clean
- [x] `scripts/rpg2k_scene_check.rb` — ticks the real `Scene::Map` render/update path (929 checks)
- [x] `scripts/rpg2k_render_check.rb` (41 checks)
- [x] `scripts/rpg2k_logic_check.rb` (1160 checks)
- [x] `scripts/rpg2k_testbed_logic_check.rb` (98 checks)

All pass, output unchanged — every frame still redraws the exact same pixels; only what gets allocated to decide that changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_0117pag6Su2mrNWMN3QByEA3)_