### PR TITLE
Cycle #221: RPG2000 sound effects now honour their own configured pan

### DIFF
--- a/changelog.d/rpg2k-se-pan.fixed.md
+++ b/changelog.d/rpg2k-se-pan.fixed.md
@@ -1,0 +1,41 @@
+- **RPG2000/2003 sound effects now honour their own configured pan (balance)
+  instead of it being unimplementable.** Cycle #220's SE-struct sweep found
+  every `Audio.se_play` call site consistently dropping the LCF `SE` struct's
+  field 5 (`balance`, `mruby-lcf/mrblib/schema.rb`) -- but, unlike the `BGM`
+  struct's own balance (cycles #202-#220), left it alone: `RGSS::Audio.se_play`
+  had no pan argument at all to forward it to, and adding one meant real
+  native (`.cxx`) work, not just Ruby-side plumbing. This cycle adds it.
+  `RgssAudioBackend::se_play`/`se_play_mem` (`include/rgss_audio.hxx`) grow a
+  4th `pan` argument; `src/sdl_audio.cxx`'s `start_se` calls
+  `Mix_SetPanning(ch, left, right)` directly on the channel `Mix_PlayChannel`
+  just handed back, right after the existing `Mix_Volume` call -- genuine
+  per-effect panning, not `bgm_pan`'s `MIX_CHANNEL_POST` master-bus
+  workaround (SDL_mixer's `Mix_SetPanning` works on an ordinary `Mix_Chunk`
+  channel directly; the postmix trick is only needed to reach a `Mix_Music`
+  stream at all). `RGSS::Audio.se_play`/`_se_play_mem` (`mruby-rgss/`) gain
+  the same optional 4th argument, defaulting to 50 (centre) so no real RGSS
+  script call site (which never passes one) changes behaviour. Every RPG2000
+  call site that builds an `SE` struct's audio now forwards its `balance`
+  through this new argument instead of silently dropping it: the Play Sound
+  Effect (11550) event command (`Interpreter#play_audio`'s own comment had
+  documented `balance` as a parameter here for cycles without it ever being
+  read), every system-SFX slot (`Scene::Base#play_system_se`/`#db_system_se`
+  -- the database-default path never read `.balance` off the LCF struct at
+  all, though the Change System SFX (10670) override path already tracked
+  it), a Move Route's "Play SE" sub-command (`MapWorld`/`VehicleWorld
+  #play_sound`, previously accepted and immediately discarded as a
+  `_balance` parameter), a battle animation's own timing SE
+  (`#play_animation_se`), a Switch/Escape skill's own `sound_effect` field
+  (`Scene::SkillMenu#play_skill_sound_effect`), the title screen's cursor SE
+  (`Scene::Title#play_cursor_se`), and RPG2003's terrain footstep SE
+  (`Scene::Map#play_terrain_footstep_se`). Covered by new
+  `scripts/rpg2k_logic_check.rb`/`scripts/rpg2k_scene_check.rb` checks
+  (confirmed to fail pre-fix, one file at a time, restoring each from `git
+  show HEAD:<path>`) and `mruby-rgss/test/test.rb`'s existing SE-resolution
+  check, extended to assert the new argument. No wine session run this
+  cycle (as with every prior BGM-pan cycle, this sandbox has no genuine
+  RPG_RT.exe or real audio device); verification is internal consistency
+  only -- the native `Mix_SetPanning` call itself, and any interaction with
+  `bgm_pan`'s own pre-existing `MIX_CHANNEL_POST` compromise when both a
+  game's BGM and an SE are simultaneously panned off-centre, is unverified
+  against genuine hardware/DirectSound behaviour.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1958,6 +1958,93 @@ The work below is roughly ordered by the critical path to a walkable game
   existing one — a materially different, larger-scoped change than either
   this cycle's fix or cycle #219's, and left alone rather than guessing at an
   unverified panning curve for it.
+
+  ✅ **Follow-up (cycle #221, 2026-08-28): the SE-balance gap cycle #220
+  correctly left open is now closed, with the genuinely new native capability
+  it named.** Method: continued the same systematic sweep one struct further
+  — cycle #217-#220 closed the `BGM` struct's `balance` family; this cycle
+  re-read cycle #220's own "left open" note above and, unlike a purely
+  Ruby-side gap, actually implemented the native plumbing it correctly
+  declined to guess at. Read `include/rgss_audio.hxx`, `mruby-rgss/src/
+  audio.cxx` and `src/sdl_audio.cxx` to confirm `start_se`'s existing
+  `Mix_PlayChannel(-1, chunk, 0)` already returns and uses a channel id
+  (`Mix_Volume(ch, ...)` right after it) — exactly the "already tracks a
+  channel id it just doesn't use" shape that made this safe to attempt
+  rather than a restructuring. `RgssAudioBackend::se_play`/`se_play_mem`
+  grew a 4th `pan` argument; `start_se` now also calls
+  `Mix_SetPanning(ch, left, right)` on that same channel, right after
+  `Mix_Volume` — genuine per-effect panning (SDL_mixer's `Mix_SetPanning`
+  works directly on an ordinary `Mix_Chunk` channel, unlike `bgm_pan`'s
+  `MIX_CHANNEL_POST` master-bus workaround, which exists only because a
+  `Mix_Music` stream has no channel of its own to target), set
+  unconditionally on every play so a channel SDL_mixer recycles from an
+  earlier, differently-panned SE never keeps stale panning.
+  `RGSS::Audio.se_play`/`_se_play_mem` gained the identical optional 4th
+  argument (default 50/centre), the same "grew a trailing argument no real
+  RGSS script ever passes" shape `me_play`'s own `fadein_ms` (cycle #204)
+  already established, so no real-RGSS call site (XP/VX/VXAce's own
+  `RPG::SE#play`/`Audio.se_play`, which never gained this argument) changes
+  behaviour. Every RPG2000 call site that builds an `SE` struct's audio was
+  then swept the same way cycle #219 swept `BGM`'s call sites, and now
+  forwards `balance` through the new argument: the Play Sound Effect (11550)
+  event command (`Interpreter#play_audio`'s own comment had named `balance`
+  as a parameter for cycles without the code ever reading it), both halves
+  of `Scene::Base#system_se` (the Change System SFX (10670) override path
+  already tracked `balance` in its stashed hash; `#db_system_se`, the
+  database-default path, never read `.balance` off the LCF struct at all —
+  its own genuinely new gap, not just the previously-undeliverable one),
+  `MapWorld`/`VehicleWorld#play_sound` (a Move Route "Play SE" sub-command —
+  previously accepted as a `_balance` parameter and immediately discarded,
+  now genuinely forwarded), `#play_animation_se` (a battle animation's own
+  timing SE), `Scene::SkillMenu#play_skill_sound_effect` (a Switch/Escape
+  skill's own `sound_effect` field), `Scene::Title#play_cursor_se`, and
+  `Scene::Map#play_terrain_footstep_se` (RPG2003's terrain footstep, whose
+  own doc comment already named `balance` as part of the full `Sound`
+  struct it reads). **Verification**: extended `mruby-rgss/test/test.rb`'s
+  existing `RGSS::Audio.se_play resolves a name to a real file` check to
+  assert the new argument defaults to 50 and forwards an explicit value (the
+  four pre-existing `_se_play` overrides elsewhere in that file needed their
+  fixed 3-arg signature widened to accept it too, or they would raise
+  `ArgumentError` once `se_play` started always passing 4); added a new
+  `rpg2k_logic_check.rb` check (`Play SE` with an explicit balance parameter
+  reaches `se_play`'s 4th argument, both full-left and full-right) and a new
+  `rpg2k_scene_check.rb` check (RPG2003 terrain footstep forwards a non-
+  default balance), plus widened five pre-existing `rpg2k_scene_check.rb`
+  assertions on exact `se_calls` arrays that would otherwise now under-count
+  their own recorded arguments. Confirmed every new/widened check actually
+  fails pre-fix: `interpreter.rb`, `scene/base.rb` and `scene/map.rb` were
+  each swapped for their `git show HEAD:...` version in turn (never
+  `git stash`, to avoid disturbing any concurrent session's own uncommitted
+  work) — the `interpreter.rb` swap failed both the widened "plays it, not a
+  stop-all" check and the new explicit-balance check with `got [nil, nil]`;
+  the `scene/map.rb` swap failed both footstep checks; the `scene/base.rb`
+  swap failed the widened `MapWorld#play_sound` check plus five `SkillMenu`
+  checks that all route through `#play_system_se`/`#play_skill_sound_effect`
+  — then each file was restored from the working tree and the suite reran
+  clean. Full suite: `rpg2k_scene_check.rb` 953 passed (952 baseline + 1 new
+  check); `rpg2k_logic_check.rb` 1188 passed (1187 baseline + 1 new check);
+  `rpg2k_render_check.rb` 41 passed (unchanged); `rpg2k3_battle_row_check.rb`
+  19/0 and `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged); `rpg2k_save_
+  load_check.rb` exit 0, zero known failures (unchanged); `cd build && ninja`
+  clean rebuild; `ctest --test-dir build` 8/8 passing (including `mruby_test`,
+  which runs the widened `test.rb` under real mruby). `.cxx`/`.hxx` files
+  were touched this cycle (`include/rgss_audio.hxx`, `src/sdl_audio.cxx`,
+  `mruby-rgss/src/audio.cxx`), so `clang-format -i` was run over all three
+  before building; `rgss_cruby_test_check.rb` (the pure-Ruby CRuby compat
+  shim, which already accepted `_se_play(*)`/`_se_play_mem(*)` variadically
+  with no ivar-based behaviour to keep in sync) passed unchanged. No wine
+  session was run this cycle — same limitation as every prior BGM/ME pan
+  cycle, audio panning is not screenshot-diffable and this sandbox has no
+  genuine RPG_RT.exe or real audio device — so the native `Mix_SetPanning`
+  call itself, and its interaction with `bgm_pan`'s own pre-existing
+  `MIX_CHANNEL_POST` master-bus effect when a game's BGM and an SE are
+  simultaneously panned off-centre (the two compound: the SE's own pan
+  applies first, then `bgm_pan`'s postmix pan applies again on top of the
+  already-mixed result), are unverified against genuine hardware/DirectSound
+  behaviour — documented as such directly in `include/rgss_audio.hxx`'s own
+  doc comment rather than left implicit. No EasyRPG source was consulted for
+  any new behavioral claim.
+
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/include/rgss_audio.hxx
+++ b/include/rgss_audio.hxx
@@ -87,8 +87,18 @@ struct RgssAudioBackend {
   void (*me_stop)(void);
   void (*me_fade)(int ms);
 
-  // Sound effect: a one-shot sample; several can overlap.
-  void (*se_play)(const char* path, int volume, int pitch);
+  // Sound effect: a one-shot sample; several can overlap. pan is not part of
+  // any real RGSS Audio.se_play signature -- it carries RPG2000's own Play
+  // Sound Effect / system-SFX balance parameter (cycle #221, the same shape
+  // as bgm_play's fadein_ms above), 0..100 on the same full-left/centre/
+  // full-right scale as bgm_pan. Unlike bgm_pan, SDL_mixer's Mix_SetPanning
+  // works directly on the Mix_Chunk channel each SE plays on -- no
+  // MIX_CHANNEL_POST master-bus trick needed -- so this is genuine
+  // per-effect panning, independent of whatever the BGM's own balance is
+  // currently set to. 50 (every real-RGSS call site's implicit value, and
+  // every RPG2000 SE struct's own schema default) is centred, matching the
+  // pre-existing unpanned behaviour exactly.
+  void (*se_play)(const char* path, int volume, int pitch, int pan);
   void (*se_stop)(void);
 
   // Called once per frame from Graphics.update so the backend can drive
@@ -125,7 +135,8 @@ struct RgssAudioBackend {
                       const void* data,
                       int size,
                       int volume,
-                      int pitch);
+                      int pitch,
+                      int pan);
 
   // Non-zero when the backend resolved a MIDI instrument configuration, i.e.
   // when a .mid BGM/ME is expected to be audible rather than silent. Lets the

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1246,10 +1246,16 @@ module RGSS
         _me_fade(time)
       end
 
-      def se_play(filename, volume = 100, pitch = 100)
+      # `pan` (cycle #221) is not part of any real RGSS Audio.se_play
+      # signature (RGSS1/2/3 scripts never pass a 4th argument here either) --
+      # it exists for RPG2000's own Play Sound Effect / system-SFX balance
+      # parameter (the LCF `SE` struct's field 5), the same 0..100 scale
+      # `#bgm_pan` already carries for BGM. 50 (centre) keeps the original
+      # unpanned behaviour.
+      def se_play(filename, volume = 100, pitch = 100, pan = 50)
         path = resolve(filename, SOUND_DIRS)
-        return _se_play(path, volume, pitch) if path
-        play_packed(:se, filename, volume, pitch)
+        return _se_play(path, volume, pitch, pan) if path
+        play_packed(:se, filename, volume, pitch, 0, 0, pan)
       end
 
       def se_stop
@@ -1295,8 +1301,11 @@ module RGSS
       # packed-path split as `pos` for the identical reason: RPG2000's Play
       # BGM / Change System BGM fade-in has to reach a released game's packed
       # archive too, not just loose files -- ME ignores `pos` (it never
-      # resumes mid-track) exactly like every non-BGM kind above.
-      def play_packed(kind, filename, volume, pitch, pos = 0, fadein = 0)
+      # resumes mid-track) exactly like every non-BGM kind above. `pan`
+      # (cycle #221) is SE's own balance parameter, the identical disk-path/
+      # packed-path split as `pos`/`fadein` for the identical reason -- every
+      # other kind ignores it.
+      def play_packed(kind, filename, volume, pitch, pos = 0, fadein = 0, pan = 50)
         return nil if filename.nil? || filename.empty?
         archive = RGSS.asset_archive
         name, bytes = archive ? find_packed(archive, kind, filename) : nil
@@ -1320,7 +1329,7 @@ module RGSS
         when :bgm then _bgm_play_mem(name, bytes, volume, pitch, pos, fadein)
         when :bgs then _bgs_play_mem(name, bytes, volume, pitch)
         when :me then _me_play_mem(name, bytes, volume, pitch, fadein)
-        else _se_play_mem(name, bytes, volume, pitch)
+        else _se_play_mem(name, bytes, volume, pitch, pan)
         end
         nil
       end

--- a/mruby-rgss/src/audio.cxx
+++ b/mruby-rgss/src/audio.cxx
@@ -36,11 +36,11 @@ void get_play_args(mrb_state* M,
   mrb_get_args(M, "z|ii", path, volume, pitch);
 }
 
-// The bgs_play_mem/se_play_mem twins take (name, bytes, volume=100,
-// pitch=100) -- bgm_play_mem and me_play_mem each grew extra trailing
-// arguments (pos_ms/fadein_ms, and fadein_ms respectively) and so define
-// their own mrb functions below rather than sharing this one. `name` is an
-// archive entry name rather than a path -- see include/rgss_audio.hxx.
+// bgs_play_mem takes (name, bytes, volume=100, pitch=100) -- bgm_play_mem,
+// me_play_mem and se_play_mem each grew extra trailing arguments
+// (pos_ms/fadein_ms, fadein_ms, and pan respectively) and so define their
+// own mrb functions below rather than sharing this one. `name` is an archive
+// entry name rather than a path -- see include/rgss_audio.hxx.
 using PlayMemFn = void (*)(const char*, const void*, int, int, int);
 
 mrb_value play_mem(mrb_state* M, PlayMemFn fn) {
@@ -163,11 +163,18 @@ mrb_value me_fade(mrb_state* M, mrb_value self) {
 }
 
 mrb_value se_play(mrb_state* M, mrb_value self) {
+  // SE grew its own 4th (pan, cycle #221) argument, so -- like me_play's own
+  // 4th (fadein_ms) argument above -- it reads its args directly rather than
+  // sharing get_play_args (bgs_play still does). pan is RPG2000's own Play
+  // Sound Effect / system-SFX balance parameter, not part of any real RGSS
+  // Audio.se_play signature; 50 (centre) keeps the original unpanned
+  // behaviour for every real-RGSS script call site, which never passes a 4th
+  // argument. See rgss_audio.hxx's own doc comment on the backend's se_play.
   const char* path;
-  mrb_int volume, pitch;
-  get_play_args(M, &path, &volume, &pitch);
+  mrb_int volume = 100, pitch = 100, pan = 50;
+  mrb_get_args(M, "z|iii", &path, &volume, &pitch, &pan);
   if (g_backend.se_play)
-    g_backend.se_play(path, (int)volume, (int)pitch);
+    g_backend.se_play(path, (int)volume, (int)pitch, (int)pan);
   return mrb_nil_value();
 }
 
@@ -229,7 +236,18 @@ mrb_value me_play_mem(mrb_state* M, mrb_value self) {
 }
 
 mrb_value se_play_mem(mrb_state* M, mrb_value self) {
-  return play_mem(M, g_backend.se_play_mem);
+  // Not the shared play_mem helper: like se_play above, SE's packed-archive
+  // twin also grew its own 5th (pan, cycle #221) argument -- see se_play's
+  // own comment.
+  const char* name;
+  const char* data;
+  mrb_int size;
+  mrb_int volume = 100, pitch = 100, pan = 50;
+  mrb_get_args(M, "zs|iii", &name, &data, &size, &volume, &pitch, &pan);
+  if (g_backend.se_play_mem && size > 0)
+    g_backend.se_play_mem(name, data, (int)size, (int)volume, (int)pitch,
+                          (int)pan);
+  return mrb_nil_value();
 }
 
 // Whether this build can play audio it did not read from a file. False with no
@@ -279,7 +297,7 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
   mrb_define_module_function(M, audio, "_me_play", me_play, MRB_ARGS_ARG(1, 3));
   mrb_define_module_function(M, audio, "_me_stop", me_stop, MRB_ARGS_NONE());
   mrb_define_module_function(M, audio, "_me_fade", me_fade, MRB_ARGS_REQ(1));
-  mrb_define_module_function(M, audio, "_se_play", se_play, MRB_ARGS_ARG(1, 2));
+  mrb_define_module_function(M, audio, "_se_play", se_play, MRB_ARGS_ARG(1, 3));
   mrb_define_module_function(M, audio, "_se_stop", se_stop, MRB_ARGS_NONE());
   mrb_define_module_function(M, audio, "_update", audio_update,
                              MRB_ARGS_NONE());
@@ -292,7 +310,7 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
   mrb_define_module_function(M, audio, "_me_play_mem", me_play_mem,
                              MRB_ARGS_ARG(2, 3));
   mrb_define_module_function(M, audio, "_se_play_mem", se_play_mem,
-                             MRB_ARGS_ARG(2, 2));
+                             MRB_ARGS_ARG(2, 3));
   mrb_define_module_function(M, audio, "_midi_available", midi_available,
                              MRB_ARGS_NONE());
   mrb_define_module_function(M, audio, "_can_play_mem?", can_play_mem,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1658,8 +1658,8 @@ assert "RGSS::Audio prefers a loose file over the archive" do
   archive = FakeArchive.new({ "Audio/SE/test-packed-se.wav" => "packed" })
   class << RGSS::Audio
     alias _se_play_orig2 _se_play
-    def _se_play(p, v, pi)
-      $audio_se_capture = [p, v, pi]
+    def _se_play(p, v, pi, pa = 50)
+      $audio_se_capture = [p, v, pi, pa]
       nil
     end
   end
@@ -1689,8 +1689,8 @@ assert "RGSS::Audio finds an upper-case extension on disk" do
   File.open(path, "wb") { |io| io.write("RIFFtestWAVEfixture") }
   class << RGSS::Audio
     alias _se_play_orig3 _se_play
-    def _se_play(p, v, pi)
-      $audio_se_capture = [p, v, pi]
+    def _se_play(p, v, pi, pa = 50)
+      $audio_se_capture = [p, v, pi, pa]
       nil
     end
   end
@@ -1723,8 +1723,8 @@ assert "RGSS::Audio skips a directory that shadows a track name" do
   File.open(path, "wb") { |io| io.write("RIFFtestWAVEfixture") }
   class << RGSS::Audio
     alias _se_play_orig4 _se_play
-    def _se_play(p, v, pi)
-      $audio_se_capture = [p, v, pi]
+    def _se_play(p, v, pi, pa = 50)
+      $audio_se_capture = [p, v, pi, pa]
       nil
     end
   end
@@ -1818,14 +1818,14 @@ end
 
 assert "RGSS::Audio.se_play resolves a name to a real file" do
   # Capture what the public API forwards to the native primitive so we can
-  # assert the filename was resolved (extension appended) and volume/pitch
-  # passed through.
+  # assert the filename was resolved (extension appended) and
+  # volume/pitch/pan passed through.
   path = "test-se-fixture.wav"
   File.open(path, "wb") { |io| io.write("RIFFtestWAVEfixture") }
   class << RGSS::Audio
     alias _se_play_orig _se_play
-    def _se_play(p, v, pi)
-      $audio_se_capture = [p, v, pi]
+    def _se_play(p, v, pi, pa = 50)
+      $audio_se_capture = [p, v, pi, pa]
       nil
     end
   end
@@ -1836,6 +1836,15 @@ assert "RGSS::Audio.se_play resolves a name to a real file" do
     assert_equal "test-se-fixture.wav", $audio_se_capture[0]
     assert_equal 80, $audio_se_capture[1]
     assert_equal 90, $audio_se_capture[2]
+    # pan (cycle #221) defaults to 50 (centre) when the caller -- every real
+    # RGSS script -- passes only the original 3 arguments.
+    assert_equal 50, $audio_se_capture[3]
+
+    # RPG2000's own system-SFX/Play Sound Effect balance parameter reaches
+    # the native primitive as this 4th argument when given explicitly.
+    $audio_se_capture = nil
+    RGSS::Audio.se_play("test-se-fixture", 80, 90, 20)
+    assert_equal 20, $audio_se_capture[3]
 
     # A name that resolves to nothing skips the native call entirely.
     $audio_se_capture = nil

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -4804,10 +4804,16 @@ module Game
         @state.bgm_stopping = false
         RGSS::Audio.bgm_pan(balance)
       else
-        # PlaySE parameters: [volume, tempo, balance].
+        # PlaySE parameters: [volume, tempo, balance]. balance (cycle #221)
+        # was documented right here but never actually read -- RGSS::Audio.
+        # se_play had no pan argument to forward it to until this cycle's own
+        # native `pan` addition (see rgss_audio.hxx's own doc comment on the
+        # backend's se_play, and RGSS::Audio.bgm_pan's identical balance
+        # scale for BGM).
         volume = cmd.parameters.size > 0 ? cmd.param(0) : 100
         pitch = cmd.parameters.size > 1 ? cmd.param(1) : 100
-        RGSS::Audio.se_play(name, volume, pitch)
+        balance = cmd.parameters.size > 2 ? cmd.param(2) : 50
+        RGSS::Audio.se_play(name, volume, pitch, balance)
       end
     rescue StandardError => e
       $stderr.puts "[RPG2k] #{kind} playback failed for '#{name}': #{e.message}"

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -330,14 +330,15 @@ class RPG2k
       def play_system_se(slot)
         se = system_se(slot)
         return unless se
-        Audio.se_play se[:name], se[:volume] || 100, se[:tempo] || 100
+        Audio.se_play se[:name], se[:volume] || 100, se[:tempo] || 100,
+                      se[:balance] || 50
       rescue StandardError => e
         $stderr.puts "[RPG2k] system SE '#{slot}' playback failed: #{e.message}"
       end
 
-      # The audio for a system slot as { name:, volume:, tempo: } — the state
-      # override (set by Change System SFX) first, then the database default for
-      # that slot, or nil when neither names a file.
+      # The audio for a system slot as { name:, volume:, tempo:, balance: } —
+      # the state override (set by Change System SFX) first, then the
+      # database default for that slot, or nil when neither names a file.
       def system_se(slot)
         ov = @state && @state.respond_to?(:system_sfx) ? @state.system_sfx[slot] : nil
         return ov if ov && ov[:name] && !ov[:name].empty?
@@ -358,8 +359,13 @@ class RPG2k
         # if (se.name == "(OFF)") { ...; return; }` -- treats blank *and*
         # the literal "(OFF)" sentinel identically as "nothing to play."
         return nil if name.nil? || name.empty? || name == '(OFF)'
+        # balance (cycle #221): the database's own SE struct carries it (LCF
+        # schema field 5, the same field id `#do_change_system_sfx`'s own
+        # override hash already tracks below), but this DB-default path never
+        # read it at all until now -- see #play_system_se's own citation.
         { name: name, volume: (se.respond_to?(:volume) ? se.volume : 100),
-          tempo: (se.respond_to?(:pitch) ? se.pitch : 100) }
+          tempo: (se.respond_to?(:pitch) ? se.pitch : 100),
+          balance: (se.respond_to?(:balance) ? se.balance : 50) }
       end
 
       # Plays a battle_anime row's own sound effect -- ported from
@@ -389,7 +395,7 @@ class RPG2k
           se = t.respond_to?(:se) ? t.se : nil
           name = se && se.file
           next if name.nil? || name.empty? || name == '(OFF)'
-          Audio.se_play name, se.volume, se.pitch
+          Audio.se_play name, se.volume, se.pitch, se.balance
           return
         end
       rescue StandardError => e
@@ -446,9 +452,12 @@ class RPG2k
       # name: "(OFF)" (liblcf's own "no sound set" default) and "(Brak)"
       # (Polish for "missing" -- a legacy artifact unique to this one
       # command in the whole reference codebase, found nowhere else in it).
-      def play_sound(name, volume, tempo, _balance)
+      # `balance` (cycle #221) was accepted and immediately discarded here
+      # (a `_balance` parameter) until RGSS::Audio.se_play grew a native pan
+      # argument to forward it to -- see that method's own doc comment.
+      def play_sound(name, volume, tempo, balance)
         return if name.nil? || name.empty? || name == '(OFF)' || name == '(Brak)'
-        RGSS::Audio.se_play(name, volume, tempo)
+        RGSS::Audio.se_play(name, volume, tempo, balance)
       rescue StandardError => e
         $stderr.puts "[RPG2k] event SE '#{name}' playback failed: #{e.message}"
         nil
@@ -499,9 +508,12 @@ class RPG2k
       # name: "(OFF)" (liblcf's own "no sound set" default) and "(Brak)"
       # (Polish for "missing" -- a legacy artifact unique to this one
       # command in the whole reference codebase, found nowhere else in it).
-      def play_sound(name, volume, tempo, _balance)
+      # `balance` (cycle #221) was accepted and immediately discarded here
+      # (a `_balance` parameter) until RGSS::Audio.se_play grew a native pan
+      # argument to forward it to -- see that method's own doc comment.
+      def play_sound(name, volume, tempo, balance)
         return if name.nil? || name.empty? || name == '(OFF)' || name == '(Brak)'
-        RGSS::Audio.se_play(name, volume, tempo)
+        RGSS::Audio.se_play(name, volume, tempo, balance)
       rescue StandardError => e
         $stderr.puts "[RPG2k] event SE '#{name}' playback failed: #{e.message}"
         nil

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -9714,7 +9714,10 @@ class RPG2k
       # Sound&, bool)` (`src/game_system.cpp`), which treats a blank name
       # *or* the literal "(OFF)" sentinel as silent no-ops, the same
       # convention every other Sound-typed field in this codebase already
-      # follows (see `#db_system_se`/`#play_animation_se`).
+      # follows (see `#db_system_se`/`#play_animation_se`). `balance` (cycle
+      # #221) now reaches `RGSS::Audio.se_play`'s own native pan argument too
+      # -- previously dropped along with every other SE call site's, before
+      # the backend had anywhere to forward it to.
       def play_terrain_footstep_se(row, damaged)
         return unless @db.respond_to?(:rpg2003?) && @db.rpg2003?
         return unless row && row.respond_to?(:footstep) && row.respond_to?(:on_damage_se)
@@ -9722,7 +9725,8 @@ class RPG2k
         se = row.footstep
         name = se && se.respond_to?(:file) ? se.file : nil
         return if name.nil? || name.empty? || name == '(OFF)'
-        RGSS::Audio.se_play(name, se.volume, se.pitch)
+        balance = se.respond_to?(:balance) ? se.balance : 50
+        RGSS::Audio.se_play(name, se.volume, se.pitch, balance)
       rescue StandardError => e
         $stderr.puts "[RPG2k] Terrain: footstep SE playback failed: #{e.message}"
       end

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -319,7 +319,7 @@ class RPG2k
         return unless se
         name = se.file
         return if name.nil? || name.empty?
-        Audio.se_play name, se.volume, se.pitch
+        Audio.se_play name, se.volume, se.pitch, se.balance
       rescue StandardError => e
         $stderr.puts "[RPG2k] skill SE '#{name}' playback failed: #{e.message}"
       end

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -388,7 +388,7 @@ class RPG2k
         return unless se
         name = se.file
         return if name.nil? || name.empty?
-        Audio.se_play name, se.volume, se.pitch
+        Audio.se_play name, se.volume, se.pitch, se.balance
       rescue StandardError => e
         $stderr.puts "[RGSS] cursor SE playback failed: #{e.message}"
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3903,7 +3903,27 @@ check 'Play SE with a real file name plays it, not a stop-all' do
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::PLAY_SE, [80, 100], string: 'cursor')])
   it.update
-  eq [[:se, 'cursor', 80, 100]], RGSS::Audio.log
+  # [volume, tempo] only -- no 3rd (balance) element at all -- defaults to
+  # centre (50), the same convention Play BGM's own omitted-balance check
+  # uses just below.
+  eq [[:se, 'cursor', 80, 100, 50]], RGSS::Audio.log
+end
+
+check 'Play SE with an explicit balance parameter forwards it as pan' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # PlaySE parameters: [volume, tempo, balance] -- param(2) is balance, here
+  # full left (0) then full right (100). Cycle #221: this parameter was
+  # documented right in #play_audio's own comment but never actually read,
+  # since RGSS::Audio.se_play had no pan argument to forward it to.
+  it.start([
+    FakeCmd.new(IC::PLAY_SE, [80, 100, 0], string: 'cursor'),
+    FakeCmd.new(IC::PLAY_SE, [80, 100, 100], string: 'cursor'),
+  ])
+  it.update
+  ses = RGSS::Audio.log.select { |e| e[0] == :se }.map { |e| e[4] }
+  eq [0, 100], ses, 'each Play SE forwards its own balance parameter as pan'
 end
 
 check 'Play BGM with the literal "(OFF)" name stops the current track' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -22069,8 +22069,10 @@ check 'RPG2k::Scene::MapWorld#play_sound skips the "(OFF)"/"(Brak)" ' \
   world.play_sound('(OFF)', 90, 100, 50)
   world.play_sound('(Brak)', 90, 100, 50)
   eq [], RGSS::Audio.se_calls, 'neither sentinel plays anything'
-  world.play_sound('bell', 90, 100, 50)
-  eq [['bell', 90, 100]], RGSS::Audio.se_calls, 'a real name still plays normally'
+  # balance (cycle #221) now reaches RGSS::Audio.se_play's own 4th (pan)
+  # argument too, here off-centre (20) to confirm it is not just defaulted.
+  world.play_sound('bell', 90, 100, 20)
+  eq [['bell', 90, 100, 20]], RGSS::Audio.se_calls, 'a real name still plays normally, balance included'
 end
 
 # Ported from EasyRPG Player's source, NOT independently confirmed against
@@ -22282,7 +22284,7 @@ check 'Scene::SkillMenu: choosing a currently-unusable skill just buzzes and sta
   RGSS::Input.reset
   eq :skills, scene.instance_variable_get(:@mode), 'no target-confirm screen opens'
   eq [], party.cast_skill_calls, 'the skill is never actually cast'
-  eq [['Buzzer1', 100, 100]], RGSS::Audio.se_calls, 'buzzer only -- no Decision SE plays at all'
+  eq [['Buzzer1', 100, 100, 50]], RGSS::Audio.se_calls, 'buzzer only -- no Decision SE plays at all'
 
   # The castable skill right next to it still works normally.
   RGSS::Input.triggered = [RGSS::Input::LEFT]
@@ -22293,7 +22295,7 @@ check 'Scene::SkillMenu: choosing a currently-unusable skill just buzzes and sta
   scene.update
   RGSS::Input.reset
   eq :target, scene.instance_variable_get(:@mode), 'a usable skill still opens target-confirm'
-  eq [['Decision1', 100, 100]], RGSS::Audio.se_calls
+  eq [['Decision1', 100, 100, 50]], RGSS::Audio.se_calls
 end
 
 check 'Scene::SkillMenu: a listed-but-unusable skill row reads the windowskin\'s ' \
@@ -22384,8 +22386,9 @@ check 'Scene::SkillMenu: a Switch skill plays its own sound_effect on a successf
   scene.update
   RGSS::Input.reset
   eq true, state.switches[17], 'the switch turned on'
-  eq [['Decision1', 100, 100], ['SwitchOn', 90, 110]], RGSS::Audio.se_calls,
-     "the ordinary Decision SE (confirming the choice) then the skill's own sound_effect"
+  eq [['Decision1', 100, 100, 50], ['SwitchOn', 90, 110, 30]], RGSS::Audio.se_calls,
+     "the ordinary Decision SE (confirming the choice) then the skill's own sound_effect, " \
+     "each with its own balance (the system default 50, then the skill's own 30)"
 end
 
 check 'Scene::SkillMenu: a successful Switch skill closes the whole menu ' \
@@ -22420,7 +22423,7 @@ check 'Scene::SkillMenu: a Switch skill with a blank sound_effect plays nothing 
   scene.update
   RGSS::Input.reset
   eq true, state.switches[18], 'the switch still turned on'
-  eq [['Decision1', 100, 100]], RGSS::Audio.se_calls,
+  eq [['Decision1', 100, 100, 50]], RGSS::Audio.se_calls,
      'only the ordinary Decision SE -- the blank sound_effect filename makes #play_sound no-op silently'
 end
 
@@ -22439,7 +22442,7 @@ check 'Scene::SkillMenu: a failed Switch cast plays only Buzzer, not the skill\'
   scene.update
   RGSS::Input.reset
   ok !state.switches[17] && !state.switches[18], 'no switch flipped'
-  eq [['Decision1', 100, 100], ['Buzzer1', 100, 100]], RGSS::Audio.se_calls,
+  eq [['Decision1', 100, 100, 50], ['Buzzer1', 100, 100, 50]], RGSS::Audio.se_calls,
      "Decision then Buzzer -- the configured sound_effect never plays on a failed cast"
 end
 
@@ -22455,7 +22458,7 @@ check 'Scene::SkillMenu: an Escape skill plays its own sound_effect on a success
   scene.update
   RGSS::Input.reset
   eq [9, 1, 2, 0], state.pending_teleport, 'queued straight from the one registered escape target'
-  eq [['Decision1', 100, 100], ['SwitchOn', 90, 110]], RGSS::Audio.se_calls,
+  eq [['Decision1', 100, 100, 50], ['SwitchOn', 90, 110, 30]], RGSS::Audio.se_calls,
      "the ordinary Decision SE then the skill's own sound_effect, before the warp closes the menu"
 end
 
@@ -23646,7 +23649,17 @@ check 'RPG2003 terrain footstep plays with its own configured volume/pitch, ' \
   scene = new_scene({}, player: [0, 0], members: [hero], rpg2003: true,
                      footstep: OpenStruct.new(file: 'Step2', volume: 80, pitch: 120))
   walk(scene, 1)
-  eq ['Step2', 80, 120], RGSS::Audio.se_calls.find { |c| c[0] == 'Step2' }
+  eq ['Step2', 80, 120, 50], RGSS::Audio.se_calls.find { |c| c[0] == 'Step2' }
+end
+
+check 'RPG2003 terrain footstep forwards its own configured balance too, ' \
+      'not just volume/pitch (cycle #221)' do
+  RGSS::Audio.reset_se
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero], rpg2003: true,
+                     footstep: OpenStruct.new(file: 'Step3', volume: 80, pitch: 120, balance: 20))
+  walk(scene, 1)
+  eq ['Step3', 80, 120, 20], RGSS::Audio.se_calls.find { |c| c[0] == 'Step3' }
 end
 
 check 'a terrain footstep explicitly set to "(OFF)" plays nothing, matching ' \

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -197,6 +197,21 @@ int to_mix_volume(int rpg_volume) {
   return rpg_volume * MIX_MAX_VOLUME / 100;
 }
 
+// RPG2000's balance scale (0 full left .. 50 centre .. 100 full right) to a
+// Mix_SetPanning left/right pair. "True panning" per SDL_mixer.h's own doc
+// comment on Mix_SetPanning is Mix_SetPanning(chan, left, 255 - left), so
+// right alone (0..255) is derived from pan and left is its complement --
+// shared by bgm_pan (below, applied to MIX_CHANNEL_POST) and start_se
+// (applied directly to the SE's own channel).
+void pan_to_lr(int pan, Uint8* left, Uint8* right) {
+  if (pan < 0)
+    pan = 0;
+  if (pan > 100)
+    pan = 100;
+  *right = (Uint8)(pan * 255 / 100);
+  *left = (Uint8)(255 - *right);
+}
+
 // Load a sample, caching it. Returns null (and logs once) on failure.
 Mix_Chunk* load_chunk(const std::string& path) {
   auto it = g_chunks.find(path);
@@ -436,16 +451,11 @@ void bgm_volume(int volume) {
 // alternative for music (see the doc comment on Mix_SetPanning in
 // SDL_mixer.h: "the panning will be done to the final mixed stream"). pan is
 // RPG2000's own Play BGM balance scale: 0 full left, 50 centre, 100 full
-// right. "True panning" per that same doc comment is Mix_SetPanning(chan,
-// left, 255 - left), so right alone (0..255) is derived from pan and left is
-// its complement.
+// right -- see pan_to_lr, above, for the left/right conversion this shares
+// with start_se's own, genuinely per-channel, SE panning.
 void bgm_pan(int pan) {
-  if (pan < 0)
-    pan = 0;
-  if (pan > 100)
-    pan = 100;
-  Uint8 right = (Uint8)(pan * 255 / 100);
-  Uint8 left = (Uint8)(255 - right);
+  Uint8 left, right;
+  pan_to_lr(pan, &left, &right);
   Mix_SetPanning(MIX_CHANNEL_POST, left, right);
 }
 
@@ -589,24 +599,47 @@ void me_fade(int ms) {
 
 // -- SE ---------------------------------------------------------------------
 
-void start_se(Mix_Chunk* chunk, int volume) {
+// pan (cycle #221): unlike bgm_pan's MIX_CHANNEL_POST master-bus hack (the
+// only way to reach a Mix_Music stream at all -- see bgm_pan's own doc
+// comment), Mix_SetPanning works directly on an ordinary Mix_Chunk channel,
+// so this is genuine per-effect panning applied straight to the channel
+// Mix_PlayChannel just handed back -- not a postmix effect, and not shared
+// with any other channel. Set unconditionally on every play (not only when
+// pan differs from centre) so a channel SDL_mixer recycles from an earlier,
+// differently-panned SE never keeps that stale panning: Mix_SetPanning's own
+// per-channel registration otherwise persists until explicitly overwritten
+// or the channel is closed, well past that earlier SE finishing and
+// se_stop's Mix_HaltChannel. Note this does compound with bgm_pan's own
+// postmix effect when a game's Play BGM balance is simultaneously off
+// centre: the final output is this SE's own pan applied first, then
+// bgm_pan's master-bus pan applied again on top of the already-mixed
+// result -- an accepted consequence of bgm_pan's own pre-existing
+// MIX_CHANNEL_POST compromise (its doc comment already discloses that it
+// "also pans BGS and SE, since there is no channel-scoped alternative for
+// music"), not something this SE-side fix introduces on its own.
+void start_se(Mix_Chunk* chunk, int volume, int pan) {
   if (!chunk)
     return;
   int ch = Mix_PlayChannel(-1, chunk, 0);
-  if (ch >= 0)
-    Mix_Volume(ch, to_mix_volume(volume));
+  if (ch < 0)
+    return;
+  Mix_Volume(ch, to_mix_volume(volume));
+  Uint8 left, right;
+  pan_to_lr(pan, &left, &right);
+  Mix_SetPanning(ch, left, right);
 }
 
-void se_play(const char* path, int volume, int /*pitch*/) {
-  start_se(load_chunk(path), volume);
+void se_play(const char* path, int volume, int /*pitch*/, int pan) {
+  start_se(load_chunk(path), volume, pan);
 }
 
 void se_play_mem(const char* name,
                  const void* data,
                  int size,
                  int volume,
-                 int /*pitch*/) {
-  start_se(load_chunk_mem(name, data, size), volume);
+                 int /*pitch*/,
+                 int pan) {
+  start_se(load_chunk_mem(name, data, size), volume, pan);
 }
 
 void se_stop(void) {


### PR DESCRIPTION
## Summary

Closes the SE-balance gap cycle #220 correctly identified but deliberately left open (it needed native `.cxx` work). Every RPG2000 call site that builds an `SE`-struct's audio (`mruby-lcf/mrblib/schema.rb`, field 5 = `balance`, default 50 = centre) was silently dropping it before this cycle.

**Native change:** `RgssAudioBackend::se_play`/`se_play_mem` (`include/rgss_audio.hxx`, `src/sdl_audio.cxx`) grow a `pan` argument. Unlike `bgm_pan`'s `Mix_SetPanning(MIX_CHANNEL_POST, ...)` master-bus workaround (the only way to reach a `Mix_Music` stream), SDL_mixer's `Mix_SetPanning` works directly on the ordinary `Mix_Chunk` channel `Mix_PlayChannel` just returned — genuine per-effect panning, applied unconditionally on every play so a channel SDL_mixer recycles from an earlier, differently-panned SE never keeps stale panning. A shared `pan_to_lr` helper (extracted from the existing `bgm_pan`) converts RPG2000's 0..100 balance scale to the left/right pair. The interaction with `bgm_pan`'s own postmix effect when both are simultaneously off-centre is disclosed directly in the new doc comment as an accepted, pre-existing consequence of `bgm_pan`'s own `MIX_CHANNEL_POST` compromise — not something this SE-side fix introduces.

**mruby binding:** `mruby-rgss/src/audio.cxx`'s `se_play`/`se_play_mem` grow a 4th/5th optional argument (default 50, matching every real RGSS script call site which never passes one). `mruby-rgss/mrblib/lib.rb`'s `Audio.se_play`/`#play_packed` thread it through, including the packed-archive path.

**RPG2000 call sites wired through:** Play Sound Effect (11550) event command, system SFX (`Scene::Base#play_system_se`/`#db_system_se`), Move Route "Play SE" (previously a discarded `_balance` parameter in `MapWorld`/`VehicleWorld#play_sound`), battle-animation timing SE (`#play_animation_se`), skill `sound_effect`, title-screen cursor SE, and RPG2003's terrain footstep SE.

## Verification

- `mruby-rgss/test/test.rb`: existing SE tests updated for the new 4th arg (default-50 assertion added), plus a new explicit-pan-value assertion
- `scripts/rpg2k_scene_check.rb` / `scripts/rpg2k_logic_check.rb`: several existing checks widened to assert `balance` reaches the native call (not just net-new checks) — independently confirmed by reverting only the Ruby-side call-site files to their pre-fix content (native side unchanged) and re-running: **8 of 953** scene checks and **2 of 1188** logic checks fail, all clean again after restoring the fix
- `scripts/rpg2k_scene_check.rb`: 953 passed, `scripts/rpg2k_logic_check.rb`: 1188 passed
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: exit 0, zero known failures (unchanged)
- `ruby scripts/rgss_cruby_test_check.rb`: passes (CRuby compat shim already handles this — no ivar-based behavior added, pure argument threading)
- `cd build && ninja`: clean build; `ctest --test-dir build`: 8/8 passing
- `clang-format --dry-run --Werror` on all three touched `.cxx`/`.hxx` files: clean
- SE-struct field id (5 = `balance`, default 50) verified against `mruby-lcf/mrblib/schema.rb`; the `mrb_get_args` format strings (`"z|iii"`/`"zs|iii"`) verified against `MRB_ARGS_ARG` registrations and the pre-existing shared `play_mem`/`get_play_args` helpers' own format strings for consistency

No wine session was run this cycle (audio panning isn't screenshot-diffable, no real audio device in this sandbox) and no new EasyRPG source citation was added — verified entirely by internal consistency: existing schema field ids, SDL_mixer's documented `Mix_SetPanning` semantics (already cited for `bgm_pan` pre-existing in this codebase), matching format-string/argument-count conventions across every sibling native binding, and regression-proven check-suite failures reverting only the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_