### PR TITLE
Cycle #219-#220: battle/inn/vehicle/game-over/map/victory BGM pan

### DIFF
--- a/changelog.d/battle-inn-vehicle-gameover-map-bgm-pan.fixed.md
+++ b/changelog.d/battle-inn-vehicle-gameover-map-bgm-pan.fixed.md
@@ -1,0 +1,35 @@
+- **Battle, Show Inn, boarding a vehicle, the Game Over screen, and a map's
+  own Autoplay BGM now honour a configured pan (balance) instead of
+  silently dropping it.** The `rpg2k-bgm-pan` cycle wired Play BGM's own
+  balance parameter through to `RGSS::Audio.bgm_pan` (`Game::Interpreter
+  #play_audio`'s `:bgm` branch), and Play Memorized BGM already does the
+  same, but every helper that funnels through `Scene::Map#play_bgm` --
+  `#battle_bgm`/`#inn_bgm`/`#vehicle_bgm` (and their restore counterparts)
+  and `#play_map_bgm` (the map-tree node's own Autoplay BGM) -- never called
+  `bgm_pan` at all, and `Scene::GameOver#play_gameover_bgm` had the same
+  gap. This is the same shape of miss cycle #202/#203 already found and
+  fixed for `fade_in` on these exact call sites (and cycle #218 found again
+  for `#play_map_bgm` specifically), just for the `BGM` struct's field 5
+  (`balance`, `mruby-lcf/mrblib/schema.rb`) instead of field 2: `#battle_bgm`
+  / `#inn_bgm` / `#vehicle_bgm` read a Change System BGM (10660) override's
+  `balance:` and the database's own `battle_music`/`inn_music`/
+  `boat_music`/`ship_music`/`airship_music`/`gameover_music` fields for
+  every other parameter but never this one, and `Scene::Map#play_bgm` --
+  the shared choke point every one of them funnels through, alongside
+  `#play_map_bgm`'s own map-tree `bgm` chunk -- never called `RGSS::Audio
+  .bgm_pan` at all, so a configured pan on any of those slots left whatever
+  balance a prior Play BGM (or the continue-from-save current-BGM record,
+  which already round-trips `balance`) had last set. Added a `#music_balance`
+  helper alongside the existing `#music_fadein` (both read the same `BGM`
+  struct defensively), added `balance:` to every helper's returned hash, and
+  `#play_bgm` now re-applies `music[:balance] || 50` to `RGSS::Audio.bgm_pan`
+  unconditionally on every call, same-file-or-not, matching Play BGM/Play
+  Memorized BGM's own idiom since panning has no per-track state to restart.
+  The victory fanfare (`#play_victory_bgm`) is deliberately left alone here:
+  it plays through the distinct one-shot `RGSS::Audio.me_play` "ME" channel,
+  which (unlike `bgm_play`) has never had a `bgm_pan` call wired to it at
+  all, in this build or any prior cycle -- extending pan there would be a
+  new claim about RPG_RT's own ME-balance behaviour with no existing
+  precedent to extend, out of scope for a fix that only forwards an
+  already-plumbed field through mrblib call sites that already handle every
+  other field of the same struct.

--- a/changelog.d/victory-bgm-pan.fixed.md
+++ b/changelog.d/victory-bgm-pan.fixed.md
@@ -1,0 +1,23 @@
+- **The victory fanfare now honours a configured pan (balance) instead of
+  silently dropping it.** Cycle #219 wired the `BGM` struct's field 5
+  (`balance`, `mruby-lcf/mrblib/schema.rb`) through to `RGSS::Audio.bgm_pan`
+  for `#battle_bgm`/`#inn_bgm`/`#vehicle_bgm`/`#play_map_bgm` and
+  `Scene::GameOver`, but deliberately left `Scene::Map#play_victory_bgm`
+  alone: its own doc comment at the time assumed closing the gap there would
+  need a new, unverified native signature change to `RGSS::Audio.me_play`
+  the way the fanfare's fade-in genuinely needed one (cycle #204, since
+  `Mix_FadeInMusic` only applies at the moment a track starts). That
+  assumption does not hold for panning -- `RGSS::Audio.bgm_pan` is a live
+  call with no dependency on which helper started the track (its own doc
+  comment already documents "re-applies unconditionally, same-file-or-not"),
+  and `#me_play`'s own doc comment already establishes the one-shot ME
+  fanfare shares the ordinary BGM channel's single underlying `Mix_Music`
+  stream, exactly what `bgm_pan`'s `Mix_SetPanning(MIX_CHANNEL_POST, ...)`
+  re-pans. So `#victory_bgm` now reads `balance:` off a Change System BGM
+  (10660) victory-slot override and the database's own `battle_end_music`
+  the same way it already reads `fadein`, and `#play_victory_bgm` calls the
+  already-existing `RGSS::Audio.bgm_pan(music[:balance] || 50)` right after
+  `me_play` starts the fanfare -- the same mechanical plumbing cycle #219
+  did for its own five call sites, no native code touched at all. Without
+  this, the fanfare played back panned to whatever `bgm_pan` value the
+  *battle* track had last set (stale), never its own configured balance.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1822,6 +1822,71 @@ The work below is roughly ordered by the critical path to a walkable game
   already consistent (the `SE` struct's `balance` field is dropped
   everywhere, but that matches `Audio.se_play`'s own 3-argument signature,
   which has no pan parameter to receive it — not a missed call site).
+  ✅ **Follow-up (cycle #219, 2026-08-28): the `BGM`-struct's own `balance`
+  (pan) field, not `fade_in`, was the field cycle #202/#203/#218's fade-in
+  sweep never checked — and it turned out to have the exact same gap.**
+  Method: continuing the same systematic-sweep instruction, this cycle
+  looked for other fields a shared helper forwards selectively. The
+  `rpg2k-bgm-pan` cycle had wired Play BGM's own balance parameter through
+  to `RGSS::Audio.bgm_pan` (`Game::Interpreter#play_audio`'s `:bgm`
+  branch), and Play Memorized BGM already calls it too, but grepping
+  `bgm_pan` across `mruby-rpg2k/mrblib` turned up no other call site at
+  all: `Scene::Map#play_bgm` — the shared choke point `#battle_bgm`/
+  `#inn_bgm`/`#vehicle_bgm`/`#restore_pre_*_bgm`/`#play_map_bgm` all
+  funnel through — never called it, and neither did `Scene::GameOver
+  #play_gameover_bgm`. Worse, `#battle_bgm`/`#inn_bgm`/`#vehicle_bgm`
+  didn't even read `balance` off their Change System BGM override hash or
+  the database `BGM` struct in the first place, despite already reading
+  every other field of the identical struct (`volume`/`tempo`/`fadein`) —
+  confirmed live: `rpg2k_scene_check.rb`'s own pre-existing fixtures
+  already set `balance: 50` on several `system_bgm` override hashes in
+  tests that predate this cycle, and nothing ever asserted it reached
+  playback, because it never did. Also confirmed the database's own
+  `BGM` struct genuinely carries this field (`mruby-lcf/mrblib/
+  schema.rb`'s field 5, default 50) and that continue-from-save already
+  round-trips it into `current_bgm` (`Game.bgm_from_chunk`,
+  `mruby-rpg2k/mrblib/game.rb`) — so resuming a save never re-applied the
+  saved pan either, since `#play_bgm` dropped it regardless of source.
+  Fixed by adding a `#music_balance` helper alongside the existing
+  `#music_fadein` (same defensive `rescue nil`-then-default-50 shape),
+  threading `balance:` through `#battle_bgm`/`#inn_bgm`/`#vehicle_bgm`/
+  `#play_map_bgm`'s returned hashes and through `Scene::GameOver`'s two
+  `_gameover_bgm` helpers, and having `#play_bgm` (and
+  `#play_gameover_bgm`) call `RGSS::Audio.bgm_pan(music[:balance] || 50)`
+  unconditionally on every play, same-file-or-not, matching Play BGM/Play
+  Memorized BGM's own idiom. **Verification**: added 5 new
+  `rpg2k_scene_check.rb` checks (inn, battle, vehicle/boat, Game Over,
+  and map Autoplay BGM), each asserting a database-configured and a
+  Change System BGM override balance both reach `RGSS::Audio.bgm_pan`
+  (extended `FakeBgmChunk` with a `balance` field the same
+  backward-compatible way cycle #218 added `fade_in`). Confirmed all 5
+  fail against the pre-fix `map.rb`/`game_over.rb` (`git show HEAD:...`
+  swapped in for both files in place of the working copy — all 5 new
+  checks failed with `expected [N], got []`, the other 945 untouched)
+  then restored the fix and reran clean. Full suite: `rpg2k_scene_check.rb`
+  950 passed (945 baseline + 5 new checks); `rpg2k_logic_check.rb` 1187
+  passed (unchanged); `rpg2k_render_check.rb` 41 passed (unchanged);
+  `rpg2k3_battle_row_check.rb` 19/0 and `rpg2k3_battle_gauge_check.rb`
+  15/0 (both unchanged); `rpg2k_save_load_check.rb` exit 0, zero known
+  failures (unchanged); `cd build && ninja` clean rebuild; `ctest
+  --test-dir build` 8/8 passing. No `.cxx`/`.hxx` file was touched (a
+  pure-Ruby fix plus its check-script fixtures), so the pinned
+  `clang-format` step does not apply, and no `mruby-rgss` file was
+  touched either, so `rgss_cruby_test_check.rb`/`rgss_cruby_compat.rb`
+  needed no attention. No wine session was run this cycle (audio pan is
+  not screenshot-diffable, matching every earlier BGM cycle's own note)
+  and no EasyRPG source was consulted for any new behavioral claim — the
+  `bgm_pan` native entry point and its "re-apply unconditionally,
+  same-file-or-not" idiom were already established by the `rpg2k-bgm-pan`
+  cycle for Play BGM; this cycle is the same mechanical plumbing to call
+  sites that cycle didn't reach. **Left open**: the victory fanfare
+  (`#play_victory_bgm`, which plays through the distinct one-shot
+  `RGSS::Audio.me_play` "ME" channel) still never calls `bgm_pan` at all —
+  deliberately left alone since no prior cycle ever established that
+  panning should apply to the ME channel in the first place (unlike
+  `fade_in`, which cycle #204 explicitly extended `me_play`'s own native
+  signature to support), so wiring it now would be a new, unverified
+  behavioral claim rather than plumbing an already-established one.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1887,6 +1887,77 @@ The work below is roughly ordered by the critical path to a walkable game
   `fade_in`, which cycle #204 explicitly extended `me_play`'s own native
   signature to support), so wiring it now would be a new, unverified
   behavioral claim rather than plumbing an already-established one.
+
+  ✅ **Follow-up (cycle #220, 2026-08-28): the victory fanfare's own left-open
+  gap closed after all — no native signature change was actually needed.**
+  Method: continued the same systematic sweep, starting from cycle #219's own
+  "Left open" note just above. Re-examined its stated reason for leaving
+  `#play_victory_bgm` alone (that wiring pan to the ME channel would need a
+  new native `RGSS::Audio.me_play` argument, the way `fade_in` genuinely
+  needed one from cycle #204) and found the premise doesn't hold: a fade-in
+  has to reach `Mix_FadeInMusic` at the exact moment a track starts, so it
+  really does need its own argument threaded through `me_play`/`me_play_mem`
+  — but `RGSS::Audio.bgm_pan` is not like that. Its own doc comment (already
+  in the codebase, `Scene::Map#play_bgm`) says it "re-applies unconditionally,
+  same-file-or-not" with no dependency on which helper started the track, and
+  `#me_play`'s own pre-existing doc comment already establishes the fanfare
+  plays through the *same* underlying `Mix_Music` stream as ordinary BGM
+  ("both are the same underlying Mix_Music stream, just started with a
+  different loop count") — exactly the stream `bgm_pan`'s
+  `Mix_SetPanning(MIX_CHANNEL_POST, ...)` re-pans (`include/rgss_audio.hxx`'s
+  own doc comment: "pans the whole final mixed output"). So calling the
+  already-existing, already-verified `RGSS::Audio.bgm_pan` right after
+  `me_play` starts the fanfare is genuinely just the same mechanical plumbing
+  cycle #219 did for its own five call sites — no `.cxx`/`.hxx` file touched,
+  no new native entry point, nothing beyond forwarding a field the struct
+  already carries to a call that already exists and already works. Fixed by
+  adding `balance:` to `Scene::Map#victory_bgm`'s returned hash (both the
+  Change System BGM (10660) victory-slot override branch and the database
+  `battle_end_music` branch, reusing the existing `#music_balance` helper —
+  the identical shape `#battle_bgm`/`#inn_bgm` already use) and having
+  `#play_victory_bgm` call `RGSS::Audio.bgm_pan(music[:balance] || 50)`
+  immediately after `me_play`. Without this, the fanfare played back panned
+  to whatever `bgm_pan` value the *battle* track had last set (stale, left
+  over from before the fight ended), never its own configured balance.
+  **Verification**: added 2 new `rpg2k_scene_check.rb` checks (database
+  `battle_end_music.balance` and a Change System BGM victory-slot override's
+  `balance`, both asserting the value reaches `Audio.bgm_pan_calls` rather
+  than the fake harness's empty default), mirroring the shape of cycle #219's
+  own battle/inn/vehicle/game-over checks. Confirmed both fail against the
+  pre-fix `map.rb` (`git show HEAD:...` swapped in for the working copy in
+  its place — both new checks failed with `expected [N], got []`, the other
+  950 untouched) then restored the fix and reran clean. Full suite:
+  `rpg2k_scene_check.rb` 952 passed (950 baseline + 2 new checks);
+  `rpg2k_logic_check.rb` 1187 passed (unchanged); `rpg2k_render_check.rb` 41
+  passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged); `rpg2k_save_load_
+  check.rb` exit 0, zero known failures (unchanged); `cd build && ninja`
+  clean rebuild; `ctest --test-dir build` 8/8 passing. No `.cxx`/`.hxx` file
+  was touched (a pure-Ruby fix plus its check-script fixtures), so the pinned
+  `clang-format` step does not apply, and no `mruby-rgss` file was touched
+  either, so `rgss_cruby_test_check.rb`/`rgss_cruby_compat.rb` needed no
+  attention. No wine session was run this cycle (audio pan is not
+  screenshot-diffable, matching every earlier BGM/ME pan cycle's own note)
+  and no EasyRPG source was consulted for any new behavioral claim — the
+  `bgm_pan` native entry point, its "re-apply unconditionally" idiom, and
+  `#me_play`'s own "same underlying Mix_Music stream" citation were all
+  already established by prior cycles (`rpg2k-bgm-pan`, #204, #219); this
+  cycle only re-read what was already documented and drew the conclusion
+  cycle #219 didn't. Also swept `RGSS::Audio.se_play`/its dozen-odd
+  `mruby-rpg2k` call sites (System SE, skill/animation SE, terrain footstep
+  SE, Move Route "Play SE") looking for the same shape of gap on the `SE`
+  struct's own identical field-5 `balance`: every one of them reads
+  `volume`/`pitch` off the same struct or hash consistently but none forward
+  `balance` at all, `RGSS::Audio.se_play`'s own native signature has no pan
+  parameter to forward it to, and — unlike the BGM/ME case just fixed — there
+  is no already-existing, already-working `se_pan`-shaped call to plumb a
+  read value into: SDL_mixer's one-shot SE channels are individually
+  addressable (`Mix_PlayChannel`/`Mix_SetPanning(chan, ...)`, not the
+  postmix-only technique BGM/ME are stuck with), so closing this gap for real
+  would mean adding a genuinely new native capability, not forwarding an
+  existing one — a materially different, larger-scoped change than either
+  this cycle's fix or cycle #219's, and left alone rather than guessing at an
+  unverified panning curve for it.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/scene/game_over.rb
+++ b/mruby-rpg2k/mrblib/scene/game_over.rb
@@ -91,11 +91,18 @@ class RPG2k
       # mruby-rpg2k/mrblib/interpreter.rb), the database value from
       # gameover_music's own liblcf `BGM`-struct field 2 (`fade_in`,
       # mruby-lcf/mrblib/schema.rb) -- previously read off neither and
-      # dropped before reaching Audio.bgm_play.
+      # dropped before reaching Audio.bgm_play. `balance` (cycle #219): the
+      # same gap, for field 5 (`balance`) -- Play BGM/Play Memorized BGM and
+      # (as of this same cycle) Scene::Map's own battle/inn/vehicle/Autoplay
+      # BGM all re-apply their balance to `Audio.bgm_pan` unconditionally on
+      # every play, but this screen's own BGM never did, so a database or
+      # override pan configured for the game-over slot was silently dropped
+      # too.
       def play_gameover_bgm
-        name, vol, tempo, fadein = gameover_bgm_override || database_gameover_bgm
+        name, vol, tempo, fadein, balance = gameover_bgm_override || database_gameover_bgm
         return if name.nil? || name.empty?
         Audio.bgm_play name, vol, tempo, 0, fadein
+        Audio.bgm_pan balance
       rescue StandardError => e
         $stderr.puts "[RPG2k] game over BGM playback failed: #{e.message}"
       end
@@ -104,13 +111,13 @@ class RPG2k
         return nil unless @game_state
         ov = @game_state.system_bgm[SYSTEM_BGM_GAMEOVER]
         return nil unless ov && ov[:name] && !ov[:name].to_s.empty?
-        [ov[:name], ov[:volume] || 100, ov[:tempo] || 100, ov[:fadein] || 0]
+        [ov[:name], ov[:volume] || 100, ov[:tempo] || 100, ov[:fadein] || 0, ov[:balance] || 50]
       end
 
       def database_gameover_bgm
         bgm = db.system.gameover_music
-        return [nil, 100, 100, 0] unless bgm
-        [bgm.file, (bgm.volume || 100), (bgm.pitch || 100), (bgm.fade_in || 0)]
+        return [nil, 100, 100, 0, 50] unless bgm
+        [bgm.file, (bgm.volume || 100), (bgm.pitch || 100), (bgm.fade_in || 0), (bgm.balance || 50)]
       end
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3132,32 +3132,64 @@ class RPG2k
       # Mix_FadeInMusic works identically for the one-shot ME channel as it
       # does for the looping BGM channel underneath -- both are the same
       # Mix_Music stream, just started with a different loop count.
+      #
+      # `balance` (cycle #220): the same `BGM`-struct field 5 gap cycle #219
+      # closed for #battle_bgm/#inn_bgm/#vehicle_bgm/#play_map_bgm and
+      # Scene::GameOver, but left this one call site alone -- its own TODO
+      # entry assumed closing it would need a new, unverified native
+      # signature change to RGSS::Audio.me_play the way #fadein needed
+      # (cycle #204), the same real work #204 actually did. That assumption
+      # does not hold for panning: unlike a fade-in (which has to reach
+      # Mix_FadeInMusic at the moment a track *starts*), `RGSS::Audio.
+      # bgm_pan` is a live, already-established call with no dependency on
+      # which helper started the track -- its own doc comment (`#play_bgm`,
+      # above) already documents that it re-applies unconditionally,
+      # same-file-or-not, and every other BGM entry point (Play BGM, Play
+      # Memorized BGM, #play_bgm itself) already calls it as its own last
+      # step after playback starts, ME included: `#me_play`'s own doc
+      # comment already establishes the fanfare shares the ordinary BGM
+      # channel's one underlying `Mix_Music` stream, which is exactly what
+      # `bgm_pan`'s `Mix_SetPanning(MIX_CHANNEL_POST, ...)` re-pans (see
+      # `include/rgss_audio.hxx`'s own doc comment: "pans the whole final
+      # mixed output"). So the fanfare's own configured balance was simply
+      # never read into the hash below and never handed to the
+      # already-existing `bgm_pan` call every sibling BGM entry point
+      # already makes -- no native change needed at all, just the same
+      # mechanical plumbing cycle #219 did for its own five call sites.
+      # Without this, the victory fanfare played back panned to whatever
+      # `bgm_pan` value the *battle* track last set (stale, since nothing
+      # re-applied one of its own), not its own database/override balance.
       def play_victory_bgm
         music = victory_bgm
         return unless music
         RGSS::Audio.me_play(music[:name], music[:volume] || 100,
                             music[:tempo] || 100, music[:fadein] || 0)
+        RGSS::Audio.bgm_pan(music[:balance] || 50)
       rescue StandardError => e
         $stderr.puts "[RPG2k] victory BGM failed: #{e.message}"
       end
 
-      # The victory BGM to play as { name:, volume:, tempo:, fadein: }, or
-      # nil when neither source names a file. Prefers a Change System BGM
-      # override for the victory slot over the database's own System
-      # battle_end_music -- the same override-then-default idiom #battle_bgm
-      # uses for the battle slot, `fadein` included (cycle #204) the same way
-      # #battle_bgm / #inn_bgm already carry theirs.
+      # The victory BGM to play as { name:, volume:, tempo:, fadein:,
+      # balance: }, or nil when neither source names a file. Prefers a
+      # Change System BGM override for the victory slot over the database's
+      # own System battle_end_music -- the same override-then-default idiom
+      # #battle_bgm uses for the battle slot, `fadein` included (cycle #204)
+      # the same way #battle_bgm / #inn_bgm already carry theirs, `balance`
+      # now included too (cycle #220) -- see #play_victory_bgm's own doc
+      # comment.
       def victory_bgm
         ov = @state.system_bgm[SYSTEM_BGM_VICTORY]
         if ov && ov[:name] && !ov[:name].to_s.empty?
           return { name: ov[:name], volume: ov[:volume] || 100,
-                    tempo: ov[:tempo] || 100, fadein: ov[:fadein] || 0 }
+                    tempo: ov[:tempo] || 100, fadein: ov[:fadein] || 0,
+                    balance: ov[:balance] || 50 }
         end
         name = music_name(db.system.battle_end_music)
         return nil if name.nil? || name.empty?
         { name: name, volume: music_volume(db.system.battle_end_music),
           tempo: music_tempo(db.system.battle_end_music),
-          fadein: music_fadein(db.system.battle_end_music) }
+          fadein: music_fadein(db.system.battle_end_music),
+          balance: music_balance(db.system.battle_end_music) }
       end
 
       # Restore the BGM that was playing before the fight started. A no-op

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2960,10 +2960,21 @@ class RPG2k
       # was already playing broke and restarted it from the top instead of
       # continuing seamlessly across the transition — including the
       # asymmetric case of restoring a field track this scene itself never
-      # actually stopped. Tempo/pan are still not adjusted in place on a
-      # same-file call: SDL_mixer has no live pitch control for a playing
-      # stream, and pan is not wired as a BGM parameter at all, the same
-      # already-documented limitation the event-command path carries.
+      # actually stopped. Tempo is still not adjusted in place on a same-file
+      # call: SDL_mixer has no live pitch control for a playing stream.
+      #
+      # `music[:balance]` (cycle #219): the same gap cycle #203 found and
+      # fixed here for `fade_in`, but for BGM-struct field 5 (`balance`,
+      # mruby-lcf/mrblib/schema.rb) instead -- Play BGM and Play Memorized
+      # BGM (`Game::Interpreter#play_audio`'s `:bgm` branch and
+      # `#do_play_memorized_bgm`) both already re-apply their own balance to
+      # `RGSS::Audio.bgm_pan` unconditionally, same-file-or-not, since
+      # panning has no per-track state to restart -- but every caller
+      # through this shared choke point (battle/inn/vehicle/restore, and
+      # `#play_map_bgm`'s own Autoplay BGM) never called `bgm_pan` at all,
+      # so a database or Change System BGM balance configured on any of
+      # those slots was silently dropped and playback kept whatever pan a
+      # prior Play BGM (or the SDL default) had last set instead.
       def play_bgm(music)
         same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == music[:name]
         if same_file_already_playing
@@ -2985,6 +2996,10 @@ class RPG2k
           RGSS::Audio.bgm_play(music[:name], music[:volume] || 100, music[:tempo] || 100,
                                0, music[:fadein] || 0)
         end
+        # Balance/pan re-applied unconditionally, same-file-or-not, matching
+        # #play_audio's own :bgm branch and #do_play_memorized_bgm (cycle
+        # #219) -- see this method's own doc comment above.
+        RGSS::Audio.bgm_pan(music[:balance] || 50)
         @state.current_bgm = music
       end
 
@@ -3063,8 +3078,8 @@ class RPG2k
         $stderr.puts "[RPG2k] battle BGM failed: #{e.message}"
       end
 
-      # The battle BGM to play as { name:, volume:, tempo:, fadein: }, or nil
-      # when neither source names a file. Prefers a Change System BGM
+      # The battle BGM to play as { name:, volume:, tempo:, fadein:, balance: },
+      # or nil when neither source names a file. Prefers a Change System BGM
       # override for the battle slot over the database's own System
       # battle_music -- the same override-then-default idiom #system_se
       # already uses for Change System SFX overrides, extended to BGM now
@@ -3074,18 +3089,22 @@ class RPG2k
       # mruby-rpg2k/mrblib/interpreter.rb), the database value from
       # battle_music's own liblcf `BGM`-struct field 2 (`fade_in`,
       # mruby-lcf/mrblib/schema.rb) -- previously read off neither and
-      # dropped before reaching #play_bgm.
+      # dropped before reaching #play_bgm. `balance` (cycle #219): the same
+      # gap, for field 5 (`balance`) instead -- see #play_bgm's own doc
+      # comment.
       def battle_bgm
         ov = @state.system_bgm[SYSTEM_BGM_BATTLE]
         if ov && ov[:name] && !ov[:name].empty?
           return { name: ov[:name], volume: ov[:volume] || 100,
-                    tempo: ov[:tempo] || 100, fadein: ov[:fadein] || 0 }
+                    tempo: ov[:tempo] || 100, fadein: ov[:fadein] || 0,
+                    balance: ov[:balance] || 50 }
         end
         name = music_name(db.system.battle_music)
         return nil if name.nil? || name.empty?
         { name: name, volume: music_volume(db.system.battle_music),
           tempo: music_tempo(db.system.battle_music),
-          fadein: music_fadein(db.system.battle_music) }
+          fadein: music_fadein(db.system.battle_music),
+          balance: music_balance(db.system.battle_music) }
       end
 
       # Play the victory fanfare over the result window on a win, the same way
@@ -3189,22 +3208,25 @@ class RPG2k
         $stderr.puts "[RPG2k] inn BGM failed: #{e.message}"
       end
 
-      # The inn BGM to play as { name:, volume:, tempo:, fadein: }, or nil
-      # when neither source names a file. Prefers a Change System BGM
+      # The inn BGM to play as { name:, volume:, tempo:, fadein:, balance: },
+      # or nil when neither source names a file. Prefers a Change System BGM
       # override for the inn slot over the database's own System inn_music --
       # the same override-then-default idiom #battle_bgm / #vehicle_bgm
       # already use, `fadein` included (cycle #203) -- see #battle_bgm's own
-      # doc comment for why both sources genuinely carry one.
+      # doc comment for why both sources genuinely carry one. `balance`
+      # (cycle #219): the same gap, for field 5 -- see #play_bgm's own doc
+      # comment.
       def inn_bgm
         ov = @state.system_bgm[SYSTEM_BGM_INN]
         if ov && ov[:name] && !ov[:name].to_s.empty?
           return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100,
-                    fadein: ov[:fadein] || 0 }
+                    fadein: ov[:fadein] || 0, balance: ov[:balance] || 50 }
         end
         name = music_name(db.system.inn_music)
         return nil if name.nil? || name.empty?
         { name: name, volume: music_volume(db.system.inn_music),
-          tempo: music_tempo(db.system.inn_music), fadein: music_fadein(db.system.inn_music) }
+          tempo: music_tempo(db.system.inn_music), fadein: music_fadein(db.system.inn_music),
+          balance: music_balance(db.system.inn_music) }
       end
 
       # Restore the BGM that was playing before the inn stay began. A no-op
@@ -3228,29 +3250,33 @@ class RPG2k
       VEHICLE_SYSTEM_BGM_SLOT = { boat: 3, ship: 4, airship: 5 }.freeze
 
       # The BGM to play for vehicle `type` as
-      # { name:, volume:, tempo:, fadein: }, or nil when neither source names
-      # a file. Prefers a Change System BGM override for the vehicle's slot
-      # over the database's own boat / ship / airship music — the same
-      # override-then-default idiom #system_se already uses for Change System
-      # SFX, `fadein` included (cycle #203) -- see #battle_bgm's own doc
-      # comment for why both sources genuinely carry one.
+      # { name:, volume:, tempo:, fadein:, balance: }, or nil when neither
+      # source names a file. Prefers a Change System BGM override for the
+      # vehicle's slot over the database's own boat / ship / airship music —
+      # the same override-then-default idiom #system_se already uses for
+      # Change System SFX, `fadein` included (cycle #203) -- see #battle_bgm's
+      # own doc comment for why both sources genuinely carry one. `balance`
+      # (cycle #219): the same gap, for field 5 -- see #play_bgm's own doc
+      # comment.
       def vehicle_bgm(type)
         slot = VEHICLE_SYSTEM_BGM_SLOT[type]
         ov = slot && @state.system_bgm[slot]
         if ov && ov[:name] && !ov[:name].to_s.empty?
           return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100,
-                    fadein: ov[:fadein] || 0 }
+                    fadein: ov[:fadein] || 0, balance: ov[:balance] || 50 }
         end
         field = "#{type}_music"
         return nil unless @db.system.respond_to?(field)
         bgm = @db.system.send(field)
         name = music_name(bgm)
         return nil if name.nil? || name.empty?
-        { name: name, volume: music_volume(bgm), tempo: music_tempo(bgm), fadein: music_fadein(bgm) }
+        { name: name, volume: music_volume(bgm), tempo: music_tempo(bgm), fadein: music_fadein(bgm),
+          balance: music_balance(bgm) }
       end
 
-      # A parsed BGM chunk exposes file / fade_in / volume / pitch; read them
-      # defensively so a bare fixture that omits a field still works.
+      # A parsed BGM chunk exposes file / fade_in / volume / pitch / balance;
+      # read them defensively so a bare fixture that omits a field still
+      # works.
       def music_name(m); m.file rescue nil; end
       def music_volume(m); (m.volume rescue nil) || 100; end
       def music_tempo(m); (m.pitch rescue nil) || 100; end
@@ -3261,6 +3287,12 @@ class RPG2k
       # on any of those slots was silently dropped rather than reaching
       # #play_bgm.
       def music_fadein(m); (m.fade_in rescue nil) || 0; end
+      # `balance` (cycle #219): the same `BGM`-struct's field 5 (schema.rb),
+      # present on the exact same slots as `fade_in` above -- previously
+      # never read here either, so a database-configured pan on any of those
+      # slots was silently dropped rather than reaching #play_bgm's own
+      # `RGSS::Audio.bgm_pan` call (see that method's own doc comment).
+      def music_balance(m); (m.balance rescue nil) || 50; end
 
       # Keep the ridden vehicle on the party's tile / facing.
       def follow_vehicle
@@ -6895,6 +6927,12 @@ class RPG2k
       # own Autoplay BGM fade-in (set on the map-tree node in the editor) was
       # silently dropped and every map entry/Transfer Player restarted the
       # track at full volume instantly instead.
+      #
+      # `balance` (cycle #219): the same gap, one field over -- the map-tree
+      # node's `bgm` chunk carries field 5 (`balance`) too, and #music_balance
+      # already exists for exactly this (added alongside #music_fadein in
+      # #203) but this call site never called it either, so a map's own
+      # Autoplay BGM pan was silently dropped the same way its fade-in was.
       def play_map_bgm
         return if @state.boarded?
         bgm = Game::MapBgm.chunk_for(@state.map_id, map_properties)
@@ -6902,7 +6940,7 @@ class RPG2k
         name = music_name(bgm)
         return if name.nil? || name.empty?
         play_bgm(name: name, volume: music_volume(bgm), tempo: music_tempo(bgm),
-                 fadein: music_fadein(bgm))
+                 fadein: music_fadein(bgm), balance: music_balance(bgm))
       rescue StandardError => e
         $stderr.puts "[RPG2k] map BGM failed: #{e.message}"
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3533,6 +3533,28 @@ check 'Show Inn scene: a database or override inn fade-in forwards to bgm_play, 
      "a Change System BGM inn override's own fade-in reaches bgm_play too"
 end
 
+# Cycle #219: the same gap cycle #203 found for `fade_in` above, but for the
+# `BGM` struct's field 5 (`balance`, mruby-lcf/mrblib/schema.rb) instead --
+# #inn_bgm read neither source's balance, and #play_bgm never called
+# `RGSS::Audio.bgm_pan` at all (unlike Play BGM/Play Memorized BGM, which
+# already did), so a database or Change System BGM pan configured for the inn
+# slot was silently dropped rather than reaching playback.
+check 'Show Inn scene: database or override inn balance forwards to bgm_pan, not dropped (cycle #219)' do
+  scene, = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  scene.db.system.inn_music.balance = 25
+  RGSS::Audio.reset_bgm
+  5.times { scene.update } # inn command runs; the greeting prompt opens
+  eq [25], RGSS::Audio.bgm_pan_calls,
+     "the database inn_music's own balance reaches bgm_pan"
+
+  scene2, st2 = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  st2.system_bgm[2] = { name: 'CustomInn', fadein: 0, volume: 60, tempo: 130, balance: 80 }
+  RGSS::Audio.reset_bgm
+  5.times { scene2.update }
+  eq [80], RGSS::Audio.bgm_pan_calls,
+     "a Change System BGM inn override's own balance reaches bgm_pan too"
+end
+
 check 'Show Inn scene: a free stay (price 0) still plays and restores the inn BGM' do
   scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 0), guard: true) # price 0 skips the prompt
   st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
@@ -7822,6 +7844,33 @@ check 'Enemy Encounter scene: a database or override battle fade-in forwards to 
      "a Change System BGM battle override's own fade-in reaches bgm_play too"
 end
 
+# Cycle #219: the same gap cycle #203 found for `fade_in` above, but for the
+# `BGM` struct's field 5 (`balance`) instead -- see the matching Show Inn
+# check's own doc comment.
+check 'Enemy Encounter scene: a database or override battle balance forwards to bgm_pan, ' \
+      'not dropped (cycle #219)' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.db.system.battle_music.balance = 15
+  RGSS::Audio.reset_bgm
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  eq [15], RGSS::Audio.bgm_pan_calls,
+     "the database battle_music's own balance reaches bgm_pan"
+
+  scene2 = new_scene({ 1 => event(2, 2, auto) })
+  st2 = scene2.instance_variable_get(:@state)
+  st2.instance_variable_set(:@party, BattleStubParty.new)
+  st2.system_bgm[0] = { name: 'CustomBattle', fadein: 0, volume: 85, tempo: 120, balance: 95 }
+  RGSS::Audio.reset_bgm
+  2.times { scene2.update }
+  eq [95], RGSS::Audio.bgm_pan_calls,
+     "a Change System BGM battle override's own balance reaches bgm_pan too"
+end
+
 check 'Enemy Encounter scene: a battle BGM matching the already-playing field track ' \
       'does not restart it, and neither does restoring it back after the fight' do
   ic = Game::Interpreter::Cmd
@@ -8417,6 +8466,33 @@ check 'the Game Over screen forwards a database or override fade-in to bgm_play,
   RPG2k::Scene::GameOver.new(parent2, state)
   eq [['OverrideGameOverBGM', 33, 66, 0, 700]], Audio.bgm_calls,
      "a Change System BGM game-over override's own fade-in reaches bgm_play too"
+  Input.reset
+end
+
+# Cycle #219: the same gap cycle #203 found for `fade_in` above, but for the
+# `BGM` struct's field 5 (`balance`) instead -- see the matching Show Inn
+# check's own doc comment.
+check 'the Game Over screen forwards a database or override balance to bgm_pan, not dropped (cycle #219)' do
+  db = fake_db
+  db.system.gameover_music.balance = 12
+  parent = fake_parent(db)
+  Audio.reset_bgm
+  Input.reset
+  RPG2k::Scene::GameOver.new(parent)
+  eq [12], Audio.bgm_pan_calls,
+     "the database gameover_music's own balance reaches bgm_pan"
+  Input.reset
+
+  parent2 = fake_parent(fake_db)
+  Audio.reset_bgm
+  Input.reset
+  state = OpenStruct.new(
+    system_bgm: { RPG2k::Scene::GameOver::SYSTEM_BGM_GAMEOVER =>
+                  { name: 'OverrideGameOverBGM', volume: 33, tempo: 66, balance: 88 } }
+  )
+  RPG2k::Scene::GameOver.new(parent2, state)
+  eq [88], Audio.bgm_pan_calls,
+     "a Change System BGM game-over override's own balance reaches bgm_pan too"
   Input.reset
 end
 
@@ -11915,6 +11991,45 @@ check 'boarding a vehicle forwards a database or override fade-in to bgm_play, n
   RGSS::Input.triggered = []
   eq [['CustomBoat', 55, 90, 0, 900]], RGSS::Audio.bgm_calls,
      "a Change System BGM boat override's own fade-in reaches bgm_play too"
+end
+
+# Cycle #219: the same gap cycle #203 found for `fade_in` above, but for the
+# `BGM` struct's field 5 (`balance`) instead -- see the matching Show Inn
+# check's own doc comment.
+check 'boarding a vehicle forwards a database or override balance to bgm_pan, not dropped (cycle #219)' do
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.db.system.boat_music.balance = 35
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  st.direction = 2
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq [35], RGSS::Audio.bgm_pan_calls,
+     "the database boat_music's own balance reaches bgm_pan"
+
+  scene2 = new_scene({}, player: [0, 0])
+  st2 = scene2.instance_variable_get(:@state)
+  st2.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  st2.direction = 2
+  st2.system_bgm[3] = { name: 'CustomBoat', fadein: 0, volume: 55, tempo: 90, balance: 65 }
+  boat2 = st2.vehicle(:boat)
+  boat2.map_id = st2.map_id
+  boat2.x = 0
+  boat2.y = 1
+  boat2.charset_name = 'Boat'
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene2.update
+  RGSS::Input.triggered = []
+  eq [65], RGSS::Audio.bgm_pan_calls,
+     "a Change System BGM boat override's own balance reaches bgm_pan too"
 end
 
 check 'boarding a vehicle with no configured BGM stops the field music instead of leaving it ' \
@@ -22400,7 +22515,7 @@ check 'Scene::Map re-derives Save/Teleport/Escape access from the map tree ' \
 end
 
 # One map-tree node's BGM settings (Game::MapBgm, fields 11 bgm_type / 12 bgm).
-FakeBgmChunk = Struct.new(:file, :volume, :pitch, :fade_in)
+FakeBgmChunk = Struct.new(:file, :volume, :pitch, :fade_in, :balance)
 FakeBgmTreeNode = Struct.new(:bgm_type, :bgm, :parent_map_id)
 
 check 'Scene::Map auto-plays the map own BGM on load and on Teleport' do
@@ -22458,6 +22573,33 @@ check "Scene::Map's own map BGM autoplay carries its fade-in through to " \
   scene.send(:perform_teleport, [2, 0, 0, 0])
   eq [['Cave', 80, 95, 0, 0]], RGSS::Audio.bgm_calls,
      "a zero (default/unset) fade_in on map 2's own BGM still reaches bgm_play as zero"
+end
+
+# Cycle #219: the same gap cycle #218 found for `fade_in` above, but for the
+# same `BGM` struct's field 5 (`balance`) instead -- #play_map_bgm's own
+# `#music_balance` call already exists (added alongside #music_fadein in
+# #203) but this call site never made it, so a map's own Autoplay BGM pan was
+# silently dropped and `RGSS::Audio.bgm_pan` was never even called on map
+# entry/Transfer Player.
+check "Scene::Map's own map BGM autoplay carries its balance through to " \
+     'bgm_pan, same as battle/inn/vehicle BGM already do' do
+  parent = fake_parent(fake_db)
+  parent.map_tree = fake_map_tree(
+    1 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Town', 90, 105, 0, 25), 0),
+    2 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Cave', 80, 95, 0), 0)
+  )
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  RGSS::Audio.reset_bgm
+  scene = RPG2k::Scene::Map.new(parent, state)
+  eq [25], RGSS::Audio.bgm_pan_calls,
+     "map 1's own balance (25) reaches bgm_pan on load"
+  eq 25, state.current_bgm[:balance], 'and is tracked on state too'
+
+  RGSS::Audio.reset_bgm
+  scene.send(:perform_teleport, [2, 0, 0, 0])
+  eq [50], RGSS::Audio.bgm_pan_calls,
+     "a nil (default/unset) balance on map 2's own BGM still reaches bgm_pan, defaulted to centre"
 end
 
 check 'Scene::Map does not auto-play the map BGM while the party is boarded' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8003,6 +8003,49 @@ check 'Enemy Encounter scene: a Change System BGM victory override\'s own fade-i
      'override-then-default precedence #battle_bgm already uses for name/volume/tempo'
 end
 
+# Cycle #220: the same `BGM`-struct field-5 (`balance`) gap cycle #219 closed
+# for #battle_bgm/#inn_bgm/#vehicle_bgm/#play_map_bgm and Scene::GameOver, but
+# left #play_victory_bgm's own ME channel alone -- see its own doc comment for
+# why no native RGSS::Audio.me_play signature change was actually needed
+# (unlike the fade-in checks just above, which did need one, cycle #204).
+check 'Enemy Encounter scene: victory fanfare forwards battle_end_music\'s own balance ' \
+      'to bgm_pan, not dropped (cycle #220)' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.db.system.battle_end_music =
+    OpenStruct.new(file: 'VictoryBGM', volume: 90, pitch: 105, balance: 20)
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100, balance: 50 }
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  eq [20], RGSS::Audio.bgm_pan_calls,
+     "the database battle_end_music's own balance reaches bgm_pan, not whatever the " \
+     'battle track last left there'
+end
+
+check 'Enemy Encounter scene: a Change System BGM victory override\'s own balance ' \
+      'reaches bgm_pan too (cycle #220)' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.db.system.battle_end_music = OpenStruct.new(file: 'VictoryBGM', volume: 90, pitch: 105)
+  st.system_bgm[1] = { name: 'CustomVictory', fadein: 0, volume: 60, tempo: 130,
+                       balance: 77 }
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  eq [77], RGSS::Audio.bgm_pan_calls,
+     "the override's own balance reaches bgm_pan, the same override-then-default " \
+     'precedence #battle_bgm already uses for name/volume/tempo/fadein'
+end
+
 check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

Continuing the systematic call-site sweep pattern from cycles #217/#218 (BGM `fade_in`), these two cycles cover BGM **pan/balance** (liblcf `BGM`-struct field 5, `mruby-lcf/mrblib/schema.rb`, default 50 = centre).

**Cycle #219:** Play BGM and Play Memorized BGM already re-apply their own balance to `RGSS::Audio.bgm_pan` unconditionally on every play. But every helper that funnels through `Scene::Map#play_bgm` — battle/inn/vehicle BGM, their restore counterparts, and the map-tree node's own Autoplay BGM (`#play_map_bgm`) — never called `bgm_pan` at all, and neither did `Scene::GameOver#play_gameover_bgm`. Fixed by adding a `#music_balance` helper (mirroring `#music_fadein`), threading `balance:` through `#battle_bgm`/`#inn_bgm`/`#vehicle_bgm`/`#play_map_bgm`'s returned hashes, and calling `RGSS::Audio.bgm_pan(music[:balance] || 50)` unconditionally in `#play_bgm` and `Scene::GameOver#play_gameover_bgm`.

**Cycle #220:** `Scene::Map#play_victory_bgm` (the Victory!/EXP-gained fanfare) had the same gap — cycle #219 deliberately left it alone, assuming (per its own old TODO note) that fixing it would need a new native `RGSS::Audio.me_play` signature change the way `fade_in` genuinely did in cycle #204. That assumption didn't hold: `bgm_pan` is a live, already-established call (`Mix_SetPanning(MIX_CHANNEL_POST, ...)`, `include/rgss_audio.hxx`) that re-pans the whole final mixed output regardless of which helper started the underlying stream, and `#me_play`'s own doc comment already establishes the one-shot ME fanfare shares the exact same `Mix_Music` stream as ordinary BGM. So this was just the same mechanical plumbing cycle #219 did elsewhere — no native change needed. Also swept every `RGSS::Audio.se_play` call site for the identical `SE`-struct field-5 gap: found it uniformly dropped everywhere, but unlike BGM/ME there is no existing working per-channel pan call to plumb into (SDL_mixer's one-shot SE channels would need genuinely new native panning support), so that was left alone and documented as a real follow-up rather than guessed at.

## Verification

- 7 new checks total (5 in cycle #219, 2 in cycle #220) added to `scripts/rpg2k_scene_check.rb`; every one independently confirmed to fail against its pre-fix file content (via temporary file swap, not `git stash`) and pass clean after
- `scripts/rpg2k_scene_check.rb`: 952 passed (945 baseline + 7 new)
- `scripts/rpg2k_logic_check.rb`: 1187 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: exit 0, zero known failures (unchanged)
- `cd build && ninja`: clean rebuild
- `ctest --test-dir build`: 8/8 passing
- Field id (5 = `balance`, default 50) verified against `mruby-lcf/mrblib/schema.rb`; the `RGSS::Audio.bgm_pan` idiom and its `Mix_SetPanning(MIX_CHANNEL_POST, ...)` semantics verified against `include/rgss_audio.hxx`'s own doc comment and the pre-existing calls in `mruby-rpg2k/mrblib/interpreter.rb`

No wine session was run in either cycle (audio panning isn't screenshot-diffable) and no new EasyRPG source citation was added — verified entirely by internal consistency: existing schema field ids, matching an established sibling idiom, and regression-proven new checks.