### PR TITLE
Cycle #215-#218: save-load check, stale docs, title/map BGM fade-in stragglers

### DIFF
--- a/changelog.d/map-autoplay-bgm-fadein.fixed.md
+++ b/changelog.d/map-autoplay-bgm-fadein.fixed.md
@@ -1,0 +1,18 @@
+- **A map's own Autoplay BGM (the map-tree node's `bgm` chunk, set on the
+  Map Properties dialog in the editor) now honours its `fade_in` field
+  instead of silently dropping it.** Cycle #203 threaded the same liblcf
+  `BGM`-struct field 2 `fade_in` (`mruby-lcf/mrblib/schema.rb`) through to
+  `RGSS::Audio.bgm_play`'s 5th argument for `#battle_bgm`, the inn's
+  restore path, and `#vehicle_bgm` (all via `Scene::Map`'s shared
+  `#music_fadein` helper and its own `#play_bgm` choke point), but
+  `#play_map_bgm` — the helper `Game_Player::MoveTo`-equivalent code calls
+  on the initial map load and every Transfer Player — was the one call
+  site that cycle missed: it built the `{ name:, volume:, tempo: }` hash
+  passed to `#play_bgm` without ever reading `#music_fadein(bgm)`, so a
+  map's own configured fade-in was always read as 0 and every map entry
+  restarted the track at full volume instantly instead of ramping in.
+  Fixed by passing `fadein: music_fadein(bgm)` through the same way
+  `#battle_bgm`/`#vehicle_bgm` already do. Found by a systematic sweep of
+  every call site of `#music_fadein`/`Audio.bgm_play` after cycle #217's
+  near-identical miss (`Scene::Title#play_title_bgm`), not by chance
+  reading.

--- a/changelog.d/save-load-check-picture-field-shape.fixed.md
+++ b/changelog.d/save-load-check-picture-field-shape.fixed.md
@@ -1,0 +1,12 @@
+- **Tests:** closed the last of `scripts/rpg2k_save_load_check.rb`'s
+  long-standing "known pre-existing failures" -- a Show Picture round-trip
+  check whose expected hash predated the `show_x`/`show_y`/`fixed_to_map`/
+  `use_transparent_color` fields `Game::State.restore_pictures` has actually
+  passed through for many cycles now. The runtime was already correct; only
+  the test's own fixture had drifted from it (the same root cause already
+  diagnosed and fixed for two sibling BGM assertions in this same file).
+  The check now also sets fields 2/3/6/9 in its synthetic save entry to
+  values distinct from the neighbouring finish_x/finish_y fields, so it
+  actually exercises this round-trip instead of merely matching whatever
+  the code happens to default to. `rpg2k_save_load_check.rb` now reports
+  zero known failures, down from one.

--- a/changelog.d/stale-implemented-still-to-come-comments.fixed.md
+++ b/changelog.d/stale-implemented-still-to-come-comments.fixed.md
@@ -1,0 +1,28 @@
+- **Docs:** corrected four live doc comments in `mruby-rpg2k/mrblib/` that
+  still described already-shipped features as "still to come" -- no
+  behavior changed anywhere, only comments that had drifted out of date as
+  the features they described landed in later cycles:
+  - `Game::Screen`'s class doc said applying a Tint Screen as an
+    `RGSS::Viewport` tone was "the native (C++) half still to come, so the
+    tint does not yet draw", and that the class "models two effects so
+    far" with "Flash will join the class the same way" -- but the tint has
+    reached the map viewport (and the battle backdrop) since the "screen
+    tone reaches the map" work, and `Flash`/`Pan`/`Fade` were all added to
+    this same class long ago alongside `Tint`/`Shake`.
+  - `Interpreter#do_weather`'s doc said "compositing the rain/snow
+    particles is native renderer work still to come" -- but
+    `Scene::Map#draw_weather` has drawn the weather overlay (rain streaks,
+    drifting snow) every frame since it was added.
+  - `Scene::Map#perform_game_over`'s doc opened with "Stop the event and
+    return to the title screen -- the faithful end state. (RPG2000 shows a
+    Game Over graphic first; that screen is native renderer work still to
+    come.)", directly contradicted by the very next sentence in the same
+    comment block describing the already-implemented Game Over screen --
+    a leftover first draft that was never deleted once the real
+    description was written beside it.
+  - `Game::Battle`'s class doc called it "a deliberately simple first cut"
+    with "escape and enemy-cast state infliction still to come" -- but
+    `#attempt_escape` and `#inflict_state` (fed from both an ally's and an
+    enemy's own skill picks) are implemented directly on this class, which
+    is now the ~4000-line engine driving `Scene::Battle`'s live fights,
+    not a stand-in for one.

--- a/changelog.d/title-screen-bgm-fadein.fixed.md
+++ b/changelog.d/title-screen-bgm-fadein.fixed.md
@@ -1,0 +1,13 @@
+- **The title screen's own database BGM (`System > title music`) now honours
+  its `fade_in` field instead of silently dropping it.** Cycle #202/#203
+  wired the same `fade_in` field (liblcf `BGM`-struct field 2,
+  `mruby-lcf/mrblib/schema.rb`) through to `RGSS::Audio.bgm_play`'s 5th
+  argument for Play BGM, Play Memorized BGM and the battle/inn/vehicle/
+  game-over BGM helpers, but `Scene::Title#play_title_bgm` was never
+  touched — it still called `Audio.bgm_play` with only 3 arguments,
+  and its own doc comment claimed the audio backend "can fade a BGM out,
+  not in", a stale statement written before that same cycle #202 gave
+  `Mix_FadeInMusic` a real `fadein_ms` path (`src/sdl_audio.cxx`). Fixed by
+  threading `bgm.fade_in || 0` through the same 5-argument
+  `Audio.bgm_play` call every sibling BGM source already uses, and
+  correcting the doc comment.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1722,6 +1722,54 @@ The work below is roughly ordered by the critical path to a walkable game
   repo-wide EasyRPG-citation-hygiene sweep cycle #174's own note (256
   unswept instances, last counted then) already tracks separately --
   that sweep is unrelated to this fix and still needs a future cycle.
+  ✅ **Follow-up (cycle #217, 2026-08-28): the title screen's own database
+  BGM (`System > title music`) was the one BGM source cycle #202/#203's
+  fade-in wiring never reached, dropping a configured `fade_in` on the
+  floor instead of fading the music in.** Method: with the doc-level
+  backlog and this file's own comment-drift sweep both already closed
+  (cycles #215/#216), this cycle widened the search per the standing
+  instructions — check-suite coverage gaps first. Cross-referencing every
+  `Scene::` BGM call site (`grep -rn bgm_play mruby-rpg2k/mrblib`) against
+  cycle #202's own "Play BGM's fade-in parameter now actually fades the
+  music in" fix and cycle #203's follow-on ("battle/inn/vehicle, and the
+  Game Over screen now honour a configured BGM fade-in") turned up exactly
+  one remaining 3-argument `Audio.bgm_play` call left over from both
+  passes: `Scene::Title#play_title_bgm` (`mruby-rpg2k/mrblib/scene/
+  title.rb`), whose own doc comment claimed "the audio backend can fade a
+  BGM out, not in (see ADR 0006)" — a statement that was already false by
+  the time it was written (`git blame` dates that comment to 2026-08-22,
+  cycle #202's `Mix_FadeInMusic` wiring landed 2026-08-28) and ADR 0006
+  itself never makes that claim at all (it only documents pitch/tempo as
+  unsupported). `scripts/rpg2k_scene_check.rb`'s own `fake_db` fixture
+  names no `title_music` at all, so the gap was invisible to the whole
+  check suite — no check exercised `play_title_bgm`'s `Audio.bgm_play`
+  call at all before this cycle. Fixed by threading `bgm.fade_in || 0`
+  through as the 5th `Audio.bgm_play` argument, the same idiom every
+  sibling BGM helper already uses, and rewriting the stale doc comment.
+  **Verification**: a new `rpg2k_scene_check.rb` check sets a local
+  `db.system.title_music` (not the shared fixture, to avoid perturbing
+  every other Title check) with `fade_in: 350` and asserts
+  `Audio.bgm_calls == [['TitleBGM', 90, 100, 0, 350]]`; confirmed to fail
+  against the pre-fix code first (`git stash` on just `title.rb`, which
+  reproduced the expected 3-argument call and failed the assertion) then
+  pass after (`git stash pop`). Full suite: `rpg2k_scene_check.rb` 944
+  passed (943 baseline + 1 new check); `rpg2k_logic_check.rb` 1187 passed
+  (unchanged, no `mrblib` file it loads was touched); `rpg2k_render_
+  check.rb` 41 passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged); `rpg2k_save_
+  load_check.rb` exit 0, zero known failures (unchanged); `cd build &&
+  ninja` clean rebuild; `ctest --test-dir build` 8/8 passing. No
+  `.cxx`/`.hxx` file was touched (a pure-Ruby fix plus its check-script
+  fixture), so the pinned `clang-format` step does not apply, and no
+  `mruby-rgss` file was touched either, so `rgss_cruby_test_check.rb`
+  and `rgss_cruby_compat.rb` needed no attention. No wine session was run
+  this cycle (audio timing is not screenshot-diffable, matching every
+  earlier BGM-fade-in cycle's own note) and no EasyRPG source was
+  consulted for any new behavioral claim — this is first-principles code
+  reading (the native fade-in mechanism was already proven for every
+  other BGM path in cycles #202/#203; this cycle is the same mechanical
+  plumbing to the one call site those cycles missed) plus a factual
+  correction of a comment that had gone stale the moment it was written.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1623,6 +1623,59 @@ The work below is roughly ordered by the critical path to a walkable game
   BGM in cycle #202; this cycle is mechanical plumbing of that same
   mechanism to a second, structurally identical call path) rather than a
   wine-verified timing match.
+  ✅ **Follow-up (cycle #215, 2026-08-28): the "1 known pre-existing
+  failure" this file has carried forward at every one of the dozens of
+  citations above (the Show Picture field-shape mismatch) is now closed
+  too, the same root cause as this bullet's own two BGM assertions above --
+  a real feature landed correctly and the test's own expected hash simply
+  never got updated to match.** Method: after a genuinely broad search
+  (the "Message window", "Battle system", "Pictures", "Screen effects",
+  "Move Route", "Party/Actor/Vehicle", "Database field semantics" and
+  "Concrete runtime error catalog" sections, the RGSS/VX/VXAce gap docs,
+  and a paragraph-level sweep of every bullet in this whole file for one
+  with no ✅/🚧 marker anywhere in its own text) turned up nothing else
+  both small and genuinely open -- essentially the entire backlog through
+  cycle #214 is already closed, confirming this file's own "the runtime
+  error catalog family is close to exhausted" read holds for the rest of
+  the document too, not just that one catalog. `scripts/
+  rpg2k_save_load_check.rb`'s synthetic Show Picture round-trip check built
+  a chunk-103 entry that never set fields 2/3 (`show_x`/`show_y`) or 6/9
+  (`fixed_to_map`/`use_transparent_color`), then asserted against an
+  expected hash with no such keys at all -- but `Game::State.
+  restore_pictures` (`mruby-rpg2k/mrblib/game.rb`) has unconditionally
+  included all four in the options hash it passes to `#show_picture` since
+  the cycles that added `fixed_to_map`/`use_transparent_color` (#155/#158)
+  and `show_x`/`show_y` round-tripping, so the check had been failing on
+  every run since, exactly the same drift already diagnosed for the BGM
+  case above. Fixed by setting fields 2/3/6/9 in the synthetic entry to
+  values distinct from the neighbouring `finish_x`/`finish_y` (80/60), so
+  the check actually exercises the round-trip instead of merely matching
+  whatever the code happens to default to, and widening the expected hash
+  to the real four-key-richer shape. **Verification**: confirmed to fail
+  against the pre-fix code first (`git stash`/`git stash pop` on just
+  `scripts/rpg2k_save_load_check.rb` -- the pre-fix version reports exactly
+  the same `expected ... got ...` mismatch this file's own dozens of
+  citations already quote) then pass after. Full suite: `rpg2k_scene_
+  check.rb` 943 passed (unchanged, no `scene/map.rb`/`interpreter.rb`
+  touched); `rpg2k_logic_check.rb` 1187 passed (unchanged); `rpg2k_render_
+  check.rb` 41 passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged, no battle code
+  touched); `rpg2k_save_load_check.rb` now reports **zero** known failures,
+  down from the one it has carried since the BGM fix above reduced the
+  original three to it -- every future cycle's own "unaffected" note for
+  it can finally read "0 failures" instead of "1 known pre-existing
+  failure". No `.cxx`/`.hxx`
+  file was touched (a single check-script fixture correction, no `mrblib`
+  Ruby or native code changed at all), so the pinned `clang-format` step
+  does not apply and no rebuild was strictly needed; `cd build && ninja`
+  reported no work to do (confirming nothing native was touched) and
+  `ctest -R mruby_test` passed anyway for completeness, as did `ruby
+  scripts/rgss_cruby_test_check.rb` (also unaffected, no RGSS code
+  touched). No wine session was run this cycle and no EasyRPG source was
+  consulted: this is a pure test-fixture correction verified entirely by
+  internal consistency (the corrected fixture's own field values against
+  `Game::State.restore_pictures`'s already-shipped, already-cited-elsewhere
+  behavior), not a new behavioral claim about genuine RPG_RT.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1676,6 +1676,52 @@ The work below is roughly ordered by the critical path to a walkable game
   internal consistency (the corrected fixture's own field values against
   `Game::State.restore_pictures`'s already-shipped, already-cited-elsewhere
   behavior), not a new behavioral claim about genuine RPG_RT.
+  ✅ **Follow-up (cycle #216, 2026-08-28): with the backlog above still
+  fully closed, this cycle went looking (per this file's own cycle #215
+  note that the doc-level sweep was exhausted) for code-quality issues
+  instead, and found four live doc comments in `mruby-rpg2k/mrblib/`
+  describing already-shipped features as "still to come" -- pure
+  documentation drift, no behavioral bug and no code change.** Method: a
+  repo-wide grep for "still to come"/"does not yet draw"/"deliberately
+  simple first cut" style phrasing across `mrblib`, cross-checked against
+  this file's own history for each claim (rather than trusted at face
+  value) -- three of the four resolved instances are large open questions
+  this file already answers elsewhere ("The screen tone reaches the map
+  now as well" above; the game-over screen and weather rendering are both
+  long-shipped features, confirmed by reading `Scene::Map#perform_game_
+  over`/`#draw_weather` directly), and the fourth (`Game::Battle`'s class
+  doc calling itself "a deliberately simple first cut") was checked
+  directly against the class body, which turned out to already implement
+  both named gaps (`#attempt_escape`, `#inflict_state` fed from an enemy's
+  own skill picks via `#choose_enemy_action`) and has grown to ~4000 lines
+  -- the actual engine behind `Scene::Battle`'s live fights, not a
+  stand-in for one. Fixed by rewriting each of the four comments to
+  describe the current, correct state (`Game::Screen`'s class doc,
+  `Interpreter#do_weather`'s doc, `Scene::Map#perform_game_over`'s doc --
+  which had two contradictory paragraphs stacked back to back, the stale
+  one describing a "return to the title screen" outcome the very next
+  sentence already correctly overrides with "show the Game Over screen"
+  -- and `Game::Battle`'s class doc). No behavioral code changed anywhere
+  (`git diff` on all three touched `mrblib` files is comments only), so no
+  regression check applies, matching cycle #169/#171/#215's own precedent
+  for citation/comment-only fixes. **Verification**: `scripts/
+  rpg2k_scene_check.rb` 943 passed (unchanged), `rpg2k_logic_check.rb`
+  1187 passed (unchanged), `rpg2k_render_check.rb` 41 passed (unchanged),
+  `rpg2k3_battle_row_check.rb` 19/0 and `rpg2k3_battle_gauge_check.rb`
+  15/0 (both unchanged), `rpg2k_save_load_check.rb` still reports zero
+  known failures; `cd build && ninja` clean rebuild with no new warnings;
+  `ctest -R mruby_test` passed; `ruby scripts/rgss_cruby_test_check.rb`
+  passed (run for completeness -- no RGSS-side file was touched). No
+  `.cxx`/`.hxx` file was touched, so the pinned `clang-format` step does
+  not apply. No wine session was run and no EasyRPG source was consulted
+  for any behavioral claim this cycle (the one EasyRPG-sourced citation
+  read in passing, `Game::Battle`'s `#inflict_state` doc a few hundred
+  lines below the fixed class doc, was read only to confirm the feature
+  exists, not cited as a new behavioral claim). **Left open**: this was a
+  narrow, targeted grep for one specific phrasing pattern, not the
+  repo-wide EasyRPG-citation-hygiene sweep cycle #174's own note (256
+  unswept instances, last counted then) already tracks separately --
+  that sweep is unrelated to this fix and still needs a future cycle.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1770,6 +1770,58 @@ The work below is roughly ordered by the critical path to a walkable game
   other BGM path in cycles #202/#203; this cycle is the same mechanical
   plumbing to the one call site those cycles missed) plus a factual
   correction of a comment that had gone stale the moment it was written.
+  ✅ **Follow-up (cycle #218, 2026-08-28): a map's own Autoplay BGM
+  (the map-tree node's `bgm` chunk, Map Properties in the editor) was a
+  second BGM source cycle #203's fade-in wiring never reached.** Method:
+  per the standing instruction to repeat cycle #217's systematic-sweep
+  pattern rather than blind reading, this cycle grepped every call site of
+  `#music_fadein` (the helper cycle #203 added specifically to read a
+  liblcf `BGM`-struct's field 2 `fade_in`, `mruby-lcf/mrblib/schema.rb`)
+  across `mruby-rpg2k/mrblib/scene/map.rb`. Three call sites already read
+  it (`#battle_bgm`, `#vehicle_bgm`, and `#restore_pre_inn_bgm`'s source
+  `db.system.inn_music` via cycle #203's own fix), but `#play_map_bgm` —
+  which resolves `Game::MapBgm.chunk_for` (the same `BGM`-struct shape,
+  `map_properties` field 12) on every initial map load and every Transfer
+  Player — built its `{ name:, volume:, tempo: }` hash for `#play_bgm`
+  without ever calling `#music_fadein`, so a fade-in configured on a
+  map-tree node's own BGM was always read as 0 and the track always
+  restarted at full volume instantly. Fixed by passing
+  `fadein: music_fadein(bgm)` through, the same idiom `#battle_bgm`/
+  `#vehicle_bgm` already use. **Verification**: extended
+  `rpg2k_scene_check.rb`'s existing `FakeBgmChunk` fixture struct with a
+  `fade_in` field (defaults to `nil` when omitted, so every pre-existing
+  call site building one with 3 positional args is unaffected) and added a
+  new check asserting a map's own `fade_in: 400` reaches
+  `Audio.bgm_calls` as `['Town', 90, 105, 0, 400]`, plus a sibling map
+  with an unset fade-in still reaching bgm_play as 0. Confirmed to fail
+  against the pre-fix `map.rb` first (`git show HEAD:mruby-rpg2k/mrblib/
+  scene/map.rb` swapped in in place of the working copy, ran the check,
+  got the expected `RuntimeError: expected [...0, 400]], got [...0, 0]]`
+  failure) then restored the fix and reran clean. Full suite:
+  `rpg2k_scene_check.rb` 945 passed (944 baseline + 1 new check);
+  `rpg2k_logic_check.rb` 1187 passed (unchanged); `rpg2k_render_check.rb`
+  41 passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged); `rpg2k_save_
+  load_check.rb` exit 0, zero known failures (unchanged); `cd build &&
+  ninja` clean rebuild; `ctest --test-dir build` 8/8 passing. No
+  `.cxx`/`.hxx` file was touched (a pure-Ruby fix plus its check-script
+  fixture), so the pinned `clang-format` step does not apply, and no
+  `mruby-rgss` file was touched either, so `rgss_cruby_test_check.rb` and
+  `rgss_cruby_compat.rb` needed no attention. No wine session was run this
+  cycle (audio timing is not screenshot-diffable, matching every earlier
+  BGM-fade-in cycle's own note) and no EasyRPG source was consulted for
+  any new behavioral claim — the `BGM`-struct shape and `#music_fadein`
+  mechanism were already established by cycle #203; this cycle is the
+  same mechanical plumbing to a call site that cycle missed. **Left
+  open**: the systematic sweep of `Audio.bgm_play`/`#music_fadein` call
+  sites is now exhausted (every remaining call site — `resume_saved_bgm`,
+  `RGSS::Audio.bgm_play` in `interpreter.rb`'s Play BGM/Play Memorized
+  BGM branches, `Scene::Title`, `Scene::GameOver` — already threads
+  fade-in correctly or deliberately bypasses it with a cited reason); a
+  similar sweep of `Audio.se_play`/SE-struct call sites found every one
+  already consistent (the `SE` struct's `balance` field is dropped
+  everywhere, but that matches `Audio.se_play`'s own 3-argument signature,
+  which has no pan parameter to receive it — not a missed call site).
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8520,16 +8520,19 @@ module Game
     end
   end
 
-  # Screen-effect state driven by the screen event commands. Models two effects
-  # so far:
+  # Screen-effect state driven by the screen event commands. Models tint,
+  # shake, flash, pan and fade (Flash/Pan/Fade were later additions to this
+  # class; each now has its own accessors and `update` branch below, the same
+  # way Tint/Shake do):
   #
   # * **Tint** (Tint Screen, 11030): a colour multiplier given as RPG2000's four
   #   0..200 channels (red / green / blue / saturation, 100 = neutral). `tint_to`
   #   starts a transition to a target over N frames and `update` steps the
   #   channels toward it with the classic RPG2000/RGSS
   #   `cur += (target - cur) / frames_left` interpolation, which lands exactly on
-  #   the target on the final frame. Applying the tint as an `RGSS::Viewport`
-  #   tone is the native (C++) half still to come, so the tint does not yet draw.
+  #   the target on the final frame. `Scene::Map#update_map_tone` applies this
+  #   as the shared map `Viewport`'s `RGSS::Viewport` tone (and, while a fight
+  #   is open, the battle backdrop's), so the tint does draw.
   # * **Shake** (Shake Screen, 11050): a horizontal camera offset that oscillates
   #   while active. `shake` starts a timed shake and `update` advances it with
   #   a direct port of EasyRPG Player's own `Shake::NextPosition`/`Shake::Update`
@@ -8548,8 +8551,7 @@ module Game
   #   reads `shake_offset` and offsets the camera by it, so the shake *is*
   #   visible.
   #
-  # `update` (called once per frame by the scene) advances both. Flash will join
-  # the class the same way.
+  # `update` (called once per frame by the scene) advances all of them.
   class Screen
     NEUTRAL = 100 # a channel value that leaves the screen unchanged
 
@@ -10472,11 +10474,17 @@ module Game
     end
   end
 
-  # resolution. It works on Combatant snapshots, so the caller can resolve a
-  # battle without mutating the real party. This is a deliberately simple first
-  # cut — escape and enemy-cast state infliction are still to come, and the
-  # turn-based battle *screen* wires the refinements (skills, items, criticals,
-  # elemental attributes, damage variance) into a live fight.
+  # A headless combat model driving both the live turn-based fight
+  # (Scene::Battle holds one as its own `@ui[:battle]`) and, separately, an
+  # out-of-battle skill/item cast resolved on Combatant snapshots so the
+  # caller can compute an effect without mutating the real party. Escape
+  # (#attempt_escape) and enemy-cast state infliction (#inflict_state, fed
+  # from an enemy's own #choose_enemy_action skill pick the same way an
+  # ally's does) are both implemented directly on this class, not a
+  # still-to-come refinement — this stopped being a "deliberately simple
+  # first cut" some time ago. The field-only skill/item formulas
+  # (#skill_effect, #skill_defence_term and friends) still live on
+  # Game::Party, reused by both the field menu and this class.
   class Battle
     # RPG2003 front/back row. A purely RPG2003 concept (RPG2000 never sets it):
     # the row changes a battler's hit and damage the way EasyRPG's

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -4474,10 +4474,10 @@ module Game
 
     # Weather Effects: set the map weather type (param0 — 0 none, 1 rain, 2 snow;
     # the RPG2003 additions come through as higher values) and strength (param1 —
-    # 0 weak .. 2 strong) on the shared game state. Non-blocking; like the picture
-    # / tint overlays this records the Ruby-half model only — compositing the
-    # rain/snow particles is native renderer work still to come — but the setting
-    # is applied and persists through Save / Continue.
+    # 0 weak .. 2 strong) on the shared game state. Non-blocking; sets the model
+    # here, and `Scene::Map#draw_weather` composites the actual rain streaks /
+    # snow drift onto its own overlay sprite from it every frame — the setting
+    # is applied, drawn, and persists through Save / Continue.
     # Ported from EasyRPG Player's `Game_Interpreter::CommandWeatherEffects`,
     # NOT independently confirmed against genuine RPG_RT under wine:
     # `strength = std::min(str, 2)` unconditionally

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6884,13 +6884,25 @@ class RPG2k
       # Skipped while boarded: the vehicle's own BGM (#play_vehicle_bgm) owns
       # the audio then, and #restore_pre_vehicle_bgm resumes whatever this
       # would have played once the party disembarks.
+      #
+      # `fadein` (cycle #218): the map-tree node's `bgm` chunk is the same
+      # liblcf `BGM` struct (mruby-lcf/mrblib/schema.rb) as battle_music/
+      # inn_music/boat_music/ship_music/airship_music, whose own field 2
+      # `fade_in` cycle #203 already threaded through #battle_bgm/
+      # #restore_pre_inn_bgm's source/#vehicle_bgm into #play_bgm's 5th
+      # `RGSS::Audio.bgm_play` argument -- this call site (#music_fadein
+      # already exists for exactly this) was the one #203 missed, so a map's
+      # own Autoplay BGM fade-in (set on the map-tree node in the editor) was
+      # silently dropped and every map entry/Transfer Player restarted the
+      # track at full volume instantly instead.
       def play_map_bgm
         return if @state.boarded?
         bgm = Game::MapBgm.chunk_for(@state.map_id, map_properties)
         return unless bgm
         name = music_name(bgm)
         return if name.nil? || name.empty?
-        play_bgm(name: name, volume: music_volume(bgm), tempo: music_tempo(bgm))
+        play_bgm(name: name, volume: music_volume(bgm), tempo: music_tempo(bgm),
+                 fadein: music_fadein(bgm))
       rescue StandardError => e
         $stderr.puts "[RPG2k] map BGM failed: #{e.message}"
       end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6988,11 +6988,10 @@ class RPG2k
       end
 
       # Game over: the party was wiped in an encounter that ends the game on
-      # defeat (also the target of the Game Over event command). Stop the event
-      # and return to the title screen — the faithful end state. (RPG2000 shows a
-      # Game Over graphic first; that screen is native renderer work still to come.)
-      # Game Over (12420), and a battle defeat the encounter marked "game over":
-      # show the Game Over screen, which returns to the title once dismissed.
+      # defeat, or the event command itself named the target directly — either
+      # way, RPG2000 shows the Game Over graphic first: Game Over (12420) and a
+      # battle defeat the encounter marked "game over" both route here to show
+      # the Game Over screen, which returns to the title once dismissed.
       # Nothing resumes, so the event is stopped rather than released.
       #
       # `interp` is whichever interpreter actually raised the :game_over wait --

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -397,16 +397,23 @@ class RPG2k
       # when the title screen comes up. Re-entering the title (Return to Title)
       # builds a new scene and so restarts it, which is what RPG_RT does too.
       #
-      # `fade_in` is read from the record but not honoured: the audio backend
-      # can fade a BGM out, not in (see ADR 0006), so the music starts at full
-      # volume. A no-op when the game defines no title music, the file is
-      # missing, or no audio backend is installed.
+      # `fade_in` (title_music's own liblcf `BGM`-struct field 2,
+      # mruby-lcf/mrblib/schema.rb) now reaches `Audio.bgm_play`'s 5th
+      # argument, the same fade-in idiom cycle #202/#203 already wired for
+      # Play BGM, Play Memorized BGM and the battle/inn/vehicle/game-over
+      # helpers (`Scene::Map`/`Scene::GameOver`) -- this call site was the one
+      # BGM source those two cycles never reached, left behind reading the
+      # stale claim (now corrected) that the audio backend could only fade a
+      # BGM out, not in; `Mix_FadeInMusic` (`src/sdl_audio.cxx`'s
+      # `start_music`) has taken a `fadein_ms` argument since cycle #202. A
+      # no-op when the game defines no title music, the file is missing, or
+      # no audio backend is installed.
       def play_title_bgm
         bgm = db.system.title_music
         return unless bgm
         name = bgm.file
         return if name.nil? || name.empty?
-        Audio.bgm_play name, (bgm.volume || 100), (bgm.pitch || 100)
+        Audio.bgm_play name, (bgm.volume || 100), (bgm.pitch || 100), 0, (bgm.fade_in || 0)
       rescue StandardError => e
         $stderr.puts "[RPG2k] title BGM playback failed: #{e.message}"
       end

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -183,14 +183,26 @@ def check_game(dir)
   entry[42] = 110
   entry[43] = 95
   entry[44] = 80
+  # Show Picture's own two checkbox flags (fields 6/9, SAVE_PICTURE's own
+  # comments) and the show_x/show_y pair (fields 2/3) round-trip too --
+  # deliberately set to values distinct from finish_x/finish_y (80/60) above
+  # so a field mixed up with the wrong one would fail loudly instead of
+  # coincidentally matching.
+  entry[2] = 200.0
+  entry[3] = 90.0
+  entry[6] = true
+  entry[9] = true
   pics[3] = entry
   restored = {}
   Game::State.restore_pictures(Struct.new(:pictures) do
     def show_picture(id, opts); pictures[id] = opts; end
   end.new(restored), pics)
-  eq({ 3 => { name: 'island', x: 80, y: 60, zoom: 150, opacity: 191,
-              red: 90, green: 110, blue: 95, saturation: 80 } }, restored,
-     'a saved picture is re-shown at its saved centre, zoom, opacity and tone')
+  eq({ 3 => { name: 'island', x: 80, y: 60, show_x: 200, show_y: 90,
+              zoom: 150, opacity: 191, red: 90, green: 110, blue: 95,
+              saturation: 80, fixed_to_map: true, use_transparent_color: true } },
+     restored,
+     'a saved picture is re-shown at its saved centre, show position, zoom, ' \
+     'opacity, tone and flags')
 
   # An entry with no file name is one of the empty slots RPG2000 always writes.
   blank = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14165,6 +14165,25 @@ check 'without HideTitle the picture shows and the window docks near its foot' d
      'the command window docks near the picture, as RPG_RT does'
 end
 
+# Cycle #217: title_music's own liblcf `BGM`-struct fade_in (field 2,
+# mruby-lcf/mrblib/schema.rb) was read off the record by #play_title_bgm and
+# then dropped before reaching Audio.bgm_play, the same gap cycle #202/#203
+# already fixed for Play BGM, Play Memorized BGM and the battle/inn/vehicle/
+# game-over BGM helpers (Scene::Map/Scene::GameOver) -- the title screen's own
+# BGM was the one source those two cycles never reached. `fake_db` names no
+# title_music at all (every other check above only cares that a title picture
+# and command window are built), so this sets one locally rather than
+# widening the shared fixture for every other Title check.
+check 'the title screen forwards the database title_music fade-in to bgm_play, not dropped (cycle #217)' do
+  db = fake_db
+  db.system.title_music = OpenStruct.new(file: 'TitleBGM', volume: 90, pitch: 100, fade_in: 350)
+  parent = TitleParent.new(db, nil, false)
+  RGSS::Audio.reset_bgm
+  RPG2k::Scene::Title.new(parent)
+  eq [['TitleBGM', 90, 100, 0, 350]], RGSS::Audio.bgm_calls,
+     "the database title_music's own fade_in reaches bgm_play's 5th argument"
+end
+
 # -- Continue disabled without save data --------------------------------------
 #
 # RPG_RT grays out Continue on the title screen when there is no save to

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -22400,7 +22400,7 @@ check 'Scene::Map re-derives Save/Teleport/Escape access from the map tree ' \
 end
 
 # One map-tree node's BGM settings (Game::MapBgm, fields 11 bgm_type / 12 bgm).
-FakeBgmChunk = Struct.new(:file, :volume, :pitch)
+FakeBgmChunk = Struct.new(:file, :volume, :pitch, :fade_in)
 FakeBgmTreeNode = Struct.new(:bgm_type, :bgm, :parent_map_id)
 
 check 'Scene::Map auto-plays the map own BGM on load and on Teleport' do
@@ -22431,6 +22431,33 @@ check 'Scene::Map auto-plays the map own BGM on load and on Teleport' do
   eq [], RGSS::Audio.bgm_calls,
      'map 3 is type 1 (none): the still-playing map-1 track is left alone, nothing restarts'
   eq 'Town', state.current_bgm[:name], 'so the tracked current BGM is untouched too'
+end
+
+# Cycle #218: the map-tree node's own `bgm` chunk is the same liblcf `BGM`
+# struct (mruby-lcf/mrblib/schema.rb) as battle_music/inn_music/boat_music/
+# ship_music/airship_music -- whose own field 2 `fade_in` cycle #203 already
+# threaded through to `RGSS::Audio.bgm_play`'s 5th argument -- but
+# #play_map_bgm was the one call site #203 missed, so a map's own Autoplay
+# BGM fade-in was read off nothing and silently dropped.
+check "Scene::Map's own map BGM autoplay carries its fade-in through to " \
+     'bgm_play, same as battle/inn/vehicle BGM already do' do
+  parent = fake_parent(fake_db)
+  parent.map_tree = fake_map_tree(
+    1 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Town', 90, 105, 400), 0),
+    2 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Cave', 80, 95, 0), 0)
+  )
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  RGSS::Audio.reset_bgm
+  scene = RPG2k::Scene::Map.new(parent, state)
+  eq [['Town', 90, 105, 0, 400]], RGSS::Audio.bgm_calls,
+     "map 1's own fade_in (400) reaches bgm_play's 5th argument on load"
+  eq 400, state.current_bgm[:fadein], 'and is tracked on state too'
+
+  RGSS::Audio.reset_bgm
+  scene.send(:perform_teleport, [2, 0, 0, 0])
+  eq [['Cave', 80, 95, 0, 0]], RGSS::Audio.bgm_calls,
+     "a zero (default/unset) fade_in on map 2's own BGM still reaches bgm_play as zero"
 end
 
 check 'Scene::Map does not auto-play the map BGM while the party is boarded' do


### PR DESCRIPTION
## Summary

**Cycle #215:** `scripts/rpg2k_save_load_check.rb`'s own "1 known pre-existing failure" was a synthetic Show Picture round-trip check whose expected hash predated fields `Game::State.restore_pictures` has actually carried since cycles #155/#158 — the runtime was already correct, only the test fixture had drifted. `rpg2k_save_load_check.rb` now reports **zero** known failures, down from one.

**Cycle #216:** Fixed four live doc comments describing already-shipped features (Tint Screen viewport rendering, weather compositing, Game Over screen, Battle's escape/state-infliction) as "still to come". Comment-only, no behavioral code changed.

**Cycle #217:** `Scene::Title#play_title_bgm` was the one BGM source cycle #202/#203's fade-in wiring never reached — it dropped the database's `title_music.fade_in` field entirely. Fixed by threading `bgm.fade_in || 0` through as `Audio.bgm_play`'s 5th argument, matching every sibling call site.

**Cycle #218:** A systematic sweep of cycle #203's original fade-in wiring found one more straggler: `Scene::Map#play_map_bgm` (the map-tree Autoplay BGM helper, called on initial map load and every Transfer Player) never called `#music_fadein` at all, so a map's own configured fade-in (map_properties field 12, same liblcf `BGM` struct as battle/inn/vehicle music) was silently read as 0 — every map entry restarted the track at full volume instantly instead of ramping in. Fixed by passing `fadein: music_fadein(bgm)` through to `#play_bgm`, the same idiom `#battle_bgm`/`#vehicle_bgm` already use. Also checked `Audio.se_play`/SE-struct call sites for the same shape of bug — all consistent, no gap found there (the SE struct's `balance` field is dropped everywhere, but `Audio.se_play` has no pan parameter to receive it in the first place, so that's not a bug).

## Verification

- `ruby scripts/rpg2k_save_load_check.rb`: exits 0, zero known failures
- `scripts/rpg2k_scene_check.rb`: 945 passed (943 baseline + 1 title-BGM-fade-in check + 1 map-BGM-fade-in check); both new checks independently confirmed to fail against their respective pre-fix file content and pass clean after, via temporary file swaps (not `git stash`, to avoid touching any concurrent session's unrelated state)
- `scripts/rpg2k_logic_check.rb`: 1187 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `cd build && ninja`: clean rebuild
- `ctest --test-dir build`: 8/8 passing
- Every doc-comment correction (cycle #216) and BGM signature/field-id claim (cycles #217/#218) independently re-verified against the actual implementing code and `mruby-lcf/mrblib/schema.rb`'s own field definitions, not just the agents' self-reports

No wine session was run in any of these four cycles, and no new EasyRPG source citation was added — cycle #215 is a pure test-fixture correction, cycle #216 is comment-only, and cycles #217/#218 are verified entirely by internal consistency (signature matching, existing schema field ids, regression-proven new checks).