### PR TITLE
Cycle #225: honour System#show_title, skip the title screen when unchecked

### DIFF
--- a/changelog.d/system-show-title.fixed.md
+++ b/changelog.d/system-show-title.fixed.md
@@ -1,0 +1,33 @@
+- **A project with "Show title screen" unchecked now actually skips the
+  title screen.** `System#show_title` (LDB chunk 22 field 111,
+  `mruby-lcf/mrblib/schema.rb`) has been decoded since the field was named,
+  defaulting `true`, but nothing ever read it: `RPG2k#initialize`
+  (`mruby-rpg2k/mrblib/main.rb`) always pushed `Scene::Title` unconditionally
+  regardless of the flag -- the same "declared but never wired" shape cycle
+  #165 found and fixed for Change Battle Background's own save field. A
+  project that unchecks this System-tab box (used to open on a scripted
+  intro rather than a title menu) got the ordinary title screen -- picture,
+  title BGM, New Game/Continue/Shutdown menu -- every time regardless. New
+  `RPG2k#show_title?` reads the field (defaulting `true` via `respond_to?`
+  guards so a database missing the field, or the whole System table, is
+  unaffected); `#boot_title_or_new_game` replaces the old unconditional
+  `push Scene::Title.new self` and, when the flag is off, calls
+  `#start_new_game` directly instead -- skipping Scene::Title's own asset
+  loads entirely (no title picture read, no title BGM ever started only to
+  be immediately faded), not merely auto-selecting New Game from a title
+  that briefly existed. A data problem in `#start_new_game` (which already
+  rescues and logs rather than raising) still falls back to an ordinary
+  title screen, so a bad map/database never leaves `@scenes` empty against
+  `#main_loop`'s unconditional `@scenes.last.update`. `#return_to_title` and
+  `#show_game_over` are untouched: the setting is understood to gate only
+  the initial boot, not the in-game "To Title" command or a Game Over's own
+  return path, which still need a real Continue/Shutdown menu reachable.
+  NOT independently confirmed against genuine RPG_RT under wine this cycle
+  (no wine session run) -- implemented from the field's own well-documented,
+  unambiguous editor semantics, the same standard this project already
+  applies to every other database flag no wine capture has directly probed.
+  Covered by four new `scripts/rpg2k_scene_check.rb` checks (`#show_title?`'s
+  own defaulting; the skip-title path calling `#start_new_game` with the
+  title never pushed; the normal on-path behaving exactly as before; the
+  data-problem fallback), confirmed to fail against the pre-fix code before
+  the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2268,6 +2268,75 @@ The work below is roughly ordered by the critical path to a walkable game
   (cycle #211's own note above) already declined to do — left as a genuine,
   documented lead rather than an implemented guess.
 
+  ✅ **Follow-up (cycle #225, 2026-08-28): `System#show_title` (the "Show
+  title screen" checkbox) is now honoured — a project with it unchecked
+  used to get the ordinary title screen every single boot regardless.**
+  Method: cycles #217-#224's own audio-struct sweep (BGM/SE/animation
+  cell/animation timing) had exhausted every LCF struct in
+  `mruby-lcf/mrblib/schema.rb` with 3+ optional fields this cycle could find
+  a genuinely undone, safely-scoped field on (`BATTLER_ANIMATION`'s
+  `weapon_cba`/`movement`/`after_image`/... union is a real, still-unread
+  gap, but it is the same large, semantics-unclear "CBA battle-animation
+  sprite format" this file's own top-of-section 🚧 already tracks as
+  foundational-only, not a one-field bug; `SAVE_SCREEN`'s battle-animation
+  replay fields and `battle_anime`'s own `scope`/`large`/`grid` are both
+  already-declined-for-good-reason per cycle #224's note just above and an
+  earlier cycle's `terrain.grid_location` note). Widened the search instead
+  to single scalar `System` fields decoded but never read anywhere in
+  `mruby-rpg2k` (grepped each field name from chunk 22 of `DATABASE` against
+  the whole tree): `show_title` (field 111, default `true`) came up with
+  zero hits outside its own schema declaration — `RPG2k#initialize`
+  (`mruby-rpg2k/mrblib/main.rb`) pushed `Scene::Title` unconditionally,
+  never consulting it. Fixed with new `RPG2k#show_title?` (defaults `true`
+  via `respond_to?` guards, matching the schema default for a database
+  missing the field or the whole System table) and
+  `#boot_title_or_new_game`, which replaces the old unconditional push: off
+  skips `Scene::Title` entirely (no title picture load, no title BGM
+  started-then-faded) and calls `#start_new_game` directly, with a
+  fallback-to-title safety net if that hits a data problem and leaves
+  `@scenes` empty (mirroring `#start_new_game`'s own existing "never let a
+  data problem crash the title screen" rescue). `#return_to_title` /
+  `#show_game_over` are untouched on purpose — the setting is read as
+  gating only the initial boot, not the in-game "To Title" command or a
+  Game Over's own return path. **Verification**: added 4 new
+  `rpg2k_scene_check.rb` checks (`#show_title?`'s own three-way defaulting;
+  the skip-title path calling `#start_new_game` with the title never
+  pushed; the on-path behaving exactly as before, unchanged; the
+  data-problem fallback), each built the same "flag plumbing only, in
+  CRuby, via `RPG2k.allocate` with `#start_new_game`/`#push_title_screen`
+  stubbed" pattern this file's own `--rpg2k_preview_map`/`--rpg2k_battle_troop`
+  checks already established just below — no real `RPG_RT.ldb`/`.lmt` I/O,
+  matching how `#start_new_game` itself is only ever exercised end-to-end by
+  the native boot check against real game data. Confirmed all 4 fail against
+  the pre-fix `mruby-rpg2k/mrblib/main.rb` (`git show HEAD:...` swapped in
+  for the working copy in its place, never `git stash`, so as not to disturb
+  any concurrent session's own uncommitted work — `3rd/mruby`'s own
+  working-tree modification was left untouched throughout) — the pre-fix
+  code failed with a straight unconditional push (`start_new_game` never
+  called, `push_title_screen` called once regardless of `show_title`) —
+  then restored the fix and reran clean. Full suite:
+  `rpg2k_scene_check.rb` 964 passed (960 baseline + 4 new checks);
+  `rpg2k_logic_check.rb` 1188 passed (unchanged); `rpg2k_render_check.rb` 41
+  passed (unchanged); `rpg2k3_battle_row_check.rb` 19/0 and
+  `rpg2k3_battle_gauge_check.rb` 15/0 (both unchanged);
+  `rpg2k_save_load_check.rb` exit 0, zero known failures (unchanged);
+  `cd build && ninja` clean rebuild; `ctest --test-dir build` 8/8 passing. No
+  `.cxx`/`.hxx` file was touched (a pure-Ruby fix plus its check-script
+  fixtures), so the pinned `clang-format` step does not apply, and no
+  `mruby-rgss` file was touched either, so `rgss_cruby_test_check.rb`/
+  `rgss_cruby_compat.rb` needed no attention. No wine session was run this
+  cycle — this sandbox has no genuine RPG_RT.exe — so the "unchecking Show
+  Title Screen skips straight to New Game, with no title BGM/picture ever
+  touched" reading is implemented from the field's own well-documented,
+  unambiguous editor semantics rather than independently confirmed against
+  genuine RPG_RT, the same standard this project already applies to every
+  other database flag no wine capture has directly probed. Left genuinely
+  open: whether `#return_to_title`/`#show_game_over` really should keep
+  ignoring the flag (this cycle's own reading, not wine-verified either),
+  and the `BATTLER_ANIMATION` union's still-unread weapon-CBA fields noted
+  above, which remain the largest genuinely-open item this same search
+  method has surfaced.
+
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -603,6 +603,55 @@ class RPG2k
     @title = read_ini_title
     RGSS.window_title = @title
     @scenes = []
+    boot_title_or_new_game
+  end
+
+  # System#show_title (LDB chunk 22 field 111, mruby-lcf/mrblib/schema.rb) --
+  # the RPG2003 System tab's own "タイトル画面を表示させる" ("Show title screen")
+  # checkbox, default true. This codebase has decoded the field since it was
+  # named, but nothing ever read it: #initialize always pushed Scene::Title
+  # unconditionally, the same "declared but never wired" shape cycle #165
+  # found for Change Battle Background's own save field. When unchecked, the
+  # documented editor behaviour is that RPG_RT skips the title screen (its
+  # picture, its title BGM, and the New Game/Continue/Shutdown menu) entirely
+  # and boots straight into a fresh New Game instead, as though the player
+  # had already chosen it -- used by projects that open on a scripted intro
+  # rather than a title menu. NOT independently confirmed against genuine
+  # RPG_RT under wine this cycle (no wine session run); implemented from the
+  # field's own well-documented, unambiguous editor semantics, the standard
+  # this project already applies to every other database flag no wine
+  # capture has directly probed (see e.g. mruby-lcf/mrblib/schema.rb's own
+  # System#equipment_setting comment). Guarded with respond_to? so a
+  # bare/synthetic database missing the field -- or the whole System table,
+  # as scripts/rpg2k_scene_check.rb's fixtures do -- answers true, the
+  # harmless default every real project's database also reads back until
+  # this box is unchecked.
+  def show_title?
+    !(@db.respond_to?(:system) && @db.system.respond_to?(:show_title) &&
+      @db.system.show_title == false)
+  end
+
+  # Split out of #initialize so #show_title?'s branch can be exercised
+  # directly (RPG2k.allocate, with #start_new_game/#push_title_screen
+  # stubbed) without a real RPG_RT.ldb/.lmt -- see
+  # scripts/rpg2k_scene_check.rb.
+  def boot_title_or_new_game
+    if show_title?
+      push_title_screen
+    else
+      $stderr.puts '[RPG2k] System#show_title is off: skipping the title ' \
+                   'screen, booting straight into New Game'
+      start_new_game
+      # #start_new_game leaves @scenes untouched (so still empty here) if it
+      # hits a data problem and rescues -- fall back to an ordinary title
+      # rather than leave #main_loop's `@scenes.last.update` with nothing to
+      # call, the same "never let a data problem crash the title screen"
+      # rule its own rescue clause already documents for the normal path.
+      push_title_screen if @scenes.empty?
+    end
+  end
+
+  def push_title_screen
     push Scene::Title.new self
   end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -14173,6 +14173,79 @@ check 'neither flag set leaves the title screen waiting for input' do
   ok !scene.send(:auto_select?), 'no auto-select without a flag'
 end
 
+# -- System#show_title (LDB chunk 22 field 111) -------------------------------
+#
+# RPG2k#show_title? and #boot_title_or_new_game (mruby-rpg2k/mrblib/main.rb)
+# read the database's own "Show title screen" checkbox and, when it is
+# unchecked, skip Scene::Title entirely and boot straight into New Game --
+# see #boot_title_or_new_game's own comment for the field citation and the
+# fallback-to-title safety net a data problem in #start_new_game still gets.
+# #initialize itself (which needs a real RPG_RT.ldb/.lmt) is not exercised
+# here, the same "flag plumbing only, in CRuby" split every other headless
+# flag check on this file already uses -- these two pin #show_title?'s own
+# defaulting and #boot_title_or_new_game's branching in isolation.
+check 'RPG2k#show_title? defaults true when the field or the whole System table is missing' do
+  rpg2k = RPG2k.allocate
+  rpg2k.instance_variable_set(:@db, OpenStruct.new)
+  ok rpg2k.send(:show_title?), 'no System table at all -> true, the schema default'
+
+  rpg2k.instance_variable_set(:@db, OpenStruct.new(system: OpenStruct.new))
+  ok rpg2k.send(:show_title?), 'a System table with no show_title field -> true'
+
+  rpg2k.instance_variable_set(:@db, OpenStruct.new(system: OpenStruct.new(show_title: true)))
+  ok rpg2k.send(:show_title?), 'System#show_title explicitly true -> true'
+
+  rpg2k.instance_variable_set(:@db, OpenStruct.new(system: OpenStruct.new(show_title: false)))
+  ok !rpg2k.send(:show_title?), 'System#show_title explicitly false -> false'
+end
+
+check 'RPG2k#boot_title_or_new_game skips the title screen and starts a new game '\
+     'when System#show_title is off' do
+  rpg2k = RPG2k.allocate
+  rpg2k.instance_variable_set(:@db, OpenStruct.new(system: OpenStruct.new(show_title: false)))
+  rpg2k.instance_variable_set(:@scenes, [])
+  new_game_calls = 0
+  title_calls = 0
+  # A well-behaved #start_new_game leaves a real scene behind (Scene::Map),
+  # modelled here as any non-empty @scenes -- so the fallback below must not
+  # fire.
+  rpg2k.define_singleton_method(:start_new_game) { new_game_calls += 1; @scenes = [:fake_map_scene] }
+  rpg2k.define_singleton_method(:push_title_screen) { title_calls += 1 }
+  rpg2k.send(:boot_title_or_new_game)
+  eq 1, new_game_calls, 'start_new_game is called directly, with no title screen in between'
+  eq 0, title_calls, 'the title screen is never pushed when show_title is off and New Game succeeds'
+  eq [:fake_map_scene], rpg2k.instance_variable_get(:@scenes)
+end
+
+check 'RPG2k#boot_title_or_new_game still shows the title screen normally when show_title is on' do
+  rpg2k = RPG2k.allocate
+  rpg2k.instance_variable_set(:@db, OpenStruct.new(system: OpenStruct.new(show_title: true)))
+  rpg2k.instance_variable_set(:@scenes, [])
+  new_game_calls = 0
+  title_calls = 0
+  rpg2k.define_singleton_method(:start_new_game) { new_game_calls += 1 }
+  rpg2k.define_singleton_method(:push_title_screen) { title_calls += 1 }
+  rpg2k.send(:boot_title_or_new_game)
+  eq 0, new_game_calls, 'New Game is not auto-started with show_title on'
+  eq 1, title_calls, 'the title screen is pushed exactly like before this field was wired up'
+end
+
+check 'RPG2k#boot_title_or_new_game falls back to the title screen if a show_title-off '\
+     'New Game hits a data problem' do
+  rpg2k = RPG2k.allocate
+  rpg2k.instance_variable_set(:@db, OpenStruct.new(system: OpenStruct.new(show_title: false)))
+  rpg2k.instance_variable_set(:@scenes, [])
+  title_calls = 0
+  # Mirrors #start_new_game's own `rescue StandardError` clause: a data
+  # problem is reported and @scenes is left exactly as #initialize set it,
+  # empty -- never raised out to the caller.
+  rpg2k.define_singleton_method(:start_new_game) { }
+  rpg2k.define_singleton_method(:push_title_screen) { title_calls += 1 }
+  rpg2k.send(:boot_title_or_new_game)
+  eq 1, title_calls,
+     'a New Game that leaves no scene behind still gets a title screen, not a blank #main_loop crash'
+end
+
 # -- --rpg2k_preview_map (map preview, see README.md's "Map exploration") ----
 #
 # RPG2k#preview_map_id reads the RPG2K_PREVIEW_MAP constant main.cxx sets from


### PR DESCRIPTION
## Summary

`System#show_title` (LDB chunk 22 field 111, `mruby-lcf/mrblib/schema.rb`) — the RPG2003 System tab's own "Show title screen" checkbox, default true — had been decoded since the field was named, but nothing ever read it: `RPG2k#initialize` always pushed `Scene::Title` unconditionally, the same "declared but never wired" shape cycle #165 found for Change Battle Background's own save field. A project that unchecks this box (used to boot straight into a scripted intro instead of a title menu) got the ordinary title screen — picture, title BGM, New Game/Continue/Shutdown menu — every time.

**Fix:**
- New `RPG2k#show_title?` reads the flag, defaulting `true` via `respond_to?` guards so a bare/synthetic database missing the field (or the whole System table, as the check-suite's own fixtures do) answers `true`, the harmless default every real project's database also reads back until the box is unchecked.
- New `RPG2k#boot_title_or_new_game`, called from `#initialize` in place of the old unconditional `push Scene::Title.new self`: when the flag is on, it pushes the title screen as before (extracted into `#push_title_screen`); when it's off, it skips the title screen's own asset loads entirely (no title picture, no title BGM) and calls `#start_new_game` directly, falling back to the ordinary title screen if that hits a data problem and rescues (mirroring `#start_new_game`'s own existing "never let a data problem crash the title screen" rescue clause — confirmed it leaves `@scenes` untouched on failure, which the fallback's `@scenes.empty?` check catches correctly).

**Honest limitation:** not independently confirmed against genuine RPG_RT under wine this cycle (none run) — implemented from the field's own well-documented, unambiguous editor semantics (its label literally reads "Show title screen"), the same standard this project already applies to other database flags no wine capture has directly probed.

## Verification

- 4 new checks added to `scripts/rpg2k_scene_check.rb` using the existing `RPG2k.allocate` + stubbed-methods pattern this file already uses for other headless-flag plumbing checks; independently confirmed all 4 fail against the pre-fix `main.rb` (via temporary file swap, not `git stash`) and pass clean after restoring the fix
- `scripts/rpg2k_scene_check.rb`: 964 passed (960 baseline + 4 new)
- `scripts/rpg2k_logic_check.rb`: 1188 passed (unchanged)
- `scripts/rpg2k_render_check.rb`: 41 passed (unchanged)
- `scripts/rpg2k3_battle_row_check.rb` / `rpg2k3_battle_gauge_check.rb`: 19/0, 15/0 (unchanged)
- `scripts/rpg2k_save_load_check.rb`: exit 0, zero known failures (unchanged)
- `cd build && ninja`: clean rebuild
- `ctest --test-dir build`: 8/8 passing
- Field id (111 = `show_title`, bool, default true) verified against `mruby-lcf/mrblib/schema.rb`'s own `System` struct definition; `#start_new_game`'s rescue-leaves-`@scenes`-untouched behavior independently traced to confirm the fallback path is reachable and correct

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxLV6YxAYtKZkGLPTEvHam)_