### PR TITLE
Lazily allocate Tilemap's above layer; RPG2003 Call Common Event dangling-id diagnostic

### DIFF
--- a/changelog.d/rpg2k3-call-common-event-dangling-id.fixed.md
+++ b/changelog.d/rpg2k3-call-common-event-dangling-id.fixed.md
@@ -1,0 +1,11 @@
+- **RPG2003's battle-page Call Common Event command no longer swallows a
+  dangling common event id with no trace.** A database shrink can leave the
+  id it targets pointing at a common event that no longer exists — the
+  "common event" case docs/TODO.md's runtime error catalog names, already
+  reported for the map-side Call Event's own common-event mode but never
+  wired up for this RPG2003-only battle sibling. `Interpreter
+  #do_call_common_event` now logs a `[RPG2k] Call Common Event: common
+  event #<id> not found` diagnostic when the resolver has nothing for the
+  id, the same reported-not-invented shape every other entry in that
+  catalog uses; the command was already a correct, harmless no-op either
+  way (control simply continues past it), only the missing trace is new.

--- a/changelog.d/tilemap-above-layer-lazy-alloc.fixed.md
+++ b/changelog.d/tilemap-above-layer-lazy-alloc.fixed.md
@@ -1,0 +1,16 @@
+- Fixed a real resource-waste bug in `mruby-rgss`: every native `Tilemap`
+  unconditionally allocated a second, internal LVGL canvas for the priority
+  "above" layer (roofs/tree crowns sorting over character sprites) at
+  construction time, even though ADR 0022's per-row priority scheme means an
+  RPG Maker XP tilemap's own priority tiles route through the per-row strips
+  exclusively and never draw a single pixel into that companion canvas -- only
+  the VX/VX Ace tile model still uses it, as a flat "above characters" layer.
+  Every XP tilemap therefore paid a permanent, always-blank 1.17 MiB canvas
+  (at XP's 640x480) plus a wasted per-refresh viewport-tone pass walking all
+  of its pixels, for a layer that could never show anything -- dead weight on
+  every RPG Maker XP game, including the psp/wio targets this code is shared
+  with. The above layer is now allocated lazily, on the first VX-path refresh
+  that actually needs it (mirroring the same lazy shape the per-row priority
+  strips already use), and picks up whatever `z`/`visible` the tilemap already
+  has at that point rather than the fixed defaults the old eager allocation in
+  `Tilemap.new` could assume.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26364,7 +26364,7 @@ nonexistent map id — error text includes the literal missing filename;
 fixed, see the ✅ below);
 invalid hero, skill, item, enemy, enemy group, battle animation, terrain,
 chipset, common event (skill/enemy/enemy-group/battle-animation/terrain/
-chipset fixed, see the ✅ entries below; all: a database shrink leaves a
+chipset/common-event fixed, see the ✅ entries below; all: a database shrink leaves a
 dangling id reference somewhere, shown as "?" in the editor);
 event-call recursion past 1000. Several of these errors are **deferred**
 until the stale reference is actually exercised at runtime rather than
@@ -26798,6 +26798,82 @@ behaviour itself is unchanged, this is diagnostics only. Covered by a new
 alongside the unchanged blank name/graphic and default-passable/terrain
 behaviour, plus that an existing id, id `0`, a `nil` id and a chipset-less
 bare fixture all stay silent.
+✅ **Follow-up (cycle #213, 2026-08-28): RPG2003's battle-page Call Common
+Event command no longer swallows a dangling common event id with no
+trace** — the last unfixed name in the "invalid hero, skill, item, enemy,
+enemy group, battle animation, terrain, chipset, common event" list above
+(the parenthetical there previously said only "skill/enemy/enemy-group/
+battle-animation/terrain/chipset fixed", silently leaving "common event"
+off; now closed too). Method: per the standing instruction to skim broadly
+first, checked `scripts/rpg2k_field_audit.rb` (unchanged since cycle #211 —
+same 8 hits, all already self-documented editor-only bookkeeping or
+formula-less RPG2003 fields, nothing new), `docs/rpgxp-rgss-api-gap.md`'s
+own remaining items (the `Window` source-rect entry is already ✅ in
+practice, `Tilemap`'s only open item is the already-declined
+formula-less `flash_data`), and several other TODO.md sections (Message
+window text codes -- exhaustively already ported per cycle #212's own
+audit; Menu screens; Database field defaults) before finding this one:
+this runtime error catalog's own parenthetical was the one place in the
+document that still literally named an un-fixed case from a list every
+sibling entry had already closed. Confirmed genuinely reachable, not
+theoretical, by direct code reading: `Interpreter#do_call_common_event`
+(`mruby-rpg2k/mrblib/interpreter.rb`), the RPG2003-only battle-page
+sibling of the map's Call Event (mode 0), resolved its target id through
+the shared `#common_event_commands` wrapper and simply `return`ed on a
+`nil` result -- unlike `#resolve_call`'s own mode-0 branch (the map-side
+Call Event targeting a common event), which already logs `"[RPG2k] Call
+Event: common event #{id} not found"` for the identical dangling-id case.
+Fixed by mirroring `#resolve_call`'s own shape exactly: `#do_call_common_event`
+now calls `@resolver.common_event_commands(id)` directly (bypassing the
+shared wrapper, whose own genuine-exception-only rescue+log stays reserved
+for its other caller, `#start_death_handler` -- deliberately not touched
+this cycle, since its own event-id-0-means-unconfigured semantics and
+"NOT independently confirmed against genuine RPG_RT under wine" framing are
+a separate, larger question this narrow fix does not need to reopen) and
+logs `"[RPG2k] Call Common Event: common event #{id} not found"` itself
+when the lookup misses, plus its own local `rescue StandardError` (moved
+out of the shared wrapper, mirroring `#resolve_call`'s own top-level
+rescue) for the genuine-exception case. Behaviour is completely unchanged
+-- the command was already a correct, harmless no-op either way (control
+simply continues past it into the page's next command) -- only the
+missing trace is now visible, the same "diagnostics only" shape every
+other entry in this catalog already uses. Covered by a new
+`scripts/rpg2k_logic_check.rb` check (a genuine RPG2003 state with a
+resolver present but no entry for the called id logs the diagnostic and
+still lets control pass through; a resolvable target stays completely
+silent), confirmed to fail against the pre-fix code first (`git stash`/
+`git stash pop` on just `mruby-rpg2k/mrblib/interpreter.rb`:
+`RuntimeError: expected a not-found diagnostic naming id 4, got: ""`) then
+pass after. (The pre-existing "Call Common Event with no resolver or an
+unknown id is a safe no-op" check's own second half turned out to never
+actually reach the resolver at all -- it defaults to a non-RPG2003
+`new_state`, so `#do_call_common_event`'s own `rpg2003?` guard bails out
+first regardless of the resolver's contents; left as-is, since it still
+correctly covers what its own no-resolver-at-all first half claims, and
+the new check exercises the genuine RPG2003 dangling-id path it was
+missing.) **Verification:** `scripts/rpg2k_scene_check.rb` 943 passed
+(unchanged, no scene-check-reachable file touched); `rpg2k_logic_check.rb`
+1186 passed (1185 baseline + 1 new check, 0 failures); `rpg2k_render_
+check.rb` 41 passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+`rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged); `rpg2k_save_
+load_check.rb` still reports exactly the same 1 known pre-existing
+failure (the unrelated Show Picture field-shape mismatch), unaffected;
+`rpg2k3_battle_command_check.rb` still decodes cleanly (unchanged);
+`scripts/rpg2k_command_soak.rb` clean on all four test beds (184166/
+184166/4042/3430 commands, no new gaps -- only the pre-existing "Open
+Video Options" line on Ch.1, present before this cycle too; notably no
+real game bed actually exercises a dangling Call Common Event id, so the
+new diagnostic never fires there, consistent with this catalog's other
+diagnostics-only fixes). No `.cxx`/`.hxx` file was touched (pure `mrblib`
+Ruby plus a check-script addition), so the pinned `clang-format` step does
+not apply; `cd build && ninja` clean rebuild succeeded; `ctest -R
+mruby_test` passed. No RGSS-side Ruby or C++ was touched, so
+`scripts/rgss_cruby_test_check.rb` does not apply this cycle. No wine
+session was run and no EasyRPG source was consulted for this fix's own
+behavioral claim -- there isn't one: this is a pure diagnostics-only
+addition to an already-correct, already-tested no-op path, mirroring an
+established in-repo pattern (`#resolve_call`'s own identical common-event
+case) rather than introducing any new behavioral assumption.
 ✅ **The Equip and Status screens no longer show a dangling equipped item id
 with no trace** — the "item" case from the "invalid hero, skill, item,
 enemy, enemy group, battle animation, terrain, chipset, common event" list

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -29848,6 +29848,111 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   `docs/rpgxp-rgss-api-gap.md`'s own Tilemap section updated to record the
   fix and drop this item from its "Remaining" list (the per-row scheme
   itself and `flash_data` are unaffected, still open).
+  ✅ **Follow-up (cycle #212, 2026-08-28): the priority "above" layer's own
+  "Remaining" note was stale — the per-row scheme it named as a follow-up
+  had already landed — and the eager allocation behind it was a real,
+  unrelated resource-waste bug, now fixed.** Method: skimmed broadly first
+  (per the standing instruction) — `docs/TODO.md`'s own "Full-site sweep"
+  clusters, the RPG2000-side message/window text-code parser
+  (`Game::Message.scan`, exhaustively already implements `\v`/`\n`/`\c`/`\s`/
+  `\.`/`\|`/`\!`/`\^`/`\$`/`\>`/`\<`/`\\`/`\_`), `scripts/rpg2k_command_soak.rb`
+  run fresh against both real game beds (clean except the already-documented,
+  deliberate `Toggle Fullscreen`/`Open Video Options` backend-limitation
+  no-ops), `mruby-lcf/mrblib/schema.rb` and every `grep`-able "not
+  implemented"/"unimplemented" comment across `mruby-rpg2k`/`mruby-lcf`/
+  `mruby-rgss` — nearly everything reachable this way was already ✅ or
+  explicitly out of scope (the RPG2003 terrain-condition back-attack/pincer
+  system cycle #211 already declined for lack of a citable formula; the
+  Maniac Patch's own Wait mode-byte encoding, explicitly a third-party
+  extension; the CBA battle-animation sprite format, a genuinely large
+  feature). Pivoted to re-reading `docs/rpgxp-rgss-api-gap.md`'s own Tilemap
+  entry line by line against the actual code it describes (`mruby-rgss/src/
+  lib.cxx`) rather than trusting the doc text, since it is the one item both
+  the api-gap doc and this doc's own cycle #211 note still listed as
+  "Remaining." That comparison found the doc (and cycle #211's note) wrong,
+  not just outdated: `docs/adr/0022-rpgxp-tilemap-priority-layering.md`'s own
+  header already says "Accepted — implemented 2026-08-06," and the code has
+  `TILEMAP_PRIO_SPAN`/`tilemap_strip`/the per-`(row+priority)`-bucket strip
+  pool right there in `tilemap_refresh` — the real per-row scheme, not the
+  flat single-canvas approximation the doc prose (and the stale code comment
+  directly above `TILEMAP_ABOVE_Z`, still labelled "INTERIM") described. Both
+  landed in the same large merge (`bd91734`) that also introduced the
+  now-outdated doc text, so the prose was never updated to match the code it
+  shipped alongside — an easy thing to miss since nothing re-reads a
+  "Remaining" line once it is written, which is exactly what let cycle #211
+  carry the same stale claim forward without checking it against `lib.cxx`
+  either. Confirmed genuinely reachable, not just theoretical, once the doc
+  claim was corrected: with the per-row strips doing all of XP's own priority
+  work, the second, flat `@_tm_above_obj`/`@_tm_above_canvas` companion
+  canvas (`TILEMAP_ABOVE_Z`, created unconditionally in `tilemap_init`) is
+  drawn into *only* by `tilemap_refresh_vx` (the VX/VX Ace tile model, which
+  still uses a flat "above characters" layer — mkxp's own fixed z=200 layer
+  for that maker, not a gap there per `docs/rpgvx-rgss-api-gap.md` item 1) —
+  never by the XP path, which routes every priority tile through
+  `tilemap_strip` exclusively. So every XP tilemap (the common case: one per
+  running game, via `Spriteset_Map`) permanently allocated a 1.17 MiB
+  (640×480 ARGB8888) canvas it could never draw a single pixel into, and
+  `tilemap_apply_viewport_tone` walked all of its pixels on every refresh
+  whenever the map has a viewport tone active — real, measurable memory and
+  CPU waste with zero possible visual benefit, on the same psp/wio-shared
+  code ADR 0022 itself spent a whole "Strip height" section budgeting
+  carefully (a bare 21×1.17 MiB naive reading was explicitly rejected there
+  as "unaffordable," yet this one always-blank 1.17 MiB canvas shipped
+  unconditionally regardless). Fixed with a new `tilemap_ensure_above`
+  (`mruby-rgss/src/lib.cxx`), mirroring `tilemap_strip`'s own lazy shape:
+  `tilemap_init` no longer allocates the above canvas/object at all;
+  `tilemap_refresh` calls `tilemap_ensure_above` only when
+  `vx_has_sheets(@bitmaps)` is true (the same condition that already gates
+  the VX branch), and the helper syncs the new companion object's `z`/hidden
+  state to the tilemap's *current* `@z`/`@visible` ivars rather than the
+  fixed always-visible/`z=TILEMAP_ABOVE_Z` defaults the old eager call in
+  `tilemap_init` could safely assume (it always ran before a script had any
+  chance to touch either; a lazy create now can run well after one has).
+  Every existing call site that touches the above object
+  (`tilemap_set_visible`, `tilemap_set_z`, `tilemap_dispose`, the trailing
+  tone/invalidate calls in `tilemap_refresh` itself) was already null-safe
+  (`mrb_test(above) && ...`), so none needed changing — an absent-until-first-
+  VX-refresh above object is indistinguishable to them from the
+  already-handled "never went through `tilemap_init`" case cycle #211's own
+  unit test exercises via `.allocate`. **Verification:** `mruby-rgss`'s test
+  binary has no live display (the same limitation ADR 0022 and cycle #211
+  both recorded — `Tilemap.new` needs `lv_canvas_create`), so this could not
+  be pinned the same `.allocate`-plus-ivar-stub way cycle #211's `z=` test
+  was; construction-timing is exactly the thing under test here, which
+  `.allocate` bypasses entirely. Extended the *display-backed* probe instead
+  (`RGSS.effect_probe`, run under Xvfb by the `render_probe` ctest and
+  `--rgss_effect_probe`) with a new `tilemap_above_layer_probe`: builds one
+  XP-shaped `Tilemap` (`tileset=`/`map_data=`, no `bitmaps`) and one
+  VX-shaped one (`bitmaps[0] =` a live `Bitmap`, then `map_data=`), and reads
+  each one's own `@_tm_above_obj` ivar directly after — a dead canvas that is
+  never drawn into leaves no pixel trace either way for `frame_mean` to
+  sample, so this reads the allocation itself rather than the frame.
+  Confirmed to fail against the pre-fix code first (`git stash` on just
+  `mruby-rgss/src/lib.cxx`, rebuild, rerun): `xp_allocated=true` (should be
+  `false`) failed the probe and the `render_probe` ctest with it — then
+  passed clean (`xp_allocated=false vx_allocated=true`) after restoring the
+  fix. Full suite (only `mruby-rgss` touched, not `mruby-rpg2k`, so no change
+  expected and none seen): `rpg2k_scene_check.rb` 943, `rpg2k_logic_check.rb`
+  1185, `rpg2k_render_check.rb` 41, `rpg2k3_battle_row_check.rb` 19/0,
+  `rpg2k3_battle_gauge_check.rb` 15/0 all unchanged; `rpg2k_save_load_check.rb`
+  still reports exactly the same 1 known pre-existing failure (the unrelated
+  Show Picture field-shape mismatch), unaffected. `ctest` (all 8 targets,
+  including `mruby_test` and the newly-touched `render_probe`) and
+  `scripts/rgss_cruby_test_check.rb` (the separate CRuby-hosted mirror of
+  `mruby-rgss/test/test.rb`, unaffected since it never calls this engine's
+  actual native `Tilemap` code at all) both pass. `mruby-rgss/src/lib.cxx`
+  run through the pinned `clang-format` 22.1.8 with **no reformatting at all**
+  (clean diff, matched the file's existing style exactly). `cd build && ninja`
+  clean rebuild succeeded throughout. No wine session was run this cycle:
+  like cycle #211's own fix in this same area, this is purely an internal
+  resource-allocation question with no pixel-visible effect either way (a
+  canvas nothing ever draws into looks identical whether it exists or not),
+  so there is no RPG_RT/RGSS behavior to compare against — correctness here
+  is "does the above layer still exist exactly when something needs to draw
+  into it," which the new probe pins directly against a live display.
+  `docs/rpgxp-rgss-api-gap.md`'s own Tilemap entry rewritten in place to
+  describe the real per-row scheme instead of the stale flat-approximation
+  prose, and to record this fix.
 - ~~🚧 **Event system**~~ — **superseded, not current.** This bullet describes
   the reimplemented `mruby-rpgxp/mrblib/interpreter.rb` `Game::Interpreter` /
   `game.rb` party-actor model that used to stand in for a game's own scripts;

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -542,28 +542,43 @@ matching RMXP/mkxp's 16-tick-per-frame `atAnimation` table), and the renderer
 shifts the autotile source into that frame's column — so water and waterfalls
 animate. `update` only re-tiles on a frame boundary, and only when the map
 actually has an animated autotile (recorded during the last refresh), so static
-maps do no per-frame work. **Priority split (interim):** `priorities=` (native)
-routes each tile by its `priorities[id]` value — priority-0 tiles into the ground
-canvas, priority ≥ 1 tiles into a second **"above" canvas** that is a companion
-z-ordered object (created in `tilemap_init`, torn down by the native
-`Tilemap#dispose`) sorting above the character sprites (`TILEMAP_ABOVE_Z`). So
-roofs and tree crowns now draw over the party. This is an **interim flat
-approximation**: it puts *every* priority tile above *every* character, not only
-the ones on lower rows, and the above layer's single `z` is a best guess (above
-characters, below fog) pending in-game confirmation. The correct **per-row**
-scheme — above-priority tiles as per-row `z` strips that interleave with
-characters — is designed in
-[ADR 0022](adr/0022-rpgxp-tilemap-priority-layering.md) and remains the follow-up.
-`tileset=`, `map_data=`, `priorities=`, `ox=`/`oy=`, `z=`, `update`,
-`visible`/`visible=`, `dispose`/`disposed?` are native and re-render on change.
-`visible=` hides the above layer along with the ground. `z=` now keeps the
-above layer pinned a fixed offset above the tilemap's own `z` too (cycle
-#211, `tilemap_set_z`, `mruby-rgss/src/lib.cxx`) — it used to leave the
-above layer at its construction-time `z` forever, so a script reassigning a
-tilemap's `z` broke the "above sorts over the ground" relationship the two
-layers are supposed to keep in lockstep, the same gap `visible=` already had
-to close for visibility a few lines above. **Remaining:** the per-row
-priority scheme (ADR 0022); `flash_data` is still ignored.
+maps do no per-frame work. **Priority split — the real per-row scheme, not the
+flat approximation this entry used to describe:** `priorities=` (native) routes
+each tile by its `priorities[id]` value — priority-0 tiles stay in the ground
+canvas; priority 1..5 tiles go into a **per-row `z` strip**
+(`TILEMAP_PRIO_SPAN`), one lazily-allocated, pooled canvas per `(row + priority)`
+bucket, positioned and z-sorted so a priority tile sorts exactly as though it
+stood `priority` rows lower — matching RMXP's own `Game_Character#screen_z`
+formula (`z = screen_y + priorities[tile_id] * 32`, confirmed against the XP
+test bed's own decompiled scripts). So a character now sorts *between* a roof
+above their own row and a tree crown below it, not merely above every priority
+tile at once — the per-row interleaving [ADR 0022](adr/0022-rpgxp-tilemap-priority-layering.md)
+designed, now implemented (its own "Remaining" note calling this out as a
+follow-up was stale; only `flash_data`, its other listed follow-up, is still
+open — see below). `tileset=`, `map_data=`, `priorities=`, `ox=`/`oy=`, `z=`,
+`update`, `visible`/`visible=`, `dispose`/`disposed?` are native and re-render
+on change; `visible=`/`z=` propagate to every allocated strip the same way
+they do to the VX above layer below.
+
+A second, separate **flat "above" canvas** (`TILEMAP_ABOVE_Z`, a single
+z-ordered companion object) still exists alongside the per-row strips, but it
+is not part of the XP priority path any more — VX/VX Ace's own tile model
+(`bitmaps=`, [VX gap](rpgvx-rgss-api-gap.md) item 1) is the only thing that
+still draws into it, as mkxp's own fixed-z "above characters" layer for that
+maker (not a gap there). **Fixed (cycle #212):** it used to be allocated
+unconditionally in `tilemap_init`, so every XP tilemap paid a permanent,
+always-blank 1.17 MiB canvas plus a wasted per-refresh viewport-tone pass over
+it for a layer its own priority tiles could never reach once the per-row
+strips took over — dead weight on every RPG Maker XP game, including the
+psp/wio targets this code is shared with. It is now allocated lazily
+(`tilemap_ensure_above`), on the first VX-path refresh that actually needs it,
+syncing to whatever `z`/`visible` the tilemap already has by then rather than
+the fixed defaults the old eager allocation in `Tilemap.new` could assume.
+**Remaining:** `flash_data` is still ignored — unlike the priority scheme, no
+formula for it has ever been confirmed against a real game (the stock XP/VX
+Ace script bundles this project has access to never call it at all, which
+also means implementing it would have nothing to verify against), so it stays
+open rather than guessed at.
 
 ### 4. `Plane` ✅ (tiling + scroll + tint/blend + zoom all rendered)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -226,6 +226,7 @@ module RGSS
     viewport.dispose
     ok = false unless window_probe
     ok = false unless windowskin_rect_probe
+    ok = false unless tilemap_above_layer_probe
     $stderr.puts "[RGSS-PROBE] #{ok ? "ok" : "failed"}"
     ok
   end
@@ -407,6 +408,51 @@ module RGSS
     end
     win.dispose
     skin.dispose
+    ok
+  end
+
+  # Prove the priority "above" layer (tilemap_ensure_above, lib.cxx) is
+  # allocated lazily rather than for every Tilemap. XP's own priority tiles
+  # route through the per-row strips (TILEMAP_PRIO_SPAN) exclusively and never
+  # draw into this companion canvas at all — only the VX/VX Ace tile model
+  # (tilemap_refresh_vx) still does — so an XP-shaped tilemap (a tileset +
+  # map_data, no bitmaps) must never allocate it, while a VX-shaped one
+  # (bitmaps assigned) must. The two probes above measure *pixels*; what a
+  # dead, never-drawn canvas leaves behind is nothing to sample — an unused
+  # 1.17 MiB allocation looks exactly like no allocation on screen — so this
+  # reads the tilemap's own internal @_tm_above_obj ivar directly instead,
+  # the same technique the z= propagation unit test in
+  # mruby-rgss/test/test.rb uses on a bare Tilemap.allocate, just against a
+  # real, refreshed Tilemap here since the thing under test is allocation
+  # timing itself, not the z arithmetic.
+  def self.tilemap_above_layer_probe
+    xp = Tilemap.new
+    xp.tileset = Bitmap.new(32, 32)
+    xp.map_data = Table.new(1, 1, 1)
+    xp_above = xp.instance_variable_get(:@_tm_above_obj)
+    xp.dispose
+
+    vx = Tilemap.new
+    vx.bitmaps[0] = Bitmap.new(32, 32)
+    vx.map_data = Table.new(1, 1, 1)
+    vx_above = vx.instance_variable_get(:@_tm_above_obj)
+    vx.dispose
+
+    $stderr.puts "[RGSS-PROBE] tilemap above layer xp_allocated=" \
+                 "#{!xp_above.nil?} vx_allocated=#{!vx_above.nil?}"
+
+    ok = true
+    unless xp_above.nil?
+      $stderr.puts "[RGSS-PROBE] FAIL an XP tilemap (no VX sheets) allocated " \
+                   'the priority "above" layer it can never draw into'
+      ok = false
+    end
+    if vx_above.nil?
+      $stderr.puts "[RGSS-PROBE] FAIL a VX tilemap (bitmaps assigned) never " \
+                   'allocated the priority "above" layer its own tile model ' \
+                   'needs'
+      ok = false
+    end
     ok
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -4858,6 +4858,65 @@ void tilemap_apply_viewport_tone(mrb_state* M,
   }
 }
 
+// Lazily create the priority "above" layer the first time it is actually
+// needed. Before ADR 0022's per-row scheme (TILEMAP_PRIO_SPAN below), this
+// flat companion canvas was the *only* place a priority tile could draw, so
+// tilemap_init created it unconditionally for every Tilemap. Now only
+// tilemap_refresh_vx (the VX/VX Ace tile model, which still uses this flat
+// "above characters" layer -- see the ADR's own "only the XP path moved")
+// ever draws into it; XP's own priorities route through the per-row strips
+// exclusively and never touch this canvas at all. Left eagerly allocated
+// anyway, every XP tilemap paid a permanent, always-blank 1.17 MiB canvas (at
+// XP's 640x480) plus a wasted per-refresh viewport-tone pass walking every
+// one of its pixels (tilemap_apply_viewport_tone) for a layer that could
+// never show anything -- dead weight on every RPG Maker XP game, including
+// the psp/wio targets this code is shared with (see TILEMAP_STRIP_SLOTS's own
+// comment on why that budget matters here). Mirrors tilemap_strip's own lazy
+// shape: created once, held on the tilemap so the GC keeps it alive, torn
+// down by tilemap_dispose exactly as before.
+void tilemap_ensure_above(mrb_state* M, mrb_value self, int w, int h) {
+  const mrb_value existing =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_above_obj"));
+  if (mrb_test(existing) && DATA_PTR(existing))
+    return;
+
+  const mrb_value vp = mrb_iv_get(M, self, mrb_intern_lit(M, "@viewport"));
+  lv_obj_t* ac = lv_canvas_create(parent_object(M, vp));
+  lv_obj_set_pos(ac, 0, 0);
+  const mrb_value above_obj = mrb_obj_value(
+      mrb_data_object_alloc(M, mrb_obj_class(M, self), ac, &obj_type));
+  lv_obj_set_user_data(ac, mrb_ptr(above_obj));
+  lv_obj_add_event_cb(ac, on_lv_delete, LV_EVENT_DELETE, nullptr);
+  register_zobj(M, above_obj);
+  // Sync to whatever this tilemap's own z/visible already are, rather than
+  // the fixed z=TILEMAP_ABOVE_Z/always-visible the old eager tilemap_init
+  // call hardcoded: that always ran before a script had any chance to touch
+  // either, so it was trivially right by construction, but a lazy create can
+  // now run well after a script has already set `z=`/`visible=` on the
+  // tilemap (its first VX-path refresh, not its construction).
+  const mrb_value self_z = mrb_iv_get(M, self, mrb_intern_lit(M, "@z"));
+  const mrb_int z = mrb_test(self_z) ? mrb_as_int(M, self_z) : 0;
+  mrb_iv_set(M, above_obj, mrb_intern_lit(M, "@z"),
+             mrb_fixnum_value(z + TILEMAP_ABOVE_Z));
+  const mrb_value self_visible =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@visible"));
+  if (!mrb_nil_p(self_visible) && !mrb_test(self_visible))
+    lv_obj_add_flag(ac, LV_OBJ_FLAG_HIDDEN);
+  update_z(M);
+
+  RClass* bmp_class =
+      mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Bitmap");
+  const mrb_value above_canvas_v =
+      DataType<Bitmap>::make(M, bmp_class, w, h, LV_COLOR_FORMAT_ARGB8888);
+  Bitmap& above_canvas = DataType<Bitmap>::get(M, above_canvas_v);
+  std::fill(above_canvas.buffer.begin(), above_canvas.buffer.end(),
+            static_cast<uint8_t>(0));
+  lv_canvas_set_buffer(ac, above_canvas.buffer.data(), w, h,
+                       LV_COLOR_FORMAT_ARGB8888);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_above_obj"), above_obj);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_above_canvas"), above_canvas_v);
+}
+
 void tilemap_refresh(mrb_state* M, mrb_value self) {
   lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
   if (!obj)
@@ -4869,9 +4928,23 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
   Bitmap& dst = DataType<Bitmap>::get(M, canvas_v);
   std::fill(dst.buffer.begin(), dst.buffer.end(), static_cast<uint8_t>(0));
 
-  // The priority "above" canvas (companion object created in tilemap_init) and
-  // its LVGL object, so priority tiles can be routed to it and it can be
-  // invalidated alongside the ground canvas.
+  const mrb_value ts_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@tileset"));
+  const mrb_value md_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@map_data"));
+
+  // RPG Maker VX / VX Ace address their nine sheets through `bitmaps` instead
+  // of XP's single `tileset` + `autotiles`, and describe each tile with the
+  // `flags` table rather than `priorities`. A tilemap that has been given any
+  // sheet is drawn the VX way; everything below stays the XP path.
+  const mrb_value bmps_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@bitmaps"));
+  const bool is_vx =
+      vx_has_sheets(M, bmps_v) && mrb_test(md_v) && DATA_PTR(md_v);
+
+  // The priority "above" canvas and its LVGL object, so priority tiles can be
+  // routed to it and it can be invalidated alongside the ground canvas -- see
+  // tilemap_ensure_above's own comment for why this is only ever created for
+  // the VX path.
+  if (is_vx)
+    tilemap_ensure_above(M, self, dst.width, dst.height);
   const mrb_value above_v =
       mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_above_canvas"));
   Bitmap* above = (mrb_test(above_v) && DATA_PTR(above_v))
@@ -4893,15 +4966,7 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
                   ? &DataType<Table>::get(M, pr_v)
                   : nullptr;
 
-  const mrb_value ts_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@tileset"));
-  const mrb_value md_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@map_data"));
-
-  // RPG Maker VX / VX Ace address their nine sheets through `bitmaps` instead
-  // of XP's single `tileset` + `autotiles`, and describe each tile with the
-  // `flags` table rather than `priorities`. A tilemap that has been given any
-  // sheet is drawn the VX way; everything below stays the XP path.
-  const mrb_value bmps_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@bitmaps"));
-  if (vx_has_sheets(M, bmps_v) && mrb_test(md_v) && DATA_PTR(md_v)) {
+  if (is_vx) {
     const mrb_value anim_v =
         mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_anim"));
     const bool animated = tilemap_refresh_vx(
@@ -5133,30 +5198,9 @@ mrb_value tilemap_init(mrb_state* M, mrb_value self) {
   mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(0));
   mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_anim"), mrb_fixnum_value(0));
 
-  // Priority "above" layer: a second canvas in the same parent, wrapped as an
-  // internal companion display object so the shared z-order (gfx_update) sorts
-  // it against the character sprites. It is held on the tilemap so the GC keeps
-  // it alive, and torn down in tilemap_dispose. Follows the same
-  // wrap_lv_obj/on_lv_delete/register_zobj pattern as a Sprite.
-  lv_obj_t* ac = lv_canvas_create(parent_object(M, vp));
-  lv_obj_set_pos(ac, 0, 0);
-  const mrb_value above_obj = mrb_obj_value(
-      mrb_data_object_alloc(M, mrb_obj_class(M, self), ac, &obj_type));
-  lv_obj_set_user_data(ac, mrb_ptr(above_obj));
-  lv_obj_add_event_cb(ac, on_lv_delete, LV_EVENT_DELETE, nullptr);
-  register_zobj(M, above_obj);
-  mrb_iv_set(M, above_obj, mrb_intern_lit(M, "@z"),
-             mrb_fixnum_value(TILEMAP_ABOVE_Z));
-  update_z(M);
-  const mrb_value above_canvas_v =
-      DataType<Bitmap>::make(M, bmp_class, w, h, LV_COLOR_FORMAT_ARGB8888);
-  Bitmap& above_canvas = DataType<Bitmap>::get(M, above_canvas_v);
-  std::fill(above_canvas.buffer.begin(), above_canvas.buffer.end(),
-            static_cast<uint8_t>(0));
-  lv_canvas_set_buffer(ac, above_canvas.buffer.data(), w, h,
-                       LV_COLOR_FORMAT_ARGB8888);
-  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_above_obj"), above_obj);
-  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_above_canvas"), above_canvas_v);
+  // Priority "above" layer: no longer created here. It is only ever drawn
+  // into by the VX/VX Ace tile model, so it is now allocated lazily on the
+  // first VX-path refresh instead -- see tilemap_ensure_above's own comment.
   return self;
 }
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3144,14 +3144,28 @@ module Game
     # #call_stack_snapshot's own scope, Game::State#foreground_event_exec/
     # #common_event_exec), per-frame identity there is deliberately out of
     # scope for this cycle.
+    #
+    # A database shrink can leave `param0` pointing at a common event id
+    # that no longer exists -- the "common event" case in docs/TODO.md's
+    # runtime error catalog, which the map-side Call Event (mode 0,
+    # #resolve_call above) already reports but this RPG2003 battle-only
+    # sibling never did: it silently swallowed the gap via the shared
+    # #common_event_commands wrapper's own `cmds.nil?` no-op. Reported the
+    # same "[RPG2k] <Command>: ..." way, diagnostics only -- the command was
+    # already a correct, harmless no-op either way, only the missing trace
+    # is new.
     def do_call_common_event(cmd)
       return unless @resolver && @state.party.rpg2003?
-      cmds = common_event_commands(cmd.param(0))
+      id = cmd.param(0)
+      cmds = @resolver.common_event_commands(id)
+      $stderr.puts "[RPG2k] Call Common Event: common event #{id} not found" if cmds.nil?
       return if cmds.nil? || cmds.empty?
       return if @call_stack.size >= MAX_CALL_DEPTH
       @call_stack.push [@list, @index, 0]
       @list = cmds
       @index = 0
+    rescue StandardError => e
+      $stderr.puts "[RPG2k] Call Common Event #{id} failed: #{e.message}"
     end
 
     def common_event_commands(id)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -21110,6 +21110,41 @@ check 'Call Common Event with no resolver or an unknown id is a safe no-op' do
   eq true, st2.switches[1]
 end
 
+# The "safe no-op" check above never actually reaches the resolver's own
+# `common_event_commands(id)` lookup at all -- both its sub-cases default to
+# a non-RPG2003 `new_state`, so #do_call_common_event's own `rpg2003?` guard
+# bails out first either way. This one drives a genuine RPG2003 state with a
+# resolver present but no entry for the called id, matching the "common
+# event" case docs/TODO.md's runtime error catalog lists (a database shrink
+# leaves a dangling id) -- the diagnostic map-side Call Event already reports
+# for its own common-event mode (see the "runs a common event" checks above).
+check 'Call Common Event reports a dangling common event id instead of a silent no-op' do
+  st = new_state(rpg2003: true)
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: {})
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CALL_COMMON_EVENT, [4]),
+              FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+    it.update
+  end
+  ok out.include?('[RPG2k] Call Common Event: common event 4 not found'),
+     "expected a not-found diagnostic naming id 4, got: #{out.inspect}"
+  eq true, st.switches[1], 'control still passed through past the unresolved call, same as before'
+
+  # The happy path (a real target) must stay silent -- no spurious diagnostic
+  # on every ordinary call.
+  st2 = new_state(rpg2003: true)
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  it2 = Game::Interpreter.new(st2)
+  it2.resolver = FakeResolver.new(common: { 4 => called })
+  out2 = capture_stderr do
+    it2.start([FakeCmd.new(IC::CALL_COMMON_EVENT, [4])])
+    it2.update
+  end
+  eq '', out2, 'a resolvable target logs nothing'
+  eq true, st2.switches[9], 'and still actually ran'
+end
+
 # -- RPG2003 English-release (2k3e) system commands ---------------------------
 
 check 'Open Load Menu and Exit Game raise their scene requests' do


### PR DESCRIPTION
## Summary

### Cycle #212: lazily allocate Tilemap's priority "above" layer

Every native `RGSS::Tilemap` unconditionally allocated a second, internal LVGL canvas for the priority "above" layer (roofs/tree crowns sorting over character sprites) at construction time — even though ADR 0022's per-row priority scheme (already implemented; a stale `docs/rpgxp-rgss-api-gap.md` claim describing it as still-pending is corrected in this PR) routes every RPG Maker XP priority tile through the per-row strips exclusively and never draws a single pixel into that companion canvas. Only the VX/VX Ace tile model still uses it, as a flat "above characters" layer.

Every XP tilemap therefore paid a permanent, always-blank 1.17 MiB canvas (at XP's 640x480) plus a wasted per-refresh viewport-tone pass walking all of its pixels, for a layer that could never show anything — dead weight on every RPG Maker XP game, including the psp/wio targets this code is shared with.

`tilemap_ensure_above` (`mruby-rgss/src/lib.cxx`) now allocates the above layer lazily, on the first VX-path refresh that actually needs it (mirroring the same lazy shape the per-row priority strips already use), syncing to whatever `z`/`visible` the tilemap already has by then rather than the fixed construction-time defaults the old eager allocation could assume.

### Cycle #213: RPG2003's Call Common Event no longer swallows a dangling id

`Game::Interpreter#do_call_common_event` (the RPG2003 battle page's own Call Common Event, distinct from the map's Call Event) silently returned when its target common event id had no matching database row after a database shrink — the "common event" case `docs/TODO.md`'s runtime error catalog names, already reported for the map-side Call Event's own common-event mode (`#resolve_call`) but never wired up for this sibling. Fixed by mirroring `#resolve_call`'s own shape: resolve through the resolver directly and log `[RPG2k] Call Common Event: common event #<id> not found` when it misses, with its own local rescue for genuine resolver exceptions. Diagnostics only — the command was already a correct, harmless no-op either way.

## Verification

- New `tilemap_above_layer_probe` (`mruby-rgss/mrblib/lib.rb`), run live under Xvfb by the `render_probe` ctest: confirmed live output `xp_allocated=false vx_allocated=true`
- `ctest` (8 targets, including `render_probe`): 8/8 pass
- `ruby scripts/rgss_cruby_test_check.rb`: passes
- Touched `.cxx` file verified against the exact CI-pinned `clang-format==22.1.8` (no diff)
- `cd build && ninja`: clean rebuild, no new warnings
- `scripts/rpg2k_logic_check.rb`: 1186 passed (1185 baseline + 1 new check: dangling id logs and still passes control through; a resolvable target stays silent)
- `scripts/rpg2k_scene_check.rb`: 943 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: still exactly 1 known pre-existing failure (unrelated Show Picture field-shape issue), unchanged
- Every new/updated check confirmed to fail against the pre-fix code before the fix

**Honest limitations**: Cycle #212 is purely an internal resource-allocation change with zero pixel-visible effect either way, so there's nothing to compare against — correctness is "does the above layer exist exactly when something needs to draw into it," pinned directly by the new live-display probe. Cycle #213 is diagnostics-only on an already-correct no-op path, adding no new behavioral claim (it mirrors an already-established, already-verified diagnostic pattern to a second call site). No wine session was needed or run for either cycle.

Per standing project convention, EasyRPG Player's C++ source was not consulted for any behavioral claim in this change.
