### PR TITLE
Report a diagnostic for Change Party Member Remove targeting a nonexistent hero id

### DIFF
--- a/changelog.d/change-party-member-remove-invalid-hero-diagnostic.fixed.md
+++ b/changelog.d/change-party-member-remove-invalid-hero-diagnostic.fixed.md
@@ -1,0 +1,9 @@
+- **Event commands:** Change Party Member's "Remove" branch now reports the
+  same `[RPG2k] actor #<id> could not be built: ...` diagnostic Add already
+  does when the targeted hero id is a genuinely dangling reference (a
+  database shrink, not merely "not currently in the party") -- closing the
+  "invalid hero" case of the runtime error catalog, which Add (and every
+  other actor-id-consuming command, via the shared `Game::Actors#[]`
+  lookup) already covered. The check is done without instantiating (and so
+  without enrolling into the save data) the actor, unlike Add's own
+  lookup, which legitimately needs to build it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26629,6 +26629,87 @@ addition to an already-correct, already-verified-elsewhere no-op path,
 following an established in-repo pattern (the four sibling diagnostics
 this same catalog already names) rather than introducing any new
 behavioral assumption.
+✅ **Follow-up (cycle #210, 2026-08-28): the "invalid hero" case of this same
+catalog — never actually closed, just never named as still-open the way
+Move-Route was — is fixed too.** Method: per the standing instruction to
+pick a genuinely different area from cycles #206-209's Event-system run
+(move-route diagonal direction, then the Move-Route diagnostic just above),
+skimmed several other sections broadly first — Message window/Show Choices,
+Screen effects, BGM/SE, Variables & Switches, Database field semantics,
+Party/Actor/Vehicle, the RPG2003-only cluster, the "Flagged for priority
+triage" list, the RGSS (XP/VX/VXAce) section, the viprpg-dev wiki backlog —
+and found nearly every leaf bullet in each already carries its own ✅; the
+`2000/デフォ戦/デフォ戦botまとめ` bot-trivia dump and the RGSS browser-
+rebuild item are the two remaining large, explicitly-flagged-as-too-big
+items, and the VX Ace `$!`/exception-global gap is mid-flight in a sibling
+session's own uncommitted `3rd/mruby` changes this session was told not to
+touch. This catalog's own intro sentence just above ("invalid hero, skill,
+item, enemy, enemy group, battle animation, terrain, chipset, common event
+... skill/enemy/enemy-group/battle-animation/terrain/chipset fixed")
+conspicuously omits "hero" from its own parenthetical fixed-list even
+though the sentence names it first — a mismatch worth checking directly
+rather than assuming stale bookkeeping either way. Traced every actor-id
+consuming site in `mruby-rpg2k/mrblib/interpreter.rb` (`stat_targets`,
+`identity_target`, `actor_operand`, `actor_condition`, `#do_name_input`,
+`#resume_name_input`, `#do_change_party`'s Add branch) and confirmed they
+already resolve a dangling hero id through `party.roster[id]` —
+`Game::Actors#[]` (`mruby-rpg2k/mrblib/game.rb`) — which already raises,
+catches and logs a deduped `[RPG2k] actor #<id> could not be built: No such
+actor: <id>` diagnostic for exactly this case (confirmed live: a scratch
+probe built off this file's own `party_state`/`FakeActorDB` fixtures showed
+`roster[999]`, `identity_target`-backed Change Actor Name/Title/etc., and
+Change Party Member's own Add branch all already emit it). The **one**
+asymmetric gap found: Change Party Member's **Remove** branch
+(`Game::Party#remove_actor`) never consulted the roster at all — it only
+ever filtered the current `@actors` list by id match, so a stale/dangling
+id reaching Remove (as opposed to Add, which shares the identical
+`cmd.param`-resolved id in `#do_change_party`) silently no-opped with no
+trace whatsoever, the exact "invalid hero" gap this catalog names, just on
+only one of Change Party Member's two radio-button settings. Fixing this
+needed more than reusing `#[]` directly, though: `Game::Actors#[]`
+instantiates-and-caches the actor into `@all`, which `Party#to_h`'s own
+`@roster.each` walks to build what the save writes out (`#existing`'s own
+doc comment already flags this exact hazard for a read-only path like
+`\N[n]`) — so naively calling `@roster[id]` from `#remove_actor` for the
+overwhelmingly common case (an ordinary, perfectly valid id that simply
+isn't a current member) would have silently enrolled a
+never-otherwise-met actor into the save data as a side effect of merely
+asking, a regression Add's own lookup does not risk (Add always needs the
+actor object for real, to add it). Fixed with a new
+`Game::Actors#known_invalid?(id)`, sharing `#[]`'s exact message and its
+`@missing` dedup table (so the same id logs once whichever path first
+reaches it) but checking `@db.player[id]` directly rather than
+instantiating anything — true (and logged) only for a positive id with no
+database row and not already a live entry in `@all`, false with no side
+effect otherwise. `#remove_actor` now calls it exactly when the id matched
+no current member, closing the gap without changing save behaviour for the
+ordinary case. **Verification:** a new `scripts/rpg2k_logic_check.rb` check
+(`git stash`/`git stash pop` on just `mruby-rpg2k/mrblib/game.rb`) confirmed
+to fail against the pre-fix code first (`RuntimeError: ` — the diagnostic
+line never appeared) then pass after; it asserts all four cases in one
+pass: a dangling id via Remove reports the diagnostic and is not enrolled
+(`party.roster.all` stays `[1]`, the starting leader only); a second
+occurrence of the same dangling id is deduped (empty stderr); an ordinary
+valid-but-never-met id (`2`, present in the fixture's own player table)
+removed while not a member stays completely silent **and** is still not
+enrolled; and removing an id that genuinely is a current member behaves
+exactly as before (silent, genuinely removed). Full suite:
+`rpg2k_scene_check.rb` 943 passed (unchanged, no `scene/map.rb` touched);
+`rpg2k_logic_check.rb` 1184 → **1185** passed (the one new check);
+`rpg2k_render_check.rb` 41 passed (unchanged); `rpg2k3_battle_row_check.rb`
+19/0 and `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged, no battle
+code touched); `rpg2k_save_load_check.rb` still reports exactly the same 1
+known pre-existing failure (the unrelated Show Picture field-shape
+mismatch), unaffected. No `.cxx`/`.hxx` file was touched (pure `mrblib`
+Ruby plus a check-script addition), so the pinned `clang-format` step does
+not apply; `cd build && ninja` clean rebuild succeeded; `ctest -R
+mruby_test` passed (8.60s). No wine session was run this cycle — the fix
+is inferred by symmetry with Add's own already-established, already-tested
+behaviour (both branches of the same command resolve the identical
+`cmd.param`-sourced id) rather than independently confirmed against genuine
+RPG_RT, the same honesty standard this catalog's own sibling entries
+(Call Event, Enemy Encounter, the Move-Route entry just above) already
+apply to themselves.
 ✅ **Terrain's `footstep` and `on_damage_se` fields (chunk 16 elements 15/16)
 are wired up** — ~~parsed by `mruby-lcf/mrblib/schema.rb` since the terrain
 chunk was first decoded (ADR 0034)~~ (see the Follow-up below — `footstep`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3665,6 +3665,25 @@ module Game
     # naming an actor does not enrol them in the roster the save writes out.
     def existing(id); id.nil? ? nil : @all[id]; end
 
+    # Whether `id` is a genuinely dangling reference -- a positive id with no
+    # matching database row at all -- **without** instantiating (and so
+    # without enrolling) the actor the way #[] does. A caller that only needs
+    # to tell "not currently relevant" apart from "this id doesn't even exist
+    # in the database" (#remove_actor's own no-op case, below) must not
+    # enroll a merely-never-met-but-otherwise-valid actor into the save data
+    # as a side effect of asking. Logs and dedupes through the exact same
+    # `@missing` table and message #[] uses, so an id already reported by one
+    # path doesn't double-report through the other.
+    def known_invalid?(id)
+      return false if id.nil? || id <= 0 || @all[id]
+      return false if @db.player[id]
+      unless @missing[id]
+        @missing[id] = true
+        $stderr.puts "[RPG2k] actor ##{id} could not be built: No such actor: #{id}"
+      end
+      true
+    end
+
     # Every instantiated actor, in ascending database id order.
     def all; @all.keys.sort.map { |i| @all[i] }; end
 
@@ -4055,6 +4074,20 @@ module Game
       before = @actors.size
       @actors.reject! { |a| a.id == id }
       @revision += 1 unless @actors.size == before
+      return unless @actors.size == before
+      # The id matched no current member -- the ordinary "not currently in
+      # the party" case, harmless and silent. But #add_actor already reports
+      # a positive id with no matching database row at all (a database
+      # shrink leaving a stale Change Party Member target, the "invalid
+      # hero" catalog case) via its own #roster[] lookup; #remove_actor had
+      # no equivalent check at all, so the identical stale id silently did
+      # nothing with no trace when the command's "Remove" radio button
+      # happened to be selected instead of "Add". #known_invalid? reports
+      # that exact same case without #[]'s side effect of building and
+      # enrolling the actor into the save data -- unlike Add, a Remove of a
+      # merely-never-met-but-otherwise-valid actor must not have that
+      # side effect.
+      @roster.known_invalid?(id)
     end
 
     # Make an already-rostered actor the leader (party slot 0). If they are

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6011,6 +6011,39 @@ check 'add_actor no-ops once the party already holds MAX_SIZE (4) members' do
      'adding is allowed again once a member has left and freed a slot'
 end
 
+check 'Change Party Member "Remove" targeting a dangling hero id reports the ' \
+      'same diagnostic Add already does, without enrolling the id into the ' \
+      'roster the save writes out' do
+  db = roster_db
+  party = Game::Party.new(db)
+
+  out = capture_stderr { party.remove_actor(99) }
+  ok out.include?('[RPG2k] actor #99 could not be built: No such actor: 99'), out
+  eq [1], party.roster.all.map(&:id), 'the dangling id was NOT built-and-enrolled ' \
+                                      '(only the starting leader, #1, is)'
+
+  # A second occurrence of the same dangling id is deduped, matching #[]'s
+  # own "logs once" behaviour (they share one @missing table).
+  out2 = capture_stderr { party.remove_actor(99) }
+  eq '', out2
+
+  # Removing an id that is simply not a *current* member -- but genuinely
+  # exists in the database -- stays completely silent, the ordinary case,
+  # and correctly does not enroll them either (matching the "merely naming
+  # an actor" rule #existing's own doc comment already establishes for a
+  # read path like `\N[n]`).
+  out3 = capture_stderr { party.remove_actor(2) }
+  eq '', out3
+  eq [1], party.roster.all.map(&:id), 'a valid-but-never-met id is not enrolled by a Remove either'
+
+  # Removing an id that *is* a current member behaves exactly as before:
+  # silent, no diagnostic, genuinely removed.
+  party.add_actor(2)
+  out4 = capture_stderr { party.remove_actor(2) }
+  eq '', out4
+  eq false, party.include_actor?(2)
+end
+
 check 'Party#reorder applies a picked front-to-back permutation, ' \
       'and can change the leader' do
   # RPG2003's Order menu command -- see Scene::Order (mruby-rpg2k/mrblib/


### PR DESCRIPTION
## Summary

`Game::Party#remove_actor` never consulted the roster at all, only filtered the current party list by id — so a dangling/database-shrunk hero id reaching Change Party Member's Remove branch silently no-opped with no trace, unlike the Add branch (which shares the identical `cmd.param`-sourced id) already reporting it via `Game::Actors#[]`'s existing `"[RPG2k] actor #<id> could not be built"` diagnostic. This closes the "invalid hero" case of the runtime error catalog in `docs/TODO.md` — the only one of its four named categories that was still unreported.

Fixed with a new `Game::Actors#known_invalid?(id)` that checks the database directly (sharing `#[]`'s message and dedup table) **without** instantiating-and-enrolling the actor into the save data the way `#[]` does — Remove of an ordinary, valid-but-never-met id must not have that side effect, unlike Add, which legitimately needs the actor object.

## Verification

- `scripts/rpg2k_logic_check.rb`: 1185 passed (1184 baseline + 1 new check covering: dangling id via Remove logs and isn't enrolled; dedup on repeat; a valid-but-never-met id stays silent and unenrolled; removing a genuine member is unaffected)
- `scripts/rpg2k_scene_check.rb`: 943 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: still exactly 1 known pre-existing failure (unrelated Show Picture field-shape issue), unchanged
- `cd build && ninja`: clean rebuild, no new warnings (no `.cxx`/`.hxx` touched, pure `mrblib` Ruby)
- `ctest -R mruby_test`: passed
- New check confirmed to fail against the pre-fix code before the fix

No wine session was run this cycle, and no EasyRPG source was consulted for this fix's own behavioral claim — it's inferred by symmetry with Add's own already-established, already-tested diagnostic for the identical `cmd.param`-resolved id, matching the disclosed-inference standard several sibling entries in the same runtime-error catalog already apply to themselves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_