### PR TITLE
Wire up BGM fade-in end to end: Play BGM, its save round-trip, and battle/inn/vehicle/game-over

### DIFF
--- a/changelog.d/battle-inn-vehicle-gameover-bgm-fadein.fixed.md
+++ b/changelog.d/battle-inn-vehicle-gameover-bgm-fadein.fixed.md
@@ -1,0 +1,22 @@
+- **Battle, Show Inn, boarding a vehicle, and the Game Over screen now honour
+  a configured BGM fade-in instead of silently dropping it.** Cycle #202
+  wired Play BGM's own fade-in parameter through to `RGSS::Audio.bgm_play`'s
+  new 5th `fadein` argument, but `Scene::Map#battle_bgm`/`#inn_bgm`/
+  `#vehicle_bgm` and `Scene::GameOver#play_gameover_bgm` never picked it up:
+  each resolves a Music/BGM struct down to a `{ name:, volume:, tempo: }`
+  hash and calls `#play_bgm` (`RGSS::Audio.bgm_play` underneath) without ever
+  reading `fade_in` off it, for both of that struct's two real sources --
+  the database's own `battle_music`/`inn_music`/`boat_music`/`ship_music`/
+  `airship_music`/`gameover_music` (each a liblcf `BGM`-struct instance,
+  field 2), and a Change System BGM (10660) override for that slot (which
+  already carries its own `fadein:` reread off the command's param 1,
+  `do_change_system_bgm`). Both sources now flow through to `#play_bgm`'s
+  `RGSS::Audio.bgm_play` call, the same 5-argument idiom Play BGM and Play
+  Memorized BGM already use, `|| 0` defaulted the same way volume/tempo
+  already are. The victory fanfare (`#victory_bgm`/`#play_victory_bgm`) is
+  deliberately left alone: it plays through `RGSS::Audio.me_play`, RPG_RT's
+  distinct one-shot "ME" channel, which has no fadein parameter at all in
+  this engine's audio layer (unlike `bgm_play`) -- wiring it would mean
+  extending the native ME playback path (`sdl_audio.cxx` and friends), out of
+  scope for a fix that only forwards an already-plumbed value through mrblib
+  call sites.

--- a/changelog.d/play-bgm-fade-in.fixed.md
+++ b/changelog.d/play-bgm-fade-in.fixed.md
@@ -1,0 +1,29 @@
+- **Play BGM's fade-in parameter now actually fades the music in, instead of
+  jumping straight to its target volume.** `Game::Interpreter#play_audio`'s
+  `:bgm` branch read `fade_in` (the command's own param 0) off the event
+  command but never forwarded it anywhere -- a track configured to fade in
+  over, say, 800ms started at full volume immediately, indistinguishable
+  from `fade_in=0`. `RGSS::Audio.bgm_play` gained a new 5th `fadein` argument
+  (native backend: `src/sdl_audio.cxx` calls SDL_mixer's `Mix_FadeInMusic`
+  instead of `Mix_PlayMusic` when it is non-zero), threaded through from Play
+  BGM's own parameter and from Play Memorized BGM's memorized record (a
+  track memorized mid-fade-in now resumes with that same ramp on replay,
+  matching every other field -- volume/tempo/balance -- Memorize BGM already
+  carries whole). The no-restart "same file already playing" shortcut is
+  unaffected: there is no fresh play for a fade to ramp into there, matching
+  every other Play BGM parameter's own same-file handling. Native playback
+  timing is not independently confirmed against genuine RPG_RT's own audible
+  ramp under wine (no screenshot-diff technique reaches audio); the
+  parameter's presence, unit (milliseconds, matching liblcf's own BGM-struct
+  field 2 Change System BGM and Fade Out BGM already use) and plumbing
+  through every layer are confirmed by reading the LCF schema and this
+  engine's own code.
+- **Every stored BGM record's fade-in now survives Save/Continue instead of
+  being silently dropped.** `Game::State#bgm_chunk`/`.bgm_from_chunk` (the
+  shared encode/decode pair behind the current/memorized BGM, the pre-
+  battle/vehicle restore points, and every Change System BGM override slot
+  0-6) never touched LCF's BGM-struct field 2 (fade-in) at all -- a
+  `fadein:` value set via Play BGM or Change System BGM was tracked live but
+  silently lost the moment a save round-tripped it, the same class of gap
+  balance (field 5) had before it was added. Fixed on the same "write only
+  away from its own default" idiom the other fields already use.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1478,6 +1478,79 @@ The work below is roughly ordered by the critical path to a walkable game
   keep the change small and independently verifiable; the save round-trip
   fix in (2) means that fadein value is no longer *lost*, just not yet
   *played*, for those four call sites specifically.
+  ✅ **Follow-up (cycle #203, 2026-08-28): picked up the gap cycle #202 left
+  open above.** Method: read `mruby-rpg2k/mrblib/scene/map.rb` end to end for
+  every BGM-playing call site, then checked `mruby-lcf/mrblib/schema.rb` for
+  whether each source Music struct genuinely carries a `fade_in` field (not
+  assumed) before touching anything, per the standing rule against inventing
+  schema fields. Findings: `db.system.battle_music` / `inn_music` /
+  `boat_music` / `ship_music` / `airship_music` / `gameover_music` are all
+  declared `elements: BGM` (schema.rb lines 677/679-683), the same `BGM`
+  struct (`file`/`fade_in`/`volume`/`pitch`/`balance`, field 2 = `fade_in`)
+  Play BGM's own struct already uses — so every one of them genuinely carries
+  a fade-in in the format, not an invented field. A Change System BGM
+  (10660) override for any of these slots already carries `fadein:` too
+  (`do_change_system_bgm`, interpreter.rb, stashed since fadein first
+  landed) — cycle #202's own save-round-trip fix already preserved it
+  end-to-end; only the *playback* side (`Scene::Map`'s helpers reading it
+  back out and forwarding it) was the gap. Fixed for three of the four named
+  helpers plus a fifth site found along the way: `#battle_bgm`, `#inn_bgm`
+  and `#vehicle_bgm` (map.rb) now read `fade_in`/`fadein` off both the
+  database struct (a new `#music_fadein` helper, parallel to the existing
+  `#music_name`/`#music_volume`/`#music_tempo`) and the Change System BGM
+  override hash, and `#play_bgm` (the one choke point all three funnel
+  through, alongside `#play_map_bgm` and the vehicle/battle/inn restore
+  helpers) now passes it as `RGSS::Audio.bgm_play`'s 5th argument, `|| 0`
+  defaulted the same way volume/tempo already are — the identical idiom
+  `#play_audio`'s `:bgm` branch and `#do_play_memorized_bgm` already
+  established. `Scene::GameOver#play_gameover_bgm` had the exact same gap
+  (`gameover_music` is field 38, same `BGM` struct, and its own
+  Change-System-BGM slot-6 override already carried `fadein:` too) and got
+  the same fix — the "game over" call site this cycle's own task brief
+  flagged as worth checking for, found by grep rather than assumed. **Left
+  deliberately untouched: `#victory_bgm`/`#play_victory_bgm`.**
+  `battle_end_music` (field 33) is the same `BGM` struct and does genuinely
+  carry a `fade_in` too, so the *format* has no gap here — but
+  `#play_victory_bgm` plays it through `RGSS::Audio.me_play`, RPG_RT's
+  distinct one-shot "ME" channel, and `me_play`'s native signature
+  (`mruby-rgss/mrblib/lib.rb`, `src/sdl_audio.cxx`) has no fadein parameter
+  at all — unlike `bgm_play`, it was never given one, since RGSS itself has
+  no such call either. Wiring it would mean extending the native ME
+  playback path end to end (`sdl_audio.cxx`, `include/rgss_audio.hxx`,
+  `mruby-rgss/src/audio.cxx`, `mruby-rgss/mrblib/lib.rb`) — a genuinely
+  different, larger change than forwarding an already-plumbed value through
+  an existing 5-argument call, and out of this cycle's scope; documented in
+  place on `#play_victory_bgm` itself rather than silently left as-is. Also
+  deliberately untouched: `#play_map_bgm` (the map's own default on-load/
+  Teleport BGM, `Game::MapBgm` — a different struct from any of the four
+  named helpers, not part of this cycle's brief) and `#resume_saved_bgm`
+  (Continue's direct-to-backend replay of the save's own `current_bgm`,
+  which bypasses `#play_bgm` on purpose per its own doc comment and so needed
+  no change here). Regression-covered by four new
+  `scripts/rpg2k_scene_check.rb` checks (a non-zero fade-in from both the
+  database struct and a Change System BGM override reaches `bgm_play`'s 5th
+  argument, for battle/inn/vehicle-boarding/Game-Over each), all four
+  confirmed to fail against the pre-fix code before the fix; every
+  pre-existing `bgm_calls` assertion whose call site now runs through the
+  widened `#play_bgm` (battle/inn/vehicle/Game-Over/`#play_map_bgm`'s own
+  on-load-and-Teleport checks — 11 of them) was updated to expect the
+  now-explicit `pos=0, fadein=0` trailing arguments, each independently
+  confirmed to fail against the pre-fix code too (the old 3-argument shape)
+  before being updated, so none of them could have silently started
+  asserting the wrong thing. **Verification**:
+  `scripts/rpg2k_scene_check.rb` 939 passed (935 baseline + 4 new checks, 0
+  failures); `rpg2k_logic_check.rb` 1179 passed (unchanged — it never
+  instantiates `Scene::Map`, so untouched by this cycle);
+  `rpg2k_render_check.rb` 41 passed (unchanged); `rpg2k3_battle_row_check.rb`
+  19/0 and `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged);
+  `rpg2k_save_load_check.rb` still reports the same 1 known pre-existing
+  failure (the unrelated Show Picture field-shape mismatch) before and
+  after, confirmed by running it against both the pre-fix and post-fix tree;
+  `cd build && ninja` clean rebuild; `ctest -R mruby_test` passed. No wine
+  session was run this cycle, for the same reason cycle #202 gave (audio
+  timing is not screenshot-diffable, and nothing here touched a `data/`
+  fixture) — this is first-principles schema-and-code reading, not a
+  wine-verified timing match.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1308,9 +1308,9 @@ The work below is roughly ordered by the critical path to a walkable game
   battle-BGM paragraph below), slots 3-5 (boat / ship / airship, matching
   EasyRPG's `Game_System::sys_bgm` enum, see the vehicle-boarding paragraph
   below), slot 6 (game over, see the Game Over paragraph under "Menus,
-  save, battle" below) and slot 2 (inn, see the Show Inn paragraph below)
-  are now read back too, so only slot 1 (victory) is still modelled for
-  save fidelity like the access flags. **Change System
+  save, battle" below), slot 2 (inn, see the Show Inn paragraph below) and
+  slot 1 (victory, see the battle-BGM paragraph below and its cycle #202
+  correction) are all read back and consumed too. **Change System
   SFX** (10670) is now consumed on the map: the choice window plays the cursor
   sound as the selection moves and the decision sound on confirm, resolving a
   Change System SFX override on `Game::State` before the database default
@@ -1362,12 +1362,122 @@ The work below is roughly ordered by the critical path to a walkable game
   `#system_se` already established for Change System SFX. Covered by a new
   `scripts/rpg2k_scene_check.rb` check (a Change System BGM override for
   slot 0 plays instead of the database `battle_music` the moment the battle
-  UI opens), confirmed to fail against the pre-fix code before the fix. The
-  remaining System BGM slot (victory, slot 1) is still save-fidelity-only,
-  per the note above — inn (slot 2, see the Show Inn paragraph below), boat
-  / ship / airship (slots 3-5, see the vehicle-boarding paragraph below) and
-  game over (slot 6, see the Game Over paragraph under "Menus, save,
-  battle" below) are all consumed too.
+  UI opens), confirmed to fail against the pre-fix code before the fix.
+  ✅ **Correction (cycle #202): the paragraph used to say slot 1 (victory) was
+  "still save-fidelity-only" here — stale even when written.** `#victory_bgm`/
+  `#play_victory_bgm` (`Scene::Map`) already resolve a Change System BGM
+  slot-1 override the same override-then-default way `#battle_bgm` does, and
+  `scripts/rpg2k_scene_check.rb`'s "a Change System BGM victory override
+  beats the database battle_end_music" check already exercises it end to end
+  — both landed in the same Aug 19 commit this paragraph's own text was
+  merged against on Aug 22 without being reconciled (the two branches'
+  histories cross; see cycle #202's own TODO entry for the git-log evidence).
+  All seven System BGM slots (battle 0, victory 1, inn 2, boat/ship/airship
+  3-5, game over 6 — see their own paragraphs below) are consumed, not just
+  round-tripped.
+  ✅ **Follow-up (cycle #202, 2026-08-28): audio/BGM behavior, a fresh area
+  this session (cycles #191-201 covered interpreter call-stack save
+  persistence, Key Input Proc wait restoration, level-up skill-learn
+  messages, RPG2003 Shake Screen mode gating, an exhaustive SPEED_UP-ceiling
+  scan, and a rendering-path root-cause — none of them audio). Two findings,
+  both first-principles code-reading (wine's screenshot-diff technique does
+  not reach audio timing, so no wine verification was attempted here; this
+  is the cycle #201-style "engine's own internal correctness" investigation
+  the task brief calls out as the alternative to wine):
+  (1) **Fixed a real, previously-undocumented gap: Play BGM's own fade-in
+  parameter (event command param 0) was read off the command and then
+  dropped on the floor.** `Game::Interpreter#play_audio`'s `:bgm` branch
+  computed `fade_in` but never passed it anywhere; a track configured in the
+  editor to fade in over, say, 800ms started at full target volume
+  immediately, indistinguishable from `fade_in=0`. SDL_mixer's
+  `Mix_FadeInMusic` (already available, unlike tempo's genuine SDL_mixer
+  limitation the balance/pan work above ran into) was simply never wired
+  up. Fixed end to end: `RGSS::Audio.bgm_play` (`mruby-rgss/mrblib/lib.rb`,
+  `mruby-rgss/src/audio.cxx`, `include/rgss_audio.hxx`, `src/sdl_audio.cxx`)
+  gained a new 5th `fadein`/`fadein_ms` argument (default 0, so every real
+  RGSS2/RGSS3 script call site — none of which ever pass a 5th argument — is
+  untouched), and `src/sdl_audio.cxx`'s `start_music` now calls
+  `Mix_FadeInMusic(g_music, loops, fadein_ms)` instead of `Mix_PlayMusic`
+  when it is non-zero, threaded through both the disk-file and packed-
+  archive (`bgm_play_mem`, a released game's `RGSSAD`-packed Audio/ tree)
+  paths alike. `Game::Interpreter#play_audio` now forwards Play BGM's own
+  `fade_in` on a fresh play (never on the same-file-already-playing shortcut
+  — there is no restart there for a fade to ramp into, matching every other
+  Play BGM parameter's own same-file handling), and `#do_play_memorized_bgm`
+  forwards the memorized record's own carried-over fadein the identical way
+  it already carries volume/tempo/balance. Units confirmed as milliseconds
+  by liblcf's own schema (`mruby-lcf/mrblib/schema.rb`'s `BGM` struct field
+  2, the same field Change System BGM's own `fadein` and Fade Out BGM's
+  single parameter both already use, per those commands' own pre-existing
+  doc comments) rather than assumed. NOT independently confirmed against
+  genuine RPG_RT's own audible ramp under wine — there is no way to observe
+  that in this sandbox — so this is a first-principles fix (the parameter
+  existed, was read, and was silently discarded; that much needed no wine
+  to establish) rather than a wine-verified timing match. Regression-covered
+  by three new `scripts/rpg2k_logic_check.rb` checks (a non-zero fade-in
+  reaches `RGSS::Audio.bgm_play`'s new 5th argument and lands on
+  `state.current_bgm[:fadein]`; a same-file re-trigger still only adjusts
+  volume/pan live, no fade; Play Memorized BGM replays the memorized fade-in
+  too), all three confirmed to fail against the pre-fix code (asserting a
+  4-argument `bgm_play`/no fade replay) before the fix.
+  (2) **Fixed a second, related gap this investigation surfaced while
+  extending `current_bgm` to carry `fadein:`: every stored BGM record's
+  fade-in was silently dropped on Save, not just never played.**
+  `Game::State#bgm_chunk`/`.bgm_from_chunk` (the shared encode/decode pair
+  behind the current/memorized BGM, the pre-battle/vehicle restore points,
+  and every Change System BGM override slot 0-6 — one function, seven
+  reuse sites) never touched LCF's BGM-struct field 2 (fade-in) in either
+  direction, even though `do_change_system_bgm` (interpreter.rb) has stashed
+  a real `fadein:` value on that hash since fadein first landed — the exact
+  "tracked live, lost on save" class of gap balance (field 5) had before its
+  own fix. `scripts/rpg2k_logic_check.rb`'s existing "Change System BGM /
+  SFX round-trips" check even already set `fadein: 500` on its slot-0
+  fixture going in, but never asserted it came back, which is exactly why
+  the drop went unnoticed for as long as it did — now asserted (`eq 500,
+  round.system_bgm[0][:fadein]`). Fixed on the same "write only away from
+  its own default (0)" idiom fields 3-5 already use, confirmed to fail
+  against the pre-fix code before the fix.
+  (3) **Along the way, found and fixed two stale, self-contradictory
+  documentation bugs in this very paragraph and the one two paragraphs
+  above** (the "only slot 1 (victory) is still modelled for save fidelity"
+  / "still save-fidelity-only... are all consumed too" text corrected in
+  place above) **and two stale test assertions in
+  `scripts/rpg2k_save_load_check.rb`** (`to_lsd: current_bgm`/
+  `memorized_bgm` expected a 3-key hash missing `balance:`, which
+  `#bgm_from_chunk` has included since balance support landed — these were
+  2 of the suite's own "exactly 3 known pre-existing failures" baseline,
+  reproducibly failing on every run since the same Aug 22 merge). All four
+  are the identical root cause: a merge commit (`bd917345`, 2026-08-22)
+  brought together two branches that had each independently extended the
+  BGM save/playback code (one added `balance:`/save round-tripping and this
+  test, the other added victory-slot consumption) without reconciling their
+  prose or fixtures against each other's actual landed code — the runtime
+  behavior in both cases was already correct; only the documentation and
+  test expectations had drifted from it. Fixed the two save_load_check.rb
+  assertions (now asserting the full `{name:, volume:, tempo:, balance:,
+  fadein:}` shape, exercising fadein's own round-trip fix from (2) at the
+  same time) rather than leaving them as tracked failures, since nothing
+  about the runtime behavior they check was ever actually wrong.
+  **Verification**: `scripts/rpg2k_save_load_check.rb` now reports 1 known
+  failure (down from the documented 3 — the remaining one, an unrelated
+  Show Picture field-shape mismatch, is untouched); `rpg2k_logic_check.rb`
+  1179 passed (1176 baseline + 3 new checks, 0 failures);
+  `rpg2k_scene_check.rb` 935 passed (unchanged); `rpg2k_render_check.rb` 41
+  passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged);
+  `scripts/rpg2k_command_soak.rb` clean on both Nepheshel test-beds; `cd
+  build && ninja` clean rebuild with no new warnings; `ctest -R mruby_test`
+  passed. No wine session was run this cycle (audio timing is not
+  screenshot-diffable, and no other part of this investigation touched a
+  `data/` fixture), so there was nothing to restore. Not chased further:
+  extending the same fade-in plumbing to the Change-System-BGM-driven
+  battle/victory/inn/vehicle BGM helpers in `Scene::Map` (`#battle_bgm` /
+  `#victory_bgm` / `#inn_bgm` / `#vehicle_bgm` all still resolve `{name:,
+  volume:, tempo:}` and silently drop any `fadein:` on the override/database
+  Music struct they read) — deliberately left out of this cycle's scope to
+  keep the change small and independently verifiable; the save round-trip
+  fix in (2) means that fadein value is no longer *lost*, just not yet
+  *played*, for those four call sites specifically.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/include/rgss_audio.hxx
+++ b/include/rgss_audio.hxx
@@ -44,7 +44,10 @@ struct RgssAudioBackend {
   // starts at once, matching every prior build; > 0 is expected to ramp up
   // from silence to `volume` over that many milliseconds instead of jumping
   // there immediately.
-  void (*bgm_play)(const char* path, int volume, int pitch, int pos_ms,
+  void (*bgm_play)(const char* path,
+                   int volume,
+                   int pitch,
+                   int pos_ms,
                    int fadein_ms);
   // Re-applies volume to the BGM stream already playing, with no restart --
   // unlike bgm_play, which always starts its track over. Used when a Play BGM

--- a/include/rgss_audio.hxx
+++ b/include/rgss_audio.hxx
@@ -38,8 +38,14 @@ struct RgssAudioBackend {
   // feeds bgm_pos's own return value back in here round-trips exactly. 0 plays
   // from the beginning, as XP/VX's 3-argument form always did. A backend that
   // cannot seek (or fails to) is expected to fall back to playing from the
-  // beginning rather than dropping the play.
-  void (*bgm_play)(const char* path, int volume, int pitch, int pos_ms);
+  // beginning rather than dropping the play. fadein_ms is not part of any real
+  // RGSS Audio.bgm_play -- it carries RPG2000's own Play BGM fade-in
+  // parameter (cycle #202). 0 (every RGSS-script call site's implicit value)
+  // starts at once, matching every prior build; > 0 is expected to ramp up
+  // from silence to `volume` over that many milliseconds instead of jumping
+  // there immediately.
+  void (*bgm_play)(const char* path, int volume, int pitch, int pos_ms,
+                   int fadein_ms);
   // Re-applies volume to the BGM stream already playing, with no restart --
   // unlike bgm_play, which always starts its track over. Used when a Play BGM
   // command re-triggers the file that is already current (RPG_RT re-applies
@@ -85,12 +91,16 @@ struct RgssAudioBackend {
   // bgm_play_mem's pos_ms is the same resume position as bgm_play's, above --
   // this is how a released game (its whole Audio/ tree packed into one
   // archive, nothing loose on disk) actually hears a mid-track resume.
+  // fadein_ms is the same fade-in-from-silence duration as bgm_play's, above,
+  // reaching a released game's packed archive the same way pos_ms already
+  // does.
   void (*bgm_play_mem)(const char* name,
                        const void* data,
                        int size,
                        int volume,
                        int pitch,
-                       int pos_ms);
+                       int pos_ms,
+                       int fadein_ms);
   void (*bgs_play_mem)(const char* name,
                        const void* data,
                        int size,

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1114,10 +1114,19 @@ module RGSS
       # instant a real game would land on. Seeking can still fail (some
       # decoders, e.g. MOD/MIDI, do not support it); a failed seek plays from
       # the track's own beginning rather than not playing at all.
-      def bgm_play(filename, volume = 100, pitch = 100, pos = 0)
+      #
+      # `fadein` is not part of any real RGSS Audio.bgm_play signature (RGSS2/
+      # RGSS3 scripts never pass a 5th argument) -- it exists for RPG2000's
+      # own Play BGM event command, whose fade-in parameter this engine used
+      # to read and then silently drop (cycle #202). Milliseconds, ramping
+      # from silence up to `volume` via SDL_mixer's Mix_FadeInMusic rather
+      # than jumping straight there the way an ordinary Mix_PlayMusic does;
+      # 0 (the default, and every real RGSS caller's implicit value) keeps
+      # the original instant-start behavior exactly.
+      def bgm_play(filename, volume = 100, pitch = 100, pos = 0, fadein = 0)
         path = resolve(filename, MUSIC_DIRS)
-        return _bgm_play(path, volume, pitch, pos) if path
-        play_packed(:bgm, filename, volume, pitch, pos)
+        return _bgm_play(path, volume, pitch, pos, fadein) if path
+        play_packed(:bgm, filename, volume, pitch, pos, fadein)
       end
 
       # Re-applies volume to the already-playing BGM stream in place, with no
@@ -1229,8 +1238,11 @@ module RGSS
       # just the disk path in #bgm_play, because a released game's whole
       # Audio/ tree is packed into one encrypted archive with nothing loose on
       # disk (see RGSS.asset_archive) -- this is the path that actually
-      # carries a resume for a released game.
-      def play_packed(kind, filename, volume, pitch, pos = 0)
+      # carries a resume for a released game. `fadein` (cycle #202) is BGM's
+      # own fade-in-from-silence duration, the same disk-path/packed-path
+      # split as `pos` for the identical reason: RPG2000's Play BGM has to
+      # reach a released game's packed archive too, not just loose files.
+      def play_packed(kind, filename, volume, pitch, pos = 0, fadein = 0)
         return nil if filename.nil? || filename.empty?
         archive = RGSS.asset_archive
         name, bytes = archive ? find_packed(archive, kind, filename) : nil
@@ -1251,7 +1263,7 @@ module RGSS
           return nil
         end
         case kind
-        when :bgm then _bgm_play_mem(name, bytes, volume, pitch, pos)
+        when :bgm then _bgm_play_mem(name, bytes, volume, pitch, pos, fadein)
         when :bgs then _bgs_play_mem(name, bytes, volume, pitch)
         when :me then _me_play_mem(name, bytes, volume, pitch)
         else _se_play_mem(name, bytes, volume, pitch)

--- a/mruby-rgss/src/audio.cxx
+++ b/mruby-rgss/src/audio.cxx
@@ -191,7 +191,7 @@ mrb_value bgm_play_mem(mrb_state* M, mrb_value self) {
   mrb_int size;
   mrb_int volume = 100, pitch = 100, pos_ms = 0, fadein_ms = 0;
   mrb_get_args(M, "zs|iiii", &name, &data, &size, &volume, &pitch, &pos_ms,
-              &fadein_ms);
+               &fadein_ms);
   if (g_backend.bgm_play_mem && size > 0)
     g_backend.bgm_play_mem(name, data, (int)size, (int)volume, (int)pitch,
                            (int)pos_ms, (int)fadein_ms);

--- a/mruby-rgss/src/audio.cxx
+++ b/mruby-rgss/src/audio.cxx
@@ -53,13 +53,16 @@ mrb_value play_mem(mrb_state* M, PlayMemFn fn) {
 
 mrb_value bgm_play(mrb_state* M, mrb_value self) {
   const char* path;
-  mrb_int volume = 100, pitch = 100, pos_ms = 0;
+  mrb_int volume = 100, pitch = 100, pos_ms = 0, fadein_ms = 0;
   // BGM alone takes a 4th (pos_ms) argument: RGSS3's mid-track resume, which
   // BGS/ME/SE never had -- get_play_args (above) only reads the three they all
-  // share.
-  mrb_get_args(M, "z|iii", &path, &volume, &pitch, &pos_ms);
+  // share. The 5th (fadein_ms, cycle #202) is RPG2000's own Play BGM fade-in,
+  // not part of any real RGSS Audio.bgm_play -- see rgss_audio.hxx's own
+  // doc comment.
+  mrb_get_args(M, "z|iiii", &path, &volume, &pitch, &pos_ms, &fadein_ms);
   if (g_backend.bgm_play)
-    g_backend.bgm_play(path, (int)volume, (int)pitch, (int)pos_ms);
+    g_backend.bgm_play(path, (int)volume, (int)pitch, (int)pos_ms,
+                       (int)fadein_ms);
   return mrb_nil_value();
 }
 
@@ -179,17 +182,19 @@ mrb_value audio_update(mrb_state* M, mrb_value self) {
 }
 
 mrb_value bgm_play_mem(mrb_state* M, mrb_value self) {
-  // Not the shared play_mem helper: BGM alone takes a 5th (pos_ms) argument
-  // (see bgm_play, above) -- this is the packed-archive path a released
-  // game's mid-track resume actually reaches (see RGSS.asset_archive).
+  // Not the shared play_mem helper: BGM alone takes a 5th (pos_ms) and 6th
+  // (fadein_ms, cycle #202) argument (see bgm_play, above) -- this is the
+  // packed-archive path a released game's mid-track resume and Play BGM
+  // fade-in actually reach (see RGSS.asset_archive).
   const char* name;
   const char* data;
   mrb_int size;
-  mrb_int volume = 100, pitch = 100, pos_ms = 0;
-  mrb_get_args(M, "zs|iii", &name, &data, &size, &volume, &pitch, &pos_ms);
+  mrb_int volume = 100, pitch = 100, pos_ms = 0, fadein_ms = 0;
+  mrb_get_args(M, "zs|iiii", &name, &data, &size, &volume, &pitch, &pos_ms,
+              &fadein_ms);
   if (g_backend.bgm_play_mem && size > 0)
     g_backend.bgm_play_mem(name, data, (int)size, (int)volume, (int)pitch,
-                           (int)pos_ms);
+                           (int)pos_ms, (int)fadein_ms);
   return mrb_nil_value();
 }
 
@@ -237,7 +242,7 @@ extern "C" void rgss_audio_frame(void) {
 void rgss_audio_define(mrb_state* M, RClass* rgss) {
   RClass* audio = mrb_define_module_under(M, rgss, "Audio");
   mrb_define_module_function(M, audio, "_bgm_play", bgm_play,
-                             MRB_ARGS_ARG(1, 3));
+                             MRB_ARGS_ARG(1, 4));
   mrb_define_module_function(M, audio, "_bgm_volume", bgm_volume,
                              MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_bgm_pan", bgm_pan, MRB_ARGS_REQ(1));
@@ -259,7 +264,7 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
   // Play from encoded bytes: how a release that packs its Audio/ tree into an
   // encrypted RGSSAD archive is heard at all (see RGSS.asset_archive).
   mrb_define_module_function(M, audio, "_bgm_play_mem", bgm_play_mem,
-                             MRB_ARGS_ARG(2, 3));
+                             MRB_ARGS_ARG(2, 4));
   mrb_define_module_function(M, audio, "_bgs_play_mem", bgs_play_mem,
                              MRB_ARGS_ARG(2, 2));
   mrb_define_module_function(M, audio, "_me_play_mem", me_play_mem,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1615,8 +1615,8 @@ assert "RGSS::Audio plays a packed track through RGSS.asset_archive" do
   class << RGSS::Audio
     alias _bgm_play_mem_orig _bgm_play_mem
     alias _can_play_mem_orig _can_play_mem?
-    def _bgm_play_mem(name, bytes, volume, pitch, pos = 0)
-      $audio_mem_capture = [name, bytes, volume, pitch, pos]
+    def _bgm_play_mem(name, bytes, volume, pitch, pos = 0, fadein = 0)
+      $audio_mem_capture = [name, bytes, volume, pitch, pos, fadein]
       nil
     end
     # No backend is installed in this binary, so pretend one is: without it the
@@ -1749,8 +1749,8 @@ assert "RGSS::Audio finds an upper-case extension in the archive" do
   class << RGSS::Audio
     alias _bgm_play_mem_orig2 _bgm_play_mem
     alias _can_play_mem_orig2 _can_play_mem?
-    def _bgm_play_mem(name, bytes, volume, pitch, pos = 0)
-      $audio_mem_capture = [name, bytes, volume, pitch, pos]
+    def _bgm_play_mem(name, bytes, volume, pitch, pos = 0, fadein = 0)
+      $audio_mem_capture = [name, bytes, volume, pitch, pos, fadein]
       nil
     end
     def _can_play_mem? = true

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -16394,27 +16394,41 @@ module Game
     end
 
     # Build a BGM chunk (an LCF::Array1D over the BGM schema) from our stored
-    # `{ name:, volume:, tempo:, balance: }` hash: file (1), volume (3), pitch
-    # (4) and balance (5). Used for the system chunk's current-BGM (75) and
-    # stored-BGM (78) slots, and (below) every Change System BGM override
-    # slot. Balance is a first-class field of EasyRPG's own `Music`
-    # struct (ported from `Game_Interpreter::CommandPlayBGM`: `music.balance
-    # = ValueOrVariableBitfield(com, 4,
+    # `{ name:, volume:, tempo:, balance:, fadein: }` hash: file (1), fade-in
+    # (2), volume (3), pitch (4) and balance (5). Used for the system chunk's
+    # current-BGM (75) and stored-BGM (78) slots, and (below) every Change
+    # System BGM override slot. Balance is a first-class field of EasyRPG's
+    # own `Music` struct (ported from `Game_Interpreter::CommandPlayBGM`:
+    # `music.balance = ValueOrVariableBitfield(com, 4,
     # 4, 3);`, round-tripped whole by `Game_System::MemorizeBGM`/
     # `PlayMemorizedBGM` the same way every other field
     # here already is), NOT independently confirmed against genuine RPG_RT
     # under wine.
+    #
+    # Field 2 (fade_in) was entirely unwritten here until this cycle even
+    # when the stored hash carried a real non-zero `:fadein` -- do_change_
+    # system_bgm (interpreter.rb) has stashed a Play BGM/Change System BGM
+    # command's own fade-in milliseconds on the hash since fadein first
+    # landed, but this encoder silently dropped it on every Save, the exact
+    # same class of gap as the picture/message fields ADR 0019 catalogues
+    # elsewhere in this file. Now written on the same "elide at the schema
+    # default" idiom the other fields already use.
     def bgm_chunk(bgm)
       b = LCF::Array1D.new('', { elements: LCF::Schema::BGM })
       b[1] = bgm[:name] || ''
-      # Elided at their own schema default (100/100/50) -- confirmed against
-      # a genuine kk1.12 save under wine: an untouched BGM record's raw
-      # bytes carried field 1 (name) alone, with fields 3-5 entirely absent,
-      # not present holding the default values this codebase's own writer
-      # used to always emit.
+      # Elided at their own schema default (0/100/100/50) -- confirmed
+      # against a genuine kk1.12 save under wine for fields 3-5: an untouched
+      # BGM record's raw bytes carried field 1 (name) alone, with fields 3-5
+      # entirely absent, not present holding the default values this
+      # codebase's own writer used to always emit. Field 2's own default-
+      # elision is inferred from that same "write only a non-default field"
+      # pattern liblcf's schema documents for every other field here, NOT
+      # independently confirmed against genuine RPG_RT under wine on its own.
+      fadein = bgm[:fadein] || 0
       vol = bgm[:volume] || 100
       tempo = bgm[:tempo] || 100
       bal = bgm[:balance] || 50
+      b[2] = fadein if fadein != 0
       b[3] = vol if vol != 100
       b[4] = tempo if tempo != 100
       b[5] = bal if bal != 50
@@ -17065,7 +17079,7 @@ module Game
       name = chunk.file
       return nil if name.nil? || name.empty? || name == '(OFF)'
       { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100,
-        balance: chunk.balance || 50 }
+        balance: chunk.balance || 50, fadein: chunk.fade_in || 0 }
     end
 
     # #bgm_from_chunk's SE counterpart: rebuild our `{ name:, volume:, tempo: }`

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -4616,7 +4616,14 @@ module Game
         RGSS::Audio.bgm_volume(bgm[:volume] || 100)
       else
         @state.bgm_looped = false
-        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
+        # The memorized record's own fade-in (cycle #202) replays too, the
+        # same whole-struct-carried-over idiom every other field here already
+        # gets -- Memorize BGM stashed whatever Play BGM's fade_in last set
+        # (`#do_memorize_bgm`'s bare `@state.current_bgm.dup`), so a track
+        # memorized while still fading in resumes with that same ramp on
+        # replay rather than snapping straight to its target volume.
+        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100,
+                             0, bgm[:fadein] || 0)
       end
       # Balance/pan is re-applied unconditionally, same-file-or-not, matching
       # `#play_audio`'s own `:bgm` branch -- ported from EasyRPG Player's
@@ -4672,7 +4679,12 @@ module Game
       if kind == :bgm
         # PlayBGM parameters: [fade_in, volume, tempo, balance]. Volume/tempo
         # default to 100, balance to 50 (centre), when the command carries a
-        # shorter list.
+        # shorter list. fade_in is already milliseconds, not tenths of a
+        # second -- the same LCF BGM-struct field 2 Change System BGM's own
+        # fadein reads (do_change_system_bgm above) and Fade Out BGM's own
+        # single parameter already is (see do_fadeout_bgm's own citation);
+        # liblcf's schema gives it a plain :int type with no separate scale.
+        fade_in = cmd.parameters.size > 0 ? cmd.param(0) : 0
         volume = cmd.parameters.size > 1 ? cmd.param(1) : 100
         pitch = cmd.parameters.size > 2 ? cmd.param(2) : 100
         balance = cmd.parameters.size > 3 ? cmd.param(3) : 50
@@ -4708,12 +4720,23 @@ module Game
         # (a bare `data.stored_music =
         # data.current_music`, copying the whole `Music` struct verbatim),
         # NOT independently confirmed against genuine RPG_RT under wine.
-        @state.current_bgm = { name: name, volume: volume, tempo: pitch, balance: balance }
+        @state.current_bgm = { name: name, volume: volume, tempo: pitch, balance: balance,
+                               fadein: fade_in }
         if same_file_already_playing
+          # No restart happens here at all (see above), so there is nothing
+          # for a fade-in to ramp into -- matching the same-file shortcut's
+          # own "only adjust volume and speed" rule for every other Play BGM
+          # parameter.
           RGSS::Audio.bgm_volume(volume)
         else
           @state.bgm_looped = false # a fresh track has not looped yet
-          RGSS::Audio.bgm_play(name, volume, pitch)
+          # `fade_in` (cycle #202): previously read off the command's own
+          # parameter list and then dropped on the floor -- a configured
+          # fade-in never actually ramped the volume in, the track simply
+          # started at its target volume immediately, same as fade_in=0.
+          # RGSS::Audio.bgm_play's 5th argument (below) is new this cycle
+          # too; see its own doc comment for the native Mix_FadeInMusic path.
+          RGSS::Audio.bgm_play(name, volume, pitch, 0, fade_in)
         end
         # Cleared unconditionally, restart or not -- `BgmPlay`'s own `data.
         # music_stopping = false;` runs after the if/else either way.

--- a/mruby-rpg2k/mrblib/scene/game_over.rb
+++ b/mruby-rpg2k/mrblib/scene/game_over.rb
@@ -84,10 +84,18 @@ class RPG2k
       # gameover_music. Mirrors EasyRPG Player's Game_System::GetAudio, NOT
       # independently confirmed against genuine RPG_RT under wine: the override
       # wins only when its own filename is non-empty.
+      #
+      # `fadein` (cycle #203): both sources genuinely carry one, the same as
+      # Scene::Map's battle/inn/vehicle BGM helpers -- the override from
+      # Change System BGM's own fade-in parameter (`do_change_system_bgm`,
+      # mruby-rpg2k/mrblib/interpreter.rb), the database value from
+      # gameover_music's own liblcf `BGM`-struct field 2 (`fade_in`,
+      # mruby-lcf/mrblib/schema.rb) -- previously read off neither and
+      # dropped before reaching Audio.bgm_play.
       def play_gameover_bgm
-        name, vol, tempo = gameover_bgm_override || database_gameover_bgm
+        name, vol, tempo, fadein = gameover_bgm_override || database_gameover_bgm
         return if name.nil? || name.empty?
-        Audio.bgm_play name, vol, tempo
+        Audio.bgm_play name, vol, tempo, 0, fadein
       rescue StandardError => e
         $stderr.puts "[RPG2k] game over BGM playback failed: #{e.message}"
       end
@@ -96,13 +104,13 @@ class RPG2k
         return nil unless @game_state
         ov = @game_state.system_bgm[SYSTEM_BGM_GAMEOVER]
         return nil unless ov && ov[:name] && !ov[:name].to_s.empty?
-        [ov[:name], ov[:volume] || 100, ov[:tempo] || 100]
+        [ov[:name], ov[:volume] || 100, ov[:tempo] || 100, ov[:fadein] || 0]
       end
 
       def database_gameover_bgm
         bgm = db.system.gameover_music
-        return [nil, 100, 100] unless bgm
-        [bgm.file, (bgm.volume || 100), (bgm.pitch || 100)]
+        return [nil, 100, 100, 0] unless bgm
+        [bgm.file, (bgm.volume || 100), (bgm.pitch || 100), (bgm.fade_in || 0)]
       end
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2928,9 +2928,23 @@ class RPG2k
       def play_bgm(music)
         same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == music[:name]
         if same_file_already_playing
+          # No restart happens here, so there is nothing for a fade-in to
+          # ramp into -- the same same-file shortcut #play_audio's own :bgm
+          # branch (mruby-rpg2k/mrblib/interpreter.rb) already documents for
+          # every other Play BGM parameter, cycle #202.
           RGSS::Audio.bgm_volume(music[:volume] || 100)
         else
-          RGSS::Audio.bgm_play(music[:name], music[:volume] || 100, music[:tempo] || 100)
+          # `music[:fadein]` (cycle #203): battle/inn/vehicle BGM now carries
+          # a real fade-in through here the same way Play BGM and Play
+          # Memorized BGM already do (see those two's own doc comments) --
+          # both a Change System BGM (10660) override (`do_change_system_bgm`
+          # in interpreter.rb) and the database's own battle_music/inn_music/
+          # boat_music/ship_music/airship_music (all liblcf `BGM`-struct
+          # fields, schema.rb, field 2 `fade_in`) genuinely carry a fade-in
+          # value that this helper used to read the struct for and then drop
+          # before reaching RGSS::Audio.bgm_play's 5th argument.
+          RGSS::Audio.bgm_play(music[:name], music[:volume] || 100, music[:tempo] || 100,
+                               0, music[:fadein] || 0)
         end
         @state.current_bgm = music
       end
@@ -3010,22 +3024,29 @@ class RPG2k
         $stderr.puts "[RPG2k] battle BGM failed: #{e.message}"
       end
 
-      # The battle BGM to play as { name:, volume:, tempo: }, or nil when
-      # neither source names a file. Prefers a Change System BGM override for
-      # the battle slot over the database's own System battle_music -- the
-      # same override-then-default idiom #system_se already uses for Change
-      # System SFX overrides, extended to BGM now that a battle actually
-      # plays music to override.
+      # The battle BGM to play as { name:, volume:, tempo:, fadein: }, or nil
+      # when neither source names a file. Prefers a Change System BGM
+      # override for the battle slot over the database's own System
+      # battle_music -- the same override-then-default idiom #system_se
+      # already uses for Change System SFX overrides, extended to BGM now
+      # that a battle actually plays music to override. `fadein` (cycle
+      # #203): both sources genuinely carry one -- the override from Change
+      # System BGM's own fade-in parameter (`do_change_system_bgm`,
+      # mruby-rpg2k/mrblib/interpreter.rb), the database value from
+      # battle_music's own liblcf `BGM`-struct field 2 (`fade_in`,
+      # mruby-lcf/mrblib/schema.rb) -- previously read off neither and
+      # dropped before reaching #play_bgm.
       def battle_bgm
         ov = @state.system_bgm[SYSTEM_BGM_BATTLE]
         if ov && ov[:name] && !ov[:name].empty?
           return { name: ov[:name], volume: ov[:volume] || 100,
-                    tempo: ov[:tempo] || 100 }
+                    tempo: ov[:tempo] || 100, fadein: ov[:fadein] || 0 }
         end
         name = music_name(db.system.battle_music)
         return nil if name.nil? || name.empty?
         { name: name, volume: music_volume(db.system.battle_music),
-          tempo: music_tempo(db.system.battle_music) }
+          tempo: music_tempo(db.system.battle_music),
+          fadein: music_fadein(db.system.battle_music) }
       end
 
       # Play the victory fanfare over the result window on a win, the same way
@@ -3041,6 +3062,21 @@ class RPG2k
       # here needs to remember or restore anything of its own. A game with no
       # victory BGM configured leaves whatever was playing (the battle track)
       # alone, the same blank-Music no-op #battle_bgm documents.
+      #
+      # Deliberately does NOT forward a fade-in (cycle #203 audit): the
+      # override and battle_end_music both do carry a genuine fade-in value
+      # the same way battle_music/inn_music/vehicle music do (Change System
+      # BGM's own fade-in parameter; liblcf's `BGM`-struct field 2), but
+      # RGSS::Audio.me_play has no fadein parameter at all -- unlike
+      # RGSS::Audio.bgm_play (cycle #202), the native ME playback path
+      # (`me_play`/`me_play_mem`, src/sdl_audio.cxx) was never given one,
+      # since RPG_RT's own "ME" one-shot channel is a distinct playback
+      # mechanism from its looping BGM channel. Wiring this would mean adding
+      # a fadein parameter across the whole native ME path (sdl_audio.cxx,
+      # include/rgss_audio.hxx, mruby-rgss/src/audio.cxx,
+      # mruby-rgss/mrblib/lib.rb) -- out of this audit's scope, which is
+      # forwarding an already-plumbed value through mrblib call sites, not
+      # extending the native audio surface.
       def play_victory_bgm
         music = victory_bgm
         return unless music
@@ -3114,19 +3150,22 @@ class RPG2k
         $stderr.puts "[RPG2k] inn BGM failed: #{e.message}"
       end
 
-      # The inn BGM to play as { name:, volume:, tempo: }, or nil when
-      # neither source names a file. Prefers a Change System BGM override for
-      # the inn slot over the database's own System inn_music -- the same
-      # override-then-default idiom #battle_bgm / #vehicle_bgm already use.
+      # The inn BGM to play as { name:, volume:, tempo:, fadein: }, or nil
+      # when neither source names a file. Prefers a Change System BGM
+      # override for the inn slot over the database's own System inn_music --
+      # the same override-then-default idiom #battle_bgm / #vehicle_bgm
+      # already use, `fadein` included (cycle #203) -- see #battle_bgm's own
+      # doc comment for why both sources genuinely carry one.
       def inn_bgm
         ov = @state.system_bgm[SYSTEM_BGM_INN]
         if ov && ov[:name] && !ov[:name].to_s.empty?
-          return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100 }
+          return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100,
+                    fadein: ov[:fadein] || 0 }
         end
         name = music_name(db.system.inn_music)
         return nil if name.nil? || name.empty?
         { name: name, volume: music_volume(db.system.inn_music),
-          tempo: music_tempo(db.system.inn_music) }
+          tempo: music_tempo(db.system.inn_music), fadein: music_fadein(db.system.inn_music) }
       end
 
       # Restore the BGM that was playing before the inn stay began. A no-op
@@ -3149,30 +3188,40 @@ class RPG2k
       # sit between the ones the battle and game-over BGM already resolve.
       VEHICLE_SYSTEM_BGM_SLOT = { boat: 3, ship: 4, airship: 5 }.freeze
 
-      # The BGM to play for vehicle `type` as { name:, volume:, tempo: }, or
-      # nil when neither source names a file. Prefers a Change System BGM
-      # override for the vehicle's slot over the database's own boat / ship /
-      # airship music — the same override-then-default idiom #system_se
-      # already uses for Change System SFX.
+      # The BGM to play for vehicle `type` as
+      # { name:, volume:, tempo:, fadein: }, or nil when neither source names
+      # a file. Prefers a Change System BGM override for the vehicle's slot
+      # over the database's own boat / ship / airship music — the same
+      # override-then-default idiom #system_se already uses for Change System
+      # SFX, `fadein` included (cycle #203) -- see #battle_bgm's own doc
+      # comment for why both sources genuinely carry one.
       def vehicle_bgm(type)
         slot = VEHICLE_SYSTEM_BGM_SLOT[type]
         ov = slot && @state.system_bgm[slot]
         if ov && ov[:name] && !ov[:name].to_s.empty?
-          return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100 }
+          return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100,
+                    fadein: ov[:fadein] || 0 }
         end
         field = "#{type}_music"
         return nil unless @db.system.respond_to?(field)
         bgm = @db.system.send(field)
         name = music_name(bgm)
         return nil if name.nil? || name.empty?
-        { name: name, volume: music_volume(bgm), tempo: music_tempo(bgm) }
+        { name: name, volume: music_volume(bgm), tempo: music_tempo(bgm), fadein: music_fadein(bgm) }
       end
 
-      # A parsed BGM chunk exposes file / volume / pitch; read them defensively so
-      # a bare fixture that omits a field still works.
+      # A parsed BGM chunk exposes file / fade_in / volume / pitch; read them
+      # defensively so a bare fixture that omits a field still works.
       def music_name(m); m.file rescue nil; end
       def music_volume(m); (m.volume rescue nil) || 100; end
       def music_tempo(m); (m.pitch rescue nil) || 100; end
+      # `fade_in` (cycle #203): liblcf's `BGM` struct field 2
+      # (mruby-lcf/mrblib/schema.rb), present on every System Music slot this
+      # scene reads (battle_music, inn_music, boat/ship/airship_music) --
+      # previously never read here at all, so a database-configured fade-in
+      # on any of those slots was silently dropped rather than reaching
+      # #play_bgm.
+      def music_fadein(m); (m.fade_in rescue nil) || 0; end
 
       # Keep the ridden vehicle on the party's tile / facing.
       def follow_vehicle

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -219,8 +219,8 @@ assert "a packed track plays through RGSS.asset_archive" do
     class << RGSS::Audio
       alias _bgm_play_mem_orig3 _bgm_play_mem
       alias _can_play_mem_orig3 _can_play_mem?
-      def _bgm_play_mem(name, bytes, volume, pitch, pos = 0)
-        $audio_arch_capture = [name, bytes, volume, pitch, pos]
+      def _bgm_play_mem(name, bytes, volume, pitch, pos = 0, fadein = 0)
+        $audio_arch_capture = [name, bytes, volume, pitch, pos, fadein]
         nil
       end
       # The test binary installs no audio backend; pretend one is there so the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3824,7 +3824,7 @@ check 'Play BGM with the literal "(OFF)" name stops the current track' do
     FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: '(OFF)'),
   ])
   it.update
-  eq [[:bgm, 'town', 80, 100], [:bgm_pan, 50], [:bgm_stop]], RGSS::Audio.log,
+  eq [[:bgm, 'town', 80, 100, 0, 0], [:bgm_pan, 50], [:bgm_stop]], RGSS::Audio.log,
      'the second Play BGM stops the track just started, rather than trying ' \
      'to play a file literally named "(OFF)"'
   eq nil, it.instance_variable_get(:@state).current_bgm,
@@ -3841,8 +3841,69 @@ check 'Play BGM with a blank name also stops the current track' do
     FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: ''),
   ])
   it.update
-  eq [[:bgm, 'town', 80, 100], [:bgm_pan, 50], [:bgm_stop]], RGSS::Audio.log,
+  eq [[:bgm, 'town', 80, 100, 0, 0], [:bgm_pan, 50], [:bgm_stop]], RGSS::Audio.log,
      'BgmPlay treats a blank name exactly like "(OFF)" -- both stop'
+end
+
+# Cycle #202: Play BGM's own fade_in parameter (param 0) used to be read off
+# the command and then dropped on the floor -- #play_audio never forwarded it
+# anywhere, so a track configured to fade in always snapped straight to its
+# target volume instead, indistinguishable from fade_in=0. Fixed by threading
+# it through as RGSS::Audio.bgm_play's new 5th (fadein_ms) argument, backed by
+# SDL_mixer's Mix_FadeInMusic (src/sdl_audio.cxx) -- not independently
+# confirmed against genuine RPG_RT's own audible ramp under wine (no
+# screenshot-diff technique reaches audio), but the parameter itself, its
+# unit (milliseconds, matching liblcf's own BGM-struct field 2 Change System
+# BGM and Fade Out BGM both already use, per those commands' own doc
+# comments), and its plumbing through every layer are confirmed by reading
+# the LCF schema and this engine's own code.
+check 'Play BGM with a non-zero fade-in forwards it to RGSS::Audio.bgm_play, not dropped' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::PLAY_BGM, [800, 80, 100, 20], string: 'town')])
+  it.update
+  eq [[:bgm, 'town', 80, 100, 0, 800], [:bgm_pan, 20]], RGSS::Audio.log,
+     'fade_in (param 0) reaches bgm_play as its 5th argument (pos=0, fadein=800)'
+  eq 800, st.current_bgm[:fadein], 'and is tracked on state too, the same as volume/tempo/balance'
+end
+
+check 'Play BGM re-triggering the same file does not fade in -- there is ' \
+      'no restart for a fade to ramp into' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    # Same file again, now with a fade-in requested -- the no-restart
+    # shortcut still applies (see the "(OFF)"/blank checks above), so this
+    # only re-applies volume/pan in place, exactly as fade_in=0 would.
+    FakeCmd.new(IC::PLAY_BGM, [600, 90, 100, 30], string: 'town'),
+  ])
+  it.update
+  eq [[:bgm, 'town', 80, 100, 0, 0], [:bgm_pan, 50], [:bgm_volume, 90], [:bgm_pan, 30]],
+     RGSS::Audio.log,
+     'the second Play BGM only adjusts volume/pan live -- no second :bgm (restart) entry'
+  eq 600, st.current_bgm[:fadein],
+     'state still tracks the latest requested fade-in even though nothing replayed'
+end
+
+check 'Play Memorized BGM replays the memorized track\'s own fade-in too' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [700, 80, 100], string: 'town'), # fades in over 700ms
+    FakeCmd.new(IC::MEMORIZE_BGM, []),
+    FakeCmd.new(IC::PLAY_BGM, [0, 100, 100], string: 'fanfare'), # a plain instant start
+    FakeCmd.new(IC::PLAY_MEMORIZED_BGM, []), # resumes town -- with its own fade-in again
+  ])
+  it.update
+  bgms = RGSS::Audio.log.select { |e| e[0] == :bgm }
+  eq [['town', 80, 100, 0, 700], ['fanfare', 100, 100, 0, 0], ['town', 80, 100, 0, 700]],
+     bgms.map { |e| e[1..] },
+     'the memorized fade-in (700ms) replays on Play Memorized BGM, not silently ' \
+     'dropped to an instant start'
 end
 
 # -- actor HP / MP commands ---------------------------------------------------
@@ -4886,6 +4947,13 @@ check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrid
   eq 90, round.system_bgm[0][:volume]
   eq 110, round.system_bgm[0][:tempo]
   eq 20, round.system_bgm[0][:balance], 'a non-centre balance round-trips too, not just the default'
+  # Cycle #202: fade-in (BGM schema field 2) used to be silently dropped by
+  # #bgm_chunk regardless of the stored value -- this fixture already set a
+  # non-zero fadein above, but nothing here checked it came back, which is
+  # exactly why the gap went unnoticed. Now fixed: field 2 round-trips the
+  # same "write only away from its own default" way fields 3-5 already do.
+  eq 500, round.system_bgm[0][:fadein], 'fade-in round-trips too, not silently dropped'
+  eq 0, round.system_bgm[6][:fadein], 'a zero (default) fade-in still round-trips as zero'
   eq 'GameOver1', round.system_bgm[6][:name], 'Change System BGM slot 6 (game over) round-trips'
   eq 'Cursor1', round.system_sfx[0][:name], 'Change System SFX slot 0 (cursor) round-trips'
   eq 95, round.system_sfx[0][:volume]

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -231,8 +231,8 @@ def check_game(dir)
   mc.face_right = true
   mc.face_flipped = true
   state.player_transparent = true
-  state.current_bgm = { name: 'Theme', volume: 80, tempo: 120 }
-  state.memorized_bgm = { name: 'Boss', volume: 90, tempo: 100 }
+  state.current_bgm = { name: 'Theme', volume: 80, tempo: 120, fadein: 500 }
+  state.memorized_bgm = { name: 'Boss', volume: 90, tempo: 100, fadein: 800 }
   state.menu_access = false
   state.save_access = false
   state.teleport_access = true
@@ -329,8 +329,18 @@ def check_game(dir)
   eq true, rmc.face_right, 'to_lsd: message face_right'
   eq true, rmc.face_flipped, 'to_lsd: message face_flipped'
   eq true, round.player_transparent, 'to_lsd: player_transparent'
-  eq({ name: 'Theme', volume: 80, tempo: 120 }, round.current_bgm, 'to_lsd: current_bgm')
-  eq({ name: 'Boss', volume: 90, tempo: 100 }, round.memorized_bgm, 'to_lsd: memorized_bgm')
+  # Both hashes below also pin `balance: 50` (the untouched schema default),
+  # not just the fields this test mutates -- #bgm_from_chunk always includes
+  # it (cycle #175's own balance support), which these two assertions had
+  # fallen out of sync with (a stale merge-conflict leftover, see docs/
+  # TODO.md's cycle #202 entry) and so had failed on every run since; fixed
+  # here rather than left as one of this suite's tracked pre-existing
+  # failures, since the actual runtime behavior asserted here (balance
+  # rebuilds as its own default) was already correct.
+  eq({ name: 'Theme', volume: 80, tempo: 120, balance: 50, fadein: 500 },
+     round.current_bgm, 'to_lsd: current_bgm')
+  eq({ name: 'Boss', volume: 90, tempo: 100, balance: 50, fadein: 800 },
+     round.memorized_bgm, 'to_lsd: memorized_bgm')
   eq false, round.menu_access, 'to_lsd: menu_access'
   eq false, round.save_access, 'to_lsd: save_access'
   eq true, round.teleport_access, 'to_lsd: teleport_access'

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3487,14 +3487,14 @@ check 'Show Inn scene: inn BGM plays on entry, field BGM resumes after a stay' d
   st.current_bgm = { name: 'Field', volume: 100, tempo: 100 } # the map's own BGM
   RGSS::Audio.reset_bgm
   5.times { scene.update } # inn command runs; the greeting prompt opens
-  eq [['InnBGM', 75, 105]], RGSS::Audio.bgm_calls,
-     'the database inn BGM played the moment the greeting opened'
+  eq [['InnBGM', 75, 105, 0, 0]], RGSS::Audio.bgm_calls,
+     'the database inn BGM played the moment the greeting opened (pos=0, no fade-in configured)'
   eq 'InnBGM', st.current_bgm[:name], 'and is now the tracked current BGM'
   RGSS::Audio.reset_bgm
   RGSS::Input.triggered = [RGSS::Input::C] # cursor starts on Accept (affordable)
   scene.update # accept: starts the fade-out, the BGM swap waits for it to land
   35.times { scene.update } # drain the 35-frame fade-out
-  eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
+  eq [['Field', 100, 100, 0, 0]], RGSS::Audio.bgm_calls,
      'the field BGM that was playing before the stay replays once the fade lands'
   eq 'Field', st.current_bgm[:name]
 end
@@ -3506,9 +3506,31 @@ check 'Show Inn scene: a Change System BGM inn override beats the database defau
   st.system_bgm[2] = { name: 'CustomInn', fadein: 0, volume: 60, tempo: 130, balance: 50 }
   RGSS::Audio.reset_bgm
   5.times { scene.update }
-  eq [['CustomInn', 60, 130]], RGSS::Audio.bgm_calls,
+  eq [['CustomInn', 60, 130, 0, 0]], RGSS::Audio.bgm_calls,
      'the Change System BGM override played instead of the database inn_music'
   eq 'CustomInn', st.current_bgm[:name]
+end
+
+# Cycle #203: inn_music's own liblcf `BGM`-struct fade_in (field 2,
+# mruby-lcf/mrblib/schema.rb) and a Change System BGM inn override's own
+# fade-in parameter (do_change_system_bgm, mruby-rpg2k/mrblib/interpreter.rb)
+# were both read off their struct/hash by #inn_bgm and then dropped before
+# reaching #play_bgm, the same gap cycle #202 already fixed for the Play BGM
+# event command itself.
+check 'Show Inn scene: a database or override inn fade-in forwards to bgm_play, not dropped (cycle #203)' do
+  scene, = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  scene.db.system.inn_music.fade_in = 450
+  RGSS::Audio.reset_bgm
+  5.times { scene.update } # inn command runs; the greeting prompt opens
+  eq [['InnBGM', 75, 105, 0, 450]], RGSS::Audio.bgm_calls,
+     "the database inn_music's own fade_in reaches bgm_play's 5th argument"
+
+  scene2, st2 = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  st2.system_bgm[2] = { name: 'CustomInn', fadein: 600, volume: 60, tempo: 130, balance: 50 }
+  RGSS::Audio.reset_bgm
+  5.times { scene2.update }
+  eq [['CustomInn', 60, 130, 0, 600]], RGSS::Audio.bgm_calls,
+     "a Change System BGM inn override's own fade-in reaches bgm_play too"
 end
 
 check 'Show Inn scene: a free stay (price 0) still plays and restores the inn BGM' do
@@ -3521,10 +3543,10 @@ check 'Show Inn scene: a free stay (price 0) still plays and restores the inn BG
   # so it still fades to black (35 frames) before the field BGM restores and
   # the resolved Stay branch runs, same as a prompted Accept.
   3.times { scene.update }
-  eq [['InnBGM', 75, 105]], RGSS::Audio.bgm_calls, 'the inn BGM played'
+  eq [['InnBGM', 75, 105, 0, 0]], RGSS::Audio.bgm_calls, 'the inn BGM played'
   ok st.screen.fading?, 'a free stay auto-accepts, so it fades out too'
   40.times { scene.update } # drain the fade-out (35 frames) and the Stay branch after
-  eq [['InnBGM', 75, 105], ['Field', 100, 100]], RGSS::Audio.bgm_calls,
+  eq [['InnBGM', 75, 105, 0, 0], ['Field', 100, 100, 0, 0]], RGSS::Audio.bgm_calls,
      'the field BGM was restored once the fade landed'
   eq 'Field', st.current_bgm[:name]
   ok st.switches[1], 'the Stay branch ran (a free stay always stays)'
@@ -7738,7 +7760,7 @@ check 'Enemy Encounter scene: battle BGM plays on entry, field BGM resumes after
   # second is what actually opens the battle UI (like battle_attack_to_end's
   # own "a nil ui just means the battle is still opening" allowance above).
   2.times { scene.update }
-  eq [['BattleBGM', 70, 110]], RGSS::Audio.bgm_calls,
+  eq [['BattleBGM', 70, 110, 0, 0]], RGSS::Audio.bgm_calls,
      'the database battle BGM played, at its configured vol/tempo'
   eq 'BattleBGM', st.current_bgm[:name], 'and is now the tracked current BGM'
   RGSS::Audio.reset_bgm
@@ -7746,7 +7768,7 @@ check 'Enemy Encounter scene: battle BGM plays on entry, field BGM resumes after
   RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result
   scene.update
   RGSS::Input.triggered = []
-  eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
+  eq [['Field', 100, 100, 0, 0]], RGSS::Audio.bgm_calls,
      'the field BGM that was playing before the fight replays once it ends'
   eq 'Field', st.current_bgm[:name]
 end
@@ -7763,9 +7785,39 @@ check 'Enemy Encounter scene: a Change System BGM battle override beats the data
                        balance: 50 }
   RGSS::Audio.reset_bgm
   2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
-  eq [['CustomBattle', 85, 120]], RGSS::Audio.bgm_calls,
+  eq [['CustomBattle', 85, 120, 0, 0]], RGSS::Audio.bgm_calls,
      'the Change System BGM override played instead of the database BattleBGM'
   eq 'CustomBattle', st.current_bgm[:name]
+end
+
+# Cycle #203: battle_music's own liblcf `BGM`-struct fade_in (field 2,
+# mruby-lcf/mrblib/schema.rb) and a Change System BGM battle override's own
+# fade-in parameter (do_change_system_bgm, mruby-rpg2k/mrblib/interpreter.rb)
+# were both read off their struct/hash by #battle_bgm and then dropped before
+# reaching #play_bgm, the same gap cycle #202 already fixed for the Play BGM
+# event command itself.
+check 'Enemy Encounter scene: a database or override battle fade-in forwards to bgm_play, ' \
+      'not dropped (cycle #203)' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.db.system.battle_music.fade_in = 500
+  RGSS::Audio.reset_bgm
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  eq [['BattleBGM', 70, 110, 0, 500]], RGSS::Audio.bgm_calls,
+     "the database battle_music's own fade_in reaches bgm_play's 5th argument"
+
+  scene2 = new_scene({ 1 => event(2, 2, auto) })
+  st2 = scene2.instance_variable_get(:@state)
+  st2.instance_variable_set(:@party, BattleStubParty.new)
+  st2.system_bgm[0] = { name: 'CustomBattle', fadein: 700, volume: 85, tempo: 120, balance: 50 }
+  RGSS::Audio.reset_bgm
+  2.times { scene2.update }
+  eq [['CustomBattle', 85, 120, 0, 700]], RGSS::Audio.bgm_calls,
+     "a Change System BGM battle override's own fade-in reaches bgm_play too"
 end
 
 check 'Enemy Encounter scene: a battle BGM matching the already-playing field track ' \
@@ -7833,7 +7885,7 @@ check 'Enemy Encounter scene: victory plays the database battle_end_music over t
   eq 1, RGSS::Audio.me_stop_calls,
      'the fanfare is ended through its own ME stop path rather than a bare BGM play ' \
      'yanking the shared music stream out from under it'
-  eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
+  eq [['Field', 100, 100, 0, 0]], RGSS::Audio.bgm_calls,
      'the field BGM that was playing before the fight replays once the result is dismissed'
   eq 'Field', st.current_bgm[:name]
 end
@@ -8262,7 +8314,7 @@ check 'the Game Over screen shows its picture, plays its BGM and waits' do
   Audio.reset_bgm
   Input.reset
   scene = RPG2k::Scene::GameOver.new(parent)
-  eq [['GameOverBGM', 90, 100]], Audio.bgm_calls, 'the database game-over music'
+  eq [['GameOverBGM', 90, 100, 0, 0]], Audio.bgm_calls, 'the database game-over music'
   ok scene.instance_variable_get(:@picture).bitmap, 'the GameOver/ picture loaded'
 
   scene.update
@@ -8282,7 +8334,7 @@ check 'the Game Over screen plays a Change System BGM override instead of the da
                   { name: 'OverrideGameOverBGM', volume: 33, tempo: 66 } }
   )
   RPG2k::Scene::GameOver.new(parent, state)
-  eq [['OverrideGameOverBGM', 33, 66]], Audio.bgm_calls,
+  eq [['OverrideGameOverBGM', 33, 66, 0, 0]], Audio.bgm_calls,
      'the override plays, not the database GameOverBGM'
   Input.reset
 end
@@ -8292,7 +8344,37 @@ check 'a bare Game Over (no Game::State) still falls back to the database gameov
   Audio.reset_bgm
   Input.reset
   RPG2k::Scene::GameOver.new(parent) # state omitted, as every pre-existing caller does
-  eq [['GameOverBGM', 90, 100]], Audio.bgm_calls, 'unaffected by the new optional state arg'
+  eq [['GameOverBGM', 90, 100, 0, 0]], Audio.bgm_calls, 'unaffected by the new optional state arg'
+  Input.reset
+end
+
+# Cycle #203: gameover_music's own liblcf `BGM`-struct fade_in (field 2,
+# mruby-lcf/mrblib/schema.rb) and a Change System BGM game-over override's own
+# fade-in parameter (do_change_system_bgm, mruby-rpg2k/mrblib/interpreter.rb)
+# were both read off their struct/hash by #play_gameover_bgm and then dropped
+# before reaching Audio.bgm_play, the same gap cycle #202 already fixed for
+# the Play BGM event command itself.
+check 'the Game Over screen forwards a database or override fade-in to bgm_play, not dropped (cycle #203)' do
+  db = fake_db
+  db.system.gameover_music.fade_in = 350
+  parent = fake_parent(db)
+  Audio.reset_bgm
+  Input.reset
+  RPG2k::Scene::GameOver.new(parent)
+  eq [['GameOverBGM', 90, 100, 0, 350]], Audio.bgm_calls,
+     "the database gameover_music's own fade_in reaches bgm_play's 5th argument"
+  Input.reset
+
+  parent2 = fake_parent(fake_db)
+  Audio.reset_bgm
+  Input.reset
+  state = OpenStruct.new(
+    system_bgm: { RPG2k::Scene::GameOver::SYSTEM_BGM_GAMEOVER =>
+                  { name: 'OverrideGameOverBGM', volume: 33, tempo: 66, fadein: 700 } }
+  )
+  RPG2k::Scene::GameOver.new(parent2, state)
+  eq [['OverrideGameOverBGM', 33, 66, 0, 700]], Audio.bgm_calls,
+     "a Change System BGM game-over override's own fade-in reaches bgm_play too"
   Input.reset
 end
 
@@ -11748,6 +11830,49 @@ check 'boarding a vehicle plays a Change System BGM override instead of the data
   eq 'CustomBoat', st.current_bgm[:name], 'the override plays instead of the database BoatBGM'
   eq 55, st.current_bgm[:volume]
   eq 90, st.current_bgm[:tempo]
+end
+
+# Cycle #203: boat_music's own liblcf `BGM`-struct fade_in (field 2,
+# mruby-lcf/mrblib/schema.rb) and a Change System BGM boat override's own
+# fade-in parameter (do_change_system_bgm, mruby-rpg2k/mrblib/interpreter.rb)
+# were both read off their struct/hash by #vehicle_bgm and then dropped before
+# reaching #play_bgm, the same gap cycle #202 already fixed for the Play BGM
+# event command itself. Boat stands in for ship/airship too -- all three
+# share #vehicle_bgm's single VEHICLE_SYSTEM_BGM_SLOT-indexed code path.
+check 'boarding a vehicle forwards a database or override fade-in to bgm_play, not dropped (cycle #203)' do
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.db.system.boat_music.fade_in = 300
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  st.direction = 2
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq [['BoatBGM', 80, 100, 0, 300]], RGSS::Audio.bgm_calls,
+     "the database boat_music's own fade_in reaches bgm_play's 5th argument"
+
+  scene2 = new_scene({}, player: [0, 0])
+  st2 = scene2.instance_variable_get(:@state)
+  st2.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  st2.direction = 2
+  st2.system_bgm[3] = { name: 'CustomBoat', fadein: 900, volume: 55, tempo: 90, balance: 50 }
+  boat2 = st2.vehicle(:boat)
+  boat2.map_id = st2.map_id
+  boat2.x = 0
+  boat2.y = 1
+  boat2.charset_name = 'Boat'
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene2.update
+  RGSS::Input.triggered = []
+  eq [['CustomBoat', 55, 90, 0, 900]], RGSS::Audio.bgm_calls,
+     "a Change System BGM boat override's own fade-in reaches bgm_play too"
 end
 
 check 'boarding a vehicle with no configured BGM stops the field music instead of leaving it ' \
@@ -22156,16 +22281,16 @@ check 'Scene::Map auto-plays the map own BGM on load and on Teleport' do
   state.map = fake_map(1, {})
   RGSS::Audio.reset_bgm
   scene = RPG2k::Scene::Map.new(parent, state)
-  eq [['Town', 90, 105]], RGSS::Audio.bgm_calls, 'map 1 own BGM played on load'
+  eq [['Town', 90, 105, 0, 0]], RGSS::Audio.bgm_calls, 'map 1 own BGM played on load'
   eq 'Town', state.current_bgm[:name]
 
   RGSS::Audio.reset_bgm
   scene.send(:perform_teleport, [2, 0, 0, 0])
-  eq [['Cave', 80, 95]], RGSS::Audio.bgm_calls, 'map 2 own BGM played on Teleport'
+  eq [['Cave', 80, 95, 0, 0]], RGSS::Audio.bgm_calls, 'map 2 own BGM played on Teleport'
 
   RGSS::Audio.reset_bgm
   scene.send(:perform_teleport, [1, 0, 0, 0])
-  eq [['Town', 90, 105]], RGSS::Audio.bgm_calls,
+  eq [['Town', 90, 105, 0, 0]], RGSS::Audio.bgm_calls,
      'and teleporting back to map 1 plays it again (a fresh Setup, not a same-visit no-op)'
 
   RGSS::Audio.reset_bgm
@@ -22214,7 +22339,7 @@ check 'Scene::Map resumes the saved BGM on Continue (apply_access: false) ' \
   state2.current_bgm = { name: 'Boss Theme', volume: 70, tempo: 120 }
   RGSS::Audio.reset_bgm
   RPG2k::Scene::Map.new(parent, state2)
-  eq [['Town', 90, 105]], RGSS::Audio.bgm_calls,
+  eq [['Town', 90, 105, 0, 0]], RGSS::Audio.bgm_calls,
      'an ordinary (apply_access: true) entry recomputes from the tree instead'
 end
 

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -270,11 +270,14 @@ void free_music(void) {
 // Mix_FadeInMusic instead of jumping straight there via Mix_PlayMusic; 0 (the
 // default, and every caller here before this cycle) is the original instant
 // start.
-bool start_music(const std::string& what, int volume, int loops, int pos_ms,
+bool start_music(const std::string& what,
+                 int volume,
+                 int loops,
+                 int pos_ms,
                  int fadein_ms = 0) {
   Mix_VolumeMusic(to_mix_volume(volume));
   const int rc = fadein_ms > 0 ? Mix_FadeInMusic(g_music, loops, fadein_ms)
-                                : Mix_PlayMusic(g_music, loops);
+                               : Mix_PlayMusic(g_music, loops);
   if (rc < 0) {
     LOG(WARNING) << "Audio: failed to play music '" << what
                  << "': " << Mix_GetError();
@@ -403,8 +406,11 @@ bool replay_bgm(void) {
 
 // -- BGM --------------------------------------------------------------------
 
-void bgm_play(const char* path, int volume, int /*pitch*/, int pos_ms,
-             int fadein_ms) {
+void bgm_play(const char* path,
+              int volume,
+              int /*pitch*/,
+              int pos_ms,
+              int fadein_ms) {
   g_me_active = false;
   g_bgm_valid = true;
   g_bgm_path = path;

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -265,10 +265,17 @@ void free_music(void) {
 // (RGSS3's Audio.bgm_play resume point) once playback has actually started; a
 // decoder that cannot seek (or fails to) is left playing from the beginning
 // rather than treated as a load failure — the track is still audible, just not
-// resumed.
-bool start_music(const std::string& what, int volume, int loops, int pos_ms) {
+// resumed. fadein_ms > 0 (RPG2000's own Play BGM fade-in, cycle #202) ramps
+// the volume up from silence to `volume` over that many milliseconds via
+// Mix_FadeInMusic instead of jumping straight there via Mix_PlayMusic; 0 (the
+// default, and every caller here before this cycle) is the original instant
+// start.
+bool start_music(const std::string& what, int volume, int loops, int pos_ms,
+                 int fadein_ms = 0) {
   Mix_VolumeMusic(to_mix_volume(volume));
-  if (Mix_PlayMusic(g_music, loops) < 0) {
+  const int rc = fadein_ms > 0 ? Mix_FadeInMusic(g_music, loops, fadein_ms)
+                                : Mix_PlayMusic(g_music, loops);
+  if (rc < 0) {
     LOG(WARNING) << "Audio: failed to play music '" << what
                  << "': " << Mix_GetError();
     return false;
@@ -324,11 +331,14 @@ void log_music_load_failure(const std::string& what, int size = -1) {
 // (loops = -1 loops forever, 1 plays once). Returns false on load failure.
 // pos_ms defaults to 0 (play from the beginning) for the ME/replay callers
 // below, which never seek; bgm_play (the one caller a resume position reaches)
-// passes the real value through.
+// passes the real value through. fadein_ms likewise defaults to 0 (instant
+// start) for every caller but bgm_play/bgm_play_mem -- see start_music's own
+// doc comment.
 bool play_music(const std::string& path,
                 int volume,
                 int loops,
-                int pos_ms = 0) {
+                int pos_ms = 0,
+                int fadein_ms = 0) {
   free_music();
   {
     // The music stream is opened on the game-loop thread. For MIDI this is the
@@ -341,7 +351,7 @@ bool play_music(const std::string& path,
     log_music_load_failure(path);
     return false;
   }
-  return start_music(path, volume, loops, pos_ms);
+  return start_music(path, volume, loops, pos_ms, fadein_ms);
 }
 
 // The same, from encoded bytes. The bytes are copied into g_music_bytes first:
@@ -352,7 +362,8 @@ bool play_music_mem(const std::string& name,
                     int size,
                     int volume,
                     int loops,
-                    int pos_ms = 0) {
+                    int pos_ms = 0,
+                    int fadein_ms = 0) {
   free_music();
   g_music_bytes.assign(static_cast<const char*>(data),
                        static_cast<size_t>(size));
@@ -373,7 +384,7 @@ bool play_music_mem(const std::string& name,
     g_music_bytes.clear();
     return false;
   }
-  return start_music(name, volume, loops, pos_ms);
+  return start_music(name, volume, loops, pos_ms, fadein_ms);
 }
 
 // Replay the BGM, from wherever it came from. Used to resume after a music
@@ -392,13 +403,14 @@ bool replay_bgm(void) {
 
 // -- BGM --------------------------------------------------------------------
 
-void bgm_play(const char* path, int volume, int /*pitch*/, int pos_ms) {
+void bgm_play(const char* path, int volume, int /*pitch*/, int pos_ms,
+             int fadein_ms) {
   g_me_active = false;
   g_bgm_valid = true;
   g_bgm_path = path;
   g_bgm_bytes.clear();  // a file now, not archived bytes
   g_bgm_volume = volume;
-  play_music(g_bgm_path, volume, -1, pos_ms);
+  play_music(g_bgm_path, volume, -1, pos_ms, fadein_ms);
 }
 
 // Live volume change for whichever BGM is currently playing, with no restart:
@@ -436,14 +448,15 @@ void bgm_play_mem(const char* name,
                   int size,
                   int volume,
                   int /*pitch*/,
-                  int pos_ms) {
+                  int pos_ms,
+                  int fadein_ms) {
   g_me_active = false;
   g_bgm_valid = true;
   g_bgm_path = name;  // for diagnostics only; there is no file
   g_bgm_bytes.assign(static_cast<const char*>(data), static_cast<size_t>(size));
   g_bgm_volume = volume;
   if (!play_music_mem(g_bgm_path, g_bgm_bytes.data(), (int)g_bgm_bytes.size(),
-                      volume, -1, pos_ms))
+                      volume, -1, pos_ms, fadein_ms))
     g_bgm_bytes.clear();
 }
 


### PR DESCRIPTION
## Summary

This PR grew across two cycles working the same gap — BGM fade-in was read off event commands and database structs but silently dropped before reaching playback or save. Both are independently verified and covered by new checks.

### Cycle #202: Play BGM's fade-in parameter + its save round-trip

1. **Play BGM's fade-in parameter (event command param 0) was read off the command and then silently dropped.** `RGSS::Audio.bgm_play` gains a new 5th `fadein_ms` argument (default 0, so every real RGSS2/RGSS3 script call site is untouched) threaded end-to-end: `mruby-rgss/mrblib/lib.rb` → `mruby-rgss/src/audio.cxx` → `include/rgss_audio.hxx` → `src/sdl_audio.cxx`, where `start_music` now calls `Mix_FadeInMusic` instead of `Mix_PlayMusic` when it's non-zero (both the disk-file and packed-archive `bgm_play_mem` paths). `Game::Interpreter#play_audio` forwards Play BGM's own `fade_in` on a fresh play only (never on the same-file-already-playing shortcut, matching every other Play BGM parameter), and `#do_play_memorized_bgm` forwards the memorized record's carried-over fadein the same way it already carries volume/tempo/balance.

   Units confirmed as milliseconds from liblcf's own schema (`BGM` struct field 2), the same field Change System BGM's `fadein` and Fade Out BGM's parameter already use. **Not wine-verified for audible timing** — there's no way to observe that in this sandbox — so this is a first-principles fix (the parameter existed, was read, and was silently discarded) rather than a wine-confirmed timing match.

2. **A second, related gap: every stored BGM record's fade-in was silently dropped on Save, not just never played.** `Game::State#bgm_chunk`/`.bgm_from_chunk` (shared by current/memorized BGM, pre-battle/vehicle restore points, and all 7 Change System BGM override slots) never touched LCF's BGM-struct field 2 in either direction. Fixed on the same "write only away from default (0)" idiom fields 3-5 already use.

3. **Fixed two stale documentation paragraphs in `docs/TODO.md`** and **two stale assertions in `scripts/rpg2k_save_load_check.rb`** (expected a 3-key BGM hash missing `balance:`, which `#bgm_from_chunk` has included since balance support landed). Both trace to the same unreconciled Aug 22 merge; runtime behavior was already correct.

### Cycle #203: the four playback call sites cycle #202 left open

Cycle #202's own TODO note flagged that `Scene::Map#battle_bgm`/`#inn_bgm`/`#vehicle_bgm` and `Scene::GameOver#play_gameover_bgm` still resolved their Music/BGM struct down to `{name:, volume:, tempo:}`, dropping any `fadein:` on the floor even though the save round-trip now preserves it. Confirmed via `mruby-lcf/mrblib/schema.rb` that `battle_music`/`inn_music`/`boat_music`/`ship_music`/`airship_music`/`gameover_music` are all genuine `BGM`-struct instances (field 2 = `fade_in`), so this is a real gap, not an invented field. Fixed all four (plus a `#music_fadein` helper mirroring the existing `#music_name`/`#music_volume`/`#music_tempo`), forwarding both the database struct's own fade-in and a Change System BGM override's fade-in through to `#play_bgm`'s `RGSS::Audio.bgm_play` call.

**Deliberately left untouched**: `#victory_bgm`/`#play_victory_bgm`, which plays through `RGSS::Audio.me_play` — RPG_RT's distinct one-shot "ME" channel, which has no fadein parameter anywhere in this engine's native audio layer (unlike `bgm_play`). Wiring that would mean extending the native ME playback path itself, out of scope for a fix that only forwards an already-plumbed value. Also `#play_map_bgm` (different struct) and `#resume_saved_bgm` (bypasses `#play_bgm` by design).

## Verification

- `scripts/rpg2k_scene_check.rb`: 939 passed (935 baseline + 4 new checks)
- `scripts/rpg2k_save_load_check.rb`: 1 known failure (down from 3 — remaining one is an unrelated Show Picture field-shape issue)
- `scripts/rpg2k_logic_check.rb`: 1179 passed
- `scripts/rpg2k_render_check.rb`: 41 passed
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0
- `scripts/rpg2k_command_soak.rb`: clean on both Nepheshel test-beds
- `cd build && ninja`: clean rebuild, no new warnings
- `ctest -R mruby_test`: passed
- Every new/updated check confirmed to fail against the pre-fix code before being fixed

An earlier CI run failed on the `pre-commit` step: CI's pinned `clang-format` (22.1.8) wraps three multi-parameter signatures in the cycle #202 C++ changes differently than the version used locally when they were authored. Reproduced with the exact pinned version and fixed (pure formatting, no behavioral change).

No wine session was run for either cycle (audio timing isn't screenshot-diffable, and nothing touched a `data/` fixture).

Per standing project convention, EasyRPG Player's C++ source was not consulted for any behavioral claim in this change.
