### PR TITLE
Cycle #223: battle animation cells now honour their own tone fields

### DIFF
--- a/changelog.d/battle-animation-cell-tone.fixed.md
+++ b/changelog.d/battle-animation-cell-tone.fixed.md
@@ -1,0 +1,34 @@
+- **A battle animation cell's four `tone_*` fields are now honoured**,
+  closing the gap cycle #222's own zoom fix deliberately left open ("Per-cell
+  tone remains unimplemented ... needs `Bitmap#tone_blt` over a cached,
+  re-toned sheet copy"). `battle_anime` chunk 19's per-cell fields 6-9
+  (`tone_red`/`tone_green`/`tone_blue`/`tone_gray`,
+  `mruby-lcf/mrblib/schema.rb`, each defaulting to 100/neutral) decode the
+  same 0..200 shape `Game::Picture`'s own `red`/`green`/`blue`/`saturation`
+  carry, and were confirmed dropped by grepping every reference to those
+  four field names across `mruby-rpg2k`: zero hits outside the schema
+  before this fix. New `Scene::Map#animation_cell_tone`/
+  `#toned_animation_cell?` read the four fields (defensive `respond_to?`
+  guards matching `#animation_cell_opacity`/`#animation_cell_zoom`'s own
+  shape). `#toned_animation_cell_src` crops a cell's raw 96x96 sheet square
+  into a small reused scratch buffer and `Bitmap#tone_blt`s it into a
+  second, cached bitmap — mirroring `#toned_picture_src`'s existing
+  cache-a-toned-copy shape for Show Picture, sized down to one cell instead
+  of a whole picture since a cell's sheet is shared across many cells. The
+  result is cached in a new bounded `@animation_tone_cache`
+  (`ANIMATION_CELL_TONE_CACHE_MAX = 16`, the same eviction shape
+  `@picture_tone_cache` already uses), keyed by sheet identity + cell id +
+  tone rather than name since a cell has no name of its own.
+  `#blit_animation_cell` reaches for the toned copy only when a cell's tone
+  differs from neutral; the untouched common case (no author-set tone)
+  blits straight from the sheet exactly as before. The saturation-channel
+  sign flip `#toned_picture_src` already applies for Show Picture's
+  `saturation` field is carried over to the cell's `tone_gray` field
+  **unconfirmed** for this specific field — asserted only by analogy to the
+  already-established Picture behaviour, not independently verified against
+  genuine RPG_RT under wine (documented directly in
+  `toned_animation_cell_src`'s own comment). Covered by new
+  `scripts/rpg2k_scene_check.rb` checks (the field-by-field default/absent
+  cases; a drawn cell staying on the raw-sheet `#blt` path when untoned,
+  switching to a distinct cached, cropped-and-toned bitmap once toned, and
+  reusing that cache on a repeat draw).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2110,6 +2110,88 @@ The work below is roughly ordered by the critical path to a walkable game
   confirmed against genuine RPG_RT under wine. No EasyRPG source was
   consulted for any new behavioral claim.
 
+  ✅ **Follow-up (cycle #223, 2026-08-28): a battle animation cell's four
+  `tone_*` fields are now honoured too**, closing the gap cycle #222's own
+  fragment (`battle-animation-cell-zoom.fixed.md`) deliberately left open
+  ("Per-cell tone remains unimplemented ... needs `Bitmap#tone_blt` over a
+  cached, re-toned sheet copy"). Method: read how Show Picture's own tone
+  already does this (`Scene::Map#toned?`/`#toned_picture_src`,
+  `mruby-rpg2k/mrblib/scene/map.rb`) and mirrored the same cache-a-toned-
+  copy-keyed-by-tone shape for animation cells, sized down to one 96x96 cell
+  instead of a whole picture since a cell's sheet is shared across many
+  cells rather than owned per-picture. `battle_anime` chunk 19's per-cell
+  fields 6-9 (`tone_red`/`tone_green`/`tone_blue`/`tone_gray`,
+  `mruby-lcf/mrblib/schema.rb`, each defaulting to 100/neutral) decode the
+  same 0..200 shape `Game::Picture`'s own `red`/`green`/`blue`/`saturation`
+  carry (cross-checked against that struct's `current_tone_red`/etc. save
+  defaults, same schema file, chunk 103) and were confirmed dropped by
+  grepping every reference to those four field names across `mruby-rpg2k`:
+  zero hits outside the schema itself before this fix. New
+  `Scene::Map#animation_cell_tone`/`#toned_animation_cell?` read the four
+  fields (defensive `respond_to?`/nil guards matching
+  `#animation_cell_opacity`/`#animation_cell_zoom`'s own shape for a bare
+  test double); `#toned_animation_cell_src` crops the cell's raw 96x96 sheet
+  square into a small reused scratch buffer
+  (`#animation_cell_crop_buffer`, disposed alongside the existing
+  `@flash_buffer`/`@flash_out_buffer` in `#dispose`) and `Bitmap#tone_blt`s
+  it into a second, cached bitmap — reusing `#tone_channel`'s existing
+  0..200-to-RGSS-Tone conversion and the same saturation-channel sign flip
+  `#toned_picture_src` already applies for Show Picture's `saturation`
+  field, carried over to the cell's `tone_gray` field **unconfirmed**: both
+  fields share the identical field shape (0..200, 100 neutral, the fourth of
+  a red/green/blue/grey-or-saturation quartet) but liblcf's own
+  `generator/csv/fields.csv` names them differently (`AnimationCellData
+  .tone_gray` vs the Picture chunk's `tone_saturation`), so the sign
+  direction is asserted only by analogy to the already-established Picture
+  behaviour in this codebase, not independently verified for this specific
+  field against genuine RPG_RT under wine — documented as such directly in
+  `toned_animation_cell_src`'s own comment. The result is cached in a new
+  bounded `@animation_tone_cache` (`ANIMATION_CELL_TONE_CACHE_MAX = 16`,
+  the same eviction shape `@picture_tone_cache`/`PICTURE_TONE_CACHE_MAX`
+  already use), keyed by `[sheet.object_id, cell_id, tone_red, tone_green,
+  tone_blue, tone_gray]` — sheet identity rather than name, since a cell has
+  no name of its own to key by and (unlike `@picture_cache`'s entries)
+  `ma[:sheet]` is already held live for an animation's whole run once
+  fetched, the same `charset.object_id` identity-key precedent
+  `#draw_vehicle_frame`/`#draw_player_frame` already use in this file.
+  `#blit_animation_cell` reaches for the toned copy (and a `(0, 0, 96, 96)`
+  source rect into it) only when a cell's tone differs from neutral,
+  otherwise blitting straight from the sheet exactly as before — the
+  untouched common case (no author-set tone) is the same call it always
+  was. **Verification**: added 2 new `rpg2k_scene_check.rb` checks —
+  `animation_cell_tone reads a cell's four tone fields with schema
+  defaults` (the field-by-field default/absent-field cases, mirroring the
+  existing `animation_cell_opacity`/`animation_cell_zoom` checks' own
+  shape) and `a toned battle animation cell tones through a cached crop
+  instead of blitting the raw sheet` (asserts an untoned cell still takes
+  the plain `#blt` path against the raw `sheet` object, and a toned one
+  blits from a *different*, cell-sized bitmap while leaving the raw sheet
+  untouched — i.e. the crop/tone/cache pipeline actually ran rather than
+  being silently skipped). Confirmed both fail against the pre-fix
+  `mruby-rpg2k/mrblib/scene/map.rb` (`git show HEAD:...` swapped in for the
+  working copy in its place, never `git stash`, to avoid disturbing any
+  concurrent session's own uncommitted work — `3rd/mruby`'s own
+  working-tree modification was left untouched throughout) — both new
+  checks failed, the other 955 untouched — then restored the fix and reran
+  clean. Full suite: `rpg2k_scene_check.rb` 957 passed (955 baseline + 2 new
+  checks); `rpg2k_logic_check.rb` 1188 passed (unchanged);
+  `rpg2k_render_check.rb` 41 passed (unchanged); `rpg2k3_battle_row_check.rb`
+  19/0 and `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged);
+  `rpg2k_save_load_check.rb` exit 0, zero known failures (unchanged);
+  `cd build && ninja` clean rebuild; `ctest --test-dir build` 8/8 passing.
+  No `.cxx`/`.hxx` file was touched (a pure-Ruby fix plus its check-script
+  fixtures), so the pinned `clang-format` step does not apply, and no
+  `mruby-rgss` file was touched either, so
+  `rgss_cruby_test_check.rb`/`rgss_cruby_compat.rb` needed no attention. No
+  wine session was run this cycle — this sandbox has no genuine RPG_RT.exe,
+  so the crop/tone/cache mechanics are verified by arithmetic and object-
+  identity assertions only, and (as noted above) the `tone_gray` channel's
+  sign direction is carried over from Picture by analogy, not independently
+  confirmed. `generator/csv/fields.csv` from EasyRPG/liblcf was consulted
+  only to confirm the four fields' IDs/types/defaults (0x06-0x09, all
+  Int32 default 100) already matched `mruby-lcf/mrblib/schema.rb` exactly —
+  no EasyRPG C++ source, and no other new behavioral claim, was consulted.
+
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the
@@ -9113,9 +9195,11 @@ The work below is roughly ordered by the critical path to a walkable game
   -- see the fuller, EasyRPG-source-verified writeup a few pages down, "A
   plain Attack now plays its own animation too"'s neighbouring bullet, which
   covers the player/map-event/vehicle target-flash mechanism this note used
-  to undersell); **per-cell zoom/tone genuinely still is** an approximation,
-  since it needs an `RGSS::Viewport` tone this codebase's map rendering
-  path has never had either -- see ADR 0037. **Set Vehicle Location** (10850) and **Change Vehicle Graphic** (10650)
+  to undersell); **per-cell zoom and tone are now both honoured** (cycles
+  #222/#223: `Scene::Map#animation_cell_zoom`/`#toned_animation_cell_src`),
+  each cell scaled and re-toned from its own database fields rather than
+  approximated as a plain blit -- see the cycle #223 follow-up below.
+  **Set Vehicle Location** (10850) and **Change Vehicle Graphic** (10650)
   place a boat / ship / airship and set its CharSet (persisted via
   `Game::Vehicle`), and the party can now **board and pilot** a placed vehicle on
   the map (`Game::State#boarded`; the airship flies over any tile whose terrain

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -340,6 +340,12 @@ class RPG2k
                                # Monster/<name> (battler graphics)
         @animation_cache = LRUBitmapCache.new(constrained_scale(ANIMATION_CACHE_BYTES))
                                # Battle/<name> (battle animation sheets)
+        # Toned copies of individual animation cells, keyed by sheet identity
+        # + cell id + tone (see #toned_animation_cell_src) -- the same
+        # per-content-key cache shape @picture_tone_cache uses below, sized
+        # per cell (96x96) rather than per whole picture since only one
+        # 96x96 square of a shared sheet is ever toned at a time.
+        @animation_tone_cache = {}
         @battlecharset_cache =
           LRUBitmapCache.new(constrained_scale(BATTLECHARSET_CACHE_BYTES))
                                # BattleCharSet/<name> (RPG2003 actor battler sprites)
@@ -579,6 +585,7 @@ class RPG2k
         @upper_viewport.dispose if @upper_viewport
         @flash_buffer.dispose if @flash_buffer
         @flash_out_buffer.dispose if @flash_out_buffer
+        @animation_cell_crop_buffer.dispose if @animation_cell_crop_buffer
         # Held by no sprite (see #setup_sprites), so nothing else frees these.
         @lower_tiles.dispose if @lower_tiles
         @upper_tiles.dispose if @upper_tiles
@@ -8322,8 +8329,8 @@ class RPG2k
       # render pass (the camera is known here): each visible cell of the frame is
       # blitted from the sheet's 96x96 grid to the target's screen position plus
       # the cell's offset, at that cell's own transparency
-      # (#animation_cell_opacity). Zoom / tone are still approximated as a plain
-      # blit.
+      # (#animation_cell_opacity) and zoom (#animation_cell_zoom) and tone
+      # (#toned_animation_cell?).
       def draw_map_animation(cam_x, cam_y)
         return unless @animation_sprite
         ma = @map_animation
@@ -8444,6 +8451,90 @@ class RPG2k
         [dx, dy, w, w]
       end
 
+      # A cell's own four tone fields (LCF `battle_anime` chunk 19's per-cell
+      # fields 6-9: tone_red/green/blue/gray, mruby-lcf/mrblib/schema.rb),
+      # each defaulting to 100 (neutral) -- exactly the same 0..200,
+      # 100-is-neutral shape `Game::Picture`'s own red/green/blue/saturation
+      # carry (confirmed by the matching `current_tone_red`/etc. save-field
+      # defaults declared in the same schema file, chunk 103), so this reuses
+      # `#toned?`'s reasoning: decoded off the real database and never read
+      # before this -- every cell drew the sheet's raw, undialled colours no
+      # matter what its author set the tone to. Defensive `respond_to?`/nil
+      # guards match `#animation_cell_opacity`/`#animation_cell_zoom`'s own
+      # shape for a bare test double.
+      def animation_cell_tone(cell)
+        [cell.respond_to?(:tone_red)   ? (cell.tone_red   || 100) : 100,
+         cell.respond_to?(:tone_green) ? (cell.tone_green || 100) : 100,
+         cell.respond_to?(:tone_blue)  ? (cell.tone_blue  || 100) : 100,
+         cell.respond_to?(:tone_gray)  ? (cell.tone_gray  || 100) : 100]
+      end
+
+      # Whether a cell asks for any tint at all.
+      def toned_animation_cell?(cell)
+        animation_cell_tone(cell).any? { |v| v != 100 }
+      end
+
+      # The transient, reused-every-call scratch a cell's raw 96x96 square is
+      # lifted into before toning -- `Bitmap#tone_blt` needs a same-size
+      # destination that is not the source (see `#toned_picture_src`'s own
+      # comment), and unlike a picture's source (one bitmap per shown
+      # picture) every cell shares one 480x480/640x640 sheet, so there is no
+      # single "whole source" to keep a toned copy of. Cropping the wanted
+      # 96x96 square into this fixed-size buffer first, the same way
+      # `#flashed_charset` lifts a CharSet frame before toning it, means the
+      # cache below only ever needs to hold cell-sized (not sheet-sized)
+      # toned copies.
+      def animation_cell_crop_buffer
+        @animation_cell_crop_buffer ||= Bitmap.new(ANIM_CELL, ANIM_CELL)
+      end
+
+      # The cell's raw sheet square with its tone baked in, cached per (sheet,
+      # cell id, tone) so the software tone pass runs when a new tone/cell
+      # combination is first drawn rather than every frame -- the same
+      # caching shape `#toned_picture_src` uses for Show Picture, sized down
+      # to one cell instead of a whole picture. Keyed by the sheet bitmap's
+      # own `#object_id` rather than its name (there is no cell-level name to
+      # key by, and unlike `@picture_cache`'s entries `ma[:sheet]` is already
+      # held live for the animation's whole run once fetched -- see
+      # `#draw_vehicle_frame`/`#draw_player_frame`'s own `charset.object_id`
+      # frame-memo keys for the same identity-key precedent in this file); a
+      # sheet reload after cache eviction simply keys fresh entries under the
+      # new object, leaving the old ones to age out of the bound below same
+      # as any other.
+      def toned_animation_cell_src(sheet, cid, sx, sy, tr, tg, tb, ty)
+        key = [sheet.object_id, cid, tr, tg, tb, ty]
+        cached = @animation_tone_cache[key]
+        return cached if cached
+        buf = animation_cell_crop_buffer
+        buf.clear
+        buf.blt 0, 0, sheet, Rect.new(sx, sy, ANIM_CELL, ANIM_CELL)
+        scratch = Bitmap.new(ANIM_CELL, ANIM_CELL)
+        tone = Tone.new(Scene::Map.tone_channel(tr), Scene::Map.tone_channel(tg),
+                        Scene::Map.tone_channel(tb),
+                        # Mirrors `#toned_picture_src`'s own sign flip for
+                        # Show Picture's `saturation` field: RPG2000's
+                        # tone-gray/saturation channel runs the other way
+                        # from RGSS's grey, so a channel under 100 becomes
+                        # positive desaturation. Carried over unconfirmed --
+                        # NOT independently verified against genuine RPG_RT
+                        # under wine for this specific field.
+                        Scene::Map.tone_channel(ty) * -1)
+        scratch.tone_blt buf, tone
+        # Bounded the same way #toned_picture_src bounds
+        # @picture_tone_cache -- see its own comment.
+        @animation_tone_cache.delete(@animation_tone_cache.keys.first) if
+          @animation_tone_cache.size >= constrained_scale(ANIMATION_CELL_TONE_CACHE_MAX)
+        @animation_tone_cache[key] = scratch
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] animation cell ##{cid} tone failed, drawn untinted: #{e.message}"
+        nil
+      end
+
+      # How many toned animation-cell variants to keep before evicting the
+      # oldest -- see #PICTURE_TONE_CACHE_MAX's own comment for why this is
+      # bounded at all.
+      ANIMATION_CELL_TONE_CACHE_MAX = 16
+
       def blit_animation_cell(sheet, cell, cx, cy)
         opacity = animation_cell_opacity(cell)
         # A fully transparent cell contributes nothing; skipping it spares the
@@ -8453,7 +8544,16 @@ class RPG2k
         cid = cell.cell_id || 0
         sx = (cid % ANIM_SHEET_COLS) * ANIM_CELL
         sy = (cid / ANIM_SHEET_COLS) * ANIM_CELL
+        src_bmp = sheet
         src_rect = Rect.new(sx, sy, ANIM_CELL, ANIM_CELL)
+        if toned_animation_cell?(cell)
+          tr, tg, tb, ty = animation_cell_tone(cell)
+          toned = toned_animation_cell_src(sheet, cid, sx, sy, tr, tg, tb, ty)
+          if toned
+            src_bmp = toned
+            src_rect = Rect.new(0, 0, ANIM_CELL, ANIM_CELL)
+          end
+        end
         zoom = animation_cell_zoom(cell)
         if zoom == 100
           # The common case (a cell whose author never touched the zoom field,
@@ -8462,11 +8562,11 @@ class RPG2k
           # destination are the same size.
           dx = cx + (cell.x || 0) - ANIM_CELL / 2
           dy = cy + (cell.y || 0) - ANIM_CELL / 2
-          @animation_bmp.blt dx, dy, sheet, src_rect, opacity
+          @animation_bmp.blt dx, dy, src_bmp, src_rect, opacity
         else
           dx, dy, w, h = animation_cell_dest_rect(cell, cx, cy)
           return if w <= 0 || h <= 0
-          @animation_bmp.stretch_blt Rect.new(dx, dy, w, h), sheet, src_rect, opacity
+          @animation_bmp.stretch_blt Rect.new(dx, dy, w, h), src_bmp, src_rect, opacity
         end
       rescue StandardError
         nil

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -17906,6 +17906,75 @@ check 'a battle animation cell blits scaled at its own zoom' do
   # mutated cell does not leak into the next check.
 end
 
+# Each animation cell also carries its own four tone fields (LCF
+# `battle_anime` chunk 19's per-cell fields 6-9 -- mruby-lcf/mrblib/schema.rb,
+# schema default 100/neutral each), decoded all along and never read the same
+# way `zoom`/`transparency` were before the checks above.
+# #animation_cell_tone is the pure-logic half.
+check "animation_cell_tone reads a cell's four tone fields with schema defaults" do
+  scene, = battle_at_command
+  t = ->(cell) { scene.send(:animation_cell_tone, cell) }
+  eq [100, 100, 100, 100],
+     t.call(OpenStruct.new(cell_id: 0, tone_red: 100, tone_green: 100,
+                            tone_blue: 100, tone_gray: 100)),
+     'the schema default: neutral on every channel'
+  eq [40, 160, 70, 130],
+     t.call(OpenStruct.new(cell_id: 0, tone_red: 40, tone_green: 160,
+                            tone_blue: 70, tone_gray: 130)),
+     'each channel reads independently'
+  eq [100, 100, 100, 100], t.call(OpenStruct.new(cell_id: 0)),
+     'a cell carrying none of the four fields reads as all-neutral, not nil'
+  ok !scene.send(:toned_animation_cell?, OpenStruct.new(cell_id: 0, tone_red: 100,
+                  tone_green: 100, tone_blue: 100, tone_gray: 100)),
+     'an all-neutral cell is not toned'
+  ok scene.send(:toned_animation_cell?, OpenStruct.new(cell_id: 0, tone_red: 40,
+                 tone_green: 100, tone_blue: 100, tone_gray: 100)),
+     'a single off-neutral channel is enough to count as toned'
+end
+
+check 'a toned battle animation cell tones through a cached crop instead of blitting the raw sheet' do
+  scene, = battle_at_command
+  scene.instance_variable_get(:@battle).send(:start_battle_animation,
+             { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+               skill_id: 8, target_index: 0, target_ally: false })
+  ma = scene.instance_variable_get(:@map_animation)
+  bmp = scene.instance_variable_get(:@animation_bmp)
+  cell = ma[:frames][0].cells[1]
+
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  eq 1, bmp.blt_calls.size, 'sanity: still one cell'
+  ok bmp.blt_calls.first[2].equal?(ma[:sheet]),
+     'an untoned cell blits straight from the raw sheet, exactly as before this fix'
+
+  cell.tone_red = 40
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  eq 1, bmp.blt_calls.size, 'still one cell'
+  toned_src = bmp.blt_calls.first[2]
+  ok !toned_src.equal?(ma[:sheet]),
+     'a toned cell blits from a different bitmap, not the raw sheet'
+  rect = bmp.blt_calls.first[3]
+  eq [0, 0, 96, 96], [rect.x, rect.y, rect.width, rect.height],
+     'the toned copy is already cropped to the cell, so its own source rect starts at (0,0)'
+  eq [ma[:targets][0][:tx] - 48, ma[:targets][0][:ty] - 48], bmp.blt_calls.first[0, 2],
+     'and still lands in exactly the same place -- only the source changed'
+  eq 255, bmp.blt_calls.first[4], 'opacity is unaffected by tone'
+
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  ok bmp.blt_calls.first[2].equal?(toned_src),
+     'redrawing the same tone reuses the cached toned copy rather than re-toning'
+
+  cell.tone_red = 100
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  ok bmp.blt_calls.first[2].equal?(ma[:sheet]),
+     'back to neutral, the cell blits from the raw sheet again'
+  # The fixture database is rebuilt per scene (#new_scene -> #fake_db), so the
+  # mutated cell does not leak into the next check.
+end
+
 check 'the battle status window shows each ally condition, or the normal term' do
   scene, ui = battle_at_command
   texts = window_texts(ui[:status_win])


### PR DESCRIPTION
## Summary

A battle-animation cell's four tone fields (LCF `battle_anime` chunk 19's per-cell fields 6-9: `tone_red`/`tone_green`/`tone_blue`/`tone_gray`, `mruby-lcf/mrblib/schema.rb`, each 0..200 with 100 = neutral) were decoded by the schema but never read — every cell drew the sheet's raw, undialled colours regardless of what its author set the tone to. This is the gap cycle #222's zoom fix deliberately left open (documented in that cycle's own changelog/TODO entries).

**Fix:** Mirrors `Scene::Map#toned_picture_src`'s existing cache-a-toned-copy technique (already used for Show Picture), scaled down from "whole picture" to "one 96×96 cell" since an animation's sheet is shared across many cells rather than owned per-picture:
- `#animation_cell_tone`/`#toned_animation_cell?` read the four fields with the same `respond_to?`-guarded-default shape `#animation_cell_opacity`/`#animation_cell_zoom` already use.
- `#animation_cell_crop_buffer` is a reused scratch bitmap the cell's raw 96×96 sheet square gets cropped into (`Bitmap#tone_blt` needs a same-size destination that isn't the source), disposed alongside the existing flash buffers in `#dispose`.
- `#toned_animation_cell_src` `tone_blt`s the crop into a **new**, cached bitmap keyed by `[sheet.object_id, cell_id, tone_red, tone_green, tone_blue, tone_gray]`, bounded by a new `@animation_tone_cache`/`ANIMATION_CELL_TONE_CACHE_MAX = 16` — the identical eviction shape (`delete(keys.first)` once at the bound) and cache size `#toned_picture_src`'s own `@picture_tone_cache`/`PICTURE_TONE_CACHE_MAX` already use.
- `#blit_animation_cell` only reaches for the toned copy when a cell's tone differs from neutral; the untouched common case (no author-set tone) still blits straight from the raw sheet exactly as before.

**Honest limitation:** the `tone_gray` channel's sign-flip direction is carried over from Picture's own `saturation`→RGSS-grey conversion by analogy only (same 100-neutral, 0..200 scale, confirmed via the matching `current_tone_red`/etc. save-field defaults in the same schema file) — not independently confirmed against genuine RPG_RT under wine for this specific field, disclosed in both the code comment and `docs/TODO.md`.

## Verification

- 2 new checks added to `scripts/rpg2k_scene_check.rb`; independently confirmed both fail against the pre-fix `map.rb` (via temporary file swap, not `git stash`) — **2 of 957** — and pass clean after restoring the fix
- `scripts/rpg2k_scene_check.rb`: 957 passed (955 baseline + 2 new)
- `scripts/rpg2k_logic_check.rb`: 1188 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: exit 0, zero known failures (unchanged)
- `cd build && ninja`: clean rebuild
- `ctest --test-dir build`: 8/8 passing
- Independently re-verified every native-API claim: `Scene::Map.tone_channel`, `Tone.new`'s 4-arg signature, and `Bitmap#tone_blt`'s same-size-destination contract all confirmed to match `#toned_picture_src`'s own existing, already-shipped usage exactly; the cache eviction shape and bound (16) confirmed identical to `@picture_tone_cache`/`PICTURE_TONE_CACHE_MAX`

No wine session was run this cycle (per-cell software tone compositing is a pure arithmetic/rendering-primitive change, verified by the sibling `#toned_picture_src` convention this mirrors) and no new EasyRPG source citation was added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_