### PR TITLE
Reuse position Arrays and drop a per-frame block in Scene::Map's update path

### DIFF
--- a/changelog.d/events-loop-no-block.changed.md
+++ b/changelog.d/events-loop-no-block.changed.md
@@ -1,0 +1,34 @@
+- **Four more of `Scene::Map`'s guaranteed-every-frame `@events.each { }`
+  loops no longer allocate a Proc/closure just to drive themselves.**
+  Continuing the `step_parallels` fix from the same round:
+  `#record_map_event_positions`, `#step_events` (the normal-gameplay
+  autonomous/custom-route movement pass), `#animate_events` and
+  `#update_sprite_flashes`'s per-event flash decay all ran a one-line
+  `@events.each { |e| ... }` unconditionally (or near-unconditionally) every
+  single frame — in mruby that allocates a real Proc plus its closure env on
+  every call, confirmed by measurement. Rewritten as plain `while` loops.
+
+  Unlike `#step_parallels`, none of these four need a defensive `#dup` of
+  `@events` first: `#step_event` only *sets up* the interpreter via
+  `#start_event`, it never drives it, so no command — Erase Event included —
+  can run synchronously from inside the loop to shrink `@events` mid-iteration;
+  `#animate_event` and `#tick_flash` only touch the one event hash / flash
+  hash they are handed, never `@events` itself. (`#step_parallels` differs
+  because a Parallel Process's own commands, unlike movement/animation
+  bookkeeping, really do run inline via `it.update`, and one of them can be
+  Erase Event on a *different* parallel's own event — see that fix's own
+  comment.)
+
+  Measured with the same temporary per-frame instrumentation used for this
+  round's other fixes (reverted before commit), clean A/B on the identical
+  deterministic Nepheshel run: **Proc allocations 43.6 → 40.6 per frame, env
+  32.6 → 29.6** — exactly three of each removed, matching the three
+  unconditionally-running loops exactly (`#record_map_event_positions`'s own
+  Array-reuse fix from earlier in this round already accounts for its Array
+  count, unaffected by this purely mechanical loop change).
+
+  Verified against `scripts/rpg2k_command_soak.rb` (368,332 real event
+  commands across both Nepheshel variants) and `scripts/rpg2k_scene_check.rb`
+  (932 checks, ticks the real `Scene::Map` update path these four loops sit
+  in), plus the rest of the RPG2000 logic/render checks — all pass,
+  unchanged.

--- a/changelog.d/record-map-event-positions-reuse.changed.md
+++ b/changelog.d/record-map-event-positions-reuse.changed.md
@@ -1,0 +1,30 @@
+- **`Scene::Map#record_map_event_positions` no longer allocates a position
+  Array for every live map event on every single frame, unconditionally.**
+  Another follow-up from the `RGSS::Profiler.stats[:object_types]`
+  investigation: this snapshot (`Game::State#map_event_positions`, read back
+  on a same-map Save/Continue) ran every frame for every event regardless of
+  whether anything had moved, and built the identical `[x, y, direction]`
+  tuple *twice* — once for `map_event_positions`, once more for the
+  positionally-redundant `@event_last_position`. Now it compares against the
+  Array already sitting in `map_event_positions` first: a stationary event
+  (the common case — an idle NPC or a decoration moves only on its own move
+  route's own schedule, not every frame) keeps the same Array object across
+  frames instead of getting a fresh equal one, and `@event_last_position`
+  shares that same object rather than a second copy. Neither hash's entries
+  are ever mutated in place elsewhere (only reassigned wholesale), so sharing
+  the reference changes nothing any reader can observe — including
+  `Game::State#to_lsd`, which only ever reads the three values back out.
+
+  Measured with the same temporary per-frame instrumentation pass (reverted
+  before commit) used for the earlier `Scene::Map` draw-path fixes, A/B on
+  the identical deterministic Nepheshel run: Array allocations 96.2 → 94.2
+  per frame on this particular run's mostly-scripted opening sequence, where
+  few of the map's events are actually holding still — the win scales with
+  how many on-screen events are idle in any given frame, so it grows in
+  ordinary gameplay away from a scripted intro.
+
+  Verified against `scripts/rpg2k_command_soak.rb` (368,332 real event
+  commands across both Nepheshel variants), `scripts/rpg2k_scene_check.rb`
+  (which exercises the saved-position-wins-over-page-default restore path
+  this snapshot feeds), and the rest of the RPG2000 logic/render checks, all
+  unaffected.

--- a/changelog.d/step-parallels-no-block.changed.md
+++ b/changelog.d/step-parallels-no-block.changed.md
@@ -1,0 +1,29 @@
+- **`Scene::Map#step_parallels` no longer allocates a Proc/closure every
+  frame just to drive its own loop.** The last of this round's
+  `RGSS::Profiler.stats[:object_types]`-driven fixes: every background
+  Parallel Process common event's per-frame step ran through
+  `@parallels.dup.each { |p| step_parallel(p) }`, and in mruby a block
+  literal allocates a real Proc plus its closure env on every call, not just
+  the first — confirmed by measurement, not assumed. Rewritten as a plain
+  `while` loop over the same defensive `@parallels.dup` snapshot (still
+  needed: an Erase Event running inside a parallel process can remove entries
+  from the live `@parallels` mid-loop — see `#erase_event`), which needs no
+  block at all. mruby's `for`/`in` was checked as an alternative and ruled
+  out: its compiler (`codegen_for` in mruby's `codegen.c`) desugars it to the
+  exact same `#each` call, so it would have cost the same. `#step_battle_owner_parallel`'s
+  `@parallels.find { }` (the mutually-exclusive in-battle counterpart, active
+  only while a Parallel Process's own fight is running) got the same
+  treatment for consistency.
+
+  Measured with the same temporary per-frame instrumentation used for this
+  round's other fixes (reverted before commit), clean A/B on the identical
+  deterministic Nepheshel run: **Proc allocations 44.6 → 43.6 per frame, env
+  33.6 → 32.6** — exactly one Proc and one env removed, matching the fix
+  exactly (Nepheshel keeps at least one background Parallel Process running
+  throughout, so `@parallels` is never empty in this run).
+
+  Verified against `scripts/rpg2k_command_soak.rb` (368,332 real event
+  commands across both Nepheshel variants) and `scripts/rpg2k_scene_check.rb`,
+  which directly exercises the mid-loop-erase invariant this rewrite has to
+  preserve ("Erase Event stops a parallel process that erases itself"), plus
+  the rest of the RPG2000 logic/render checks — all pass, unchanged.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1531,11 +1531,26 @@ class RPG2k
       def record_map_event_positions
         @events.each do |e|
           ch = e[:char]
-          @state.map_event_positions[e[:id]] = [ch.x, ch.y, ch.direction]
-          @state.map_event_route_index[e[:id]] = e[:route].index if e[:route]
+          id = e[:id]
+          # A stationary event's tuple reads the same every frame -- reuse the
+          # Array already sitting in @state.map_event_positions instead of
+          # allocating an identical replacement each time; #event_last_position
+          # (below) shares that same object rather than a second copy of it.
+          # Neither hash's own entries are ever mutated in place elsewhere
+          # (only reassigned wholesale, e.g. #set_char_location's own hidden-
+          # target @event_last_position write), so sharing the reference is
+          # safe.
+          cur = @state.map_event_positions[id]
+          if cur && cur[0] == ch.x && cur[1] == ch.y && cur[2] == ch.direction
+            pos = cur
+          else
+            pos = [ch.x, ch.y, ch.direction]
+            @state.map_event_positions[id] = pos
+          end
+          @state.map_event_route_index[id] = e[:route].index if e[:route]
           # Also keeps @event_last_position current for #event_id_at's hidden-
           # event fallback -- see #build_events' seeding comment.
-          @event_last_position[e[:id]] = [ch.x, ch.y, ch.direction]
+          @event_last_position[id] = pos
         end
       end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2072,8 +2072,18 @@ class RPG2k
       # (narrower) actual pause conditions.
       def step_parallels
         # Iterate a copy: an Erase Event in a parallel process removes it from
-        # @parallels mid-loop (see erase_event).
-        @parallels.dup.each { |p| step_parallel(p) }
+        # @parallels mid-loop (see erase_event). A plain while loop instead of
+        # #each avoids allocating a Proc+env for the block on every single
+        # frame -- mruby's `for` is sugar for the identical #each call (see
+        # its NODE_FOR codegen), so it would not save anything here; only a
+        # loop with no block at all does.
+        snapshot = @parallels.dup
+        i = 0
+        size = snapshot.size
+        while i < size
+          step_parallel(snapshot[i])
+          i += 1
+        end
       end
 
       # Keep a Parallel Process's own battle advancing once it has opened one
@@ -2093,8 +2103,16 @@ class RPG2k
         return unless @battle
         owner = @battle.owner
         return if owner.nil? || owner.equal?(@interpreter)
-        p = @parallels.find { |pp| pp[:interp].equal?(owner) }
-        step_parallel(p) if p
+        i = 0
+        size = @parallels.size
+        while i < size
+          pp = @parallels[i]
+          if pp[:interp].equal?(owner)
+            step_parallel(pp)
+            return
+          end
+          i += 1
+        end
       end
 
       def step_parallel(p)

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1529,7 +1529,12 @@ class RPG2k
       # into Game::State#map_event_route_index, so the same restore resumes an
       # in-progress custom route at its exact command rather than the top.
       def record_map_event_positions
-        @events.each do |e|
+        # A plain while loop instead of #each avoids allocating a Proc+env for
+        # the block on every single frame.
+        i = 0
+        size = @events.size
+        while i < size
+          e = @events[i]
           ch = e[:char]
           id = e[:id]
           # A stationary event's tuple reads the same every frame -- reuse the
@@ -1551,6 +1556,7 @@ class RPG2k
           # Also keeps @event_last_position current for #event_id_at's hidden-
           # event fallback -- see #build_events' seeding comment.
           @event_last_position[id] = pos
+          i += 1
         end
       end
 
@@ -3329,7 +3335,18 @@ class RPG2k
       # case #update calls this a second way (allow_trigger: false) while a
       # message window is open; see #events_move_during_message?.
       def step_events(allow_trigger: true)
-        @events.each { |e| step_event(e, allow_trigger: allow_trigger) }
+        # A plain while loop instead of #each avoids allocating a Proc+env for
+        # the block on every single frame. Safe without a defensive #dup
+        # (unlike #step_parallels' own loop): #step_event only sets up the
+        # interpreter via #start_event, it never drives it, so no command --
+        # Erase Event included -- can run synchronously here to shrink
+        # @events mid-loop.
+        i = 0
+        size = @events.size
+        while i < size
+          step_event(@events[i], allow_trigger: allow_trigger)
+          i += 1
+        end
       end
 
       # Run `route`'s sub-commands until one actually costs a frame of pacing
@@ -3444,7 +3461,16 @@ class RPG2k
       # Game::EventGraphic.frame reads @moving / @anim_phase to pick the drawn
       # column, and event_pixel reads the slide for the draw position.
       def animate_events
-        @events.each { |e| animate_event(e) }
+        # A plain while loop instead of #each avoids allocating a Proc+env for
+        # the block on every single frame. Safe without a defensive #dup:
+        # #animate_event only advances an event's own slide/animation
+        # counters, it never touches @events itself.
+        i = 0
+        size = @events.size
+        while i < size
+          animate_event(@events[i])
+          i += 1
+        end
       end
 
       def animate_event(e)
@@ -4240,7 +4266,17 @@ class RPG2k
         # replaced by the plain one instead of staying baked in.
         @last_frame = nil if @state.player_flash
         @state.player_flash = tick_flash(@state.player_flash)
-        @events.each { |e| e[:flash] = tick_flash(e[:flash]) if e[:flash] }
+        # A plain while loop instead of #each avoids allocating a Proc+env for
+        # the block on every single frame. Safe without a defensive #dup:
+        # #tick_flash only mutates the flash hash it is handed, it never
+        # touches @events itself.
+        i = 0
+        size = @events.size
+        while i < size
+          e = @events[i]
+          e[:flash] = tick_flash(e[:flash]) if e[:flash]
+          i += 1
+        end
         # A vehicle-target Flash Sprite has no CharSet-tone hash of its own to
         # decay here (its visuals are the native sprite #update_vehicle_flashes
         # already drives) -- @flash_wait's `:vehicle` marker is only ever set


### PR DESCRIPTION
## Summary

Follow-up to #1436 and #1438, continuing the `RGSS::Profiler.stats[:object_types]` investigation into `Scene::Map`'s per-frame allocation churn — this round on the update side rather than the draw path:

- **`#record_map_event_positions`** ran for every live map event on every frame unconditionally, building the identical `[x, y, direction]` Array *twice* — once for `Game::State#map_event_positions`, once more (same values) for the positionally-redundant `@event_last_position`. It now compares against the Array already sitting in `map_event_positions` first: a stationary event (the common case — an idle NPC or decoration moves only on its own move route's own schedule, not every frame) keeps the same Array object across frames instead of getting a fresh equal one, and `@event_last_position` shares that object rather than allocating a second copy. Neither hash's entries are ever mutated in place elsewhere (only reassigned wholesale), so sharing the reference changes nothing any reader — including `Game::State#to_lsd` — can observe.
- **`#step_parallels`** drove every background Parallel Process through `@parallels.dup.each { |p| step_parallel(p) }` every frame. In mruby a block literal allocates a real Proc plus its closure env on every call, not just the first — confirmed by measurement, not assumed. Rewritten as a plain `while` loop over the same defensive `@parallels.dup` snapshot (still needed: an Erase Event running inside a parallel process can remove entries from the live `@parallels` mid-loop), which needs no block at all. mruby's `for`/`in` was checked as an alternative and ruled out: its compiler (`codegen_for` in mruby's `codegen.c`) desugars it to the exact same `#each` call. `#step_battle_owner_parallel`'s `@parallels.find { }` (the mutually-exclusive in-battle counterpart) got the same treatment for consistency.

## Measurements

Via a temporary per-frame instrumentation pass (reverted before each commit), A/B on the identical deterministic Nepheshel run used for the earlier rounds:

| | before | after |
| --- | ---: | ---: |
| Array allocs/frame (position-Array fix) | 96.2 | 94.2 |
| Proc allocs/frame (step_parallels fix) | 44.6 | 43.6 |
| env allocs/frame (step_parallels fix) | 33.6 | 32.6 |

The position-Array win is modest here since this run's scripted opening keeps most events actively moving — it scales with how many on-screen events are idle in a given frame, which grows in ordinary gameplay away from a scripted intro. The `step_parallels` win is exactly one Proc and one env removed, matching the fix precisely (Nepheshel keeps at least one background Parallel Process running throughout).

## Test plan

- [x] `ctest -R mruby_test`
- [x] `scripts/rpg2k_command_soak.rb` — 368,332 real event commands across both Nepheshel variants, clean
- [x] `scripts/rpg2k_scene_check.rb` (932 checks) — directly exercises "Erase Event stops a parallel process that erases itself", the exact mid-loop-mutation invariant the `step_parallels` rewrite has to preserve, and the saved-position-wins-over-page-default restore path the position-Array fix feeds
- [x] `scripts/rpg2k_render_check.rb` (41 checks)
- [x] `scripts/rpg2k_logic_check.rb` (1176 checks)
- [x] `scripts/rpg2k_testbed_logic_check.rb` (98 checks)
- [x] `scripts/rgss_cruby_test_check.rb`

All pass, output unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_0117pag6Su2mrNWMN3QByEA3)_