### PR TITLE
Cycle #196: disclose EasyRPG-source citations in six field-menu scene files

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6875,6 +6875,74 @@ The work below is roughly ordered by the critical path to a walkable game
   be a false claim -- this cycle's honest assessment is that the sweep is
   further from done than cycle #189 believed, not closer, precisely because
   this cycle went looking in a place no prior cycle had ever checked.
+  ✅ **Follow-up (cycle #196, 2026-08-28): picked up item (2) from cycle #190's
+  own "left open" list -- the six smaller `scene/*.rb` files (`status_menu.rb`
+  13, `menu.rb` 10, `title.rb` 8, `equip_menu.rb`/`save_load.rb` 7 each,
+  `base.rb` 6) -- and fully swept all six**, following cycle #190's own
+  established method exactly: read each file whole, top to bottom, and for
+  every `EasyRPG`/`confirmed against`/`RPG_RT's [own] live source` citation
+  that presented a behavioral claim as verified fact without disclosure,
+  rewrote it to honestly disclose "ported from EasyRPG['s [own]] source, NOT
+  independently confirmed against genuine RPG_RT under wine" while preserving
+  the underlying technical description (including quoted EasyRPG source, now
+  attributed to EasyRPG rather than presented as this project's own finding);
+  genuine wine-confirmed citations already present (several in each file --
+  `save_load.rb` and `equip_menu.rb` especially, both citing real pixel-level
+  wine measurements from cycles #121-#127) were read and correctly left
+  untouched, and cross-references to an already-disclosed wine-measured
+  citation elsewhere in the same codebase (the `Input.repeat?` auto-repeat
+  timing, independently measured against genuine RPG_RT.exe and cited
+  identically in `menu.rb`/`title.rb`/`item_menu.rb`/`equip_menu.rb`/
+  `save_load.rb`) were likewise left as the legitimate shorthand cycle #190
+  itself established, not re-flagged. One additional, distinct bug found
+  along the way, not just a citation-hygiene gap: `save_load.rb`'s own
+  class-doc comment (documenting the `:save` mode) still carried the *exact*
+  "confirmed against RPG_RT's own live source, `Scene_Save::Action`" framing
+  that this same file's `#confirm_selection` method had already debunked and
+  corrected back in cycle #126 ("mislabeled at the time as 'RPG_RT's own live
+  source'... independently confirmed [instead]... against a genuine
+  RPG_RT.exe under wine") -- the class comment was simply never updated when
+  the method-level comment was fixed, so the file carried both the honest,
+  wine-confirmed version and its own stale, debunked EasyRPG-sourced
+  duplicate side by side. Fixed by pointing the class comment at
+  `#confirm_selection`'s own real wine confirmation instead of restating the
+  discredited citation. Counted precisely against cycle #190's own tally
+  before starting (`grep -c` for `EasyRPG` plus the `src/[a-z0-9_]+\.(cpp|h)`
+  pattern per file, matching cycle #190's own method): every undisclosed
+  instance in all six files is now either honestly disclosed or was already a
+  genuine wine-confirmed citation -- re-grepping after the fix turns up only
+  disclosed/wine-confirmed occurrences in each of the six.
+
+  **Verification:** `ruby -c` clean on all six edited files. Diff isolation
+  per file, the same command cycle #190 used (`git diff -- <file> | grep -E
+  '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-][[:space:]]*#' |
+  grep -vE '^[+-][[:space:]]*$'`): empty for all six, confirming every edit
+  is comment-only. Before/after check counts, all matching baseline exactly:
+  `rpg2k_scene_check.rb` 932, `rpg2k_logic_check.rb` 1176,
+  `rpg2k_render_check.rb` 41, `rpg2k3_battle_row_check.rb` 19/0 failures,
+  `rpg2k3_battle_gauge_check.rb` 15/0 failures, `rpg2k_save_load_check.rb`'s 3
+  known pre-existing failures reconfirmed identical (screen-transition arity,
+  saved-picture fields, BGM balance field). `cd build && ninja && ctest -R
+  mruby_test` passed. No wine/Xvfb/matchbox process started this cycle, no
+  `data/` file touched (`git status` on it stayed clean throughout). No
+  changelog fragment: comment-only documentation work, matching cycle #190's
+  own precedent for this exact class of fix, not a behavioral change.
+
+  **Left open for a future cycle, unchanged in priority from cycle #190's own
+  list except for the six files this cycle closed:** `scene/battle.rb`
+  (34 file-path citations, 78 `EasyRPG` mentions at last count) is now the
+  only remaining unswept file this measure identified, and by a wide margin
+  the largest -- comparable in density to `game.rb`/`map.rb` before they were
+  swept, and roughly 4-5x the size of any one file this cycle closed. Given
+  this cycle's own lighter-weight, comment-only framing (matching cycle
+  #190's own choice to fully finish several small files rather than rush a
+  partial pass at a large one), `battle.rb` was deliberately left for a
+  dedicated future cycle rather than attempted partially here. Cycle #190's
+  own item (3) -- a parity check of whether `scripts/*.rb` files quote or
+  restate any of the newly-swept scenes' undisclosed citations, the same
+  cross-file leakage shape cycle #189 found between `rpg2k_scene_check.rb`
+  and `scene/map.rb` -- also remains untouched by this cycle and is still
+  open.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -187,9 +187,11 @@ class RPG2k
          Game::States.color(id, table)]
       end
 
-      # Draw an actor's condition, as RPG_RT does in every field window that
-      # shows one — the menu party list, the item / skill target list and the
-      # status screen (EasyRPG's Window_Base#DrawActorState).
+      # Draw an actor's condition, the same field-window fixture every
+      # database-driven scene shows it in -- the menu party list, the item /
+      # skill target list and the status screen. Ported from EasyRPG
+      # Player's source (Window_Base#DrawActorState), NOT independently
+      # confirmed against genuine RPG_RT under wine.
       def draw_actor_state(bmp, actor, x, y, w, h, skin, align = 0)
         text, color = state_display(actor.states)
         draw_system_text bmp, x, y, w, h, text, skin, color, align
@@ -197,7 +199,8 @@ class RPG2k
 
       # The palette colour index an actor's live HP/SP figure draws in --
       # ported verbatim from EasyRPG's live `Window_Base::GetValueFontColor`
-      # (`src/window_base.cpp`), the shared routine behind `DrawActorHp`/
+      # (`src/window_base.cpp`), NOT independently confirmed against genuine
+      # RPG_RT under wine -- the shared routine behind `DrawActorHp`/
       # `DrawActorSp`: knockout gray (5) at exactly 0 with `can_knockout` set
       # (HP only -- `DrawActorSp` always passes false, so SP never shows this
       # colour even at 0), else critical red/orange (4) at or below a quarter
@@ -273,8 +276,9 @@ class RPG2k
       # `attacker_ally: false` (an enemy's own plain Attack, never a
       # skill/item hit -- EasyRPG's Game_BattleAlgorithm::Normal::GetStartSe
       # returns SFX_EnemyAttacks only for an enemy source, and only the
-      # Normal algorithm ever returns it). Confirmed against EasyRPG Player's
-      # source (scene_battle_rpg2k.cpp): ProcessBattleActionUsage plays
+      # Normal algorithm ever returns it). Ported from EasyRPG Player's
+      # source (scene_battle_rpg2k.cpp), NOT independently confirmed against
+      # genuine RPG_RT under wine: ProcessBattleActionUsage plays
       # GetStartSe() before ProcessBattleActionAnimation and
       # ProcessBattleActionExecute -- the very start of the action, before
       # any sprite swing or hit/miss/damage resolution -- and, for a
@@ -319,20 +323,22 @@ class RPG2k
         return nil unless field && db.system.respond_to?(field)
         se = db.system.send(field)
         name = se && se.respond_to?(:file) ? se.file : nil
-        # Confirmed against EasyRPG's actual C++ source: `Game_System::
-        # SePlay(const lcf::rpg::Sound&, bool)` (`src/game_system.cpp`) --
-        # `if (se.name.empty()) { return; } else if (se.name == "(OFF)")
-        # { ...; return; }` -- treats blank *and* the literal "(OFF)"
-        # sentinel identically as "nothing to play," the same convention
-        # `Interpreter#play_audio` already ports for the Play SE/Play BGM
-        # event commands.
+        # Ported from EasyRPG's actual C++ source, NOT independently
+        # confirmed against genuine RPG_RT under wine (matching the
+        # identical, already-disclosed convention `Interpreter#play_audio`
+        # carries for the Play SE/Play BGM event commands, see there):
+        # `Game_System::SePlay(const lcf::rpg::Sound&, bool)`
+        # (`src/game_system.cpp`) -- `if (se.name.empty()) { return; } else
+        # if (se.name == "(OFF)") { ...; return; }` -- treats blank *and*
+        # the literal "(OFF)" sentinel identically as "nothing to play."
         return nil if name.nil? || name.empty? || name == '(OFF)'
         { name: name, volume: (se.respond_to?(:volume) ? se.volume : 100),
           tempo: (se.respond_to?(:pitch) ? se.pitch : 100) }
       end
 
-      # Plays a battle_anime row's own sound effect -- confirmed against
-      # EasyRPG's actual C++ source: `Game_System::SePlay(const RPG::
+      # Plays a battle_anime row's own sound effect -- ported from
+      # EasyRPG's actual C++ source, NOT independently confirmed against
+      # genuine RPG_RT under wine: `Game_System::SePlay(const RPG::
       # Animation&)` (`src/game_system.cpp`) walks the animation's own
       # `timings` and plays only the *first* one with a real SE, then
       # returns; it never plays every timing's SE, and never draws the
@@ -404,7 +410,8 @@ class RPG2k
         @scene.state.switches[id] = on
       end
 
-      # Confirmed against EasyRPG's actual C++ source:
+      # Ported from EasyRPG's actual C++ source, NOT independently
+      # confirmed against genuine RPG_RT under wine:
       # `Game_Character::MoveTypeCustomCommand`'s `Code::play_sound_effect`
       # case (`src/game_character.cpp`) -- `if (move_command.
       # parameter_string != "(OFF)" && move_command.parameter_string !=
@@ -456,7 +463,8 @@ class RPG2k
         @scene.state.switches[id] = on
       end
 
-      # Confirmed against EasyRPG's actual C++ source:
+      # Ported from EasyRPG's actual C++ source, NOT independently
+      # confirmed against genuine RPG_RT under wine:
       # `Game_Character::MoveTypeCustomCommand`'s `Code::play_sound_effect`
       # case (`src/game_character.cpp`) -- `if (move_command.
       # parameter_string != "(OFF)" && move_command.parameter_string !=

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -36,12 +36,14 @@ class RPG2k
 
       # `actor_index` is which party member the screen opens on -- the one
       # `Scene::Menu#enter_actor_selection` preselected from the menu's own
-      # party list (confirmed against EasyRPG's `Scene_Equip` constructor,
-      # which takes the same parameter), defaulting to 0 (the leader) for
+      # party list, matching EasyRPG's `Scene_Equip` constructor (which
+      # takes the same parameter), defaulting to 0 (the leader) for
       # callers that never had a picker to begin with, e.g. the host test
       # harnesses. LEFT/RIGHT still cycle from there once inside, unlike
-      # Scene::SkillMenu -- EasyRPG's own `Scene_Equip::UpdateEquipSelection`
-      # does the same, unlike `Scene_Skill`.
+      # Scene::SkillMenu, the same way EasyRPG's own `Scene_Equip::
+      # UpdateEquipSelection` does (unlike `Scene_Skill`); ported from
+      # EasyRPG's source, NOT independently confirmed against genuine
+      # RPG_RT under wine.
       def initialize parent, state, actor_index = 0
         super parent
         @state = state
@@ -110,8 +112,9 @@ class RPG2k
       # genuine `Window_Equip`, a `Window_Selectable` subclass, whose own
       # `Update()` falls through to `Input::IsRepeated` the same as every
       # other list here (see Scene::ItemMenu#update_items's fuller
-      # writeup). The actor switch (RIGHT/LEFT) does **not**: confirmed
-      # against EasyRPG's actual source -- `Scene_Equip::
+      # writeup). The actor switch (RIGHT/LEFT) does **not**: ported from
+      # EasyRPG's actual source, NOT independently confirmed against
+      # genuine RPG_RT under wine -- `Scene_Equip::
       # UpdateEquipSelection` (`src/scene_equip.cpp`) checks
       # `Input::IsTriggered(Input::RIGHT/LEFT)` only, no `IsRepeated` at
       # all, since each switch pushes a whole new `Scene_Equip` rather than
@@ -158,11 +161,13 @@ class RPG2k
           play_system_se(SFX_CURSOR)
         elsif Input.trigger?(Input::C)
           # 装備固定 / 呪われた装備: RPG_RT refuses to even open the item list
-          # for such an actor, or for a slot currently holding a cursed item
-          # (EasyRPG's Scene_Equip#UpdateEquipSelection), rather than opening
-          # it and rejecting whatever gets chosen there -- confirmed a
-          # rejected Decision plays Buzzer, matching every other "confirmed
-          # but refused" case this scene's siblings handle the same way.
+          # for such an actor, or for a slot currently holding a cursed item,
+          # ported from EasyRPG's Scene_Equip#UpdateEquipSelection (NOT
+          # independently confirmed against genuine RPG_RT under wine),
+          # rather than opening it and rejecting whatever gets chosen there
+          # -- a rejected Decision plays Buzzer, matching every other
+          # "confirmed but refused" case this scene's siblings handle the
+          # same way.
           if actor.equipment_fixed? || actor.slot_cursed?(@slot_index)
             play_system_se(SFX_BUZZER)
           else
@@ -326,8 +331,10 @@ class RPG2k
       # method / state-flag quintuples for the four battle stats, in the
       # order EasyRPG's own `Window_EquipStatus::DrawParameter`
       # (`src/window_equipstatus.cpp`) draws them (Atk/Def/Spirit/Agility --
-      # this codebase's own `term(:mind, ...)`/`#int` name RPG2000's
-      # "Spirit" stat "Int" instead, matching status_menu.rb).
+      # ported from EasyRPG's source, NOT independently confirmed against
+      # genuine RPG_RT under wine); this codebase's own `term(:mind, ...)`/
+      # `#int` name RPG2000's "Spirit" stat "Int" instead, matching
+      # status_menu.rb.
       STAT_DEFS = [
         [:attack, 'Atk', :atk_points1, :atk, :effective_atk, :affect_attack],
         [:defense, 'Def', :def_points1, :def, :effective_def, :affect_defense],
@@ -337,9 +344,10 @@ class RPG2k
 
       # Four independent stat rows -- one "label value" per row while
       # browsing the slot list, or, while browsing candidates, "label value
-      # > new_value" comparisons -- confirmed against EasyRPG's actual
+      # > new_value" comparisons -- ported from EasyRPG's actual
       # `Window_EquipStatus::Refresh`/`DrawParameter`
-      # (`src/window_equipstatus.cpp`), which draws the actor name once,
+      # (`src/window_equipstatus.cpp`), NOT independently confirmed against
+      # genuine RPG_RT under wine: it draws the actor name once,
       # then loops the four stats at `y_offset + ((12 + 4) * i)` -- a
       # genuinely separate row per stat, each an old value, an arrow, and a
       # new value coloured by `GetNewParameterColor` (0 unchanged / 2 up / 3
@@ -354,8 +362,9 @@ class RPG2k
           y = LINE_H * (1 + i)
           x = 0
           # State-adjusted (halve/double), not the raw base+equip total --
-          # confirmed against RPG_RT's own live source: `Window_EquipStatus::
-          # DrawParameter` (`src/window_equipstatus.cpp`) draws
+          # ported from EasyRPG's `Window_EquipStatus::
+          # DrawParameter` (`src/window_equipstatus.cpp`), NOT independently
+          # confirmed against genuine RPG_RT under wine: it draws
           # `actor.GetAtk()` et al., which run the base value through
           # `Game_Battler::AdjustParam` (`src/game_battler.cpp`) against
           # whatever states the actor currently carries. `Game::Party
@@ -472,7 +481,8 @@ class RPG2k
 
       # The candidate's real net delta for one raw database `field` against
       # what is equipped now -- not just the two items landing in *this*
-      # slot. Confirmed against EasyRPG's actual C++ source: `Scene_Equip::
+      # slot. Ported from EasyRPG's actual C++ source, NOT independently
+      # confirmed against genuine RPG_RT under wine: `Scene_Equip::
       # UpdateStatusWindow` (`src/scene_equip.cpp`) also subtracts the
       # *other* hand's item when either it or the candidate is a 両手持ち
       # weapon (`Actor#two_handed?`), since equipping either one forces the

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -7,10 +7,11 @@ class RPG2k
     # Equip/Status then open the corresponding scene (Scene::SkillMenu /
     # EquipMenu / StatusMenu) for that one, while Row instead toggles the
     # picked actor's front/back row right there and returns to the command
-    # list without opening anything -- confirmed against EasyRPG's own
+    # list without opening anything -- ported from EasyRPG Player's own
     # `Scene_Menu::UpdateCommand`/`UpdateActorSelection`, where all four cases
     # share this one actor-selection panel (there is no separate `Scene_Row`;
-    # the Row toggle is inline in `UpdateActorSelection`'s own `switch`).
+    # the Row toggle is inline in `UpdateActorSelection`'s own `switch`), NOT
+    # independently confirmed against genuine RPG_RT under wine.
     # Order -- which acts on the whole party at once, not one actor -- pushes
     # Scene::Order directly instead, the same `UpdateCommand` shape Item/Save
     # already use. Cancelling back out of actor selection returns focus to
@@ -65,7 +66,8 @@ class RPG2k
       # arranges them -- matching EasyRPG's `CommandOptionType` enum (Item=1,
       # Skill=2, Equipment=3, Save=4, Status=5, Row=6, Order=7, Wait=8; Quit=9
       # is never itself in the list -- `Scene_Menu` appends it unconditionally
-      # after the loop, which #build_commands mirrors below). Row (id 6, the
+      # after the loop, which #build_commands mirrors below), NOT
+      # independently confirmed against genuine RPG_RT under wine. Row (id 6, the
       # battle front/back toggle) is modelled the same actor-selection-panel
       # way Skill/Equipment/Status are (see the class comment) -- picking an
       # actor there flips `Game::Actor#battle_row` via `Game::Party
@@ -75,10 +77,11 @@ class RPG2k
       # save-system `atb_mode` toggle (LSD chunk 140) that makes a gauge
       # battle's command menu freeze (wait) or keep running (active) -- the
       # Wait-off (active) mode follow-up ADR 0054 named -- and its label
-      # shows the *current* mode via the `wait_on` / `wait_off` terms, exactly
-      # as EasyRPG's own Wait row does (`GetAtbMode() == wait ? wait_on :
-      # wait_off`, and #select_command's :wait branch relabels it after
-      # flipping). Order (party reordering, id 7) is also modelled -- unlike
+      # shows the *current* mode via the `wait_on` / `wait_off` terms, ported
+      # from EasyRPG's own Wait row (`GetAtbMode() == wait ? wait_on :
+      # wait_off`, NOT independently confirmed against genuine RPG_RT under
+      # wine), and #select_command's :wait branch relabels it after
+      # flipping. Order (party reordering, id 7) is also modelled -- unlike
       # Row it has no battle-system dependency at all, just Game::Party#
       # reorder and Scene::Order (see #select_command's :order branch). A real
       # RPG2003 game's array (mtf-meido-action's is `[1, 2, 3, 4, 5, 6, 7, 8]`,
@@ -144,8 +147,9 @@ class RPG2k
 
       # Undo #suspend once the child screen above this menu is popped and it
       # is active again -- called by RPG2k#pop. Redraws the gold panel too,
-      # matching EasyRPG's own `Scene_Menu::Continue` (`src/scene_menu.cpp`),
-      # which unconditionally calls `gold_window->Refresh()` (alongside the
+      # ported from EasyRPG's own `Scene_Menu::Continue` (`src/scene_menu.cpp`),
+      # NOT independently confirmed against genuine RPG_RT under wine: it
+      # unconditionally calls `gold_window->Refresh()` (alongside the
       # status panel's own `menustatus_window->Refresh()`, already mirrored
       # by #refresh_status_cursor/rebuilds elsewhere) every time control
       # returns from a popped child screen.
@@ -226,8 +230,9 @@ class RPG2k
       def confirm_actor_selection
         actor = @state.party.actors[@actor_index]
         # A currently-restricted actor (asleep/paralysed) cannot be given a
-        # Skill command at all -- confirmed against EasyRPG's own
-        # `UpdateActorSelection`, whose Skill case alone gates on
+        # Skill command at all -- ported from EasyRPG's own
+        # `UpdateActorSelection`, NOT independently confirmed against
+        # genuine RPG_RT under wine: its Skill case alone gates on
         # `actor->CanAct()`; Equip/Status have no such gate. Checked first,
         # and left in actor-selection focus on failure (matching
         # `UpdateActorSelection`'s own early `return` there, buzzer instead
@@ -244,10 +249,12 @@ class RPG2k
         when :equip  then @parent.push Scene::EquipMenu.new(@parent, @state, index)
         when :status then @parent.push Scene::StatusMenu.new(@parent, @state, index)
         when :row
-          # No sub-scene: EasyRPG's own Row case toggles the picked actor's
-          # row right on the actor-selection panel and falls straight back to
-          # the command list, playing Decision regardless of whether the
-          # toggle actually took (`Game::Party#toggle_actor_row` silently
+          # No sub-scene: ported from EasyRPG's own Row case, NOT
+          # independently confirmed against genuine RPG_RT under wine --
+          # it toggles the picked actor's row right on the actor-selection
+          # panel and falls straight back to the command list, playing
+          # Decision regardless of whether the toggle actually took
+          # (`Game::Party#toggle_actor_row` silently
           # no-ops a refused one -- see its own comment on the "don't empty
           # the front row" guard).
           @state.party.toggle_actor_row(actor) if @state.party.respond_to?(:toggle_actor_row)
@@ -292,8 +299,9 @@ class RPG2k
 
       # The Wait command row's label: `wait_on` while the fight is set to
       # pause on its command menu (wait mode, raw `atb_mode` 1), `wait_off`
-      # once it is active (raw 0, the default) -- confirmed against
-      # EasyRPG's own `Scene_Menu` Wait row (`src/scene_menu.cpp`):
+      # once it is active (raw 0, the default) -- ported from EasyRPG's own
+      # `Scene_Menu` Wait row, NOT independently confirmed against genuine
+      # RPG_RT under wine (`src/scene_menu.cpp`):
       # `GetAtbMode() == AtbMode_atb_wait ? wait_on : wait_off`.
       def wait_label
         @state.atb_mode == 1 ? term(:wait_on, 'Wait On') : term(:wait_off, 'Wait Off')
@@ -336,8 +344,9 @@ class RPG2k
         build_gold_window
       end
 
-      # The party's own Gold, bottom-left corner -- confirmed against
-      # RPG_RT's own live source: `Scene_Menu::Start` (`src/scene_menu.cpp`)
+      # The party's own Gold, bottom-left corner -- ported from EasyRPG
+      # Player's source, NOT independently confirmed against genuine RPG_RT
+      # under wine: `Scene_Menu::Start` (`src/scene_menu.cpp`)
       # creates a `Window_Gold` there unconditionally (88x32, no version or
       # feature gate anywhere in the file), for both RPG2000 and RPG2003
       # alike. `Window_Gold::Refresh` (`src/window_gold.cpp`) draws the
@@ -384,8 +393,9 @@ class RPG2k
       end
 
       # Whether command `key`'s row should read the windowskin's own
-      # *disabled* swatch instead of its default text colour -- confirmed
-      # directly against RPG_RT's live source: `Scene_Menu::
+      # *disabled* swatch instead of its default text colour -- ported
+      # directly from EasyRPG Player's source, NOT independently confirmed
+      # against genuine RPG_RT under wine: `Scene_Menu::
       # CreateCommandWindow` (`src/scene_menu.cpp`) disables Save on
       # `!GetAllowSave()`, Order on `GetActors().size() <= 1`, and every
       # other command (Item/Skill/Equipment/Status/Row) on
@@ -404,7 +414,8 @@ class RPG2k
 
       # Draw every command row into `cc`, in the windowskin's own default
       # text colour or its *disabled* swatch (system-colour index 3) per
-      # `#command_disabled?` -- confirmed against RPG_RT's live source:
+      # `#command_disabled?` -- ported from EasyRPG Player's source, NOT
+      # independently confirmed against genuine RPG_RT under wine:
       # `Window_Command::SetItemEnabled`/`DrawItem` (`src/window_command.cpp`)
       # always draws a disabled row through `Font::ColorDisabled` (swatch
       # index 3, `src/font.h`), the same windowskin-blended path every
@@ -450,9 +461,10 @@ class RPG2k
 
       # Which SE a command-list confirm plays -- Decision when the command
       # actually does something, Buzzer when it is confirmed but refused
-      # outright, matching `Scene_Menu::UpdateCommand`'s own per-branch
+      # outright, ported from `Scene_Menu::UpdateCommand`'s own per-branch
       # `SePlay` calls (Item/Skill/Equipment/Status all gate on an empty
-      # party the same way; Save gates on `save_access` instead).
+      # party the same way; Save gates on `save_access` instead), NOT
+      # independently confirmed against genuine RPG_RT under wine.
       def select_command
         key, label = @commands[@index]
         case key
@@ -479,8 +491,9 @@ class RPG2k
           end
         when :order
           # Reordering a single-member (or empty) party is meaningless --
-          # confirmed against EasyRPG's own `Scene_Menu::UpdateCommand`'s
-          # `Order` branch, which gates on `GetActors().size() <= 1` rather
+          # ported from EasyRPG's own `Scene_Menu::UpdateCommand`'s
+          # `Order` branch, NOT independently confirmed against genuine
+          # RPG_RT under wine: it gates on `GetActors().size() <= 1` rather
           # than the plain-empty check every other command here uses.
           if @state.party.actors.size <= 1
             play_system_se(SFX_BUZZER)
@@ -500,8 +513,9 @@ class RPG2k
           redraw_command_labels
         when :save
           # A disabled Save command (Change Save Access off) just refuses the
-          # selection outright -- confirmed against EasyRPG's own
-          # Scene_Menu::UpdateCommand, whose disabled-Save branch plays the
+          # selection outright -- ported from EasyRPG's own
+          # Scene_Menu::UpdateCommand, NOT independently confirmed against
+          # genuine RPG_RT under wine: its disabled-Save branch plays the
           # buzzer SE and does nothing else, no message of any kind. This
           # engine drew a hardcoded English "You cannot save right now.",
           # the same class of gap the Item/Skill empty-list placeholders and

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -11,9 +11,11 @@ class RPG2k
     #     Game::State to write out. Every slot -- occupied or not -- is
     #     selectable; confirming one calls RPG2k#save_game(state, slot) and
     #     pops straight back to the menu the same frame, no feedback of any
-    #     kind either way -- confirmed against RPG_RT's own live source,
-    #     `Scene_Save::Action` (`src/scene_save.cpp`), which discards
-    #     `Save`'s own boolean result outright.
+    #     kind either way -- independently confirmed against a genuine
+    #     RPG_RT.exe under wine (cycle #126, see #confirm_selection's own
+    #     fuller writeup below), not just EasyRPG's `Scene_Save::Action`
+    #     (`src/scene_save.cpp`), which discards `Save`'s own boolean result
+    #     outright.
     #   * `:load`, from Scene::Title's Continue entry, with `state` nil (there
     #     is no running game yet). Only an occupied slot is selectable;
     #     confirming one calls RPG2k#continue_game(slot), which tears down the
@@ -71,8 +73,9 @@ class RPG2k
       # (not a scrollbar/track -- there is no such thing anywhere in
       # RPG_RT), pinned at the very top and bottom of the whole slot
       # viewport and shown only while a slot is hidden in that direction.
-      # Confirmed against EasyRPG's own `Scene_File` (`src/scene_file.cpp`,
-      # `MakeArrowSprite`/`UpdateArrows`): this is entirely `Scene_File`'s
+      # Ported from EasyRPG's own `Scene_File` (`src/scene_file.cpp`,
+      # `MakeArrowSprite`/`UpdateArrows`), NOT independently confirmed
+      # against genuine RPG_RT under wine: this is entirely `Scene_File`'s
       # own doing, outside `Window_SaveFile` (which has no scroll logic of
       # its own -- it just draws one slot's contents) and outside the
       # generic `Window_Selectable` scroll-arrow mechanism other list
@@ -248,9 +251,11 @@ class RPG2k
       end
 
       # Tick the blink phase every frame (RPG_RT's own arrows keep animating
-      # even while, say, this screen's save-result message is up -- there is
-      # nothing in EasyRPG's `UpdateArrows` that gates it on anything besides
-      # whether more slots are hidden) and refresh visibility from it.
+      # even while, say, this screen's save-result message is up, per
+      # EasyRPG's `UpdateArrows` -- NOT independently confirmed against
+      # genuine RPG_RT under wine -- there is nothing in it that gates the
+      # blink on anything besides whether more slots are hidden) and refresh
+      # visibility from it.
       def tick_arrows
         return unless @up_arrow
         @arrow_anim = (@arrow_anim + 1) % (ARROW_BLINK_FRAMES * 2)
@@ -261,8 +266,9 @@ class RPG2k
       # in that direction -- `@top > 0` for up, and for down: whether the
       # viewport's last visible row (`@top + VISIBLE_SLOTS - 1`) is still
       # short of the last real slot (`SLOT_COUNT - 1`), i.e. `@top <
-      # SLOT_COUNT - VISIBLE_SLOTS` -- the same shape as EasyRPG's own
-      # `top_index < max_index - 2` for its fixed 3-visible layout.
+      # SLOT_COUNT - VISIBLE_SLOTS` -- matching EasyRPG's own
+      # `top_index < max_index - 2` for its fixed 3-visible layout, NOT
+      # independently confirmed against genuine RPG_RT under wine.
       def refresh_arrows
         return unless @up_arrow
         blink_on = @arrow_anim < ARROW_BLINK_FRAMES
@@ -359,9 +365,10 @@ class RPG2k
       #
       # Every line renders through `#draw_system_text` (the windowskin
       # system-colour swatch blend, with RPG_RT's own one-pixel shadow) now,
-      # not a flat `draw_text` -- EasyRPG's `Window_SaveFile::Refresh`
-      # (`src/window_savefile.cpp`) draws every text element in the box
-      # through `TextDraw(x, y, fc, text)`, never a raw colour, with `fc`
+      # not a flat `draw_text` -- ported from EasyRPG's `Window_SaveFile::
+      # Refresh` (`src/window_savefile.cpp`), NOT independently confirmed
+      # against genuine RPG_RT under wine: it draws every text element in
+      # the box through `TextDraw(x, y, fc, text)`, never a raw colour, with `fc`
       # itself `has_save ? Font::ColorDefault : Font::ColorDisabled` (system
       # colour index 0 or 3, `src/font.h`) for the file label specifically --
       # the same disabled-swatch convention `Scene::Title`'s own Continue
@@ -403,8 +410,9 @@ class RPG2k
 
       # The level/HP line at RPG_RT's own fixed pixel columns (x=4 for the
       # level label, x=46 for HP), not proportioned to the label text --
-      # confirmed against RPG_RT's live source: `Window_SaveFile::Refresh`
-      # (`src/window_savefile.cpp`) is four separate `TextDraw` calls at
+      # ported from EasyRPG's `Window_SaveFile::Refresh`
+      # (`src/window_savefile.cpp`), NOT independently confirmed against
+      # genuine RPG_RT under wine: it is four separate `TextDraw` calls at
       # those exact x-coordinates, each number space-padded to a fixed
       # width (`std::setw(2)` for level, `std::setw(Player::IsRPG2k3() ? 4
       # : 3)` for HP) -- so a level 9 vs. 99 leader never shifts where "HP"
@@ -422,9 +430,10 @@ class RPG2k
       end
 
       # Clamp a database term string to exactly 2 characters, space-padded
-      # if shorter -- matches RPG_RT's own `lvl_short`/`hp_short` handling
-      # (`Window_SaveFile::Refresh`: `if (lvl_short.size() != 2)
-      # lvl_short.resize(2, ' ')`).
+      # if shorter -- ported from EasyRPG's own `lvl_short`/`hp_short`
+      # handling (`Window_SaveFile::Refresh`: `if (lvl_short.size() != 2)
+      # lvl_short.resize(2, ' ')`), NOT independently confirmed against
+      # genuine RPG_RT under wine.
       def fixed_width_term(name, fallback)
         s = term(name, fallback)
         s.length > 2 ? s[0, 2] : s.ljust(2)
@@ -484,9 +493,11 @@ class RPG2k
 
       # Crop one 48x48 cell out of a FaceSet sheet. Unlike
       # `Scene::Map#build_face_cell`, this screen never mirrors a face --
-      # EasyRPG's own `Window_Base::DrawFace` call for the save-file screen
-      # always passes `flip: false`, unlike a message window's Change Face
-      # Graphic, the only place a mirror flag exists in the data at all.
+      # ported from EasyRPG's own `Window_Base::DrawFace` call for the
+      # save-file screen, NOT independently confirmed against genuine
+      # RPG_RT under wine: it always passes `flip: false`, unlike a message
+      # window's Change Face Graphic, the only place a mirror flag exists
+      # in the data at all.
       def build_face_cell(sheet, index)
         src_x = (index % 4) * FACE_SIZE
         src_y = (index / 4) * FACE_SIZE

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -4,10 +4,11 @@ class RPG2k
     # detail -- name/title, level, EXP and the next level's absolute EXP
     # threshold, HP/MP, the six stats and the five equipment slots; LEFT/
     # RIGHT cycle the member. Read-only, so there is no sub-mode. The "Next"
-    # figure is Game::Actor#next_level_exp -- the absolute threshold RPG_RT's
-    # own `Window_ActorStatus::DrawStatus` displays (`GetNextExpString`),
-    # not the remaining-EXP delta `#exp_to_next` computes (host-tested); the
-    # rest reads existing accessors.
+    # figure is Game::Actor#next_level_exp -- the absolute threshold, matching
+    # EasyRPG Player's `Window_ActorStatus::DrawStatus` (`GetNextExpString`)
+    # rather than the remaining-EXP delta `#exp_to_next` computes; ported from
+    # EasyRPG's source, NOT independently confirmed against genuine RPG_RT
+    # under wine (host-tested only); the rest reads existing accessors.
     class StatusMenu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
@@ -25,11 +26,12 @@ class RPG2k
 
       # `actor_index` is which party member the screen opens on -- the one
       # `Scene::Menu#enter_actor_selection` preselected from the menu's own
-      # party list (confirmed against EasyRPG's `Scene_Status` constructor,
-      # which takes the same parameter), defaulting to 0 (the leader) for
+      # party list, matching EasyRPG's `Scene_Status` constructor (which
+      # takes the same parameter) -- defaulting to 0 (the leader) for
       # callers that never had a picker to begin with, e.g. the host test
-      # harnesses. LEFT/RIGHT still cycle from there once inside -- EasyRPG's
-      # own `Scene_Status::vUpdate` does the same.
+      # harnesses. LEFT/RIGHT still cycle from there once inside, the same
+      # way EasyRPG's own `Scene_Status::vUpdate` does; ported from EasyRPG's
+      # source, NOT independently confirmed against genuine RPG_RT under wine.
       def initialize parent, state, actor_index = 0
         super parent
         @state = state
@@ -52,8 +54,9 @@ class RPG2k
         if Input.trigger?(Input::B)
           play_system_se(SFX_CANCEL)
           @parent.pop
-        # A solo party leaves RIGHT/LEFT silent no-ops -- confirmed against
-        # RPG_RT's own live source: `Scene_Status::vUpdate`
+        # A solo party leaves RIGHT/LEFT silent no-ops -- ported from
+        # EasyRPG Player's source, NOT independently confirmed against
+        # genuine RPG_RT under wine: `Scene_Status::vUpdate`
         # (`src/scene_status.cpp`) gates both branches on `actors.size() >
         # 1`, not just the trigger itself, so a lone hero's Status screen
         # plays no cursor SE and rebuilds nothing on either key.
@@ -113,8 +116,9 @@ class RPG2k
         title = a.title.to_s
         header = title.empty? ? a.name.to_s : "#{a.name}  #{title}"
         # The "Next" figure is the *absolute* EXP threshold for the next
-        # level, not the remaining delta -- confirmed directly against
-        # RPG_RT's live source: `Window_ActorStatus::DrawStatus`
+        # level, not the remaining delta -- ported from EasyRPG Player's
+        # source, NOT independently confirmed against genuine RPG_RT under
+        # wine: `Window_ActorStatus::DrawStatus`
         # (`src/window_actorstatus.cpp`) draws the Exp row via
         # `DrawMinMax(90, 34, -1, -1)`, whose `-1, -1` sentinel routes both
         # halves through `actor.GetExpString(true)`/`GetNextExpString(true)`
@@ -130,8 +134,10 @@ class RPG2k
         lines = [
           header,
           # RPG_RT always draws a labelled Class/Profession row on this
-          # screen too, between Name and Title -- confirmed against
-          # `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`):
+          # screen too, between Name and Title -- ported from EasyRPG
+          # Player's source, NOT independently confirmed against genuine
+          # RPG_RT under wine: `Window_ActorInfo::DrawInfo`
+          # (`src/window_actorinfo.cpp`):
           # `TextDraw(..., "Class"); DrawActorClass(actor, ...)`, with no
           # version gate around it (unlike the RPG2003-only Row line just
           # above it in the same function), so it draws blank rather than
@@ -145,8 +151,9 @@ class RPG2k
           "#{term(:exp_short, 'EXP')} #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
           # Drawn separately, after this flat pass -- see #draw_hp_mp_row.
           '',
-          # ATK/DEF/Int(Spirit)/AGI, state-adjusted -- confirmed against
-          # RPG_RT's own live source: `Window_ParamStatus::Refresh`
+          # ATK/DEF/Int(Spirit)/AGI, state-adjusted -- ported from EasyRPG
+          # Player's source, NOT independently confirmed against genuine
+          # RPG_RT under wine: `Window_ParamStatus::Refresh`
           # (`src/window_paramstatus.cpp`) draws `actor.GetAtk()`/`GetDef()`/
           # `GetSpi()`/`GetAgi()` directly, and `Game_Battler::GetAtk` et al.
           # (`src/game_battler.cpp`) run the base value through `AdjustParam`,
@@ -170,13 +177,15 @@ class RPG2k
         ]
         eqp = a.equipment
         @slots.each_with_index { |label, i| lines.push("#{label}: #{item_name(eqp[i])}") }
-        # RPG_RT always shows the party's own Gold on this screen -- its own
-        # `Window_Gold` (`src/window_gold.cpp`) sits right under the
-        # actor-info box, drawn unconditionally by `Scene_Status::Start`
-        # (`src/scene_status.cpp`, no visibility gate anywhere in the file) --
-        # confirmed missing here entirely, not merely mispositioned.
-        # `DrawCurrencyValue` (`src/window_base.cpp`) draws just the amount
-        # and the term, no extra label of its own.
+        # RPG_RT always shows the party's own Gold on this screen -- per
+        # EasyRPG Player's source (NOT independently confirmed against
+        # genuine RPG_RT under wine), its own `Window_Gold`
+        # (`src/window_gold.cpp`) sits right under the actor-info box, drawn
+        # unconditionally by `Scene_Status::Start` (`src/scene_status.cpp`,
+        # no visibility gate anywhere in the file) -- this screen was missing
+        # it here entirely before this line was added, not merely
+        # mispositioning it. `DrawCurrencyValue` (`src/window_base.cpp`)
+        # draws just the amount and the term, no extra label of its own.
         lines.push("#{@state.party.gold}#{term(:gold, 'G')}")
         lines.each_with_index do |line, i|
           c.draw_text 0, i * LINE_H, inner_w, LINE_H, line
@@ -189,8 +198,9 @@ class RPG2k
       end
 
       # RPG_RT's own status screen additionally shows which RPG2003 battle
-      # row the displayed actor is currently in -- confirmed against
-      # `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`):
+      # row the displayed actor is currently in -- ported from EasyRPG
+      # Player's source, NOT independently confirmed against genuine RPG_RT
+      # under wine: `Window_ActorInfo::DrawInfo` (`src/window_actorinfo.cpp`):
       # `if (Feature::HasRow()) { ... TextDraw(width, 2, ..., battle_row,
       # AlignRight); }`, right-aligned at the top of the panel, above the
       # face/name block. `Feature::HasRow` (`src/feature.cpp`) reduces to
@@ -206,10 +216,12 @@ class RPG2k
         @state.party.respond_to?(:rpg2003?) && @state.party.rpg2003?
       end
 
-      # This screen's HP/MP row: RPG_RT's own `Window_ActorStatus::DrawStatus`
-      # (`src/window_actorstatus.cpp`) draws it through the same
-      # `DrawActorHp`/`DrawActorSp` (`src/window_base.cpp`) the battle status
-      # panel uses, so it carries the identical per-value colouring (see
+      # This screen's HP/MP row: ported from EasyRPG Player's source, NOT
+      # independently confirmed against genuine RPG_RT under wine --
+      # `Window_ActorStatus::DrawStatus` (`src/window_actorstatus.cpp`)
+      # draws it through the same `DrawActorHp`/`DrawActorSp`
+      # (`src/window_base.cpp`) the battle status panel uses, so it carries
+      # the identical per-value colouring (see
       # #draw_stat_segment) -- only ever applied to this screen's *current*
       # HP/MP figures, never their label or max.
       def draw_hp_mp_row(c, a, y, inner_w)

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -13,10 +13,11 @@ class RPG2k
       # three 48px-wide labels the window lands at (128, 148) 64x64.
       BOTTOM_NUM = 53
       BOTTOM_DEN = 60
-      # RPG_RT unrolls the title command window open over 8 frames (EasyRPG's
-      # scene_title.cpp: `command_window->SetOpenAnimation(8)`), skipped under
-      # HideTitle -- the centred window appears with the rest of the screen
-      # rather than flourishing in on its own.
+      # RPG_RT unrolls the title command window open over 8 frames, ported
+      # from EasyRPG's scene_title.cpp (`command_window->SetOpenAnimation(8)`),
+      # NOT independently confirmed against genuine RPG_RT under wine --
+      # skipped under HideTitle: the centred window appears with the rest of
+      # the screen rather than flourishing in on its own.
       OPEN_ANIM_FRAMES = 8
 
       def initialize parent
@@ -78,10 +79,12 @@ class RPG2k
         # Render the (unchanging) menu labels once, in the windowskin's own
         # default text colour (system-colour swatch 0) with RPG_RT's
         # one-pixel shadow. A disabled Continue reads the windowskin's own
-        # *disabled* swatch instead -- EasyRPG's `Window_Command::DrawItem`
-        # (`src/window_command.cpp`), which `Scene_Title` drives via
+        # *disabled* swatch instead -- ported from EasyRPG's
+        # `Window_Command::DrawItem` (`src/window_command.cpp`), NOT
+        # independently confirmed against genuine RPG_RT under wine: driven
+        # by `Scene_Title` via
         # `command_window->SetItemEnabled(1, continue_enabled)`
-        # (`src/scene_title.cpp`), always looks up `Font::ColorDisabled`
+        # (`src/scene_title.cpp`), it always looks up `Font::ColorDisabled`
         # (`src/font.h`, swatch index 3) rather than hardcoding a flat gray --
         # a custom windowskin whose disabled swatch is tinted (not neutral
         # gray) shows that tint on real RPG_RT, with the same drop-shadow
@@ -110,13 +113,18 @@ class RPG2k
         @window.update
 
         # Holding Down/Up auto-repeats the cursor after the initial delay,
-        # not just a single step per tap -- confirmed against EasyRPG's
-        # actual source: `Scene_Title::vUpdate` (`src/scene_title.cpp`)
+        # not just a single step per tap -- ported from EasyRPG's actual
+        # source: `Scene_Title::vUpdate` (`src/scene_title.cpp`)
         # calls `command_window->Update()` unconditionally every frame, a
         # genuine `Window_Command` (`Window_Selectable` subclass) whose own
         # `Update()` is what drives the cursor via the standard
-        # trigger-then-repeat (see `Scene::ItemMenu#update_items`'s fuller
-        # writeup and docs/TODO.md).
+        # trigger-then-repeat. `Input.repeat?`'s own timing already matches
+        # EasyRPG's repeat constants exactly, independently measured against
+        # genuine RPG_RT.exe under wine (see `Scene::ItemMenu#update_items`'s
+        # fuller writeup and docs/TODO.md) -- so only the specific claim that
+        # *this* window's cursor is driven the same way as every other
+        # `Window_Selectable`-based list is ported from EasyRPG's source
+        # rather than independently confirmed here.
         if Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
           move_selection 1
         elsif Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
@@ -126,8 +134,9 @@ class RPG2k
         confirmed = Input.trigger?(Input::C)
         if confirmed && @selected_index == 1 && !@continue_available
           # Continue is grayed out with nothing to resume, but confirming it
-          # anyway is not silent -- confirmed against EasyRPG's own
-          # `Scene_Title::CommandContinue`, whose disabled branch is
+          # anyway is not silent -- ported from EasyRPG's own
+          # `Scene_Title::CommandContinue`, NOT independently confirmed
+          # against genuine RPG_RT under wine: its disabled branch is
           # `SePlay(...SFX_Buzzer...); return;`, not a plain no-op (the
           # enabled check lives inside the handler itself, not a guard in
           # `vUpdate()` around calling it at all).
@@ -135,11 +144,12 @@ class RPG2k
         elsif confirmed || (auto = auto_select?)
           case @selected_index
           when 0  # New Game
-            # RPG_RT does not hard-cut the title music -- `Player::
-            # SetupNewGame` (`src/player.cpp`) is `Main_Data::game_system->
-            # BgmFade(800, true); ...`, an 800ms fade, not `BgmStop()`'s
-            # immediate stop (the two are genuinely different `Game_System`
-            # calls, confirmed against `src/game_system.cpp`). The blanket
+            # RPG_RT does not hard-cut the title music -- ported from
+            # EasyRPG's `Player::SetupNewGame` (`src/player.cpp`), NOT
+            # independently confirmed against genuine RPG_RT under wine: it
+            # is `Main_Data::game_system->BgmFade(800, true); ...`, an 800ms
+            # fade, not `BgmStop()`'s immediate stop (the two are genuinely
+            # different `Game_System` calls per `src/game_system.cpp`). The blanket
             # `Audio.bgm_stop` this method used to run before every
             # selection (including this one) skipped straight to silence
             # instead.
@@ -155,9 +165,10 @@ class RPG2k
             # scripts/compare-nepheshel-wine.bash (watching stderr for the
             # [RPG2k-MAP] marker only #continue_game emits) needs.
             #
-            # The headless auto-select path fades here too, matching
+            # The headless auto-select path fades here too, ported from
             # `Player::LoadSavegame`'s own `if (!load_on_map) { BgmFade(800);
-            # ... }` (`src/player.cpp`) -- true from the title, the only case
+            # ... }` (`src/player.cpp`), NOT independently confirmed against
+            # genuine RPG_RT under wine -- true from the title, the only case
             # this shortcut ever takes. The interactive `Scene::SaveLoad`
             # push is deliberately left alone: that scene's own `:load` mode
             # is shared with the RPG2003 in-map "Open Load Menu" event
@@ -174,12 +185,14 @@ class RPG2k
               parent.push(Scene::SaveLoad.new(parent, nil, :load))
             end
           when 2  # Shutdown
-            # No confirmation dialog -- EasyRPG's own `CommandShutdown` plays
-            # Decision then exits immediately (a fade-out transition into
-            # `Scene::Pop`), unlike the field menu's own End Game command,
-            # which pushes a yes/no confirm screen this runtime does not
-            # model either. `CommandShutdown` (`src/scene_title.cpp`) makes
-            # no BGM call at all -- confirmed by reading its full body -- so
+            # No confirmation dialog -- ported from EasyRPG's own
+            # `CommandShutdown`, NOT independently confirmed against genuine
+            # RPG_RT under wine: it plays Decision then exits immediately (a
+            # fade-out transition into `Scene::Pop`), unlike the field menu's
+            # own End Game command, which pushes a yes/no confirm screen this
+            # runtime does not model either. `CommandShutdown`
+            # (`src/scene_title.cpp`) makes no BGM call at all in EasyRPG's
+            # own source -- so
             # this branch touches neither `bgm_fade` nor `bgm_stop`, matching
             # the blanket `Audio.bgm_stop` this method used to run
             # unconditionally before every selection, this one included.


### PR DESCRIPTION
## Summary

Picks up an explicitly-open item from cycle #190's own "left open, in priority order" list (#1430): the second tier of files in the multi-cycle EasyRPG-citation-hygiene sweep (cycles #174, #176, #177, #184-190) — `status_menu.rb`, `menu.rb`, `title.rb`, `equip_menu.rb`, `save_load.rb`, and `base.rb` under `mruby-rpg2k/mrblib/scene/` — none of which any prior cycle had read in full.

Each file carried comments phrased as "confirmed against EasyRPG's actual C++ source" or, more seriously, "confirmed against RPG_RT's own live source" while citing an EasyRPG Player file path (`src/*.cpp`) — presenting a straight port from EasyRPG as if it were independently verified RPG_RT behavior. Rewrote every such citation to honestly read "ported from EasyRPG['s own] source, NOT independently confirmed against genuine RPG_RT under wine," preserving the technical substance. Genuine wine-confirmed citations already present (several strong ones in `save_load.rb`/`equip_menu.rb` from cycles #121-127) were read and correctly left untouched.

One extra bug found along the way: `save_load.rb`'s class-level doc comment still carried the exact "confirmed against RPG_RT's own live source, `Scene_Save::Action`" framing that the same file's `#confirm_selection` method had already debunked and corrected in cycle #126 (a genuine wine confirmation) — the class comment was simply never updated when the method-level fix landed. Fixed by pointing it at the real citation instead.

Comment-only — no assertions changed.

## Verification

Independently re-verified before shipping:
- Every changed line across all 6 files confirmed comment-only (`git diff | grep -vE 'comment/blank'` filter, per-file).
- `ruby -c` clean on all 6 files.
- Full check suite unchanged: `rpg2k_scene_check.rb`=932, `rpg2k_logic_check.rb`=1176, `rpg2k_render_check.rb`=41, `rpg2k3_battle_row_check.rb`=19/0, `rpg2k3_battle_gauge_check.rb`=15/0, `rpg2k_save_load_check.rb`'s 3 known pre-existing failures.
- `ctest -R mruby_test` passes.
- No `data/` files touched, no wine/Xvfb used (not needed for comment-only work).

Left open: `scene/battle.rb` (34 file-path citations, 78 EasyRPG mentions) is now the only unswept file from cycle #190's list, left for a dedicated future cycle since it's roughly 4-5x the size of everything closed here. See `docs/TODO.md`'s cycle #196 entry.

## Changelog

None — comment-only documentation work, matching cycle #190's own precedent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_