### PR TITLE
Add a per-frame allocation regression check for the RPG2000 map scene

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,8 +289,9 @@ jobs:
       # on the editor bed plus script host on Pray for You, each its own step
       # and its own display so they run concurrently rather than the four of
       # them serially in one step; 116..119 stays free for another pass to be
-      # added without renumbering anything else) and the RGSSAD packed-asset
-      # smoke=120..121 (two runs, one per arm of its A/B) below. Every
+      # added without renumbering anything else), the RGSSAD packed-asset
+      # smoke=120..121 (two runs, one per arm of its A/B) and the RPG2k
+      # per-frame allocation regression check=122 below. Every
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
       # check.
@@ -472,6 +473,21 @@ jobs:
           # per game. See ADR 0021.
           - name: RPG2k real-game boot smoke test
             run: ./scripts/rpg2k_boot_check.bash 109
+
+          # Regression guard for the RPG2000 map scene's per-frame mruby
+          # object churn (Array/Proc/env allocations/sec): boots the engine on
+          # Nepheshel, samples RGSS::Profiler's own cumulative per-type alloc
+          # counters (mirrored into the profiler trace as the
+          # `mruby_type_allocs` counter series) at two points in a steady
+          # window, and fails if the measured rate exceeds a ceiling set from
+          # this scene's own measured baseline (docs/profiling.md) -- a
+          # reverted per-frame optimization (see the script's own header for
+          # the list) shows up as a failing check instead of just a quieter
+          # frame budget nobody happens to notice. Display 122.
+          - name: RPG2k per-frame allocation regression check
+            env:
+              SERVER_NUM: 122
+            run: ./scripts/rpg2k_alloc_regression_check.rb
 
           # The same guard for the RPG Maker XP runtime: the XP checks above run
           # mruby-rpgxp's sources under CRuby, so only booting the real binary

--- a/README.md
+++ b/README.md
@@ -691,12 +691,25 @@
   specific window (e.g. one battle) with
   `RGSS::Profiler.trace_start("trace.json")` / `RGSS::Profiler.trace_stop`. The
   stream stays loadable even if the process is killed mid-run, so it is safe to
-  trace a long session and stop it with `Ctrl-C`
+  trace a long session and stop it with `Ctrl-C`. Alongside `mruby_types`
+  (live counts, which rise and fall with GC) each sample also writes
+  `mruby_type_allocs`: the same per-type breakdown as **cumulative**,
+  never-reset allocation counts, so diffing two samples' values by their
+  timestamps gives a real per-second (or per-frame, dividing by the frame
+  count over the same span) allocation *rate* — exactly what
+  `scripts/rpg2k_alloc_regression_check.rb` checks
 - [`docs/profiling.md`](docs/profiling.md) records a measured baseline for the
   RPG2000 map scene — what the sections above currently say, which one is the
   bottleneck, and why moving audio to another thread does not help the frame
   rate (SDL_mixer already mixes on its own thread; only asset load blocks the
   game loop)
+- `scripts/rpg2k_alloc_regression_check.rb` boots the engine against a real
+  game, samples `mruby_type_allocs` at two points in a steady window and fails
+  if the measured per-second Array/Proc/env allocation rate exceeds a ceiling
+  set from the RPG2000 map scene's own measured baseline — a regression guard
+  for the per-frame object-churn fixes documented in `changelog.d/`, so a
+  reverted one (or a new per-frame `.each { }`/throwaway-Array pattern) shows
+  up as a failing check instead of just a quieter frame budget nobody notices
 
 ### Performance
 

--- a/changelog.d/alloc-regression-check.added.md
+++ b/changelog.d/alloc-regression-check.added.md
@@ -1,0 +1,29 @@
+- **A standing regression guard for the RPG2000 map scene's per-frame mruby
+  object churn.** The `RGSS::Profiler.stats[:object_types]` investigation
+  behind PRs #1436, #1438, #1447 and this one cut the map scene's per-frame
+  Array/Proc/env allocation by well over half across several rounds, each
+  found and measured by hand with a temporary instrumentation pass reverted
+  before commit — none of it was guarded against silently regressing. Two
+  new pieces close that gap:
+  - The profiler's Chrome trace export now mirrors a `mruby_type_allocs`
+    counter series alongside the existing `mruby_types` (live counts, which
+    rise and fall with GC): the same per-type breakdown as **cumulative**,
+    never-reset allocation counts, straight off `RGSS::Profiler`'s own
+    counters (`mruby-gc-type-live-counts.patch`) — no new cost, the numbers
+    were already computed for the live breakdown. Diffing two samples' values
+    by their timestamps gives a real per-second (or per-frame) allocation
+    *rate*, which the live-count series alone cannot answer.
+  - `scripts/rpg2k_alloc_regression_check.rb` automates the exact manual
+    measurement this whole investigation used: boots the engine on Nepheshel,
+    samples that new series at two points in a steady window, and fails if
+    the measured Array/Proc/env rate exceeds a ceiling set from this scene's
+    own measured baseline (docs/profiling.md's new "Per-frame object
+    allocation" section) — checked to actually catch reverting this round's
+    fixes (`env` trips first, then `Proc`, well before `Array`). Wired into
+    CI alongside the other RPG2000 boot smokes (display 122).
+
+  Verified: `ctest` (all 8 targets, including the real compiled binary with
+  the new trace field), the new script itself in both `--report` and
+  asserting mode (against the current tree, against `Array#include?`'s fix
+  alone reverted, and against this whole round's fixes reverted), and the
+  rest of the RPG2000 ruby-checks trio — all pass unchanged.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -275,6 +275,40 @@ audio calls are the ones that touch the decoder, not the ones that mix.
   can move; `Mix_PlayMusic`/`Mix_PlayChannel` and the `g_chunks` cache should
   stay owned by one thread.
 
+## Per-frame object allocation
+
+Separate from frame *time*: how many mruby objects the map scene allocates
+each frame, tracked because a string of fixes (skip_to's terminator arrays
+hoisted to frozen constants; `Scene::Map#events_dirty?`/
+`#record_map_event_positions` reusing Arrays instead of rebuilding them every
+frame; `#step_parallels` and four other `@events.each` loops rewritten as
+block-free `while` loops; `Game::Interpreter#range` returning a `Range`
+instead of a throwaway Array; `Array#include?` given a native-equivalent
+override because mruby's own falls through to a block-allocating
+`Enumerable#include?`) cut it by well over half across several rounds — see
+`changelog.d/` for each one's own measurement.
+
+Measured the same way as the time baseline above (same command, same
+Nepheshel run), reading `RGSS::Profiler.stats[:object_types]`'s cumulative
+`:allocs` per type at two points in a steady window rather than the summary
+line's live counts (those rise and fall with GC and cannot answer "how many
+were allocated between two points"):
+
+| type | allocs/sec |
+| --- | ---: |
+| `Array` | ~4000 |
+| `Proc` | ~1650 |
+| `env` | ~985 |
+
+`scripts/rpg2k_alloc_regression_check.rb` automates exactly this measurement
+(via the profiler trace's `mruby_type_allocs` counter series, see
+[README.md](../README.md#profiling)) and fails if any of the three exceeds a
+ceiling set from this table — the standing regression guard for the fixes
+above, run in CI alongside the other RPG2000 boot smokes. Re-run it with
+`--report` to see fresh rates without asserting, e.g. after a deliberate new
+per-frame feature that genuinely needs to raise a ceiling (with a comment in
+the script saying why), or while investigating whether a change regressed one.
+
 ## Caveats on these numbers
 
 - Software rendering under Xvfb with `SDL_AUDIODRIVER=dummy`. Absolute

--- a/mruby-rgss/src/profiler.cxx
+++ b/mruby-rgss/src/profiler.cxx
@@ -383,16 +383,30 @@ void report(uint64_t now) {
                   static_cast<long long>(g_live_blocks));
     trace_counter("mruby_blocks", now, args);
     if (!types.empty()) {
-      std::string type_args;
+      std::string type_args, alloc_args;
       for (const TypeCount& t : types) {
-        if (!type_args.empty())
+        if (!type_args.empty()) {
           type_args += ',';
+          alloc_args += ',';
+        }
         type_args += "\"";
         type_args += json_escape(t.name);
         type_args += "\":";
         type_args += std::to_string(t.live);
+        alloc_args += "\"";
+        alloc_args += json_escape(t.name);
+        alloc_args += "\":";
+        alloc_args += std::to_string(t.allocs);
       }
       trace_counter("mruby_types", now, type_args);
+      // Cumulative (never-reset) allocation counts per type, the same source
+      // `types[i].allocs` -- as opposed to `mruby_types`' live counts, which
+      // rise and fall with GC and so cannot answer "how many objects of this
+      // type were allocated between two points in the run": a script sampling
+      // this series at two timestamps and dividing the delta by the elapsed
+      // frame count gets a real per-frame allocation rate. See
+      // scripts/rpg2k_alloc_regression_check.rb.
+      trace_counter("mruby_type_allocs", now, alloc_args);
     }
     std::fflush(g_trace_file);
   }

--- a/scripts/rpg2k_alloc_regression_check.rb
+++ b/scripts/rpg2k_alloc_regression_check.rb
@@ -1,0 +1,141 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Regression guard for per-frame mruby object churn on the RPG2000 map scene.
+#
+# Why this exists: a string of fixes (skip_to's terminator arrays hoisted to
+# frozen constants; Scene::Map#events_dirty?/#record_map_event_positions
+# reusing Arrays instead of rebuilding them every frame; #step_parallels and
+# four other @events.each loops rewritten as block-free while loops;
+# Game::Interpreter#range returning a Range instead of a throwaway Array;
+# Array#include? given a native-equivalent override because mruby's own falls
+# through to a block-allocating Enumerable#include?) cut this scene's
+# per-frame Array/Proc/env allocation by well over half over several rounds,
+# each one found by hand with a temporary instrumentation pass and reverted
+# before commit. None of that is guarded against silently regressing -- a
+# reverted fix, a new per-frame `.each { }` on @events, a new `[a, b]`-style
+# throwaway array in a hot command handler -- would show up as nothing but a
+# quieter frame budget until the fix's own PR reads like ancient history.
+#
+# This script is the standing version of that same manual pass: it boots the
+# real engine against a real game, samples RGSS::Profiler's own per-type
+# cumulative allocation counters (mirrored into the Chrome trace as the
+# `mruby_type_allocs` counter series -- see mruby-rgss/src/profiler.cxx and
+# README.md's Profiling section) at two points in a steady window, and fails
+# if the measured per-second rate for Array, Proc or env exceeds a ceiling
+# generously above what this scene measures today. It is a floor for "did
+# something make this a lot worse", not a tight bound -- a genuine new
+# per-frame feature can legitimately raise the true number, in which case
+# re-run with `--report` to see the fresh rates and raise CEILINGS to match,
+# with a comment saying why.
+#
+# Usage:
+#   ruby scripts/rpg2k_alloc_regression_check.rb [GAME_DIR] [--report]
+#     GAME_DIR   defaults to data/Nepheshel206beta/Nepheshel206Rbeta
+#     --report   print the measured rates and exit 0 regardless of the
+#                ceilings, for re-baselining after a deliberate change
+#
+# Env vars (mirroring the other boot-check scripts):
+#   ENGINE               path to the built binary (default ./build/rpg_maker_clone)
+#   SERVER_NUM            xvfb-run --server-num to use (default 122; see the
+#                         reserved display numbers in .github/workflows/build.yml)
+#   RPG2K_ALLOC_TIMEOUT_MS how long to let the engine run (default 25000)
+#
+# Exits non-zero if the build is missing, the game data is missing, the trace
+# came back with fewer than two samples, or a measured rate exceeds its ceiling.
+
+require 'json'
+require 'tmpdir'
+
+ENGINE = ENV['ENGINE'] || './build/rpg_maker_clone'
+SERVER_NUM = ENV['SERVER_NUM'] || '122'
+TIMEOUT_MS = (ENV['RPG2K_ALLOC_TIMEOUT_MS'] || '25000').to_i
+
+report_only = ARGV.delete('--report') ? true : false
+game_dir = ARGV[0] || 'data/Nepheshel206beta/Nepheshel206Rbeta'
+
+# Ceilings in allocations/second, ~1.1-1.15x the steady-state rate this scene
+# actually measures on Nepheshel's scripted opening with every fix above
+# applied (docs/profiling.md's own baseline run: Array ~4000/s, Proc ~1650/s,
+# env ~985/s, stable within 1% run to run). Checked against reverting just
+# the Array#include? fix (Array 4496/s, Proc 2008/s, env 1347/s) and against
+# reverting this whole round -- #range's Array fix included (Array 4692/s,
+# Proc 2228/s, env 1574/s): margins this tight catch either, with enough
+# slack above the measured baseline's own <1% run-to-run variance that a
+# clean tree does not flap. Only the three types this investigation was
+# about; the same `mruby_type_allocs` sample carries every type
+# RGSS::Profiler tracks, for `--report`'s sake.
+CEILINGS = { 'Array' => 4500.0, 'Proc' => 1900.0, 'env' => 1140.0 }.freeze
+
+unless File.executable?(ENGINE)
+  warn "error: #{ENGINE} not built; run cmake --build build first"
+  exit 1
+end
+
+unless File.exist?(File.join(game_dir, 'RPG_RT.ldb'))
+  puts "skip: no RPG_RT.ldb under #{game_dir} (run scripts/download-nepheshel.bash first)"
+  exit 0
+end
+
+Dir.mktmpdir('rpg2k_alloc_regression') do |dir|
+  trace_path = File.join(dir, 'trace.json')
+  cmd = ['xvfb-run', "--server-num=#{SERVER_NUM}",
+         ENGINE, '--test_play', '--profile', '--profile_interval_ms=2000',
+         "--profile_trace=#{trace_path}", "--timeout_ms=#{TIMEOUT_MS}",
+         '--game_dir', game_dir, '--rpg2k_new_game']
+  ok = system({ 'SDL_AUDIODRIVER' => 'dummy' }, *cmd, out: File::NULL, err: File::NULL)
+  unless File.exist?(trace_path)
+    warn "error: no trace produced -- the engine failed to start " \
+         "(exit status: #{ok.inspect}); run the command by hand to see why:\n" \
+         "  SDL_AUDIODRIVER=dummy xvfb-run --server-num=#{SERVER_NUM} #{ENGINE} " \
+         "--test_play --profile --profile_trace=#{trace_path} --game_dir #{game_dir} --rpg2k_new_game"
+    exit 1
+  end
+
+  # The trace stream stays loadable even if the process was killed mid-run
+  # (README.md's Profiling section documents this deliberately: no trailing
+  # `]` is guaranteed) -- append one if it is missing rather than treat that
+  # as a parse error.
+  content = File.read(trace_path).rstrip
+  content = content[0..-2] if content.end_with?(',')
+  content += ']' unless content.end_with?(']')
+  events = JSON.parse(content)
+
+  samples = events.select { |e| e['name'] == 'mruby_type_allocs' }
+  if samples.size < 3
+    warn "error: only #{samples.size} mruby_type_allocs sample(s) captured -- " \
+         "raise RPG2K_ALLOC_TIMEOUT_MS or lower --profile_interval_ms"
+    exit 1
+  end
+
+  # Drop the first sample: it covers the load-time burst (asset decode, the
+  # title -> map transition), not steady per-frame gameplay churn -- the same
+  # caveat every manual capture in this investigation noted by hand.
+  first = samples[1]
+  last = samples[-1]
+  elapsed_s = (last['ts'] - first['ts']) / 1_000_000.0
+
+  puts "measured over #{elapsed_s.round(1)}s (#{samples.size - 1} steady samples):"
+  failures = []
+  CEILINGS.each do |type, ceiling|
+    delta = (last['args'][type] || 0) - (first['args'][type] || 0)
+    rate = delta / elapsed_s
+    over = rate > ceiling
+    failures << type if over && !report_only
+    status = over ? 'FAIL' : '  ok'
+    puts format('  %s %-6s %8.1f/s  (ceiling %.0f/s)', status, type, rate, ceiling)
+  end
+
+  if report_only
+    puts 'report only -- not asserting against ceilings'
+  elsif failures.empty?
+    puts 'OK: per-frame object churn within bounds'
+  else
+    warn "FAILED: allocation regression in #{failures.join(', ')} -- " \
+         "re-run with --report, then either find and fix the reverted/missing " \
+         "optimization (see this file's own header for the fixes it guards) " \
+         "or, if the increase is a genuine reviewed one (a new per-frame " \
+         "feature), raise its CEILINGS entry here with a comment saying why."
+    exit 1
+  end
+end


### PR DESCRIPTION
## Summary

Every fix in this investigation (#1436, #1438, #1447, #1454) was found and measured by hand with a temporary instrumentation pass reverted before commit — none of it was guarded against silently regressing. This PR closes that gap with two pieces:

- **The profiler's Chrome trace export now mirrors a `mruby_type_allocs` counter series** alongside the existing `mruby_types` (live counts, which rise and fall with GC): the same per-type breakdown as **cumulative**, never-reset allocation counts, straight off `RGSS::Profiler`'s own counters (`mruby-gc-type-live-counts.patch`) — no new cost, the numbers were already computed for the live breakdown (`TypeCount::allocs`), just not written into the trace. Diffing two samples by their timestamps gives a real per-second allocation *rate*, which the live-count series alone cannot answer.
- **`scripts/rpg2k_alloc_regression_check.rb`** automates the exact manual measurement this whole investigation used: boots the engine on Nepheshel, samples that new series at two points in a steady window, and fails if the measured Array/Proc/env rate exceeds a ceiling set from this scene's own measured baseline. Checked to actually catch a regression: reverting just the `Array#include?` fix trips `env` and `Proc`; reverting this whole round's fixes (`range(cmd)` included) trips `env` comfortably. Wired into CI alongside the other RPG2000 boot smokes (display 122 — the next free number after the RGSSAD packed-asset smoke's 120..121).

Also documents the new trace field in README.md's Profiling section and adds a "Per-frame object allocation" section to `docs/profiling.md` recording the measured baseline the script's ceilings are set from.

## Test plan

- [x] `ctest` — all 8 targets, including the real compiled binary with the new trace field
- [x] The new script itself, in both `--report` and asserting mode:
  - against the current (all-fixes-applied) tree — passes
  - against `Array#include?`'s fix alone reverted — `env`/`Proc` correctly flagged in `--report`
  - against this whole round's fixes reverted — `env` correctly fails assertion mode
- [x] `scripts/rpg2k_scene_check.rb` (943 checks)
- [x] `scripts/rpg2k_render_check.rb` (41 checks)
- [x] `scripts/rpg2k_logic_check.rb` (1185 checks)

All pass, output unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_0117pag6Su2mrNWMN3QByEA3)_