### PR TITLE
Extend RGSS::Audio.me_play with a fadein parameter, wire up the victory fanfare's fade-in

### DIFF
--- a/changelog.d/victory-bgm-me-fadein.fixed.md
+++ b/changelog.d/victory-bgm-me-fadein.fixed.md
@@ -1,0 +1,22 @@
+- **The victory fanfare now honours a configured BGM fade-in instead of
+  silently dropping it.** Cycle #203 wired battle/inn/vehicle-boarding/
+  Game-Over BGM fade-ins through to `RGSS::Audio.bgm_play`, but deliberately
+  left `Scene::Map#victory_bgm`/`#play_victory_bgm` alone: the victory
+  fanfare plays through `RGSS::Audio.me_play`, RPG_RT's distinct one-shot
+  "ME" channel, whose native signature (`sdl_audio.cxx`,
+  `include/rgss_audio.hxx`, `mruby-rgss/src/audio.cxx`,
+  `mruby-rgss/mrblib/lib.rb`) had no fadein parameter at all -- unlike
+  `bgm_play`, it was never given one. This cycle extends the native ME
+  playback path the same way `bgm_play`'s was extended in cycle #202:
+  `RgssAudioBackend::me_play`/`me_play_mem` each grew a trailing `fadein_ms`
+  parameter, `sdl_audio.cxx`'s implementations forward it to the same
+  `play_music`/`play_music_mem` helpers `bgm_play` already uses (which
+  already supported `fadein_ms` for any loop count, ME's "play once" `1`
+  included -- `Mix_FadeInMusic` works identically for a one-shot ME as for a
+  looping BGM, since both are the same underlying `Mix_Music` stream), and
+  `RGSS::Audio.me_play`/`_me_play_mem` grew a matching optional 4th/5th
+  argument. `Scene::Map#victory_bgm` now reads `fade_in`/`fadein` off both
+  the database's `battle_end_music` and a Change System BGM victory-slot
+  override the same way `#battle_bgm`/`#inn_bgm` already do, and
+  `#play_victory_bgm` forwards it as `RGSS::Audio.me_play`'s new 4th
+  argument, `|| 0` defaulted the same way volume/tempo already are.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1551,6 +1551,78 @@ The work below is roughly ordered by the critical path to a walkable game
   timing is not screenshot-diffable, and nothing here touched a `data/`
   fixture) — this is first-principles schema-and-code reading, not a
   wine-verified timing match.
+  ✅ **Follow-up (cycle #204, 2026-08-28): picked up the `#victory_bgm`/
+  `#play_victory_bgm` gap cycle #203 left deliberately untouched above,
+  extending the native "ME" playback path to accept a fade-in rather than
+  just forwarding an already-plumbed value.** Method: read
+  `src/sdl_audio.cxx`'s `me_play`/`me_play_mem` alongside `bgm_play`/
+  `bgm_play_mem` first, since cycle #203's own note already named the exact
+  reason this one was out of scope (`me_play` had no `fadein_ms` parameter
+  at all) — found that both ME entry points already funnel into the same
+  `play_music`/`play_music_mem` helpers `bgm_play` uses, and those helpers
+  already accept a `fadein_ms` defaulted to 0 (added in cycle #202 for BGM),
+  so `me_play`/`me_play_mem` only needed to gain the parameter and pass it
+  through one layer down — not a new fade-in mechanism, just plumbing the
+  existing one to a second pair of call sites. Confirmed `Mix_FadeInMusic`
+  itself has no notion of "BGM vs ME": `start_music` (the shared tail
+  `play_music`/`play_music_mem` both call) picks `Mix_FadeInMusic` over
+  `Mix_PlayMusic` purely off `fadein_ms > 0`, with no other BGM-specific
+  state involved, so the extension is mechanically identical to `bgm_play`'s
+  cycle #202 one. Extended the whole chain end to end: `RgssAudioBackend::
+  me_play`/`me_play_mem` (`include/rgss_audio.hxx`) each gained a trailing
+  `fadein_ms` parameter; `sdl_audio.cxx`'s implementations forward it to
+  `play_music(path, volume, 1, 0, fadein_ms)` /
+  `play_music_mem(name, data, size, volume, 1, 0, fadein_ms)`; the gem-side
+  `mruby-rgss/src/audio.cxx` `me_play`/`me_play_mem` mrb functions each grew
+  a matching optional trailing argument (`me_play_mem` needed its own
+  dedicated function, no longer sharing the generic `play_mem`/`PlayMemFn`
+  helper still used by `bgs_play_mem`/`se_play_mem`, the same shape
+  `bgm_play_mem` already has for the identical reason); and
+  `mruby-rgss/mrblib/lib.rb`'s public `Audio.me_play(filename, volume, pitch,
+  fadein = 0)` forwards to `_me_play` on the loose-file path and threads
+  `fadein` through `#play_packed`'s `:me` branch to `_me_play_mem` for the
+  packed-archive path, the same disk/packed split `#bgm_play` already has.
+  On the mrblib call-site side, `Scene::Map#victory_bgm` (`mruby-rpg2k/
+  mrblib/scene/map.rb`) now reads `fade_in`/`fadein` off both the database's
+  `battle_end_music` (via the existing `#music_fadein` helper cycle #203
+  added) and a Change System BGM victory-slot override, returning it as a
+  `fadein:` key the same shape `#battle_bgm`/`#inn_bgm` already return; and
+  `#play_victory_bgm` forwards it as `RGSS::Audio.me_play`'s new 4th
+  argument, `|| 0` defaulted the same way volume/tempo already are. Checked
+  for other native or mrblib call sites that pass a fixed positional argument
+  count to `Audio.me_play`/`_me_play`/`_me_play_mem` that an added optional
+  argument could break (`mruby-rpgvx/mrblib/rgss2_runtime.rb`,
+  `mruby-mvjs/mrblib/mv.rb`, `scripts/rgss_cruby_compat.rb`'s stub, and
+  `mruby-rgss/test/test.rb`'s probe) — all call with 3 or fewer arguments, so
+  the new optional 4th/5th argument defaulting to 0 changes nothing for any
+  of them. Regression-covered by 2 new `scripts/rpg2k_scene_check.rb` checks
+  (a non-zero `fade_in` from the database's `battle_end_music`, and from a
+  Change System BGM victory override, each reach `RGSS::Audio.me_play`'s new
+  4th argument), both confirmed to fail against the pre-fix code (asserting a
+  4-argument `me_calls` tuple against code that still only ever passed 3)
+  before the fix; the suite's 2 pre-existing victory-fanfare `me_calls`
+  assertions were also updated to expect the now-explicit trailing `0`
+  (no fade-in configured in either fixture), both independently confirmed to
+  fail against the pre-fix code too (the old 3-argument shape) before being
+  updated. **Verification**: `scripts/rpg2k_scene_check.rb` 941 passed (939
+  baseline + 2 new checks, 0 failures); `rpg2k_logic_check.rb` 1179 passed
+  (unchanged — it never instantiates `Scene::Map`, so untouched by this
+  cycle, matching cycle #203's own note); `rpg2k_render_check.rb` 41 passed
+  (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged); `rpg2k_save_load_check.rb`
+  still reports the same 1 known pre-existing failure (the unrelated Show
+  Picture field-shape mismatch) before and after; `scripts/rpg2k_command_soak.rb`
+  clean on both Nepheshel test-beds (184166 commands each, no gaps or
+  raises); the touched `.cxx`/`.hxx` files were run through the exact pinned
+  `clang-format==22.1.8` before committing (idempotent — a second run made no
+  further changes); `cd build && ninja` clean rebuild with no new warnings;
+  `ctest -R mruby_test` passed. No wine session was run this cycle, for the
+  same reason cycles #202/#203 gave (audio timing is not screenshot-diffable,
+  and nothing here touched a `data/` fixture) — this is first-principles
+  code reading (the native fade-in mechanism was already proven correct for
+  BGM in cycle #202; this cycle is mechanical plumbing of that same
+  mechanism to a second, structurally identical call path) rather than a
+  wine-verified timing match.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/include/rgss_audio.hxx
+++ b/include/rgss_audio.hxx
@@ -76,8 +76,14 @@ struct RgssAudioBackend {
   void (*bgs_fade)(int ms);
   int (*bgs_pos)(void);
 
-  // Music effect: plays once over the music, then the interrupted BGM resumes.
-  void (*me_play)(const char* path, int volume, int pitch);
+  // Music effect: plays once over the music, then the interrupted BGM
+  // resumes. fadein_ms is the same fade-in-from-silence duration as
+  // bgm_play's, above (RPG2000's own Play BGM / Change System BGM fade-in
+  // parameter, reaching the victory fanfare's ME channel this way starting
+  // cycle #204) -- SDL_mixer's Mix_FadeInMusic applies identically to a
+  // one-shot ME as to a looping BGM, since both are the same underlying
+  // Mix_Music stream, just started with a different loop count.
+  void (*me_play)(const char* path, int volume, int pitch, int fadein_ms);
   void (*me_stop)(void);
   void (*me_fade)(int ms);
 
@@ -113,7 +119,8 @@ struct RgssAudioBackend {
                       const void* data,
                       int size,
                       int volume,
-                      int pitch);
+                      int pitch,
+                      int fadein_ms);
   void (*se_play_mem)(const char* name,
                       const void* data,
                       int size,

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1180,10 +1180,16 @@ module RGSS
         _bgs_pos
       end
 
-      def me_play(filename, volume = 100, pitch = 100)
+      # `fadein` is not part of any real RGSS Audio.me_play signature (RGSS2/
+      # RGSS3 scripts never pass a 4th argument here either) -- it exists for
+      # RPG2000's own Change System BGM fade-in parameter reaching the
+      # victory fanfare's one-shot ME channel (`Scene::Map#play_victory_bgm`,
+      # cycle #204), the same reason #bgm_play grew its own `fadein` in cycle
+      # #202. 0 (the default) keeps the original instant-start behavior.
+      def me_play(filename, volume = 100, pitch = 100, fadein = 0)
         path = resolve(filename, MUSIC_DIRS)
-        return _me_play(path, volume, pitch) if path
-        play_packed(:me, filename, volume, pitch)
+        return _me_play(path, volume, pitch, fadein) if path
+        play_packed(:me, filename, volume, pitch, 0, fadein)
       end
 
       def me_stop
@@ -1238,10 +1244,12 @@ module RGSS
       # just the disk path in #bgm_play, because a released game's whole
       # Audio/ tree is packed into one encrypted archive with nothing loose on
       # disk (see RGSS.asset_archive) -- this is the path that actually
-      # carries a resume for a released game. `fadein` (cycle #202) is BGM's
-      # own fade-in-from-silence duration, the same disk-path/packed-path
-      # split as `pos` for the identical reason: RPG2000's Play BGM has to
-      # reach a released game's packed archive too, not just loose files.
+      # carries a resume for a released game. `fadein` (cycle #202 for BGM,
+      # #204 for ME) is a fade-in-from-silence duration, the same disk-path/
+      # packed-path split as `pos` for the identical reason: RPG2000's Play
+      # BGM / Change System BGM fade-in has to reach a released game's packed
+      # archive too, not just loose files -- ME ignores `pos` (it never
+      # resumes mid-track) exactly like every non-BGM kind above.
       def play_packed(kind, filename, volume, pitch, pos = 0, fadein = 0)
         return nil if filename.nil? || filename.empty?
         archive = RGSS.asset_archive
@@ -1265,7 +1273,7 @@ module RGSS
         case kind
         when :bgm then _bgm_play_mem(name, bytes, volume, pitch, pos, fadein)
         when :bgs then _bgs_play_mem(name, bytes, volume, pitch)
-        when :me then _me_play_mem(name, bytes, volume, pitch)
+        when :me then _me_play_mem(name, bytes, volume, pitch, fadein)
         else _se_play_mem(name, bytes, volume, pitch)
         end
         nil

--- a/mruby-rgss/src/audio.cxx
+++ b/mruby-rgss/src/audio.cxx
@@ -36,7 +36,10 @@ void get_play_args(mrb_state* M,
   mrb_get_args(M, "z|ii", path, volume, pitch);
 }
 
-// The *_play_mem twins take (name, bytes, volume=100, pitch=100). `name` is an
+// The bgs_play_mem/se_play_mem twins take (name, bytes, volume=100,
+// pitch=100) -- bgm_play_mem and me_play_mem each grew extra trailing
+// arguments (pos_ms/fadein_ms, and fadein_ms respectively) and so define
+// their own mrb functions below rather than sharing this one. `name` is an
 // archive entry name rather than a path -- see include/rgss_audio.hxx.
 using PlayMemFn = void (*)(const char*, const void*, int, int, int);
 
@@ -55,10 +58,11 @@ mrb_value bgm_play(mrb_state* M, mrb_value self) {
   const char* path;
   mrb_int volume = 100, pitch = 100, pos_ms = 0, fadein_ms = 0;
   // BGM alone takes a 4th (pos_ms) argument: RGSS3's mid-track resume, which
-  // BGS/ME/SE never had -- get_play_args (above) only reads the three they all
-  // share. The 5th (fadein_ms, cycle #202) is RPG2000's own Play BGM fade-in,
-  // not part of any real RGSS Audio.bgm_play -- see rgss_audio.hxx's own
-  // doc comment.
+  // BGS/ME/SE never had -- get_play_args (above) only reads the three BGS/SE
+  // still share (ME grew its own 4th argument too, cycle #204; see me_play,
+  // below). The 5th (fadein_ms, cycle #202) is RPG2000's own Play BGM
+  // fade-in, not part of any real RGSS Audio.bgm_play -- see rgss_audio.hxx's
+  // own doc comment.
   mrb_get_args(M, "z|iiii", &path, &volume, &pitch, &pos_ms, &fadein_ms);
   if (g_backend.bgm_play)
     g_backend.bgm_play(path, (int)volume, (int)pitch, (int)pos_ms,
@@ -131,10 +135,16 @@ mrb_value bgs_pos(mrb_state* M, mrb_value self) {
 
 mrb_value me_play(mrb_state* M, mrb_value self) {
   const char* path;
-  mrb_int volume, pitch;
-  get_play_args(M, &path, &volume, &pitch);
+  mrb_int volume = 100, pitch = 100, fadein_ms = 0;
+  // ME grew its own 4th (fadein_ms, cycle #204) argument, so it reads its
+  // args directly rather than sharing get_play_args (bgs_play/se_play still
+  // do, above/below) -- the same Play-BGM-style fade-in
+  // RGSS::Audio.bgm_play's own 5th argument carries (cycle #202), reaching
+  // the victory fanfare's one-shot ME channel via
+  // Scene::Map#play_victory_bgm.
+  mrb_get_args(M, "z|iii", &path, &volume, &pitch, &fadein_ms);
   if (g_backend.me_play)
-    g_backend.me_play(path, (int)volume, (int)pitch);
+    g_backend.me_play(path, (int)volume, (int)pitch, (int)fadein_ms);
   return mrb_nil_value();
 }
 
@@ -203,7 +213,19 @@ mrb_value bgs_play_mem(mrb_state* M, mrb_value self) {
 }
 
 mrb_value me_play_mem(mrb_state* M, mrb_value self) {
-  return play_mem(M, g_backend.me_play_mem);
+  // Not the shared play_mem helper: unlike bgs_play_mem/se_play_mem, ME
+  // takes a 5th (fadein_ms, cycle #204) argument (see me_play, above) -- this
+  // is the packed-archive path a released game's victory-fanfare fade-in
+  // actually reaches (see RGSS.asset_archive).
+  const char* name;
+  const char* data;
+  mrb_int size;
+  mrb_int volume = 100, pitch = 100, fadein_ms = 0;
+  mrb_get_args(M, "zs|iii", &name, &data, &size, &volume, &pitch, &fadein_ms);
+  if (g_backend.me_play_mem && size > 0)
+    g_backend.me_play_mem(name, data, (int)size, (int)volume, (int)pitch,
+                          (int)fadein_ms);
+  return mrb_nil_value();
 }
 
 mrb_value se_play_mem(mrb_state* M, mrb_value self) {
@@ -254,7 +276,7 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
   mrb_define_module_function(M, audio, "_bgs_stop", bgs_stop, MRB_ARGS_NONE());
   mrb_define_module_function(M, audio, "_bgs_fade", bgs_fade, MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_bgs_pos", bgs_pos, MRB_ARGS_NONE());
-  mrb_define_module_function(M, audio, "_me_play", me_play, MRB_ARGS_ARG(1, 2));
+  mrb_define_module_function(M, audio, "_me_play", me_play, MRB_ARGS_ARG(1, 3));
   mrb_define_module_function(M, audio, "_me_stop", me_stop, MRB_ARGS_NONE());
   mrb_define_module_function(M, audio, "_me_fade", me_fade, MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_se_play", se_play, MRB_ARGS_ARG(1, 2));
@@ -268,7 +290,7 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
   mrb_define_module_function(M, audio, "_bgs_play_mem", bgs_play_mem,
                              MRB_ARGS_ARG(2, 2));
   mrb_define_module_function(M, audio, "_me_play_mem", me_play_mem,
-                             MRB_ARGS_ARG(2, 2));
+                             MRB_ARGS_ARG(2, 3));
   mrb_define_module_function(M, audio, "_se_play_mem", se_play_mem,
                              MRB_ARGS_ARG(2, 2));
   mrb_define_module_function(M, audio, "_midi_available", midi_available,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3063,43 +3063,43 @@ class RPG2k
       # victory BGM configured leaves whatever was playing (the battle track)
       # alone, the same blank-Music no-op #battle_bgm documents.
       #
-      # Deliberately does NOT forward a fade-in (cycle #203 audit): the
-      # override and battle_end_music both do carry a genuine fade-in value
-      # the same way battle_music/inn_music/vehicle music do (Change System
-      # BGM's own fade-in parameter; liblcf's `BGM`-struct field 2), but
-      # RGSS::Audio.me_play has no fadein parameter at all -- unlike
-      # RGSS::Audio.bgm_play (cycle #202), the native ME playback path
-      # (`me_play`/`me_play_mem`, src/sdl_audio.cxx) was never given one,
-      # since RPG_RT's own "ME" one-shot channel is a distinct playback
-      # mechanism from its looping BGM channel. Wiring this would mean adding
-      # a fadein parameter across the whole native ME path (sdl_audio.cxx,
-      # include/rgss_audio.hxx, mruby-rgss/src/audio.cxx,
-      # mruby-rgss/mrblib/lib.rb) -- out of this audit's scope, which is
-      # forwarding an already-plumbed value through mrblib call sites, not
-      # extending the native audio surface.
+      # Forwards a fade-in (cycle #204 follow-up to the cycle #203 audit
+      # above): the override and battle_end_music both carry a genuine
+      # fade-in value the same way battle_music/inn_music/vehicle music do
+      # (Change System BGM's own fade-in parameter; liblcf's `BGM`-struct
+      # field 2), and RGSS::Audio.me_play now has a fadein parameter of its
+      # own -- the native ME playback path (`me_play`/`me_play_mem`,
+      # src/sdl_audio.cxx) was extended to accept one the same way
+      # RGSS::Audio.bgm_play's was (cycle #202), since SDL_mixer's
+      # Mix_FadeInMusic works identically for the one-shot ME channel as it
+      # does for the looping BGM channel underneath -- both are the same
+      # Mix_Music stream, just started with a different loop count.
       def play_victory_bgm
         music = victory_bgm
         return unless music
-        RGSS::Audio.me_play(music[:name], music[:volume] || 100, music[:tempo] || 100)
+        RGSS::Audio.me_play(music[:name], music[:volume] || 100,
+                            music[:tempo] || 100, music[:fadein] || 0)
       rescue StandardError => e
         $stderr.puts "[RPG2k] victory BGM failed: #{e.message}"
       end
 
-      # The victory BGM to play as { name:, volume:, tempo: }, or nil when
-      # neither source names a file. Prefers a Change System BGM override for
-      # the victory slot over the database's own System battle_end_music --
-      # the same override-then-default idiom #battle_bgm uses for the battle
-      # slot.
+      # The victory BGM to play as { name:, volume:, tempo:, fadein: }, or
+      # nil when neither source names a file. Prefers a Change System BGM
+      # override for the victory slot over the database's own System
+      # battle_end_music -- the same override-then-default idiom #battle_bgm
+      # uses for the battle slot, `fadein` included (cycle #204) the same way
+      # #battle_bgm / #inn_bgm already carry theirs.
       def victory_bgm
         ov = @state.system_bgm[SYSTEM_BGM_VICTORY]
         if ov && ov[:name] && !ov[:name].to_s.empty?
           return { name: ov[:name], volume: ov[:volume] || 100,
-                    tempo: ov[:tempo] || 100 }
+                    tempo: ov[:tempo] || 100, fadein: ov[:fadein] || 0 }
         end
         name = music_name(db.system.battle_end_music)
         return nil if name.nil? || name.empty?
         { name: name, volume: music_volume(db.system.battle_end_music),
-          tempo: music_tempo(db.system.battle_end_music) }
+          tempo: music_tempo(db.system.battle_end_music),
+          fadein: music_fadein(db.system.battle_end_music) }
       end
 
       # Restore the BGM that was playing before the fight started. A no-op

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7873,8 +7873,9 @@ check 'Enemy Encounter scene: victory plays the database battle_end_music over t
   battle_attack_to_end(scene) # Attack the Slimes each round until they fall
   eq [], RGSS::Audio.bgm_calls,
      'the fanfare is a one-shot ME, not an ordinary looping BGM play'
-  eq [['VictoryBGM', 90, 105]], RGSS::Audio.me_calls,
-     'the victory fanfare played over the result screen through the ME channel'
+  eq [['VictoryBGM', 90, 105, 0]], RGSS::Audio.me_calls,
+     'the victory fanfare played over the result screen through the ME channel, ' \
+     'with no fade-in configured'
   eq 'BattleBGM', st.current_bgm[:name],
      "the ME is not tracked as the ongoing BGM -- #current_bgm still names " \
      'whatever the last actual BGM play was (the battle track)'
@@ -7907,9 +7908,48 @@ check 'Enemy Encounter scene: a Change System BGM victory override beats the dat
   battle_attack_to_end(scene) # Attack the Slimes each round until they fall
   eq [], RGSS::Audio.bgm_calls,
      'the fanfare is a one-shot ME, not an ordinary looping BGM play'
-  eq [['CustomVictory', 60, 130]], RGSS::Audio.me_calls,
+  eq [['CustomVictory', 60, 130, 0]], RGSS::Audio.me_calls,
      'the Change System BGM override played instead of the database battle_end_music'
   eq 'BattleBGM', st.current_bgm[:name]
+end
+
+check 'Enemy Encounter scene: victory fanfare forwards battle_end_music\'s own fade-in to the ME channel' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  # `fade_in` is liblcf's own BGM-struct field 2 -- the same field
+  # battle_music/inn_music/etc. already carry (see #battle_bgm's own doc
+  # comment) -- present on battle_end_music too.
+  scene.db.system.battle_end_music =
+    OpenStruct.new(file: 'VictoryBGM', volume: 90, pitch: 105, fade_in: 1500)
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  eq [['VictoryBGM', 90, 105, 1500]], RGSS::Audio.me_calls,
+     "the database battle_end_music's own fade-in reaches Audio.me_play's 4th argument"
+end
+
+check 'Enemy Encounter scene: a Change System BGM victory override\'s own fade-in reaches the ME channel too' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.db.system.battle_end_music =
+    OpenStruct.new(file: 'VictoryBGM', volume: 90, pitch: 105, fade_in: 1500)
+  st.system_bgm[1] = { name: 'CustomVictory', fadein: 750, volume: 60, tempo: 130,
+                       balance: 50 }
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  eq [['CustomVictory', 60, 130, 750]], RGSS::Audio.me_calls,
+     "the override's own fadein beats the database battle_end_music's, the same " \
+     'override-then-default precedence #battle_bgm already uses for name/volume/tempo'
 end
 
 check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -537,7 +537,11 @@ int bgs_pos(void) {
 
 // -- ME ---------------------------------------------------------------------
 
-void me_play(const char* path, int volume, int /*pitch*/) {
+// fadein_ms > 0 (RPG2000's own Change System BGM fade-in, reaching the
+// victory fanfare's ME channel via Scene::Map#play_victory_bgm, cycle #204)
+// ramps the ME up from silence the same way bgm_play's does -- play_music
+// already supports this for any loop count, ME's `1` (play once) included.
+void me_play(const char* path, int volume, int /*pitch*/, int fadein_ms) {
   // Play once over the BGM; update() restores the BGM when the effect ends.
   // Capture the BGM's own position now, before g_me_active flips bgm_pos() to
   // 0 -- but only on the first ME of a run, not one that replaces another
@@ -545,7 +549,7 @@ void me_play(const char* path, int volume, int /*pitch*/) {
   if (!g_me_active)
     g_bgm_resume_pos_ms = bgm_pos();
   g_me_active = true;
-  if (!play_music(path, volume, 1))
+  if (!play_music(path, volume, 1, 0, fadein_ms))
     g_me_active = false;  // load failed: nothing to wait for.
 }
 
@@ -553,11 +557,12 @@ void me_play_mem(const char* name,
                  const void* data,
                  int size,
                  int volume,
-                 int /*pitch*/) {
+                 int /*pitch*/,
+                 int fadein_ms) {
   if (!g_me_active)
     g_bgm_resume_pos_ms = bgm_pos();
   g_me_active = true;
-  if (!play_music_mem(name, data, size, volume, 1))
+  if (!play_music_mem(name, data, size, volume, 1, 0, fadein_ms))
     g_me_active = false;
 }
 


### PR DESCRIPTION
## Summary

Cycle #203 wired battle/inn/vehicle-boarding/Game-Over BGM fade-ins through to `RGSS::Audio.bgm_play`, but deliberately left `Scene::Map#victory_bgm`/`#play_victory_bgm` alone: the victory fanfare plays through `RGSS::Audio.me_play`, RPG_RT's distinct one-shot "ME" channel, whose native signature had no fadein parameter at all — unlike `bgm_play`, it was never given one.

This cycle extends the native ME playback path the same way `bgm_play`'s was extended in cycle #202:
- `RgssAudioBackend::me_play`/`me_play_mem` (`include/rgss_audio.hxx`) each grew a trailing `fadein_ms` parameter.
- `src/sdl_audio.cxx`'s implementations forward it to the same `play_music`/`play_music_mem` helpers `bgm_play` already uses — these already supported `fadein_ms` for any loop count (ME's "play once" `1` included), since `Mix_FadeInMusic` works identically for a one-shot ME as for a looping BGM (both are the same underlying `Mix_Music` stream).
- `RGSS::Audio.me_play`/`_me_play_mem` (`mruby-rgss/mrblib/lib.rb`, `mruby-rgss/src/audio.cxx`) grew a matching optional 4th/5th argument. `me_play_mem`'s mrb function is no longer shared with the generic `play_mem` helper, the same pattern `bgm_play_mem` already established.
- `Scene::Map#victory_bgm` now reads `fade_in`/`fadein` off both the database's `battle_end_music` and a Change System BGM victory-slot override, the same way `#battle_bgm`/`#inn_bgm` already do, and `#play_victory_bgm` forwards it as `RGSS::Audio.me_play`'s new 4th argument, `|| 0` defaulted the same way volume/tempo already are.

## Verification

- `scripts/rpg2k_scene_check.rb`: 941 passed (939 baseline + 2 new checks; 2 pre-existing `me_calls` assertions updated for the now-explicit trailing `0`)
- `scripts/rpg2k_logic_check.rb`: 1179 passed (unchanged — never instantiates `Scene::Map`)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: still exactly 1 known pre-existing failure (unrelated Show Picture field-shape issue), unchanged
- `scripts/rpg2k_command_soak.rb`: clean on both Nepheshel test-beds
- `cd build && ninja`: clean rebuild, no new warnings
- `ctest -R mruby_test`: passed
- Touched `.cxx`/`.hxx` files verified against the exact CI-pinned `clang-format==22.1.8` (no diff)
- Every new/updated check confirmed to fail against the pre-fix code before being fixed

No wine session was run — audio fade timing isn't screenshot-diffable, and nothing here touches a `data/` fixture, consistent with cycles #202/#203's own reasoning. The fade-in mechanism itself was already established correct for BGM in cycle #202; this cycle confirmed it's mechanically identical for the ME channel and plumbed the existing parameter through a second, structurally identical call path.

Per standing project convention, EasyRPG Player's C++ source was not consulted for any behavioral claim in this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_