### PR TITLE
RPG2003's Change Class no longer swallows a dangling class id

### DIFF
--- a/changelog.d/rpg2003-change-class-dangling-id.fixed.md
+++ b/changelog.d/rpg2003-change-class-dangling-id.fixed.md
@@ -1,0 +1,14 @@
+- **RPG2003's Change Class command no longer swallows a dangling class id
+  with no trace.** A database shrink can leave the id it targets pointing
+  at a class (chunk 30) that no longer exists — shown as "?" in the editor,
+  the exact shape docs/TODO.md's runtime error catalog already reports for
+  the sibling hero/skill/item/enemy/enemy-group/battle-animation/terrain/
+  chipset/common-event lookups, but "class" was never among them.
+  `Game::Actor#change_class` now logs a `[RPG2k] Change Class: class #<id>
+  not found in database, actor left unchanged` diagnostic before its
+  existing early return, `respond_to?`-guarded the same way those sibling
+  diagnostics are so a database with no class table at all (every RPG2000
+  project, and any bare test fixture) stays quiet — this only fires for a
+  genuine dangling reference in a database that does carry a class table.
+  Behaviour is otherwise unchanged: the command was already a correct,
+  harmless no-op for that actor either way, only the missing trace is new.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26874,6 +26874,75 @@ behavioral claim -- there isn't one: this is a pure diagnostics-only
 addition to an already-correct, already-tested no-op path, mirroring an
 established in-repo pattern (`#resolve_call`'s own identical common-event
 case) rather than introducing any new behavioral assumption.
+✅ **Follow-up (cycle #214, 2026-08-28): RPG2003's Change Class command no
+longer swallows a dangling class id with no trace — a lookup this
+catalog's own "invalid hero, skill, item, enemy, enemy group, battle
+animation, terrain, chipset, common event" list never named at all.**
+Method: per the standing instruction to skim broadly first rather than
+default to the nearest recent entries, read across battle mechanics,
+message/window text processing, database field defaults, picture/sprite
+rendering, save-file round-tripping, both RGSS API-gap docs
+(`docs/rpgxp-rgss-api-gap.md`, `docs/rpgvx-rgss-api-gap.md`) and the
+viprpg-dev/yado.tk untriaged backlogs; nearly every leaf bullet in each was
+already resolved by an earlier cycle, needed a genuine wine session this
+environment doesn't have, or was already explicitly flagged as too large/
+uncertain for one cycle by cycles #209-#213 (the デフォ戦botまとめ
+140-item dump, the SPEED_UP ceiling investigation, the within-frame
+Autorun-restart feature, the RGSS browser-rebuild item, the VX Ace `$!`
+gap mid-flight in a sibling session, and the Approach-Hero-plus-Autorun
+freeze **Bug** bullet a few thousand lines up, itself already passed over
+by cycles #209/#211 as event/movement-adjacent). Re-ran the same
+`class_row_for`/`db_item`/`db_enemy_group` family of database-lookup call
+sites this catalog's own prior entries fixed, this time specifically
+checking every RPG2003-only field/command this codebase resolves through
+a similar `respond_to?`-guarded database lookup for one the catalog's own
+intro sentence had not yet named: `Game::Actor#change_class`
+(`mruby-rpg2k/mrblib/game.rb`), the Change Class (1008) event command's
+own backing method, already had the identical shape — `return false if
+class_id > 0 && class_row_for(class_id).nil?`, a silent no-op for a
+database shrink deleting a class (chunk 30) an event still references,
+shown as "?" in the editor exactly like every other entry in this catalog
+— but never reported the gap. Confirmed genuinely reachable: `Interpreter
+#do_change_class`'s only production call site passes `cmd.param(2)`
+straight through with no validation of its own, so any RPG2003 project
+whose database once had more classes than it does now reaches this path
+the instant a leftover Change Class command runs. Fixed by adding a
+`[RPG2k] Change Class: class #<id> not found in database, actor left
+unchanged` diagnostic right before the existing early return, guarded by
+the identical `@db.respond_to?(:job) && @db.job` check `class_row_for`
+itself already uses, so a database with no class table at all (every
+RPG2000 project, which can never even reach this method — `do_change_class`
+gates on `party.rpg2003?` first) stays quiet; behaviour itself is
+completely unchanged, only the missing trace is now visible. Covered by a
+new `scripts/rpg2k_logic_check.rb` check (a dangling class id against a
+database that does carry a class table logs the diagnostic and still
+leaves the actor's `class_id`/stats untouched; the identical call against
+a database with no class table at all — `jobs: nil`, matching a genuine
+RPG2000 `.ldb`'s own absent chunk — stays silent), confirmed to fail
+against the pre-fix code (`git stash`/`git stash pop` on just
+`mruby-rpg2k/mrblib/game.rb`: `RuntimeError: expected a not-found
+diagnostic naming class id 99`) then pass after. **Verification:**
+`scripts/rpg2k_scene_check.rb` 943 passed (unchanged, no scene-check-
+reachable file touched); `rpg2k_logic_check.rb` 1187 passed (1186
+baseline + 1 new check, 0 failures); `rpg2k_render_check.rb` 41 passed
+(unchanged); `rpg2k3_battle_row_check.rb` 19/0 and `rpg2k3_battle_
+gauge_check.rb` 15/0 (both unchanged); `rpg2k_save_load_check.rb` still
+reports exactly the same 1 known pre-existing failure (the unrelated Show
+Picture field-shape mismatch), unaffected; `scripts/rpg2k_command_soak.rb`
+clean on all four test beds (184166/184166/4042/3430 commands, no new
+gaps — only the pre-existing "Open Video Options" line on Ch.1, present
+before this cycle too; no real game bed actually exercises a dangling
+Change Class id, so the new diagnostic never fires there, consistent with
+this catalog's other diagnostics-only fixes). No `.cxx`/`.hxx` file was
+touched (pure `mrblib` Ruby plus a check-script addition), so the pinned
+`clang-format` step does not apply; `cd build && ninja` clean rebuild
+succeeded; `ctest -R mruby_test` passed. No RGSS-side Ruby or C++ was
+touched, so `scripts/rgss_cruby_test_check.rb` does not apply this cycle.
+No wine session was run and no EasyRPG source was consulted for this
+fix's own behavioral claim — there isn't one: this is a pure diagnostics-
+only addition to an already-correct, already-tested no-op path, mirroring
+this catalog's own established in-repo pattern rather than introducing
+any new behavioral assumption.
 ✅ **The Equip and Status screens no longer show a dangling equipped item id
 with no trace** — the "item" case from the "invalid hero, skill, item,
 enemy, enemy group, battle animation, terrain, chipset, common event" list

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3218,9 +3218,24 @@ module Game
     #
     # Current HP/SP survive the change, re-clamped to the refreshed maxima.
     # Returns whether the class actually changed — false for a class id this
-    # database does not define, which RPG_RT leaves entirely alone.
+    # database does not define, which RPG_RT leaves entirely alone. A
+    # database shrink deleting a class (chunk 30) an event still references
+    # -- shown as "?" in the editor -- is now reported too, rather than
+    # silently no-opping with no trace: docs/TODO.md's runtime error catalog
+    # lists this exact shape for hero/skill/item/enemy/enemy-group/battle-
+    # animation/terrain/chipset/common-event ids, but never named "class" as
+    # one of them. `respond_to?`-guarded the same way those are, so a bare
+    # test fixture (or any RPG2000 database, which carries no job table at
+    # all) stays quiet -- this only fires for a genuine dangling id in a
+    # database that does have one.
     def change_class(class_id, new_level, skill_mode, param_mode)
-      return false if class_id > 0 && class_row_for(class_id).nil?
+      if class_id > 0 && class_row_for(class_id).nil?
+        if @db.respond_to?(:job) && @db.job
+          $stderr.puts "[RPG2k] Change Class: class ##{class_id} not found " \
+                       'in database, actor left unchanged'
+        end
+        return false
+      end
 
       unequip(EQUIP_ORDER.size)
       hp = @hp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7005,6 +7005,39 @@ check "an actor with a startup class reads class_id immediately, but its curve, 
   eq 0, b.class_id
 end
 
+# A database shrink deleting a class (chunk 30) an event still references --
+# shown as "?" in the editor -- used to leave Change Class a silent no-op with
+# no trace, the one lookup docs/TODO.md's runtime error catalog never named
+# alongside its sibling hero/skill/item/enemy/enemy-group/battle-animation/
+# terrain/chipset/common-event cases.
+check 'a dangling class id in Change Class reports and is a no-op, unlike a ' \
+      'database with no class table at all' do
+  hero = class_state.party.actor_by_id(1) # class_db(0): class-less, jobs 1/2 exist
+  before_hp = hero.max_hp
+  changed = nil
+  out = capture_stderr do
+    changed = hero.change_class(99, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                                 Game::Actor::CLASS_PARAM_NO_CHANGE)
+  end
+  eq false, changed, 'a dangling class id is still a no-op, same as before this fix'
+  ok out.include?('[RPG2k] Change Class: class #99 not found in database'), out
+  eq 0, hero.class_id, "the actor's class_id is left untouched"
+  eq before_hp, hero.max_hp, 'stats are untouched too'
+
+  # A database with no class table at all (jobs: nil, matching a genuine
+  # RPG2000 .ldb -- the same guard `Actor#class_row_for` already uses) stays
+  # quiet: there is no class concept for this database, so this is not a
+  # dangling reference.
+  no_job_players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                             atk: 10, def: 8) }
+  no_job_hero = Game::Party.new(FakeActorDB.new(no_job_players, [1], {}, {}, nil)).actor_by_id(1)
+  out2 = capture_stderr do
+    no_job_hero.change_class(99, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                              Game::Actor::CLASS_PARAM_NO_CHANGE)
+  end
+  eq '', out2, 'no class table at all stays quiet, unlike a genuine dangling reference'
+end
+
 check "Party save/Continue does not fabricate a Change Class for an actor " \
       "merely starting in one" do
   # Party#to_h/#load_state (this engine's own Marshal Save/Continue, distinct


### PR DESCRIPTION
## Summary

A database shrink deleting a class (chunk 30) an event still references — shown as "?" in the editor — used to leave Change Class a silent no-op with no trace. This is the exact "invalid id degrades silently" shape `docs/TODO.md`'s "Concrete runtime error catalog" already reports for the sibling hero/skill/item/enemy/enemy-group/battle-animation/terrain/chipset/common-event lookups, but "class" was never named alongside them.

`Game::Actor#change_class` now logs `[RPG2k] Change Class: class #<id> not found in database, actor left unchanged` before its existing early return, `respond_to?`-guarded the same way the sibling diagnostics are — so a database with no class table at all (every RPG2000 project, and any bare test fixture) stays quiet, and this only fires for a genuine dangling reference in a database that does carry a class table. Behavior is otherwise unchanged — the command was already a correct, harmless no-op either way.

## Verification

- `scripts/rpg2k_logic_check.rb`: 1187 passed (1186 baseline + 1 new check: dangling id logs and is a no-op; a database with no class table at all stays quiet)
- `scripts/rpg2k_scene_check.rb`: 943 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: still exactly 1 known pre-existing failure (unrelated Show Picture field-shape issue), unchanged
- `scripts/rpg2k_command_soak.rb`: clean on all four real test-bed games
- `cd build && ninja`: clean rebuild, no new warnings (no `.cxx`/`.hxx` touched, pure `mrblib` Ruby)
- `ctest -R mruby_test`: passed
- New check confirmed to fail against the pre-fix code before the fix

No wine session was run this cycle, and no EasyRPG source was consulted for this fix's own behavioral claim — the behavior itself (a dangling-id lookup degrading to a harmless no-op) was already established and tested; this fix only adds visibility, mirroring the runtime error catalog's existing pattern exactly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_