### PR TITLE
Cycle #222: battle animation cells now honour their own zoom field

### DIFF
--- a/changelog.d/battle-animation-cell-zoom.fixed.md
+++ b/changelog.d/battle-animation-cell-zoom.fixed.md
@@ -1,0 +1,23 @@
+- **A battle animation cell's own `zoom` is now honoured**, instead of every
+  cell being blitted at its sheet's native 96x96. The LCF `battle_anime`
+  schema (`mruby-lcf/mrblib/schema.rb`, chunk 19's per-cell field 5, schema
+  default 100) has always decoded the field, and
+  `Scene::Map#blit_animation_cell` has always ignored it — the same gap its
+  own `transparency` field had before `battle-animation-cell-transparency`
+  closed it (that fragment's own note flagged zoom and tone as still
+  "approximated as a plain blit, unchanged"). A new
+  `Scene::Map#animation_cell_zoom` reads the field as a percentage (100
+  unscaled, clamped to 0 at the bottom so a corrupt negative value cannot ask
+  for an inverted rect), and `#animation_cell_dest_rect` scales the cell's
+  96x96 source square by it, centred on the same placement pixel the unzoomed
+  path already centres on — the identical "position/size by centre"
+  convention `Scene::Map#draw_picture`'s own `pic.zoom` already established
+  for Show Picture. `#blit_animation_cell` keeps the cheap, unchanged `Bitmap
+  #blt` path for the common case (zoom at its schema default of 100) and only
+  reaches for `Bitmap#stretch_blt` — already used for Show Picture's own zoom
+  — once a cell actually asks for a different size. Per-cell tone remains
+  unimplemented. Covered by new `scripts/rpg2k_scene_check.rb` checks (the
+  percentage-to-scale math including the defaulted and clamped cases; a drawn
+  cell staying on the plain `#blt` path at 100%, and taking the `#stretch_blt`
+  path at 200%/50%, landing at the doubled/halved size still centred on the
+  same pixel).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2045,6 +2045,71 @@ The work below is roughly ordered by the critical path to a walkable game
   doc comment rather than left implicit. No EasyRPG source was consulted for
   any new behavioral claim.
 
+  ✅ **Follow-up (cycle #222, 2026-08-28): a battle animation cell's own
+  `zoom` field is now honoured too, closing the gap the
+  `battle-animation-cell-transparency` changelog fragment itself flagged as
+  still open ("Per-cell zoom and tone remain approximated as a plain blit,
+  unchanged").** Method: cycles #217-#221 closed the BGM/SE audio-panning
+  family end to end, so this cycle swept `mruby-lcf/mrblib/schema.rb` for the
+  next struct with multiple optional fields where a consumer reads some and
+  drops others. The `ANIMATION` cell struct (chunk 19 field 12→cells,
+  `mruby-lcf/mrblib/schema.rb`) has ten fields; `Scene::Map
+  #blit_animation_cell` (`mruby-rpg2k/mrblib/scene/map.rb`) already read
+  `visible`/`cell_id`/`x`/`y`/`transparency` but silently ignored `zoom`
+  (field 5, schema default 100) and the four `tone_*` fields (6-9) —
+  confirmed by grepping every reference to those field names across
+  `mruby-rpg2k`: zero hits outside the schema itself and the changelog
+  fragment's own "unchanged" note. Fixed the `zoom` half: a new
+  `Scene::Map#animation_cell_zoom` reads the field as a percentage (100
+  unscaled, clamped to 0 at the bottom against a corrupt negative value),
+  and a new `#animation_cell_dest_rect` scales the cell's 96x96 source
+  square by it, centred on the same placement pixel the unzoomed path
+  already centres on — the identical "position/size by centre" convention
+  `#draw_picture`'s own `pic.zoom` already established for Show Picture
+  (`Scene::Map#draw_picture`, `mruby-rpg2k/mrblib/scene/map.rb`), reusing
+  that same code's existing `Bitmap#stretch_blt` call shape rather than
+  inventing a new one. `#blit_animation_cell` keeps the cheap, unchanged
+  `Bitmap#blt` path when a cell's zoom is at its schema default (100) and
+  only reaches for `#stretch_blt` once a cell actually asks for a different
+  size, so the untouched common case is byte-for-byte the same call it was
+  before this fix. Per-cell tone (fields 6-9) is left open for a future
+  cycle — applying it would need `Bitmap#tone_blt` (already used for Show
+  Picture's own tone, see `#toned_picture_src`) run over a cached, re-toned
+  copy of the animation sheet rather than the destination bitmap directly,
+  a materially bigger change than this cycle's zoom fix, deliberately left
+  alone rather than rushed. **Verification**: added 2 new
+  `rpg2k_scene_check.rb` checks — `animation_cell_zoom converts a cell zoom
+  percentage to a clamped scale` (the pure-logic percentage math, including
+  the schema-default-when-absent and negative-clamps-to-0 cases, mirroring
+  the existing `animation_cell_opacity` check's own shape) and `a battle
+  animation cell blits scaled at its own zoom` (asserts the plain `#blt`
+  path at zoom 100, and the `#stretch_blt` path with the exact doubled/
+  halved destination rect, still centred on the same pixel, at zoom 200/50).
+  Confirmed both fail against the pre-fix `mruby-rpg2k/mrblib/scene/map.rb`
+  (`git show HEAD:...` swapped in for the working copy in its place, never
+  `git stash`, to avoid disturbing any concurrent session's own uncommitted
+  work — `3rd/mruby`'s own working-tree modification was left untouched
+  throughout) — both new checks failed, the other 953 untouched — then
+  restored the fix and reran clean. Full suite: `rpg2k_scene_check.rb` 955
+  passed (953 baseline + 2 new checks); `rpg2k_logic_check.rb` 1188 passed
+  (unchanged); `rpg2k_render_check.rb` 41 passed (unchanged);
+  `rpg2k3_battle_row_check.rb` 19/0 and `rpg2k3_battle_gauge_check.rb` 15/0
+  (both unchanged); `rpg2k_save_load_check.rb` exit 0, zero known failures
+  (unchanged); `cd build && ninja` clean rebuild; `ctest --test-dir build`
+  8/8 passing. No `.cxx`/`.hxx` file was touched (a pure-Ruby fix plus its
+  check-script fixtures), so the pinned `clang-format` step does not apply,
+  and no `mruby-rgss` file was touched either, so
+  `rgss_cruby_test_check.rb`/`rgss_cruby_compat.rb` needed no attention. No
+  wine session was run this cycle — the zoom math is arithmetic
+  (`ANIM_CELL * zoom / 100`, centred the same way `#draw_picture`'s own
+  already-established zoom is) rather than anything needing a screenshot
+  diff, and this sandbox has no genuine RPG_RT.exe — so the exact centring
+  convention (scaling about the cell's own placement pixel, not its
+  top-left corner) is asserted only by analogy to Show Picture's own
+  already-established behaviour in this codebase, not independently
+  confirmed against genuine RPG_RT under wine. No EasyRPG source was
+  consulted for any new behavioral claim.
+
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8410,6 +8410,40 @@ class RPG2k
         255 * (100 - t) / 100
       end
 
+      # A cell's own `zoom` field (LCF `battle_anime` chunk 19's per-cell field
+      # 5, mruby-lcf/mrblib/schema.rb; schema default 100 -- normal size), a
+      # percentage the same way `#draw_picture`'s own `pic.zoom` already is:
+      # 100 unscaled, below shrinks, above enlarges. Decoded off the real
+      # database and never read before this -- every cell drew at its sheet's
+      # native 96x96 no matter what its author dialled the zoom to. Clamped to
+      # 0 at the bottom (a negative value would otherwise ask
+      # `#animation_cell_dest_rect` for an inverted, off-by-its-own-width rect)
+      # the same defensive shape `#animation_cell_opacity` already uses for
+      # `transparency`; no ceiling, matching that a picture's own zoom has none
+      # either.
+      def animation_cell_zoom(cell)
+        z = cell.respond_to?(:zoom) ? cell.zoom : nil
+        z = 100 if z.nil?
+        z = 0 if z < 0
+        z
+      end
+
+      # The destination rect a zoomed cell blits into: `ANIM_CELL` scaled by
+      # its own `#animation_cell_zoom`, centred on the same placement pixel
+      # (`cx + cell.x, cy + cell.y`) the unzoomed path already centres on --
+      # scaling around the cell's own centre, not its top-left corner, the
+      # same "position/size by centre" convention `#draw_picture`'s own
+      # zoom-vs-`pic.x`/`pic.y` centring already established for Show
+      # Picture's identical zoom field. NOT independently confirmed against
+      # genuine RPG_RT under wine.
+      def animation_cell_dest_rect(cell, cx, cy)
+        z = animation_cell_zoom(cell)
+        w = ANIM_CELL * z / 100
+        dx = cx + (cell.x || 0) - w / 2
+        dy = cy + (cell.y || 0) - w / 2
+        [dx, dy, w, w]
+      end
+
       def blit_animation_cell(sheet, cell, cx, cy)
         opacity = animation_cell_opacity(cell)
         # A fully transparent cell contributes nothing; skipping it spares the
@@ -8419,9 +8453,21 @@ class RPG2k
         cid = cell.cell_id || 0
         sx = (cid % ANIM_SHEET_COLS) * ANIM_CELL
         sy = (cid / ANIM_SHEET_COLS) * ANIM_CELL
-        dx = cx + (cell.x || 0) - ANIM_CELL / 2
-        dy = cy + (cell.y || 0) - ANIM_CELL / 2
-        @animation_bmp.blt dx, dy, sheet, Rect.new(sx, sy, ANIM_CELL, ANIM_CELL), opacity
+        src_rect = Rect.new(sx, sy, ANIM_CELL, ANIM_CELL)
+        zoom = animation_cell_zoom(cell)
+        if zoom == 100
+          # The common case (a cell whose author never touched the zoom field,
+          # or set it back to 100) keeps the plain, cheaper #blt path exactly
+          # as before this fix -- no resample needed when the source and
+          # destination are the same size.
+          dx = cx + (cell.x || 0) - ANIM_CELL / 2
+          dy = cy + (cell.y || 0) - ANIM_CELL / 2
+          @animation_bmp.blt dx, dy, sheet, src_rect, opacity
+        else
+          dx, dy, w, h = animation_cell_dest_rect(cell, cx, cy)
+          return if w <= 0 || h <= 0
+          @animation_bmp.stretch_blt Rect.new(dx, dy, w, h), sheet, src_rect, opacity
+        end
       rescue StandardError
         nil
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17852,6 +17852,60 @@ check 'a battle animation cell blits at its own transparency' do
   # mutated cell does not leak into the next check.
 end
 
+# Each animation cell also carries its own `zoom` (LCF `battle_anime` chunk
+# 19's per-cell field 5 -- mruby-lcf/mrblib/schema.rb, schema default 100),
+# decoded all along and never read the same way `transparency` was before the
+# check above -- every cell drew at its sheet's native 96x96 no matter what
+# its author dialled the zoom to. #animation_cell_zoom is the pure-logic half.
+check 'animation_cell_zoom converts a cell zoom percentage to a clamped scale' do
+  scene, = battle_at_command
+  z = ->(v) { scene.send(:animation_cell_zoom, OpenStruct.new(cell_id: 0, zoom: v)) }
+  eq 100, z.call(100), 'the schema default: unscaled'
+  eq 200, z.call(200), 'zoom above 100 enlarges'
+  eq 50, z.call(50), 'zoom below 100 shrinks'
+  eq 0, z.call(-10), 'a negative zoom clamps to 0, not an inverted rect'
+  eq 100, scene.send(:animation_cell_zoom, OpenStruct.new(cell_id: 0)),
+     'a cell carrying no zoom field at all reads as the 100 default, not as nil'
+end
+
+check 'a battle animation cell blits scaled at its own zoom' do
+  scene, = battle_at_command
+  scene.instance_variable_get(:@battle).send(:start_battle_animation,
+             { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+               skill_id: 8, target_index: 0, target_ally: false })
+  ma = scene.instance_variable_get(:@map_animation)
+  bmp = scene.instance_variable_get(:@animation_bmp)
+  cell = ma[:frames][0].cells[1]
+
+  bmp.clear_blt_calls
+  bmp.clear_stretch_calls
+  scene.send(:draw_map_animation, 500, 400)
+  eq 1, bmp.blt_calls.size,
+     'a cell at the schema default zoom still takes the plain #blt path, exactly as before this fix'
+  ok bmp.stretch_calls.empty?, 'and never touches #stretch_blt'
+
+  cell.zoom = 200
+  bmp.clear_blt_calls
+  bmp.clear_stretch_calls
+  scene.send(:draw_map_animation, 500, 400)
+  ok bmp.blt_calls.empty?, 'a zoomed cell takes the #stretch_blt path instead of #blt'
+  eq 1, bmp.stretch_calls.size, 'still one cell'
+  dest, _src, _rect, op = bmp.stretch_calls.first
+  eq [ma[:targets][0][:tx] - 96, ma[:targets][0][:ty] - 96, 192, 192],
+     [dest.x, dest.y, dest.width, dest.height],
+     '200% doubles the 96x96 cell to 192x192, still centred on the same placement pixel'
+  eq 255, op, 'opacity is unaffected by zoom'
+
+  cell.zoom = 50
+  bmp.clear_stretch_calls
+  scene.send(:draw_map_animation, 500, 400)
+  dest, = bmp.stretch_calls.first
+  eq [ma[:targets][0][:tx] - 24, ma[:targets][0][:ty] - 24, 48, 48],
+     [dest.x, dest.y, dest.width, dest.height], '50% halves the cell to 48x48, still centred'
+  # The fixture database is rebuilt per scene (#new_scene -> #fake_db), so the
+  # mutated cell does not leak into the next check.
+end
+
 check 'the battle status window shows each ally condition, or the normal term' do
   scene, ui = battle_at_command
   texts = window_texts(ui[:status_win])


### PR DESCRIPTION
## Summary

The LCF `battle_anime` schema (`mruby-lcf/mrblib/schema.rb`, chunk 19's per-cell fields) decodes each animation cell's `zoom` (field 5, default 100), but `Scene::Map#blit_animation_cell` has always ignored it, drawing every cell at its sheet's native 96×96 regardless of the field's value — a gap an earlier cycle's own `changelog.d/battle-animation-cell-transparency.fixed.md` fragment explicitly flagged as still open ("Per-cell zoom and tone remain approximated as a plain blit, unchanged").

**Fix:**
- New `Scene::Map#animation_cell_zoom(cell)` reads the field defensively (nil → 100, the schema default; negative → clamped to 0, mirroring `#animation_cell_opacity`'s existing defensive shape for `transparency`).
- New `Scene::Map#animation_cell_dest_rect(cell, cx, cy)` scales the cell's 96×96 destination square by that zoom percentage, centred on the same placement pixel the unzoomed path already centres on — mirroring `#draw_picture`'s own established "position/size by centre" convention for Show Picture's identical `zoom` field (`dx = pic.x - zw / 2`).
- `#blit_animation_cell` keeps the original, cheaper `Bitmap#blt` path unchanged when a cell's zoom is at the schema default (100 — the overwhelming common case, since most animations never touch this field), and only switches to the existing `Bitmap#stretch_blt` primitive (already used elsewhere, e.g. windowskin stretching) when a cell's zoom actually departs from 100.
- Per-cell tone (fields 6-9) is deliberately left open for a future cycle — a materially bigger change (`Bitmap#tone_blt` over a cached, re-toned sheet copy, the technique already used for Picture tone) — and documented as such in both the changelog and `docs/TODO.md`.

## Verification

- 2 new checks added to `scripts/rpg2k_scene_check.rb`; independently confirmed both fail against the pre-fix `map.rb` (via temporary file swap, not `git stash`) — **2 of 955** — and pass clean after restoring the fix
- `scripts/rpg2k_scene_check.rb`: 955 passed (953 baseline + 2 new)
- `scripts/rpg2k_logic_check.rb`: 1188 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: exit 0, zero known failures (unchanged)
- `cd build && ninja`: clean rebuild
- `ctest --test-dir build`: 8/8 passing
- Field id (5 = `zoom`, default 100) verified against `mruby-lcf/mrblib/schema.rb`'s own animation-cell struct definition; `Bitmap#stretch_blt`'s signature (`dest_rect, src_bitmap, src_rect, opacity=255`, `mruby-rgss/src/lib.cxx`) verified to match exactly how the fix calls it; the "position/size by centre" convention verified against `#draw_picture`'s own existing zoom-centring code (`mruby-rpg2k/mrblib/scene/map.rb`), not asserted from scratch

No wine session was run this cycle (per-cell zoom scaling is a pure arithmetic/rendering-primitive change, verified by the sibling `#draw_picture` convention this mirrors, not independently confirmed against genuine RPG_RT) and no new EasyRPG source citation was added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_