### PR TITLE
Fix jump-block direction tracking for a diagonal move followed by Move Forward or a Turn

### DIFF
--- a/changelog.d/jump-move-forward-diagonal-direction.fixed.md
+++ b/changelog.d/jump-move-forward-diagonal-direction.fixed.md
@@ -1,0 +1,21 @@
+- **A move-route "Move Forward" inside a Begin Jump / End Jump block now
+  repeats the diagonal move it directly follows, instead of sliding back
+  onto whichever cardinal direction was in hand *before* that diagonal
+  ran.** `Game::MoveRoute#jump_move_direction` tracked the jump-scan's
+  running direction as a single cardinal value; a diagonal move sub-command
+  (Move Upper-Right/Upper-Left/Lower-Right/Lower-Left) fell into the same
+  bare `else dir` branch as Move Forward itself, so it left the tracked
+  direction completely unchanged — the diagonal step's own displacement was
+  still correct (`#jump_delta` computes that straight from the command id,
+  not the tracked direction), but a *following* Move Forward in the same
+  jump block read the stale pre-diagonal direction instead of continuing
+  the diagonal, the mirror image of the (already-fixed) non-jump "Move
+  Upper-Right, Move Forward" bug. Fixed by having a diagonal sub-command
+  leave its own `[horizontal, vertical]` pair in hand (mirroring
+  `Character#last_move_direction`'s existing pair convention outside a
+  jump) and teaching `#jump_delta` to compute a diagonal offset from that
+  pair when a later Move Forward carries it forward. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (Begin Jump / Move Upper-Right /
+  Move Forward / End Jump lands two tiles up-right of start, not one
+  up-right plus one back down), confirmed to fail against the pre-fix code
+  before the fix.

--- a/changelog.d/jump-turn-after-diagonal-direction.fixed.md
+++ b/changelog.d/jump-turn-after-diagonal-direction.fixed.md
@@ -1,0 +1,20 @@
+- **A Turn Right / Turn Left / Turn 180 (or the matching half of Turn 90
+  Right/Left/180 Random) inside a Begin Jump / End Jump block now actually
+  rotates the diagonal direction it follows, instead of silently leaving it
+  unrotated.** This is the narrower sibling of the "Move Forward repeats the
+  diagonal in hand" jump-block fix: once a diagonal move sub-command
+  (Move Upper-Right/Upper-Left/Lower-Right/Lower-Left) leaves its own
+  `[horizontal, vertical]` pair as the jump-scan's tracked direction,
+  `Character::TURN_RIGHT`/`TURN_LEFT`/`TURN_180` — which a Turn/Face command
+  inside the same jump block looks that direction up in — only had
+  cardinal-int keys, so the lookup missed and `#jump_face_direction`'s own
+  `|| dir` fallback quietly kept the *unrotated* diagonal in hand. A
+  following Move Forward in the same jump block then repeated the pre-turn
+  diagonal rather than the turned one. Fixed by keying those three hashes
+  with the four diagonal pairs too, rotated the same 90/180 degrees the
+  existing cardinal entries already encode. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (Begin Jump / Move Upper-Right /
+  Turn Right / Move Forward / End Jump lands at the Down-Right-rotated
+  offset rather than repeating Up-Right; the same route with Turn 180 in
+  place of Turn Right cancels out and lands back at the start), both
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21899,6 +21899,92 @@ not yet verified:
   named as unexercised, a self-contained internal-consistency fix
   discoverable by reading `MoveRoute#do_jump`/`#jump_move_direction`/
   `#jump_delta` directly, needing no fresh reference confirmation.
+  ✅ **Follow-up (cycle #207, 2026-08-28): closed the narrower sibling gap
+  cycle #206 itself named and deliberately left untouched --
+  `#jump_face_direction`'s own diagonal-Array hash-lookup miss.** Method:
+  skimmed several other sections of this file first (menus/save/battle,
+  the untriaged/full-site-sweep backlog, VX/VXAce and RGSS material) looking
+  for a fresher, unrelated candidate outside move-route territory, but
+  most open-looking items there either needed a genuine wine session this
+  environment doesn't have this cycle or were already resolved; cycle
+  #206's own named "Still open" (well, "further, narrower edge case") --
+  a self-contained, code-only gap needing no fresh behavioral citation --
+  was the best-scoped target available, so picked it up. While reading the
+  surrounding code for context, noticed (but did not touch, being out of
+  this cycle's own scope) two pre-existing direct citations of EasyRPG
+  Player's own C++ source as behavioral justification still sitting in
+  `mruby-rpg2k/mrblib/game.rb` — `Character#direction_toward`'s "Corrected
+  to match EasyRPG Player's own `Game_Character::GetDirectionToCharacter`"
+  and `Character#diagonal_facing`'s "ported from EasyRPG Player's own
+  `Game_Character::UpdateFacing`" — both explicitly self-flagged in their
+  own comments as "NOT independently confirmed against genuine RPG_RT under
+  wine," i.e. already known-weak, uncited-in-this-cycle's-work citations
+  rather than something this fix relied on; noting them here for whichever
+  future cycle resumes cycle #174's own citation-hygiene sweep (256 unswept
+  instances as of that cycle; these two were apparently missed by it, or
+  postdate it). Confirmed by direct code reading: `Character::TURN_RIGHT`/
+  `TURN_LEFT`/`TURN_180` (`mruby-rpg2k/mrblib/game.rb`) were plain
+  cardinal-int-keyed hashes (`{8=>6, 6=>2, 2=>4, 4=>8}` etc.); `#jump_face_
+  direction`'s `TURN_RIGHT`/`TURN_LEFT`/`TURN_180` case arms look a jump
+  block's tracked direction up in exactly these hashes, and that tracked
+  direction is a `[horizontal, vertical]` Array pair right after a diagonal
+  move sub-command (per cycle #206's own fix) — an Array key always misses
+  a hash built from bare integers, so the `|| dir` fallback silently kept
+  the *unrotated* diagonal, rather than crashing (a graceful no-op, exactly
+  as cycle #206's note described it). Fixed by keying all three hashes with
+  the four diagonal pairs too (`[6,8]` Up-Right, `[6,2]` Down-Right, `[4,2]`
+  Down-Left, `[4,8]` Up-Left), rotated 90/90/180 degrees the same way the
+  existing cardinal entries already do: treating the four cardinals plus
+  four diagonals as eight positions evenly spaced around a compass circle
+  (Up=0, Up-Right=1, Right=2, Down-Right=3, Down=4, Down-Left=5, Left=6,
+  Up-Left=7), a turn is a +-2-position rotation and 180 is a 4-position
+  rotation — verified this generalization reproduces the *existing*
+  cardinal-only table exactly before trusting it for the new diagonal
+  entries (e.g. Up(0) +2 -> Right(2), matching the pre-existing `TURN_RIGHT
+  = {8 => 6, ...}`; Up(0) -2 -> Left(6), matching `TURN_LEFT = {8 => 4,
+  ...}`), so the four new diagonal entries in each hash are a direct
+  extrapolation of an already-established rule, not a fresh, uncited
+  behavioral claim. Reused the existing hashes (rather than a separate
+  table) since a character's own on-map `@direction` is always cardinal —
+  `#turn_right`/`#turn_left`/`#turn_around` and `#direction_away` only ever
+  look up a plain Integer there, so the new Array-keyed entries are inert
+  for every call site except `#jump_face_direction`. **Verification:**
+  hand-traced the fix's own arithmetic before writing the checks (character
+  at `(2, 2)` facing Down, `Begin Jump / Move Upper-Right / Turn Right /
+  Move Forward / End Jump` — diagonal step adds `(1, -1)` landing at
+  `(3, 1)`; Turn Right rotates Up-Right's `[6, 8]` pair to Down-Right's
+  `[6, 2]`; Move Forward then adds `(1, 1)`, landing at `(4, 2)`; a second
+  check swapped Turn Right for Turn 180, rotating to Down-Left's `[4, 2]`
+  pair, whose `(-1, 1)` delta exactly cancels the diagonal step's `(1, -1)`
+  and lands back at the start `(2, 2)` — still a jump, per `Character#
+  jumped`, just a net-zero one; a first draft of this second check's
+  expected value was arithmetically wrong (`[2, 4]`) and was caught by
+  re-deriving the delta table by hand rather than trusting the initial
+  guess). Both new `scripts/rpg2k_logic_check.rb` checks were confirmed to
+  fail against the pre-fix code first (`git stash`/`git stash pop` on just
+  `mruby-rpg2k/mrblib/game.rb`: both landed at `[4, 0]`, matching the bug —
+  the diagonal repeating unrotated a second time exactly as cycle #206's
+  fix already covers for the *unturned* case) then pass after. Full suite:
+  `rpg2k_logic_check.rb` 1182 passed (1180 baseline + 2 new, 0 failures);
+  `rpg2k_scene_check.rb` 943 passed (unchanged); `rpg2k_render_check.rb` 41
+  passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and `rpg2k3_battle_
+  gauge_check.rb` 15/0 (both unchanged, no battle code touched); `rpg2k_
+  save_load_check.rb` still reports exactly the same 1 known pre-existing
+  failure (the unrelated Show Picture field-shape mismatch), unaffected. No
+  `.cxx`/`.hxx` file was touched (pure `mrblib` Ruby plus a check-script
+  addition), so the pinned `clang-format` step does not apply; `cd build &&
+  ninja` clean rebuild succeeded with no new warnings; `ctest -R mruby_test`
+  passed (7.13s). No wine session was run this cycle and no EasyRPG source
+  was consulted for this fix's own behavioral claim (the two pre-existing
+  EasyRPG citations noted above were read incidentally while orienting in
+  the surrounding code, not relied on for this fix, and were left
+  untouched as out of this cycle's own scope) — the rule being extended (a
+  90/180-degree rotation applies uniformly across all eight compass
+  positions, cardinal and diagonal alike) is a direct arithmetic
+  generalization of the already-established, wine-adjacent cardinal table
+  this same file already carries citations for, verified by reproducing
+  that existing table's own four entries with the general formula before
+  trusting the formula for the four new ones.
   ✅ **Follow-up (2026-08-21): Move Forward after an explicit Face/Turn
   sub-command continued in the direction last *physically walked* instead
   of the newly faced direction — the opposite of what the original fix in

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21833,6 +21833,72 @@ not yet verified:
   the same root cause (this codebase's direction state could only hold a
   single cardinal), just not exercised by this fix, which only touched the
   non-jump path.
+  ✅ **Follow-up (cycle #206, 2026-08-28): closed this exact "Still open"
+  jump-path gap.** Method: after skimming several sections of this file
+  looking for a well-scoped, currently-open item outside the last five
+  cycles' BGM-fade-in/HP-MP-recolor territory (most of the "Untriaged
+  backlog"/"Full-site sweep" material turned out to already be resolved,
+  or explicitly deferred pending a genuine wine session this environment
+  doesn't have this cycle), this dangling cross-reference from the
+  already-fixed non-jump diagonal bug was exactly the kind of self-
+  contained, code-only gap that needed no fresh behavioral citation — the
+  underlying rule (a diagonal move-route sub-command must leave its own
+  `[horizontal, vertical]` pair in hand for a following Move Forward to
+  repeat, not collapse to one cardinal axis) was already established and
+  wine-adjacent-confirmed by the non-jump fix directly above; this cycle's
+  own contribution is recognizing the jump-scan path (`MoveRoute#do_jump`'s
+  local `dir` variable) never received it. Confirmed by direct code
+  reading: `#jump_move_direction`'s `else dir` branch caught both Move
+  Forward *and* all four diagonal move ids (`MOVE_UPRIGHT`/`_DOWNRIGHT`/
+  `_DOWNLEFT`/`_UPLEFT` sit inside the `MOVE_UP..MOVE_FORWARD` id range but
+  had no explicit `when` arm), so a diagonal sub-command left `dir`
+  completely unchanged — the diagonal's own displacement stayed correct
+  regardless, since `#jump_delta` computes it straight from the command
+  `id` when `id` itself is diagonal, not from `dir` — but a *following*
+  Move Forward (`jump_delta(MOVE_FORWARD, dir)`, `id` not diagonal) fell
+  through to the untouched, stale pre-diagonal `dir`. Fixed by giving
+  `#jump_move_direction` an explicit diagonal `when` arm returning
+  `DIAGONAL[id]` (the same `[horizontal, vertical]` pair
+  `Character#last_move_direction` already uses outside a jump), and
+  widening `#jump_delta` to also treat `dir` itself as a diagonal pair
+  (`Array`) when the *current* command isn't one — the two-line change
+  `pair = DIAGONAL[id] || (dir if dir.is_a?(Array))`. `#jump_face_direction`
+  (Turn/Face commands inside a jump block) is untouched: a Turn command
+  immediately after a diagonal, before any Move Forward, is a further,
+  narrower edge case this bullet's own claim never named (`TURN_RIGHT[dir]`
+  etc. simply fail their hash lookup on an `Array` key and fall back to
+  `|| dir`, leaving the pair as-is rather than crashing — a graceful
+  no-op, not a regression, and out of this cycle's scope). **Verification**:
+  hand-traced the fix's own arithmetic before writing the check (Character
+  at `(2, 2)` facing Down, `Begin Jump / Move Upper-Right / Move Forward /
+  End Jump` — pre-fix: diagonal step correctly adds `(1, -1)`, but Move
+  Forward then reads the untouched pre-jump `dir` (Down) and adds `(0, 1)`,
+  landing at `(3, 2)`; post-fix: Move Forward reads the `[6, 8]` pair left
+  by the diagonal and adds `(1, -1)` again, landing at `(4, 0)`) — the new
+  `scripts/rpg2k_logic_check.rb` check asserts exactly `(4, 0)` and was
+  confirmed to fail against the pre-fix code first (`expected [4, 0], got
+  [3, 2]`, matching the hand trace precisely) via `git stash`/`git stash
+  pop` on just `mruby-rpg2k/mrblib/game.rb`, then pass after. Full suite:
+  `rpg2k_logic_check.rb` 1180 passed (1179 baseline + 1 new, 0 failures);
+  `rpg2k_scene_check.rb` 943 passed (unchanged, this cycle touches no
+  `scene/*.rb` file); `rpg2k_render_check.rb` 41 passed (unchanged);
+  `rpg2k3_battle_row_check.rb` 19/0 and `rpg2k3_battle_gauge_check.rb`
+  15/0 (both unchanged, no battle code touched); `rpg2k_save_load_check.rb`
+  still reports exactly the same 1 known pre-existing failure (the
+  unrelated Show Picture field-shape mismatch), unaffected. No `.cxx`/
+  `.hxx` file was touched (pure `mrblib` Ruby), so the pinned
+  `clang-format` step does not apply; `cd build && ninja` clean rebuild
+  with no new warnings; `ctest -R mruby_test` passed. No wine session was
+  run this cycle and no EasyRPG source was consulted for this fix's own
+  behavioral claim — the rule being extended (a diagonal move-route
+  sub-command's direction persists for a following Move Forward, rather
+  than collapsing to one cardinal axis) is the identical, already-
+  established one the non-jump fix directly above this bullet already
+  carries its own citation for; this cycle only closes the one code path
+  (`do_jump`'s local `dir` tracking) that fix's own "Still open" note
+  named as unexercised, a self-contained internal-consistency fix
+  discoverable by reading `MoveRoute#do_jump`/`#jump_move_direction`/
+  `#jump_delta` directly, needing no fresh reference confirmation.
   ✅ **Follow-up (2026-08-21): Move Forward after an explicit Face/Turn
   sub-command continued in the direction last *physically walked* instead
   of the newly faced direction — the opposite of what the original fix in

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7171,21 +7171,40 @@ module Game
 
     # The direction a move command inside a jump block contributes. The moves
     # that would pick a direction at run time (random, toward / away from the
-    # hero) still pick one; Move Forward keeps the direction in hand.
+    # hero) still pick one; Move Forward keeps the direction in hand. A
+    # diagonal now leaves its own `[horizontal, vertical]` pair in hand too
+    # (mirroring #move_diagonal's `#last_move_direction` outside a jump) --
+    # it used to fall into the bare `else dir` catch-all alongside Move
+    # Forward itself, so the diagonal never actually updated the running
+    # `dir` a *later* Move Forward in the same jump block reads: "Begin
+    # Jump, Move Upper-Right, Move Forward, End Jump" repeated the
+    # *pre*-diagonal direction instead of the diagonal just walked, the same
+    # root cause #last_move_direction was introduced for outside a jump (see
+    # #move_diagonal's own doc comment), just never carried into this
+    # separate jump-scan path. This still leaves the diagonal step's own
+    # delta correct even before this fix, since #jump_delta computes it
+    # straight from `id`, not `dir` -- only a *following* Move Forward was
+    # affected.
     def jump_move_direction(id, dir, character, world)
       case id
       when MOVE_UP, MOVE_RIGHT, MOVE_DOWN, MOVE_LEFT then MOVE_DIR[id]
+      when MOVE_UPRIGHT, MOVE_DOWNRIGHT, MOVE_DOWNLEFT, MOVE_UPLEFT then DIAGONAL[id]
       when MOVE_RANDOM then Character::CARDINALS[world.random(4)]
       when MOVE_TOWARD_HERO then toward_hero(character, world)
       when MOVE_AWAY_HERO then away_hero(character, world)
-      else dir # Move Forward, and the diagonals (which carry their own delta)
+      else dir # Move Forward: keeps whatever direction (cardinal or diagonal pair) is in hand
       end
     end
 
-    # The tile offset a move command inside a jump block adds. A diagonal moves
-    # on both axes at once; everything else moves one tile along `dir`.
+    # The tile offset a move command inside a jump block adds. A diagonal
+    # moves on both axes at once -- whether it comes from an explicit
+    # diagonal sub-command (`id` itself names one) or from Move Forward
+    # continuing a diagonal `dir` a prior diagonal command left in hand (a
+    # two-element `[horizontal, vertical]` pair, see #jump_move_direction
+    # above); everything else moves one tile along the cardinal `dir`.
     def jump_delta(id, dir)
-      if (pair = DIAGONAL[id])
+      pair = DIAGONAL[id] || (dir if dir.is_a?(Array))
+      if pair
         horizontal, vertical = pair
         hx, = Character::DIR_DELTA[horizontal] || [0, 0]
         _, vy = Character::DIR_DELTA[vertical] || [0, 0]

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6475,9 +6475,23 @@ module Game
     # numpad direction -> [dx, dy] step in tiles.
     DIR_DELTA = { 8 => [0, -1], 2 => [0, 1], 4 => [-1, 0], 6 => [1, 0] }.freeze
     # 90-degree clockwise / counter-clockwise rotations and the 180-degree flip.
-    TURN_RIGHT = { 8 => 6, 6 => 2, 2 => 4, 4 => 8 }.freeze
-    TURN_LEFT  = { 8 => 4, 4 => 2, 2 => 6, 6 => 8 }.freeze
-    TURN_180   = { 8 => 2, 2 => 8, 4 => 6, 6 => 4 }.freeze
+    # Diagonal directions (as the [horizontal, vertical] pairs #move_diagonal /
+    # MoveRoute's own DIAGONAL table use, e.g. [6, 8] for Up-Right) are keyed
+    # in too, rotated the same 90/180 degrees around the 8-way compass these
+    # four cardinals sit on (Up=0, Up-Right=1, Right=2, Down-Right=3, Down=4,
+    # Down-Left=5, Left=6, Up-Left=7; a turn moves +-2 steps, 180 moves 4) --
+    # only #jump_face_direction ever looks up a diagonal key here, for a
+    # Turn/Face command that follows a diagonal move inside the same jump
+    # block, since a character's own on-map @direction is always cardinal.
+    TURN_RIGHT = { 8 => 6, 6 => 2, 2 => 4, 4 => 8,
+                   [6, 8] => [6, 2], [6, 2] => [4, 2],
+                   [4, 2] => [4, 8], [4, 8] => [6, 8] }.freeze
+    TURN_LEFT  = { 8 => 4, 4 => 2, 2 => 6, 6 => 8,
+                   [6, 8] => [4, 8], [4, 8] => [4, 2],
+                   [4, 2] => [6, 2], [6, 2] => [6, 8] }.freeze
+    TURN_180   = { 8 => 2, 2 => 8, 4 => 6, 6 => 4,
+                   [6, 8] => [4, 2], [4, 2] => [6, 8],
+                   [6, 2] => [4, 8], [4, 8] => [6, 2] }.freeze
     # The four cardinal directions, indexable for random selection.
     CARDINALS = [2, 4, 6, 8].freeze
 
@@ -7216,6 +7230,17 @@ module Game
 
     # The direction a face / turn command inside a jump block leaves in hand. It
     # contributes no offset of its own — it only steers the next move command.
+    # A Turn Right/Left/180 (or the matching half of Turn 90 Right/Left/180
+    # Random) right after a diagonal move in the same block used to be a
+    # silent no-op: `dir` was the diagonal's own `[horizontal, vertical]`
+    # pair by then (see #jump_move_direction above), and Character::
+    # TURN_RIGHT/TURN_LEFT/TURN_180 only had cardinal-int keys, so the hash
+    # lookup missed and `|| dir` left the pair completely unrotated -- a
+    # following Move Forward kept walking the pre-turn diagonal instead of
+    # the turned one. Fixed by keying those three hashes with the four
+    # diagonal pairs too (see their own doc comment), rotated the same
+    # 90/180 degrees the cardinal entries already encode; the lookups here
+    # are unchanged.
     def jump_face_direction(id, dir, character, world)
       case id
       when FACE_UP, FACE_RIGHT, FACE_DOWN, FACE_LEFT then FACE_DIR[id]

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -438,6 +438,38 @@ check 'Move Forward inside a jump repeats the diagonal just walked, not the ' \
   eq [4, 0], [c.x, c.y], 'the diagonal in hand repeats twice, landing (2,-2) away'
 end
 
+check 'a Turn Right inside a jump rotates the diagonal in hand, not just a ' \
+      'cardinal' do
+  # Sibling gap to the check above: a Turn/Face command between a diagonal
+  # move and a following Move Forward, still inside the same jump block.
+  # Character::TURN_RIGHT/TURN_LEFT/TURN_180 used to have only cardinal-int
+  # keys, so looking one up with the diagonal's own [horizontal, vertical]
+  # pair missed and fell back to `|| dir`, silently leaving the pair
+  # unrotated -- Move Forward then repeated the pre-turn diagonal instead of
+  # the turned one. Begin Jump, Move Upper-Right, Turn Right, Move Forward:
+  # Up-Right (dx +1, dy -1) rotated 90 degrees clockwise is Down-Right (dx
+  # +1, dy +1), so Move Forward should add (+1, +1), not repeat (+1, -1).
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_UPRIGHT), mc(R::TURN_RIGHT),
+                 mc(R::MOVE_FORWARD), mc(R::END_JUMP)])
+  c = Game::Character.new(2, 2, 2)
+  eq :moved, route.step(c, FakeWorld.new)
+  eq [4, 2], [c.x, c.y], 'Up-Right then a 90-degree right turn to Down-Right'
+end
+
+check 'a Turn 180 inside a jump flips the diagonal in hand' do
+  # Same gap, exercising Character::TURN_180's own new diagonal keys: Begin
+  # Jump, Move Upper-Right, Turn 180, Move Forward. Up-Right (dx +1, dy -1)
+  # flipped 180 degrees is Down-Left (dx -1, dy +1), which exactly cancels
+  # the diagonal step just walked, so the block lands back where it started
+  # -- still a jump (see Character#jumped), just a net-zero one.
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_UPRIGHT), mc(R::TURN_180),
+                 mc(R::MOVE_FORWARD), mc(R::END_JUMP)])
+  c = Game::Character.new(2, 2, 2)
+  eq :moved, route.step(c, FakeWorld.new)
+  eq [2, 2], [c.x, c.y], 'Up-Right then a 180-degree flip to Down-Left cancels out'
+  eq true, c.jumped
+end
+
 check 'a jump only tests where it lands, not what it clears' do
   # (1, 0) is a wall; the jump passes straight over it onto (2, 0).
   route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_RIGHT),

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -420,6 +420,24 @@ check 'faces inside a jump steer the next move without moving anything' do
   eq [4, 5], [c.x, c.y]
 end
 
+check 'Move Forward inside a jump repeats the diagonal just walked, not the ' \
+      'pre-diagonal direction it had in hand' do
+  # Mirrors the already-fixed non-jump "Move Upper-Right, Move Forward"
+  # case (#do_diagonal_dir / Character#last_move_direction): a diagonal
+  # move-route sub-command must leave its own [horizontal, vertical] pair
+  # in hand, not the direction from before it ran, so a Move Forward right
+  # after it inside the *same* jump block repeats the diagonal rather than
+  # sliding back onto one cardinal axis. Character starts facing Down (2);
+  # Move Upper-Right then Move Forward should land two tiles up-right of
+  # start, not one tile up-right plus one tile down (the pre-fix bug: the
+  # second command re-read the stale pre-jump `dir`, Down).
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_UPRIGHT), mc(R::MOVE_FORWARD),
+                 mc(R::END_JUMP)])
+  c = Game::Character.new(2, 2, 2)
+  eq :moved, route.step(c, FakeWorld.new)
+  eq [4, 0], [c.x, c.y], 'the diagonal in hand repeats twice, landing (2,-2) away'
+end
+
 check 'a jump only tests where it lands, not what it clears' do
   # (1, 0) is a wall; the jump passes straight over it onto (2, 0).
   route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_RIGHT),


### PR DESCRIPTION
## Summary

This PR grew across two cycles fixing the same underlying gap in move-route jump-block direction tracking.

### Cycle #206: Move Forward after a diagonal

Move-route jump blocks (Begin Jump/End Jump) tracked their running direction as a single cardinal value: a diagonal move sub-command (Move Upper-Right/Upper-Left/Lower-Right/Lower-Left) fell into the same catch-all branch as Move Forward itself, so the tracked direction never actually updated. The diagonal step's own displacement was still correct (`#jump_delta` reads the command id directly for that), but a following Move Forward in the same jump block silently reverted to whichever cardinal direction was in hand before the diagonal, instead of repeating it — the same bug class the non-jump "Move Upper-Right, Move Forward" fix closed earlier. This was an explicitly flagged "Still open" gap in `docs/TODO.md`.

Fixed by having a diagonal jump sub-command leave its own `[horizontal, vertical]` pair in hand (mirroring `Character#last_move_direction`'s existing convention outside a jump), and teaching `#jump_delta` to compute a diagonal offset from that pair when a later Move Forward carries it forward.

### Cycle #207: Turn/Face after a diagonal

The narrower sibling gap cycle #206 explicitly left open: a Turn Right/Left/180 (or the matching half of Turn 90 Random) right after a diagonal move in the same jump block looked its tracked direction up in `Character::TURN_RIGHT`/`TURN_LEFT`/`TURN_180`, which only had cardinal-int keys — an Array `[horizontal, vertical]` key (left in hand by the diagonal move, per cycle #206) always missed, so the `|| dir` fallback silently kept the diagonal *unrotated* instead of turning it.

Fixed by keying the three hashes with the four diagonal pairs too, rotated the same 90/90/180 degrees the existing cardinal entries already encode (verified by modeling all 8 directions as positions on a compass circle and reproducing the existing 4 cardinal entries with the same formula before trusting it for the 4 new ones).

## Verification

- `scripts/rpg2k_logic_check.rb`: 1182 passed (1179 baseline + 3 new checks across both cycles)
- `scripts/rpg2k_scene_check.rb`: 943 passed (unchanged, no `scene/*.rb` touched)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: still exactly 1 known pre-existing failure (unrelated Show Picture field-shape issue), unchanged
- `cd build && ninja`: clean rebuild, no new warnings (no `.cxx`/`.hxx` touched, pure `mrblib` Ruby)
- `ctest -R mruby_test`: passed
- Every new check confirmed to fail against the pre-fix code (matching hand-traced arithmetic) before the fix

**Left deliberately untouched**: nothing further identified in this specific jump-block direction-tracking area.

No wine session was run for either cycle, and no EasyRPG source was consulted for either fix's own behavioral claim — both are direct extrapolations of an already-established rule (the non-jump diagonal-direction-persistence fix, and its own cardinal rotation table) rather than fresh independently-verified claims.
