### PR TITLE
Cycle #224: battle animations now play their own per-frame timing SE

### DIFF
--- a/changelog.d/battle-animation-timing-se.fixed.md
+++ b/changelog.d/battle-animation-timing-se.fixed.md
@@ -1,0 +1,25 @@
+- **A battle animation's own per-frame sound effects now actually play**
+  during a real battle round or a Show Battle Animation (11210/13260)
+  command, instead of staying silent. The LCF `battle_anime` schema
+  (`mruby-lcf/mrblib/schema.rb`, chunk 19's `timings` sub-table, field 2 `se`)
+  has always decoded a `Sound` struct (file/volume/pitch/balance) alongside
+  each timing's `frame`, and `Scene::Map#fire_animation_flashes` — the one
+  place that walks a live animation's timings frame by frame — has always
+  read that same struct's `flash_scope`/`screen_shaking` siblings there
+  (fixed in earlier cycles) but never `se`. The only place an animation's own
+  sound ever played was `Scene::Base#play_animation_se`, a deliberately
+  narrower helper for the field item/skill menu's own success cue: a
+  single-shot summary that plays the *first* timing across the whole
+  animation with a real sound, once, before the animation itself even
+  starts — not a substitute for a genuine battle round or a map-triggered
+  Show Battle Animation sounding each frame's own timing as that frame
+  arrives. `#fire_animation_flashes` now also plays a matching timing's `se`
+  (blank/`"(OFF)"` treated as a no-op, mirroring `#play_animation_se`'s own
+  convention for the identical field), unconditionally in both the map and
+  battle-round context — a sound has no "screen vs target" split to gate on,
+  unlike its flash/shake siblings. NOT independently confirmed against
+  genuine RPG_RT under wine. Covered by three new `scripts/rpg2k_scene_check.rb`
+  checks (a timing's `se` plays with volume/pitch/balance forwarded on the
+  map path; a blank or `"(OFF)"` `se` plays nothing; the same `se` also plays
+  on the battle-round path), confirmed to fail against the pre-fix code
+  before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2192,6 +2192,82 @@ The work below is roughly ordered by the critical path to a walkable game
   Int32 default 100) already matched `mruby-lcf/mrblib/schema.rb` exactly —
   no EasyRPG C++ source, and no other new behavioral claim, was consulted.
 
+  ✅ **Follow-up (cycle #224, 2026-08-28): a battle animation *timing*'s own
+  `se` field is now honoured too — a genuine battle round or a Show Battle
+  Animation command played its flash/shake but stayed silent.** Method:
+  cycles #222/#223 closed the animation *cell* struct's zoom/tone gap, so
+  this cycle swept the sibling `Timing` struct on the same `battle_anime`
+  schema (chunk 19 field 6→`timings`, `mruby-lcf/mrblib/schema.rb`: `frame`,
+  `se`, `flash_scope`, `flash_red`/`_green`/`_blue`/`_power`,
+  `screen_shaking`) for the same shape of gap. `Scene::Map
+  #fire_animation_flashes` (`mruby-rpg2k/mrblib/scene/map.rb`) is the single
+  choke point every live animation's timings are walked frame-by-frame
+  through — already reading `flash_scope`/`screen_shaking` there (each fixed
+  in an earlier cycle, per that method's own pre-existing comments) — but
+  never `se`, confirmed by grepping `mruby-rpg2k` for any `.se`/`t.se` read
+  outside `flash_scope`/`screen_shaking`'s own name: the only hit was
+  `Scene::Base#play_animation_se`, a narrower, pre-existing helper (added a
+  few cycles back for the field item/skill menu's own success cue) that
+  plays a single-shot summary — the *first* timing across the *whole*
+  animation with a real sound, once, before the animation itself even starts
+  — never called from `scene/battle.rb` or from the map's own Show Battle
+  Animation path at all, so neither a battle round nor 11210/13260 ever
+  played any of an animation's own per-frame sounds. Fixed by reading `t.se`
+  inside `#fire_animation_flashes`'s existing per-matching-timing loop
+  (alongside the flash/shake it already fires there) and playing it via
+  `RGSS::Audio.se_play` with volume/pitch/balance forwarded — the same
+  four-argument call shape `#play_animation_se` already established for the
+  identical field, including its blank/`"(OFF)"` no-op convention. Fires
+  unconditionally in both the map and battle-round context (`ma[:battle]`
+  true or false): unlike its flash/shake siblings, a sound has no
+  "screen vs target" split to gate on. No EasyRPG source was consulted for
+  this claim — the field sits in the same per-frame struct beside
+  `flash_scope`/`screen_shaking`, decoded by the same schema, fired by the
+  same per-frame loop, so "play the named sound when its frame arrives" is
+  read directly off the struct's own shape (a `frame` paired with an `se`),
+  not from any new external citation. **Verification**: added 3 new
+  `rpg2k_scene_check.rb` checks — a hand-built timing's `se` plays through
+  the map path (`ma[:battle]` absent) with volume/pitch/balance forwarded
+  exactly; a blank name and the literal `"(OFF)"` sentinel both play nothing
+  (mirroring `#play_animation_se`'s own already-established handling); and
+  the identical `se` also plays through the battle-round path
+  (`ma[:battle]` true). Confirmed all three fail against the pre-fix
+  `mruby-rpg2k/mrblib/scene/map.rb` (`git show HEAD:...` swapped in for the
+  working copy in its place, never `git stash`, to avoid disturbing any
+  concurrent session's own uncommitted work — `3rd/mruby`'s own
+  working-tree modification was left untouched throughout): the map-path and
+  battle-round checks failed with "got nil" (no `se_play` call recorded at
+  all), the other 958 checks (957 baseline + the blank/`"(OFF)"` no-op check,
+  which passes against old code too since it plays nothing either way)
+  untouched — then restored the fix and reran clean. Full suite:
+  `rpg2k_scene_check.rb` 960 passed (957 baseline + 3 new checks);
+  `rpg2k_logic_check.rb` 1188 passed (unchanged); `rpg2k_render_check.rb` 41
+  passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged);
+  `rpg2k_save_load_check.rb` exit 0, zero known failures (unchanged);
+  `cd build && ninja` clean rebuild; `ctest --test-dir build` 8/8 passing. No
+  `.cxx`/`.hxx` file was touched (a pure-Ruby fix plus its check-script
+  fixtures), so the pinned `clang-format` step does not apply, and no
+  `mruby-rgss` file was touched either, so `rgss_cruby_test_check.rb`/
+  `rgss_cruby_compat.rb` needed no attention. No wine session was run this
+  cycle — this sandbox has no genuine RPG_RT.exe, so the fix is verified by
+  the check suite's recorded `se_play` call arguments only, and (as stated
+  above) the "SE fires per-frame, unconditionally of battle/map context"
+  reading is inferred from the struct's own shape and this codebase's own
+  established `#play_animation_se` convention, not independently confirmed
+  against genuine RPG_RT. Left open for a future cycle: `battle_anime`'s own
+  *top-level* `scope` (0 single/1 all), `large` (2003, 0: 480x480/1:
+  640x640) and `grid` fields (chunk 19 fields 9/3/11) are similarly decoded
+  by the schema but never read anywhere in `mruby-rpg2k` (confirmed by the
+  same grep method as above, done this cycle) — genuinely set by real
+  test-bed data (`scope` 1 on roughly half of Nepheshel/mtf-meido-action's
+  battle animations, not a rare edge case), but their exact runtime effect
+  on rendering/positioning is not established from the schema's own
+  transcribed comment alone, so implementing a concrete behavior for them
+  now would be guessing a formula the same way `terrain.grid_location`
+  (cycle #211's own note above) already declined to do — left as a genuine,
+  documented lead rather than an implemented guess.
+
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8211,8 +8211,11 @@ class RPG2k
       # #fire_target_flash in battle, #fire_map_target_flash on the map), plus
       # screen_shaking 2 (whole screen) / 1 (the animation's own target --
       # #fire_target_shake in battle only, see there for why the map path is a
-      # genuine no-op rather than a gap). RPG2000 stores the flash colour /
-      # power as 0..31, scaled up to the 0..255 range every flash path uses.
+      # genuine no-op rather than a gap), plus (below) the timing's own `se`,
+      # played unconditionally in both battle and map context -- a sound has
+      # no "screen vs target" split to gate on. RPG2000 stores the flash
+      # colour / power as 0..31, scaled up to the 0..255 range every flash
+      # path uses.
       def fire_animation_flashes(ma)
         ma[:timings].each do |t|
           next unless (t.frame || 0) == ma[:frame_i]
@@ -8265,6 +8268,30 @@ class RPG2k
               end
             end
           end
+          # A timing's own `se` (the Timing struct's field 2, mruby-lcf/
+          # mrblib/schema.rb) sits in this exact same per-frame struct as
+          # flash_scope/screen_shaking just above, decoded the same way, but
+          # was never read here at all -- the identical "decoded, never
+          # wired up" shape those two fields each already needed fixing for
+          # in this very method (see their own comments above). The only
+          # place an animation's own sound ever played before this fix was
+          # #play_animation_se (Scene::Base) -- a deliberately narrower,
+          # single-shot summary (the *first* timing across the *whole*
+          # animation with a real sound, played once before the animation
+          # itself even starts, for the field item/skill menu's own success
+          # cue -- see that method's own citation) -- not a substitute for a
+          # genuine battle round or a Show Battle Animation (11210/13260)
+          # command actually sounding each frame's own timing as that frame
+          # arrives, exactly the way flash_scope/screen_shaking already do a
+          # few lines up. NOT independently confirmed against genuine
+          # RPG_RT under wine (no EasyRPG source consulted this cycle, per
+          # this project's own standing rule against new citations there);
+          # the blank/"(OFF)" no-op convention mirrors #play_animation_se's
+          # own already-established handling of the identical field.
+          se = t.respond_to?(:se) ? t.se : nil
+          name = se && se.respond_to?(:file) ? se.file : nil
+          next unless name && !name.empty? && name != '(OFF)'
+          RGSS::Audio.se_play name, (se.volume || 100), (se.pitch || 100), (se.balance || 50)
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10650,6 +10650,53 @@ check 'a map-context screen-scope animation shake triggers the same Game::Screen
   ok st.screen.shaking?, 'the screen shake started on the map path too'
 end
 
+# `se` (the Timing struct's own field 2, mruby-lcf/mrblib/schema.rb) was
+# decoded but never read by #fire_animation_flashes at all -- the same
+# "decoded, never wired up" shape the flash_scope/screen_shaking checks
+# above already caught for their own fields. Before this fix an animation's
+# own per-frame sound only ever played through #play_animation_se (the
+# field item/skill menu's own single-shot success cue, a different method
+# entirely) -- a genuine battle round or a map-triggered Show Battle
+# Animation played its flash/shake but stayed silent. No :battle key (the
+# map path) isolates this from the battle-round SE check further down; the
+# volume/pitch/balance forwarding mirrors #play_animation_se's own already-
+# established convention for the identical field.
+check "a timing's own se plays through the map path, forwarding volume/pitch/balance" do
+  scene = new_scene({})
+  RGSS::Audio.reset_se
+  timing = OpenStruct.new(frame: 0, se: OpenStruct.new(file: 'Zap1', volume: 90, pitch: 110, balance: 25))
+  ma = { frame_i: 0, timings: [timing] } # no :battle key -- the map path
+  scene.send(:fire_animation_flashes, ma)
+  eq ['Zap1', 90, 110, 25], RGSS::Audio.se_calls.last, "the timing's own se played with its own fields forwarded"
+end
+
+# A blank name or the literal "(OFF)" sentinel (liblcf's own schema default)
+# is a no-op, matching #play_animation_se's own already-established
+# handling of the identical field on the same struct.
+check "a timing with no se (or the literal (OFF) sentinel) plays nothing" do
+  scene = new_scene({})
+  RGSS::Audio.reset_se
+  blank = OpenStruct.new(frame: 0, se: OpenStruct.new(file: '', volume: 100, pitch: 100, balance: 50))
+  off = OpenStruct.new(frame: 0, se: OpenStruct.new(file: '(OFF)', volume: 100, pitch: 100, balance: 50))
+  none = OpenStruct.new(frame: 0)
+  ma = { frame_i: 0, timings: [blank, off, none] }
+  scene.send(:fire_animation_flashes, ma)
+  eq [], RGSS::Audio.se_calls, 'no timing here names a real sound'
+end
+
+# The battle-round path (ma[:battle] true) plays a timing's own se exactly
+# the same way the map path above does -- se has no "screen vs target"
+# split to gate on, unlike flash_scope/screen_shaking just above it in
+# #fire_animation_flashes.
+check "a timing's own se plays through the battle-round path too" do
+  scene = new_scene({})
+  RGSS::Audio.reset_se
+  timing = OpenStruct.new(frame: 0, se: OpenStruct.new(file: 'Zap1', volume: 100, pitch: 100, balance: 50))
+  ma = { frame_i: 0, timings: [timing], battle: true, targets: [] }
+  scene.send(:fire_animation_flashes, ma)
+  eq ['Zap1', 100, 100, 50], RGSS::Audio.se_calls.last, 'the timing SE plays in battle context too'
+end
+
 # screen_shaking 1 ("target") on a map-triggered Show Battle Animation is a
 # genuine no-op per EasyRPG Player's source (NOT independently confirmed
 # against genuine RPG_RT under wine), not a dropped feature: its `BattleAnimationMap::


### PR DESCRIPTION
## Summary

`Scene::Map#fire_animation_flashes` already read a `battle_anime` timing's `flash_scope`/`screen_shaking` fields when firing each matching frame, but never its sibling `se` field (`Timing` struct field 2, `mruby-lcf/mrblib/schema.rb`) — the identical "decoded, never wired up" shape those two fields each needed fixing for in this very method. Net effect: a real battle round or a Show Battle Animation (11210/13260) command drew its flash/shake but played **no sound at all** for the animation's own per-frame SE timings.

The only place an animation's own sound ever played before this fix was `Scene::Base#play_animation_se` — a deliberately narrower, single-shot summary (the *first* timing across the *whole* animation with a real sound, played once before the animation itself even starts, for the field item/skill menu's own success cue) — never a substitute for genuinely sounding each frame's own timing as that frame arrives.

**Fix:** `#fire_animation_flashes` now also reads a matching timing's `se` and plays it via `RGSS::Audio.se_play` (volume/pitch/balance forwarded; blank/`"(OFF)"` treated as a no-op, mirroring `#play_animation_se`'s own already-established convention for the identical field), fired unconditionally in both map and battle context since a sound has no "screen vs target" split to gate on.

**Related, deliberately not attempted this cycle:** `battle_anime`'s top-level `scope`/`large`/`grid` fields are also decoded but never read anywhere — genuinely set by real test-bed data, but their exact runtime semantics aren't determinable from the schema alone without guessing a formula (declined for the same reason an earlier cycle declined `terrain.grid_location`). Documented in `docs/TODO.md` as an honest open lead for a future cycle.

## Verification

- 3 new checks added to `scripts/rpg2k_scene_check.rb`: map-path playback with fields forwarded, blank/`"(OFF)"`/absent-`se` no-op, and battle-round-path playback. Independently confirmed **2 of 960** fail against the pre-fix `map.rb` (the no-op check is expected to pass unchanged either way, since pre-fix code never called `se_play` at all in any case) — via temporary file swap, not `git stash` — and all pass clean after restoring the fix
- `scripts/rpg2k_scene_check.rb`: 960 passed (957 baseline + 3 new)
- `scripts/rpg2k_logic_check.rb`: 1188 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: exit 0, zero known failures (unchanged)
- `cd build && ninja`: clean rebuild
- `ctest --test-dir build`: 8/8 passing
- Field id (2 = `se`, an `SE`-struct array) verified against `mruby-lcf/mrblib/schema.rb`'s own `Timing` struct definition; the blank/`(OFF)`-no-op idiom and `Audio.se_play(name, volume, pitch, balance)` call shape verified to match `Scene::Base#play_animation_se`'s own existing, already-shipped handling of the identical field exactly; confirmed the new SE-playing code sits correctly inside the same per-timing `next unless (t.frame || 0) == ma[:frame_i]` frame-match guard the flash/shake logic already uses, not a separate unguarded loop

No wine session was run this cycle (this sandbox has no genuine RPG_RT.exe) and no EasyRPG source was consulted for this claim — the "SE fires per-frame, the same as flash/shake" reading is inferred from the struct's own shape (three sibling fields decoded together in the same per-frame record) and this codebase's existing conventions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_