### PR TITLE
Fix mruby's missing Array#include? and interpreter-side per-frame allocation

### DIFF
--- a/changelog.d/array-include-and-control-vars-range.changed.md
+++ b/changelog.d/array-include-and-control-vars-range.changed.md
@@ -1,0 +1,53 @@
+- **`Array#include?` no longer allocates a Proc on every call, engine-wide.**
+  The headline find of this round: mruby's `Array` class has no native
+  `#include?` of its own — there is no such entry in mruby's `src/array.c` or
+  `mruby-array-ext` — so it falls through to `Enumerable#include?`
+  (`self.each {|*val| return true if val.__svalue == obj }`), which allocates
+  a Proc plus its closure env on *every single call*, however small the
+  array or however early it returns. A per-condition-type
+  `RGSS::Profiler.stats[:object_types]` pass tracing `Scene::Map
+  #step_parallels`'s dominant remaining allocation cost down through
+  `Game::Interpreter#do_conditional` → `#actor_condition` landed on
+  `Game::Actor#state?`'s `@states.include?` — one of dozens of `.include?`
+  call sites across the whole engine (skills, equipment, party membership,
+  the RPG2000 interpreter's own command handlers, ...) that all pay the
+  identical tax. Fixed once, for everything, with a plain index-loop
+  `Array#include?` override in `mruby-rgss/mrblib/array_include.rb`
+  (engine-wide like `array_sort.rb`'s `Array#sort`/`#sort!` fix beside it,
+  not RPG2000-specific) — same ISO-15.3.2.2.10 `==`-based semantics, zero
+  allocation.
+
+- **`Game::Interpreter#range` returns the `Range` its two callers immediately
+  rebuilt anyway, instead of a throwaway `[a, b]` Array.** Control
+  Switches/Variables' shared range-resolver built a 2-element Array every
+  single call — the dominant single source of interpreter-side per-command
+  Array churn, per the same profiling pass — that both `#do_control_switches`
+  and `#do_control_vars` immediately destructured and then reconstructed
+  into `(a..b)` to iterate. `#range` now returns that `Range` directly, reused
+  for the iteration rather than rebuilt; `#begin`/`#end` give a caller that
+  still needs the two scalars separately (`#do_control_vars`'s own `a < b`
+  check and range-variable split) the identical values. Both callers also
+  skip the iteration itself for the overwhelmingly common single-target case
+  (`a == b` — a plain `Var[5] = ...`, not a batch `Var[1..5] = ...`), which
+  otherwise still paid a block's Proc+env for a one-element Range every call.
+
+- **`Game::Party#include_actor?`/`#actor_by_id`/`#any_alive?` no longer use
+  `#any?`/`#find` blocks** for the same reason, on the same call path
+  (`#include_actor?` backs Conditional Branch's "actor in party"
+  sub-condition) — plain `while` loops instead.
+
+  Measured with the same temporary per-frame instrumentation used for this
+  round's other fixes (reverted before commit), clean A/B on the identical
+  deterministic Nepheshel run: **Array allocations 71.2 → 67.1 per frame,
+  Proc 31.6 → 27.5, env 20.5 → 16.5** in this run's own capture window — and
+  since `Array#include?` is engine-wide rather than scoped to whatever this
+  one map's background Parallel Processes happen to poll, its real impact
+  reaches every scene (menus, battle, every other `.include?` call site) this
+  capture never exercises.
+
+  Verified against `ctest -R mruby_test` (the one check that runs the real
+  compiled mruby binary with `array_include.rb` loaded, covering every
+  bundled gem's own test suite — mruby-rgss, mruby-rpg2k, mruby-rpgxp,
+  mruby-rpgvx, mruby-mvjs alike), `scripts/rpg2k_command_soak.rb` (368,332
+  real event commands across both Nepheshel variants), and the rest of the
+  RPG2000 logic/render/scene checks — all pass, unchanged.

--- a/changelog.d/call-stack-snapshot-no-enumerator.changed.md
+++ b/changelog.d/call-stack-snapshot-no-enumerator.changed.md
@@ -1,0 +1,35 @@
+- **Two more unconditional per-frame allocators found via
+  `RGSS::Profiler.stats[:object_types]`, both outside `Scene::Map`'s draw
+  path this time — in the interpreter's own state-snapshotting.**
+  - **`Game::Interpreter#call_stack_snapshot`** (`Scene::Map
+    #record_foreground_event_exec`'s own every-frame call, backing the
+    Save/Continue call-stack persistence added in cycle #191) built
+    `@call_stack + [[@list, live_index, ...]]` — two extra array literals to
+    hold the current frame's own tuple — then walked the result via
+    `#each_with_index.map`, which allocates an Enumerator, boxes one `[item,
+    index]` pair per iteration, and allocates a Proc plus its closure env for
+    the block. Rewritten as a preallocated `Array.new(n + 1)` filled by a
+    plain `while` loop, with the current (innermost) frame handled once
+    after it since it never actually lived in `@call_stack`. Same per-frame
+    values (checked against `rpg2k_logic_check.rb`'s existing
+    `#call_stack_snapshot` unit tests, which already cover the nested-Call-
+    Event multi-frame case and the Key Input Proc rewind this rewrite has to
+    reproduce exactly): measured **16 → 2 Array allocations per frame** on
+    this section, in the same profiler run used for the rest of this round's
+    fixes.
+  - **`Game::Map#substitution_snapshot`** (`Scene::Map
+    #record_tile_substitutions`'s own every-frame call) unconditionally
+    `dup`'d both Tile Substitution tables every frame regardless of whether
+    a substitution had ever actually run — Tile Substitution itself is a
+    rare command. The dup'd pair is now cached and only rebuilt when
+    `@substitutions[0]`/`[1]` are no longer the same objects last dup'd
+    from: `#substitute_tile` and `#restore_substitutions` both only ever
+    *reassign* those slots to a fresh Hash/Array, never mutate one in place,
+    so an unchanged object identity really does mean unchanged contents.
+    Measured **~1.0 → ~0.0 Array allocations per frame** on this section
+    (no substitution ever ran during the capture window).
+
+  Verified against `scripts/rpg2k_command_soak.rb` (368,332 real event
+  commands across both Nepheshel variants), `scripts/rpg2k_logic_check.rb`'s
+  dedicated `#call_stack_snapshot`/`#restore_call_stack` unit tests, and the
+  rest of the RPG2000 logic/render/scene checks — all pass, unchanged.

--- a/mruby-rgss/mrblib/array_include.rb
+++ b/mruby-rgss/mrblib/array_include.rb
@@ -1,0 +1,39 @@
+# Array#include? without mruby's own Enumerable#include? block allocation.
+#
+# mruby's Array class has no native #include? of its own -- there is no
+# MRB_SYM(include?) entry in 3rd/mruby/src/array.c or mruby-array-ext -- so it
+# falls through to Enumerable#include? (3rd/mruby/mrblib/enum.rb):
+#
+#     def include?(obj)
+#       self.each {|*val|
+#         return true if val.__svalue == obj
+#       }
+#       false
+#     end
+#
+# Every single call allocates a Proc plus its closure env for that block, no
+# matter how small the array or how early it returns. Confirmed the single
+# largest remaining source of interpreter-side Proc/env churn in a real
+# playthrough by a per-condition-type RGSS::Profiler.stats[:object_types]
+# pass: it traced straight to Game::Actor#state?'s `@states.include?`, one of
+# dozens of .include? call sites across the engine (Game::Actor#knows_skill?/
+# #equipped? alongside it, Game::Party, the RPG2000 interpreter's own command
+# handlers, ...) that all pay the identical tax on every call.
+#
+# A plain index loop calling #== directly gives the identical ISO-15.3.2.2.10
+# semantics -- Enumerable#include? also compares with == -- with no block and
+# so no allocation.
+#
+# Engine-wide rather than RGSS-only, like array_sort.rb's Array#sort/#sort!
+# fix beside this file: this is mruby's own gap, not this game's.
+class Array
+  def include?(obj)
+    i = 0
+    n = length
+    while i < n
+      return true if self[i] == obj
+      i += 1
+    end
+    false
+  end
+end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6362,9 +6362,21 @@ module Game
     # A snapshot ({old_id => new_id} per layer) safe to stash on Game::State
     # for a Save/Continue -- see Scene::Map#record_tile_substitutions -- dup'd
     # so later #substitute_tile calls on the live map cannot mutate a saved
-    # copy out from under it.
+    # copy out from under it. Called every frame regardless of whether a
+    # substitution ever ran (Tile Substitution itself is a rare command), so
+    # the dup'd pair is cached and only rebuilt when @substitutions[0]/[1]
+    # are no longer the same objects last dup'd from -- #substitute_tile and
+    # #restore_substitutions both only ever *reassign* those slots to a fresh
+    # Hash/Array, never mutate one in place, so an unchanged object identity
+    # here really does mean unchanged contents.
     def substitution_snapshot
-      [@substitutions[0].dup, @substitutions[1].dup]
+      lower = @substitutions[0]
+      upper = @substitutions[1]
+      return @substitution_snapshot_cache if @substitution_snapshot_src_lower.equal?(lower) &&
+                                              @substitution_snapshot_src_upper.equal?(upper)
+      @substitution_snapshot_src_lower = lower
+      @substitution_snapshot_src_upper = upper
+      @substitution_snapshot_cache = [lower.dup, upper.dup]
     end
 
     # Reapply a snapshot taken by #substitution_snapshot (real RPG_RT's own

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3911,11 +3911,44 @@ module Game
       end
     end
 
-    def include_actor?(id); @actors.any? { |a| a.id == id }; end
-    def actor_by_id(id); @actors.find { |a| a.id == id }; end
+    # Plain while loops instead of #any?/#find blocks -- Conditional Branch's
+    # "actor in party" sub-condition (actor_condition, interpreter.rb) calls
+    # #include_actor? every time it runs, confirmed via a per-condition-type
+    # RGSS::Profiler.stats[:object_types] pass to be the single largest
+    # source of interpreter-side Proc/env churn in a real playthrough -- a
+    # block literal allocates a Proc plus its closure env on every call in
+    # this mruby, however small the block body.
+    def include_actor?(id)
+      i = 0
+      n = @actors.size
+      while i < n
+        return true if @actors[i].id == id
+        i += 1
+      end
+      false
+    end
+
+    def actor_by_id(id)
+      i = 0
+      n = @actors.size
+      while i < n
+        a = @actors[i]
+        return a if a.id == id
+        i += 1
+      end
+      nil
+    end
 
     # Whether any party member is still standing. An empty party counts as wiped.
-    def any_alive?; @actors.any? { |a| !a.dead? }; end
+    def any_alive?
+      i = 0
+      n = @actors.size
+      while i < n
+        return true unless @actors[i].dead?
+        i += 1
+      end
+      false
+    end
 
     # Whether the whole party is knocked out (戦闘不能) -- the game-over condition.
     def all_dead?; !any_alive?; end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1868,6 +1868,17 @@ module Game
 
     # -- state commands -------------------------------------------------------
 
+    # Returns a Range rather than the [a, b] pair the name might suggest: both
+    # callers immediately turn a/b right back into (a..b) to iterate it, so
+    # building the Range once here and handing it straight to them skips both
+    # that redundant reconstruction and the throwaway 2-element Array a plain
+    # `a, b = range(cmd)` destructure would otherwise cost on every single
+    # Control Switches/Variables command -- confirmed the dominant single
+    # source of interpreter-side per-command Array churn by a section-level
+    # RGSS::Profiler.stats[:object_types] pass. #begin/#end on the result give
+    # back the same two scalars for a caller that still needs them separately
+    # (#do_control_vars, for its own `a < b` check and the range-variable
+    # split).
     def range(cmd)
       mode = cmd.param(0)
       a = cmd.param(1)
@@ -1880,26 +1891,36 @@ module Game
         # variable slot 0 or a negative one. An already-empty range gets the
         # same "does nothing" result do_control_switches/do_control_vars
         # already produce for a descending batch range.
-        return [1, 0] if a <= 0
+        return 1..0 if a <= 0
         b = a
       end
-      [a, b]
+      a..b
     end
 
     def do_control_switches(cmd)
-      a, b = range(cmd)
       op = cmd.param(3) # 0 on, 1 off, 2 toggle
-      (a..b).each do |id|
-        case op
-        when 0 then switches[id] = true
-        when 1 then switches[id] = false
-        when 2 then switches.flip(id)
-        end
+      r = range(cmd)
+      # The overwhelmingly common case (a single-switch target, mode 0 or a
+      # resolved-to-one-id mode 2) needs no iteration at all -- skip straight
+      # to #set_switch instead of paying a block's Proc+env for a one-element
+      # Range every single time. A genuine multi-id batch (mode 1) still
+      # walks the whole range.
+      return set_switch(r.begin, op) if r.begin == r.end
+      r.each { |id| set_switch(id, op) }
+    end
+
+    def set_switch(id, op)
+      case op
+      when 0 then switches[id] = true
+      when 1 then switches[id] = false
+      when 2 then switches.flip(id)
       end
     end
 
     def do_control_vars(cmd)
-      a, b = range(cmd)
+      r = range(cmd)
+      a = r.begin
+      b = r.end
       op = cmd.param(3)  # 0 =, 1 +, 2 -, 3 *, 4 /, 5 %
       # A random operand (type 3) rolls independently for each variable in the
       # range, matching RPG_RT -- a batch "Var[1..5] = random 1~6" is five
@@ -1922,8 +1943,15 @@ module Game
       # operand out of the same range it writes).
       live = cmd.param(4) == 3 || cmd.param(4) == 2
       return do_control_vars_range_variable(cmd, a, b, op) if !live && cmd.param(4) == 1 && a < b
+      # The overwhelmingly common case (a single-variable target) needs no
+      # iteration at all, and reading the operand exactly once either way
+      # makes "before the loop" vs. "inside its one iteration" the same
+      # moment -- skip straight to the write instead of paying a block's
+      # Proc+env for a one-element Range every single time. A genuine
+      # multi-id batch still walks the whole range.
+      return variables[a] = apply(op, variables[a], operand_value(cmd)) if a == b
       val = operand_value(cmd) unless live
-      (a..b).each { |id| variables[id] = apply(op, variables[id], live ? operand_value(cmd) : val) }
+      r.each { |id| variables[id] = apply(op, variables[id], live ? operand_value(cmd) : val) }
     end
 
     # A batch (range) Control Variables write whose operand is itself a plain

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -799,15 +799,34 @@ module Game
       # applies for its own "message window still open" case, just triggered
       # here instead of by the interpreter's own next #update.
       live_index = (@waiting && @wait_kind == :key_input) ? @index - 1 : @index
-      frames = @call_stack + [[@list, live_index, @call_frame_event_id || @event_id || 0]]
-      frames.each_with_index.map do |(list, index, event_id), i|
-        {
+      # A plain preallocated Array + while loop instead of building
+      # @call_stack + [[...]] (two more array literals to hold the current
+      # frame's own tuple) and walking it via #each_with_index.map (an
+      # Enumerator, one boxed [item, index] pair per iteration, and a block
+      # Proc+env) -- same frame-by-frame values, one Array allocated instead
+      # of one per @call_stack entry plus the Enumerator machinery. The
+      # current (innermost) frame is handled after the loop since it never
+      # actually lived in @call_stack.
+      n = @call_stack.size
+      out = Array.new(n + 1)
+      i = 0
+      while i < n
+        list, index, event_id = @call_stack[i]
+        out[i] = {
           commands: list,
           current_command: index,
           event_id: (i.zero? ? @event_id : event_id) || 0,
           triggered_by_decision_key: i.zero? && !!@triggered_by_decision_key,
         }
+        i += 1
       end
+      out[n] = {
+        commands: @list,
+        current_command: live_index,
+        event_id: n.zero? ? (@event_id || 0) : (@call_frame_event_id || @event_id || 0),
+        triggered_by_decision_key: n.zero? && !!@triggered_by_decision_key,
+      }
+      out
     end
 
     # Restore a previously #call_stack_snapshot-captured stack (or the


### PR DESCRIPTION
## Summary

Two more rounds continuing the `RGSS::Profiler.stats[:object_types]` investigation from #1436/#1438/#1447 — this time on the interpreter's own state-snapshotting and command dispatch, ending in an engine-wide mruby gap.

### Round 1: `call_stack_snapshot` / `substitution_snapshot`

- **`Game::Interpreter#call_stack_snapshot`** (backs the Save/Continue call-stack persistence, called every frame): built `@call_stack + [[...]]` — two extra array literals for the current frame's own tuple — then walked the result via `#each_with_index.map`, which allocates an Enumerator, boxes one `[item, index]` pair per iteration, and allocates a Proc plus its closure env for the block. Rewritten as a preallocated array filled by a plain `while` loop. Measured **16 → 2 Array allocations per frame** on this call, checked against `rpg2k_logic_check.rb`'s existing dedicated unit tests (nested-Call-Event multi-frame case, Key Input Proc rewind).
- **`Game::Map#substitution_snapshot`** (Tile Substitution save state, called every frame): unconditionally `dup`'d both tables even though Tile Substitution is rare and nothing had changed. Now caches the pair, only re-dupping when the underlying hashes are actually reassigned (`#substitute_tile`/`#restore_substitutions` never mutate in place).

### Round 2: `range(cmd)` and mruby's missing `Array#include?`

Used a per-command-type profiler pass (temporarily wrapping `execute` → `eval_condition` → `actor_condition`, reverted before commit) to trace `Scene::Map#step_parallels`'s dominant remaining allocation cost:

- **`Game::Interpreter#range`** built a throwaway `[a, b]` Array on every Control Switches/Variables command that both callers immediately destructured and rebuilt into `(a..b)` anyway. Now returns the `Range` directly, reused for iteration; both callers also skip iteration entirely for the common single-target case (`Var[5] = ...`, not a batch).
- **The headline finding: mruby's `Array` class has no native `#include?`.** Checked `3rd/mruby/src/array.c` and `mruby-array-ext` — genuinely absent, not project-specific. It falls through to `Enumerable#include?` (`self.each {|*val| return true if val.__svalue == obj }`), which allocates a Proc plus its closure env on *every single call*. Traced from `actor_condition` down to `Game::Actor#state?`'s `@states.include?`, one of dozens of `.include?` call sites across the whole engine (skills, equipment, party membership, the interpreter's own command handlers) all paying the identical tax. Fixed once, engine-wide, with a plain index-loop override in `mruby-rgss/mrblib/array_include.rb` — same file/pattern as the existing `array_sort.rb` fix, same `==`-based ISO-15.3.2.2.10 semantics, zero allocation.
- **`Game::Party#include_actor?`/`#actor_by_id`/`#any_alive?`** (the same call path — `#include_actor?` backs Conditional Branch's "actor in party" sub-condition) get the same `#any?`/`#find` → `while`-loop treatment.

## Measurements

Via temporary per-frame instrumentation (reverted before each commit), A/B on the identical deterministic Nepheshel run used throughout this investigation:

| | before | after |
| --- | ---: | ---: |
| Array allocs/frame (call_stack/substitution fix) | 96.2 | 94.2 |
| Array allocs/frame (range/Array#include? fix) | 71.2 | 67.1 |
| Proc allocs/frame (range/Array#include? fix) | 31.6 | 27.5 |
| env allocs/frame (range/Array#include? fix) | 20.5 | 16.5 |

Since `Array#include?` is engine-wide rather than scoped to this one map's background Parallel Processes, its real impact reaches every scene (menus, battle, every other `.include?` call site) this capture window never exercises.

## Test plan

- [x] `ctest -R mruby_test` — the one check that runs the real compiled mruby binary with `array_include.rb` loaded, covering every bundled gem's own test suite (mruby-rgss, mruby-rpg2k, mruby-rpgxp, mruby-rpgvx, mruby-mvjs alike)
- [x] `scripts/rpg2k_command_soak.rb` — 368,332 real event commands across both Nepheshel variants, clean
- [x] `scripts/rpg2k_scene_check.rb` (943 checks) — ticks the real `Scene::Map` update path
- [x] `scripts/rpg2k_render_check.rb` (41 checks)
- [x] `scripts/rpg2k_logic_check.rb` (1185 checks) — includes `call_stack_snapshot`'s own dedicated nested-Call-Event and Key Input Proc unit tests
- [x] `scripts/rpg2k_testbed_logic_check.rb` (98 checks)
- [x] `scripts/rgss_cruby_test_check.rb`

All pass, output unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_0117pag6Su2mrNWMN3QByEA3)_