### PR TITLE
Tilemap#z= now shifts the priority "above" layer with it

### DIFF
--- a/changelog.d/tilemap-z-above-layer-offset.fixed.md
+++ b/changelog.d/tilemap-z-above-layer-offset.fixed.md
@@ -1,0 +1,11 @@
+- Fixed a real gap in `mruby-rgss`: reassigning a native `Tilemap`'s `z`
+  (e.g. a script moving the tilemap behind/above some other z-managed
+  object) never moved its priority "above" layer along with it. The above
+  layer is a second, internal LVGL canvas holding priority-tile pixels
+  (roofs, tree crowns) so they sort over the character sprites; its own `z`
+  used to be set once at construction and never touched again, so a script
+  that ever reassigned `tilemap.z` broke the "above sorts higher than the
+  tilemap itself" relationship the two layers are supposed to keep in
+  lockstep -- only the ground canvas actually moved. `Tilemap#z=` now keeps
+  the above layer pinned a fixed offset above the tilemap's own `z`, the
+  same propagation `Tilemap#visible=` already had to learn for visibility.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -29764,6 +29764,90 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   and a follow camera. Remaining: per-row priority interleaving rather than one
   flat above-layer (ADR 0022), and the character effects the sprites ignore —
   opacity, blend mode, hue and step animation.
+  ✅ **Follow-up (cycle #211, 2026-08-28): `Tilemap#z=` never moved the
+  priority "above" layer along with it.** Method: per the standing
+  instruction to pick a genuinely different area from cycles #206-210's
+  Event-system run, skimmed broadly first — Menus/save/battle, the
+  `2k/09_bug/`/`2k/01_shoshin/011_siyou/` untriaged backlogs, the
+  Full-site-sweep's per-topic clusters (Message window, Battle system,
+  Party/Actor/Vehicle, Save/Load persistence, Database field semantics),
+  the viprpg-dev wiki backlog, VX/VX Ace — and found nearly every leaf
+  bullet already carries its own ✅, the handful of genuinely open items
+  either explicitly flagged as too large for one cycle (the SPEED_UP
+  ceiling investigation, the within-frame Autorun-restart feature, the
+  デフォ戦botまとめ 140-item dump) or event/movement-adjacent (the
+  Approach-Hero-plus-Autorun freeze **Bug** bullet a few thousand lines up).
+  Re-ran `scripts/rpg2k_field_audit.rb` for a fresh, code-grounded lead
+  instead: of its 8 unread-field hits, 6 (`system.battle_test_*`,
+  `saved_times`, `selected_condition`, `maker_version`) are already
+  self-documented in `mruby-lcf/mrblib/schema.rb` as editor-only "Battle
+  test"/"Battle animation editor leftovers" bookkeeping RPG_RT itself never
+  reads, and the 2 RPG2003 `terrain.grid_location`/`battlecommands.
+  section_flags_24` fields have no established formula anywhere this
+  codebase can cite (the schema's own comment on the latter says so
+  outright) — implementing either from a guessed formula would violate
+  this project's own evidence-based standard, not a one-cycle task. Pivoted
+  to `docs/rpgxp-rgss-api-gap.md`'s own still-open Tilemap item instead
+  (RGSS-side rendering, a suggested area, and unlike the RPG2000-side items
+  above this doc had marked it explicitly unresolved, not merely
+  unmentioned): "`z=` on the tilemap does not yet shift the above layer's
+  fixed `z`." Confirmed genuinely reachable, not just theoretical: the
+  priority "above" layer (`tilemap_init`, `mruby-rgss/src/lib.cxx`) is a
+  second, independent LVGL canvas registered for z-ordering with its own
+  `@z` pinned to the file-scope `TILEMAP_ABOVE_Z` constant (900) once, at
+  construction — `tilemap`'s own generic `z=` (`obj_set_z`, shared by every
+  Sprite/Viewport/Plane/Window/Tilemap) only ever touched `self`'s `@z`,
+  never the above object's, so a script reassigning a tilemap's `z` (moving
+  it behind/above some other z-managed object, e.g. a HUD viewport) broke
+  the "above sorts over the ground/characters" relationship the two layers
+  are supposed to keep in lockstep — exactly the same "companion propagation"
+  gap `tilemap_set_visible` already had to close for visibility a few
+  functions above it in the same file (its own comment: "the above canvas
+  is a separate LVGL object that obj_set_visible on the tilemap alone would
+  leave showing"), just never extended to `z=`. Fixed with a new
+  `tilemap_set_z` (mirroring `tilemap_set_visible`'s shape): sets `self`'s
+  `@z` as before, then — when `@_tm_above_obj` is set — pins the above
+  object's own `@z` to `z + TILEMAP_ABOVE_Z`, preserving the fixed 900-unit
+  gap across any reassignment instead of leaving the above layer frozen at
+  its original construction-time value; registered in place of the shared
+  `obj_set_z` for the `Tilemap` class only, every other class untouched.
+  **Verification:** since the mrbtest binary has no live display (`Tilemap.
+  new` needs `lv_canvas_create`/a real display, which the headless test
+  harness lacks — the existing "RGSS::Tilemap API surface" test already
+  documents this and only asserts the method surface), the new
+  `mruby-rgss/test/test.rb` check instead uses `RGSS::Tilemap.allocate`
+  (no native construction, matching the existing `Sprite#width`/`#height`
+  test's identical technique) with a plain `Object.new` standing in for the
+  above canvas — `tilemap_set_z` never dereferences `self`'s own native
+  pointer, only ivars, so this exercises the real C function safely without
+  a display. Asserts the above stand-in's `@z` tracks two different
+  reassigned tilemap `z` values by the *same* fixed offset (not a specific
+  hardcoded number, so the test does not encode `TILEMAP_ABOVE_Z`'s own
+  value) and that a bare `Tilemap.allocate` with no above-layer ivar at all
+  does not raise. Confirmed to fail against the pre-fix code first
+  (`git stash`/`git stash pop` on just `mruby-rgss/src/lib.cxx`, rebuild,
+  rerun): `NoMethodError: undefined method '-' for NilClass` (the above
+  stand-in's `@z` was never touched, so `instance_variable_get(:@z)` read
+  `nil`) — then passed clean after restoring the fix. Full suite (only
+  `mruby-rgss`/RGSS-side code touched, not `mruby-rpg2k`, so no change
+  expected and none seen): `rpg2k_scene_check.rb` 943, `rpg2k_logic_
+  check.rb` 1185, `rpg2k_render_check.rb` 41, `rpg2k3_battle_row_check.rb`
+  19/0, `rpg2k3_battle_gauge_check.rb` 15/0 all unchanged; `rpg2k_save_
+  load_check.rb` still reports exactly the same 1 known pre-existing
+  failure (the unrelated Show Picture field-shape mismatch), unaffected.
+  `mruby-rgss/src/lib.cxx` run through the pinned `clang-format` 22.1.8
+  (no reformatting beyond the new code — clean diff); `cd build && ninja`
+  clean rebuild succeeded; `ctest -R mruby_test` passed. No wine session
+  was run this cycle: this is this project's own internal rendering
+  approximation (the "above" canvas split has no counterpart in real RGSS
+  at all — a genuine Tilemap draws priority tiles inline, per-row, with no
+  separate object), not an RPG_RT/RGSS behavioral claim, so there is
+  nothing external to verify against; correctness here is purely "does
+  this engine's own two-canvas approximation stay internally consistent
+  when a script moves the tilemap," which the new unit test pins directly.
+  `docs/rpgxp-rgss-api-gap.md`'s own Tilemap section updated to record the
+  fix and drop this item from its "Remaining" list (the per-row scheme
+  itself and `flash_data` are unaffected, still open).
 - ~~🚧 **Event system**~~ — **superseded, not current.** This bullet describes
   the reimplemented `mruby-rpgxp/mrblib/interpreter.rb` `Game::Interpreter` /
   `game.rb` party-actor model that used to stand in for a game's own scripts;

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -556,9 +556,14 @@ characters — is designed in
 [ADR 0022](adr/0022-rpgxp-tilemap-priority-layering.md) and remains the follow-up.
 `tileset=`, `map_data=`, `priorities=`, `ox=`/`oy=`, `z=`, `update`,
 `visible`/`visible=`, `dispose`/`disposed?` are native and re-render on change.
-`visible=` hides the above layer along with the ground. **Remaining:** the per-row
-priority scheme (ADR 0022); `z=` on the tilemap does not yet shift the above
-layer's fixed `z`; and `flash_data` is still ignored.
+`visible=` hides the above layer along with the ground. `z=` now keeps the
+above layer pinned a fixed offset above the tilemap's own `z` too (cycle
+#211, `tilemap_set_z`, `mruby-rgss/src/lib.cxx`) — it used to leave the
+above layer at its construction-time `z` forever, so a script reassigning a
+tilemap's `z` broke the "above sorts over the ground" relationship the two
+layers are supposed to keep in lockstep, the same gap `visible=` already had
+to close for visibility a few lines above. **Remaining:** the per-row
+priority scheme (ADR 0022); `flash_data` is still ignored.
 
 ### 4. `Plane` ✅ (tiling + scroll + tint/blend + zoom all rendered)
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -5326,6 +5326,29 @@ mrb_value tilemap_set_visible(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// Sets the tilemap's own z and keeps the priority "above" layer pinned
+// TILEMAP_ABOVE_Z higher than it, the same z= propagation
+// tilemap_set_visible already does for visibility. The generic obj_set_z
+// only ever touched `self`'s own `@z`; the above canvas (`@_tm_above_obj`,
+// a separate LVGL object of its own -- see tilemap_init) was left at its
+// construction-time z forever, so a script that ever reassigned a
+// tilemap's z (moving it behind/above some other z-managed object) lost
+// the "above sorts over characters" relationship the two layers are
+// supposed to keep in lockstep, since only the ground canvas actually
+// moved.
+mrb_value tilemap_set_z(mrb_state* M, mrb_value self) {
+  mrb_int z;
+  mrb_get_args(M, "i", &z);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@z"), mrb_fixnum_value(z));
+  const mrb_value above =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_above_obj"));
+  if (mrb_test(above))
+    mrb_iv_set(M, above, mrb_intern_lit(M, "@z"),
+               mrb_fixnum_value(z + TILEMAP_ABOVE_Z));
+  update_z(M);
+  return self;
+}
+
 // Real RGSS treats `ox`/`oy` as a cheap, hardware-composited draw offset --
 // stock Spriteset_Map#update reassigns it every single frame regardless of
 // whether the camera actually moved. This engine instead re-composites the
@@ -6848,7 +6871,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, tilemap, "ox=", tilemap_set_ox, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "oy=", tilemap_set_oy, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "update", tilemap_update, MRB_ARGS_NONE());
-  mrb_define_method(M, tilemap, "z=", obj_set_z, MRB_ARGS_REQ(1));
+  mrb_define_method(M, tilemap, "z=", tilemap_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, tilemap, "visible=", tilemap_set_visible,
                     MRB_ARGS_REQ(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -2407,6 +2407,39 @@ assert "RGSS::Tilemap API surface" do
   end
 end
 
+# The priority "above" layer (see tilemap_init/lib.cxx) is a second, separate
+# LVGL object holding priority-tile pixels (roofs, tree crowns) so they sort
+# over the character sprites. Its own `z` used to be set once at construction
+# and never touched again -- only `self`'s own `@z` moved when a script
+# assigned `tilemap.z = ...`, so the "above sorts higher than the tilemap"
+# relationship the two layers are supposed to keep in lockstep drifted apart
+# the moment a script ever reassigned a tilemap's z (`tilemap_set_visible`
+# right above already had to learn this same "propagate to the above layer"
+# lesson for visibility; z= never did). `Tilemap.allocate` (no live display
+# needed, like the Sprite#width/#height test above -- `z=` never touches the
+# native LVGL pointer, only ivars) with a plain stand-in object standing in
+# for the above canvas is enough to prove the offset without a real display.
+assert "RGSS::Tilemap#z= keeps the priority \"above\" layer offset above it" do
+  tm = RGSS::Tilemap.allocate
+  above = Object.new
+  tm.instance_variable_set(:@_tm_above_obj, above)
+
+  tm.z = 100
+  offset = above.instance_variable_get(:@z) - 100
+  tm.z = 500
+  assert_equal offset, above.instance_variable_get(:@z) - 500,
+               "above layer must track a reassigned tilemap z by a fixed offset"
+  tm.z = -2000
+  assert_equal offset, above.instance_variable_get(:@z) - (-2000),
+               "above layer must track a reassigned tilemap z by a fixed offset"
+
+  # A Tilemap with no above-layer ivar set at all (never went through
+  # tilemap_init, e.g. this same #allocate) must not raise.
+  bare = RGSS::Tilemap.allocate
+  bare.z = 42
+  assert_equal 42, bare.instance_variable_get(:@z)
+end
+
 # RGSS::Sprite.new needs an initialized display (it references RGSS::_display),
 # which the headless mrbtest build does not set up, so the Sprite extended
 # properties cannot be exercised here — they are load-verified with the rest of

--- a/scripts/rgss_cruby_compat.rb
+++ b/scripts/rgss_cruby_compat.rb
@@ -1967,8 +1967,23 @@ module RGSS
       nil
     end
 
+    # Mirrors tilemap_set_z (mruby-rgss/src/lib.cxx, cycle #211): the native
+    # side keeps the priority "above" layer (@_tm_above_obj, a real ivar only
+    # under a live Tilemap that went through tilemap_init -- absent here,
+    # this compat class has no such object of its own) offset a fixed amount
+    # above the tilemap's own z on every reassignment. This compat class
+    # never actually builds an above layer, but scripts/rgss_cruby_test_check.rb
+    # runs mruby-rgss/test/test.rb's own "z= keeps the priority above layer
+    # offset above it" check against this shim too, and that check pokes
+    # @_tm_above_obj directly to stand in for it -- so this needs the same
+    # propagation the native side has, or that one shared test diverges
+    # between the two hosts.
+    TILEMAP_ABOVE_Z = 900
+
     def z=(v)
       @z = v
+      above = instance_variable_get(:@_tm_above_obj)
+      above.instance_variable_set(:@z, v + TILEMAP_ABOVE_Z) if above
     end
 
     attr_reader :visible


### PR DESCRIPTION
## Summary

The native RGSS `Tilemap`'s priority "above" canvas (roofs/tree crowns sorting over characters) had its own `z` pinned to `TILEMAP_ABOVE_Z` once at construction and never touched again, so a script reassigning a tilemap's `z` broke the "above sorts over the ground" relationship the two layers are supposed to keep in lockstep — the same companion-propagation gap `Tilemap#visible=` already had to close for visibility.

Fixed with a new `tilemap_set_z` that keeps the above layer offset by a fixed amount (`TILEMAP_ABOVE_Z`) above the tilemap's own `z` on every reassignment. Verified the offset formula against `tilemap_init`'s own construction-time values: `register_zobj` initializes the tilemap's own `@z` to `0`, and the above layer is set to `TILEMAP_ABOVE_Z` directly at construction — exactly `0 + TILEMAP_ABOVE_Z`, matching the new `z + TILEMAP_ABOVE_Z` formula.

Covered by a new `mruby-rgss/test/test.rb` check (`RGSS::Tilemap.allocate`, no live display needed — `z=` never touches the native LVGL pointer, only ivars), confirmed to fail against the pre-fix code before the fix.

**Follow-up commit**: the first push's CI failed on "RGSS mrbtest suite under CRuby" — that job runs the same `test.rb` against `scripts/rgss_cruby_compat.rb`'s pure-Ruby compatibility shim, which never learned the same above-layer propagation `tilemap_set_z` gained natively, so the new check's `NoMethodError: undefined method '-' for nil` diverged between hosts. Fixed by mirroring the identical `TILEMAP_ABOVE_Z` offset in the compat shim's own `Tilemap#z=`. Reproduced and confirmed fixed locally via `ruby scripts/rgss_cruby_test_check.rb`.

## Verification

- `mruby-rgss` unit test (`ctest -R mruby_test`): passed
- `ruby scripts/rgss_cruby_test_check.rb` (the CRuby compat host CI failed on): passed
- Touched `.cxx` file verified against the exact CI-pinned `clang-format==22.1.8` (no diff)
- `cd build && ninja`: clean rebuild, no new warnings
- Full rpg2k check suite reconfirmed unchanged, since only RGSS-side code was touched: `scripts/rpg2k_scene_check.rb` 943, `rpg2k_logic_check.rb` 1185, `rpg2k_render_check.rb` 41, `rpg2k3_battle_row_check.rb` 19/0, `rpg2k3_battle_gauge_check.rb` 15/0, `rpg2k_save_load_check.rb`'s 1 known pre-existing failure unaffected

**Honest limitation**: This fix targets this engine's own internal two-canvas rendering approximation (the "above" layer split has no counterpart in real RGSS at all — a genuine Tilemap draws priority tiles inline per-row with no separate object), not an RPG_RT/RGSS behavioral claim, so there's nothing external to verify against — correctness here is purely internal consistency (does the approximation stay coherent when a script moves the tilemap), which the new unit test pins directly. No wine session was needed or run.

Per standing project convention, EasyRPG Player's C++ source was not consulted for any behavioral claim in this change.
